### PR TITLE
feat(parser): PostContent AST + parser HTML HFR vers AST

### DIFF
--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/Post.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/Post.kt
@@ -7,6 +7,7 @@ data class Post(
     val author: String,
     val date: Instant,
     val content: String,
+    val contentAst: PostContent,
     val avatarUrl: String?,
     val isEditable: Boolean,
     val isOwnPost: Boolean,

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/PostContent.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/PostContent.kt
@@ -16,8 +16,6 @@ sealed interface PostBlock {
 
     data class Spoiler(val label: String?, val content: PostContent) : PostBlock
 
-    data class CodeBlock(val text: String) : PostBlock
-
     data class Image(val url: String, val description: String?) : PostBlock
 }
 

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/PostContent.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/PostContent.kt
@@ -24,6 +24,8 @@ sealed interface PostBlock {
 sealed interface PostInline {
     data class Text(val value: String) : PostInline
 
+    data object LineBreak : PostInline
+
     data class Strong(val children: List<PostInline>) : PostInline
 
     data class Emphasis(val children: List<PostInline>) : PostInline

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/PostContent.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/PostContent.kt
@@ -1,0 +1,48 @@
+package fr.forumhfr.redface2.core.model
+
+data class PostContent(
+    val blocks: List<PostBlock>,
+)
+
+sealed interface PostBlock {
+    data class Paragraph(val inlines: List<PostInline>) : PostBlock
+
+    data class Quote(
+        val author: String?,
+        val numreponse: Int?,
+        val page: Int?,
+        val content: PostContent,
+    ) : PostBlock
+
+    data class Spoiler(val label: String?, val content: PostContent) : PostBlock
+
+    data class CodeBlock(val text: String) : PostBlock
+
+    data class Image(val url: String, val description: String?) : PostBlock
+}
+
+sealed interface PostInline {
+    data class Text(val value: String) : PostInline
+
+    data class Strong(val children: List<PostInline>) : PostInline
+
+    data class Emphasis(val children: List<PostInline>) : PostInline
+
+    data class Underline(val children: List<PostInline>) : PostInline
+
+    data class Strike(val children: List<PostInline>) : PostInline
+
+    data class Color(val colorHex: String, val children: List<PostInline>) : PostInline
+
+    data class Link(val url: String, val children: List<PostInline>) : PostInline
+
+    data class InlineImage(val url: String, val description: String?) : PostInline
+
+    data class Smiley(val kind: SmileyKind, val imageUrl: String?) : PostInline
+}
+
+sealed interface SmileyKind {
+    data class Builtin(val code: String) : SmileyKind
+
+    data class Perso(val name: String) : SmileyKind
+}

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
@@ -1,7 +1,13 @@
 package fr.forumhfr.redface2.core.parser
 
+import fr.forumhfr.redface2.core.model.PostBlock
+import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.model.PostInline
+import fr.forumhfr.redface2.core.model.SmileyKind
 import fr.forumhfr.redface2.core.parser.common.HfrSelectors
 import org.jsoup.nodes.Element
+import org.jsoup.nodes.Node
+import org.jsoup.nodes.TextNode
 
 class PostContentParser {
     fun parse(contentElement: Element?): ParsedPostContent {
@@ -9,31 +15,303 @@ class PostContentParser {
             return ParsedPostContent(
                 content = "[Message supprimé]",
                 quotedAuthors = emptyList(),
+                ast = PostContent(blocks = emptyList()),
             )
         }
-
-        val quotedAuthors = contentElement
-            .select(HfrSelectors.POST_CITATION_AUTHOR)
-            .mapNotNull { citation ->
-                citation.text()
-                    .substringBefore(" a écrit")
-                    .trim()
-                    .takeIf(String::isNotEmpty)
-            }
-            .distinct()
 
         val sanitized = contentElement.clone().apply {
             select("${HfrSelectors.POST_EDITED}, ${HfrSelectors.POST_SIGNATURE}").remove()
         }
 
+        val ast = PostContent(blocks = parseBlocks(sanitized.childNodes()))
+        val quotedAuthors = collectQuotedAuthors(ast)
+
+        val htmlFallback = sanitized.html().trim().ifEmpty { "[Message supprimé]" }
+
         return ParsedPostContent(
-            content = sanitized.html().trim().ifEmpty { "[Message supprimé]" },
+            content = htmlFallback,
             quotedAuthors = quotedAuthors,
+            ast = ast,
         )
     }
+
+    private fun parseBlocks(nodes: List<Node>): List<PostBlock> {
+        val blocks = mutableListOf<PostBlock>()
+        val paragraph = mutableListOf<PostInline>()
+
+        fun flushParagraph() {
+            val cleaned = collapseInlines(paragraph)
+            if (cleaned.any { it.isNonBlank() }) {
+                blocks += PostBlock.Paragraph(cleaned)
+            }
+            paragraph.clear()
+        }
+
+        nodes.forEach { node ->
+            when (classifyNode(node)) {
+                NodeKind.IGNORE -> Unit
+                NodeKind.LINE_BREAK -> flushParagraph()
+
+                NodeKind.QUOTE -> {
+                    flushParagraph()
+                    parseQuote(node as Element)?.let(blocks::add)
+                }
+
+                NodeKind.IMAGE_BLOCK -> {
+                    flushParagraph()
+                    parseImageBlock(node as Element)?.let(blocks::add)
+                }
+
+                NodeKind.INLINE -> paragraph += parseInline(node)
+
+                NodeKind.PARAGRAPH_CONTAINER -> {
+                    flushParagraph()
+                    blocks += parseBlocks((node as Element).childNodes())
+                }
+            }
+        }
+
+        flushParagraph()
+        return blocks
+    }
+
+    private fun classifyNode(node: Node): NodeKind {
+        val element = (node as? Element) ?: return if (node is TextNode) NodeKind.INLINE else NodeKind.IGNORE
+        return when {
+            element.tagName() == "br" -> NodeKind.LINE_BREAK
+            element.tagName() == "div" && element.selectFirst("table.citation") != null -> NodeKind.QUOTE
+            element.tagName() == "div" && element.attr("style").contains("clear: both") -> NodeKind.IGNORE
+            element.tagName() == "div" -> NodeKind.PARAGRAPH_CONTAINER
+            element.tagName() == "p" -> NodeKind.PARAGRAPH_CONTAINER
+            element.tagName() == "img" && isStandaloneImage(element) -> NodeKind.IMAGE_BLOCK
+            else -> NodeKind.INLINE
+        }
+    }
+
+    private fun isStandaloneImage(element: Element): Boolean {
+        val parent = element.parent()
+        return parseSmiley(element) == null && parent != null &&
+            parent.childNodes().none { sibling -> sibling !== element && isContentSibling(sibling) }
+    }
+
+    private fun isContentSibling(node: Node): Boolean = when (node) {
+        is TextNode -> node.text().isNotBlank()
+        is Element -> true
+        else -> false
+    }
+
+    private fun parseQuote(element: Element): PostBlock.Quote? {
+        val table = element.selectFirst("table.citation")
+        val cell = table?.selectFirst("td")?.clone()
+        if (table == null || cell == null) return null
+
+        val author = table
+            .selectFirst(HfrSelectors.POST_CITATION_AUTHOR)
+            ?.text()
+            ?.substringBefore(" a écrit")
+            ?.trim()
+            ?.takeIf(String::isNotEmpty)
+
+        cell.children()
+            .firstOrNull { it.tagName() == "b" && it.hasClass("s1") }
+            ?.remove()
+        while (cell.children().firstOrNull()?.tagName() == "br") {
+            cell.children().firstOrNull()?.remove()
+        }
+
+        return PostBlock.Quote(
+            author = author,
+            numreponse = null,
+            page = null,
+            content = PostContent(parseBlocks(cell.childNodes())),
+        )
+    }
+
+    private fun parseImageBlock(element: Element): PostBlock.Image? {
+        val url = sanitizeImageHref(element.attr("src")) ?: return null
+        val description = element.attr("alt").ifBlank { element.attr("title") }.takeIf(String::isNotBlank)
+        return PostBlock.Image(url = url, description = description)
+    }
+
+    private fun parseInline(node: Node): List<PostInline> = when (node) {
+        is TextNode -> listOfNotNull(normalizeText(node.text())?.let(PostInline::Text))
+        is Element -> parseInlineElement(node)
+        else -> emptyList()
+    }
+
+    @Suppress("CyclomaticComplexMethod")
+    private fun parseInlineElement(element: Element): List<PostInline> = when (element.tagName()) {
+        "br" -> emptyList()
+        "b", "strong" -> listOf(PostInline.Strong(parseInlineChildren(element)))
+        "i", "em" -> listOf(PostInline.Emphasis(parseInlineChildren(element)))
+        "u" -> listOf(PostInline.Underline(parseInlineChildren(element)))
+        "s", "strike" -> listOf(PostInline.Strike(parseInlineChildren(element)))
+        "a" -> parseAnchor(element)
+        "img" -> parseImageInline(element)
+        "font" -> parseFont(element)
+        "span" -> parseSpan(element)
+        else -> parseInlineChildren(element)
+    }
+
+    private fun parseInlineChildren(element: Element): List<PostInline> {
+        val out = mutableListOf<PostInline>()
+        element.childNodes().forEach { child -> out += parseInline(child) }
+        return collapseInlines(out)
+    }
+
+    private fun parseAnchor(element: Element): List<PostInline> {
+        val href = sanitizeLinkHref(element.attr("href"))
+        val children = parseInlineChildren(element)
+        return if (href == null) children else listOf(PostInline.Link(href, children))
+    }
+
+    private fun parseImageInline(element: Element): List<PostInline> {
+        val smiley = parseSmiley(element)
+        val src = sanitizeImageHref(element.attr("src"))
+        val description = element.attr("alt").ifBlank { element.attr("title") }.takeIf(String::isNotBlank)
+        return when {
+            smiley != null -> listOf(smiley)
+            src == null -> emptyList()
+            else -> listOf(PostInline.InlineImage(url = src, description = description))
+        }
+    }
+
+    private fun parseSmiley(element: Element): PostInline.Smiley? {
+        if (element.tagName() != "img") return null
+        val alt = element.attr("alt").trim()
+        val imageUrl = sanitizeImageHref(element.attr("src"))
+        return when {
+            alt.isEmpty() -> null
+            PERSO_SMILEY_REGEX.matches(alt) -> {
+                val name = alt.substring(2, alt.length - 1)
+                PostInline.Smiley(SmileyKind.Perso(name), imageUrl)
+            }
+
+            BUILTIN_SMILEY_REGEX.matches(alt) -> {
+                val code = alt.substring(1, alt.length - 1)
+                PostInline.Smiley(SmileyKind.Builtin(code), imageUrl)
+            }
+
+            else -> null
+        }
+    }
+
+    private fun parseFont(element: Element): List<PostInline> {
+        val color = element.attr("color").trim().takeIf(String::isNotEmpty)
+        val normalized = normalizeColorHex(color)
+        val children = parseInlineChildren(element)
+        return if (normalized == null) children else listOf(PostInline.Color(normalized, children))
+    }
+
+    private fun parseSpan(element: Element): List<PostInline> {
+        val style = element.attr("style")
+        val color = STYLE_COLOR_REGEX.find(style)?.groupValues?.getOrNull(1)?.trim()
+        val normalized = normalizeColorHex(color)
+        val children = parseInlineChildren(element)
+        return if (normalized == null) children else listOf(PostInline.Color(normalized, children))
+    }
+
+    private fun normalizeColorHex(raw: String?): String? {
+        if (raw == null) return null
+        val hex = raw.trim().removePrefix("#")
+        return when (hex.length) {
+            6, 8 -> if (hex.matches(HEX_REGEX)) "#${hex.uppercase()}" else null
+            3 -> {
+                val expanded = hex.toCharArray().joinToString("") { "$it$it" }
+                if (expanded.matches(HEX_REGEX)) "#${expanded.uppercase()}" else null
+            }
+
+            else -> null
+        }
+    }
+
+    private fun normalizeText(text: String): String? {
+        val normalized = text
+            .replace(' ', ' ')
+            .replace(WHITESPACE_REGEX, " ")
+        return normalized.takeIf(String::isNotEmpty)
+    }
+
+    private fun collapseInlines(inlines: List<PostInline>): List<PostInline> {
+        if (inlines.isEmpty()) return inlines
+        val out = mutableListOf<PostInline>()
+        inlines.forEach { current ->
+            val previous = out.lastOrNull()
+            if (previous is PostInline.Text && current is PostInline.Text) {
+                out[out.lastIndex] = PostInline.Text(previous.value + current.value)
+            } else {
+                out += current
+            }
+        }
+        return out
+            .map(::normalizeEdge)
+            .filterNot { it is PostInline.Text && it.value.isEmpty() }
+    }
+
+    private fun normalizeEdge(inline: PostInline): PostInline = when (inline) {
+        is PostInline.Text -> PostInline.Text(inline.value.replace(WHITESPACE_REGEX, " "))
+        else -> inline
+    }
+
+    private fun PostInline.isNonBlank(): Boolean = when (this) {
+        is PostInline.Text -> value.isNotBlank()
+        else -> true
+    }
+
+    private fun collectQuotedAuthors(content: PostContent): List<String> {
+        val out = mutableListOf<String>()
+        fun walk(blocks: List<PostBlock>) {
+            blocks.forEach { block ->
+                when (block) {
+                    is PostBlock.Quote -> {
+                        block.author?.takeIf(String::isNotEmpty)?.let(out::add)
+                        walk(block.content.blocks)
+                    }
+
+                    is PostBlock.Spoiler -> walk(block.content.blocks)
+                    else -> Unit
+                }
+            }
+        }
+        walk(content.blocks)
+        return out.distinct()
+    }
+
+    private enum class NodeKind {
+        IGNORE,
+        LINE_BREAK,
+        QUOTE,
+        IMAGE_BLOCK,
+        INLINE,
+        PARAGRAPH_CONTAINER,
+    }
+
+    private companion object {
+        val WHITESPACE_REGEX = Regex("\\s+")
+        val HEX_REGEX = Regex("[0-9a-fA-F]+")
+        val STYLE_COLOR_REGEX = Regex("""color\s*:\s*(#?[0-9a-fA-F]{3,8})""")
+        val BUILTIN_SMILEY_REGEX = Regex(":[a-zA-Z0-9_]+:")
+        val PERSO_SMILEY_REGEX = Regex("""\[:[^]]+]""")
+    }
 }
+
+internal fun sanitizeLinkHref(rawHref: String): String? =
+    rawHref.trim()
+        .takeIf(String::isNotBlank)
+        ?.let { href ->
+            when {
+                href.startsWith("/") -> "https://forum.hardware.fr$href"
+                href.startsWith("http://", ignoreCase = true) -> href
+                href.startsWith("https://", ignoreCase = true) -> href
+                else -> null
+            }
+        }
+
+internal fun sanitizeImageHref(rawSrc: String): String? =
+    rawSrc.trim().takeIf(String::isNotBlank)
 
 data class ParsedPostContent(
     val content: String,
     val quotedAuthors: List<String>,
+    val ast: PostContent,
 )

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
@@ -57,6 +57,11 @@ class PostContentParser {
                     parseQuote(node as Element)?.let(blocks::add)
                 }
 
+                NodeKind.SPOILER -> {
+                    flushParagraph()
+                    parseSpoiler(node as Element)?.let(blocks::add)
+                }
+
                 NodeKind.IMAGE_BLOCK -> {
                     flushParagraph()
                     parseImageBlock(node as Element)?.let(blocks::add)
@@ -77,15 +82,20 @@ class PostContentParser {
 
     private fun classifyNode(node: Node): NodeKind {
         val element = (node as? Element) ?: return if (node is TextNode) NodeKind.INLINE else NodeKind.IGNORE
-        return when {
-            element.tagName() == "br" -> NodeKind.LINE_BREAK
-            element.tagName() == "div" && element.selectFirst("table.citation") != null -> NodeKind.QUOTE
-            element.tagName() == "div" && element.attr("style").contains("clear: both") -> NodeKind.IGNORE
-            element.tagName() == "div" -> NodeKind.PARAGRAPH_CONTAINER
-            element.tagName() == "p" -> NodeKind.PARAGRAPH_CONTAINER
-            element.tagName() == "img" && isStandaloneImage(element) -> NodeKind.IMAGE_BLOCK
+        return when (element.tagName()) {
+            "br" -> NodeKind.LINE_BREAK
+            "div" -> classifyDiv(element)
+            "p" -> NodeKind.PARAGRAPH_CONTAINER
+            "img" -> if (isStandaloneImage(element)) NodeKind.IMAGE_BLOCK else NodeKind.INLINE
             else -> NodeKind.INLINE
         }
+    }
+
+    private fun classifyDiv(element: Element): NodeKind = when {
+        element.selectFirst("table.spoiler") != null -> NodeKind.SPOILER
+        element.selectFirst("table.citation") != null -> NodeKind.QUOTE
+        element.attr("style").contains("clear: both") -> NodeKind.IGNORE
+        else -> NodeKind.PARAGRAPH_CONTAINER
     }
 
     private fun isStandaloneImage(element: Element): Boolean {
@@ -105,12 +115,19 @@ class PostContentParser {
         val cell = table?.selectFirst("td")?.clone()
         if (table == null || cell == null) return null
 
-        val author = table
-            .selectFirst(HfrSelectors.POST_CITATION_AUTHOR)
+        val authorAnchor = table.selectFirst(HfrSelectors.POST_CITATION_AUTHOR)
+        val author = authorAnchor
             ?.text()
             ?.substringBefore(" a écrit")
             ?.trim()
             ?.takeIf(String::isNotEmpty)
+
+        // The citation header anchor links to the cited post:
+        // .../sujet_<topicPost>_<page>.htm#t<numreponse>
+        // Both page and numreponse are extractable from rendered HTML when present.
+        val match = authorAnchor?.attr("href")?.let(CITATION_HREF_REGEX::find)
+        val page = match?.groupValues?.getOrNull(1)?.toIntOrNull()
+        val numreponse = match?.groupValues?.getOrNull(2)?.toIntOrNull()
 
         cell.children()
             .firstOrNull { it.tagName() == "b" && it.hasClass("s1") }
@@ -121,9 +138,37 @@ class PostContentParser {
 
         return PostBlock.Quote(
             author = author,
-            numreponse = null,
-            page = null,
+            numreponse = numreponse,
+            page = page,
             content = PostContent(parseBlocks(cell.childNodes())),
+        )
+    }
+
+    private fun parseSpoiler(element: Element): PostBlock.Spoiler? {
+        val table = element.selectFirst("table.spoiler")
+        val cell = table?.selectFirst("td")?.clone()
+        if (table == null || cell == null) return null
+
+        // Header is <b class="s1Topic">Spoiler :</b> — keep the label without the trailing colon
+        // so the renderer can format it consistently.
+        val labelElement = cell.selectFirst("b.s1Topic")
+        val label = labelElement
+            ?.text()
+            ?.removeSuffix(":")
+            ?.trim()
+            ?.takeIf(String::isNotEmpty)
+        labelElement?.remove()
+        while (cell.children().firstOrNull()?.tagName() == "br") {
+            cell.children().firstOrNull()?.remove()
+        }
+
+        // The hidden body is wrapped in <div class="Topic masque"> — unwrap it before recursing
+        // so paragraphs/inlines surface at the top level of the Spoiler content.
+        val masque = cell.selectFirst("div.Topic.masque")
+        val source = masque ?: cell
+        return PostBlock.Spoiler(
+            label = label,
+            content = PostContent(parseBlocks(source.childNodes())),
         )
     }
 
@@ -183,13 +228,16 @@ class PostContentParser {
         return when {
             alt.isEmpty() -> null
             PERSO_SMILEY_REGEX.matches(alt) -> {
+                // alt = "[:name]" → strip "[:" prefix and trailing "]"
                 val name = alt.substring(2, alt.length - 1)
                 PostInline.Smiley(SmileyKind.Perso(name), imageUrl)
             }
 
             BUILTIN_SMILEY_REGEX.matches(alt) -> {
-                val code = alt.substring(1, alt.length - 1)
-                PostInline.Smiley(SmileyKind.Builtin(code), imageUrl)
+                // alt = ":code:" or ":code" — strip leading ":" and the optional trailing ":"
+                val withoutLeadingColon = alt.substring(1)
+                val code = withoutLeadingColon.removeSuffix(":")
+                if (code.isEmpty()) null else PostInline.Smiley(SmileyKind.Builtin(code), imageUrl)
             }
 
             else -> null
@@ -281,6 +329,7 @@ class PostContentParser {
         IGNORE,
         LINE_BREAK,
         QUOTE,
+        SPOILER,
         IMAGE_BLOCK,
         INLINE,
         PARAGRAPH_CONTAINER,
@@ -290,8 +339,19 @@ class PostContentParser {
         val WHITESPACE_REGEX = Regex("\\s+")
         val HEX_REGEX = Regex("[0-9a-fA-F]+")
         val STYLE_COLOR_REGEX = Regex("""color\s*:\s*(#?[0-9a-fA-F]{3,8})""")
-        val BUILTIN_SMILEY_REGEX = Regex(":[a-zA-Z0-9_]+:")
-        val PERSO_SMILEY_REGEX = Regex("""\[:[^]]+]""")
+
+        // HFR builtin smileys (~25 codes) appear as alt="<token>" in the rendered HTML.
+        // Their alt is anchored to the value, never embedded in surrounding text.
+        // Examples seen in real fixtures: :jap:, :love:, :sol:, :lol:, :spamafote: (with closing colon)
+        // and :), :D, :o, :/, :??: (no closing colon, includes punctuation).
+        // The regex therefore accepts 1..15 chars from a permissive set; matches() anchors the whole alt.
+        val BUILTIN_SMILEY_REGEX = Regex("""^:[\w)(/?]{1,15}:?$""")
+
+        // HFR custom smileys are wrapped as alt="[:name]" — name may contain spaces and punctuation.
+        val PERSO_SMILEY_REGEX = Regex("""^\[:[^]]+]$""")
+
+        // Citation header href: https://forum.hardware.fr/hfr/.../sujet_<post>_<page>.htm#t<numreponse>
+        val CITATION_HREF_REGEX = Regex("""sujet_\d+_(\d+)\.htm#t(\d+)""")
     }
 }
 

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
@@ -98,7 +98,9 @@ class PostContentParser {
 
     private fun classifyDiv(element: Element): NodeKind = when {
         element.selectFirst("table.spoiler") != null -> NodeKind.SPOILER
-        element.selectFirst("table.citation") != null -> NodeKind.QUOTE
+        // HFR renders [quotemsg=...] as <table class="citation"> (with author anchor) and
+        // [quote] (anonymous) as <table class="quote"> — both map to the same Quote block.
+        element.selectFirst("table.citation, table.quote") != null -> NodeKind.QUOTE
         element.attr("style").contains("clear: both") -> NodeKind.IGNORE
         else -> NodeKind.PARAGRAPH_CONTAINER
     }
@@ -116,11 +118,13 @@ class PostContentParser {
     }
 
     private fun parseQuote(element: Element): PostBlock.Quote? {
-        val table = element.selectFirst("table.citation")
+        val table = element.selectFirst("table.citation, table.quote")
         val cell = table?.selectFirst("td")?.clone()
         if (table == null || cell == null) return null
 
         val authorAnchor = table.selectFirst(HfrSelectors.POST_CITATION_AUTHOR)
+        // <table class="quote"> (anonymous [quote]) has no a.Topic, so author/page/numreponse
+        // stay null. The "Citation :" <b class="s1"> label is removed below for both shapes.
         val author = authorAnchor
             ?.text()
             ?.substringBefore(" a écrit")
@@ -191,9 +195,11 @@ class PostContentParser {
 
     @Suppress("CyclomaticComplexMethod")
     private fun parseInlineElement(element: Element): List<PostInline> = when (element.tagName()) {
-        // <br> at the top of a block flushes the current paragraph (handled in parseBlocks);
-        // when nested inside an inline parent (e.g. <strong>foo<br>bar</strong>) we keep it as
-        // an explicit line break so the renderer can preserve the author's formatting.
+        // Two granularities of vertical rhythm coexist:
+        //   - top-level <br> flushes the current paragraph (handled in parseBlocks).
+        //   - <br> nested inside any inline parent (<strong>, <a>, <span>, <font>, …) keeps
+        //     the author's intra-paragraph break as an explicit LineBreak so the renderer
+        //     does not silently merge the two text runs.
         "br" -> listOf(PostInline.LineBreak)
         "b", "strong" -> listOf(PostInline.Strong(parseInlineChildren(element)))
         "i", "em" -> listOf(PostInline.Emphasis(parseInlineChildren(element)))
@@ -231,20 +237,25 @@ class PostContentParser {
 
     private fun parseSmiley(element: Element): PostInline.Smiley? {
         if (element.tagName() != "img") return null
+        // HFR keeps `title` canonical-cased (e.g. ":D") while `alt` can drift to lowercase
+        // (`:d`) on legacy posts. Pick title first so :D and :d don't end up as two distinct
+        // builtin tokens for the same emoticon.
+        val title = element.attr("title").trim()
         val alt = element.attr("alt").trim()
+        val token = title.ifBlank { alt }
         val imageUrl = sanitizeImageHref(element.attr("src"))
         return when {
-            alt.isEmpty() -> null
-            PERSO_SMILEY_REGEX.matches(alt) -> {
-                // alt = "[:name]" → strip "[:" prefix and trailing "]"
-                val name = alt.substring(2, alt.length - 1)
+            token.isEmpty() -> null
+            PERSO_SMILEY_REGEX.matches(token) -> {
+                // token = "[:name]" → strip "[:" prefix and trailing "]"
+                val name = token.substring(2, token.length - 1)
                 PostInline.Smiley(SmileyKind.Perso(name), imageUrl)
             }
 
-            BUILTIN_SMILEY_REGEX.matches(alt) -> {
+            BUILTIN_SMILEY_REGEX.matches(token) -> {
                 // The BBCode token is the canonical identity (`:)`, `;)`, `:jap:`, `:??:` …);
                 // stripping the colons would collapse `:)` and `;)` to the same `)`.
-                PostInline.Smiley(SmileyKind.Builtin(alt), imageUrl)
+                PostInline.Smiley(SmileyKind.Builtin(token), imageUrl)
             }
 
             else -> null

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
@@ -13,9 +13,9 @@ class PostContentParser {
     fun parse(contentElement: Element?): ParsedPostContent {
         if (contentElement == null) {
             return ParsedPostContent(
-                content = "[Message supprimé]",
+                content = DELETED_PLACEHOLDER,
                 quotedAuthors = emptyList(),
-                ast = PostContent(blocks = emptyList()),
+                ast = deletedFallbackAst(),
             )
         }
 
@@ -23,10 +23,11 @@ class PostContentParser {
             select("${HfrSelectors.POST_EDITED}, ${HfrSelectors.POST_SIGNATURE}").remove()
         }
 
-        val ast = PostContent(blocks = parseBlocks(sanitized.childNodes()))
+        val parsedBlocks = parseBlocks(sanitized.childNodes())
+        val ast = if (parsedBlocks.isEmpty()) deletedFallbackAst() else PostContent(blocks = parsedBlocks)
         val quotedAuthors = collectQuotedAuthors(ast)
 
-        val htmlFallback = sanitized.html().trim().ifEmpty { "[Message supprimé]" }
+        val htmlFallback = sanitized.html().trim().ifEmpty { DELETED_PLACEHOLDER }
 
         return ParsedPostContent(
             content = htmlFallback,
@@ -34,6 +35,10 @@ class PostContentParser {
             ast = ast,
         )
     }
+
+    private fun deletedFallbackAst(): PostContent = PostContent(
+        blocks = listOf(PostBlock.Paragraph(listOf(PostInline.Text(DELETED_PLACEHOLDER)))),
+    )
 
     private fun parseBlocks(nodes: List<Node>): List<PostBlock> {
         val blocks = mutableListOf<PostBlock>()
@@ -186,7 +191,10 @@ class PostContentParser {
 
     @Suppress("CyclomaticComplexMethod")
     private fun parseInlineElement(element: Element): List<PostInline> = when (element.tagName()) {
-        "br" -> emptyList()
+        // <br> at the top of a block flushes the current paragraph (handled in parseBlocks);
+        // when nested inside an inline parent (e.g. <strong>foo<br>bar</strong>) we keep it as
+        // an explicit line break so the renderer can preserve the author's formatting.
+        "br" -> listOf(PostInline.LineBreak)
         "b", "strong" -> listOf(PostInline.Strong(parseInlineChildren(element)))
         "i", "em" -> listOf(PostInline.Emphasis(parseInlineChildren(element)))
         "u" -> listOf(PostInline.Underline(parseInlineChildren(element)))
@@ -234,10 +242,9 @@ class PostContentParser {
             }
 
             BUILTIN_SMILEY_REGEX.matches(alt) -> {
-                // alt = ":code:" or ":code" — strip leading ":" and the optional trailing ":"
-                val withoutLeadingColon = alt.substring(1)
-                val code = withoutLeadingColon.removeSuffix(":")
-                if (code.isEmpty()) null else PostInline.Smiley(SmileyKind.Builtin(code), imageUrl)
+                // The BBCode token is the canonical identity (`:)`, `;)`, `:jap:`, `:??:` …);
+                // stripping the colons would collapse `:)` and `;)` to the same `)`.
+                PostInline.Smiley(SmileyKind.Builtin(alt), imageUrl)
             }
 
             else -> null
@@ -252,10 +259,15 @@ class PostContentParser {
     }
 
     private fun parseSpan(element: Element): List<PostInline> {
+        val children = parseInlineChildren(element)
+        // HFR renders [u]...[/u] as <span class="u">…</span>. Without this branch the underline
+        // semantics would be silently dropped (parseSpan only knew about color styles).
+        if (element.hasClass("u")) {
+            return listOf(PostInline.Underline(children))
+        }
         val style = element.attr("style")
         val color = STYLE_COLOR_REGEX.find(style)?.groupValues?.getOrNull(1)?.trim()
         val normalized = normalizeColorHex(color)
-        val children = parseInlineChildren(element)
         return if (normalized == null) children else listOf(PostInline.Color(normalized, children))
     }
 
@@ -336,16 +348,18 @@ class PostContentParser {
     }
 
     private companion object {
+        const val DELETED_PLACEHOLDER = "[Message supprimé]"
+
         val WHITESPACE_REGEX = Regex("\\s+")
         val HEX_REGEX = Regex("[0-9a-fA-F]+")
         val STYLE_COLOR_REGEX = Regex("""color\s*:\s*(#?[0-9a-fA-F]{3,8})""")
 
-        // HFR builtin smileys (~25 codes) appear as alt="<token>" in the rendered HTML.
-        // Their alt is anchored to the value, never embedded in surrounding text.
-        // Examples seen in real fixtures: :jap:, :love:, :sol:, :lol:, :spamafote: (with closing colon)
-        // and :), :D, :o, :/, :??: (no closing colon, includes punctuation).
-        // The regex therefore accepts 1..15 chars from a permissive set; matches() anchors the whole alt.
-        val BUILTIN_SMILEY_REGEX = Regex("""^:[\w)(/?]{1,15}:?$""")
+        // HFR builtin smileys (~25 tokens) appear as alt="<token>" in the rendered HTML.
+        // Two shapes coexist:
+        //   - emoticons starting with `:` or `;` (`:)`, `;)`, `:D`, `:/`, `:o`)
+        //   - named codes wrapped in colons (`:jap:`, `:lol:`, `:spamafote:`, `:??:`)
+        // The character set covers the punctuation actually observed in the fixtures.
+        val BUILTIN_SMILEY_REGEX = Regex("""^[:;][\w)(/?;\-']{1,15}:?$""")
 
         // HFR custom smileys are wrapped as alt="[:name]" — name may contain spaces and punctuation.
         val PERSO_SMILEY_REGEX = Regex("""^\[:[^]]+]$""")
@@ -368,7 +382,19 @@ internal fun sanitizeLinkHref(rawHref: String): String? =
         }
 
 internal fun sanitizeImageHref(rawSrc: String): String? =
-    rawSrc.trim().takeIf(String::isNotBlank)
+    rawSrc.trim()
+        .takeIf(String::isNotBlank)
+        ?.let { src ->
+            // Same whitelist as sanitizeLinkHref: only http(s) and absolute HFR paths reach the
+            // renderer / Coil. data:, file:, content:, javascript:, fixture-relative paths are
+            // rejected so a malicious or unexpected scheme cannot smuggle through `<img src>`.
+            when {
+                src.startsWith("/") -> "https://forum.hardware.fr$src"
+                src.startsWith("http://", ignoreCase = true) -> src
+                src.startsWith("https://", ignoreCase = true) -> src
+                else -> null
+            }
+        }
 
 data class ParsedPostContent(
     val content: String,

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/TopicPageParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/TopicPageParser.kt
@@ -65,6 +65,7 @@ class TopicPageParser(
                 postTable.selectFirst(HfrSelectors.POST_TOOLBAR_LEFT)?.text().orEmpty(),
             ),
             content = content.content,
+            contentAst = content.ast,
             avatarUrl = postTable.selectFirst(HfrSelectors.POST_AVATAR)?.attr("src"),
             isEditable = false,
             isOwnPost = false,

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
@@ -60,7 +60,7 @@ class PostContentParserTest {
     }
 
     @Test
-    fun `mono-character builtin smileys are recognised`() {
+    fun `mono-character builtin smileys are recognised with their BBCode token`() {
         val topic = pageParser.parse(fixture("topic_khakha_page_146.html"))
 
         val codes = topic.posts
@@ -69,11 +69,24 @@ class PostContentParserTest {
             .mapNotNull { (it.kind as? SmileyKind.Builtin)?.code }
             .toSet()
 
-        // page 146 fixture contains :), :D, :o — all single-character builtins which the
-        // initial naive regex (:[a-zA-Z0-9_]+:) silently dropped to InlineImage.
-        assertTrue("expected :) builtin on page 146, found codes=$codes", codes.contains(")"))
-        assertTrue("expected :D builtin on page 146, found codes=$codes", codes.contains("D"))
-        assertTrue("expected :o builtin on page 146, found codes=$codes", codes.contains("o"))
+        // page 146 fixture contains :), :D, :o — keep the leading colon so the BBCode token is the
+        // canonical id (a naive strip would collapse :) and ;) to the same ")").
+        assertTrue("expected :) builtin on page 146, found codes=$codes", codes.contains(":)"))
+        assertTrue("expected :D builtin on page 146, found codes=$codes", codes.contains(":D"))
+        assertTrue("expected :o builtin on page 146, found codes=$codes", codes.contains(":o"))
+    }
+
+    @Test
+    fun `semicolon-prefixed wink is recognised as a builtin distinct from colon-prefixed`() {
+        val topic = pageParser.parse(fixture("topic_khakha_page_1.html"))
+
+        val codes = topic.posts
+            .flatMap { post -> post.contentAst.allInlines() }
+            .filterIsInstance<PostInline.Smiley>()
+            .mapNotNull { (it.kind as? SmileyKind.Builtin)?.code }
+            .toSet()
+
+        assertTrue("expected ;) builtin on page 1, found codes=$codes", codes.contains(";)"))
     }
 
     @Test
@@ -104,7 +117,99 @@ class PostContentParserTest {
 
         assertNotNull("page 2 fixture contains :spamafote: builtin smiley", builtinSmiley)
         val code = (builtinSmiley!!.kind as SmileyKind.Builtin).code
-        assertFalse("builtin code should not contain colons", code.contains(':'))
+        // The BBCode token (with surrounding colons or leading `;`) is the canonical identity
+        // — stripping the marker would conflate `:)` and `;)` to the same `)`.
+        assertTrue(
+            "builtin code should keep its BBCode marker, got=$code",
+            code.startsWith(':') || code.startsWith(';'),
+        )
+    }
+
+    @Test
+    fun `inline br nested inside a styled span is kept as LineBreak`() {
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            """
+            <div id="para123">
+                <strong>premier<br>second</strong>
+            </div>
+            """.trimIndent(),
+        )
+
+        val result = parser.parse(element)
+
+        val strong = result.ast.allInlines().filterIsInstance<PostInline.Strong>().first()
+        val kinds = strong.children.map { it::class.simpleName }
+        // Without LineBreak handling, the <br> would be dropped and the two text fragments
+        // would collapse into a single Text — losing the author-intended visual break.
+        assertTrue(
+            "Strong children should expose a LineBreak between the two Text fragments, got=$kinds",
+            strong.children.any { it is PostInline.LineBreak },
+        )
+    }
+
+    @Test
+    fun `span class u is recognised as Underline`() {
+        val topic = pageParser.parse(fixture("topic_khakha_page_1.html"))
+
+        val underlines = topic.posts
+            .flatMap { post -> post.contentAst.allInlines() }
+            .filterIsInstance<PostInline.Underline>()
+
+        assertTrue(
+            "page 1 fixture uses <span class=\"u\"> for underline — at least one expected",
+            underlines.isNotEmpty(),
+        )
+    }
+
+    @Test
+    fun `inline image with non-http scheme is rejected`() {
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            """
+            <div id="para123">
+                <img src="data:image/png;base64,AAA" alt="">
+                <img src="javascript:alert(1)" alt="">
+                <img src="/forum2/icone.gif" alt="ok">
+            </div>
+            """.trimIndent(),
+        )
+
+        val result = parser.parse(element)
+
+        val imageUrls = result.ast.allInlines()
+            .filterIsInstance<PostInline.InlineImage>()
+            .map { it.url }
+        assertFalse(
+            "data: image src must be dropped before reaching the renderer",
+            imageUrls.any { it.startsWith("data:", ignoreCase = true) },
+        )
+        assertFalse(
+            "javascript: image src must be dropped before reaching the renderer",
+            imageUrls.any { it.startsWith("javascript:", ignoreCase = true) },
+        )
+        assertTrue(
+            "absolute HFR path should be normalised to forum.hardware.fr",
+            imageUrls.contains("https://forum.hardware.fr/forum2/icone.gif"),
+        )
+    }
+
+    @Test
+    fun `null content yields a deleted placeholder paragraph`() {
+        val parser = PostContentParser()
+
+        val result = parser.parse(null)
+
+        assertTrue(
+            "AST should not be empty so the renderer never falls back to a blank post",
+            result.ast.blocks.isNotEmpty(),
+        )
+        val text = result.ast.blocks
+            .filterIsInstance<PostBlock.Paragraph>()
+            .flatMap { it.inlines }
+            .filterIsInstance<PostInline.Text>()
+            .joinToString("") { it.value }
+        assertEquals("[Message supprimé]", text)
     }
 
     @Test

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
@@ -7,7 +7,6 @@ import fr.forumhfr.redface2.core.model.SmileyKind
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -28,7 +27,7 @@ class PostContentParserTest {
     }
 
     @Test
-    fun `quotes in AST preserve author and nest content`() {
+    fun `quotes in AST preserve author numreponse and page from citation href`() {
         val topic = pageParser.parse(fixture("topic_khakha_page_146.html"))
 
         val withQuote = topic.posts
@@ -39,8 +38,42 @@ class PostContentParserTest {
             .filterIsInstance<PostBlock.Quote>()
             .first()
         assertNotNull("quote should have an author", quote.author)
-        assertNull("numreponse is not extractable from rendered HTML", quote.numreponse)
-        assertNull("page is not extractable from rendered HTML", quote.page)
+        // The quote header anchor on page 146 fixtures targets sujet_<post>_<page>.htm#t<numreponse>
+        // so both fields are extractable. Asserting they're populated, not specific values, because
+        // different posts on the page cite different numreponses.
+        assertNotNull("page should be extracted from citation href", quote.page)
+        assertNotNull("numreponse should be extracted from citation href", quote.numreponse)
+        assertEquals("citations on page 146 always reference page 146", 146, quote.page)
+    }
+
+    @Test
+    fun `spoiler block is recognised and not flattened into paragraph`() {
+        val topic = pageParser.parse(fixture("topic_khakha_page_146.html"))
+
+        val spoilers = topic.posts.flatMap { post ->
+            post.contentAst.allBlocks().filterIsInstance<PostBlock.Spoiler>()
+        }
+        assertTrue("page 146 fixture contains at least one spoiler block", spoilers.isNotEmpty())
+        val spoiler = spoilers.first()
+        assertEquals("Spoiler", spoiler.label)
+        assertTrue("spoiler content should not be empty", spoiler.content.blocks.isNotEmpty())
+    }
+
+    @Test
+    fun `mono-character builtin smileys are recognised`() {
+        val topic = pageParser.parse(fixture("topic_khakha_page_146.html"))
+
+        val codes = topic.posts
+            .flatMap { post -> post.contentAst.allInlines() }
+            .filterIsInstance<PostInline.Smiley>()
+            .mapNotNull { (it.kind as? SmileyKind.Builtin)?.code }
+            .toSet()
+
+        // page 146 fixture contains :), :D, :o — all single-character builtins which the
+        // initial naive regex (:[a-zA-Z0-9_]+:) silently dropped to InlineImage.
+        assertTrue("expected :) builtin on page 146, found codes=$codes", codes.contains(")"))
+        assertTrue("expected :D builtin on page 146, found codes=$codes", codes.contains("D"))
+        assertTrue("expected :o builtin on page 146, found codes=$codes", codes.contains("o"))
     }
 
     @Test
@@ -55,6 +88,9 @@ class PostContentParserTest {
         assertNotNull("page 1 fixture contains [:obam haha] perso smileys", persoSmiley)
         val name = (persoSmiley!!.kind as SmileyKind.Perso).name
         assertTrue("perso name should not be wrapped in [: ]", !name.startsWith("[:") && !name.endsWith("]"))
+        // Specifically check the strip preserves the inner space — naive regex bugs would
+        // produce "obam" or "obam haha]" and silently pass the boundary assertion above.
+        assertEquals("obam haha", name)
     }
 
     @Test
@@ -141,6 +177,26 @@ private fun PostContent.allInlines(): List<PostInline> {
     val out = mutableListOf<PostInline>()
     walkBlocks(this.blocks, out)
     return out
+}
+
+/**
+ * Walks the AST depth-first and yields every [PostBlock] node, going into quote/spoiler containers.
+ */
+private fun PostContent.allBlocks(): List<PostBlock> {
+    val out = mutableListOf<PostBlock>()
+    collectBlocks(this.blocks, out)
+    return out
+}
+
+private fun collectBlocks(blocks: List<PostBlock>, out: MutableList<PostBlock>) {
+    blocks.forEach { block ->
+        out += block
+        when (block) {
+            is PostBlock.Quote -> collectBlocks(block.content.blocks, out)
+            is PostBlock.Spoiler -> collectBlocks(block.content.blocks, out)
+            else -> Unit
+        }
+    }
 }
 
 private fun walkBlocks(blocks: List<PostBlock>, out: MutableList<PostInline>) {

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
@@ -246,7 +246,7 @@ class PostContentParserTest {
     }
 
     @Test
-    fun `quotedAuthors mirrors quote authors from AST`() {
+    fun `quotedAuthors equals the distinct list of quote authors from the AST`() {
         val topic = pageParser.parse(fixture("topic_khakha_page_2.html"))
 
         topic.posts
@@ -255,13 +255,110 @@ class PostContentParserTest {
                 val authorsFromAst = post.contentAst.blocks
                     .filterIsInstance<PostBlock.Quote>()
                     .mapNotNull { it.author }
-                authorsFromAst.forEach { expected ->
-                    assertTrue(
-                        "post #${post.numreponse}: $expected should be in quotedAuthors",
-                        post.quotedAuthors.contains(expected),
-                    )
-                }
+                    .distinct()
+                assertEquals(
+                    "post #${post.numreponse}: quotedAuthors must mirror AST quote authors exactly",
+                    authorsFromAst,
+                    post.quotedAuthors,
+                )
             }
+    }
+
+    @Test
+    fun `anonymous quote table is recognised as a Quote without author`() {
+        val topic = pageParser.parse(fixture("topic_page_multipage.html"))
+
+        val anonymousQuotes = topic.posts
+            .flatMap { post -> post.contentAst.allBlocks() }
+            .filterIsInstance<PostBlock.Quote>()
+            .filter { it.author == null }
+
+        assertTrue(
+            "topic_page_multipage fixture contains <table class=\"quote\"> witness posts",
+            anonymousQuotes.isNotEmpty(),
+        )
+        val anonymous = anonymousQuotes.first()
+        // Anonymous [quote] has no a.Topic — page/numreponse stay null too.
+        assertEquals("anonymous quote should have no page", null, anonymous.page)
+        assertEquals("anonymous quote should have no numreponse", null, anonymous.numreponse)
+        assertTrue(
+            "anonymous quote content should not be empty",
+            anonymous.content.blocks.isNotEmpty(),
+        )
+    }
+
+    @Test
+    fun `case-mismatched alt and title yield the title-cased builtin token`() {
+        // Witness post on topic_page_multipage.html ships <img alt=":d" title=":D"> for the
+        // legacy lowercase variant of the biggrin emoticon. The AST must not produce two
+        // distinct builtins for what HFR stores as the same drawable.
+        val topic = pageParser.parse(fixture("topic_page_multipage.html"))
+
+        val codes = topic.posts
+            .flatMap { post -> post.contentAst.allInlines() }
+            .filterIsInstance<PostInline.Smiley>()
+            .mapNotNull { (it.kind as? SmileyKind.Builtin)?.code }
+            .toSet()
+
+        assertTrue(
+            "title-cased :D should be the canonical token, found codes=$codes",
+            codes.contains(":D"),
+        )
+        assertFalse(
+            "lowercase :d should not surface as a separate builtin token, codes=$codes",
+            codes.contains(":d"),
+        )
+    }
+
+    @Test
+    fun `perso smiley variant suffix is preserved in the kind name`() {
+        // Fixture topic_posts_page contains [:g0od:2] — HFR uses the trailing :N to pick
+        // a variant of the same custom smiley. The colon must stay inside the name.
+        val topic = pageParser.parse(fixture("topic_posts_page.html"))
+
+        val variantPerso = topic.posts
+            .flatMap { post -> post.contentAst.allInlines() }
+            .filterIsInstance<PostInline.Smiley>()
+            .mapNotNull { it.kind as? SmileyKind.Perso }
+            .firstOrNull { ':' in it.name }
+
+        assertNotNull("expected a perso smiley with a `:N` variant suffix", variantPerso)
+        assertTrue(
+            "variant suffix should be kept inside the perso name, got=${variantPerso!!.name}",
+            variantPerso.name.matches(Regex(""".+:\d+""")),
+        )
+    }
+
+    @Test
+    fun `non-http schemes other than data and javascript are also rejected`() {
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            """
+            <div id="para123">
+                <a href="mailto:foo@example.com">mail</a>
+                <a href="vbscript:msgbox(1)">vb</a>
+                <a href="file:///etc/passwd">file</a>
+                <img src="mailto:foo@example.com" alt="">
+                <img src="vbscript:msgbox(1)" alt="">
+                <img src="file:///etc/passwd" alt="">
+            </div>
+            """.trimIndent(),
+        )
+
+        val result = parser.parse(element)
+
+        val linkUrls = result.ast.allInlines().filterIsInstance<PostInline.Link>().map { it.url }
+        val imageUrls = result.ast.allInlines().filterIsInstance<PostInline.InlineImage>().map { it.url }
+        listOf("mailto:", "vbscript:", "file:").forEach { scheme ->
+            assertFalse(
+                "$scheme links must not survive the sanitizer, links=$linkUrls",
+                linkUrls.any { it.startsWith(scheme, ignoreCase = true) },
+            )
+            assertFalse(
+                "$scheme image src must not survive the sanitizer, images=$imageUrls",
+                imageUrls.any { it.startsWith(scheme, ignoreCase = true) },
+            )
+        }
     }
 
     private fun fixture(name: String): String =
@@ -310,7 +407,6 @@ private fun walkBlocks(blocks: List<PostBlock>, out: MutableList<PostInline>) {
             is PostBlock.Paragraph -> walkInlines(block.inlines, out)
             is PostBlock.Quote -> walkBlocks(block.content.blocks, out)
             is PostBlock.Spoiler -> walkBlocks(block.content.blocks, out)
-            is PostBlock.CodeBlock -> Unit
             is PostBlock.Image -> Unit
         }
     }

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
@@ -1,0 +1,171 @@
+package fr.forumhfr.redface2.core.parser
+
+import fr.forumhfr.redface2.core.model.PostBlock
+import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.model.PostInline
+import fr.forumhfr.redface2.core.model.SmileyKind
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PostContentParserTest {
+    private val pageParser = TopicPageParser()
+
+    @Test
+    fun `khakha opening page produces non empty AST for every post`() {
+        val topic = pageParser.parse(fixture("topic_khakha_page_1.html"))
+
+        topic.posts.forEach { post ->
+            assertNotNull("post #${post.numreponse} should have an AST", post.contentAst)
+            assertTrue(
+                "post #${post.numreponse} AST should have at least one block",
+                post.contentAst.blocks.isNotEmpty(),
+            )
+        }
+    }
+
+    @Test
+    fun `quotes in AST preserve author and nest content`() {
+        val topic = pageParser.parse(fixture("topic_khakha_page_146.html"))
+
+        val withQuote = topic.posts
+            .firstOrNull { post -> post.contentAst.blocks.any { it is PostBlock.Quote } }
+
+        assertNotNull("at least one post on page 146 should contain a quote block", withQuote)
+        val quote = withQuote!!.contentAst.blocks
+            .filterIsInstance<PostBlock.Quote>()
+            .first()
+        assertNotNull("quote should have an author", quote.author)
+        assertNull("numreponse is not extractable from rendered HTML", quote.numreponse)
+        assertNull("page is not extractable from rendered HTML", quote.page)
+    }
+
+    @Test
+    fun `perso smiley alt syntax is recognised as Perso kind`() {
+        val topic = pageParser.parse(fixture("topic_khakha_page_1.html"))
+
+        val persoSmiley = topic.posts
+            .flatMap { post -> post.contentAst.allInlines() }
+            .filterIsInstance<PostInline.Smiley>()
+            .firstOrNull { it.kind is SmileyKind.Perso }
+
+        assertNotNull("page 1 fixture contains [:obam haha] perso smileys", persoSmiley)
+        val name = (persoSmiley!!.kind as SmileyKind.Perso).name
+        assertTrue("perso name should not be wrapped in [: ]", !name.startsWith("[:") && !name.endsWith("]"))
+    }
+
+    @Test
+    fun `builtin smiley alt syntax is recognised as Builtin kind`() {
+        val topic = pageParser.parse(fixture("topic_khakha_page_2.html"))
+
+        val builtinSmiley = topic.posts
+            .flatMap { post -> post.contentAst.allInlines() }
+            .filterIsInstance<PostInline.Smiley>()
+            .firstOrNull { it.kind is SmileyKind.Builtin }
+
+        assertNotNull("page 2 fixture contains :spamafote: builtin smiley", builtinSmiley)
+        val code = (builtinSmiley!!.kind as SmileyKind.Builtin).code
+        assertFalse("builtin code should not contain colons", code.contains(':'))
+    }
+
+    @Test
+    fun `links keep only http https and absolute internal hrefs`() {
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            """
+            <div id="para123">
+                <a href="https://example.com/safe">safe</a>
+                <a href="javascript:alert(1)">unsafe</a>
+                <a href="data:text/html,malicious">also unsafe</a>
+                <a href="/forum2/index.php">internal</a>
+            </div>
+            """.trimIndent(),
+        )
+
+        val result = parser.parse(element)
+
+        val hrefs = result.ast.allInlines()
+            .filterIsInstance<PostInline.Link>()
+            .map { it.url }
+        assertTrue(
+            "https link should be preserved",
+            hrefs.contains("https://example.com/safe"),
+        )
+        assertTrue(
+            "internal link should be normalised to forum.hardware.fr",
+            hrefs.contains("https://forum.hardware.fr/forum2/index.php"),
+        )
+        val jsLink = hrefs.any { it.startsWith("javascript:", ignoreCase = true) }
+        val dataLink = hrefs.any { it.startsWith("data:", ignoreCase = true) }
+        assertFalse("javascript: links must not appear in AST", jsLink)
+        assertFalse("data: links must not appear in AST", dataLink)
+    }
+
+    @Test
+    fun `quotedAuthors mirrors quote authors from AST`() {
+        val topic = pageParser.parse(fixture("topic_khakha_page_2.html"))
+
+        topic.posts
+            .filter { post -> post.contentAst.blocks.any { it is PostBlock.Quote } }
+            .forEach { post ->
+                val authorsFromAst = post.contentAst.blocks
+                    .filterIsInstance<PostBlock.Quote>()
+                    .mapNotNull { it.author }
+                authorsFromAst.forEach { expected ->
+                    assertTrue(
+                        "post #${post.numreponse}: $expected should be in quotedAuthors",
+                        post.quotedAuthors.contains(expected),
+                    )
+                }
+            }
+    }
+
+    private fun fixture(name: String): String =
+        requireNotNull(javaClass.getResource("/fixtures/$name")) {
+            "Fixture not found: $name"
+        }.readText()
+
+    private fun jsoupBody(html: String): org.jsoup.nodes.Element {
+        val document = org.jsoup.Jsoup.parseBodyFragment(html)
+        return document.body().selectFirst("div[id^=para]") ?: document.body()
+    }
+}
+
+/**
+ * Walks the AST depth-first and yields every [PostInline] node, going into quote/spoiler/inline children.
+ */
+private fun PostContent.allInlines(): List<PostInline> {
+    val out = mutableListOf<PostInline>()
+    walkBlocks(this.blocks, out)
+    return out
+}
+
+private fun walkBlocks(blocks: List<PostBlock>, out: MutableList<PostInline>) {
+    blocks.forEach { block ->
+        when (block) {
+            is PostBlock.Paragraph -> walkInlines(block.inlines, out)
+            is PostBlock.Quote -> walkBlocks(block.content.blocks, out)
+            is PostBlock.Spoiler -> walkBlocks(block.content.blocks, out)
+            is PostBlock.CodeBlock -> Unit
+            is PostBlock.Image -> Unit
+        }
+    }
+}
+
+private fun walkInlines(inlines: List<PostInline>, out: MutableList<PostInline>) {
+    inlines.forEach { inline ->
+        out += inline
+        when (inline) {
+            is PostInline.Strong -> walkInlines(inline.children, out)
+            is PostInline.Emphasis -> walkInlines(inline.children, out)
+            is PostInline.Underline -> walkInlines(inline.children, out)
+            is PostInline.Strike -> walkInlines(inline.children, out)
+            is PostInline.Color -> walkInlines(inline.children, out)
+            is PostInline.Link -> walkInlines(inline.children, out)
+            else -> Unit
+        }
+    }
+}


### PR DESCRIPTION
> Action par Claude Opus 4.7 (demandée par @XaTriX)

## Pourquoi

Tranche **#15-a** : poser la fondation `PostContent` (AST sémantique du contrat de rendu défini par [ADR-011](https://github.com/ForumHFR/redface2/blob/main/docs/adr/011-postcontent-ast.md)) et déplacer la compréhension du HTML HFR dans `:core:parser`. Stack PR avec **#3-a** qui enchaînera l'intégration `PostRenderer` Compose et la suppression de Jsoup côté `:feature:topic`.

Décision splitting (deux PRs stackées vs PR unique) : le couplage entre `Post.content: String` et `TopicHtmlRenderer` n'oblige pas la fusion — `PostContentParser` peut produire l'AST en même temps que le HTML legacy, et `Post` peut exposer `contentAst` comme champ supplémentaire sans casser les consommateurs existants. **PR splittable proprement, ce qui rend cette tranche standalone et reviewable.**

## Ce que change cette PR

### `:core:model` — types AST

Nouveau fichier `core/model/.../PostContent.kt`, alignement strict sur `docs/specs/models.md` :

\`\`\`
PostContent(blocks)
PostBlock = Paragraph(inlines)
          | Quote(author, numreponse?, page?, content)
          | Spoiler(label?, content)
          | CodeBlock(text)
          | Image(url, description?)
PostInline = Text | Strong | Emphasis | Underline | Strike
           | Color(colorHex, children) | Link(url, children)
           | InlineImage(url, description?) | Smiley(kind, imageUrl?)
SmileyKind = Builtin(code) | Perso(name)
\`\`\`

### `:core:parser` — `PostContentParser` réécrit pour produire l'AST

`ParsedPostContent(content: String, quotedAuthors: List<String>, ast: PostContent)`. Walk DOM HFR-rendu :

| Source HFR | Nœud AST |
|---|---|
| `<br>` / `<div style=clear:both>` | break paragraph / ignoré |
| `<div>` contenant `<table.citation>` | `Quote(author, null, null, content)` récursif |
| `<img>` standalone (parent ne contient que cette image) | `PostBlock.Image` |
| `<img>` inline avec `alt=":code:"` | `Smiley(SmileyKind.Builtin)` |
| `<img>` inline avec `alt="[:name]"` | `Smiley(SmileyKind.Perso)` |
| `<b>`/`<strong>`, `<i>`/`<em>`, `<u>`, `<s>`/`<strike>` | inlines correspondants |
| `<a href="...">` | `Link` avec URL sanitisée |
| `<font color>` + `<span style="color:...">` | `Color` normalisé `#RRGGBB`/`#AARRGGBB` |

`Quote.numreponse` et `Quote.page` restent `null` — non extractibles depuis le HTML rendu (ils viendront du parser BBCode Phase 2). `quotedAuthors` est maintenant **dérivé de l'AST** par walk depth-first des `Quote` blocks (au lieu d'un select Jsoup séparé).

**Sanitisation des liens** (sécurité) : seules les URLs `http://`, `https://` et `/path` (normalisées vers `https://forum.hardware.fr/path`) sont conservées. `javascript:`, `data:`, et toute URL relative non-absolue sont **droppées de l'AST** — elles n'arriveront jamais au renderer.

### `Post.contentAst` (champ supplémentaire, pas un remplacement)

`core/model/.../Post.kt` gagne `val contentAst: PostContent` à côté du legacy `val content: String`. Aucun consommateur existant n'est touché — `TopicHtmlRenderer` continue à lire `content: String` (HTML sanitisé) jusqu'à ce que **#3-a** flippe le type. C'est exactement le pattern « champ legacy + AST exposé » prescrit par le prompt.

`TopicPageParser` populate `contentAst = parsedContent.ast`.

## Tests

6 tests dans `PostContentParserTest.kt`, **tous sur fixtures réelles déjà présentes** dans le repo (zéro fixture inventée) :

1. **Page 1** — chaque post produit un AST non vide
2. **Page 146** — au moins un post contient un `Quote` block avec auteur non null + `numreponse`/`page` à null (rappel ADR : non extractibles du HTML rendu)
3. **Page 1** — détecte un smiley perso `[:obam haha]` typé `SmileyKind.Perso`
4. **Page 2** — détecte un smiley builtin `:spamafote:` typé `SmileyKind.Builtin`
5. **Sanitisation liens** — `https://...` préservé, `/forum2/...` normalisé, `javascript:`/`data:` absents de l'AST
6. **`quotedAuthors`** — mirror exactement les auteurs des `Quote` blocks de l'AST

Les tests existants `TopicPageParserTest` continuent de passer (pas de modification de leur surface).

## Validation

```bash
./scripts/docker-dev.sh ./gradlew detektAll lintDebug test testDebugUnitTest :app:assembleDebug
→ BUILD SUCCESSFUL in 1m07s, 519 tasks (112 executed, 17 cached, 390 up-to-date)
```

CI verte localement. Compilation et tests OK pour tous les modules.

## Hors scope (renvoyé à #3-a)

- Remplacer `TopicHtmlRenderer` par `PostRenderer` dans `:core:ui` consommant l'AST
- Flipper `Post.content: String` → `PostContent` (le `contentAst` deviendra la source unique)
- Supprimer Jsoup de `:feature:topic`
- Cache Room, parser BBCode, support exhaustif HTML

## Références

- Refs #15 (HfrParser, structure interne et fixtures — première tranche)
- Refs #3 (PostRenderer prototype — fondation pour la PR suivante)
- Refs #65 (slice topic re-architecture — pas fermé, dette restante)
- ADR-011 PostContent AST