### PR TITLE
feat: bootstrap hilt wiring (resubmit for codex review)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("redface.android.compose.application")
+    id("redface.android.hilt.application")
     id("org.jetbrains.kotlin.plugin.serialization")
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
+        android:name=".RedfaceApplication"
         android:allowBackup="true"
         android:enableOnBackInvokedCallback="true"
         android:label="@string/app_name"

--- a/app/src/main/java/fr/forumhfr/redface2/MainActivity.kt
+++ b/app/src/main/java/fr/forumhfr/redface2/MainActivity.kt
@@ -8,8 +8,10 @@ import androidx.activity.compose.setContent
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import dagger.hilt.android.AndroidEntryPoint
 import fr.forumhfr.redface2.navigation.RedfaceApp
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     private var latestIntent by mutableStateOf<Intent?>(null)
 

--- a/app/src/main/java/fr/forumhfr/redface2/RedfaceApplication.kt
+++ b/app/src/main/java/fr/forumhfr/redface2/RedfaceApplication.kt
@@ -1,0 +1,18 @@
+package fr.forumhfr.redface2
+
+import android.app.Application
+import android.util.Log
+import dagger.hilt.android.HiltAndroidApp
+import java.time.Clock
+import javax.inject.Inject
+
+@HiltAndroidApp
+class RedfaceApplication : Application() {
+    @Inject
+    lateinit var clock: Clock
+
+    override fun onCreate() {
+        super.onCreate()
+        Log.d("RedfaceApplication", "Hilt graph ready at ${clock.instant()}")
+    }
+}

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -7,6 +7,8 @@ dependencies {
     implementation(libs.android.gradle.plugin)
     implementation(libs.kotlin.gradle.plugin)
     implementation(libs.kotlin.compose.gradle.plugin)
+    implementation(libs.ksp.gradle.plugin)
+    implementation(libs.hilt.android.gradle.plugin)
 }
 
 gradlePlugin {
@@ -26,6 +28,14 @@ gradlePlugin {
         register("redfaceAndroidComposeLibrary") {
             id = "redface.android.compose.library"
             implementationClass = "fr.forumhfr.redface2.buildlogic.RedfaceAndroidComposeLibraryConventionPlugin"
+        }
+        register("redfaceAndroidHiltApplication") {
+            id = "redface.android.hilt.application"
+            implementationClass = "fr.forumhfr.redface2.buildlogic.RedfaceAndroidHiltApplicationConventionPlugin"
+        }
+        register("redfaceAndroidHiltLibrary") {
+            id = "redface.android.hilt.library"
+            implementationClass = "fr.forumhfr.redface2.buildlogic.RedfaceAndroidHiltLibraryConventionPlugin"
         }
         register("redfaceKotlinJvmLibrary") {
             id = "redface.kotlin.jvm.library"

--- a/build-logic/src/main/kotlin/fr/forumhfr/redface2/buildlogic/RedfaceConventionPlugins.kt
+++ b/build-logic/src/main/kotlin/fr/forumhfr/redface2/buildlogic/RedfaceConventionPlugins.kt
@@ -110,6 +110,30 @@ class RedfaceAndroidComposeLibraryConventionPlugin : Plugin<Project> {
     }
 }
 
+class RedfaceAndroidHiltApplicationConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        pluginManager.withPlugin("com.android.application") {
+            pluginManager.apply("com.google.devtools.ksp")
+            pluginManager.apply("com.google.dagger.hilt.android")
+
+            dependencies.add("implementation", libs.library("hilt-android"))
+            dependencies.add("ksp", libs.library("hilt-android-compiler"))
+        }
+    }
+}
+
+class RedfaceAndroidHiltLibraryConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        pluginManager.withPlugin("com.android.library") {
+            pluginManager.apply("com.google.devtools.ksp")
+            pluginManager.apply("com.google.dagger.hilt.android")
+
+            dependencies.add("implementation", libs.library("hilt-android"))
+            dependencies.add("ksp", libs.library("hilt-android-compiler"))
+        }
+    }
+}
+
 class RedfaceKotlinJvmLibraryConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         pluginManager.apply("org.jetbrains.kotlin.jvm")
@@ -132,3 +156,6 @@ private val Project.libs: VersionCatalog
 
 private fun VersionCatalog.versionInt(alias: String): Int =
     findVersion(alias).get().requiredVersion.toInt()
+
+private fun VersionCatalog.library(alias: String) =
+    findLibrary(alias).get().get()

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("redface.android.library")
+    id("redface.android.hilt.library")
 }
 
 android {
@@ -11,4 +12,5 @@ dependencies {
     implementation(project(":core:network"))
     implementation(project(":core:parser"))
     implementation(project(":core:database"))
+    implementation(libs.kotlinx.coroutines.core)
 }

--- a/core/data/src/main/java/fr/forumhfr/redface2/core/data/di/DispatchersQualifiers.kt
+++ b/core/data/src/main/java/fr/forumhfr/redface2/core/data/di/DispatchersQualifiers.kt
@@ -1,0 +1,11 @@
+package fr.forumhfr.redface2.core.data.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DefaultDispatcher
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class IoDispatcher

--- a/core/data/src/main/java/fr/forumhfr/redface2/core/data/di/PlatformBindingsModule.kt
+++ b/core/data/src/main/java/fr/forumhfr/redface2/core/data/di/PlatformBindingsModule.kt
@@ -1,0 +1,28 @@
+package fr.forumhfr.redface2.core.data.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import java.time.Clock
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+@Module
+@InstallIn(SingletonComponent::class)
+object PlatformBindingsModule {
+    @Provides
+    @Singleton
+    fun provideRedfaceClock(): Clock = Clock.systemUTC()
+
+    @Provides
+    @Singleton
+    @IoDispatcher
+    fun provideIoDispatcher(): CoroutineDispatcher = Dispatchers.IO
+
+    @Provides
+    @Singleton
+    @DefaultDispatcher
+    fun provideDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "9.1.0"
 kotlin = "2.3.20"
 ksp = "2.3.6"
-hilt = "2.57.2"
+hilt = "2.59.2"
 android-minSdk = "29"
 android-targetSdk = "36"
 android-compileSdk = "36"
@@ -37,6 +37,8 @@ hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-compose-gradle-plugin = { module = "org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin", version.ref = "kotlin" }
+ksp-gradle-plugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
+hilt-android-gradle-plugin = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt" }
 
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
@@ -57,7 +59,7 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
-hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
+hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }


### PR DESCRIPTION
Nouvelle PR équivalente à #58, ouverte pour tester l'intégration Codex review sur nouvelle PR.

Contenu identique à #58 (cherry-pick du commit `02849e5`) :
- `RedfaceApplication.kt` (`@HiltAndroidApp`)
- `MainActivity.kt` (`@AndroidEntryPoint`)
- `core/data/.../di/DispatchersQualifiers.kt`
- `core/data/.../di/PlatformBindingsModule.kt`
- convention plugin Hilt dans `build-logic`
- `app/build.gradle.kts`, `core/data/build.gradle.kts`, `AndroidManifest.xml`, `libs.versions.toml`

Adresse : #50.

Note : si cette PR est retenue au détriment de #58, fermer #58 et merger celle-ci.

> Action par Claude Opus 4.7 (1M context) (demandée par @XaaT)