### PR TITLE
docs: add PostContent AST ADR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Format inspiré de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/). Les
 - `Dependabot` est recalibré en cadence mensuelle groupée et la CI annule les runs obsolètes sur la même ref.
 - `Dependabot` n'ouvre plus une seule PR Gradle fourre-tout : les mises à jour sont désormais regroupées par lanes cohérentes (`build-toolchain`, `androidx-ui-navigation`, `network-imaging`, `test-quality`, etc.) pour faciliter la review.
 - les checks Konsist Phase 0 n'acceptent plus des scopes vides silencieux et assertent désormais explicitement un scope non vide avant d'appliquer les règles.
-- les specs `models`, `architecture`, `mvi`, `stack`, `methodology`, `roadmap` et `protocol-hfr` s'alignent sur le contrat `PostContent` au lieu de traiter `Post.content` comme une chaîne HTML ou BBCode brute.
+- les specs `models`, `architecture`, `mvi`, `navigation`, `stack`, `methodology`, `roadmap`, `protocol-hfr` et `contributing` s'alignent sur le contrat `PostContent` au lieu de traiter `Post.content` comme une chaîne HTML ou BBCode brute.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format inspiré de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/). Les
 ## [Unreleased]
 
 ### Added
+- `docs/adr/011-postcontent-ast.md` formalise `PostContent` comme AST sémantique commune pour le rendu des posts, alimentée par le HTML HFR lu et le BBCode éditeur.
 - `LICENSE` ajouté à la racine avec le texte officiel **GNU GPL v3**, et `docs/adr/010-licence-client-android.md` formalise le choix de licence du client Android.
 - `docs/guides/contributing.md` documente désormais le workflow **MCP documentaire optionnel** : Context7 recommandé, Docfork en fallback, lien vers les setups officiels et cas validés sur AGP 9 / built-in Kotlin et Navigation 3.
 - bootstrap **Dev env Docker + Dev Container** : `Dockerfile`, `scripts/docker-dev.sh` et `.devcontainer/devcontainer.json` standardisent l'env Android sur `ghcr.io/cirruslabs/android-sdk:36`.
@@ -25,6 +26,7 @@ Format inspiré de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/). Les
 - `Dependabot` est recalibré en cadence mensuelle groupée et la CI annule les runs obsolètes sur la même ref.
 - `Dependabot` n'ouvre plus une seule PR Gradle fourre-tout : les mises à jour sont désormais regroupées par lanes cohérentes (`build-toolchain`, `androidx-ui-navigation`, `network-imaging`, `test-quality`, etc.) pour faciliter la review.
 - les checks Konsist Phase 0 n'acceptent plus des scopes vides silencieux et assertent désormais explicitement un scope non vide avant d'appliquer les règles.
+- les specs `models`, `architecture`, `mvi`, `stack`, `methodology`, `roadmap` et `protocol-hfr` s'alignent sur le contrat `PostContent` au lieu de traiter `Post.content` comme une chaîne HTML ou BBCode brute.
 
 ---
 

--- a/docs/adr/000-methodologie-triple-hybride.md
+++ b/docs/adr/000-methodologie-triple-hybride.md
@@ -40,7 +40,7 @@ La page canonique est [`docs/specs/methodology.md`]({{ site.baseurl }}/specs/met
 ## Conséquences
 
 - la méthode n'est plus dupliquée dans `README.md`, `AGENTS.md`, `docs/guides/contributing.md` et `docs/guides/rationale.md`
-- les écrans Compose, le schéma Room et le rendu BBCode doivent être validés par prototype avant d'être figés
+- les écrans Compose, le schéma Room et le rendu de posts doivent être validés par prototype avant d'être figés
 - les parsers, helpers purs, mappers et reducers MVI sont de bons candidats au TDD strict
 - un audit de specs n'est plus un réflexe ; il doit avoir un déclencheur concret
 - les changements structurants demandent une validation séparée du producteur du changement

--- a/docs/adr/011-postcontent-ast.md
+++ b/docs/adr/011-postcontent-ast.md
@@ -12,6 +12,8 @@ permalink: /adr/011-postcontent-ast
 
 Accepté — 2026-04-24
 
+Périmètre accepté : le contrat cible `PostContent`. L'implémentation complète reste à valider par prototype Phase 1 sur [#3](https://github.com/ForumHFR/redface2/issues/3), après résorption de la dette [#65](https://github.com/ForumHFR/redface2/issues/65).
+
 ## Contexte
 
 Redface 2 doit rendre les posts HFR en Compose natif, sans WebView. Le flux réel impose deux sources différentes :
@@ -43,7 +45,7 @@ Les règles associées sont :
 
 - `Post.content` et `PMMessage.content` portent un `PostContent`, pas une chaîne HTML ou BBCode brute ;
 - `:core:parser` transforme le HTML HFR réel en modèles domaine et en `PostContent` ;
-- le parser BBCode de l'éditeur transforme le BBCode HFR brut vers la même AST `PostContent` ;
+- le parser BBCode de l'éditeur transforme le BBCode HFR brut vers la même AST `PostContent` quand l'éditeur arrive en Phase 2 ;
 - `:core:ui` expose `PostRenderer` et ne dépend ni de Jsoup ni d'un parser BBCode ;
 - le renderer Compose consomme uniquement `PostContent` ;
 - le chemin `HTML -> BBCode -> AST` est exclu ;
@@ -53,29 +55,30 @@ L'AST est sémantique, pas une copie de DOM HTML. Elle représente des blocs et 
 
 - texte, gras, italique, souligné, barré, couleur ;
 - liens ;
-- smileys HFR ;
-- citations récursives avec auteur quand connu ;
+- smileys HFR builtin (`:code:`) et perso (`[:name]`) sans heuristique côté renderer ;
+- citations récursives avec auteur, `numreponse` et page quand connus ;
 - spoilers ;
 - blocs monospace `[fixed]` ;
-- images et médias ;
+- images et médias, en bloc ou inline selon le contexte HTML ou BBCode source ;
 - paragraphes et sauts de ligne.
 
-La liste exacte des nœuds peut évoluer avec les fixtures réelles, mais la frontière reste stable : les sources HTML/BBCode sont normalisées avant d'atteindre l'UI.
+La liste exacte des nœuds peut évoluer avec les fixtures réelles, mais la frontière reste stable : les sources HTML et BBCode sont normalisées avant d'atteindre l'UI. Les types Kotlin canoniques vivent dans [models.md]({{ site.baseurl }}/specs/models#topics-et-posts).
 
 Le slice actuel qui garde un fragment HTML dans `Post.content` est une dette de prototype. Il doit être résorbé par [#65](https://github.com/ForumHFR/redface2/issues/65) avant que ce pattern soit reproduit ailleurs.
 
 ## Conséquences
 
 - `:core:model` contient les types purs `PostContent`, `PostBlock` et `PostInline`.
-- `:core:parser` contient les parseurs déterministes vers `PostContent`, couverts par fixtures réelles et tests unitaires.
+- `:core:parser` contient les parseurs déterministes vers `PostContent`, couverts par fixtures réelles et tests unitaires. Le parser HTML topic arrive en Phase 1 ; le parser BBCode éditeur peut attendre la Phase 2.
 - `PostRenderer` devient réutilisable pour la lecture, la preview éditeur et les éventuels rendus texte simplifiés.
 - La preview éditeur Phase 2 ne duplique pas un renderer BBCode séparé.
-- Le cache Room peut décider plus tard de stocker aussi la source brute ou une forme sérialisée de l'AST, mais le modèle domaine exposé aux features reste `PostContent`.
+- Le cache Room peut décider plus tard de stocker aussi la source brute ou une forme sérialisée de l'AST, mais le modèle domaine exposé aux features reste `PostContent`. Le grain exact de stockage reste couvert par [#26](https://github.com/ForumHFR/redface2/issues/26).
 - Les extensions de type `PostDecorator` travaillent sur le modèle domaine et peuvent inspecter l'AST sans parser du HTML.
 
 ## Alternatives considérées
 
 - **HTML HFR subset -> renderer Compose** : très simple pour la lecture initiale, mais fuite de détails HTML dans l'UI et mauvaise réutilisation pour l'éditeur.
+- **AST HTML-only en Phase 1, BBCode différé Phase 2** : pragmatique comme staging d'implémentation, mais insuffisant comme contrat d'architecture. On garde `PostContent` comme cible stable tout en autorisant l'arrivée du parser BBCode seulement avec l'éditeur.
 - **HTML -> BBCode -> AST BBCode** : séduisant pour avoir un seul parser BBCode, mais fragile. Le HTML HFR rendu ne préserve pas toujours l'intention BBCode originale.
 - **BBCode brut dans `Post.content` partout** : incompatible avec le flux lecture réel, qui reçoit du HTML de topic.
 - **WebView** : plus rapide à court terme, mais reproduit les problèmes de scroll, recyclage et mémoire de Redface v1.

--- a/docs/adr/011-postcontent-ast.md
+++ b/docs/adr/011-postcontent-ast.md
@@ -1,0 +1,81 @@
+---
+title: ADR-011
+parent: ADRs
+grand_parent: Spécifications
+nav_order: 11
+permalink: /adr/011-postcontent-ast
+---
+
+# ADR-011 — AST sémantique `PostContent` comme contrat de rendu
+
+## Statut
+
+Accepté — 2026-04-24
+
+## Contexte
+
+Redface 2 doit rendre les posts HFR en Compose natif, sans WebView. Le flux réel impose deux sources différentes :
+
+- en lecture de topic, HFR fournit du **HTML déjà rendu** ;
+- dans l'éditeur, les formulaires HFR manipulent du **BBCode brut**.
+
+La première tranche de lecture de topic fixe a volontairement rendu un sous-ensemble HTML directement dans `:feature:topic` pour apprendre vite sur des fixtures réelles. Ce chemin reste un prototype : il ne doit pas devenir le contrat stable du renderer.
+
+Le risque architectural est de choisir une représentation trop proche d'une source :
+
+- une AST HTML rend le lecteur simple, mais réutilise mal le renderer pour la preview BBCode ;
+- une AST BBCode pure colle à l'éditeur, mais force la lecture de topic à reconstruire du BBCode depuis du HTML HFR, ce qui est fragile et potentiellement lossy ;
+- une WebView reproduit les limites de Redface v1.
+
+## Décision
+
+Redface 2 retient une AST sémantique commune, `PostContent`, comme contrat entre parsing et rendu.
+
+Le contrat cible est :
+
+```text
+HTML HFR topic  ─┐
+                 ├─> PostContent AST ─> PostRenderer Compose
+BBCode éditeur  ─┘
+```
+
+Les règles associées sont :
+
+- `Post.content` et `PMMessage.content` portent un `PostContent`, pas une chaîne HTML ou BBCode brute ;
+- `:core:parser` transforme le HTML HFR réel en modèles domaine et en `PostContent` ;
+- le parser BBCode de l'éditeur transforme le BBCode HFR brut vers la même AST `PostContent` ;
+- `:core:ui` expose `PostRenderer` et ne dépend ni de Jsoup ni d'un parser BBCode ;
+- le renderer Compose consomme uniquement `PostContent` ;
+- le chemin `HTML -> BBCode -> AST` est exclu ;
+- le renderer WebView est exclu pour le flux principal.
+
+L'AST est sémantique, pas une copie de DOM HTML. Elle représente des blocs et inlines utiles à Redface :
+
+- texte, gras, italique, souligné, barré, couleur ;
+- liens ;
+- smileys HFR ;
+- citations récursives avec auteur quand connu ;
+- spoilers ;
+- blocs monospace `[fixed]` ;
+- images et médias ;
+- paragraphes et sauts de ligne.
+
+La liste exacte des nœuds peut évoluer avec les fixtures réelles, mais la frontière reste stable : les sources HTML/BBCode sont normalisées avant d'atteindre l'UI.
+
+Le slice actuel qui garde un fragment HTML dans `Post.content` est une dette de prototype. Il doit être résorbé par [#65](https://github.com/ForumHFR/redface2/issues/65) avant que ce pattern soit reproduit ailleurs.
+
+## Conséquences
+
+- `:core:model` contient les types purs `PostContent`, `PostBlock` et `PostInline`.
+- `:core:parser` contient les parseurs déterministes vers `PostContent`, couverts par fixtures réelles et tests unitaires.
+- `PostRenderer` devient réutilisable pour la lecture, la preview éditeur et les éventuels rendus texte simplifiés.
+- La preview éditeur Phase 2 ne duplique pas un renderer BBCode séparé.
+- Le cache Room peut décider plus tard de stocker aussi la source brute ou une forme sérialisée de l'AST, mais le modèle domaine exposé aux features reste `PostContent`.
+- Les extensions de type `PostDecorator` travaillent sur le modèle domaine et peuvent inspecter l'AST sans parser du HTML.
+
+## Alternatives considérées
+
+- **HTML HFR subset -> renderer Compose** : très simple pour la lecture initiale, mais fuite de détails HTML dans l'UI et mauvaise réutilisation pour l'éditeur.
+- **HTML -> BBCode -> AST BBCode** : séduisant pour avoir un seul parser BBCode, mais fragile. Le HTML HFR rendu ne préserve pas toujours l'intention BBCode originale.
+- **BBCode brut dans `Post.content` partout** : incompatible avec le flux lecture réel, qui reçoit du HTML de topic.
+- **WebView** : plus rapide à court terme, mais reproduit les problèmes de scroll, recyclage et mémoire de Redface v1.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,3 +35,4 @@ Règles du repo :
 | [ADR-008]({{ site.baseurl }}/adr/008-compose-navigation-3) | Compose Navigation 3 retenu pour la navigation |
 | [ADR-009]({{ site.baseurl }}/adr/009-okhttp-5-3-plus) | OkHttp 5.3+ retenu comme client HTTP principal |
 | [ADR-010]({{ site.baseurl }}/adr/010-licence-client-android) | GPL-3.0-only retenue pour le client Android |
+| [ADR-011]({{ site.baseurl }}/adr/011-postcontent-ast) | AST sémantique `PostContent` comme contrat de rendu |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,8 +22,10 @@ Chaque ADR contient :
 Règles du repo :
 - pas d'ADR spéculative
 - pas d'ADR pour un micro-choix sans portée structurelle
-- statut simple : `Accepté` ou `Superseded par ADR-XXX`
+- statut simple : `Proposé`, `Accepté` ou `Superseded par ADR-XXX`
 - les pages canoniques de `docs/specs/` restent la source détaillée ; l'ADR capture le **pourquoi** et le **choix**
+
+Les numéros `003` à `007` sont volontairement laissés libres pour des décisions Phase 1 pressenties mais pas encore actées au moment où les ADR `008` à `010` ont été créées. Ils ne correspondent pas à des ADR supprimées.
 
 ## Index initial
 

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -64,7 +64,7 @@ redface2/
     domain/               # Interfaces de repositories, règles métier
     data/                 # Implémentations de repositories
     network/              # OkHttp, session HFR
-    parser/               # Jsoup, HTML → modèles
+    parser/               # Jsoup, HTML/BBCode HFR → modèles + PostContent
     database/             # Room, cache, sync MPStorage
     ui/                   # Thème, composants partagés, PostRenderer
     extension/            # Points d'extension (Phase 4)
@@ -183,7 +183,7 @@ Cette page décrit **comment** contribuer ; elle ne redéfinit pas la méthode d
 - Outil de mesure (Kover) pour info, pas comme gate CI
 
 **Stratégie :**
-- **TDD sélectif** sur fonctions pures (parser, BBCode AST, ViewModels, helpers, mappers) — red → green → refactor
+- **TDD sélectif** sur fonctions pures (parser, PostContent AST, ViewModels, helpers, mappers) — red → green → refactor
 - **Test-after** sur intégrations (repositories cache/network, deep linking)
 - **Pas de TDD** sur UI Compose (Compose Preview + review visuelle suffisent ; Roborazzi non retenu en MVP, à reconsidérer Phase 4+ si régressions visuelles multi-features)
 

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -64,7 +64,7 @@ redface2/
     domain/               # Interfaces de repositories, règles métier
     data/                 # Implémentations de repositories
     network/              # OkHttp, session HFR
-    parser/               # Jsoup, HTML/BBCode HFR → modèles + PostContent
+    parser/               # Jsoup, HTML HFR → modèles + PostContent ; BBCode éditeur en Phase 2
     database/             # Room, cache, sync MPStorage
     ui/                   # Thème, composants partagés, PostRenderer
     extension/            # Points d'extension (Phase 4)

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -115,13 +115,13 @@ graph TB
 
 | Module | Responsabilité | Dépend de |
 |--------|---------------|-----------|
-| `:core:model` | Modèles domaine purs (`Topic`, `Post`, `Category`, `Flag`, `MP`). Aucune dépendance Android. | rien |
+| `:core:model` | Modèles domaine purs (`Topic`, `Post`, `PostContent`, `Category`, `Flag`, `MP`). Aucune dépendance Android. | rien |
 | `:core:domain` | Interfaces de repositories (`TopicRepository`, `FlagRepository`, `AuthRepository`...) et règles métier partagées. Aucune dépendance framework. | `:core:model` |
 | `:core:data` | Implémentations des repositories. Orchestre réseau, parser et cache. Fournit les bindings Hilt. | `:core:domain`, `:core:network`, `:core:parser`, `:core:database` |
 | `:core:network` | `HfrClient` : requêtes HTTP, cookies, session, login. Encapsule OkHttp. | `:core:model` |
-| `:core:parser` | `HfrParser` : transforme le HTML HFR en modèles domaine via Jsoup. | `:core:model` |
+| `:core:parser` | `HfrParser` : transforme le HTML HFR et le BBCode HFR en modèles domaine, dont l'AST `PostContent`. | `:core:model` |
 | `:core:database` | Room DB, DAOs, entities, mappers entity↔model. Cache locale + cache MPStorage. | `:core:model` |
-| `:core:ui` | Thème Material 3 (6 sous-packages : `theme/`, `components/`, `adaptive/`, `semantics/`, `util/`, `extensions/`), composants partagés, `PostRenderer` (BBCode → Compose). Seul module autorisé à instancier `ColorScheme`, `Typography`, `Shapes`. | `:core:model` |
+| `:core:ui` | Thème Material 3 (6 sous-packages : `theme/`, `components/`, `adaptive/`, `semantics/`, `util/`, `extensions/`), composants partagés, `PostRenderer` (`PostContent` → Compose). Seul module autorisé à instancier `ColorScheme`, `Typography`, `Shapes`. | `:core:model` |
 | `:core:extension` | Interfaces d'extension : `PostDecorator`, `TopicToolbarContributor`, `EditorToolbarContributor`. | `:core:model` |
 
 ### Modules feature (base)
@@ -206,11 +206,13 @@ class HfrClient @Inject constructor(
 
 ### `:core:parser` — HfrParser
 
-Le parser transforme le HTML en modèles domaine. Isolé de toute logique réseau.
+Le parser transforme le HTML HFR et le BBCode HFR en modèles domaine. Isolé de toute logique réseau et UI.
 
 ```kotlin
 class HfrParser @Inject constructor() {
     fun parseTopicPage(html: String): Topic
+    fun parsePostContentFromHtml(html: String): PostContent
+    fun parsePostContentFromBbcode(bbcode: String): PostContent
     fun parseFlags(html: String): List<FlaggedTopic>
     fun parseCategories(html: String): List<Category>
     fun parseEditPage(html: String): EditInfo

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -119,7 +119,7 @@ graph TB
 | `:core:domain` | Interfaces de repositories (`TopicRepository`, `FlagRepository`, `AuthRepository`...) et règles métier partagées. Aucune dépendance framework. | `:core:model` |
 | `:core:data` | Implémentations des repositories. Orchestre réseau, parser et cache. Fournit les bindings Hilt. | `:core:domain`, `:core:network`, `:core:parser`, `:core:database` |
 | `:core:network` | `HfrClient` : requêtes HTTP, cookies, session, login. Encapsule OkHttp. | `:core:model` |
-| `:core:parser` | `HfrParser` : transforme le HTML HFR et le BBCode HFR en modèles domaine, dont l'AST `PostContent`. | `:core:model` |
+| `:core:parser` | `HfrParser` : transforme le HTML HFR et, à partir de l'éditeur Phase 2, le BBCode HFR en modèles domaine, dont l'AST `PostContent`. | `:core:model` |
 | `:core:database` | Room DB, DAOs, entities, mappers entity↔model. Cache locale + cache MPStorage. | `:core:model` |
 | `:core:ui` | Thème Material 3 (6 sous-packages : `theme/`, `components/`, `adaptive/`, `semantics/`, `util/`, `extensions/`), composants partagés, `PostRenderer` (`PostContent` → Compose). Seul module autorisé à instancier `ColorScheme`, `Typography`, `Shapes`. | `:core:model` |
 | `:core:extension` | Interfaces d'extension : `PostDecorator`, `TopicToolbarContributor`, `EditorToolbarContributor`. | `:core:model` |
@@ -206,13 +206,13 @@ class HfrClient @Inject constructor(
 
 ### `:core:parser` — HfrParser
 
-Le parser transforme le HTML HFR et le BBCode HFR en modèles domaine. Isolé de toute logique réseau et UI.
+Le parser transforme le HTML HFR et, à partir de l'éditeur Phase 2, le BBCode HFR en modèles domaine. Isolé de toute logique réseau et UI.
 
 ```kotlin
 class HfrParser @Inject constructor() {
     fun parseTopicPage(html: String): Topic
     fun parsePostContentFromHtml(html: String): PostContent
-    fun parsePostContentFromBbcode(bbcode: String): PostContent
+    fun parsePostContentFromBbcode(bbcode: String): PostContent // Phase 2 éditeur
     fun parseFlags(html: String): List<FlaggedTopic>
     fun parseCategories(html: String): List<Category>
     fun parseEditPage(html: String): EditInfo

--- a/docs/specs/methodology.md
+++ b/docs/specs/methodology.md
@@ -29,11 +29,11 @@ D'autres zones doivent être **découvertes en codant** :
 - l'UI Compose
 - le schéma Room
 - les arbitrages de perf
-- le rendu BBCode
+- le rendu de posts
 
 Enfin, certaines briques gagnent à être **testées en TDD strict** parce qu'elles sont pures et déterministes :
 - parser HTML → domaine
-- BBCode → AST
+- HTML/BBCode HFR → AST `PostContent`
 - reducers / helpers MVI
 - mappers
 
@@ -46,8 +46,8 @@ Cette page est la **source canonique** de la méthode du projet. L'ADR-000 en fo
 | Règle | Application |
 |---|---|
 | **1. Spec ce qui doit tenir** *(SDD sélectif)* | Protocole HFR, architecture des couches, sécurité credentials, contrats externes, langage métier. Une erreur ici crée de la dette silencieuse. |
-| **2. Prototype ce qu'on découvre** | UI/UX Compose, schéma Room, perf, interactions features, rendu BBCode. Le design émerge du 2e use case, pas du 0e. |
-| **3. TDD sélectif sur fonctions pures** | Parser (HTML → domain), BBCode → AST, ViewModels MVI, helpers (`matchesFilter`, `comparatorFor`), date parser, mappers. Red → Green → Refactor. |
+| **2. Prototype ce qu'on découvre** | UI/UX Compose, schéma Room, perf, interactions features, rendu de posts. Le design émerge du 2e use case, pas du 0e. |
+| **3. TDD sélectif sur fonctions pures** | Parser (HTML → domaine), HTML/BBCode → AST `PostContent`, ViewModels MVI, helpers (`matchesFilter`, `comparatorFor`), date parser, mappers. Red → Green → Refactor. |
 | **4. Test-after sur intégrations** | Repositories réseau+parser+cache, deep linking, flows authentifiés. Les tests viennent après l'impl, avec des mocks ou fixtures réalistes. |
 | **5. Coverage guidée par risque** | Pas d'objectif "100%". On couvre les edge cases réels, les régressions plausibles et les fixtures HFR capturées. |
 | **6. ADRs a posteriori** | Les ADRs formalisent les décisions après arbitrage réel. Pas de RFC spéculative avant code. |
@@ -72,7 +72,7 @@ Quand un nouveau sujet arrive, commencer par cette question :
 |---|---|---|
 | **Protocole HFR** (`docs/specs/protocol-hfr.md`) | Spec-first | Contrat externe mal documenté ; une erreur casse l'app silencieusement. |
 | **Parser HFR** (`HfrParser.parseTopicPage`) | TDD strict | Fonction pure, fixtures réelles, edge cases identifiables. Cf. [#15](https://github.com/ForumHFR/redface2/issues/15). |
-| **BBCode → AST** | TDD strict | Transformation pure ; facile à verrouiller par tests ciblés. |
+| **HTML/BBCode → `PostContent` AST** | TDD strict | Transformation pure ; facile à verrouiller par fixtures et tests ciblés. Cf. [ADR-011]({{ site.baseurl }}/adr/011-postcontent-ast). |
 | **Écran Drapeaux** | Prototype-first | L'ergonomie réelle n'émerge pas d'une spec statique. |
 | **PostRenderer Compose** | Prototype-first | Le rendu de posts en UI réelle se découvre de manière incrémentale sur de vraies fixtures. Cf. [#3](https://github.com/ForumHFR/redface2/issues/3). |
 | **Schéma Room** | Prototype-first | Le bon grain de stockage dépend des premiers use cases réellement codés. Cf. [#26](https://github.com/ForumHFR/redface2/issues/26). |

--- a/docs/specs/methodology.md
+++ b/docs/specs/methodology.md
@@ -33,7 +33,7 @@ D'autres zones doivent être **découvertes en codant** :
 
 Enfin, certaines briques gagnent à être **testées en TDD strict** parce qu'elles sont pures et déterministes :
 - parser HTML → domaine
-- HTML/BBCode HFR → AST `PostContent`
+- HTML HFR → AST `PostContent` en Phase 1, puis BBCode HFR → même AST avec l'éditeur Phase 2
 - reducers / helpers MVI
 - mappers
 
@@ -47,7 +47,7 @@ Cette page est la **source canonique** de la méthode du projet. L'ADR-000 en fo
 |---|---|
 | **1. Spec ce qui doit tenir** *(SDD sélectif)* | Protocole HFR, architecture des couches, sécurité credentials, contrats externes, langage métier. Une erreur ici crée de la dette silencieuse. |
 | **2. Prototype ce qu'on découvre** | UI/UX Compose, schéma Room, perf, interactions features, rendu de posts. Le design émerge du 2e use case, pas du 0e. |
-| **3. TDD sélectif sur fonctions pures** | Parser (HTML → domaine), HTML/BBCode → AST `PostContent`, ViewModels MVI, helpers (`matchesFilter`, `comparatorFor`), date parser, mappers. Red → Green → Refactor. |
+| **3. TDD sélectif sur fonctions pures** | Parser (HTML → domaine), HTML HFR → AST `PostContent` en Phase 1, BBCode → `PostContent` avec l'éditeur Phase 2, ViewModels MVI, helpers (`matchesFilter`, `comparatorFor`), date parser, mappers. Red → Green → Refactor. |
 | **4. Test-after sur intégrations** | Repositories réseau+parser+cache, deep linking, flows authentifiés. Les tests viennent après l'impl, avec des mocks ou fixtures réalistes. |
 | **5. Coverage guidée par risque** | Pas d'objectif "100%". On couvre les edge cases réels, les régressions plausibles et les fixtures HFR capturées. |
 | **6. ADRs a posteriori** | Les ADRs formalisent les décisions après arbitrage réel. Pas de RFC spéculative avant code. |
@@ -72,7 +72,7 @@ Quand un nouveau sujet arrive, commencer par cette question :
 |---|---|---|
 | **Protocole HFR** (`docs/specs/protocol-hfr.md`) | Spec-first | Contrat externe mal documenté ; une erreur casse l'app silencieusement. |
 | **Parser HFR** (`HfrParser.parseTopicPage`) | TDD strict | Fonction pure, fixtures réelles, edge cases identifiables. Cf. [#15](https://github.com/ForumHFR/redface2/issues/15). |
-| **HTML/BBCode → `PostContent` AST** | TDD strict | Transformation pure ; facile à verrouiller par fixtures et tests ciblés. Cf. [ADR-011]({{ site.baseurl }}/adr/011-postcontent-ast). |
+| **HTML → `PostContent` AST** | TDD strict | Transformation pure prioritaire Phase 1 pour la lecture ; facile à verrouiller par fixtures et tests ciblés. Le parser BBCode vers `PostContent` arrive avec l'éditeur Phase 2. Cf. [ADR-011]({{ site.baseurl }}/adr/011-postcontent-ast). |
 | **Écran Drapeaux** | Prototype-first | L'ergonomie réelle n'émerge pas d'une spec statique. |
 | **PostRenderer Compose** | Prototype-first | Le rendu de posts en UI réelle se découvre de manière incrémentale sur de vraies fixtures. Cf. [#3](https://github.com/ForumHFR/redface2/issues/3). |
 | **Schéma Room** | Prototype-first | Le bon grain de stockage dépend des premiers use cases réellement codés. Cf. [#26](https://github.com/ForumHFR/redface2/issues/26). |

--- a/docs/specs/models.md
+++ b/docs/specs/models.md
@@ -59,12 +59,16 @@ classDiagram
         +Int numreponse
         +String author
         +Instant date
-        +String content
+        +PostContent content
         +String? avatarUrl
         +Boolean isEditable
         +Boolean isOwnPost
         +List~String~ quotedAuthors
         +Int postIndex
+    }
+
+    class PostContent {
+        +List~PostBlock~ blocks
     }
 
     class Category {
@@ -90,6 +94,7 @@ classDiagram
     }
 
     Topic --> Post : contient
+    Post --> PostContent : rend
     Topic --> Poll : optionnel
     Category --> SubCategory : contient
     FlaggedTopic --> FlagType : type
@@ -141,14 +146,39 @@ data class Post(
     val numreponse: Int,                 // unique par (cat), PAS globalement — clé composite (cat, numreponse) au niveau base
     val author: String,
     val date: Instant,                   // parsé depuis "dd-MM-yyyy à HH:mm:ss"
-    val content: String,                 // BBCode brut, rendu par PostRenderer
+    val content: PostContent,            // AST sémantique, rendu par PostRenderer (cf. ADR-011)
     val avatarUrl: String?,
     val isEditable: Boolean,             // calculé client-side : post.author == currentUser && !isLocked
     val isOwnPost: Boolean,              // calculé client-side : post.author == currentUser
-    val quotedAuthors: List<String>,     // extraits des [quotemsg=]
+    val quotedAuthors: List<String>,     // dérivé de PostContent pour recherche, filtres et décorateurs
     val postIndex: Int,                  // (page-1) * postsPerPage + position — postsPerPage vient des préférences HFR de l'utilisateur, PAS une constante (voir UserSettings)
 )
+
+data class PostContent(
+    val blocks: List<PostBlock>,
+)
+
+sealed interface PostBlock {
+    data class Paragraph(val inlines: List<PostInline>) : PostBlock
+    data class Quote(val author: String?, val content: PostContent) : PostBlock
+    data class Spoiler(val label: String?, val content: PostContent) : PostBlock
+    data class CodeBlock(val text: String) : PostBlock
+    data class Image(val url: String, val description: String?) : PostBlock
+}
+
+sealed interface PostInline {
+    data class Text(val value: String) : PostInline
+    data class Strong(val children: List<PostInline>) : PostInline
+    data class Emphasis(val children: List<PostInline>) : PostInline
+    data class Underline(val children: List<PostInline>) : PostInline
+    data class Strike(val children: List<PostInline>) : PostInline
+    data class Color(val argb: Long, val children: List<PostInline>) : PostInline
+    data class Link(val url: String, val children: List<PostInline>) : PostInline
+    data class Smiley(val code: String, val imageUrl: String?) : PostInline
+}
 ```
+
+`PostContent` est le contrat cible décrit par [ADR-011]({{ site.baseurl }}/adr/011-postcontent-ast). Le slice de topic fixe issu de la Phase 0 peut encore transporter temporairement un fragment HTML brut ; cette dette est suivie par [#65](https://github.com/ForumHFR/redface2/issues/65).
 
 ---
 
@@ -245,7 +275,7 @@ data class PMMessage(
     val numreponse: Int,
     val author: String,
     val date: Instant,
-    val content: String,            // BBCode brut, rendu par PostRenderer
+    val content: PostContent,       // AST sémantique, rendu par PostRenderer
     val isEditable: Boolean,        // calculé client-side : author == currentUser
 )
 

--- a/docs/specs/models.md
+++ b/docs/specs/models.md
@@ -91,10 +91,21 @@ classDiagram
         +Instant lastDate
         +Boolean isRead
         +Boolean isMultiMP
+        +List~PMMessage~ messages
+    }
+
+    class PMMessage {
+        +Int numreponse
+        +String author
+        +Instant date
+        +PostContent content
+        +Boolean isEditable
     }
 
     Topic --> Post : contient
     Post --> PostContent : rend
+    PrivateMessage --> PMMessage : contient
+    PMMessage --> PostContent : rend
     Topic --> Poll : optionnel
     Category --> SubCategory : contient
     FlaggedTopic --> FlagType : type
@@ -160,7 +171,12 @@ data class PostContent(
 
 sealed interface PostBlock {
     data class Paragraph(val inlines: List<PostInline>) : PostBlock
-    data class Quote(val author: String?, val content: PostContent) : PostBlock
+    data class Quote(
+        val author: String?,
+        val numreponse: Int?,            // depuis [quotemsg=N,P,auteur], null si la source HTML ne l'expose pas
+        val page: Int?,                  // idem, sert à reconstruire un lien vers le post cité quand disponible
+        val content: PostContent,
+    ) : PostBlock
     data class Spoiler(val label: String?, val content: PostContent) : PostBlock
     data class CodeBlock(val text: String) : PostBlock
     data class Image(val url: String, val description: String?) : PostBlock
@@ -172,13 +188,19 @@ sealed interface PostInline {
     data class Emphasis(val children: List<PostInline>) : PostInline
     data class Underline(val children: List<PostInline>) : PostInline
     data class Strike(val children: List<PostInline>) : PostInline
-    data class Color(val argb: Long, val children: List<PostInline>) : PostInline
+    data class Color(val colorHex: String, val children: List<PostInline>) : PostInline
     data class Link(val url: String, val children: List<PostInline>) : PostInline
-    data class Smiley(val code: String, val imageUrl: String?) : PostInline
+    data class InlineImage(val url: String, val description: String?) : PostInline
+    data class Smiley(val kind: SmileyKind, val imageUrl: String?) : PostInline
+}
+
+sealed interface SmileyKind {
+    data class Builtin(val code: String) : SmileyKind   // syntaxe HFR : :jap:, :o, :D
+    data class Perso(val name: String) : SmileyKind     // syntaxe HFR : [:corran_horn]
 }
 ```
 
-`PostContent` est le contrat cible décrit par [ADR-011]({{ site.baseurl }}/adr/011-postcontent-ast). Le slice de topic fixe issu de la Phase 0 peut encore transporter temporairement un fragment HTML brut ; cette dette est suivie par [#65](https://github.com/ForumHFR/redface2/issues/65).
+`PostContent` est le contrat cible décrit par [ADR-011]({{ site.baseurl }}/adr/011-postcontent-ast). Le slice de topic fixe issu de la Phase 0 peut encore transporter temporairement un fragment HTML brut ; cette dette est suivie par [#65](https://github.com/ForumHFR/redface2/issues/65). `PostInline.Color.colorHex` conserve la couleur sous forme textuelle normalisée (`#RRGGBB` ou `#AARRGGBB`) pour préserver le round-trip BBCode HFR.
 
 ---
 

--- a/docs/specs/mvi.md
+++ b/docs/specs/mvi.md
@@ -259,7 +259,7 @@ data class EditorState(
     val subject: String = "",           // visible en mode EditFP
     val poll: PollData? = null,         // visible en mode EditFP
     val isSending: Boolean = false,
-    val preview: String? = null,        // rendu BBCode preview
+    val preview: PostContent? = null,   // AST de preview issue du BBCode courant, rendu par PostRenderer
     val error: String? = null,
 )
 

--- a/docs/specs/navigation.md
+++ b/docs/specs/navigation.md
@@ -148,7 +148,7 @@ Formulaire complet :
 - **Sujet** : titre du topic
 - **Contenu** : éditeur BBCode avec toolbar
 - **Sondage** (optionnel) : question + options + choix multiple oui/non
-- **Preview** : avant-première du rendu BBCode
+- **Preview** : avant-première du rendu du BBCode
 
 ### Messages
 

--- a/docs/specs/protocol-hfr.md
+++ b/docs/specs/protocol-hfr.md
@@ -300,7 +300,7 @@ Pattern dans le HTML des posts : `Message édité par <auteur> le DD-MM-YYYY à 
 
 ### Posts supprimés / modérés
 
-Structure HTML altérée : le `<table class="messagetable">` peut ne plus contenir que le bandeau d'auteur + une mention de suppression. Le parser doit gérer ce cas sans crasher — `Post.content` devient vide ou marqueur sentinel `"[Message supprimé]"`.
+Structure HTML altérée : le `<table class="messagetable">` peut ne plus contenir que le bandeau d'auteur + une mention de suppression. Le parser doit gérer ce cas sans crasher — `Post.content` devient un `PostContent` vide ou un bloc sentinel `"Message supprimé"`.
 
 ### Emails obfusqués
 

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -83,7 +83,7 @@ Les dépôts en cylindre (`MPStorage2`, `hfr-redflag`) sont des **dépendances e
 - [ ] Login HFR (cookies persistants)
 - [ ] Écran Drapeaux (accueil) — tri par date/catégorie, filtres
 - [ ] Écran Topic — lecture, pagination, scroll fluide
-- [ ] PostRenderer — rendu natif `PostContent` en Compose
+- [ ] PostRenderer — rendu natif `PostContent` en Compose (cf. [ADR-011]({{ site.baseurl }}/adr/011-postcontent-ast))
 - [ ] Écran Forum — catégories, sous-catégories, liste de topics
 - [ ] Cache Room — topics et drapeaux
 - [ ] Deep linking (URLs HFR → app)

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -31,7 +31,7 @@ Pour la liste des capabilities et des non-goals, voir le [scope fonctionnel]({{ 
 | **4 — Extensions** | Bookmarks, Blacklist, Qualitay, Redflag | L | Phase 3 + **hfr-redflag Worker** | À faire |
 | **5 — Polish** | Animations, offline, thème dynamique, Play Store | M | Phases 2, 3, 4 | À faire |
 
-**Taille** : S = petit sous-chantier, M = quelques composants, L = plusieurs features indépendantes, XL = écran majeur + parseurs + cache (ex. `PostRenderer` BBCode natif).
+**Taille** : S = petit sous-chantier, M = quelques composants, L = plusieurs features indépendantes, XL = écran majeur + parseurs + cache (ex. `PostRenderer` natif).
 
 ### Graphe des dépendances
 
@@ -83,7 +83,7 @@ Les dépôts en cylindre (`MPStorage2`, `hfr-redflag`) sont des **dépendances e
 - [ ] Login HFR (cookies persistants)
 - [ ] Écran Drapeaux (accueil) — tri par date/catégorie, filtres
 - [ ] Écran Topic — lecture, pagination, scroll fluide
-- [ ] PostRenderer — rendu BBCode natif en Compose
+- [ ] PostRenderer — rendu natif `PostContent` en Compose
 - [ ] Écran Forum — catégories, sous-catégories, liste de topics
 - [ ] Cache Room — topics et drapeaux
 - [ ] Deep linking (URLs HFR → app)
@@ -94,7 +94,7 @@ Les dépôts en cylindre (`MPStorage2`, `hfr-redflag`) sont des **dépendances e
 
 ### PostRenderer — le sous-chantier critique
 
-Le rendu natif Compose du BBCode HFR est le composant le plus complexe de toute l'app. Il doit gérer :
+Le rendu natif Compose du contenu HFR est le composant le plus complexe de toute l'app. Il doit gérer :
 
 | Élément | Complexité |
 |---------|-----------|

--- a/docs/specs/stack.md
+++ b/docs/specs/stack.md
@@ -98,7 +98,7 @@ Les 4 choix design de base sont actés pour Phase 0 :
 | Seed color HFR | `#A62C2C` (rouge brique HFR) | Cohérent avec le nom "Redface". Material Theme Builder génère tout le `ColorScheme` depuis cette seed. À revoir si le naming final (#1) s'en écarte. |
 | Dynamic color par défaut | **OFF** (opt-in settings Phase 5) | Préserve l'identité visuelle HFR constante ; Material You reste disponible via toggle utilisateur |
 | Font family | **Roboto** (système Android) | 0 KB APK impact. Roboto Flex / Inter = trendy sans bénéfice technique pour une app forum |
-| Rendu de posts | **`PostContent` AST** + `AnnotatedString` inline + composables block | HTML HFR et BBCode éditeur convergent vers la même AST. Cf. [ADR-011]({{ site.baseurl }}/adr/011-postcontent-ast) et [#3](https://github.com/ForumHFR/redface2/issues/3). |
+| Rendu de posts | **`PostContent` AST** + `AnnotatedString` inline + composables block | Contrat cible acté, implémentation Phase 1. HTML HFR et BBCode éditeur convergent vers la même AST, avec le parser BBCode différable jusqu'à l'éditeur Phase 2. Cf. [ADR-011]({{ site.baseurl }}/adr/011-postcontent-ast) et [#3](https://github.com/ForumHFR/redface2/issues/3). |
 | Thèmes v1 | **Clair, Sombre, AMOLED** | Material You et HFR Classique reportés Phase 5 polish (1-2 jours d'ajout chacun, pas d'imbrication architecturale) |
 
 Le draft `drafts/material3-ui-ux.md` contient les détails étendus (30 color roles, 15 typography styles, motion tokens, adaptive layouts) — c'est un document de référence pédagogique, pas une spec canonique.

--- a/docs/specs/stack.md
+++ b/docs/specs/stack.md
@@ -63,8 +63,8 @@ textView.setText(post.getContent());
 
 // Après (Compose)
 @Composable
-fun PostContent(post: Post) {
-    Text(text = post.content)
+fun PostBody(post: Post) {
+    PostRenderer(content = post.content)
 }
 ```
 
@@ -98,7 +98,7 @@ Les 4 choix design de base sont actés pour Phase 0 :
 | Seed color HFR | `#A62C2C` (rouge brique HFR) | Cohérent avec le nom "Redface". Material Theme Builder génère tout le `ColorScheme` depuis cette seed. À revoir si le naming final (#1) s'en écarte. |
 | Dynamic color par défaut | **OFF** (opt-in settings Phase 5) | Préserve l'identité visuelle HFR constante ; Material You reste disponible via toggle utilisateur |
 | Font family | **Roboto** (système Android) | 0 KB APK impact. Roboto Flex / Inter = trendy sans bénéfice technique pour une app forum |
-| BBCode rendering | **Hybride** `AnnotatedString` inline + composables block | Cf. [#3](https://github.com/ForumHFR/redface2/issues/3) (PostRenderer prototype) pour le détail |
+| Rendu de posts | **`PostContent` AST** + `AnnotatedString` inline + composables block | HTML HFR et BBCode éditeur convergent vers la même AST. Cf. [ADR-011]({{ site.baseurl }}/adr/011-postcontent-ast) et [#3](https://github.com/ForumHFR/redface2/issues/3). |
 | Thèmes v1 | **Clair, Sombre, AMOLED** | Material You et HFR Classique reportés Phase 5 polish (1-2 jours d'ajout chacun, pas d'imbrication architecturale) |
 
 Le draft `drafts/material3-ui-ux.md` contient les détails étendus (30 color roles, 15 typography styles, motion tokens, adaptive layouts) — c'est un document de référence pédagogique, pas une spec canonique.


### PR DESCRIPTION
## Summary

Ajoute l'ADR-011 pour trancher le contrat de rendu des posts : HTML HFR topic et BBCode éditeur convergent vers une AST sémantique `PostContent`, consommée par `PostRenderer`.

## Linked Issue

- Refs #3
- Refs #65

## Changes

- Ajout de `docs/adr/011-postcontent-ast.md` et de l'entrée dans l'index ADR.
- Alignement des specs `models`, `architecture`, `mvi`, `stack`, `methodology`, `roadmap` et `protocol-hfr` sur le contrat `PostContent`.
- Changelog `Unreleased` mis à jour.

## Validation Run

- [ ] `./gradlew detektAll`
- [ ] `./gradlew lintDebug`
- [ ] `./gradlew testDebugUnitTest`
- [ ] `./gradlew :app:assembleDebug`
- [x] `git diff --check`
- [x] Scan `rg` des anciennes formulations contradictoires autour de `Post.content`, `BBCode AST` et `PostRenderer`

Gradle non exécuté : PR docs-only.

## Docs / Specs Impact

- [ ] Aucun
- [x] Oui, docs/specs mises à jour

## AI Attribution

> Action par GPT-5 Codex (demandée par @XaaT)
