### PR TITLE
feat(app): in-app CSAE reporting button

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -15,6 +15,24 @@ Workflow : bumper `versionCode` + `versionName` dans `app/build.gradle.kts`, ajo
 
 ---
 
+## v19 — `0.1.0-phase1b.5` — 2026-04-28
+
+**Statut** : `local`
+**Commit** : à venir
+**Fichier** : `redface2-v19-<date>-<sha>.aab`
+
+In-app reporting channel pour la conformité Google Play CSAE.
+
+### Added
+- **Bouton "Signaler un contenu"** sur `FlagsScreen` — `Intent.ACTION_SENDTO` avec `mailto:xat@azora.fr` + sujet pré-rempli `Redface 2 — Signalement`. Catch `ActivityNotFoundException` → Toast français quand aucun client mail n'est dispo.
+- 3 strings : `report_content_cta`, `report_email_subject`, `report_no_email_client`.
+
+### Notes
+- La page CSAE (`docs/legal/csae/index.html`, déployée Phase 1B.1 sur GitHub Pages) **claim** explicitement ce mécanisme de signalement in-app — sans cette livraison, la déclaration au Play Console serait factuellement incohérente avec l'app.
+- Reste sur `FlagsScreen` (point d'entrée toujours visible) en attendant un écran `:feature:settings` réel.
+
+---
+
 ## v18 — `0.1.0-phase1b.4` — 2026-04-28
 
 **Statut** : `local`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         // upload signing config).
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their phase / commit lineage to the user.
-        versionCode = 18
-        versionName = "0.1.0-phase1b.4"
+        versionCode = 19
+        versionName = "0.1.0-phase1b.5"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/kotlin/fr/forumhfr/redface2/FlagsScreen.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/FlagsScreen.kt
@@ -1,5 +1,8 @@
 package fr.forumhfr.redface2
 
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -11,8 +14,10 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.model.AuthState
@@ -27,6 +32,7 @@ fun FlagsScreen(
     val viewModel = hiltViewModel<FlagsHomeViewModel>()
     val authState by viewModel.authState.collectAsStateWithLifecycle()
     val unreadMpCount by viewModel.unreadMpCount.collectAsStateWithLifecycle()
+    val context = LocalContext.current
 
     RedfacePlaceholderScreen(
         title = stringResource(R.string.flags_title),
@@ -63,8 +69,34 @@ fun FlagsScreen(
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+
+        // In-app reporting channel required by the Google Play Child Safety Standards
+        // policy. The CSAE page (docs/legal/csae/index.html) advertises this affordance, so
+        // the app must expose it visibly to users. ACTION_SENDTO with a mailto: URI hands
+        // off to the user's email client without leaving the app's context.
+        val reportSubject = stringResource(R.string.report_email_subject)
+        val reportNoClientMessage = stringResource(R.string.report_no_email_client)
+        TextButton(
+            onClick = {
+                val intent = Intent(Intent.ACTION_SENDTO).apply {
+                    data = "mailto:$REPORT_EMAIL".toUri()
+                    putExtra(Intent.EXTRA_EMAIL, arrayOf(REPORT_EMAIL))
+                    putExtra(Intent.EXTRA_SUBJECT, reportSubject)
+                }
+                try {
+                    context.startActivity(intent)
+                } catch (_: ActivityNotFoundException) {
+                    Toast.makeText(context, reportNoClientMessage, Toast.LENGTH_LONG).show()
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(stringResource(R.string.report_content_cta))
+        }
     }
 }
+
+private const val REPORT_EMAIL = "xat@azora.fr"
 
 @Composable
 private fun AuthFooter(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,5 +12,8 @@
     <string name="flags_logged_in_as">Connecté en tant que %1$s</string>
     <string name="flags_logout_cta">Se déconnecter</string>
     <string name="flags_unread_mps">MPs non lus : %1$d</string>
+    <string name="report_content_cta">Signaler un contenu</string>
+    <string name="report_email_subject">Redface 2 — Signalement</string>
+    <string name="report_no_email_client">Aucune application e-mail trouvée. Écrivez à xat@azora.fr.</string>
     <string name="app_version_footer">Redface 2 — v%1$s (build %2$d)</string>
 </resources>


### PR DESCRIPTION
## Résumé

Suite directe de [PR #91](https://github.com/ForumHFR/redface2/pull/91) qui a livré la page CSAE (`docs/legal/csae/index.html`). Cette page **claim** explicitement un mécanisme de signalement in-app vers `xat@azora.fr` ; sans le bouton dans l'app, la déclaration au Play Console serait factuellement incohérente.

- `FlagsScreen` expose un `TextButton` "Signaler un contenu" en bas du placeholder home
- `Intent.ACTION_SENDTO` avec `mailto:xat@azora.fr` + subject `Redface 2 — Signalement` pré-rempli
- `ActivityNotFoundException` → Toast français listant l'adresse à la main si aucun client mail dispo
- Strings localisées (`report_content_cta`, `report_email_subject`, `report_no_email_client`)

## Pourquoi sur `FlagsScreen`

C'est l'entrée toujours-visible aujourd'hui. Quand `:feature:settings` aura un About screen réel, le bouton migrera là.

## Bump version

`versionCode` 18 → 19, `versionName` `0.1.0-phase1b.4` → `0.1.0-phase1b.5`. v18 déjà uploadée côté Play Console.

## Plan de validation

- [ ] Tap "Signaler un contenu" → ouvre le client mail par défaut avec destinataire et sujet pré-remplis
- [ ] Sur un device sans client mail (peu probable en prod), le Toast français s'affiche

## Refs

- Refs [#91](https://github.com/ForumHFR/redface2/pull/91) — page CSAE qui motive cette livraison