### PR TITLE
fix(auth): harden Phase 1B session handling

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -26,11 +26,11 @@ Durcissement final Phase 1B avant 1C : login failure, cookies, session expirée 
 ### Changed
 - **Login HFR** : le POST `login_validation.php` utilise maintenant un cookie jar de staging avec redirects désactivés. Les `Set-Cookie` reçus sur une réponse 200 ou une redirection 302 ne sont commités dans le `PersistentCookieJar` qu'après classification `Authenticated`, donc `InvalidCredentials`, `RateLimited` ou `Unknown` ne peuvent plus installer une session par effet de bord.
 - **Cookies persistants** : `PersistentCookieJar` sérialise les écritures avec une version de mutation ; un `clear()` plus récent gagne contre un `saveFromResponse()` plus ancien qui n'aurait pas encore atteint le store. `DataStoreCookieStore.observe()` fail-close sur payload corrompu sans terminer le flow, afin qu'une future écriture valide soit observée.
-- **Session expirée** : `HfrClient.getFlagsPage()` et `getPrivateMessageListPage()` lèvent maintenant `SessionExpiredException` si HFR redirige vers `/login.php` ou renvoie un formulaire login en HTTP 200. L'écran Drapeaux affiche un message dédié avec action de reconnexion au lieu d'une liste vide trompeuse.
+- **Session expirée** : `HfrClient.getFlagsPage()`, `getPrivateMessageListPage()` et `getTopicPage(useAuth = true)` lèvent maintenant `SessionExpiredException` si HFR redirige vers `/login.php` ou renvoie un formulaire login en HTTP 200. `getTopicPage(useAuth = false)` garde le passthrough anonyme pour le prefetch. L'écran Drapeaux affiche un message dédié avec action de reconnexion au lieu d'une liste vide trompeuse.
 - **`protocol-hfr.md`** : documente le cookie `md_user` form-url-encoded (`Colonel MythO` -> `Colonel+MythO`), distingue absence de cookie et mismatch après décodage, et acte le staging cookie du login.
 
 ### Tests
-- Tests MockWebServer sur login failure + `Set-Cookie` non persisté, login success + commit explicite, session expirée flags/MP, vraie page vide non confondue avec login.
+- Tests MockWebServer sur login failure + `Set-Cookie` non persisté, login success + commit explicite, session expirée flags/MP/topic authentifié, passthrough topic anonyme, vraie page vide non confondue avec login.
 - Tests cookie store sur `clear()` vs save stale et recovery après payload DataStore corrompu.
 
 ---

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -15,6 +15,26 @@ Workflow : bumper `versionCode` + `versionName` dans `app/build.gradle.kts`, ajo
 
 ---
 
+## v24 — `0.1.0-phase1b.10` — 2026-05-01
+
+**Statut** : `local`
+**Commit** : à venir
+**Fichier** : `redface2-v24-<date>-<sha>.aab`
+
+Durcissement final Phase 1B avant 1C : login failure, cookies, session expirée et spec HFR.
+
+### Changed
+- **Login HFR** : le POST `login_validation.php` utilise maintenant un cookie jar de staging avec redirects désactivés. Les `Set-Cookie` reçus sur une réponse 200 ou une redirection 302 ne sont commités dans le `PersistentCookieJar` qu'après classification `Authenticated`, donc `InvalidCredentials`, `RateLimited` ou `Unknown` ne peuvent plus installer une session par effet de bord.
+- **Cookies persistants** : `PersistentCookieJar` sérialise les écritures avec une version de mutation ; un `clear()` plus récent gagne contre un `saveFromResponse()` plus ancien qui n'aurait pas encore atteint le store. `DataStoreCookieStore.observe()` fail-close sur payload corrompu sans terminer le flow, afin qu'une future écriture valide soit observée.
+- **Session expirée** : `HfrClient.getFlagsPage()` et `getPrivateMessageListPage()` lèvent maintenant `SessionExpiredException` si HFR redirige vers `/login.php` ou renvoie un formulaire login en HTTP 200. L'écran Drapeaux affiche un message dédié avec action de reconnexion au lieu d'une liste vide trompeuse.
+- **`protocol-hfr.md`** : documente le cookie `md_user` form-url-encoded (`Colonel MythO` -> `Colonel+MythO`), distingue absence de cookie et mismatch après décodage, et acte le staging cookie du login.
+
+### Tests
+- Tests MockWebServer sur login failure + `Set-Cookie` non persisté, login success + commit explicite, session expirée flags/MP, vraie page vide non confondue avec login.
+- Tests cookie store sur `clear()` vs save stale et recovery après payload DataStore corrompu.
+
+---
+
 ## v23 — `0.1.0-phase1b.9` — 2026-04-29
 
 **Statut** : `local`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         // upload signing config).
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their phase / commit lineage to the user.
-        versionCode = 23
-        versionName = "0.1.0-phase1b.9"
+        versionCode = 24
+        versionName = "0.1.0-phase1b.10"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/auth/DataStoreCookieStore.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/auth/DataStoreCookieStore.kt
@@ -24,11 +24,17 @@ class DataStoreCookieStore @Inject constructor(
 
     override fun observe(): Flow<List<Cookie>> = dataStore.data.map { prefs ->
         val raw = prefs[cookiesKey] ?: return@map emptyList()
-        json.decodeFromString<List<CookieDto>>(raw)
-            .mapNotNull { it.toCookie() }
-            .filter { it.expiresAt > System.currentTimeMillis() }
+        runCatching {
+            json.decodeFromString<List<CookieDto>>(raw)
+                .mapNotNull { it.toCookie() }
+                .filter { it.expiresAt > System.currentTimeMillis() }
+        }.getOrElse {
+            // Fail closed but keep the DataStore flow alive: the next valid write must be
+            // observed normally instead of being swallowed by a terminal catch block.
+            emptyList()
+        }
     }.catch {
-        // Fail closed: a corrupt DataStore payload must not leave PersistentCookieJar stuck
+        // DataStore-level failure: fail closed so PersistentCookieJar is never stuck
         // waiting forever for its first non-null cache value.
         emit(emptyList())
     }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/auth/DefaultAuthRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/auth/DefaultAuthRepository.kt
@@ -43,10 +43,17 @@ class DefaultAuthRepository @Inject constructor(
         .distinctUntilChanged()
 
     /**
-     * The persistence side-effect happens implicitly: AuthRemoteDataSource POSTs through the
-     * @AuthenticatedClient OkHttp instance, whose CookieJar (PersistentCookieJar) writes the
-     * Set-Cookie headers to its in-memory cache *and* through to CookieStore. The Result we
-     * return here is the immediate classification — useful for LoginViewModel's UX path.
+     * Cookie persistence is *explicit*, not implicit: AuthRemoteDataSource POSTs through a
+     * derived OkHttp instance with `cookieJar(NO_COOKIES).followRedirects(false)` so HFR's
+     * Set-Cookie headers are staged on the response only — never written to disk by the
+     * CookieJar machinery. The remote then commits them to the @AuthenticatedClient's
+     * PersistentCookieJar (in-memory cache + DataStore) **iff** classify() returns
+     * Authenticated. Failed logins (InvalidCredentials, RateLimited, Unknown, Network) leave
+     * no cookie behind, fixing the "rejected login installs a half-valid session" risk.
+     *
+     * The Result returned here is the same classification — useful for LoginViewModel's UX
+     * path. observeAuthState() flips to Authenticated on the next CookieJar emission, which
+     * happens synchronously inside that explicit commit.
      */
     override suspend fun login(pseudo: String, password: String): Result<AuthState.Authenticated> =
         withContext(ioDispatcher) { remote.login(pseudo, password) }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/auth/DataStoreCookieStoreTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/auth/DataStoreCookieStoreTest.kt
@@ -143,6 +143,25 @@ class DataStoreCookieStoreTest {
         }
     }
 
+    @Test
+    fun `corrupt persisted payload fails closed but observe recovers after valid save`() =
+        runTest(UnconfinedTestDispatcher()) {
+            dataStore.edit { prefs ->
+                prefs[stringPreferencesKey(DataStoreCookieStore.KEY_SESSION_COOKIES)] = "not-json"
+            }
+
+            store.observe().test {
+                assertEquals(emptyList<Cookie>(), awaitItem())
+
+                store.save(listOf(makeCookie(name = "md_user", value = "xaat")))
+
+                val cookies = awaitItem()
+                assertEquals(1, cookies.size)
+                assertEquals("md_user", cookies.single().name)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
     private fun makeCookie(
         name: String,
         value: String,

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepositoryTest.kt
@@ -3,6 +3,7 @@ package fr.forumhfr.redface2.core.data.messages
 import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.auth.LoginError
+import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.network.HfrClient
 import fr.forumhfr.redface2.core.parser.messages.PrivateMessageListParser
@@ -64,6 +65,29 @@ class DefaultMessagesRepositoryTest {
             authStates.emit(AuthState.Authenticated("xaat"))
             assertNull(
                 "A failed fetch must surface as null rather than a stale or zero count",
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `observeUnreadMpCount emits null when fetch throws SessionExpiredException`() = runTest {
+        // The footer line is intentionally silenced on session expiry — the body of FlagsRoute
+        // already surfaces a reconnect CTA via FlagsResult.Failure(SessionExpiredException),
+        // so doubling that signal in the footer would be noisy. This test pins that contract:
+        // the MP repository must NOT propagate SessionExpiredException to its caller, it must
+        // swallow it silently like any other fetch failure.
+        val hfrClient = mockk<HfrClient>()
+        coEvery { hfrClient.getPrivateMessageListPage(page = 1) } throws
+            SessionExpiredException("https://forum.hardware.fr/login.php")
+
+        val (repo, authStates) = buildRepository(hfrClient = hfrClient)
+
+        repo.observeUnreadMpCount().test {
+            authStates.emit(AuthState.Authenticated("xaat"))
+            assertNull(
+                "SessionExpiredException must surface as null in the footer (FlagsRoute body owns the CTA)",
                 awaitItem(),
             )
             cancelAndIgnoreRemainingEvents()

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/auth/SessionExpiredException.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/auth/SessionExpiredException.kt
@@ -1,0 +1,11 @@
+package fr.forumhfr.redface2.core.domain.auth
+
+import java.io.IOException
+
+/**
+ * Authenticated HFR endpoint returned the login page instead of the requested resource.
+ * Callers must treat this as a stale session, not as an empty flags/MP/topic payload.
+ */
+class SessionExpiredException(
+    val finalUrl: String,
+) : IOException("HFR session expired; final URL was $finalUrl")

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
@@ -1,11 +1,13 @@
 package fr.forumhfr.redface2.core.network
 
+import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.network.qualifiers.AnonymousClient
 import fr.forumhfr.redface2.core.network.qualifiers.AuthenticatedClient
 import fr.forumhfr.redface2.core.network.qualifiers.HfrBaseUrl
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
+import okhttp3.Call
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -62,12 +64,7 @@ class HfrClient @Inject constructor(
             .build()
 
         val request = Request.Builder().url(url).get().build()
-        return authenticated.newCall(request).execute().use { response ->
-            if (!response.isSuccessful) {
-                throw IOException("HFR returned ${response.code} for $url")
-            }
-            response.body.string()
-        }
+        return authenticated.newCall(request).executeAuthenticatedHtml()
     }
 
     /**
@@ -94,11 +91,28 @@ class HfrClient @Inject constructor(
             .build()
 
         val request = Request.Builder().url(url).get().build()
-        return authenticated.newCall(request).execute().use { response ->
-            if (!response.isSuccessful) {
-                throw IOException("HFR returned ${response.code} for $url")
-            }
-            response.body.string()
+        return authenticated.newCall(request).executeAuthenticatedHtml()
+    }
+
+    private fun Call.executeAuthenticatedHtml(): String = execute().use { response ->
+        if (!response.isSuccessful) {
+            throw IOException("HFR returned ${response.code} for ${response.request.url}")
         }
+        val html = response.body.string()
+        val finalUrl = response.request.url
+        if (finalUrl.isLoginUrl() || html.looksLikeLoginPage()) {
+            throw SessionExpiredException(finalUrl.toString())
+        }
+        html
+    }
+
+    private fun HttpUrl.isLoginUrl(): Boolean =
+        encodedPath.endsWith("/login.php") || encodedPath.endsWith("/login_validation.php")
+
+    private fun String.looksLikeLoginPage(): Boolean {
+        val lower = lowercase()
+        return "login_validation.php" in lower &&
+            "name=\"pseudo\"" in lower &&
+            "name=\"password\"" in lower
     }
 }

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
@@ -32,13 +32,19 @@ class HfrClient @Inject constructor(
             .addQueryParameter("page", page.toString())
             .build()
 
-        val client = if (useAuth) authenticated else anonymous
         val request = Request.Builder().url(url).get().build()
-        return client.newCall(request).execute().use { response ->
-            if (!response.isSuccessful) {
-                throw IOException("HFR returned ${response.code} for $url")
+        return if (useAuth) {
+            // Authenticated read: an expired session would otherwise be parsed silently as an
+            // empty topic. executeAuthenticatedHtml() raises SessionExpiredException so the
+            // caller can surface a reconnect CTA instead of a misleading empty screen.
+            authenticated.newCall(request).executeAuthenticatedHtml()
+        } else {
+            anonymous.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IOException("HFR returned ${response.code} for $url")
+                }
+                response.body.string()
             }
-            response.body.string()
         }
     }
 

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/auth/AuthRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/auth/AuthRemoteDataSource.kt
@@ -12,6 +12,7 @@ import java.net.URLDecoder
 import javax.inject.Inject
 import javax.inject.Singleton
 import okhttp3.Cookie
+import okhttp3.CookieJar
 import okhttp3.FormBody
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
@@ -45,9 +46,9 @@ class AuthRemoteDataSource @Inject constructor(
     }
 
     /**
-     * POSTs the login form to HFR. The CookieJar attached to the @AuthenticatedClient is what
-     * actually persists the session — this method only classifies the response. Returns a
-     * typed [LoginError] inside Result.failure on every non-success path so the caller can
+     * POSTs the login form to HFR. Cookies are staged until the response is classified, then
+     * committed to the CookieJar attached to the @AuthenticatedClient only on success. Returns
+     * a typed [LoginError] inside Result.failure on every non-success path so the caller can
      * branch without parsing messages.
      *
      * Detection logic (mirrors hfr-mcp/internal/hfr/client.go::Login, kept as the single
@@ -84,10 +85,21 @@ class AuthRemoteDataSource @Inject constructor(
         logD("login request: POST $url body=$redactedBody")
 
         val (status, cookies, html) = try {
-            client.newCall(request).execute().use { response ->
-                val parsed = response.headers("Set-Cookie").mapNotNull { Cookie.parse(url, it) }
-                Triple(response.code, parsed, response.body.string())
-            }
+            // Use a no-cookie staging client for the POST itself: OkHttp normally persists
+            // Set-Cookie before this method can classify the response. Login failures must
+            // never install a session by side effect, so we manually commit cookies only
+            // after classify() returns Authenticated. Redirects are disabled so cookies set
+            // on HFR's login 302 are still visible on the response we classify.
+            client.newBuilder()
+                .cookieJar(CookieJar.NO_COOKIES)
+                .followRedirects(false)
+                .build()
+                .newCall(request)
+                .execute()
+                .use { response ->
+                    val parsed = response.headers("Set-Cookie").mapNotNull { Cookie.parse(url, it) }
+                    Triple(response.code, parsed, response.body.string())
+                }
         } catch (e: IOException) {
             logW("login network failure for pseudo='$pseudo'", e)
             return Result.failure(LoginError.Network(e))
@@ -103,6 +115,9 @@ class AuthRemoteDataSource @Inject constructor(
         )
 
         return classify(cookies, html, pseudo).also { result ->
+            result.onSuccess {
+                client.cookieJar.saveFromResponse(url, cookies)
+            }
             result.onFailure { error ->
                 val detail = (error as? LoginError.Unknown)?.detail ?: error::class.simpleName
                 logW("login classified as failure for pseudo='$pseudo': $detail")

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/cookie/PersistentCookieJar.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/cookie/PersistentCookieJar.kt
@@ -3,6 +3,7 @@ package fr.forumhfr.redface2.core.network.cookie
 import android.os.Looper
 import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
 import java.io.Closeable
+import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
@@ -41,8 +42,9 @@ import okhttp3.HttpUrl
  * - `saveFromResponse` updates the StateFlow synchronously and launches a coroutine to
  *   persist via [CookieStore.save]. The fire-and-forget is intentional — OkHttp shouldn't
  *   wait for disk I/O.
- * - The collector launched in `init` mirrors store updates back into the cache (e.g. a
- *   logout that clears the store from another component is observed here too).
+ * - The collector launched in `init` primes the runtime cache from the persisted store.
+ *   After the first local mutation, the runtime cache is the source of truth; store
+ *   emissions are ignored so a stale async save can never resurrect cookies after logout.
  */
 @Singleton
 class PersistentCookieJar @Inject constructor(
@@ -61,6 +63,7 @@ class PersistentCookieJar @Inject constructor(
      * where order matters for crash-survivability of the auth state.
      */
     private val storeMutex = Mutex()
+    private val mutationVersion = AtomicLong(0L)
 
     /**
      * Runtime cookie state. Emits `null` until the persisted store has been read for the
@@ -71,7 +74,11 @@ class PersistentCookieJar @Inject constructor(
 
     init {
         scope.launch {
-            store.observe().collect { cookies -> cache.value = cookies }
+            store.observe().collect { cookies ->
+                if (mutationVersion.get() == 0L) {
+                    cache.value = cookies
+                }
+            }
         }
     }
 
@@ -104,9 +111,16 @@ class PersistentCookieJar @Inject constructor(
 
     override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
         if (cookies.isEmpty()) return
+        val version = mutationVersion.incrementAndGet()
         val merged = merge(cache.value ?: emptyList(), cookies)
         cache.value = merged
-        scope.launch { storeMutex.withLock { store.save(merged) } }
+        scope.launch {
+            storeMutex.withLock {
+                if (version == mutationVersion.get()) {
+                    store.save(merged)
+                }
+            }
+        }
     }
 
     /**
@@ -116,8 +130,15 @@ class PersistentCookieJar @Inject constructor(
      * logout can never be reordered behind a stale `saveFromResponse` on the way to disk.
      */
     fun clear() {
+        val version = mutationVersion.incrementAndGet()
         cache.value = emptyList()
-        scope.launch { storeMutex.withLock { store.clear() } }
+        scope.launch {
+            storeMutex.withLock {
+                if (version == mutationVersion.get()) {
+                    store.clear()
+                }
+            }
+        }
     }
 
     override fun close() {

--- a/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/HfrClientTest.kt
+++ b/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/HfrClientTest.kt
@@ -77,4 +77,38 @@ class HfrClientTest {
 
         assertEquals("<html><body>Aucun sujet</body></html>", html)
     }
+
+    @Test
+    fun `getTopicPage throws SessionExpired when authenticated and final URL is login`() = runTest {
+        // Without this hardening, an expired session would be parsed silently as an empty
+        // topic — wrong empty screen, no reconnect CTA. Mirrors the getFlagsPage / getMP
+        // protection.
+        server.enqueue(MockResponse().setResponseCode(302).addHeader("Location", "/login.php"))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("<html>login</html>"))
+
+        val error = runCatching {
+            client.getTopicPage(cat = 23, post = 35395, page = 1, useAuth = true)
+        }.exceptionOrNull()
+
+        assertTrue("expected SessionExpiredException, got $error", error is SessionExpiredException)
+    }
+
+    @Test
+    fun `getTopicPage with useAuth=false skips session expiry detection`() = runTest {
+        // The anonymous prefetch path must NOT raise SessionExpired even on a login-like body:
+        // there is no session to expire, the caller wants whatever HTML the server returned.
+        val loginLikeBody = """
+            <html><body>
+              <form action="/login_validation.php?config=hfr.inc">
+                <input name="pseudo">
+                <input name="password" type="password">
+              </form>
+            </body></html>
+        """.trimIndent()
+        server.enqueue(MockResponse().setResponseCode(200).setBody(loginLikeBody))
+
+        val html = client.getTopicPage(cat = 23, post = 35395, page = 1, useAuth = false)
+
+        assertEquals(loginLikeBody, html)
+    }
 }

--- a/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/HfrClientTest.kt
+++ b/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/HfrClientTest.kt
@@ -1,0 +1,80 @@
+package fr.forumhfr.redface2.core.network
+
+import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class HfrClientTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: HfrClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().apply { start() }
+        val okHttp = OkHttpClient.Builder().build()
+        client = HfrClient(
+            authenticated = okHttp,
+            anonymous = okHttp,
+            baseUrl = server.url("/"),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `getFlagsPage throws SessionExpired when final URL is login page`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(302)
+                .addHeader("Location", "/login.php"),
+        )
+        server.enqueue(MockResponse().setResponseCode(200).setBody("<html>login</html>"))
+
+        val error = runCatching { client.getFlagsPage(owntopic = 1) }.exceptionOrNull()
+
+        assertTrue("expected SessionExpiredException, got $error", error is SessionExpiredException)
+        assertTrue((error as SessionExpiredException).finalUrl.endsWith("/login.php"))
+    }
+
+    @Test
+    fun `getPrivateMessageListPage throws SessionExpired on login form served as HTTP 200`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """
+                    <html><body>
+                      <form action="/login_validation.php?config=hfr.inc">
+                        <input name="pseudo">
+                        <input name="password" type="password">
+                      </form>
+                    </body></html>
+                    """.trimIndent(),
+                ),
+        )
+
+        val error = runCatching { client.getPrivateMessageListPage(page = 1) }.exceptionOrNull()
+
+        assertTrue("expected SessionExpiredException, got $error", error is SessionExpiredException)
+    }
+
+    @Test
+    fun `getFlagsPage keeps a real empty flags page distinct from session expired`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("<html><body>Aucun sujet</body></html>"))
+
+        val html = client.getFlagsPage(owntopic = 3)
+
+        assertEquals("<html><body>Aucun sujet</body></html>", html)
+    }
+}

--- a/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/auth/AuthRemoteDataSourceTest.kt
+++ b/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/auth/AuthRemoteDataSourceTest.kt
@@ -4,6 +4,9 @@ import fr.forumhfr.redface2.core.domain.auth.LoginError
 import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
 import fr.forumhfr.redface2.core.model.AuthState
 import kotlinx.coroutines.test.runTest
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -23,13 +26,8 @@ class AuthRemoteDataSourceTest {
     @Before
     fun setUp() {
         server = MockWebServer().apply { start() }
-        val client = OkHttpClient.Builder().build()
         diagnostics = DiagnosticsLog()
-        dataSource = AuthRemoteDataSource(
-            client = client,
-            baseUrl = server.url("/"),
-            diagnostics = diagnostics,
-        )
+        dataSource = buildDataSource()
     }
 
     @After
@@ -79,6 +77,26 @@ class AuthRemoteDataSourceTest {
     }
 
     @Test
+    fun `successful login keeps Set-Cookie from login redirect`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(302)
+                .addHeader("Location", "/forum1.php")
+                .addHeader("Set-Cookie", "md_user=xaat; Path=/")
+                .addHeader("Set-Cookie", "md_pass=deadbeef; Path=/; HttpOnly"),
+        )
+
+        val result = dataSource.login("xaat", "secret")
+
+        assertEquals(AuthState.Authenticated("xaat"), result.getOrNull())
+        assertEquals(
+            "staging login client must not follow redirects before parsing Set-Cookie",
+            1,
+            server.requestCount,
+        )
+    }
+
+    @Test
     fun `invalid credentials returns LoginError InvalidCredentials`() = runTest {
         server.enqueue(
             MockResponse()
@@ -89,6 +107,23 @@ class AuthRemoteDataSourceTest {
         val result = dataSource.login("xaat", "wrong")
 
         assertEquals(LoginError.InvalidCredentials, result.exceptionOrNull())
+    }
+
+    @Test
+    fun `invalid credentials with Set-Cookie does not persist cookies`() = runTest {
+        val cookieJar = RecordingCookieJar()
+        dataSource = buildDataSource(cookieJar)
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .addHeader("Set-Cookie", "md_user=xaat; Path=/")
+                .setBody("<html><body>Votre mot de passe ou nom d'utilisateur n'est pas valide</body></html>"),
+        )
+
+        val result = dataSource.login("xaat", "wrong")
+
+        assertEquals(LoginError.InvalidCredentials, result.exceptionOrNull())
+        assertTrue("login failure must not persist Set-Cookie", cookieJar.savedCookies.isEmpty())
     }
 
     @Test
@@ -105,6 +140,23 @@ class AuthRemoteDataSourceTest {
     }
 
     @Test
+    fun `rate-limited response with Set-Cookie does not persist cookies`() = runTest {
+        val cookieJar = RecordingCookieJar()
+        dataSource = buildDataSource(cookieJar)
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .addHeader("Set-Cookie", "md_user=xaat; Path=/")
+                .setBody("<html><body>Afin de prévenir les tentatives de flood, veuillez patienter</body></html>"),
+        )
+
+        val result = dataSource.login("xaat", "secret")
+
+        assertEquals(LoginError.RateLimited, result.exceptionOrNull())
+        assertTrue("login failure must not persist Set-Cookie", cookieJar.savedCookies.isEmpty())
+    }
+
+    @Test
     fun `success page without md_user cookie returns LoginError Unknown`() = runTest {
         server.enqueue(
             MockResponse()
@@ -117,6 +169,24 @@ class AuthRemoteDataSourceTest {
         val error = result.exceptionOrNull()
         assertTrue("expected Unknown but was ${error?.javaClass?.simpleName}", error is LoginError.Unknown)
         assertEquals("expected md_user cookie not set", (error as LoginError.Unknown).detail)
+    }
+
+    @Test
+    fun `unknown response with partial Set-Cookie but no md_user does not persist cookies`() = runTest {
+        val cookieJar = RecordingCookieJar()
+        dataSource = buildDataSource(cookieJar)
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .addHeader("Set-Cookie", "md_pass=deadbeef; Path=/; HttpOnly")
+                .addHeader("Set-Cookie", "md_id=42; Path=/")
+                .setBody("<html><body>Bienvenue</body></html>"),
+        )
+
+        val result = dataSource.login("xaat", "secret")
+
+        assertEquals("expected md_user cookie not set", (result.exceptionOrNull() as LoginError.Unknown).detail)
+        assertTrue("partial login cookies must not be persisted without md_user", cookieJar.savedCookies.isEmpty())
     }
 
     @Test
@@ -148,6 +218,42 @@ class AuthRemoteDataSourceTest {
     }
 
     @Test
+    fun `unknown response with mismatching Set-Cookie does not persist cookies`() = runTest {
+        val cookieJar = RecordingCookieJar()
+        dataSource = buildDataSource(cookieJar)
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .addHeader("Set-Cookie", "md_user=someone_else; Path=/")
+                .addHeader("Set-Cookie", "md_pass=deadbeef; Path=/; HttpOnly")
+                .setBody("<html><body>OK</body></html>"),
+        )
+
+        val result = dataSource.login("xaat", "secret")
+
+        assertTrue(result.exceptionOrNull() is LoginError.Unknown)
+        assertTrue("login failure must not persist Set-Cookie", cookieJar.savedCookies.isEmpty())
+    }
+
+    @Test
+    fun `successful login commits staged cookies to the original cookie jar`() = runTest {
+        val cookieJar = RecordingCookieJar()
+        dataSource = buildDataSource(cookieJar)
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .addHeader("Set-Cookie", "md_user=xaat; Path=/")
+                .addHeader("Set-Cookie", "md_pass=deadbeef; Path=/; HttpOnly")
+                .setBody("<html><body>Bienvenue xaat</body></html>"),
+        )
+
+        val result = dataSource.login("xaat", "secret")
+
+        assertEquals(AuthState.Authenticated("xaat"), result.getOrNull())
+        assertEquals(listOf("md_user", "md_pass"), cookieJar.savedCookies.map { it.name })
+    }
+
+    @Test
     fun `network failure returns LoginError Network with the IOException attached`() = runTest {
         server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AFTER_REQUEST))
 
@@ -155,5 +261,27 @@ class AuthRemoteDataSourceTest {
 
         val error = result.exceptionOrNull()
         assertTrue("expected Network but was ${error?.javaClass?.simpleName}", error is LoginError.Network)
+    }
+
+    private fun buildDataSource(cookieJar: CookieJar = CookieJar.NO_COOKIES): AuthRemoteDataSource {
+        val client = OkHttpClient.Builder()
+            .cookieJar(cookieJar)
+            .build()
+        return AuthRemoteDataSource(
+            client = client,
+            baseUrl = server.url("/"),
+            diagnostics = diagnostics,
+        )
+    }
+
+    private class RecordingCookieJar : CookieJar {
+        var savedCookies: List<Cookie> = emptyList()
+            private set
+
+        override fun loadForRequest(url: HttpUrl): List<Cookie> = emptyList()
+
+        override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+            savedCookies = cookies
+        }
     }
 }

--- a/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/cookie/PersistentCookieJarTest.kt
+++ b/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/cookie/PersistentCookieJarTest.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import okhttp3.Cookie
 import okhttp3.HttpUrl
@@ -132,6 +134,22 @@ class PersistentCookieJarTest {
 
         assertEquals(emptyList<Cookie>(), jar.state.value)
         assertEquals(emptyList<Cookie>(), store.lastSaved)
+        assertTrue(store.cleared)
+    }
+
+    @Test
+    fun `clear wins over a stale save coroutine that has not reached the store yet`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val store = FakeCookieStore(initial = emptyList())
+        val jar = PersistentCookieJar(store, dispatcher)
+
+        jar.saveFromResponse(baseUrl, listOf(cookie("md_user", "xaat")))
+        jar.clear()
+        runCurrent()
+
+        assertEquals(emptyList<Cookie>(), jar.state.value)
+        assertEquals(emptyList<Cookie>(), store.lastSaved)
+        assertEquals("stale save should be skipped before reaching the store", 0, store.saveCount)
         assertTrue(store.cleared)
     }
 

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -248,7 +248,7 @@ class HfrClient @Inject constructor(
 }
 ```
 
-Le login HFR est isolé dans `:core:network.auth.AuthRemoteDataSource`, pas dans `HfrClient` : il POSTe `login_validation.php`, classe la réponse, puis laisse le `@AuthenticatedClient` persister les cookies via `PersistentCookieJar`.
+Le login HFR est isolé dans `:core:network.auth.AuthRemoteDataSource`, pas dans `HfrClient` : il POSTe `login_validation.php` avec un cookie jar de staging, classe la réponse, puis commite explicitement les cookies dans le `@AuthenticatedClient` seulement si la réponse est `Authenticated`.
 
 `@AnonymousClient` (cookie jar = `CookieJar.NO_COOKIES`) permet à un caller — typiquement le prefetch de la page suivante — d'aller chercher du HTML sans que HFR ne marque les drapeaux comme lus côté serveur. Les écrans qui doivent honorer la lecture (lecture utilisateur) appellent avec `useAuth = true` (default).
 
@@ -381,9 +381,10 @@ sequenceDiagram
     participant HFR
 
     App->>OkHttp: login(user, pass)
-    OkHttp->>HFR: POST /login_validation.php
+    OkHttp->>HFR: POST /login_validation.php (cookie jar staging, no redirect)
     HFR-->>OkHttp: Set-Cookie md_user, md_pass
-    OkHttp->>OkHttp: CookieJar stocke les cookies
+    OkHttp->>OkHttp: classify Authenticated
+    OkHttp->>OkHttp: commit cookies dans PersistentCookieJar
 
     Note over App,HFR: Toutes les requêtes suivantes incluent les cookies
 
@@ -424,7 +425,7 @@ Les cookies sont persistés via un `PersistentCookieJar` adossé à un DataStore
 
 ### Session expirée
 
-Un futur `Interceptor` OkHttp détectera la redirection vers la page de login (HTTP 302 ou absence du cookie `md_user` dans la réponse). Il émettra un événement `SessionExpired` que `RedfaceApp` traduira en navigation vers la route de login livrée par `:feature:auth`. L'utilisateur ré-entre son mot de passe (Option A, pas de re-login transparent : le password n'est pas stocké).
+Les fetchers authentifiés lèvent `SessionExpiredException` quand HFR renvoie la page de login à la place du payload demandé (URL finale `/login.php` / `/login_validation.php`, ou formulaire login en HTTP 200). L'écran concerné affiche un état session expirée et propose la reconnexion via la route de login livrée par `:feature:auth`. L'utilisateur ré-entre son mot de passe (Option A, pas de re-login transparent : le password n'est pas stocké).
 
 ### HFR indisponible
 

--- a/docs/specs/protocol-hfr.md
+++ b/docs/specs/protocol-hfr.md
@@ -104,11 +104,16 @@ Détection de la réponse (mirror de l'impl `:core:network/auth/AuthRemoteDataSo
 
 | Cas | Marqueur | Action client |
 |---|---|---|
-| Succès | cookie `Set-Cookie: md_user=<pseudo>` présent | `AuthState.Authenticated(pseudo)`, cookie persisté par `PersistentCookieJar` |
+| Succès | cookie `Set-Cookie: md_user=<pseudo form-url-encoded>` présent et décodable vers le pseudo soumis | `AuthState.Authenticated(pseudo)`, cookies commités dans `PersistentCookieJar` |
 | Mauvais identifiants | body contient `Votre mot de passe ou nom d'utilisateur n'est pas valide` | `LoginError.InvalidCredentials` |
 | Anti-flood | body contient `Afin de prévenir les tentatives de flood` | `LoginError.RateLimited` (l'utilisateur attend quelques minutes et retente) |
-| Cookie `md_user` avec valeur ≠ pseudo soumis | défensif : `AuthRemoteDataSource` refuse de revendiquer une autre identité | `LoginError.Unknown("expected md_user cookie not set")` |
+| Cookie `md_user` absent | aucun cookie d'identité exploitable | `LoginError.Unknown("expected md_user cookie not set")` |
+| Cookie `md_user` présent mais valeur décodée ≠ pseudo soumis | défensif : `AuthRemoteDataSource` refuse de revendiquer une autre identité | `LoginError.Unknown("md_user cookie does not match requested pseudo (...)")` |
 | Tout autre format | aucun marqueur reconnu | `LoginError.Unknown(detail)` |
+
+HFR encode la valeur du cookie `md_user` comme un form body (`application/x-www-form-urlencoded`) : espace `+`, accents `%XX`, etc. Le client doit donc décoder `md_user` avant comparaison (`Colonel MythO` ↔ `Colonel+MythO`). Ce contrat est couvert par le test `pseudo with space matches md_user cookie URL-form-encoded`.
+
+Le POST login utilise un cookie jar de staging avec redirects désactivés : les `Set-Cookie` posés par une réponse 200 ou par la redirection 302 de login restent visibles pour classification, puis ne sont commités dans le `PersistentCookieJar` qu'après classification `Authenticated`. Une réponse classée `InvalidCredentials`, `RateLimited` ou `Unknown` ne doit jamais installer une session par effet de bord.
 
 ---
 
@@ -250,15 +255,16 @@ Deux sources distinctes :
 | `md_forum` | Identifiant de forum | session |
 | Cookies divers (tracking interne HFR) | — | variable |
 
-**Indicateur de session active** : présence du cookie `md_user`. Si une réponse HTTP redirige vers la page de login ou si le DOM ne contient plus le pseudo de l'utilisateur connecté, la session a expiré.
+**Indicateur de session active** : présence du cookie `md_user`. Si une réponse HTTP redirige vers la page de login ou si le DOM contient le formulaire login à la place du payload demandé, la session a expiré.
 
 ### Détection et recovery de session expirée
 
-Un `Interceptor` OkHttp :
+Les fetchers authentifiés doivent distinguer une vraie liste vide d'une page login servie en HTTP 200. Phase 1B hardening : `HfrClient` lève `SessionExpiredException` au minimum quand :
 
-1. Détecte HTTP 302 vers `/login.php` ou absence du pseudo dans la réponse.
-2. Émet un événement `SessionExpired`.
-3. Quand ce détecteur sera implémenté, `RedfaceApp` (`NavDisplay`) réinitialisera le back stack courant vers la route de login livrée par `:feature:auth` et effacera le cache Room concerné.
+1. l'URL finale après redirection pointe vers `/login.php` ou `/login_validation.php` ;
+2. le HTML contient un formulaire login HFR (`login_validation.php`, champ `pseudo`, champ `password`).
+
+Ce signal est branché sur les endpoints authentifiés `getFlagsPage()` et `getPrivateMessageListPage()`. L'UI drapeaux affiche alors un état “session expirée” avec action de reconnexion, au lieu de parser la page login comme une liste vide.
 
 L'utilisateur ré-entre son mot de passe (Option A : pas de re-login transparent, le password n'est pas stocké — voir [architecture.md#stockage-sécurisé-des-credentials](architecture.md#stockage-sécurisé-des-credentials)).
 

--- a/docs/specs/protocol-hfr.md
+++ b/docs/specs/protocol-hfr.md
@@ -264,7 +264,7 @@ Les fetchers authentifiés doivent distinguer une vraie liste vide d'une page lo
 1. l'URL finale après redirection pointe vers `/login.php` ou `/login_validation.php` ;
 2. le HTML contient un formulaire login HFR (`login_validation.php`, champ `pseudo`, champ `password`).
 
-Ce signal est branché sur les endpoints authentifiés `getFlagsPage()` et `getPrivateMessageListPage()`. L'UI drapeaux affiche alors un état “session expirée” avec action de reconnexion, au lieu de parser la page login comme une liste vide.
+Ce signal est branché sur les endpoints authentifiés `getFlagsPage()`, `getPrivateMessageListPage()` et `getTopicPage(useAuth = true)`. Le chemin `getTopicPage(useAuth = false)` garde son passthrough anonyme pour le prefetch : il ne peut pas avoir de session expirée et le caller veut le HTML brut retourné par HFR. L'UI drapeaux affiche alors un état “session expirée” avec action de reconnexion, au lieu de parser la page login comme une liste vide.
 
 L'utilisateur ré-entre son mot de passe (Option A : pas de re-login transparent, le password n'est pas stocké — voir [architecture.md#stockage-sécurisé-des-credentials](architecture.md#stockage-sécurisé-des-credentials)).
 

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -81,7 +81,7 @@ Les dépôts en cylindre (`MPStorage2`, `hfr-redflag`) sont des **dépendances e
 
 **Objectif :** lire le forum. C'est 80% du use case.
 
-- [x] **Login HFR (cookies persistants)** — `:feature:auth.LoginScreen` + `AuthRepository` cache-aside (DataStore + `PersistentCookieJar`), session persistée via `md_user`/`md_pass` (cf. [ADR-002]({{ site.baseurl }}/adr/002-credentials-option-a) — DataStore non chiffré + FBE, AAB v14 / `0.1.0-phase1b.0`)
+- [x] **Login HFR (cookies persistants)** — `:feature:auth.LoginScreen` + `AuthRepository` cache-aside (DataStore + `PersistentCookieJar`), session persistée via `md_user`/`md_pass`, commit cookies seulement après classification `Authenticated`, détection session expirée sur endpoints authentifiés (cf. [ADR-002]({{ site.baseurl }}/adr/002-credentials-option-a) — DataStore non chiffré + FBE, AAB v14 / `0.1.0-phase1b.0`, hardening v24 / `0.1.0-phase1b.10`)
 - [x] **Écran Drapeaux (accueil)** — `:feature:flags.FlagsRoute` + `FlagRepository` (HFR `forum1f.php?owntopic={1,2,3}`, parser `FlagsListParser`), 3 onglets (« Mes sujets » / « Lus uniquement » / « Favoris »), boutons « Réessayer » / « Actualiser » sans pull-to-refresh complet en 1B, footer auth + MP unread (Phase 1B.2-1B.5)
 - [x] **Slice topic fixe** — historique : `TopicScreen` a rendu une fixture HFR via parser → AST → renderer le temps que le pipeline réseau soit posé
 - [x] **Parser HTML topic** — `:core:parser` produit `PostContent` depuis le HTML HFR (cf. [PR #78](https://github.com/ForumHFR/redface2/pull/78))

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.domain.flags.FlagsResult
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.Flag
@@ -94,9 +95,12 @@ fun FlagsRoute(
                     is AuthState.Authenticated -> AuthenticatedBody(
                         selectedTab = selectedTab,
                         flagsState = flagsState,
-                        onSelectTab = viewModel::selectTab,
-                        onOpenFlag = onOpenFlag,
-                        onRefresh = viewModel::refresh,
+                        actions = AuthenticatedActions(
+                            onSelectTab = viewModel::selectTab,
+                            onOpenFlag = onOpenFlag,
+                            onRefresh = viewModel::refresh,
+                            onLoginRequested = onLoginRequested,
+                        ),
                     )
                 }
 
@@ -156,9 +160,7 @@ private fun AnonymousBody(onLoginRequested: () -> Unit) {
 private fun ColumnScope.AuthenticatedBody(
     selectedTab: FlagType,
     flagsState: FlagsResult?,
-    onSelectTab: (FlagType) -> Unit,
-    onOpenFlag: (Flag) -> Unit,
-    onRefresh: () -> Unit,
+    actions: AuthenticatedActions,
 ) {
     val tabs = listOf(
         FlagType.CYAN to stringResource(R.string.flags_tab_my_topics),
@@ -171,7 +173,7 @@ private fun ColumnScope.AuthenticatedBody(
         tabs.forEachIndexed { index, (type, label) ->
             Tab(
                 selected = index == selectedIndex,
-                onClick = { onSelectTab(type) },
+                onClick = { actions.onSelectTab(type) },
                 text = { Text(label, style = MaterialTheme.typography.labelLarge) },
             )
         }
@@ -193,19 +195,28 @@ private fun ColumnScope.AuthenticatedBody(
                 .padding(24.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
+            val sessionExpired = current.cause is SessionExpiredException
             Text(
-                text = stringResource(R.string.flags_error),
+                text = stringResource(
+                    if (sessionExpired) R.string.flags_session_expired else R.string.flags_error,
+                ),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.error,
             )
-            TextButton(onClick = onRefresh) {
-                Text(stringResource(R.string.flags_retry))
+            if (sessionExpired) {
+                TextButton(onClick = actions.onLoginRequested) {
+                    Text(stringResource(R.string.flags_login_cta))
+                }
+            } else {
+                TextButton(onClick = actions.onRefresh) {
+                    Text(stringResource(R.string.flags_retry))
+                }
             }
         }
 
         is FlagsResult.Success -> {
             TextButton(
-                onClick = onRefresh,
+                onClick = actions.onRefresh,
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(stringResource(R.string.flags_refresh))
@@ -238,7 +249,7 @@ private fun ColumnScope.AuthenticatedBody(
                         FlagItem(
                             flag = flag,
                             metadata = flagMetadata(flag),
-                            onClick = { onOpenFlag(flag) },
+                            onClick = { actions.onOpenFlag(flag) },
                         )
                         FlagItemDivider()
                     }
@@ -247,6 +258,13 @@ private fun ColumnScope.AuthenticatedBody(
         }
     }
 }
+
+private data class AuthenticatedActions(
+    val onSelectTab: (FlagType) -> Unit,
+    val onOpenFlag: (Flag) -> Unit,
+    val onRefresh: () -> Unit,
+    val onLoginRequested: () -> Unit,
+)
 
 private data class FooterActions(
     val onLogout: () -> Unit,

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="flags_loading">Chargement…</string>
     <string name="flags_empty">Aucun drapeau dans cette vue.</string>
     <string name="flags_error">Impossible de récupérer les drapeaux. Vérifie ta connexion ou réessaie.</string>
+    <string name="flags_session_expired">Session HFR expirée. Reconnecte-toi pour recharger tes drapeaux.</string>
     <string name="flags_retry">Réessayer</string>
     <string name="flags_refresh">Actualiser</string>
 

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -3,6 +3,7 @@ package fr.forumhfr.redface2.feature.flags
 import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.auth.LoginError
+import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.domain.flags.FlagRepository
 import fr.forumhfr.redface2.core.domain.flags.FlagsResult
 import fr.forumhfr.redface2.core.domain.messages.MessagesRepository
@@ -115,6 +116,30 @@ class FlagsViewModelTest {
 
         assertTrue(auth.logoutCalled)
         assertTrue("expected logout to clear private flags cache", flags.clearSessionCacheCallCount >= 1)
+    }
+
+    @Test
+    fun `flagsState propagates SessionExpiredException cause to drive the reconnect CTA`() = runTest {
+        // FlagsRoute renders the reconnect CTA branch when `current.cause is SessionExpiredException`.
+        // A future refactor that drops the `cause` field on FlagsResult.Failure (e.g. flattening
+        // it to a `String message`) would silently break that detection. This test pins the
+        // contract: the SessionExpiredException must traverse the repository → ViewModel →
+        // exposed state without being unwrapped.
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"))
+        val flags = FakeFlagRepository()
+        val vm = FlagsViewModel(auth, flags, FakeMessagesRepository())
+        val expired = SessionExpiredException("https://forum.hardware.fr/login.php")
+
+        vm.flagsState.test {
+            awaitItem() // initial null
+            flags.emit(FlagType.CYAN, FlagsResult.Failure(expired))
+            val failure = awaitItem() as FlagsResult.Failure
+            assertTrue(
+                "expected SessionExpiredException to traverse the stack — got ${failure.cause::class.simpleName}",
+                failure.cause is SessionExpiredException,
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Closes #95
- Closes #96
- Closes #97
- Closes #98
- Stage login cookies with redirects disabled, then commit only after Authenticated classification.
- Harden PersistentCookieJar/DataStoreCookieStore against stale async writes and corrupt persisted payloads.
- Add SessionExpiredException detection for flags/MP authenticated fetches and a reconnect CTA in FlagsRoute.
- Align protocol/architecture/roadmap docs and bump dogfood build to v24 / 0.1.0-phase1b.10.

## Test plan
- ./scripts/docker-dev.sh ./gradlew :core:network:testDebugUnitTest
- ./scripts/docker-dev.sh ./gradlew :core:network:testDebugUnitTest :core:data:testDebugUnitTest :feature:flags:testDebugUnitTest
- ./scripts/docker-dev.sh ./gradlew detektAll lintDebug test testDebugUnitTest :app:assembleDebug
- spec-check manual pass on auth/session docs via cross-file search

## Attribution IA
- Action par GPT-5 Codex (demandée par @XaaT)