### PR TITLE
feat: bootstrap hilt wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Format inspiré de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/). Les
 ### Changed
 - `AGENTS.md` ne prescrit plus une identité git personnelle (`xat`, `xat@azora.fr`) et les lignes d'attribution IA utilisent désormais `@<demandeur>` pour mieux refléter le caractère multi-contributeur du repo.
 - La licence du client Android Redface 2 passe de la mention implicite `Apache 2.0` à **`GPL-3.0-only`** dans le repo (`AGENTS.md`, `README.md`, `docs/guides/contributing.md`).
+- le bootstrap Hilt Phase 0 s'aligne sur **Hilt 2.59.2** dans le version catalog, et `docs/specs/stack.md` reflète désormais cette référence d'implémentation.
 - l'image Docker / CI de référence est désormais **épinglée par digest** et documentée comme manifest list multi-arch (`amd64` + `arm64`).
 - le wrapper `docker-dev.sh` et le dev container ne tournent plus en root par défaut.
 - `Dependabot` est recalibré en cadence mensuelle groupée et la CI annule les runs obsolètes sur la même ref.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("redface.android.compose.application")
+    id("redface.android.hilt.application")
     id("org.jetbrains.kotlin.plugin.serialization")
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
+        android:name=".RedfaceApplication"
         android:allowBackup="true"
         android:enableOnBackInvokedCallback="true"
         android:label="@string/app_name"

--- a/app/src/main/java/fr/forumhfr/redface2/MainActivity.kt
+++ b/app/src/main/java/fr/forumhfr/redface2/MainActivity.kt
@@ -8,8 +8,10 @@ import androidx.activity.compose.setContent
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import dagger.hilt.android.AndroidEntryPoint
 import fr.forumhfr.redface2.navigation.RedfaceApp
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     private var latestIntent by mutableStateOf<Intent?>(null)
 

--- a/app/src/main/java/fr/forumhfr/redface2/RedfaceApplication.kt
+++ b/app/src/main/java/fr/forumhfr/redface2/RedfaceApplication.kt
@@ -1,18 +1,7 @@
 package fr.forumhfr.redface2
 
 import android.app.Application
-import android.util.Log
 import dagger.hilt.android.HiltAndroidApp
-import java.time.Clock
-import javax.inject.Inject
 
 @HiltAndroidApp
-class RedfaceApplication : Application() {
-    @Inject
-    lateinit var clock: Clock
-
-    override fun onCreate() {
-        super.onCreate()
-        Log.d("RedfaceApplication", "Hilt graph ready at ${clock.instant()}")
-    }
-}
+class RedfaceApplication : Application()

--- a/app/src/main/java/fr/forumhfr/redface2/RedfaceApplication.kt
+++ b/app/src/main/java/fr/forumhfr/redface2/RedfaceApplication.kt
@@ -1,0 +1,18 @@
+package fr.forumhfr.redface2
+
+import android.app.Application
+import android.util.Log
+import dagger.hilt.android.HiltAndroidApp
+import java.time.Clock
+import javax.inject.Inject
+
+@HiltAndroidApp
+class RedfaceApplication : Application() {
+    @Inject
+    lateinit var clock: Clock
+
+    override fun onCreate() {
+        super.onCreate()
+        Log.d("RedfaceApplication", "Hilt graph ready at ${clock.instant()}")
+    }
+}

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -7,6 +7,8 @@ dependencies {
     implementation(libs.android.gradle.plugin)
     implementation(libs.kotlin.gradle.plugin)
     implementation(libs.kotlin.compose.gradle.plugin)
+    implementation(libs.ksp.gradle.plugin)
+    implementation(libs.hilt.android.gradle.plugin)
 }
 
 gradlePlugin {
@@ -26,6 +28,14 @@ gradlePlugin {
         register("redfaceAndroidComposeLibrary") {
             id = "redface.android.compose.library"
             implementationClass = "fr.forumhfr.redface2.buildlogic.RedfaceAndroidComposeLibraryConventionPlugin"
+        }
+        register("redfaceAndroidHiltApplication") {
+            id = "redface.android.hilt.application"
+            implementationClass = "fr.forumhfr.redface2.buildlogic.RedfaceAndroidHiltApplicationConventionPlugin"
+        }
+        register("redfaceAndroidHiltLibrary") {
+            id = "redface.android.hilt.library"
+            implementationClass = "fr.forumhfr.redface2.buildlogic.RedfaceAndroidHiltLibraryConventionPlugin"
         }
         register("redfaceKotlinJvmLibrary") {
             id = "redface.kotlin.jvm.library"

--- a/build-logic/src/main/kotlin/fr/forumhfr/redface2/buildlogic/RedfaceConventionPlugins.kt
+++ b/build-logic/src/main/kotlin/fr/forumhfr/redface2/buildlogic/RedfaceConventionPlugins.kt
@@ -110,6 +110,30 @@ class RedfaceAndroidComposeLibraryConventionPlugin : Plugin<Project> {
     }
 }
 
+class RedfaceAndroidHiltApplicationConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        pluginManager.withPlugin("com.android.application") {
+            pluginManager.apply("com.google.devtools.ksp")
+            pluginManager.apply("com.google.dagger.hilt.android")
+
+            dependencies.add("implementation", libs.library("hilt-android"))
+            dependencies.add("ksp", libs.library("hilt-android-compiler"))
+        }
+    }
+}
+
+class RedfaceAndroidHiltLibraryConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        pluginManager.withPlugin("com.android.library") {
+            pluginManager.apply("com.google.devtools.ksp")
+            pluginManager.apply("com.google.dagger.hilt.android")
+
+            dependencies.add("implementation", libs.library("hilt-android"))
+            dependencies.add("ksp", libs.library("hilt-android-compiler"))
+        }
+    }
+}
+
 class RedfaceKotlinJvmLibraryConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         pluginManager.apply("org.jetbrains.kotlin.jvm")
@@ -132,3 +156,6 @@ private val Project.libs: VersionCatalog
 
 private fun VersionCatalog.versionInt(alias: String): Int =
     findVersion(alias).get().requiredVersion.toInt()
+
+private fun VersionCatalog.library(alias: String) =
+    findLibrary(alias).get().get()

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("redface.android.library")
+    id("redface.android.hilt.library")
 }
 
 android {
@@ -11,4 +12,5 @@ dependencies {
     implementation(project(":core:network"))
     implementation(project(":core:parser"))
     implementation(project(":core:database"))
+    implementation(libs.kotlinx.coroutines.core)
 }

--- a/core/data/src/main/java/fr/forumhfr/redface2/core/data/di/DispatchersQualifiers.kt
+++ b/core/data/src/main/java/fr/forumhfr/redface2/core/data/di/DispatchersQualifiers.kt
@@ -1,0 +1,11 @@
+package fr.forumhfr.redface2.core.data.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DefaultDispatcher
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class IoDispatcher

--- a/core/data/src/main/java/fr/forumhfr/redface2/core/data/di/PlatformBindingsModule.kt
+++ b/core/data/src/main/java/fr/forumhfr/redface2/core/data/di/PlatformBindingsModule.kt
@@ -1,0 +1,28 @@
+package fr.forumhfr.redface2.core.data.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import java.time.Clock
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+@Module
+@InstallIn(SingletonComponent::class)
+object PlatformBindingsModule {
+    @Provides
+    @Singleton
+    fun provideRedfaceClock(): Clock = Clock.systemUTC()
+
+    @Provides
+    @Singleton
+    @IoDispatcher
+    fun provideIoDispatcher(): CoroutineDispatcher = Dispatchers.IO
+
+    @Provides
+    @Singleton
+    @DefaultDispatcher
+    fun provideDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
+}

--- a/core/data/src/main/java/fr/forumhfr/redface2/core/data/di/PlatformBindingsModule.kt
+++ b/core/data/src/main/java/fr/forumhfr/redface2/core/data/di/PlatformBindingsModule.kt
@@ -4,6 +4,9 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import fr.forumhfr.redface2.core.domain.coroutines.DefaultDispatcher
+import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
+import fr.forumhfr.redface2.core.domain.coroutines.MainDispatcher
 import java.time.Clock
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
@@ -25,4 +28,9 @@ object PlatformBindingsModule {
     @Singleton
     @DefaultDispatcher
     fun provideDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
+
+    @Provides
+    @Singleton
+    @MainDispatcher
+    fun provideMainDispatcher(): CoroutineDispatcher = Dispatchers.Main.immediate
 }

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
 
 dependencies {
     api(project(":core:model"))
+    api(libs.javax.inject)
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/coroutines/DispatchersQualifiers.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/coroutines/DispatchersQualifiers.kt
@@ -1,6 +1,10 @@
-package fr.forumhfr.redface2.core.data.di
+package fr.forumhfr.redface2.core.domain.coroutines
 
 import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class IoDispatcher
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
@@ -8,4 +12,4 @@ annotation class DefaultDispatcher
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
-annotation class IoDispatcher
+annotation class MainDispatcher

--- a/docs/specs/stack.md
+++ b/docs/specs/stack.md
@@ -167,6 +167,8 @@ Voir `docs/specs/navigation.md` pour les exemples concrets (`NavDisplay`, `Scene
 
 Hilt avec KSP (pas KAPT) résout le problème historique de build time. La sécurité à la compilation et l'intégration native avec Jetpack font la différence pour un projet open-source.
 
+Le bootstrap de code Phase 0 s'aligne actuellement sur **Hilt 2.59.2** dans le version catalog. Cette version sert de référence d'implémentation tant que le couple Kotlin/AGP 9 reste en place.
+
 **Note** : Koin a évolué significativement. Le [compiler plugin K2](https://insert-koin.io/docs/reference/koin-annotations/start) (1.0.0-RC1) permet la génération du graphe de DI à la compilation, éliminant le risque de crash runtime. Koin est également KMP-natif. Si le projet évolue vers KMP, Koin deviendra le choix naturel. Hilt reste le choix pour la v1 Android-only grâce à son intégration Jetpack et sa base de contributeurs plus large.
 
 ### Perspectives KMP

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "9.1.0"
 kotlin = "2.3.20"
 ksp = "2.3.6"
-hilt = "2.57.2"
+hilt = "2.59.2"
 android-minSdk = "29"
 android-targetSdk = "36"
 android-compileSdk = "36"
@@ -37,6 +37,8 @@ hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-compose-gradle-plugin = { module = "org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin", version.ref = "kotlin" }
+ksp-gradle-plugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
+hilt-android-gradle-plugin = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt" }
 
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
@@ -57,7 +59,7 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
-hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
+hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ mockk = "1.14.9"
 robolectric = "4.16.1"
 turbine = "1.2.1"
 konsist = "0.17.3"
+javax-inject = "1"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -55,6 +56,7 @@ robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectr
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 konsist = { module = "com.lemonappdev:konsist", version.ref = "konsist" }
 detekt-cli = { module = "io.gitlab.arturbosch.detekt:detekt-cli", version.ref = "detekt" }
+javax-inject = { module = "javax.inject:javax.inject", version.ref = "javax-inject" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 


### PR DESCRIPTION
> Action par GPT-5 Codex (demandée par @XaaT)

Closes #50

## Summary

- ajoute le bootstrap Hilt minimal côté `app` et `:core:data`
- introduit `RedfaceApplication` avec `@HiltAndroidApp`
- marque `MainActivity` en `@AndroidEntryPoint` pour préparer l’injection future côté navigation / ViewModel
- ajoute des bindings de base dans `:core:data` (`Clock`, `Dispatchers.IO`, `Dispatchers.Default`)
- extrait le wiring Hilt/KSP dans `build-logic` via deux convention plugins dédiés

## Notes

- scope volontairement minimal : pas de modules Hilt par feature, pas de faux repositories, pas de `@HiltViewModel` tant qu’aucun ViewModel réel n’existe
- bump Hilt vers `2.59.2` dans le version catalog : c’est la première ligne stable qui supporte AGP 9, déjà utilisé par le repo
- le premier point d’injection utile est l’application ; l’activité est rendue Hilt-ready pour les prochains écrans stateful

## Validation run

- `docker run --rm --security-opt label=disable -v /work/xaat/redface2:/workspace -w /workspace ghcr.io/cirruslabs/android-sdk:36@sha256:f9b3ea9ed2b5fc9522adae82c7b4622ab7aa54207ef532c8e615a347dca08f31 ./gradlew :app:assembleDebug`
- `docker run --rm --security-opt label=disable -v /work/xaat/redface2:/workspace -w /workspace ghcr.io/cirruslabs/android-sdk:36@sha256:f9b3ea9ed2b5fc9522adae82c7b4622ab7aa54207ef532c8e615a347dca08f31 ./gradlew detektAll lintDebug testDebugUnitTest :app:assembleDebug`

## Sources

- https://dagger.dev/hilt/gradle-setup
- https://developer.android.com/training/dependency-injection/hilt-android
- Context7 `/websites/dagger_dev_hilt`
- https://github.com/google/dagger/releases/tag/dagger-2.59
