### PR TITLE
feat(core): TopicRepository backbone (Phase 1A — closes parts of #87)

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("redface.android.library")
     id("redface.android.hilt.library")
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -13,4 +14,11 @@ dependencies {
     implementation(project(":core:parser"))
     implementation(project(":core:database"))
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.serialization.json)
+
+    testImplementation(libs.junit4)
+    testImplementation(libs.mockk)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.turbine)
 }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -6,6 +6,12 @@ plugins {
 
 android {
     namespace = "fr.forumhfr.redface2.core.data"
+
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+    }
 }
 
 dependencies {
@@ -21,4 +27,8 @@ dependencies {
     testImplementation(libs.robolectric)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.turbine)
+    testImplementation(platform(libs.okhttp.bom))
+    testImplementation(libs.okhttp)
+    testImplementation(libs.okhttp.mockwebserver)
+    testImplementation(libs.androidx.test.core)
 }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicMappers.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicMappers.kt
@@ -1,0 +1,112 @@
+package fr.forumhfr.redface2.core.data.topic
+
+import fr.forumhfr.redface2.core.database.entities.PostEntity
+import fr.forumhfr.redface2.core.database.entities.TopicEntity
+import fr.forumhfr.redface2.core.model.Poll
+import fr.forumhfr.redface2.core.model.PollOption
+import fr.forumhfr.redface2.core.model.Post
+import fr.forumhfr.redface2.core.model.Topic
+import java.time.Instant
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+
+internal object TopicMappers {
+    private val json: Json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    fun toEntities(topic: Topic, fetchedAt: Instant): Pair<TopicEntity, List<PostEntity>> {
+        val topicEntity = TopicEntity(
+            cat = topic.cat,
+            post = topic.post,
+            page = topic.page,
+            title = topic.title,
+            totalPages = topic.totalPages,
+            isFirstPostOwner = topic.isFirstPostOwner,
+            pollJson = topic.poll?.let { json.encodeToString(PollDto.serializer(), it.toDto()) },
+            numreponses = topic.posts.map { it.numreponse },
+            fetchedAt = fetchedAt,
+        )
+        val postEntities = topic.posts.map { post -> post.toEntity(topic.cat, topic.post, fetchedAt) }
+        return topicEntity to postEntities
+    }
+
+    fun toDomain(topic: TopicEntity, posts: List<PostEntity>): Topic {
+        val byNumreponse = posts.associateBy { it.numreponse }
+        val orderedPosts = topic.numreponses.mapNotNull { byNumreponse[it]?.toDomain() }
+        return Topic(
+            cat = topic.cat,
+            post = topic.post,
+            page = topic.page,
+            title = topic.title,
+            totalPages = topic.totalPages,
+            isFirstPostOwner = topic.isFirstPostOwner,
+            posts = orderedPosts,
+            poll = topic.pollJson?.let { json.decodeFromString(PollDto.serializer(), it).toDomain() },
+        )
+    }
+
+    private fun Post.toEntity(cat: Int, postId: Int, fetchedAt: Instant): PostEntity = PostEntity(
+        cat = cat,
+        post = postId,
+        numreponse = numreponse,
+        author = author,
+        date = date,
+        content = content,
+        avatarUrl = avatarUrl,
+        isEditable = isEditable,
+        isOwnPost = isOwnPost,
+        quotedAuthors = quotedAuthors,
+        postIndex = postIndex,
+        fetchedAt = fetchedAt,
+    )
+
+    private fun PostEntity.toDomain(): Post = Post(
+        numreponse = numreponse,
+        author = author,
+        date = date,
+        content = content,
+        avatarUrl = avatarUrl,
+        isEditable = isEditable,
+        isOwnPost = isOwnPost,
+        quotedAuthors = quotedAuthors,
+        postIndex = postIndex,
+    )
+
+    @Serializable
+    private data class PollDto(
+        val question: String,
+        val options: List<PollOptionDto>,
+        val multipleChoice: Boolean,
+        val totalVotes: Int,
+        val hasVoted: Boolean,
+    )
+
+    @Serializable
+    private data class PollOptionDto(
+        val text: String,
+        val votes: Int,
+        val percentage: Float,
+    )
+
+    private fun Poll.toDto(): PollDto = PollDto(
+        question = question,
+        options = options.map { PollOptionDto(it.text, it.votes, it.percentage) },
+        multipleChoice = multipleChoice,
+        totalVotes = totalVotes,
+        hasVoted = hasVoted,
+    )
+
+    private fun PollDto.toDomain(): Poll = Poll(
+        question = question,
+        options = options.map { PollOption(it.text, it.votes, it.percentage) },
+        multipleChoice = multipleChoice,
+        totalVotes = totalVotes,
+        hasVoted = hasVoted,
+    )
+
+    @Suppress("unused")
+    private val pollListSerializer = ListSerializer(PollDto.serializer())
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicMappers.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicMappers.kt
@@ -8,7 +8,6 @@ import fr.forumhfr.redface2.core.model.Post
 import fr.forumhfr.redface2.core.model.Topic
 import java.time.Instant
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 
 internal object TopicMappers {
@@ -106,7 +105,4 @@ internal object TopicMappers {
         totalVotes = totalVotes,
         hasVoted = hasVoted,
     )
-
-    @Suppress("unused")
-    private val pollListSerializer = ListSerializer(PollDto.serializer())
 }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImpl.kt
@@ -1,0 +1,46 @@
+package fr.forumhfr.redface2.core.data.topic
+
+import fr.forumhfr.redface2.core.database.dao.TopicDao
+import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
+import fr.forumhfr.redface2.core.domain.topic.TopicRepository
+import fr.forumhfr.redface2.core.model.Topic
+import fr.forumhfr.redface2.core.network.HfrClient
+import fr.forumhfr.redface2.core.parser.HfrParser
+import java.time.Clock
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.withContext
+
+@Singleton
+class TopicRepositoryImpl @Inject constructor(
+    private val client: HfrClient,
+    private val parser: HfrParser,
+    private val topicDao: TopicDao,
+    private val clock: Clock,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) : TopicRepository {
+
+    override fun observeTopicPage(cat: Int, post: Int, page: Int): Flow<Topic> = flow {
+        val cached = withContext(ioDispatcher) { loadFromCache(cat, post, page) }
+        if (cached != null) emit(cached)
+        emit(refreshTopicPage(cat, post, page))
+    }
+
+    override suspend fun refreshTopicPage(cat: Int, post: Int, page: Int): Topic =
+        withContext(ioDispatcher) {
+            val html = client.getTopicPage(cat = cat, post = post, page = page, useAuth = true)
+            val topic = parser.parseTopicPage(html)
+            val (topicEntity, postEntities) = TopicMappers.toEntities(topic, clock.instant())
+            topicDao.upsertTopicPageWithPosts(topicEntity, postEntities)
+            topic
+        }
+
+    private suspend fun loadFromCache(cat: Int, post: Int, page: Int): Topic? {
+        val topicEntity = topicDao.getTopicPage(cat, post, page) ?: return null
+        val postEntities = topicDao.getPostsByNumreponse(cat, topicEntity.numreponses)
+        return TopicMappers.toDomain(topicEntity, postEntities)
+    }
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryModule.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryModule.kt
@@ -1,0 +1,16 @@
+package fr.forumhfr.redface2.core.data.topic
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import fr.forumhfr.redface2.core.domain.topic.TopicRepository
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class TopicRepositoryModule {
+    @Binds
+    @Singleton
+    abstract fun bindTopicRepository(impl: TopicRepositoryImpl): TopicRepository
+}

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -104,16 +104,22 @@ class TopicRepositoryImplTest {
             awaitItem()
             awaitComplete()
         }
+        assertEquals("first call should warm the cache with one network request", 1, server.requestCount)
 
         repository.observeTopicPage(1, 999_395, 1).test {
             val cached = awaitItem()
             val fresh = awaitItem()
             assertEquals(cached.title, fresh.title)
             assertEquals(cached.posts.size, fresh.posts.size)
+            // Round-trip the PostContent AST through the Room JSON converter:
+            // the cached read goes through PostContentSerializer.decode while the
+            // fresh read comes straight from HfrParser, so equality proves the
+            // converter preserves the polymorphic block/inline hierarchy.
+            assertEquals(fresh.posts.first().content, cached.posts.first().content)
             awaitComplete()
         }
 
-        assertEquals(2, server.requestCount)
+        assertEquals("second call should hit network exactly once for refresh", 2, server.requestCount)
     }
 
     @Test

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -1,0 +1,141 @@
+package fr.forumhfr.redface2.core.data.topic
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
+import fr.forumhfr.redface2.core.database.RedfaceDatabase
+import fr.forumhfr.redface2.core.database.dao.TopicDao
+import fr.forumhfr.redface2.core.network.HfrClient
+import fr.forumhfr.redface2.core.parser.HfrParser
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class TopicRepositoryImplTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var database: RedfaceDatabase
+    private lateinit var dao: TopicDao
+    private lateinit var client: HfrClient
+    private lateinit var repository: TopicRepositoryImpl
+
+    private val fixedClock: Clock = Clock.fixed(Instant.parse("2026-04-26T18:00:00Z"), ZoneOffset.UTC)
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().apply { start() }
+
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        database = Room.inMemoryDatabaseBuilder(context, RedfaceDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = database.topicDao()
+
+        val okHttp = OkHttpClient.Builder().build()
+        client = HfrClient(
+            authenticated = okHttp,
+            anonymous = okHttp,
+            baseUrl = server.url("/"),
+        )
+
+        repository = TopicRepositoryImpl(
+            client = client,
+            parser = HfrParser(),
+            topicDao = dao,
+            clock = fixedClock,
+            ioDispatcher = Dispatchers.Unconfined,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+        server.shutdown()
+    }
+
+    @Test
+    fun `observeTopicPage emits fresh fetch when cache is empty`() = runTest {
+        server.enqueue(MockResponse().setBody(fixtureHtml("topic_page_single.html")))
+
+        repository.observeTopicPage(cat = 1, post = 999_395, page = 1).test {
+            val fresh = awaitItem()
+            assertEquals(1, fresh.cat)
+            assertEquals(999_395, fresh.post)
+            assertEquals(1, fresh.page)
+            assertTrue("expected at least one post", fresh.posts.isNotEmpty())
+            awaitComplete()
+        }
+
+        val recorded = server.takeRequest()
+        val requestUrl = recorded.requestUrl
+        assertNotNull(requestUrl)
+        requestUrl!!
+        assertEquals("forum2.php", requestUrl.pathSegments.first())
+        assertEquals("hfr.inc", requestUrl.queryParameter("config"))
+        assertEquals("1", requestUrl.queryParameter("cat"))
+        assertEquals("999395", requestUrl.queryParameter("post"))
+        assertEquals("1", requestUrl.queryParameter("page"))
+    }
+
+    @Test
+    fun `observeTopicPage emits cache then fresh on second call`() = runTest {
+        server.enqueue(MockResponse().setBody(fixtureHtml("topic_page_single.html")))
+        server.enqueue(MockResponse().setBody(fixtureHtml("topic_page_single.html")))
+
+        repository.observeTopicPage(1, 999_395, 1).test {
+            awaitItem()
+            awaitComplete()
+        }
+
+        repository.observeTopicPage(1, 999_395, 1).test {
+            val cached = awaitItem()
+            val fresh = awaitItem()
+            assertEquals(cached.title, fresh.title)
+            assertEquals(cached.posts.size, fresh.posts.size)
+            awaitComplete()
+        }
+
+        assertEquals(2, server.requestCount)
+    }
+
+    @Test
+    fun `refreshTopicPage upserts the topic page into Room`() = runTest {
+        server.enqueue(MockResponse().setBody(fixtureHtml("topic_page_single.html")))
+
+        assertNull(dao.getTopicPage(1, 999_395, 1))
+        val refreshed = repository.refreshTopicPage(1, 999_395, 1)
+
+        val cachedTopic = dao.getTopicPage(1, 999_395, 1)
+        assertNotNull(cachedTopic)
+        cachedTopic!!
+        assertEquals(refreshed.title, cachedTopic.title)
+        assertEquals(refreshed.posts.map { it.numreponse }, cachedTopic.numreponses)
+
+        val cachedPosts = dao.getPostsByNumreponse(1, cachedTopic.numreponses)
+        assertEquals(refreshed.posts.size, cachedPosts.size)
+    }
+
+    private fun fixtureHtml(name: String): String {
+        return requireNotNull(javaClass.getResource("/fixtures/$name")) {
+            "Fixture not found: $name"
+        }.readText()
+    }
+}

--- a/core/data/src/test/resources/fixtures/topic_page_single.html
+++ b/core/data/src/test/resources/fixtures/topic_page_single.html
@@ -1,0 +1,314 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr" lang="fr"><head><title>S'allume difficilement et garde les actions du bouton de démarrage! - Matériels &amp; problèmes divers - Hardware - FORUM HardWare.fr</title><link type="text/css" rel="stylesheet" href="/include/the_style1.php?color_key=FFFFFF/DEDFDF/000080/C2C3F4/2F3740/FFFFFF/FFFFFF/000000/000080/000000/000080/F7F7F7/DEDFDF/F7F7F7/DEDFDF/C0C0C0/C0C0C0/FFFFFF/000000/000000/0000FF/EEEEFF/DDDDEE/000000/FFEEEE/000000/FFFFFF/FF0000/FFFFFF/0/1/forum-images.hardware.fr/NULL/&amp;abs_img_path=%40data%40sites%40forum%40www%40static%40&amp;hide_bg_onglet=0&amp;v=11102781422" /><link type="text/css" rel="stylesheet" href="http://forum-images.hardware.fr/compressed/the_style.css?v=11102781422" /><script language="Javascript" type="text/javascript" src="http://forum-images.hardware.fr/compressed/tabs.js?v=11102781422"></script><script language="Javascript" type="text/javascript" src="http://forum-images.hardware.fr/compressed/forum2.js?v=11102781422"></script><script language="Javascript" type="text/javascript" src="http://forum-images.hardware.fr/compressed/common.js?v=11102781422"></script><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /><meta name="Robots" content="index, follow" /><meta name="Description" content="Bonjour, Quand je débranche mon ordi ( tour ), il ne veut plus s'allumer. J'appuie plusieurs fois [...]" /><style type="text/css">
+    <!--
+    .fastsearchMain{ width: 330px; }
+    .fastsearchInput{ width: 70px; border: 1px solid black; }
+    .fastsearchSubmit{ background-color: ; border: 0px;}
+    .header2 { background-image: url(http://forum-images.hardware.fr/img/forum3_1.gif);background-repeat: repeat-x; }
+    .menuExt { font-family: Arial, Helvetica, sans-serif; font-size: 10px; color:#000; }
+    .menuExt a { color:#000;text-decoration:none; }
+    .menuExt a:hover { color:#000;text-decoration:underline; }
+    form { display: inline; }
+    .header { background-image: url(http://forum-images.hardware.fr/img/header-bg.gif); background-repeat: repeat-x; }
+    .tdmenu { width: 1px;height: 1px;color: #000000; }
+    .hfrheadmenu { font-family: Arial, Helvetica, sans-serif;font-size:13px;font-weight:bold; }
+    .hfrheadmenu span {color:;}
+    .hfrheadmenu a { color:;text-decoration: none; }
+    .hfrheadmenu a:hover { color:;text-decoration: underline; }
+    .concours { font-family: Arial, Helvetica, sans-serif;color:;font-size: 16px;text-decoration: none;font-weight: bold;}
+    .concours:hover { font-family: Arial, Helvetica, sans-serif;color:;font-size: 16px;text-decoration: underline;font-weight: bold; }
+    .searchmenu { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: none;font-weight: bold; }
+    .fastsearch { display: none; }
+    .fastsearchHeader { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: none;font-weight: bold; }
+    .fastsearchHeader:hover { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: underline;font-weight: bold; }
+    -->
+</style>
+    <script type='text/javascript' src='http://partner.googleadservices.com/gampad/google_service.js'>
+    </script>
+    <script type='text/javascript'>
+GS_googleAddAdSenseService("ca-pub-5422505850558952");
+GS_googleEnableAllServices();
+</script>
+    <script type='text/javascript'>
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_accueil_banniere");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_achats_ventes_banniere_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_achats_ventes_carre_bas");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_achats_ventes_carre_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_achats_ventes_carre_milieu");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_apple_banniere_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_apple_carre_bas");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_apple_carre_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_apple_carre_milieu");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_banniere_jpdc");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_discussions_banniere_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_discussions_carre_bas");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_discussions_carre_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_discussions_carre_milieu");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_emploi_etude_banniere_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_emploi_etude_carre_bas");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_emploi_etude_carre_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_emploi_etude_carre_milieu");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_graphisme_banniere_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_graphisme_carre_bas");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_graphisme_carre_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_graphisme_carre_milieu");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_hardware_banniere");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_hardware_banniere_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_hardware_carre_bas");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_hardware_carre_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_hardware_carre_milieu");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_hardware_peripheriques_banniere_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_hardware_peripheriques_carre_bas");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_hardware_peripheriques_carre_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_hardware_peripheriques_carre_milieu");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_jeux_video_banniere_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_jeux_video_carre_bas");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_jeux_video_carre_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_jeux_video_carre_milieu");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_ordinateurs_portables_banniere_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_ordinateurs_portables_carre_bas");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_ordinateurs_portables_carre_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_ordinateurs_portables_carre_milieu");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_os_alternatif_banniere_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_os_alternatif_carre_bas");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_os_alternatif_carre_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_os_alternatif_carre_milieu");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_overclocking_banniere_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_overclocking_carre_bas");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_overclocking_carre_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_overclocking_carre_milieu");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_photo_numerique_banniere_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_photo_numerique_carre_bas");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_photo_numerique_carre_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_photo_numerique_carre_milieu");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_programmation_banniere_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_programmation_carre_bas");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_programmation_carre_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_programmation_carre_milieu");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_reseaux_grand_public_banniere_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_reseaux_grand_public_carre_bas");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_reseaux_grand_public_carre_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_reseaux_grand_public_carre_milieu");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_seti_banniere_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_seti_carre_bas");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_seti_carre_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_seti_carre_milieu");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_systemes_reseaux_pro_banniere_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_systemes_reseaux_pro_carre_bas");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_systemes_reseaux_pro_carre_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_systemes_reseaux_pro_carre_milieu");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_technologies_mobiles_banniere_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_technologies_mobiles_carre_bas");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_technologies_mobiles_carre_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_technologies_mobiles_carre_milieu");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_video_son_banniere_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_video_son_carre_bas");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_video_son_carre_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_video_son_carre_milieu");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_windows_software_banniere_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_windows_software_carre_bas");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_windows_software_carre_haut");
+GA_googleAddSlot("ca-pub-5422505850558952", "forum_windows_software_carre_milieu");
+</script>
+    <script type='text/javascript'>
+GA_googleFetchAds();
+</script>
+</head><body id="category__inside_topics__normal_topic"  ><script type="text/javascript">
+(function() {
+  var ARTICLE_URL = window.location.href;
+  var CONTENT_ID = 'everything';
+  document.write(
+    '<scr'+'ipt '+
+    'src="//survey.g.doubleclick.net/survey?site=_lxxeo7oc5kbn6556k5uaas7vra'+
+    '&amp;url='+encodeURIComponent(ARTICLE_URL)+
+    (CONTENT_ID ? '&amp;cid='+encodeURIComponent(CONTENT_ID) : '')+
+    '&amp;random='+(new Date).getTime()+
+    '" type="text/javascript">'+'\x3C/scr'+'ipt>');
+})();
+</script>
+<script language="JavaScript" type="text/javascript" src="http://www.hardware.fr/js/cookiechoices.js"></script>
+<script language="javascript" type="text/javascript" src="http://www.hardware.fr/js/jquery-1.11.1.min.js"></script>
+<script language="JavaScript" type="text/javascript" src="http://www.hardware.fr/js/cnil.js"></script>
+<script>
+ document.addEventListener('DOMContentLoaded', function(event) {
+    cookieChoices.showCookieConsentBar('HardWare.fr utilise des cookies pour une navigation optimale et des cookies tiers pour l\'analyse du trafic et la publicité',
+      'Fermer', 'En savoir plus', 'http://www.hardware.fr/html/donnees_personnelles/');
+  });
+</script>
+<style>
+    #cookieChoiceInfo span
+    ,#cookieChoiceDismiss
+    ,#PlusCookieChoice{
+    font-family:Tahoma,Arial,Helvetica,sans-serif;
+    }
+    #cookieChoiceDismiss
+    ,#PlusCookieChoice
+    {
+    color:black;
+    text-decoration:none;
+    }
+    #cookieChoiceDismiss:hover
+    ,#PlusCookieChoice:hover
+    {
+    color:#cc6908;
+    }
+</style>
+<table cellspacing="0" cellpadding="0" width="98%" bgcolor="#000000" border="0" align="center" class="hfrheadmenu" style="border:1px solid #000;border-top:0;">
+    <tr>
+        <td style="vertical-align: top">
+            <table cellspacing="0" cellpadding="0" width="100%" border="0">
+                <tr>
+                    <td style="width: 100%" align="left" valign="middle" colspan="2" class="header2"><span class="md_cryptlink45CBCBC02D1F1FCCCCCC19454AC14BCC4AC1431944C1"><img src="http://forum.hardware.fr/img/forum_logo.gif" width="750" height="71" border="0" alt="" /></span></td>
+                </tr>
+                <tr>
+                    <td style="background-color:#2F3740">
+                        <table cellspacing="0" cellpadding="2" width="100%" border="0">
+                            <tr>
+                                <td>&nbsp;<a class="cHeader" href="http://forum.hardware.fr/">Forum</a>&nbsp;|&nbsp;
+                                    <a class="cHeader" href="http://www.hardware.fr/">HardWare.fr</a>&nbsp;|&nbsp;<a class="cHeader" href="http://www.hardware.fr/html/news/">News</a>&nbsp;|&nbsp;<a class="cHeader" href="http://www.hardware.fr/html/articles/">Articles</a>&nbsp;|&nbsp;<a class="cHeader" href="http://www.hardware.fr/articles/786-1/guide-pc-hardware-fr.html">PC</a>&nbsp;|&nbsp;<a class="cHeader" href="http://www.hardware.fr/prix/">Prix</a>&nbsp;|&nbsp;<span class="md_cryptlink45CBCBC02D1F1F444FC1C34E19454AC14BCC4AC1431944C11F484F4C464919C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">S'identifier</span>&nbsp;|&nbsp;<span class="md_cryptlink45CBCBC02D1F1F444FC1C34E19454AC14BCC4AC1431944C11F4649C242C146C0CB464F4919C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">S'inscrire</span>&nbsp;|&nbsp;<span class="md_cryptlink45CBCBC02D1F1FCC464746194ACB484AC2194B4F42CB46C2C2464E4F1944C11F4B46C2C0484AC61FBEBB1FBB4F42C34E4349CB4ACB464F4917C3CB464846C24ACB43C3C1174BC317444FC1C34E">Aide</span></td>
+                                <td align="right"><a class="cHeader" href="http://forum.hardware.fr/search.php?config=hardwarefr.inc&cat=1&subcat=253">Recherche <img src="http://forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif"></a></td>
+                            </tr>
+                        </table></td></tr></table>
+        </td></tr></table><div style="width: 99%" align="right">
+    <span class="s2Ext menuExt"><span class="md_cryptlink45CBCBC02D1F1F444FC1C34E19454AC14BCC4AC1431944C11F4F494846494319C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">1831 connect&eacute;s&nbsp;</span></span></div><br /><script type='text/javascript'>
+(function(f,ee,l,i,g,o){f[l]=f[l]||{};o&&(o+='').length?(f[l].context={viewer:
+{id:o},platform:{name:i,version:g}})&&(o='-'+o):(o='');(function(s,t,k,r){
+t=ee.createElement(r='script');k=ee.getElementsByTagName(r)[0];t.async=1;t.src=s;
+k.parentNode.insertBefore(t,k);})(
+'http://hfr.stickersapp.feeligo.com/forum.hardware.fr/loader'+o+'.js')})
+(window,document,'flg','mesdiscussions','2010.2','');
+</script><div class="container"><div class="mesdiscussions" id="mesdiscussions"><div class="arbo" id="md_arbo_top">
+    <span  id="md_arbo_tree_1" ><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/" class="Ext">FORUM HardWare.fr</a></span>
+    <br />
+    <span  id="md_arbo_tree_2" ><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/tline.gif" alt="" /><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/hfr/Hardware/liste_sujet-1.htm" class="Ext">Hardware</a></span>
+    <br />
+    <span  id="md_arbo_tree_3" ><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/tline3.gif" alt="" /><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/hfr/Hardware/Materiels-problemes-divers/liste_sujet-1.htm" class="Ext">Matériels &amp; problèmes divers</a></span>
+    <br />
+    <h1  id="md_arbo_tree_4" ><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/tline4.gif" alt="" /><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;S'allume difficilement et garde les actions du bouton de démarrage!</h1>
+</div><div class="rightbutton fastsearch"><table class="main fastsearchMain" cellspacing="0" cellpadding="2"><tr class="cBackHeader fondForumDescription"><th><form method="post" id="fastsearch" action="/forum1.php"><input type="hidden" name="hash_check" value="REDACTED" /><label for="fastsearchinputid"><a rel="nofollow" href="/search.php?config=hfr.inc&amp;cat=1&amp;subcat=253" class="cHeader fastsearchHeader">Recherche :</a>&nbsp;<input type="text" name="search" id="fastsearchinputid" value="" class="fastsearchInput" alt="Search string" /></label><input type="hidden" name="recherches" value="1" /><input type="hidden" name="searchtype" value="1" /><input type="hidden" name="titre" value="3" /><input type="hidden" name="resSearch" value="200" /><input type="hidden" name="orderSearch" value="1" /><input type="hidden" name="config" value="hfr.inc" /><input type="hidden" name="cat" value="1" /><input type="hidden" name="subcat" value="253" />&nbsp;<input type="image" src="http://forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif" class="fastsearchSubmit" title="Lancer une recherche" alt="Lancer une recherche" /></form></th></tr></table></div><div class="spacer">&nbsp;</div><br /><div class="s1Ext"><!-- forum_hardware_banniere_haut -->
+    <script type='text/javascript'>
+GA_googleFillSlot("forum_hardware_banniere_haut");
+</script>
+</div><br /><a name="haut"></a><table class="main" cellspacing="0" cellpadding="4"><tr class="cBackHeader fondForum2Fonctions"><th class="padding" colspan="2"><form action="/transsearch.php" method="post"><input type="hidden" name="hash_check" value="REDACTED" /><input type="hidden" name="post"	value="999395" /><input type="hidden" name="cat"	value="1" /><input type="hidden" name="config"	value="hfr.inc" /><input type="hidden" name="p"		value="1" /><input type="hidden" name="sondage"	value="0" /><input type="hidden" name="owntopic" value="0" /><div class="left">&nbsp;Mot : <input type="text" name="word" value="" size="10" id="md_search_word" />&nbsp;&nbsp;Pseudo : <input type="text" name="spseudo" value="" size="10" id="md_search_pseudo" /> <input class="checkbox" type="checkbox" name="filter" id="filter" value="1"  /><label for="filter" title="N'afficher que les messages correspondant à la recherche">Filtrer</label>&nbsp;<input type="submit" onclick="document.getElementById('currentnum').value=''; return true;" value="Rechercher" class="boutton" /><input type="hidden" name="dep" value="0" /><input type="hidden" value="9760188" name="firstnum" /></div></form><div class="right" style="margin-top:2px"><a href="javascript:void(0)" onclick="vider_liste('quoteshardwarefr-1-999395')" class="cHeader"><img style="display:none" id="viderliste" src="http://forum-images.hardware.fr/themes_static/images_forum/1/viderliste.gif" alt="Vider la liste des messages à citer" title="Vider la liste des messages à citer" /></a> &nbsp;</div></th></tr><tr class="cBackHeader fondForum2PagesHaut"><th class="padding" colspan="2"><a href="#bas" class="cHeader">Bas de page</a></th></tr><tr class="cBackHeader fondForum2Title"><th scope="col" class="messCase1" width="180">Auteur</th><th scope="col" class="padding">&nbsp;Sujet : <h3>S'allume difficilement et garde les actions du bouton de démarrage!</h3></th></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message cBackCouleurTab2"><td class="messCase1" width="180" valign="top" rowspan="1"><a name="t9760188"></a><div class="right"><a href="#t9760188"><img src="http://forum-images.hardware.fr/icones/message/icon1.gif" title="n°9760188" alt="n°9760188" /></a></div><div><b class="s2">jubjub</b></div><span class="MoodStatus">jubjub</span></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 14-03-2016&nbsp;à&nbsp;11:24:58&nbsp;&nbsp;<a href="/hfr/profil-212685.htm" target="_blank"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil" alt="profil" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2E2A14C04FC2CB2E2626262226231449C34EC143C02E262C24202A252514C143442E2A14C04A4C432E2A14C02E2A14C2C341424ACB2E21232214C24F494B4A4C432E20144FCC49CB4FC046422E20144943CC2E2012444FC14EC3484A46C143"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></span></div><div class="spacer">&nbsp;</div></div><div id="para9760188"><p>Bonjour, &nbsp;<br />&nbsp;<br />Quand je débranche mon ordi ( tour ), il ne veut plus s'allumer.
+    <br />&nbsp;<br />J'appuie plusieurs fois sur le bouton de démarrage, longtemps, avec répétition etc.
+    <br />Et un beau jour, une pression sur le bouton et HOP ! &nbsp;il démarre !! ( ?)
+    <br />&nbsp;<br /><strong>De plus : il garde en mémoire les actions que j'ai fait sur le bouton d'allumage lors de mes tentative !</strong>...
+    <br />&nbsp;<br />Donc il démarre, se re-éteint, windows se lance, windows redémarre, windows se met en veille ETC.
+    <br />&nbsp;<br />&nbsp;<br />Là j''ai dû le débrancher... Et impossible de le rallumer... &nbsp;<br />&nbsp;<br />Dois-je : changer la carte mère, l'alim ? Est-ce une sécurité ? Electricité statique ?...
+    <br />&nbsp;<br />- Alimentation : ANTEC High Current Gamer Series - 520W - 80+ Bronze
+    <br />- Carte mère MSI H61M-P20 (G3)
+    <br />- pas de poussière
+    <br />&nbsp;<br />Merci pour votre aide<div style="clear: both;"> </div></p><div class="edited"><a href="/forum2.php?config=hfr.inc&amp;cat=1&amp;subcat=253&amp;post=999395&amp;page=1&amp;p=1&amp;sondage=&amp;owntopic=&amp;trash=&amp;trash_post=&amp;print=&amp;numreponse=9760188&amp;quote_only=1&amp;new=0&amp;nojs=0" class="cLink" rel="nofollow">Message cité 1 fois</a><br />Message édité par jubjub le 14-03-2016&nbsp;à&nbsp;12:09:00</div></div></td></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message  cBackCouleurTab1"><td class="messCase1" width="180" valign="top" rowspan="1"><div class="right"><img src="http://forum-images.hardware.fr/icones/message/icon1.gif" alt="mood" /></div><div><b class="s2">Publicité</b></div></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 14-03-2016&nbsp;à&nbsp;11:24:58&nbsp;&nbsp;<img src="http://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil (Etat inconnu)" alt="profil" /><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></div><div class="spacer">&nbsp;</div></div><div><p><script type="text/javascript">
+  GA_googleFillSlot("forum_hardware_carre_haut");
+</script></p></div></td></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message cBackCouleurTab2"><td class="messCase1" width="180" valign="top" rowspan="1"><a name="t9762063"></a><div class="right"><a href="#t9762063"><img src="http://forum-images.hardware.fr/icones/message/icon1.gif" title="n°9762063" alt="n°9762063" /></a></div><div><b class="s2">Mitch2Pain</b></div></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 16-03-2016&nbsp;à&nbsp;14:33:35&nbsp;&nbsp;<a href="/hfr/profil-163659.htm" target="_blank"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil" alt="profil" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2E2A14C04FC2CB2E2626262226231449C34EC143C02E262C242120242214C143442E2114C04A4C432E2A14C02E2A14C2C341424ACB2E21232214C24F494B4A4C432E20144FCC49CB4FC046422E20144943CC2E2012444FC14EC3484A46C143"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></span></div><div class="spacer">&nbsp;</div></div><div id="para9762063"><p></p><div class="container"><table class="citation"><tr class="none"><td><b class="s1"><a href="/hfr/Hardware/Materiels-problemes-divers/difficilement-actions-demarrage-sujet_999395_1.htm#t9760188" class="Topic">jubjub a écrit :</a></b><br /><br /><p>Quand je débranche mon ordi ( tour ), il ne veut plus s'allumer.<br /></p></td></tr></table></div>&nbsp;<p>Un ordinateur fonctionne avec de l'électricité, donc si tu le débranches, il ne peut plus s'allumer. C'est normal.</p>&nbsp;<div class="container"><table class="citation"><tr class="none"><td><b class="s1"><a href="/hfr/Hardware/Materiels-problemes-divers/difficilement-actions-demarrage-sujet_999395_1.htm#t9760188" class="Topic">jubjub a écrit :</a></b><br /><br /><p>J'appuie plusieurs fois sur le bouton de démarrage, longtemps, avec répétition etc.<br /></p></td></tr></table></div>&nbsp;<p>C'est inutile: pour démarrer il suffit d'appuyer une fois.<br />Le système est bien capable de détecter les appuis long et courts mais ça n'est utile que pour éteindre normalement / provoquer un arrêt forcé ou toute autre action que l'utilisateur aura configuré dans l'OS.<br />Mais pour démarrer il suffit d'appuyer une fois.</p>&nbsp;<div class="container"><table class="citation"><tr class="none"><td><b class="s1"><a href="/hfr/Hardware/Materiels-problemes-divers/difficilement-actions-demarrage-sujet_999395_1.htm#t9760188" class="Topic">jubjub a écrit :</a></b><br /><br /><p>Et un beau jour, une pression sur le bouton et HOP ! &nbsp;il démarre !! ( ?)<br /></p></td></tr></table></div>&nbsp;<p>Sans l'avoir rebranché ? J'en doute. Donc j'en déduis que tu l'as rebranché mais tu ne l'as pas dit. Si tu nous cache certaines de tes actions, c'est très difficile pour nous de diagnostiquer.</p>&nbsp;<div class="container"><table class="citation"><tr class="none"><td><b class="s1"><a href="/hfr/Hardware/Materiels-problemes-divers/difficilement-actions-demarrage-sujet_999395_1.htm#t9760188" class="Topic">jubjub a écrit :</a></b><br /><br /><p><strong>De plus : il garde en mémoire les actions que j'ai fait sur le bouton d'allumage lors de mes tentative !</strong>...</p>&nbsp;<p>Donc il démarre, se re-éteint, windows se lance, windows redémarre, windows se met en veille ETC.<br /></p></td></tr></table></div>&nbsp;<p>Impossible: l'ordinateur ne garde pas en mémoire les actions que tu as menées sur les boutons lorsqu'il était éteint.</p>&nbsp;<p>Ton ordinateur a un problème: au démarrage il a un comportement anormal, mais je t'assure que ce n'est pas lié aux actions précédentes sur le bouton.</p>&nbsp;<div class="container"><table class="citation"><tr class="none"><td><b class="s1"><a href="/hfr/Hardware/Materiels-problemes-divers/difficilement-actions-demarrage-sujet_999395_1.htm#t9760188" class="Topic">jubjub a écrit :</a></b><br /><br /><p>Là j''ai dû le débrancher... Et impossible de le rallumer... <br /></p></td></tr></table></div>&nbsp;<p>Un ordinateur fonctionne avec de l'électricité, donc si tu le débranches, il ne peut plus s'allumer. C'est normal.</p>&nbsp;&nbsp;&nbsp;<p><br />Pour trouver une solution, il faut d'abord comprendre le problème.<br />Je te propose de débrancher ton PC, attendre 10 secondes, rebrancher, et appuyer sur le bouton.<br />Ne touche plus à rien et décris-nous ce qu'il se passe.<div style="clear: both;"> </div></p><div class="edited"><br />Message édité par Mitch2Pain le 16-03-2016&nbsp;à&nbsp;14:35:19</div><br /><span class="signature"> ---------------
+			<br />Toutes les 7 secondes un soldat allemand meurt en Russie. Stalingrad, fosse commune.<br /><div style="clear: both;"> </div></span></div></td></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message cBackCouleurTab1"><td class="messCase1" width="180" valign="top" rowspan="1"><a name="t9762116"></a><div class="right"><a href="#t9762116"><img src="http://forum-images.hardware.fr/icones/message/icon1.gif" title="n°9762116" alt="n°9762116" /></a></div><div><b class="s2">fafarex</b></div><span class="MoodStatus">pseudo steam: SHAD</span></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 16-03-2016&nbsp;à&nbsp;15:11:21&nbsp;&nbsp;<a href="/hfr/profil-780119.htm" target="_blank"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil" alt="profil" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2E2A14C04FC2CB2E2626262226231449C34EC143C02E262C24212A2A2414C143442E2214C04A4C432E2A14C02E2A14C2C341424ACB2E21232214C24F494B4A4C432E20144FCC49CB4FC046422E20144943CC2E2012444FC14EC3484A46C143"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></span></div><div class="spacer">&nbsp;</div></div><div id="para9762116"><p>Je parie pour un bouton défectueux vu la description,<br />le genre à moitié collé par du sucre de soda ou whatever.<div style="clear: both;"> </div></p><div class="edited"><a href="/forum2.php?config=hfr.inc&amp;cat=1&amp;subcat=253&amp;post=999395&amp;page=1&amp;p=1&amp;sondage=&amp;owntopic=&amp;trash=&amp;trash_post=&amp;print=&amp;numreponse=9762116&amp;quote_only=1&amp;new=0&amp;nojs=0" class="cLink" rel="nofollow">Message cité 2 fois</a><br />Message édité par fafarex le 16-03-2016&nbsp;à&nbsp;15:43:43</div><br /><span class="signature"> ---------------
+			<br />SteamID: fafarex &nbsp;<br /><div style="clear: both;"> </div></span></div></td></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message cBackCouleurTab2"><td class="messCase1" width="180" valign="top" rowspan="1"><a name="t9762123"></a><div class="right"><a href="#t9762123"><img src="http://forum-images.hardware.fr/icones/message/icon1.gif" title="n°9762123" alt="n°9762123" /></a></div><div><b class="s2">giHefca</b></div><span class="MoodStatus">occupé à ne rien faire</span></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 16-03-2016&nbsp;à&nbsp;15:18:56&nbsp;&nbsp;<a href="/hfr/profil-189681.htm" target="_blank"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil" alt="profil" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2E2A14C04FC2CB2E2626262226231449C34EC143C02E262C24212A212214C143442E2B14C04A4C432E2A14C02E2A14C2C341424ACB2E21232214C24F494B4A4C432E20144FCC49CB4FC046422E20144943CC2E2012444FC14EC3484A46C143"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></span></div><div class="spacer">&nbsp;</div></div><div id="para9762123"><p></p><div class="container"><table class="citation"><tr class="none"><td><b class="s1"><a href="/hfr/Hardware/Materiels-problemes-divers/difficilement-actions-demarrage-sujet_999395_1.htm#t9762116" class="Topic">fafarex a écrit :</a></b><br /><br /><p>Je paris pour un bouton défectueux vu la description,
+    <br />le genre à moitié collé par du sucre de soda ou <strong>whatever</strong>.<br /></p></td></tr></table></div><p>
+    <br />du jus de ju(b)jube ?<div style="clear: both;"> </div></p></div></td></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message cBackCouleurTab1"><td class="messCase1" width="180" valign="top" rowspan="1"><a name="t9762139"></a><div class="right"><a href="#t9762139"><img src="http://forum-images.hardware.fr/icones/message/icon1.gif" title="n°9762139" alt="n°9762139" /></a></div><div><b class="s2">clads92</b></div><span class="MoodStatus">HFR10 User :)</span></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 16-03-2016&nbsp;à&nbsp;15:29:15&nbsp;&nbsp;<a href="/hfr/profil-728638.htm" target="_blank"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil" alt="profil" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2E2A14C04FC2CB2E2626262226231449C34EC143C02E262C24212A222614C143442E2314C04A4C432E2A14C02E2A14C2C341424ACB2E21232214C24F494B4A4C432E20144FCC49CB4FC046422E20144943CC2E2012444FC14EC3484A46C143"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></span></div><div class="spacer">&nbsp;</div></div><div id="para9762139"><p></p><div class="container"><table class="citation"><tr class="none"><td><b class="s1"><a href="/hfr/Hardware/Materiels-problemes-divers/difficilement-actions-demarrage-sujet_999395_1.htm#t9762116" class="Topic">fafarex a écrit :</a></b><br /><br /><p>Je paris pour un bouton défectueux vu la description,
+    <br />le genre à moitié collé par du sucre de soda ou whatever.<br /></p></td></tr></table></div><p>
+    <br />&nbsp;<br />1 piece sur fafarex &nbsp;<img src="http://forum-images.hardware.fr/images/perso/5/nekromanttik.gif" alt="[:nekromanttik:5]" title="[:nekromanttik:5]" />, ou peut être un probleme au niveau boitier/pin carte mere, je faisait ça au lycée, j'inversait les power et reste et led HDD sur les pin front panel
+    <br /><img src="http://www.choixpc.com/m_connectique4.jpg" alt="http://www.choixpc.com/m_connectique4.jpg" title="http://www.choixpc.com/m_connectique4.jpg" onload="md_verif_size(this,'Cliquez pour agrandir','2','250')" style="margin: 5px"/><div style="clear: both;"> </div></p><br /><span class="signature"> ---------------
+			<br />Vends <a rel="nofollow" href="http://tinyurl.com/jk6szrf" target="_blank" class="cLink">Jeux Videos</a> | <a rel="nofollow" href="http://www.speedtest.net/result/4515632868.png" target="_blank" class="cLink">Speedtest</a> ~ <a rel="nofollow" href="http://tinyurl.com/gpfho5v" target="_blank" class="cLink">Collec</a><br /><div style="clear: both;"> </div></span></div></td></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message cBackCouleurTab2"><td class="messCase1" width="180" valign="top" rowspan="1"><a name="t9762789"></a><div class="right"><a href="#t9762789"><img src="http://forum-images.hardware.fr/icones/message/icon1.gif" title="n°9762789" alt="n°9762789" /></a></div><div><b class="s2">jubjub</b></div><span class="MoodStatus">jubjub</span></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 17-03-2016&nbsp;à&nbsp;11:58:05&nbsp;&nbsp;<a href="/hfr/profil-212685.htm" target="_blank"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil" alt="profil" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2E2A14C04FC2CB2E2626262226231449C34EC143C02E262C24212C252614C143442E2414C04A4C432E2A14C02E2A14C2C341424ACB2E21232214C24F494B4A4C432E20144FCC49CB4FC046422E20144943CC2E2012444FC14EC3484A46C143"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></span></div><div class="spacer">&nbsp;</div></div><div id="para9762789"><p></p><div class="container"><table class="quote"><tr class="none"><td><b class="s1">Citation :</b><br /><br /><p>Un ordinateur fonctionne avec de l'électricité, donc si tu le débranches, il ne peut plus s'allumer. C'est normal.<br /></p></td></tr></table></div><p>
+    <br />&nbsp;<br />heu oui biensur ! j'aurais peut etre dû préciser : quand coupe la multiprise, ( apres avoir éteint l'ordi biensur ) et que je la rallume, l'ordi ne démarre plus.
+    <br /></p><div class="container"><table class="quote"><tr class="none"><td><b class="s1">Citation :</b><br /><br /><p>
+    <br />Là j'ai dû le débrancher... Et impossible de le rallumer... <br /></p></td></tr></table></div><p>
+    <br />&nbsp;<br />J'ai dû couper le jus. Apres avoir rebranché le cable d'alim, il ne s'allume plus
+    <br /></p><div class="container"><table class="quote"><tr class="none"><td><b class="s1">Citation :</b><br /><br /><p>
+    <br />&nbsp;Je te propose de débrancher ton PC, attendre 10 secondes, rebrancher, et appuyer sur le bouton.<br /></p></td></tr></table></div><p>
+    <br />Il ne se passe rien. J'ai enlevé la pile de la carte mère plusieurs secondes aussi. Rien.
+    <br />&nbsp;<br />Je pense acheter une nouvelle alim en esperant que la carte mère ne soit pas la cause du probleme<div style="clear: both;"> </div></p><div class="edited"><br />Message édité par jubjub le 17-03-2016&nbsp;à&nbsp;11:59:10</div></div></td></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message cBackCouleurTab1"><td class="messCase1" width="180" valign="top" rowspan="1"><a name="t9762793"></a><div class="right"><a href="#t9762793"><img src="http://forum-images.hardware.fr/icones/message/icon1.gif" title="n°9762793" alt="n°9762793" /></a></div><div><b class="s2">fafarex</b></div><span class="MoodStatus">pseudo steam: SHAD</span></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 17-03-2016&nbsp;à&nbsp;12:01:45&nbsp;&nbsp;<a href="/hfr/profil-780119.htm" target="_blank"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil" alt="profil" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2E2A14C04FC2CB2E2626262226231449C34EC143C02E262C24212C262214C143442E2C14C04A4C432E2A14C02E2A14C2C341424ACB2E21232214C24F494B4A4C432E20144FCC49CB4FC046422E20144943CC2E2012444FC14EC3484A46C143"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></span></div><div class="spacer">&nbsp;</div></div><div id="para9762793"><p>N'achete pas d'alim,
+    <br />&nbsp;<br /></p><div class="container"><table class="quote"><tr class="none"><td><b class="s1">Citation :</b><br /><br /><p>De plus : il garde en mémoire les actions que j'ai fait sur le bouton d'allumage lors de mes tentative !... &nbsp;<br />&nbsp;
+    <br />Donc il démarre, se re-éteint, windows se lance, windows redémarre, windows se met en veille ETC. &nbsp;<br />&nbsp;<br /></p></td></tr></table></div><p>
+    <br />&nbsp;<br />ça exclue l'alim globalement, c'est soit un court circuit quelque part ( probablement sur le bouton d'allumage) soit sur la CM ( ça peut être un débris métallique quelconque qui touche le mauvais endroit, mais l'alim ne déclencherais pas un reboot ou une veille.)<div style="clear: both;"> </div></p><br /><span class="signature"> ---------------
+			<br />SteamID: fafarex &nbsp;<br /><div style="clear: both;"> </div></span></div></td></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message cBackCouleurTab2"><td class="messCase1" width="180" valign="top" rowspan="1"><a name="t9762808"></a><div class="right"><a href="#t9762808"><img src="http://forum-images.hardware.fr/icones/message/icon1.gif" title="n°9762808" alt="n°9762808" /></a></div><div><b class="s2">jubjub</b></div><span class="MoodStatus">jubjub</span></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 17-03-2016&nbsp;à&nbsp;12:23:28&nbsp;&nbsp;<a href="/hfr/profil-212685.htm" target="_blank"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil" alt="profil" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2E2A14C04FC2CB2E2626262226231449C34EC143C02E262C242125202514C143442E2514C04A4C432E2A14C02E2A14C2C341424ACB2E21232214C24F494B4A4C432E20144FCC49CB4FC046422E20144943CC2E2012444FC14EC3484A46C143"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></span></div><div class="spacer">&nbsp;</div></div><div id="para9762808"><p>Ok merci pour ce sonseil <img src="http://forum-images.hardware.fr/icones/smile.gif" alt=":)" title=":)" />
+    <br />&nbsp;<br />JE PRECISE : si je mets l'ordi <strong>en veille</strong>, ou que j'arrête windows, il démarre à tous le coups après pression sur le bouton d'allumage.
+    <br />Il ne démarre plus QUE apres coupure du jus ( bouton off sur multiprise par ex ) ( et je reprécise, j'essaie de la rallumer avec la multiprise sur ON, évidemment...)<div style="clear: both;"> </div></p><div class="edited"><a href="/forum2.php?config=hfr.inc&amp;cat=1&amp;subcat=253&amp;post=999395&amp;page=1&amp;p=1&amp;sondage=&amp;owntopic=&amp;trash=&amp;trash_post=&amp;print=&amp;numreponse=9762808&amp;quote_only=1&amp;new=0&amp;nojs=0" class="cLink" rel="nofollow">Message cité 2 fois</a><br />Message édité par jubjub le 17-03-2016&nbsp;à&nbsp;12:24:20</div></div></td></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message cBackCouleurTab1"><td class="messCase1" width="180" valign="top" rowspan="1"><a name="t9762810"></a><div class="right"><a href="#t9762810"><img src="http://forum-images.hardware.fr/icones/message/icon1.gif" title="n°9762810" alt="n°9762810" /></a></div><div><b class="s2">fafarex</b></div><span class="MoodStatus">pseudo steam: SHAD</span></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 17-03-2016&nbsp;à&nbsp;12:26:10&nbsp;&nbsp;<a href="/hfr/profil-780119.htm" target="_blank"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil" alt="profil" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2E2A14C04FC2CB2E2626262226231449C34EC143C02E262C2421252A2014C143442E2614C04A4C432E2A14C02E2A14C2C341424ACB2E21232214C24F494B4A4C432E20144FCC49CB4FC046422E20144943CC2E2012444FC14EC3484A46C143"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></span></div><div class="spacer">&nbsp;</div></div><div id="para9762810"><p>donc carte mère ou système d'exploitation qui déconne.<div style="clear: both;"> </div></p><br /><span class="signature"> ---------------
+			<br />SteamID: fafarex &nbsp;<br /><div style="clear: both;"> </div></span></div></td></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message cBackCouleurTab2"><td class="messCase1" width="180" valign="top" rowspan="1"><a name="t9762814"></a><div class="right"><a href="#t9762814"><img src="http://forum-images.hardware.fr/icones/message/icon1.gif" title="n°9762814" alt="n°9762814" /></a></div><div><b class="s2">Mitch2Pain</b></div></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 17-03-2016&nbsp;à&nbsp;12:31:12&nbsp;&nbsp;<a href="/hfr/profil-163659.htm" target="_blank"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil" alt="profil" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2E2A14C04FC2CB2E2626262226231449C34EC143C02E262C2421252A2B14C143442E2A2014C04A4C432E2A14C02E2A14C2C341424ACB2E21232214C24F494B4A4C432E20144FCC49CB4FC046422E20144943CC2E2012444FC14EC3484A46C143"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></span></div><div class="spacer">&nbsp;</div></div><div id="para9762814"><p></p><div class="container"><table class="citation"><tr class="none"><td><b class="s1"><a href="/hfr/Hardware/Materiels-problemes-divers/difficilement-actions-demarrage-sujet_999395_1.htm#t9762808" class="Topic">jubjub a écrit :</a></b><br /><br /><p>si [...] j'arrête windows, il démarre à tous le coups après pression sur le bouton d'allumage.<br /></p></td></tr></table></div><p>
+    <br />&nbsp;<br />Oui, c'est comme ça qu'il faut faire. Tout le temps. &nbsp;<img src="http://forum-images.hardware.fr/icones/smilies/sweat.gif" alt=":sweat:" title=":sweat:" /> &nbsp;<br />Tu ne dois jamais couper l'alimentation électrique de ta multiprise &nbsp;alors que le PC est allumé. Ce n'est pas un grille-pain.
+    <br />&nbsp;<br />Du coup problème résolu.<div style="clear: both;"> </div></p><br /><span class="signature"> ---------------
+			<br />Toutes les 7 secondes un soldat allemand meurt en Russie. Stalingrad, fosse commune.<br /><div style="clear: both;"> </div></span></div></td></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message  cBackCouleurTab1"><td class="messCase1" width="180" valign="top" rowspan="1"><div class="right"><img src="http://forum-images.hardware.fr/icones/message/icon1.gif" alt="mood" /></div><div><b class="s2">Publicité</b></div></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 17-03-2016&nbsp;à&nbsp;12:31:12&nbsp;&nbsp;<img src="http://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil (Etat inconnu)" alt="profil" /><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></div><div class="spacer">&nbsp;</div></div><div><p><script type="text/javascript">
+  GA_googleFillSlot("forum_hardware_carre_milieu");
+</script></p></div></td></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message cBackCouleurTab2"><td class="messCase1" width="180" valign="top" rowspan="1"><a name="t9762816"></a><div class="right"><a href="#t9762816"><img src="http://forum-images.hardware.fr/icones/message/icon1.gif" title="n°9762816" alt="n°9762816" /></a></div><div><b class="s2">ascrounch</b></div><span class="MoodStatus">91200</span></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 17-03-2016&nbsp;à&nbsp;12:35:41&nbsp;&nbsp;<a href="/hfr/profil-1098018.htm" target="_blank"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil" alt="profil" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2E2A14C04FC2CB2E2626262226231449C34EC143C02E262C2421252A2414C143442E2A2A14C04A4C432E2A14C02E2A14C2C341424ACB2E21232214C24F494B4A4C432E20144FCC49CB4FC046422E20144943CC2E2012444FC14EC3484A46C143"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></span></div><div class="spacer">&nbsp;</div></div><div id="para9762816"><p>Yo, &nbsp;<br />&nbsp;<br />Pour tester si c'est &nbsp;ton bouton d'allumage ou pas, &nbsp;débranche le sur la carte mère, &nbsp;puis shunt les deux picots avec un tournevis par exemple. &nbsp;<br />&nbsp;<br />Si ca démarre du 1er coup, &nbsp;éteint et recommence 3 ou 4 fois. &nbsp;<br />Si ca fonctionne a chaque fois, &nbsp;tu peut deja te dire que ca viens de là. &nbsp;<br />&nbsp;<br />Si aucun changement, &nbsp;il y a de grandes chance que la carte mère deconne. Ca ne ressemble pas a un problème d'alim.<div style="clear: both;"> </div></p><div class="edited"><br />Message édité par ascrounch le 17-03-2016&nbsp;à&nbsp;12:37:13</div><br /><span class="signature"> ---------------
+			<br /><a rel="nofollow" href="http://www.coolermaster.com/power-supply-calculator/" target="_blank" class="cLink">pour le calcul de l'alimentation c'est ICI</a><br /><div style="clear: both;"> </div></span></div></td></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message cBackCouleurTab1"><td class="messCase1" width="180" valign="top" rowspan="1"><a name="t9762819"></a><div class="right"><a href="#t9762819"><img src="http://forum-images.hardware.fr/icones/message/icon1.gif" title="n°9762819" alt="n°9762819" /></a></div><div><b class="s2">jubjub</b></div><span class="MoodStatus">jubjub</span></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 17-03-2016&nbsp;à&nbsp;12:40:07&nbsp;&nbsp;<a href="/hfr/profil-212685.htm" target="_blank"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil" alt="profil" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2E2A14C04FC2CB2E2626262226231449C34EC143C02E262C2421252A2614C143442E2A2114C04A4C432E2A14C02E2A14C2C341424ACB2E21232214C24F494B4A4C432E20144FCC49CB4FC046422E20144943CC2E2012444FC14EC3484A46C143"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></span></div><div class="spacer">&nbsp;</div></div><div id="para9762819"><p></p><div class="container"><table class="quote"><tr class="none"><td><b class="s1">Citation :</b><br /><br /><p>Tu ne dois jamais couper l'alimentation électrique de ta multiprise &nbsp;alors que le PC est allumé. Ce n'est pas un grille-pain. <br /></p></td></tr></table></div><p>
+    <br />&nbsp;<br />nan mais je dois tout préciser ?! Bien sur que je ne coupe pas l'alimentation de l'ordi alors qu'il est allumé !!!!
+    <br />Je l'éteins avant !! &nbsp;<img src="http://forum-images.hardware.fr/icones/wink.gif" alt=";)" title=";)" /><div style="clear: both;"> </div></p><div class="edited"><br />Message édité par jubjub le 17-03-2016&nbsp;à&nbsp;12:41:39</div></div></td></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message cBackCouleurTab2"><td class="messCase1" width="180" valign="top" rowspan="1"><a name="t9762822"></a><div class="right"><a href="#t9762822"><img src="http://forum-images.hardware.fr/icones/message/icon1.gif" title="n°9762822" alt="n°9762822" /></a></div><div><b class="s2">jubjub</b></div><span class="MoodStatus">jubjub</span></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 17-03-2016&nbsp;à&nbsp;12:41:16&nbsp;&nbsp;<a href="/hfr/profil-212685.htm" target="_blank"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil" alt="profil" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2E2A14C04FC2CB2E2626262226231449C34EC143C02E262C242125212114C143442E2A2214C04A4C432E2A14C02E2A14C2C341424ACB2E21232214C24F494B4A4C432E20144FCC49CB4FC046422E20144943CC2E2012444FC14EC3484A46C143"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></span></div><div class="spacer">&nbsp;</div></div><div id="para9762822"><p>Merci <strong>ascrounch</strong> très bonne idée !! Je fais ça ce soir <img src="http://forum-images.hardware.fr/icones/biggrin.gif" alt=":D" title=":D" /> <div style="clear: both;"> </div></p></div></td></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message cBackCouleurTab1"><td class="messCase1" width="180" valign="top" rowspan="1"><a name="t9763604"></a><a name="bas"></a><div class="right"><a href="#t9763604"><img src="http://forum-images.hardware.fr/icones/message/icon1.gif" title="n°9763604" alt="n°9763604" /></a></div><div><b class="s2">Mitch2Pain</b></div></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 18-03-2016&nbsp;à&nbsp;15:17:28&nbsp;&nbsp;<a href="/hfr/profil-163659.htm" target="_blank"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil" alt="profil" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2E2A14C04FC2CB2E2626262226231449C34EC143C02E262C242224202B14C143442E2A2B14C04A4C432E2A14C02E2A14C2C341424ACB2E21232214C24F494B4A4C432E20144FCC49CB4FC046422E20144943CC2E2012444FC14EC3484A46C143"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></span></div><div class="spacer">&nbsp;</div></div><div id="para9763604"><p></p><div class="container"><table class="citation"><tr class="none"><td><b class="s1"><a href="/hfr/Hardware/Materiels-problemes-divers/difficilement-actions-demarrage-sujet_999395_1.htm#t9762808" class="Topic">jubjub a écrit :</a></b><br /><br /><p>Il ne démarre plus QUE apres coupure du jus ( bouton off sur multiprise par ex ) ( et je reprécise, j'essaie de la rallumer avec la multiprise sur ON, évidemment...)<br /></p></td></tr></table></div><p>
+    <br />&nbsp;<br />Et si tu le branche directement à la prise ?
+    <br />&nbsp;<br /><div style="clear: both;"> </div></p><br /><span class="signature"> ---------------
+			<br />Toutes les 7 secondes un soldat allemand meurt en Russie. Stalingrad, fosse commune.<br /><div style="clear: both;"> </div></span></div></td></tr></table><br /><script language="javascript" type="text/javascript">var listenumreponse=new Array("9760188","9762063","9762116","9762123","9762139","9762789","9762793","9762808","9762810","9762814","9762816","9762819","9762822","9763604")</script><form action="/forum1.php" method="get" id="goto"><input type="hidden" name="hash_check" value="REDACTED" />
+    <div class="nombres">
+        <b>Aller à : </b>
+        <input type="hidden" name="config" value="hfr.inc" />
+        <select name="cat" onchange="document.getElementById('goto').submit()"><option value="1" selected="selected">Hardware</option><option value="16" >Hardware - Périphériques</option><option value="15" >Ordinateurs portables</option><option value="2" >Overclocking, Cooling &amp; Modding</option><option value="30" >Electronique, domotique, DIY</option><option value="23" >Technologies Mobiles</option><option value="25" >Apple</option><option value="3" >Video &amp; Son</option><option value="14" >Photo numérique</option><option value="5" >Jeux Video</option><option value="4" >Windows &amp; Software</option><option value="22" >Réseaux grand public / SoHo</option><option value="21" >Systèmes &amp; Réseaux Pro</option><option value="11" >Linux et OS Alternatifs</option><option value="10" >Programmation</option><option value="12" >Graphisme</option><option value="6" >Achats &amp; Ventes</option><option value="8" >Emploi &amp; Etudes</option><option value="9" >Seti et projets distribués</option><option value="13" >Discussions</option><option value="prive">Messages privés</option></select>
+        <input type="submit" value="Go" />
+    </div></form><div class="left"><a rel="nofollow" href="/message.php?config=hfr.inc&amp;cat=1&amp;post=999395&amp;page=1&amp;p=1&amp;subcat=253&amp;sondage=0&amp;owntopic=0&amp;new=0" accesskey="r"><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/repondre.gif" title="Ajouter une réponse" alt="Ajouter une réponse" /></a></div><div class="arbo" style="margin:0px 0px 0px 20px;" id="md_arbo_bottom">
+    <span  id="md_arbo_tree_b_1" ><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/" class="Ext">FORUM HardWare.fr</a></span>
+    <br />
+    <span  id="md_arbo_tree_b_2" ><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/tline.gif" alt="" /><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/hfr/Hardware/liste_sujet-1.htm" class="Ext">Hardware</a></span>
+    <br />
+    <span  id="md_arbo_tree_b_3" ><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/tline3.gif" alt="" /><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/hfr/Hardware/Materiels-problemes-divers/liste_sujet-1.htm" class="Ext">Matériels &amp; problèmes divers</a></span>
+    <br />
+    <h1  id="md_arbo_tree_b_4" ><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/tline4.gif" alt="" /><img src="http://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;S'allume difficilement et garde les actions du bouton de démarrage!</h1>
+</div><div class="spacer">&nbsp;</div><br />
+    <table class="main" id="sujetrelatif" cellspacing="0" cellpadding="3">
+        <tr class="cBackHeader"><th scope="colgroup" colspan="2">Sujets relatifs</th></tr><tr class="cBackTab1 s2"><td><a class="cLink" href="/hfr/Hardware/Alimentation/nouvelle-allume-resolu-sujet_999384_1.htm">Nouvelle alim, PC qui ne s'allume pas [résolu, pb de câble]</a></td><td><a class="cLink" href="/hfr/Hardware/Materiels-problemes-divers/allume-affichage-windows-sujet_999317_1.htm">[Résolu] Écran All-in-one allumé mais pas d'affichage windows</a></td></tr><tr class="cBackTab1 s2"><td><a class="cLink" href="/hfr/Hardware/Materiels-problemes-divers/pc-allume-sujet_999312_1.htm">PC qui ne s'allume plus, mais ...</a></td><td><a class="cLink" href="/hfr/Hardware/conseilsachats/aidez-config-plait-sujet_999150_1.htm">Aidez moi a faire une config S'il vous Plaît</a></td></tr><tr class="cBackTab1 s2"><td><a class="cLink" href="/hfr/Hardware/Materiels-problemes-divers/problemes-affichage-saute-sujet_999077_1.htm">Problémes d'affichage qui saute :S</a></td><td><a class="cLink" href="/hfr/Hardware/Materiels-problemes-divers/pc-allume-boot-sujet_999054_1.htm">Mon PC s'allume mais ne boot pas</a></td></tr><tr class="cBackTab1 s2"><td><a class="cLink" href="/hfr/Hardware/Materiels-problemes-divers/machine-allume-boot-sujet_999012_1.htm">Machine s'allume mais ne boot pas</a></td><td><a class="cLink" href="/hfr/Hardware/Materiels-problemes-divers/resolu-maximus-formula-sujet_998687_1.htm">[Résolu]Maximus VIII Formula H.S ?</a></td></tr><tr class="cBackTab1 s2"><td><a class="cLink" href="/hfr/Hardware/carte-mere/demarre-clavier-allume-sujet_998672_1.htm">PC démarre, mais ni souris ni ecran ni clavier allumé...</a></td><td><a class="cLink" href="/hfr/Hardware/Materiels-problemes-divers/logitech-master-bouton-sujet_998416_1.htm">Logitech MX Master - Bouton Prec. Suiv avec Excel</a></td></tr><tr class="cBackTab2 s1"><th colspan="2"><span class="cLink"><span class="md_noclass_cryptlink1F4544C11FB54AC14BCC4AC1431FC2C34D43CB1EC143484ACB46441E2626262226231945CB4E">Plus de sujets relatifs à : S'allume difficilement et garde les actions du bouton de démarrage!</span></span></th></tr></table><br />
+    <div class="copyright">
+        <a href="http://www.mesdiscussions.net" target="_blank" class="copyright">Forum MesDiscussions.Net</a>, Version 2010.2 <br />(c) 2000-2011 Doctissimo<br /><div class='gene'>Page générée en  0.091 secondes</div></div></div></div>
+<center>
+    <script type="text/javascript">
+var cw_catcheck = window.location.pathname.substring(window.location.pathname.lastIndexOf('/') );
+if (cw_catcheck.indexOf("/liste_sujet") !== 0 && cw_catcheck.indexOf("/forum1") !== 0)
+{
+	$(".messagetable:not(:contains('Publicité'))").addClass('p402_hide');
+	try { _402_Show(); } catch(e) {}
+}
+</script>
+    <script type="text/javascript">
+/*Widget_HFR*/
+var u;if(u === window.twWidgets){twWidgets = [];}var id="twWidgets".concat(twWidgets.length); document.write('<iframe allowtransparency="true" frameborder="0" ' . concat('id=', id, ' src="http://fr.primary.affinitad.com?f=1010x227&ck=5107ed15bd171"', ' height="227"', ' width="1010">', '</iframe>')); twWidgets.push({id:"5107ed15bd171", div:id});
+</script></center>
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-174007-1', 'auto');
+  ga('send', 'pageview');
+
+</script><center><br /><a href="http://www.xiti.com/xiti.asp?s=28067" target="_top">
+    <script language="JavaScript1.1" type="text/javascript">
+<!--
+Xt_param = 's=28067&p=forum';
+Xt_r = document.referrer;
+Xt_h = new Date();
+Xt_i = '<img width="39" height="25" border="0" ';
+Xt_i += 'src="http://logv5.xiti.com/hit.xiti?'+Xt_param;
+Xt_i += '&hl='+Xt_h.getHours()+'x'+Xt_h.getMinutes()+'x'+Xt_h.getSeconds();
+if(parseFloat(navigator.appVersion)>=4)
+{Xt_s=screen;Xt_i+='&r='+Xt_s.width+'x'+Xt_s.height+'x'+Xt_s.pixelDepth+'x'+Xt_s.colorDepth;}
+document.write(Xt_i+'&ref='+Xt_r.replace(/[<>"]/g, '').replace(/&/g, '$')+'" title="Analyse d\'audience">');
+//-->
+</script></a>
+    <noscript><a href="http://www.xiti.com/xiti.asp?s=28067" target="_top">
+        analyse mesure frequentation internet par <img width="39" height="25" border="0" src="http://logv5.xiti.com/hit.xiti?s=28067&amp;p=forum" alt="Analyse d'audience" /></a>
+    </noscript>
+    <font color="#000000" size="1" face="Arial, Helvetica, sans-serif"><br />Copyright © 1997-2016 <a href="http://www.hardware.fr">Hardware.fr SARL</a> (<a href="http://www.hardware.fr/html/a_propos/">Signaler un contenu illicite</a>) / Groupe <a href="http://www.ldlc.com" title="Achat de materiel Informatique">LDLC</a></font></center>
+
+<script type="text/javascript">
+var affilizr_cid = "3j816asd";
+var affilizr_wsid = 1;
+var affilizr_words = true;
+</script>
+<script src="http://script.affilizr.com/js/affilizr.js" type="text/javascript"></script>
+
+<script>var noskimwords = 'true';</script>
+<script type="text/javascript" src="http://s.skimresources.com/js/20737X784658.skimlinks.js"></script>
+<script type="text/javascript">
+if(!navigator.userAgent.match(/MSIE/i) || navigator.userAgent.match(/IEMobile/i) || navigator.userAgent.match(/ZuneWP7/i))
+window.onload= new function(){checkClient();};
+</script><script type="text/javascript">
+md_forum_decryptlink.init();
+</script>
+<script type="text/javascript">
+md_forum_decryptlink.init();
+</script>
+</body></html>

--- a/core/data/src/test/resources/fixtures/topic_page_single.source.txt
+++ b/core/data/src/test/resources/fixtures/topic_page_single.source.txt
@@ -1,0 +1,7 @@
+Source: forum.hardware.fr (fixture publique reprise de ForumHFR/Redface)
+Original fixture: app/src/test/resources/hfr_single_page_topic.html
+Captured page: forum2.php?config=hfr.inc&cat=1&post=999395&page=1
+Notes: single-page topic fixture, hash_check sanitized for redface2
+Duplicated from: core/parser/src/test/resources/fixtures/topic_page_single.html
+  → kept until :core:parser exposes a java-test-fixtures source set
+  (deferred per AGENTS.md anti-over-engineering rules in Phase 1A).

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -1,11 +1,24 @@
 plugins {
     id("redface.android.library")
+    id("redface.android.hilt.library")
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
     namespace = "fr.forumhfr.redface2.core.database"
 }
 
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
+}
+
 dependencies {
-    implementation(project(":core:model"))
+    api(project(":core:model"))
+
+    api(libs.room.runtime)
+    api(libs.room.ktx)
+    ksp(libs.room.compiler)
+
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.serialization.json)
 }

--- a/core/database/schemas/fr.forumhfr.redface2.core.database.RedfaceDatabase/1.json
+++ b/core/database/schemas/fr.forumhfr.redface2.core.database.RedfaceDatabase/1.json
@@ -1,0 +1,175 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "be478c2c14d3d336f1f6ec2e600dbd54",
+    "entities": [
+      {
+        "tableName": "topic_pages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cat` INTEGER NOT NULL, `post` INTEGER NOT NULL, `page` INTEGER NOT NULL, `title` TEXT NOT NULL, `totalPages` INTEGER NOT NULL, `isFirstPostOwner` INTEGER NOT NULL, `pollJson` TEXT, `numreponses` TEXT NOT NULL, `fetchedAt` INTEGER NOT NULL, PRIMARY KEY(`cat`, `post`, `page`))",
+        "fields": [
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "post",
+            "columnName": "post",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPages",
+            "columnName": "totalPages",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFirstPostOwner",
+            "columnName": "isFirstPostOwner",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pollJson",
+            "columnName": "pollJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "numreponses",
+            "columnName": "numreponses",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cat",
+            "post",
+            "page"
+          ]
+        }
+      },
+      {
+        "tableName": "posts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cat` INTEGER NOT NULL, `numreponse` INTEGER NOT NULL, `post` INTEGER NOT NULL, `author` TEXT NOT NULL, `date` INTEGER NOT NULL, `content` TEXT NOT NULL, `avatarUrl` TEXT, `isEditable` INTEGER NOT NULL, `isOwnPost` INTEGER NOT NULL, `quotedAuthors` TEXT NOT NULL, `postIndex` INTEGER, `fetchedAt` INTEGER NOT NULL, PRIMARY KEY(`cat`, `numreponse`))",
+        "fields": [
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numreponse",
+            "columnName": "numreponse",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "post",
+            "columnName": "post",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isEditable",
+            "columnName": "isEditable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOwnPost",
+            "columnName": "isOwnPost",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quotedAuthors",
+            "columnName": "quotedAuthors",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postIndex",
+            "columnName": "postIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cat",
+            "numreponse"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_posts_cat_post",
+            "unique": false,
+            "columnNames": [
+              "cat",
+              "post"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_posts_cat_post` ON `${TABLE_NAME}` (`cat`, `post`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'be478c2c14d3d336f1f6ec2e600dbd54')"
+    ]
+  }
+}

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/RedfaceDatabase.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/RedfaceDatabase.kt
@@ -1,0 +1,23 @@
+package fr.forumhfr.redface2.core.database
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import fr.forumhfr.redface2.core.database.converters.Converters
+import fr.forumhfr.redface2.core.database.dao.TopicDao
+import fr.forumhfr.redface2.core.database.entities.PostEntity
+import fr.forumhfr.redface2.core.database.entities.TopicEntity
+
+@Database(
+    entities = [TopicEntity::class, PostEntity::class],
+    version = 1,
+    exportSchema = true,
+)
+@TypeConverters(Converters::class)
+abstract class RedfaceDatabase : RoomDatabase() {
+    abstract fun topicDao(): TopicDao
+
+    companion object {
+        const val DATABASE_NAME: String = "redface.db"
+    }
+}

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/converters/Converters.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/converters/Converters.kt
@@ -1,0 +1,54 @@
+package fr.forumhfr.redface2.core.database.converters
+
+import androidx.room.TypeConverter
+import fr.forumhfr.redface2.core.database.serialization.PostContentSerializer
+import fr.forumhfr.redface2.core.model.PostContent
+import java.time.Instant
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+
+internal object Converters {
+    private val json: Json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+    private val intListSerializer = ListSerializer(Int.serializer())
+    private val stringListSerializer = ListSerializer(String.serializer())
+
+    @TypeConverter
+    @JvmStatic
+    fun instantToEpochMillis(value: Instant?): Long? = value?.toEpochMilli()
+
+    @TypeConverter
+    @JvmStatic
+    fun instantFromEpochMillis(value: Long?): Instant? = value?.let(Instant::ofEpochMilli)
+
+    @TypeConverter
+    @JvmStatic
+    fun intListToJson(value: List<Int>): String = json.encodeToString(intListSerializer, value)
+
+    @TypeConverter
+    @JvmStatic
+    fun intListFromJson(value: String): List<Int> = json.decodeFromString(intListSerializer, value)
+
+    @TypeConverter
+    @JvmStatic
+    fun stringListToJson(value: List<String>): String =
+        json.encodeToString(stringListSerializer, value)
+
+    @TypeConverter
+    @JvmStatic
+    fun stringListFromJson(value: String): List<String> =
+        json.decodeFromString(stringListSerializer, value)
+
+    @TypeConverter
+    @JvmStatic
+    fun postContentToJson(value: PostContent): String =
+        PostContentSerializer.encode(value)
+
+    @TypeConverter
+    @JvmStatic
+    fun postContentFromJson(value: String): PostContent =
+        PostContentSerializer.decode(value)
+}

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/dao/TopicDao.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/dao/TopicDao.kt
@@ -1,0 +1,29 @@
+package fr.forumhfr.redface2.core.database.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Upsert
+import fr.forumhfr.redface2.core.database.entities.PostEntity
+import fr.forumhfr.redface2.core.database.entities.TopicEntity
+
+@Dao
+interface TopicDao {
+    @Query("SELECT * FROM topic_pages WHERE cat = :cat AND post = :post AND page = :page LIMIT 1")
+    suspend fun getTopicPage(cat: Int, post: Int, page: Int): TopicEntity?
+
+    @Query("SELECT * FROM posts WHERE cat = :cat AND numreponse IN (:numreponses)")
+    suspend fun getPostsByNumreponse(cat: Int, numreponses: List<Int>): List<PostEntity>
+
+    @Upsert
+    suspend fun upsertTopicPage(topic: TopicEntity)
+
+    @Upsert
+    suspend fun upsertPosts(posts: List<PostEntity>)
+
+    @Transaction
+    suspend fun upsertTopicPageWithPosts(topic: TopicEntity, posts: List<PostEntity>) {
+        upsertTopicPage(topic)
+        upsertPosts(posts)
+    }
+}

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/di/DatabaseModule.kt
@@ -1,0 +1,29 @@
+package fr.forumhfr.redface2.core.database.di
+
+import android.content.Context
+import androidx.room.Room
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import fr.forumhfr.redface2.core.database.RedfaceDatabase
+import fr.forumhfr.redface2.core.database.dao.TopicDao
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+    @Provides
+    @Singleton
+    fun provideRedfaceDatabase(
+        @ApplicationContext context: Context,
+    ): RedfaceDatabase = Room.databaseBuilder(
+        context,
+        RedfaceDatabase::class.java,
+        RedfaceDatabase.DATABASE_NAME,
+    ).build()
+
+    @Provides
+    fun provideTopicDao(database: RedfaceDatabase): TopicDao = database.topicDao()
+}

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/entities/PostEntity.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/entities/PostEntity.kt
@@ -1,0 +1,26 @@
+package fr.forumhfr.redface2.core.database.entities
+
+import androidx.room.Entity
+import androidx.room.Index
+import fr.forumhfr.redface2.core.model.PostContent
+import java.time.Instant
+
+@Entity(
+    tableName = "posts",
+    primaryKeys = ["cat", "numreponse"],
+    indices = [Index(value = ["cat", "post"])],
+)
+data class PostEntity(
+    val cat: Int,
+    val numreponse: Int,
+    val post: Int,
+    val author: String,
+    val date: Instant,
+    val content: PostContent,
+    val avatarUrl: String?,
+    val isEditable: Boolean,
+    val isOwnPost: Boolean,
+    val quotedAuthors: List<String>,
+    val postIndex: Int?,
+    val fetchedAt: Instant,
+)

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/entities/TopicEntity.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/entities/TopicEntity.kt
@@ -1,0 +1,20 @@
+package fr.forumhfr.redface2.core.database.entities
+
+import androidx.room.Entity
+import java.time.Instant
+
+@Entity(
+    tableName = "topic_pages",
+    primaryKeys = ["cat", "post", "page"],
+)
+data class TopicEntity(
+    val cat: Int,
+    val post: Int,
+    val page: Int,
+    val title: String,
+    val totalPages: Int,
+    val isFirstPostOwner: Boolean,
+    val pollJson: String?,
+    val numreponses: List<Int>,
+    val fetchedAt: Instant,
+)

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/serialization/PostContentSerializer.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/serialization/PostContentSerializer.kt
@@ -1,0 +1,16 @@
+package fr.forumhfr.redface2.core.database.serialization
+
+import fr.forumhfr.redface2.core.model.PostContent
+import kotlinx.serialization.json.Json
+
+internal object PostContentSerializer {
+    private val json: Json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+        classDiscriminator = "type"
+    }
+
+    fun encode(value: PostContent): String = json.encodeToString(PostContent.serializer(), value)
+
+    fun decode(value: String): PostContent = json.decodeFromString(PostContent.serializer(), value)
+}

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -5,4 +5,5 @@ plugins {
 dependencies {
     api(project(":core:model"))
     api(libs.javax.inject)
+    api(libs.kotlinx.coroutines.core)
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/topic/TopicRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/topic/TopicRepository.kt
@@ -1,0 +1,16 @@
+package fr.forumhfr.redface2.core.domain.topic
+
+import fr.forumhfr.redface2.core.model.Topic
+import kotlinx.coroutines.flow.Flow
+
+interface TopicRepository {
+    /**
+     * Emits the cached page first if available, then a fresh copy fetched from HFR. The
+     * second emission may be the same instance as the first if the cache and the network
+     * agree. Errors during the network refresh are surfaced as exceptions on the flow.
+     */
+    fun observeTopicPage(cat: Int, post: Int, page: Int): Flow<Topic>
+
+    /** Forces a network fetch and caches the result, ignoring any existing cache. */
+    suspend fun refreshTopicPage(cat: Int, post: Int, page: Int): Topic
+}

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -1,3 +1,8 @@
 plugins {
     id("redface.kotlin.jvm.library")
+    alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+    api(libs.kotlinx.serialization.core)
 }

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/PostContent.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/PostContent.kt
@@ -1,12 +1,18 @@
 package fr.forumhfr.redface2.core.model
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class PostContent(
     val blocks: List<PostBlock>,
 )
 
+@Serializable
 sealed interface PostBlock {
+    @Serializable
     data class Paragraph(val inlines: List<PostInline>) : PostBlock
 
+    @Serializable
     data class Quote(
         val author: String?,
         val numreponse: Int?,
@@ -14,35 +20,51 @@ sealed interface PostBlock {
         val content: PostContent,
     ) : PostBlock
 
+    @Serializable
     data class Spoiler(val label: String?, val content: PostContent) : PostBlock
 
+    @Serializable
     data class Image(val url: String, val description: String?) : PostBlock
 }
 
+@Serializable
 sealed interface PostInline {
+    @Serializable
     data class Text(val value: String) : PostInline
 
+    @Serializable
     data object LineBreak : PostInline
 
+    @Serializable
     data class Strong(val children: List<PostInline>) : PostInline
 
+    @Serializable
     data class Emphasis(val children: List<PostInline>) : PostInline
 
+    @Serializable
     data class Underline(val children: List<PostInline>) : PostInline
 
+    @Serializable
     data class Strike(val children: List<PostInline>) : PostInline
 
+    @Serializable
     data class Color(val colorHex: String, val children: List<PostInline>) : PostInline
 
+    @Serializable
     data class Link(val url: String, val children: List<PostInline>) : PostInline
 
+    @Serializable
     data class InlineImage(val url: String, val description: String?) : PostInline
 
+    @Serializable
     data class Smiley(val kind: SmileyKind, val imageUrl: String?) : PostInline
 }
 
+@Serializable
 sealed interface SmileyKind {
+    @Serializable
     data class Builtin(val code: String) : SmileyKind
 
+    @Serializable
     data class Perso(val name: String) : SmileyKind
 }

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -1,7 +1,22 @@
 plugins {
-    id("redface.kotlin.jvm.library")
+    id("redface.android.library")
+    id("redface.android.hilt.library")
+}
+
+android {
+    namespace = "fr.forumhfr.redface2.core.network"
 }
 
 dependencies {
     api(project(":core:model"))
+    api(project(":core:domain"))
+
+    implementation(platform(libs.okhttp.bom))
+    api(libs.okhttp)
+    implementation(libs.okhttp.logging)
+
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.android)
+
+    testImplementation(libs.junit4)
 }

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -8,9 +8,6 @@ android {
 }
 
 dependencies {
-    api(project(":core:model"))
-    api(project(":core:domain"))
-
     implementation(platform(libs.okhttp.bom))
     api(libs.okhttp)
     implementation(libs.okhttp.logging)

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
@@ -3,6 +3,7 @@ package fr.forumhfr.redface2.core.network
 import fr.forumhfr.redface2.core.network.qualifiers.AnonymousClient
 import fr.forumhfr.redface2.core.network.qualifiers.AuthenticatedClient
 import fr.forumhfr.redface2.core.network.qualifiers.HfrBaseUrl
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 import okhttp3.HttpUrl
@@ -32,7 +33,9 @@ class HfrClient @Inject constructor(
         val client = if (useAuth) authenticated else anonymous
         val request = Request.Builder().url(url).get().build()
         return client.newCall(request).execute().use { response ->
-            check(response.isSuccessful) { "HFR returned ${response.code} for $url" }
+            if (!response.isSuccessful) {
+                throw IOException("HFR returned ${response.code} for $url")
+            }
             response.body.string()
         }
     }

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
@@ -2,9 +2,10 @@ package fr.forumhfr.redface2.core.network
 
 import fr.forumhfr.redface2.core.network.qualifiers.AnonymousClient
 import fr.forumhfr.redface2.core.network.qualifiers.AuthenticatedClient
+import fr.forumhfr.redface2.core.network.qualifiers.HfrBaseUrl
 import javax.inject.Inject
 import javax.inject.Singleton
-import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 
@@ -12,6 +13,7 @@ import okhttp3.Request
 class HfrClient @Inject constructor(
     @param:AuthenticatedClient private val authenticated: OkHttpClient,
     @param:AnonymousClient private val anonymous: OkHttpClient,
+    @param:HfrBaseUrl private val baseUrl: HttpUrl,
 ) {
     suspend fun getTopicPage(
         cat: Int,
@@ -19,7 +21,7 @@ class HfrClient @Inject constructor(
         page: Int,
         useAuth: Boolean = true,
     ): String {
-        val url = HfrConstants.BASE_URL.toHttpUrl().newBuilder()
+        val url = baseUrl.newBuilder()
             .addPathSegment("forum2.php")
             .addQueryParameter("config", "hfr.inc")
             .addQueryParameter("cat", cat.toString())

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
@@ -1,0 +1,37 @@
+package fr.forumhfr.redface2.core.network
+
+import fr.forumhfr.redface2.core.network.qualifiers.AnonymousClient
+import fr.forumhfr.redface2.core.network.qualifiers.AuthenticatedClient
+import javax.inject.Inject
+import javax.inject.Singleton
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+@Singleton
+class HfrClient @Inject constructor(
+    @param:AuthenticatedClient private val authenticated: OkHttpClient,
+    @param:AnonymousClient private val anonymous: OkHttpClient,
+) {
+    suspend fun getTopicPage(
+        cat: Int,
+        post: Int,
+        page: Int,
+        useAuth: Boolean = true,
+    ): String {
+        val url = HfrConstants.BASE_URL.toHttpUrl().newBuilder()
+            .addPathSegment("forum2.php")
+            .addQueryParameter("config", "hfr.inc")
+            .addQueryParameter("cat", cat.toString())
+            .addQueryParameter("post", post.toString())
+            .addQueryParameter("page", page.toString())
+            .build()
+
+        val client = if (useAuth) authenticated else anonymous
+        val request = Request.Builder().url(url).get().build()
+        return client.newCall(request).execute().use { response ->
+            check(response.isSuccessful) { "HFR returned ${response.code} for $url" }
+            response.body.string()
+        }
+    }
+}

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrConstants.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrConstants.kt
@@ -1,0 +1,14 @@
+package fr.forumhfr.redface2.core.network
+
+import java.time.Duration
+
+object HfrConstants {
+    const val BASE_URL: String = "https://forum.hardware.fr/"
+
+    const val USER_AGENT: String = "Redface2/0.1 (Android; +https://github.com/ForumHFR/redface2)"
+
+    val ConnectTimeout: Duration = Duration.ofSeconds(15)
+    val ReadTimeout: Duration = Duration.ofSeconds(20)
+    val WriteTimeout: Duration = Duration.ofSeconds(20)
+    val CallTimeout: Duration = Duration.ofSeconds(30)
+}

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/cookie/InMemoryCookieJar.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/cookie/InMemoryCookieJar.kt
@@ -1,0 +1,44 @@
+package fr.forumhfr.redface2.core.network.cookie
+
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.HttpUrl
+
+/**
+ * In-memory cookie jar used during Phase 1A. A persistent Keystore-backed jar will replace
+ * this implementation in Phase 1B (cf. ADR-002 — DataStore + Android Keystore, no plaintext
+ * password). Cookies are keyed by host so that requests to forum.hardware.fr always replay
+ * the same session, regardless of the URL path.
+ */
+@Singleton
+class InMemoryCookieJar @Inject constructor() : CookieJar {
+    private val store: MutableMap<String, MutableList<Cookie>> = ConcurrentHashMap()
+
+    override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+        if (cookies.isEmpty()) return
+        val bucket = store.getOrPut(url.host) { mutableListOf() }
+        synchronized(bucket) {
+            cookies.forEach { incoming ->
+                bucket.removeAll { existing -> existing.name == incoming.name }
+                if (!incoming.hasExpired()) bucket += incoming
+            }
+        }
+    }
+
+    override fun loadForRequest(url: HttpUrl): List<Cookie> {
+        val bucket = store[url.host] ?: return emptyList()
+        synchronized(bucket) {
+            bucket.removeAll { it.hasExpired() }
+            return bucket.filter { it.matches(url) }.toList()
+        }
+    }
+
+    fun clear() {
+        store.clear()
+    }
+
+    private fun Cookie.hasExpired(): Boolean = expiresAt < System.currentTimeMillis()
+}

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/di/CookieJarModule.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/di/CookieJarModule.kt
@@ -1,0 +1,17 @@
+package fr.forumhfr.redface2.core.network.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import fr.forumhfr.redface2.core.network.cookie.InMemoryCookieJar
+import javax.inject.Singleton
+import okhttp3.CookieJar
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class CookieJarModule {
+    @Binds
+    @Singleton
+    abstract fun bindCookieJar(impl: InMemoryCookieJar): CookieJar
+}

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/di/NetworkModule.kt
@@ -7,13 +7,21 @@ import dagger.hilt.components.SingletonComponent
 import fr.forumhfr.redface2.core.network.HfrConstants
 import fr.forumhfr.redface2.core.network.qualifiers.AnonymousClient
 import fr.forumhfr.redface2.core.network.qualifiers.AuthenticatedClient
+import fr.forumhfr.redface2.core.network.qualifiers.HfrBaseUrl
 import javax.inject.Singleton
 import okhttp3.CookieJar
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 
 @Module
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
+    @Provides
+    @Singleton
+    @HfrBaseUrl
+    fun provideHfrBaseUrl(): HttpUrl = HfrConstants.BASE_URL.toHttpUrl()
+
     @Provides
     @Singleton
     fun provideBaseClient(): OkHttpClient = OkHttpClient.Builder()

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/di/NetworkModule.kt
@@ -1,0 +1,43 @@
+package fr.forumhfr.redface2.core.network.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import fr.forumhfr.redface2.core.network.HfrConstants
+import fr.forumhfr.redface2.core.network.qualifiers.AnonymousClient
+import fr.forumhfr.redface2.core.network.qualifiers.AuthenticatedClient
+import javax.inject.Singleton
+import okhttp3.CookieJar
+import okhttp3.OkHttpClient
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+    @Provides
+    @Singleton
+    fun provideBaseClient(): OkHttpClient = OkHttpClient.Builder()
+        .connectTimeout(HfrConstants.ConnectTimeout)
+        .readTimeout(HfrConstants.ReadTimeout)
+        .writeTimeout(HfrConstants.WriteTimeout)
+        .callTimeout(HfrConstants.CallTimeout)
+        .addInterceptor(UserAgentInterceptor(HfrConstants.USER_AGENT))
+        .build()
+
+    @Provides
+    @Singleton
+    @AuthenticatedClient
+    fun provideAuthenticatedClient(
+        baseClient: OkHttpClient,
+        cookieJar: CookieJar,
+    ): OkHttpClient = baseClient.newBuilder()
+        .cookieJar(cookieJar)
+        .build()
+
+    @Provides
+    @Singleton
+    @AnonymousClient
+    fun provideAnonymousClient(baseClient: OkHttpClient): OkHttpClient = baseClient.newBuilder()
+        .cookieJar(CookieJar.NO_COOKIES)
+        .build()
+}

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/di/UserAgentInterceptor.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/di/UserAgentInterceptor.kt
@@ -1,0 +1,13 @@
+package fr.forumhfr.redface2.core.network.di
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+internal class UserAgentInterceptor(private val userAgent: String) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request().newBuilder()
+            .header("User-Agent", userAgent)
+            .build()
+        return chain.proceed(request)
+    }
+}

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/qualifiers/HfrClientQualifiers.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/qualifiers/HfrClientQualifiers.kt
@@ -9,3 +9,7 @@ annotation class AuthenticatedClient
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class AnonymousClient
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class HfrBaseUrl

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/qualifiers/HfrClientQualifiers.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/qualifiers/HfrClientQualifiers.kt
@@ -1,0 +1,11 @@
+package fr.forumhfr.redface2.core.network.qualifiers
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class AuthenticatedClient
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class AnonymousClient

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -241,28 +241,33 @@ class HfrParser @Inject constructor() {
 Les implémentations de repositories orchestrent réseau, parser et cache. Elles vivent dans `:core:data`, jamais dans les features.
 
 ```kotlin
-// Dans :core:data — l'implémentation
+// Dans :core:data — l'implémentation (Phase 1A)
+@Singleton
 class TopicRepositoryImpl @Inject constructor(
     private val client: HfrClient,
     private val parser: HfrParser,
     private val topicDao: TopicDao,
+    private val clock: Clock,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : TopicRepository {
 
-    override suspend fun getTopic(cat: Int, post: Int, page: Int): Result<Topic> {
-        // 1. Vérifier le cache
-        topicDao.getCached(cat, post, page)?.let { return Result.success(it) }
+    override fun observeTopicPage(cat: Int, post: Int, page: Int): Flow<Topic> = flow {
+        // 1. Si on a une copie en cache, l'émettre tout de suite (UI réactive)
+        val cached = withContext(ioDispatcher) { loadFromCache(cat, post, page) }
+        if (cached != null) emit(cached)
 
-        // 2. Fetch + parse
-        return runCatching {
-            val html = client.fetchTopicPage(cat, post, page)
+        // 2. Re-fetch + re-parse + cache, puis émettre la version fraîche
+        emit(refreshTopicPage(cat, post, page))
+    }
+
+    override suspend fun refreshTopicPage(cat: Int, post: Int, page: Int): Topic =
+        withContext(ioDispatcher) {
+            val html = client.getTopicPage(cat, post, page, useAuth = true)
             val topic = parser.parseTopicPage(html)
-
-            // 3. Mettre en cache
-            topicDao.insert(topic.toEntity())
-
+            val (topicEntity, postEntities) = TopicMappers.toEntities(topic, clock.instant())
+            topicDao.upsertTopicPageWithPosts(topicEntity, postEntities)
             topic
         }
-    }
 }
 ```
 

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -96,7 +96,6 @@ graph TB
     CDATA --> CP[":core:parser"]
     CDATA --> CD[":core:database"]
 
-    CN --> CM
     CP --> CM
     CD --> CM
 
@@ -118,7 +117,7 @@ graph TB
 | `:core:model` | Modèles domaine purs (`Topic`, `Post`, `PostContent`, `Category`, `Flag`, `MP`). Aucune dépendance Android. | rien |
 | `:core:domain` | Interfaces de repositories (`TopicRepository`, `FlagRepository`, `AuthRepository`...) et règles métier partagées. Aucune dépendance framework. | `:core:model` |
 | `:core:data` | Implémentations des repositories. Orchestre réseau, parser et cache. Fournit les bindings Hilt. | `:core:domain`, `:core:network`, `:core:parser`, `:core:database` |
-| `:core:network` | `HfrClient` : requêtes HTTP, cookies, session, login. Encapsule OkHttp. | `:core:model` |
+| `:core:network` | `HfrClient` : requêtes HTTP, cookies, session, login. Encapsule OkHttp. Renvoie du HTML brut ou `Result<Unit>` — n'expose aucun type domaine. | rien |
 | `:core:parser` | `HfrParser` : transforme le HTML HFR et, à partir de l'éditeur Phase 2, le BBCode HFR en modèles domaine, dont l'AST `PostContent`. | `:core:model` |
 | `:core:database` | Room DB, DAOs, entities, mappers entity↔model. Cache locale + cache MPStorage. | `:core:model` |
 | `:core:ui` | Thème Material 3 (`theme/`) et `PostRenderer` (`post/`, `PostContent` → Compose). D'autres sous-packages (`components/`, `adaptive/`, `semantics/`, `util/`, `extensions/`) sont prévus mais n'apparaîtront qu'au fur et à mesure de l'arrivée des features qui les justifient — pas de module vide en avance. Seul module autorisé à instancier `ColorScheme`, `Typography`, `Shapes`. | `:core:model` |
@@ -142,7 +141,7 @@ Les features ne dépendent que de `:core:domain` (interfaces) et `:core:ui` (com
 
 Les 8 modules extension arrivent en **Phase 4** uniquement. En Phases 0 à 3, le projet compte 15 modules (8 core + 7 features base). Les extensions sont des modules Gradle isolés qui s'enregistrent via Hilt `@IntoSet` — ajouter une extension ne demande aucune modification du code existant. La décision de découpage v1 est formalisée dans [ADR-001]({{ site.baseurl }}/adr/001-modules-gradle-v1).
 
-> **État réel des modules en Phase 1 (cycle topic fixe)** : tous les modules core et feature de base sont déclarés dans `settings.gradle.kts`, mais beaucoup ne contiennent encore que le squelette Gradle (`build.gradle.kts`) sans code Kotlin — `:core:network`, `:core:database`, `:core:extension`, `:feature:auth` et `:feature:settings` notamment. C'est volontaire : le découpage est fixé dès le bootstrap (ADR-001) pour figer les frontières, mais le code arrive feature par feature. La prose ci-dessus décrit le **contrat cible** ; la réalité courante est trackée par la roadmap.
+> **État réel des modules en Phase 1 (cycle topic réel en cours)** : tous les modules core et feature de base sont déclarés dans `settings.gradle.kts`, mais certains ne contiennent encore que le squelette Gradle (`build.gradle.kts`) sans code Kotlin — `:core:extension`, `:feature:auth` et `:feature:settings` notamment. `:core:network` et `:core:database` ont reçu leur backbone Phase 1A (`HfrClient`, `TopicRepositoryImpl` cache-aside, schema Room v1). C'est volontaire : le découpage est fixé dès le bootstrap (ADR-001) pour figer les frontières, mais le code arrive feature par feature. La prose ci-dessus décrit le **contrat cible** ; la réalité courante est trackée par la roadmap.
 
 | Module | Fonction | Dépend de |
 |--------|----------|-----------|
@@ -198,17 +197,25 @@ interface AuthRepository {
 Le client HTTP ne parse rien. Il retourne du HTML brut ou des confirmations d'action.
 
 ```kotlin
+@Singleton
 class HfrClient @Inject constructor(
-    private val okHttpClient: OkHttpClient,
+    @AuthenticatedClient private val authenticated: OkHttpClient,
+    @AnonymousClient private val anonymous: OkHttpClient,
+    @HfrBaseUrl private val baseUrl: HttpUrl,
 ) {
-    suspend fun fetchTopicPage(cat: Int, post: Int, page: Int): String
-    suspend fun fetchFlags(): String
+    // Phase 1A — livrée
+    suspend fun getTopicPage(cat: Int, post: Int, page: Int, useAuth: Boolean = true): String
+
+    // Phase 1B+ — à implémenter
+    suspend fun getFlags(): String
     suspend fun postReply(cat: Int, post: Int, content: String): Result<Unit>
     suspend fun editPost(cat: Int, post: Int, numreponse: Int, content: String): Result<Unit>
     suspend fun login(username: String, password: String): Result<Unit>
     // ...
 }
 ```
+
+`@AnonymousClient` (cookie jar = `CookieJar.NO_COOKIES`) permet à un caller — typiquement le prefetch de la page suivante — d'aller chercher du HTML sans que HFR ne marque les drapeaux comme lus côté serveur. Les écrans qui doivent honorer la lecture (lecture utilisateur) appellent avec `useAuth = true` (default).
 
 ### `:core:parser` — HfrParser
 

--- a/docs/specs/protocol-hfr.md
+++ b/docs/specs/protocol-hfr.md
@@ -267,26 +267,37 @@ Les requêtes de prefetch (pages suivantes d'un topic, drapeaux préchargés) **
 **Implémentation** :
 
 ```kotlin
-class NetworkModule {
-    @Provides @AuthenticatedClient
-    fun provideAuthClient(@UserCookieJar jar: CookieJar): OkHttpClient = /* ... */
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+    @Provides @Singleton @HfrBaseUrl
+    fun provideHfrBaseUrl(): HttpUrl = HfrConstants.BASE_URL.toHttpUrl()
 
-    @Provides @AnonymousClient
-    fun provideAnonymousClient(): OkHttpClient = OkHttpClient.Builder()
-        .cookieJar(CookieJar.NO_COOKIES)  // ou un CookieJar vide dédié
-        .build()
+    @Provides @Singleton @AuthenticatedClient
+    fun provideAuthClient(base: OkHttpClient, jar: CookieJar): OkHttpClient =
+        base.newBuilder().cookieJar(jar).build()
+
+    @Provides @Singleton @AnonymousClient
+    fun provideAnonymousClient(base: OkHttpClient): OkHttpClient =
+        base.newBuilder().cookieJar(CookieJar.NO_COOKIES).build()
 }
 
+@Singleton
 class HfrClient @Inject constructor(
-    @AuthenticatedClient private val auth: OkHttpClient,
-    @AnonymousClient private val anon: OkHttpClient,
+    @AuthenticatedClient private val authenticated: OkHttpClient,
+    @AnonymousClient private val anonymous: OkHttpClient,
+    @HfrBaseUrl private val baseUrl: HttpUrl,
 ) {
-    suspend fun fetchTopicPage(cat: Int, post: Int, page: Int): String = /* auth */
-    suspend fun prefetchTopicPage(cat: Int, post: Int, page: Int): String = /* anon */
+    suspend fun getTopicPage(
+        cat: Int,
+        post: Int,
+        page: Int,
+        useAuth: Boolean = true,  // false ⇒ @AnonymousClient ⇒ pas de mise à jour des drapeaux
+    ): String { /* ... */ }
 }
 ```
 
-Un test Konsist enforce la règle : tout appel à `prefetch*` doit utiliser `@AnonymousClient`.
+Le contrat se ramène à un **flag de booléen** côté caller : `useAuth = true` (default) pour la lecture explicite, `useAuth = false` pour tout appel de prefetch / pré-chauffage de cache. Un test Konsist enforcera la règle Phase 1A — toute fonction dont le nom commence par `prefetch*` (ou tout call-site marqué prefetch dans le repository) doit passer `useAuth = false`. La règle est trackée dans [#42](https://github.com/ForumHFR/redface2/issues/42) et reste désactivée tant qu'aucun call-site prefetch n'existe — elle s'active avec la PR `1A-bind`.
 
 Confirmé par Corran Horn sur le topic HFR Redface 2 : *« en utilisant un cookie d'un compte anonyme pour pas péter les drapeaux »*.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ android-minSdk = "29"
 android-targetSdk = "36"
 android-compileSdk = "36"
 androidx-core = "1.18.0"
+androidx-test-core = "1.7.0"
 androidx-activity = "1.13.0"
 androidx-lifecycle = "2.10.0"
 compose-bom = "2026.04.01"
@@ -44,6 +45,7 @@ ksp-gradle-plugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.
 hilt-android-gradle-plugin = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt" }
 
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
+androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test-core" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
@@ -78,6 +80,7 @@ room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
+okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,6 +53,7 @@ androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecy
 androidx-material3-adaptive = { module = "androidx.compose.material3.adaptive:adaptive", version.ref = "material3-adaptive" }
 androidx-material3-adaptive-navigation-suite = { module = "androidx.compose.material3:material3-adaptive-navigation-suite" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 junit4 = { module = "junit:junit", version.ref = "junit4" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }


### PR DESCRIPTION
## Résumé

Backbone de la **Phase 1A — Topic réel** ([#87](https://github.com/ForumHFR/redface2/issues/87)) : on remplace le pipeline fixture par un vrai pipeline `HfrClient` → `HfrParser` → `TopicRepository` (cache-aside Room) sur les modules core. Le branchement de `TopicScreen` sur le vrai repository (et l'activation de la règle Konsist `@AnonymousClient`) sont volontairement laissés à la PR suivante (`1A-bind`) pour garder cette PR reviewable.

## Découpage en 5 commits

1. `feat(network): :core:network skeleton with HfrClient + InMemoryCookieJar` — module passe de Kotlin JVM vide à Android+Hilt library, fournit `OkHttpClient` `@AuthenticatedClient` / `@AnonymousClient`, `HfrClient.getTopicPage(cat, post, page, useAuth)` et un `InMemoryCookieJar` host-keyed (Keystore-backed différé Phase 1B, cf. ADR-002)
2. `feat(database): Room schema topics + posts + PostContent JSON converter` — `TopicEntity` (PK `cat,post,page`) + `PostEntity` (PK `cat,numreponse`, index `(cat,post)`), `TopicDao` avec `upsertTopicPageWithPosts`, `RedfaceDatabase` v1, schéma exporté dans `core/database/schemas/`. `:core:model` reçoit `@Serializable` pour que `PostContent` round-trip en JSON via le `TypeConverter`
3. `feat(domain): TopicRepository interface` — contrat `observeTopicPage(cat,post,page): Flow<Topic>` + `refreshTopicPage(...)`
4. `feat(data): TopicRepositoryImpl + Hilt binding` — implémentation cache-aside (emit cache puis refetch), `TopicMappers` bidirectionnels avec `Poll` sérialisé via DTO privé (le `:core:model` reste métier-pur), `TopicRepositoryModule` `@Binds`
5. `test(data): integration tests with MockWebServer` — 3 scénarios end-to-end (cache vide, cache chaud, refresh explicite) avec une fixture HFR réelle (`topic_page_single.html`, capturée via `hfr-mcp`)

## Décisions actées

- **Cookie jar Phase 1A = in-memory** ; persistance Keystore reste pour 1B (ADR-002 — DataStore + Keystore, sans password stocké)
- **`PostContent` en JSON Room** via `kotlinx.serialization` (sans table relationnelle séparée) — round-trip vérifié par les tests
- **PK composites** : `(cat,post,page)` pour topics, `(cat,numreponse)` + index `(cat,post)` pour posts — un post est unique par catégorie côté HFR (cf. AGENTS.md)
- **Cache-invalidation TTL/purge** : différée Phase 1D, le `flow { emit(cache); emit(refresh) }` évite déjà la stale data tant que la requête réseau aboutit
- **`HfrClient.baseUrl`** désormais injectable via `@HfrBaseUrl` HttpUrl pour rendre `MockWebServer` possible (default = `HfrConstants.BASE_URL`)

## Volume

| Métrique | Valeur |
|---|---|
| Production code (Kotlin) | ~720 LOC sur `:core:network`, `:core:database`, `:core:domain`, `:core:data` |
| Tests (Robolectric + MockWebServer + Turbine) | ~140 LOC, 3 scénarios |
| Fixture copiée (`topic_page_single.html`) | 61 KB |
| Schéma Room exporté | 1 fichier JSON tracké en git |

## Hors scope (suivront)

- **PR `1A-bind`** : brancher `TopicScreen` / `TopicViewModel` sur `TopicRepository` (remplace `TopicFixtureRepository`), activer Konsist `@AnonymousClient` (#42), tests `:core:ui` (#83)
- **PR Phase 1B** : `PersistentCookieJar` Keystore + `SessionExpiredInterceptor`
- **PR Phase 1D** : TTL / purge cache, parser blocs `[fixed]` / `[code]` (#79), reality-check HFR (#81)

## Test plan

- [x] `./scripts/docker-dev.sh ./gradlew :core:network:compileDebugKotlin` → vert
- [x] `./scripts/docker-dev.sh ./gradlew :core:database:compileDebugKotlin` → vert (schéma Room exporté)
- [x] `./scripts/docker-dev.sh ./gradlew :core:data:testDebugUnitTest` → 3 / 3 OK
- [x] `./scripts/docker-dev.sh ./gradlew test` → tous modules verts (parser, topic, app, data)
- [x] `./scripts/docker-dev.sh ./gradlew detektAll lintDebug` → vert
- [x] `./scripts/docker-dev.sh ./gradlew :app:assembleDebug` → vert

## Liens

- Closes parts of #87 (Phase 1 umbrella roadmap)
- Référence ADR-001 (modules), ADR-002 (auth), ADR-009 (OkHttp 5), ADR-011 (PostContent AST)
- Track suite : prochaine PR `feature/1a-bind-topic-screen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)