### PR TITLE
refactor(topic): introduce MVI boundary with TopicViewModel

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     implementation(libs.androidx.material3.adaptive.navigation.suite)
     implementation(libs.androidx.navigation3.runtime)
     implementation(libs.androidx.navigation3.ui)
+    implementation(libs.androidx.lifecycle.viewmodel.navigation3)
     implementation(libs.kotlinx.serialization.core)
 
     testImplementation(libs.junit4)

--- a/app/src/main/java/fr/forumhfr/redface2/MainActivity.kt
+++ b/app/src/main/java/fr/forumhfr/redface2/MainActivity.kt
@@ -9,15 +9,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import dagger.hilt.android.AndroidEntryPoint
-import fr.forumhfr.redface2.core.domain.fixtures.TopicFixtureRepository
 import fr.forumhfr.redface2.navigation.RedfaceApp
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-    @Inject
-    lateinit var topicFixtureRepository: TopicFixtureRepository
-
     private var latestIntent by mutableStateOf<Intent?>(null)
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -26,10 +21,7 @@ class MainActivity : ComponentActivity() {
         latestIntent = intent
 
         setContent {
-            RedfaceApp(
-                intent = latestIntent,
-                topicFixtureRepository = topicFixtureRepository,
-            )
+            RedfaceApp(intent = latestIntent)
         }
     }
 

--- a/app/src/main/java/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/java/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -22,7 +22,6 @@ import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
 import fr.forumhfr.redface2.core.domain.fixtures.FixedTopicFixtures
-import fr.forumhfr.redface2.core.domain.fixtures.TopicFixtureRepository
 import fr.forumhfr.redface2.FlagsScreen
 import fr.forumhfr.redface2.R
 import fr.forumhfr.redface2.core.ui.RedfaceTheme
@@ -94,10 +93,7 @@ private data class ParsedDeepLink(
 )
 
 @Composable
-fun RedfaceApp(
-    intent: Intent?,
-    topicFixtureRepository: TopicFixtureRepository,
-) {
+fun RedfaceApp(intent: Intent?) {
     RedfaceTheme {
         val flagsBackStack = rememberNavBackStack(FlagsListRoute)
         val forumBackStack = rememberNavBackStack(ForumRoute)
@@ -139,20 +135,14 @@ fun RedfaceApp(
         ) {
             Surface(modifier = Modifier.padding(horizontal = 8.dp)) {
                 val activeBackStack = backStacks.getValue(currentDestination)
-                RedfaceNavHost(
-                    backStack = activeBackStack,
-                    topicFixtureRepository = topicFixtureRepository,
-                )
+                RedfaceNavHost(backStack = activeBackStack)
             }
         }
     }
 }
 
 @Composable
-private fun RedfaceNavHost(
-    backStack: NavBackStack<NavKey>,
-    topicFixtureRepository: TopicFixtureRepository,
-) {
+private fun RedfaceNavHost(backStack: NavBackStack<NavKey>) {
     NavDisplay(
         backStack = backStack,
         onBack = {
@@ -243,7 +233,6 @@ private fun RedfaceNavHost(
                         page = route.page,
                         scrollTo = route.scrollTo,
                     ),
-                    topicFixtureRepository = topicFixtureRepository,
                     onReply = { postId ->
                         backStack.add(
                             EditorRoute(

--- a/app/src/main/java/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/java/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -16,10 +16,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import fr.forumhfr.redface2.core.domain.fixtures.FixedTopicFixtures
 import fr.forumhfr.redface2.FlagsScreen
@@ -150,6 +152,10 @@ private fun RedfaceNavHost(backStack: NavBackStack<NavKey>) {
                 backStack.removeAt(backStack.lastIndex)
             }
         },
+        entryDecorators = listOf(
+            rememberSaveableStateHolderNavEntryDecorator(),
+            rememberViewModelStoreNavEntryDecorator(),
+        ),
         entryProvider = entryProvider {
             entry<FlagsListRoute> {
                 FlagsScreen(

--- a/feature/topic/build.gradle.kts
+++ b/feature/topic/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("redface.android.compose.library")
+    id("redface.android.hilt.library")
 }
 
 android {
@@ -12,8 +13,13 @@ dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:extension"))
 
+    implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.jsoup)
     implementation(libs.kotlinx.coroutines.android)
 
     testImplementation(libs.junit4)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.turbine)
 }

--- a/feature/topic/src/main/java/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/java/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Button
@@ -23,13 +24,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.produceState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import fr.forumhfr.redface2.core.domain.fixtures.FixedTopicFixtures
-import fr.forumhfr.redface2.core.domain.fixtures.TopicFixtureRepository
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.model.Poll
 import fr.forumhfr.redface2.core.model.Post
 import fr.forumhfr.redface2.core.model.Topic
@@ -37,50 +37,38 @@ import fr.forumhfr.redface2.core.ui.RedfacePlaceholderScreen
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
-import kotlinx.coroutines.CancellationException
 
 @Composable
 fun TopicScreen(
     request: TopicRequest,
-    topicFixtureRepository: TopicFixtureRepository,
     onReply: (Int) -> Unit,
     onOpenPage: (Int) -> Unit,
 ) {
-    if (!FixedTopicFixtures.isFixedTopic(request.cat, request.post)) {
-        RedfacePlaceholderScreen(
-            title = stringResource(R.string.topic_title, request.post),
-            body = stringResource(R.string.topic_body_placeholder, request.cat, request.page),
-        ) {
-            request.scrollTo?.let {
-                Text(text = stringResource(R.string.topic_scroll_to, it))
-            }
-            Button(onClick = { onReply(request.post) }) {
-                Text(text = stringResource(R.string.topic_reply))
-            }
-        }
-        return
-    }
+    val viewModel = hiltViewModel<TopicViewModel, TopicViewModel.Factory>(
+        creationCallback = { factory -> factory.create(request) },
+    )
+    val state by viewModel.state.collectAsStateWithLifecycle()
 
+    TopicContent(
+        state = state,
+        onIntent = viewModel::send,
+        onReply = { onReply(request.post) },
+        onOpenPage = onOpenPage,
+    )
+}
+
+@Composable
+internal fun TopicContent(
+    state: TopicUiState,
+    onIntent: (TopicIntent) -> Unit,
+    onReply: () -> Unit,
+    onOpenPage: (Int) -> Unit,
+) {
+    val request = state.request
     val lazyListState = rememberLazyListState()
-    val state by produceState<TopicScreenState>(
-        initialValue = TopicScreenState.Loading,
-        key1 = request.page,
-        key2 = topicFixtureRepository,
-    ) {
-        value = runCatching { topicFixtureRepository.loadTopicPage(request.page) }
-            .fold(
-                onSuccess = TopicScreenState::Loaded,
-                onFailure = { error ->
-                    if (error is CancellationException) {
-                        throw error
-                    }
-                    TopicScreenState.Error(error.message ?: "Unknown error")
-                },
-            )
-    }
 
-    LaunchedEffect(state, request.scrollTo) {
-        val topic = (state as? TopicScreenState.Loaded)?.topic ?: return@LaunchedEffect
+    LaunchedEffect(state.mode, request.scrollTo) {
+        val topic = (state.mode as? TopicUiState.Mode.Loaded)?.topic ?: return@LaunchedEffect
         val target = request.scrollTo ?: return@LaunchedEffect
         val index = topic.posts.indexOfFirst { it.numreponse == target }
         if (index >= 0) {
@@ -92,8 +80,22 @@ fun TopicScreen(
         modifier = Modifier.fillMaxSize(),
         color = MaterialTheme.colorScheme.surface,
     ) {
-        when (val uiState = state) {
-            TopicScreenState.Loading -> {
+        when (val mode = state.mode) {
+            TopicUiState.Mode.Placeholder -> {
+                RedfacePlaceholderScreen(
+                    title = stringResource(R.string.topic_title, request.post),
+                    body = stringResource(R.string.topic_body_placeholder, request.cat, request.page),
+                ) {
+                    request.scrollTo?.let { target ->
+                        Text(text = stringResource(R.string.topic_scroll_to, target))
+                    }
+                    Button(onClick = onReply) {
+                        Text(text = stringResource(R.string.topic_reply))
+                    }
+                }
+            }
+
+            TopicUiState.Mode.Loading -> {
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
@@ -110,23 +112,27 @@ fun TopicScreen(
                 }
             }
 
-            is TopicScreenState.Error -> {
+            is TopicUiState.Mode.Error -> {
                 RedfacePlaceholderScreen(
                     title = stringResource(R.string.topic_fixed_title),
-                    body = stringResource(R.string.topic_error_body, request.page, uiState.message),
+                    body = stringResource(R.string.topic_error_body, request.page, mode.message),
                 ) {
                     TopicPageButtons(
+                        availablePages = state.availablePages,
                         currentPage = request.page,
                         onOpenPage = onOpenPage,
                     )
+                    OutlinedButton(onClick = { onIntent(TopicIntent.Retry) }) {
+                        Text(text = stringResource(R.string.topic_retry))
+                    }
                 }
             }
 
-            is TopicScreenState.Loaded -> {
-                TopicLoadedScreen(
-                    topic = uiState.topic,
-                    scrollTo = request.scrollTo,
-                    onReply = { onReply(request.post) },
+            is TopicUiState.Mode.Loaded -> {
+                TopicLoadedContent(
+                    state = state,
+                    topic = mode.topic,
+                    onReply = onReply,
                     onOpenPage = onOpenPage,
                     listState = lazyListState,
                 )
@@ -136,13 +142,14 @@ fun TopicScreen(
 }
 
 @Composable
-private fun TopicLoadedScreen(
+private fun TopicLoadedContent(
+    state: TopicUiState,
     topic: Topic,
-    scrollTo: Int?,
     onReply: () -> Unit,
     onOpenPage: (Int) -> Unit,
-    listState: androidx.compose.foundation.lazy.LazyListState,
+    listState: LazyListState,
 ) {
+    val scrollTo = state.request.scrollTo
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
@@ -155,6 +162,7 @@ private fun TopicLoadedScreen(
         item {
             TopicHeaderCard(
                 topic = topic,
+                availablePages = state.availablePages,
                 scrollTo = scrollTo,
                 onReply = onReply,
                 onOpenPage = onOpenPage,
@@ -175,6 +183,7 @@ private fun TopicLoadedScreen(
 @Composable
 private fun TopicHeaderCard(
     topic: Topic,
+    availablePages: List<Int>,
     scrollTo: Int?,
     onReply: () -> Unit,
     onOpenPage: (Int) -> Unit,
@@ -209,6 +218,7 @@ private fun TopicHeaderCard(
                 )
             }
             TopicPageButtons(
+                availablePages = availablePages,
                 currentPage = topic.page,
                 onOpenPage = onOpenPage,
             )
@@ -224,11 +234,12 @@ private fun TopicHeaderCard(
 
 @Composable
 private fun TopicPageButtons(
+    availablePages: List<Int>,
     currentPage: Int,
     onOpenPage: (Int) -> Unit,
 ) {
     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-        FixedTopicFixtures.availablePages.forEach { page ->
+        availablePages.forEach { page ->
             if (page == currentPage) {
                 Button(onClick = {}) {
                     Text(text = page.toString())
@@ -333,18 +344,6 @@ private fun TopicPostCard(
             TopicHtmlRenderer(html = post.content)
         }
     }
-}
-
-private sealed interface TopicScreenState {
-    data object Loading : TopicScreenState
-
-    data class Loaded(
-        val topic: Topic,
-    ) : TopicScreenState
-
-    data class Error(
-        val message: String,
-    ) : TopicScreenState
 }
 
 private val topicDateFormatter = DateTimeFormatter

--- a/feature/topic/src/main/java/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/java/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -1,0 +1,40 @@
+package fr.forumhfr.redface2.feature.topic
+
+import fr.forumhfr.redface2.core.domain.fixtures.FixedTopicFixtures
+import fr.forumhfr.redface2.core.model.Topic
+
+data class TopicUiState(
+    val request: TopicRequest,
+    val mode: Mode,
+    val availablePages: List<Int>,
+) {
+    sealed interface Mode {
+        data object Loading : Mode
+
+        data class Loaded(
+            val topic: Topic,
+        ) : Mode
+
+        data class Error(
+            val message: String,
+        ) : Mode
+
+        data object Placeholder : Mode
+    }
+
+    companion object {
+        fun initial(
+            request: TopicRequest,
+            availablePages: List<Int> = FixedTopicFixtures.availablePages,
+        ): TopicUiState =
+            TopicUiState(
+                request = request,
+                mode = Mode.Loading,
+                availablePages = availablePages,
+            )
+    }
+}
+
+sealed interface TopicIntent {
+    data object Retry : TopicIntent
+}

--- a/feature/topic/src/main/java/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/java/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -1,6 +1,5 @@
 package fr.forumhfr.redface2.feature.topic
 
-import fr.forumhfr.redface2.core.domain.fixtures.FixedTopicFixtures
 import fr.forumhfr.redface2.core.model.Topic
 
 data class TopicUiState(
@@ -23,14 +22,11 @@ data class TopicUiState(
     }
 
     companion object {
-        fun initial(
-            request: TopicRequest,
-            availablePages: List<Int> = FixedTopicFixtures.availablePages,
-        ): TopicUiState =
+        fun initial(request: TopicRequest): TopicUiState =
             TopicUiState(
                 request = request,
                 mode = Mode.Loading,
-                availablePages = availablePages,
+                availablePages = emptyList(),
             )
     }
 }

--- a/feature/topic/src/main/java/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/java/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.fixtures.FixedTopicFixtures
 import fr.forumhfr.redface2.core.domain.fixtures.TopicFixtureRepository
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -24,6 +25,8 @@ class TopicViewModel @AssistedInject constructor(
     private val _state = MutableStateFlow(TopicUiState.initial(request))
     val state: StateFlow<TopicUiState> = _state.asStateFlow()
 
+    private var loadJob: Job? = null
+
     init {
         loadCurrentPage()
     }
@@ -36,11 +39,23 @@ class TopicViewModel @AssistedInject constructor(
 
     private fun loadCurrentPage() {
         if (!FixedTopicFixtures.isFixedTopic(request.cat, request.post)) {
-            _state.update { it.copy(mode = TopicUiState.Mode.Placeholder) }
+            loadJob?.cancel()
+            _state.update {
+                it.copy(
+                    mode = TopicUiState.Mode.Placeholder,
+                    availablePages = emptyList(),
+                )
+            }
             return
         }
-        _state.update { it.copy(mode = TopicUiState.Mode.Loading) }
-        viewModelScope.launch {
+        loadJob?.cancel()
+        _state.update {
+            it.copy(
+                mode = TopicUiState.Mode.Loading,
+                availablePages = FixedTopicFixtures.availablePages,
+            )
+        }
+        loadJob = viewModelScope.launch {
             val outcome = runCatching { topicFixtureRepository.loadTopicPage(request.page) }
                 .fold(
                     onSuccess = { topic -> TopicUiState.Mode.Loaded(topic) },

--- a/feature/topic/src/main/java/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/java/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -1,0 +1,62 @@
+package fr.forumhfr.redface2.feature.topic
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.fixtures.FixedTopicFixtures
+import fr.forumhfr.redface2.core.domain.fixtures.TopicFixtureRepository
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@HiltViewModel(assistedFactory = TopicViewModel.Factory::class)
+class TopicViewModel @AssistedInject constructor(
+    @Assisted private val request: TopicRequest,
+    private val topicFixtureRepository: TopicFixtureRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(TopicUiState.initial(request))
+    val state: StateFlow<TopicUiState> = _state.asStateFlow()
+
+    init {
+        loadCurrentPage()
+    }
+
+    fun send(intent: TopicIntent) {
+        when (intent) {
+            TopicIntent.Retry -> loadCurrentPage()
+        }
+    }
+
+    private fun loadCurrentPage() {
+        if (!FixedTopicFixtures.isFixedTopic(request.cat, request.post)) {
+            _state.update { it.copy(mode = TopicUiState.Mode.Placeholder) }
+            return
+        }
+        _state.update { it.copy(mode = TopicUiState.Mode.Loading) }
+        viewModelScope.launch {
+            val outcome = runCatching { topicFixtureRepository.loadTopicPage(request.page) }
+                .fold(
+                    onSuccess = { topic -> TopicUiState.Mode.Loaded(topic) },
+                    onFailure = { error ->
+                        if (error is CancellationException) {
+                            throw error
+                        }
+                        TopicUiState.Mode.Error(error.message ?: "Unknown error")
+                    },
+                )
+            _state.update { it.copy(mode = outcome) }
+        }
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(request: TopicRequest): TopicViewModel
+    }
+}

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -13,4 +13,5 @@
     <string name="topic_poll_summary">%1$d votes au total • %2$s</string>
     <string name="topic_poll_multiple_choices">multi-choix</string>
     <string name="topic_poll_single_choice">choix unique</string>
+    <string name="topic_retry">Réessayer</string>
 </resources>

--- a/feature/topic/src/test/java/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/java/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -1,0 +1,148 @@
+package fr.forumhfr.redface2.feature.topic
+
+import app.cash.turbine.test
+import fr.forumhfr.redface2.core.domain.fixtures.FixedTopicFixtures
+import fr.forumhfr.redface2.core.domain.fixtures.TopicFixtureRepository
+import fr.forumhfr.redface2.core.model.Topic
+import java.io.IOException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TopicViewModelTest {
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial load succeeds and exposes loaded state`() = runTest {
+        val topic = fakeTopic(page = 1)
+        val repository = FakeTopicFixtureRepository(responses = listOf(Result.success(topic)))
+
+        val viewModel = TopicViewModel(
+            request = fixedRequest(page = 1),
+            topicFixtureRepository = repository,
+        )
+
+        viewModel.state.test {
+            val loaded = awaitItem()
+            val mode = assertMode<TopicUiState.Mode.Loaded>(loaded)
+            assertEquals(topic, mode.topic)
+            assertEquals(FixedTopicFixtures.availablePages, loaded.availablePages)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(listOf(1), repository.pagesRequested)
+    }
+
+    @Test
+    fun `initial load failure exposes error mode`() = runTest {
+        val repository = FakeTopicFixtureRepository(responses = listOf(Result.failure(IOException("network"))))
+
+        val viewModel = TopicViewModel(
+            request = fixedRequest(page = 1),
+            topicFixtureRepository = repository,
+        )
+
+        viewModel.state.test {
+            val state = awaitItem()
+            val mode = assertMode<TopicUiState.Mode.Error>(state)
+            assertEquals("network", mode.message)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `non-fixed topic request resolves to placeholder without hitting repository`() = runTest {
+        val repository = FakeTopicFixtureRepository(responses = emptyList())
+
+        val viewModel = TopicViewModel(
+            request = TopicRequest(cat = 1, post = 2, page = 1, scrollTo = null),
+            topicFixtureRepository = repository,
+        )
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertMode<TopicUiState.Mode.Placeholder>(state)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertTrue(repository.pagesRequested.isEmpty())
+    }
+
+    @Test
+    fun `retry after error replays the current page and succeeds`() = runTest {
+        val topic = fakeTopic(page = 2)
+        val repository = FakeTopicFixtureRepository(
+            responses = listOf(
+                Result.failure(IllegalStateException("boom")),
+                Result.success(topic),
+            ),
+        )
+
+        val viewModel = TopicViewModel(
+            request = fixedRequest(page = 2),
+            topicFixtureRepository = repository,
+        )
+
+        assertMode<TopicUiState.Mode.Error>(viewModel.state.value)
+
+        viewModel.send(TopicIntent.Retry)
+
+        val loadedMode = assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value)
+        assertEquals(topic, loadedMode.topic)
+        assertEquals(listOf(2, 2), repository.pagesRequested)
+    }
+
+    private fun fixedRequest(page: Int): TopicRequest = TopicRequest(
+        cat = FixedTopicFixtures.cat,
+        post = FixedTopicFixtures.post,
+        page = page,
+        scrollTo = null,
+    )
+
+    private fun fakeTopic(page: Int): Topic = Topic(
+        cat = FixedTopicFixtures.cat,
+        post = FixedTopicFixtures.post,
+        title = "fake",
+        posts = emptyList(),
+        page = page,
+        totalPages = 3,
+        isFirstPostOwner = false,
+        poll = null,
+    )
+
+    private inline fun <reified T : TopicUiState.Mode> assertMode(state: TopicUiState): T {
+        val mode = state.mode
+        assertTrue("expected mode ${T::class.simpleName} but was ${mode::class.simpleName}", mode is T)
+        return mode as T
+    }
+}
+
+private class FakeTopicFixtureRepository(
+    responses: List<Result<Topic>>,
+) : TopicFixtureRepository {
+    private val queue = ArrayDeque(responses)
+    val pagesRequested: MutableList<Int> = mutableListOf()
+
+    override suspend fun loadTopicPage(page: Int): Topic {
+        pagesRequested += page
+        val result = queue.removeFirstOrNull()
+            ?: error("No more fake responses queued")
+        return result.getOrThrow()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ android-targetSdk = "36"
 android-compileSdk = "36"
 androidx-core = "1.18.0"
 androidx-activity = "1.13.0"
-androidx-lifecycle = "2.9.0"
+androidx-lifecycle = "2.10.0"
 compose-bom = "2026.04.01"
 navigation3 = "1.1.1"
 material3-adaptive = "1.2.0"
@@ -49,6 +49,7 @@ androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = 
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
 androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "navigation3" }
 androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
+androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "androidx-lifecycle" }
 androidx-material3-adaptive = { module = "androidx.compose.material3.adaptive:adaptive", version.ref = "material3-adaptive" }
 androidx-material3-adaptive-navigation-suite = { module = "androidx.compose.material3:material3-adaptive-navigation-suite" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,11 +3,13 @@ agp = "9.2.0"
 kotlin = "2.3.21"
 ksp = "2.3.7"
 hilt = "2.59.2"
+hilt-navigation-compose = "1.3.0"
 android-minSdk = "29"
 android-targetSdk = "36"
 android-compileSdk = "36"
 androidx-core = "1.18.0"
 androidx-activity = "1.13.0"
+androidx-lifecycle = "2.9.0"
 compose-bom = "2026.04.01"
 navigation3 = "1.1.1"
 material3-adaptive = "1.2.0"
@@ -62,6 +64,10 @@ kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutine
 
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
+androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hilt-navigation-compose" }
+androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }


### PR DESCRIPTION
> Action par Claude Opus 4.7 (1M context) (demandée par @XaTriX)

## Résumé

Refactor du slice topic vers une vraie frontière MVI avec `TopicViewModel` injectable via Hilt. Le composable `TopicScreen` ne charge plus les fixtures lui-même : un wrapper stateful adopte le ViewModel via `hiltViewModel<VM, Factory>(creationCallback = …)`, le `TopicContent` interne devient stateless (state + intents/callbacks).

`TopicFixtureRepository` n'est plus tiré explicitement à travers `MainActivity → RedfaceApp → TopicScreen` ; le ViewModel l'injecte directement, et l'identité de la `TopicRequest` est passée au VM via assisted-injection (`@HiltViewModel(assistedFactory = …)`).

## Changements

- `feature/topic` :
  - `TopicUiState` (sealed `Mode`: `Loading`/`Loaded`/`Error`/`Placeholder`) + `TopicIntent.Retry`
  - `TopicViewModel` (`@HiltViewModel(assistedFactory)`, `@AssistedInject`)
  - `TopicScreen` réduit à un wrapper stateful → `TopicContent(state, onIntent, onReply, onOpenPage)` stateless
  - Bouton **Réessayer** branché sur l'état `Error`
- `app` :
  - `RedfaceApp(intent)` : suppression du paramètre `TopicFixtureRepository`
  - `MainActivity` : suppression de `@Inject lateinit var topicFixtureRepository`
- Build :
  - libs : ajout `androidx.hilt:hilt-navigation-compose 1.3.0`, `androidx.lifecycle:lifecycle-viewmodel-compose` & `lifecycle-runtime-compose 2.9.0`, `kotlinx-coroutines-test 1.10.2`
  - `feature/topic` : adoption convention `redface.android.hilt.library`
- Tests :
  - `TopicViewModelTest` : initial success / initial failure / placeholder (non-fixed topic) / retry après erreur

## Hors scope (dette assumée, à traiter ailleurs)

Conformément au point 8 du brief : Jsoup et `TopicHtmlRenderer` restent dans `feature/topic`. Les bouger proprement dépend de :
- **#15** — `HfrParser` complet (parser hors `feature/topic` derrière le contrat domain)
- **#3** — `PostRenderer` prototype consommant `PostContent` (ADR-011) à la place du rendu HTML inline

Ces deux items sont déjà priorisés Phase 1 — Core et leur PR finalisera la sortie de Jsoup du module feature.

`Refs #65`

## Validation

```
scripts/docker-dev.sh ./gradlew detektAll lintDebug test testDebugUnitTest :app:assembleDebug
```

→ **BUILD SUCCESSFUL** (523 tasks, 472 executed). Lancée depuis un worktree git propre pour contourner les artefacts `build/` possédés par `nobody` du workspace principal.

## Critères d'acceptation #65

- [x] `produceState` / chargement repository retiré de `TopicScreen`
- [x] `TopicScreen` UI-first, chargement via ViewModel/MVI
- [x] Pas de nouvelle branche permanente type `internal`
- [x] PR ciblée uniquement sur #65
- [x] Tests utiles ajoutés sur le ViewModel
- [x] Commits respectent l'attribution IA
- [ ] Frontière domain/data complète : reste Jsoup dans `feature/topic` → tracé pour #15 / #3