### PR TITLE
docs(adr): adopt hybrid HFR REST strategy

### DIFF
--- a/core/parser/src/test/resources/fixtures/rest_cat23_participated.json
+++ b/core/parser/src/test/resources/fixtures/rest_cat23_participated.json
@@ -1,0 +1,62 @@
+{
+    "resource": {
+        "page": 1,
+        "results_count": 1,
+        "results_per_page": 1,
+        "resources": [
+            {
+                "id": 35395,
+                "title": "Redface 2 \u2014 PHASE 1 @ ALPHA",
+                "last_post_date": "2026-05-01 17:07",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35395/posts/?page=12&results_per_page=40",
+                        "count": 541
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "qwazer",
+                        "tns3": "mesdiscussions-959354.jpg"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "XaTriX",
+                        "tns3": "mesdiscussions-54596.png"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35395/",
+                "is_read": false,
+                "flag_owntopic": 1,
+                "last_position": 479,
+                "last_post_read_id": 2783256
+            }
+        ],
+        "list_type": "topic",
+        "type": "list",
+        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/topics/participated/?page=1&results_per_page=1"
+    }
+}

--- a/core/parser/src/test/resources/fixtures/rest_cat23_participated.source.txt
+++ b/core/parser/src/test/resources/fixtures/rest_cat23_participated.source.txt
@@ -1,0 +1,17 @@
+Source: forum.hardware.fr — REST API (authentifié)
+Captured endpoint: GET /webservices/rest_api.php?uri=forums/hardwarefr/categories/23/topics/participated/
+Captured: 2026-05-01 avec cookies md_user/md_passs/md_id (compte test)
+Type: topics participés (drapeau cyan owntopic=1 du legacy) scopés cat=23
+
+Champs ADDITIONNELS vs anonymous (cf. rest_topics_cat23_subcat550_p1.json) :
+- `is_read: bool`              → drapeau lu/non-lu (false = non-lu = drapeau coloré)
+- `flag_owntopic: int`         → 1 (cyan participé)
+- `last_position: int`         → numéro de page où l'utilisateur s'est arrêté la dernière fois
+- `last_post_read_id: int`     → ID du dernier post lu (utile pour deep-link "aller au dernier message lu")
+- `links.subcategory`          → href vers la sous-catégorie d'origine du topic (le topic 35395 est en sub=550)
+- `links.posts.href` contient déjà `?page=N` où N = page du dernier post lu (ici page=12) — utilisable directement
+
+Conséquence pour Redface 2 :
+- Cet endpoint remplace HfrClient.getFlagsPage(owntopic=1) côté REST
+- Le payload JSON donne directement la cible "Aller au dernier message lu" (links.posts.href est ready)
+- Pas besoin de parser le tooltip HTML "Allez au dernier message lu dans un sujet auquel vous avez participé"

--- a/core/parser/src/test/resources/fixtures/rest_categories.json
+++ b/core/parser/src/test/resources/fixtures/rest_categories.json
@@ -1,0 +1,506 @@
+{
+    "resource": {
+        "page": 1,
+        "results_count": 19,
+        "results_per_page": 19,
+        "resources": [
+            {
+                "id": 1,
+                "name": "Hardware",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/1/subcategories/",
+                        "count": 15
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/1/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/1/",
+                "number_of_subcategories": 15,
+                "force_subcat": true
+            },
+            {
+                "id": 16,
+                "name": "Hardware - P\u00e9riph\u00e9riques",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/16/subcategories/",
+                        "count": 8
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/16/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/16/",
+                "number_of_subcategories": 8,
+                "force_subcat": true
+            },
+            {
+                "id": 15,
+                "name": "Ordinateurs portables",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/15/subcategories/",
+                        "count": 8
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/15/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/15/",
+                "number_of_subcategories": 8,
+                "force_subcat": true
+            },
+            {
+                "id": 2,
+                "name": "Overclocking, Cooling &amp; Modding",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/2/subcategories/",
+                        "count": 7
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/2/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/2/",
+                "number_of_subcategories": 7,
+                "force_subcat": true
+            },
+            {
+                "id": 30,
+                "name": "Electronique, domotique, DIY",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/30/subcategories/",
+                        "count": 7
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/30/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/30/",
+                "number_of_subcategories": 7,
+                "force_subcat": false
+            },
+            {
+                "id": 23,
+                "name": "Technologies Mobiles",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/",
+                        "count": 10
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/",
+                "number_of_subcategories": 10,
+                "force_subcat": true
+            },
+            {
+                "id": 25,
+                "name": "Apple",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/25/subcategories/",
+                        "count": 7
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/25/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/25/",
+                "number_of_subcategories": 7,
+                "force_subcat": false
+            },
+            {
+                "id": 3,
+                "name": "Video &amp; Son",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/3/subcategories/",
+                        "count": 4
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/3/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/3/",
+                "number_of_subcategories": 4,
+                "force_subcat": true
+            },
+            {
+                "id": 14,
+                "name": "Photo num\u00e9rique",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/14/subcategories/",
+                        "count": 10
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/14/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/14/",
+                "number_of_subcategories": 10,
+                "force_subcat": true
+            },
+            {
+                "id": 5,
+                "name": "Jeux Video",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/5/subcategories/",
+                        "count": 7
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/5/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/5/",
+                "number_of_subcategories": 7,
+                "force_subcat": true
+            },
+            {
+                "id": 4,
+                "name": "Windows &amp; Software",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/4/subcategories/",
+                        "count": 12
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/4/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/4/",
+                "number_of_subcategories": 12,
+                "force_subcat": true
+            },
+            {
+                "id": 22,
+                "name": "R\u00e9seaux grand public / SoHo",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/22/subcategories/",
+                        "count": 8
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/22/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/22/",
+                "number_of_subcategories": 8,
+                "force_subcat": true
+            },
+            {
+                "id": 21,
+                "name": "Syst\u00e8mes &amp; R\u00e9seaux Pro",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/21/subcategories/",
+                        "count": 8
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/21/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/21/",
+                "number_of_subcategories": 8,
+                "force_subcat": true
+            },
+            {
+                "id": 11,
+                "name": "Linux et OS Alternatifs",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/11/subcategories/",
+                        "count": 8
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/11/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/11/",
+                "number_of_subcategories": 8,
+                "force_subcat": true
+            },
+            {
+                "id": 10,
+                "name": "Programmation",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/10/subcategories/",
+                        "count": 27
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/10/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/10/",
+                "number_of_subcategories": 27,
+                "force_subcat": true
+            },
+            {
+                "id": 12,
+                "name": "Graphisme",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/12/subcategories/",
+                        "count": 10
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/12/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/12/",
+                "number_of_subcategories": 10,
+                "force_subcat": true
+            },
+            {
+                "id": 6,
+                "name": "Achats &amp; Ventes",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/6/subcategories/",
+                        "count": 11
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/6/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/6/",
+                "number_of_subcategories": 11,
+                "force_subcat": true
+            },
+            {
+                "id": 8,
+                "name": "Emploi &amp; Etudes",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/8/subcategories/",
+                        "count": 5
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/8/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/8/",
+                "number_of_subcategories": 5,
+                "force_subcat": true
+            },
+            {
+                "id": 13,
+                "name": "Discussions",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/",
+                        "count": 15
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/",
+                "number_of_subcategories": 15,
+                "force_subcat": true
+            }
+        ],
+        "list_type": "forum_category",
+        "type": "list",
+        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/"
+    }
+}

--- a/core/parser/src/test/resources/fixtures/rest_categories.source.txt
+++ b/core/parser/src/test/resources/fixtures/rest_categories.source.txt
@@ -1,0 +1,16 @@
+Source: forum.hardware.fr — REST API
+Captured endpoint: GET /webservices/rest_api.php?uri=forums/hardwarefr/categories/
+Captured: 2026-05-01 (anonymous, no cookies)
+Type: liste des 19 catégories publiques HFR exposées via l'API REST JSON
+
+Notes:
+- 19 catégories publiques, IDs non contigus (7, 9, 17-20, 26-29 non exposés ; 24 est conditionnelle, cf. ci-dessous)
+- Chaque entrée a `id`, `name`, `force_subcat`, `number_of_subcategories`, `links.{forum,subcategories,last_topics}`, `type`, `href`
+- `name` contient des entités HTML non décodées (ex. `&amp;` pour `&`) — à décoder côté parser
+- La cat=24 "Blabla - Divers" est une catégorie privée/conditionnelle : elle n'est pas
+  visible par défaut en anonymous ni pour tous les comptes authentifiés. Elle peut
+  apparaître seulement après réglage administrateur sur un profil. Elle ne fait donc
+  pas partie de la navigation publique REST canonique.
+- Pas de `is_*` flags (rien de personnalisé en anonymous)
+
+Voir aussi: rest_categories_auth.json (mêmes 19 cats + links.{read_topics,participated_topics,favorite_topics} en auth).

--- a/core/parser/src/test/resources/fixtures/rest_categories_auth.json
+++ b/core/parser/src/test/resources/fixtures/rest_categories_auth.json
@@ -1,0 +1,791 @@
+{
+    "resource": {
+        "page": 1,
+        "results_count": 19,
+        "results_per_page": 19,
+        "resources": [
+            {
+                "id": 1,
+                "name": "Hardware",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/1/subcategories/",
+                        "count": 15
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/1/topics/last/?page=1&results_per_page=25"
+                    },
+                    "read_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/1/topics/read/"
+                    },
+                    "participated_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/1/topics/participated/"
+                    },
+                    "favorite_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/1/topics/favorites/"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/1/",
+                "number_of_subcategories": 15,
+                "force_subcat": true
+            },
+            {
+                "id": 16,
+                "name": "Hardware - P\u00e9riph\u00e9riques",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/16/subcategories/",
+                        "count": 8
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/16/topics/last/?page=1&results_per_page=25"
+                    },
+                    "read_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/16/topics/read/"
+                    },
+                    "participated_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/16/topics/participated/"
+                    },
+                    "favorite_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/16/topics/favorites/"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/16/",
+                "number_of_subcategories": 8,
+                "force_subcat": true
+            },
+            {
+                "id": 15,
+                "name": "Ordinateurs portables",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/15/subcategories/",
+                        "count": 8
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/15/topics/last/?page=1&results_per_page=25"
+                    },
+                    "read_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/15/topics/read/"
+                    },
+                    "participated_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/15/topics/participated/"
+                    },
+                    "favorite_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/15/topics/favorites/"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/15/",
+                "number_of_subcategories": 8,
+                "force_subcat": true
+            },
+            {
+                "id": 2,
+                "name": "Overclocking, Cooling &amp; Modding",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/2/subcategories/",
+                        "count": 7
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/2/topics/last/?page=1&results_per_page=25"
+                    },
+                    "read_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/2/topics/read/"
+                    },
+                    "participated_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/2/topics/participated/"
+                    },
+                    "favorite_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/2/topics/favorites/"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/2/",
+                "number_of_subcategories": 7,
+                "force_subcat": true
+            },
+            {
+                "id": 30,
+                "name": "Electronique, domotique, DIY",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/30/subcategories/",
+                        "count": 7
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/30/topics/last/?page=1&results_per_page=25"
+                    },
+                    "read_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/30/topics/read/"
+                    },
+                    "participated_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/30/topics/participated/"
+                    },
+                    "favorite_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/30/topics/favorites/"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/30/",
+                "number_of_subcategories": 7,
+                "force_subcat": false
+            },
+            {
+                "id": 23,
+                "name": "Technologies Mobiles",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/",
+                        "count": 10
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/topics/last/?page=1&results_per_page=25"
+                    },
+                    "read_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/topics/read/"
+                    },
+                    "participated_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/topics/participated/"
+                    },
+                    "favorite_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/topics/favorites/"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/",
+                "number_of_subcategories": 10,
+                "force_subcat": true
+            },
+            {
+                "id": 25,
+                "name": "Apple",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/25/subcategories/",
+                        "count": 7
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/25/topics/last/?page=1&results_per_page=25"
+                    },
+                    "read_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/25/topics/read/"
+                    },
+                    "participated_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/25/topics/participated/"
+                    },
+                    "favorite_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/25/topics/favorites/"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/25/",
+                "number_of_subcategories": 7,
+                "force_subcat": false
+            },
+            {
+                "id": 3,
+                "name": "Video &amp; Son",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/3/subcategories/",
+                        "count": 4
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/3/topics/last/?page=1&results_per_page=25"
+                    },
+                    "read_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/3/topics/read/"
+                    },
+                    "participated_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/3/topics/participated/"
+                    },
+                    "favorite_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/3/topics/favorites/"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/3/",
+                "number_of_subcategories": 4,
+                "force_subcat": true
+            },
+            {
+                "id": 14,
+                "name": "Photo num\u00e9rique",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/14/subcategories/",
+                        "count": 10
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/14/topics/last/?page=1&results_per_page=25"
+                    },
+                    "read_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/14/topics/read/"
+                    },
+                    "participated_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/14/topics/participated/"
+                    },
+                    "favorite_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/14/topics/favorites/"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/14/",
+                "number_of_subcategories": 10,
+                "force_subcat": true
+            },
+            {
+                "id": 5,
+                "name": "Jeux Video",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/5/subcategories/",
+                        "count": 7
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/5/topics/last/?page=1&results_per_page=25"
+                    },
+                    "read_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/5/topics/read/"
+                    },
+                    "participated_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/5/topics/participated/"
+                    },
+                    "favorite_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/5/topics/favorites/"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/5/",
+                "number_of_subcategories": 7,
+                "force_subcat": true
+            },
+            {
+                "id": 4,
+                "name": "Windows &amp; Software",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/4/subcategories/",
+                        "count": 12
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/4/topics/last/?page=1&results_per_page=25"
+                    },
+                    "read_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/4/topics/read/"
+                    },
+                    "participated_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/4/topics/participated/"
+                    },
+                    "favorite_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/4/topics/favorites/"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/4/",
+                "number_of_subcategories": 12,
+                "force_subcat": true
+            },
+            {
+                "id": 22,
+                "name": "R\u00e9seaux grand public / SoHo",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/22/subcategories/",
+                        "count": 8
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/22/topics/last/?page=1&results_per_page=25"
+                    },
+                    "read_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/22/topics/read/"
+                    },
+                    "participated_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/22/topics/participated/"
+                    },
+                    "favorite_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/22/topics/favorites/"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/22/",
+                "number_of_subcategories": 8,
+                "force_subcat": true
+            },
+            {
+                "id": 21,
+                "name": "Syst\u00e8mes &amp; R\u00e9seaux Pro",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/21/subcategories/",
+                        "count": 8
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/21/topics/last/?page=1&results_per_page=25"
+                    },
+                    "read_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/21/topics/read/"
+                    },
+                    "participated_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/21/topics/participated/"
+                    },
+                    "favorite_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/21/topics/favorites/"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/21/",
+                "number_of_subcategories": 8,
+                "force_subcat": true
+            },
+            {
+                "id": 11,
+                "name": "Linux et OS Alternatifs",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/11/subcategories/",
+                        "count": 8
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/11/topics/last/?page=1&results_per_page=25"
+                    },
+                    "read_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/11/topics/read/"
+                    },
+                    "participated_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/11/topics/participated/"
+                    },
+                    "favorite_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/11/topics/favorites/"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/11/",
+                "number_of_subcategories": 8,
+                "force_subcat": true
+            },
+            {
+                "id": 10,
+                "name": "Programmation",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/10/subcategories/",
+                        "count": 27
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/10/topics/last/?page=1&results_per_page=25"
+                    },
+                    "read_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/10/topics/read/"
+                    },
+                    "participated_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/10/topics/participated/"
+                    },
+                    "favorite_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/10/topics/favorites/"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/10/",
+                "number_of_subcategories": 27,
+                "force_subcat": true
+            },
+            {
+                "id": 12,
+                "name": "Graphisme",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/12/subcategories/",
+                        "count": 10
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/12/topics/last/?page=1&results_per_page=25"
+                    },
+                    "read_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/12/topics/read/"
+                    },
+                    "participated_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/12/topics/participated/"
+                    },
+                    "favorite_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/12/topics/favorites/"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/12/",
+                "number_of_subcategories": 10,
+                "force_subcat": true
+            },
+            {
+                "id": 6,
+                "name": "Achats &amp; Ventes",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/6/subcategories/",
+                        "count": 11
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/6/topics/last/?page=1&results_per_page=25"
+                    },
+                    "read_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/6/topics/read/"
+                    },
+                    "participated_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/6/topics/participated/"
+                    },
+                    "favorite_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/6/topics/favorites/"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/6/",
+                "number_of_subcategories": 11,
+                "force_subcat": true
+            },
+            {
+                "id": 8,
+                "name": "Emploi &amp; Etudes",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/8/subcategories/",
+                        "count": 5
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/8/topics/last/?page=1&results_per_page=25"
+                    },
+                    "read_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/8/topics/read/"
+                    },
+                    "participated_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/8/topics/participated/"
+                    },
+                    "favorite_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/8/topics/favorites/"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/8/",
+                "number_of_subcategories": 5,
+                "force_subcat": true
+            },
+            {
+                "id": 13,
+                "name": "Discussions",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "subcategories": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/",
+                        "count": 15
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/topics/last/?page=1&results_per_page=25"
+                    },
+                    "read_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/topics/read/"
+                    },
+                    "participated_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/topics/participated/"
+                    },
+                    "favorite_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/topics/favorites/"
+                    }
+                },
+                "type": "forum_category",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/",
+                "number_of_subcategories": 15,
+                "force_subcat": true
+            }
+        ],
+        "list_type": "forum_category",
+        "type": "list",
+        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/"
+    }
+}

--- a/core/parser/src/test/resources/fixtures/rest_categories_auth.source.txt
+++ b/core/parser/src/test/resources/fixtures/rest_categories_auth.source.txt
@@ -1,0 +1,21 @@
+Source: forum.hardware.fr — REST API (authentifié)
+Captured endpoint: GET /webservices/rest_api.php?uri=forums/hardwarefr/categories/
+Captured: 2026-05-01 avec cookies md_user/md_passs/md_id (compte test)
+Type: liste catégories en mode authentifié
+
+Différences vs anonymous (rest_categories.json):
+Pour CHAQUE catégorie, `links` contient en plus :
+- `read_topics`     → href vers /categories/{cat}/topics/read/        (drapeaux rouges, lecture suivie scopée à la cat)
+- `participated_topics` → href vers /categories/{cat}/topics/participated/ (drapeaux cyan, sujets participés scopés cat)
+- `favorite_topics` → href vers /categories/{cat}/topics/favorites/   (étoiles jaunes, favoris scopés cat)
+
+Aux niveaux globaux, ces 3 endpoints existent aussi sans scope cat:
+- /webservices/rest_api.php?uri=forums/hardwarefr/topics/{read,participated,favorites}/
+  → format différent : resources[] est un tableau de groupements par cat (chaque groupe contient ses topics)
+
+Conséquence pour Redface 2 :
+- L'écran "Drapeaux" actuellement servi par forum1f.php?owntopic={1,2,3} peut entièrement passer par REST :
+    owntopic=1 (cyan)  → topics/participated/
+    owntopic=2 (rouge) → topics/read/
+    owntopic=3 (jaune) → topics/favorites/
+- Plus besoin de scraper le HTML pour cet écran.

--- a/core/parser/src/test/resources/fixtures/rest_subcategories_cat13.json
+++ b/core/parser/src/test/resources/fixtures/rest_subcategories_cat13.json
@@ -1,0 +1,357 @@
+{
+    "resource": {
+        "page": 1,
+        "results_count": 15,
+        "results_per_page": 15,
+        "resources": [
+            {
+                "id": 422,
+                "name": "Actualit\u00e9",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/"
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/422/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_subcategory",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/422/"
+            },
+            {
+                "id": 482,
+                "name": "Politique",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/"
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/482/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_subcategory",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/482/"
+            },
+            {
+                "id": 423,
+                "name": "Soci\u00e9t\u00e9",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/"
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/423/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_subcategory",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/423/"
+            },
+            {
+                "id": 424,
+                "name": "Cin\u00e9ma",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/"
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/424/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_subcategory",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/424/"
+            },
+            {
+                "id": 425,
+                "name": "Musique",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/"
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/425/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_subcategory",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/425/"
+            },
+            {
+                "id": 426,
+                "name": "Arts &amp; Lecture",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/"
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/426/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_subcategory",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/426/"
+            },
+            {
+                "id": 427,
+                "name": "TV, Radio",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/"
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/427/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_subcategory",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/427/"
+            },
+            {
+                "id": 428,
+                "name": "Sciences",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/"
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/428/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_subcategory",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/428/"
+            },
+            {
+                "id": 429,
+                "name": "Sant\u00e9",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/"
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/429/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_subcategory",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/429/"
+            },
+            {
+                "id": 430,
+                "name": "Sports",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/"
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/430/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_subcategory",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/430/"
+            },
+            {
+                "id": 431,
+                "name": "Auto / Moto",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/"
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/431/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_subcategory",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/431/"
+            },
+            {
+                "id": 433,
+                "name": "Cuisine",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/"
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/433/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_subcategory",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/433/"
+            },
+            {
+                "id": 434,
+                "name": "Loisirs",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/"
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/434/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_subcategory",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/434/"
+            },
+            {
+                "id": 557,
+                "name": "Voyages",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/"
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/557/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_subcategory",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/557/"
+            },
+            {
+                "id": 432,
+                "name": "Vie pratique",
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/"
+                    },
+                    "last_topics": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/432/topics/last/?page=1&results_per_page=25"
+                    }
+                },
+                "type": "forum_subcategory",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/432/"
+            }
+        ],
+        "list_type": "forum_subcategory",
+        "type": "list",
+        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/"
+    }
+}

--- a/core/parser/src/test/resources/fixtures/rest_subcategories_cat13.source.txt
+++ b/core/parser/src/test/resources/fixtures/rest_subcategories_cat13.source.txt
@@ -1,0 +1,11 @@
+Source: forum.hardware.fr — REST API
+Captured endpoint: GET /webservices/rest_api.php?uri=forums/hardwarefr/categories/13/subcategories/
+Captured: 2026-05-01 (anonymous)
+Type: 15 sous-catégories de Discussions (cat=13)
+
+Notes:
+- 15 subcats : Actualité, Politique, Société, Cinéma, Musique, Arts & Lecture, TV/Radio, Sciences,
+  Santé, Sports, Auto/Moto, Cuisine, Loisirs, Voyages, Vie pratique
+- Chaque entrée: `id`, `name`, `links.{forum,category,last_topics}`, `type`, `href`
+- `id` subcat est globalement unique (422 = "Actualité" dans cat=13, 550 = "Android" dans cat=23)
+- Ordre HFR (pertinence éditoriale), pas lexicographique ni par ID

--- a/core/parser/src/test/resources/fixtures/rest_topic_meta_35395.json
+++ b/core/parser/src/test/resources/fixtures/rest_topic_meta_35395.json
@@ -1,0 +1,43 @@
+{
+    "resource": {
+        "id": 35395,
+        "title": "Redface 2 \u2014 PHASE 1 @ ALPHA",
+        "last_post_date": "2026-05-01 17:07",
+        "is_closed": false,
+        "is_sticky": true,
+        "links": {
+            "forum": {
+                "linked_type": "forum",
+                "type": "link",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+            },
+            "category": {
+                "linked_type": "forum_category",
+                "type": "link",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+            },
+            "posts": {
+                "linked_type": "list",
+                "type": "link",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/topics/35395/posts/?page=1&results_per_page=40",
+                "count": 541
+            },
+            "last_author": {
+                "linked_type": "user",
+                "type": "link",
+                "href": null,
+                "title": "qwazer",
+                "tns3": "mesdiscussions-959354.jpg"
+            },
+            "author": {
+                "linked_type": "user",
+                "type": "link",
+                "href": null,
+                "title": "XaTriX",
+                "tns3": "mesdiscussions-54596.png"
+            }
+        },
+        "type": "topic",
+        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/topics/35395/"
+    }
+}

--- a/core/parser/src/test/resources/fixtures/rest_topic_meta_35395.source.txt
+++ b/core/parser/src/test/resources/fixtures/rest_topic_meta_35395.source.txt
@@ -1,0 +1,8 @@
+Source: forum.hardware.fr — REST API
+Captured endpoint: GET /webservices/rest_api.php?uri=forums/hardwarefr/categories/23/topics/35395/
+Captured: 2026-05-01 (anonymous)
+Type: metadata standalone du topic 35395 (Redface 2 — PHASE 1 @ ALPHA)
+
+Mêmes champs que dans une ligne de la liste topics, sans wrapper de pagination.
+À utiliser pour le header de l'écran TopicReader (titre, sticky/locked, count posts, auteur, dernier auteur).
+La lecture du contenu (posts) reste obligatoirement HTML via forum2.php — endpoint REST /posts/ cassé HTTP 500.

--- a/core/parser/src/test/resources/fixtures/rest_topics_cat23_subcat550_p1.json
+++ b/core/parser/src/test/resources/fixtures/rest_topics_cat23_subcat550_p1.json
@@ -1,0 +1,1313 @@
+{
+    "resource": {
+        "page": 1,
+        "results_count": 1008,
+        "results_per_page": 25,
+        "resources": [
+            {
+                "id": 35367,
+                "title": "D\u00e9c\u00e8s de Marc, fondateur du forum",
+                "last_post_date": "2026-02-09 16:26",
+                "is_closed": true,
+                "is_sticky": true,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/topics/35367/posts/?page=1&results_per_page=40",
+                        "count": 1
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "Wolfman",
+                        "tns3": "mesdiscussions-54374.jpg"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "Wolfman",
+                        "tns3": "mesdiscussions-54374.jpg"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/topics/35367/"
+            },
+            {
+                "id": 13,
+                "title": "[T\u00e9l\u00e9phonie Mobile] - Liste des topics uniques",
+                "last_post_date": "2025-11-09 14:30",
+                "is_closed": false,
+                "is_sticky": true,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/510/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/510/topics/13/posts/?page=1&results_per_page=40",
+                        "count": 190
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "conforoa",
+                        "tns3": "mesdiscussions-10029.jpg"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "Wolfman",
+                        "tns3": "mesdiscussions-54374.jpg"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/510/topics/13/"
+            },
+            {
+                "id": 26638,
+                "title": "[Tablettes] - Liste des topics uniques",
+                "last_post_date": "2024-04-30 09:07",
+                "is_closed": false,
+                "is_sticky": true,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/540/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/540/topics/26638/posts/?page=1&results_per_page=40",
+                        "count": 17
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "NAUSSAC"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "Wolfman",
+                        "tns3": "mesdiscussions-54374.jpg"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/540/topics/26638/"
+            },
+            {
+                "id": 14227,
+                "title": "/!\\ R\u00e8gles - A lire avant de poster !",
+                "last_post_date": "2007-08-19 16:06",
+                "is_closed": true,
+                "is_sticky": true,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/topics/14227/posts/?page=1&results_per_page=40",
+                        "count": 1
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "CharlesT",
+                        "tns3": "mesdiscussions-127415.jpg"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "CharlesT",
+                        "tns3": "mesdiscussions-127415.jpg"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/topics/14227/"
+            },
+            {
+                "id": 28190,
+                "title": "[Topic Unique] Les Autoradio/GPS/Multimedia sous Android (new Soc7870)",
+                "last_post_date": "2026-05-01 19:34",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/28190/posts/?page=1&results_per_page=40",
+                        "count": 12693
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "EE8",
+                        "tns3": "mesdiscussions-816398.jpg"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "mum1989",
+                        "tns3": "mesdiscussions-781637.png"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/28190/"
+            },
+            {
+                "id": 35395,
+                "title": "Redface 2 \u2014 PHASE 1 @ ALPHA",
+                "last_post_date": "2026-05-01 17:07",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35395/posts/?page=1&results_per_page=40",
+                        "count": 541
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "qwazer",
+                        "tns3": "mesdiscussions-959354.jpg"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "XaTriX",
+                        "tns3": "mesdiscussions-54596.png"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35395/"
+            },
+            {
+                "id": 35077,
+                "title": "[topic unique] balises GFH: Google Find Hub",
+                "last_post_date": "2026-04-30 12:18",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35077/posts/?page=1&results_per_page=40",
+                        "count": 587
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "Gui3gui"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "Poly"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35077/"
+            },
+            {
+                "id": 21184,
+                "title": "[Topic Unik] Applications Android - read the FP noob !!!",
+                "last_post_date": "2026-04-29 09:21",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/21184/posts/?page=1&results_per_page=40",
+                        "count": 62803
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "bulldozer_fusion",
+                        "tns3": "mesdiscussions-802171.jpg"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "fafarex",
+                        "tns3": "mesdiscussions-780119.jpg"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/21184/"
+            },
+            {
+                "id": 21748,
+                "title": "[Projet] HFR4droid 0.8.7 - 15 ans d\u00e9j\u00e0 !",
+                "last_post_date": "2026-04-28 22:35",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/21748/posts/?page=1&results_per_page=40",
+                        "count": 18058
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "SenorPollo",
+                        "tns3": "mesdiscussions-1065212.png"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "ToYonos",
+                        "tns3": "mesdiscussions-51660.png"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/21748/"
+            },
+            {
+                "id": 27774,
+                "title": "[Android] S\u00e9curit\u00e9, vie priv\u00e9e",
+                "last_post_date": "2026-04-19 09:51",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/27774/posts/?page=1&results_per_page=40",
+                        "count": 63
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "Rem82",
+                        "tns3": "mesdiscussions-646455.jpg"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "Maratus",
+                        "tns3": "mesdiscussions-963009.jpg"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/27774/"
+            },
+            {
+                "id": 29332,
+                "title": "[TU] Redface, le client HFR pour Android [v5.0.1 dispo !]",
+                "last_post_date": "2026-04-16 19:55",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/29332/posts/?page=1&results_per_page=40",
+                        "count": 13888
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "XaTriX",
+                        "tns3": "mesdiscussions-54596.png"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "Ayuget",
+                        "tns3": "mesdiscussions-65747.jpg"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/29332/"
+            },
+            {
+                "id": 35259,
+                "title": "Un lecteur IPTV gratuit sur Android Box ?",
+                "last_post_date": "2026-04-14 12:57",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35259/posts/?page=1&results_per_page=40",
+                        "count": 4
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "Richard007x"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "Miketvnexus"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35259/"
+            },
+            {
+                "id": 35394,
+                "title": "Droid2PC : continuit\u00e9 Android vers Mac sans workflow cloud impos\u00e9",
+                "last_post_date": "2026-04-11 01:29",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35394/posts/?page=1&results_per_page=40",
+                        "count": 1
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "droid2pc"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "droid2pc"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35394/"
+            },
+            {
+                "id": 35391,
+                "title": "La \"prison\" android.....",
+                "last_post_date": "2026-04-06 22:23",
+                "is_closed": true,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35391/posts/?page=1&results_per_page=40",
+                        "count": 2
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "Mod\u00e9ration"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "merise2",
+                        "tns3": "mesdiscussions-1207239.jpg"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35391/"
+            },
+            {
+                "id": 17825,
+                "title": "[Topic Unique] Android NOUGAT 7.0",
+                "last_post_date": "2026-03-31 22:57",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/17825/posts/?page=1&results_per_page=40",
+                        "count": 18211
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "-JLL-",
+                        "tns3": "mesdiscussions-631390.png"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "Olivie",
+                        "tns3": "mesdiscussions-563008.jpg"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/17825/"
+            },
+            {
+                "id": 35380,
+                "title": "Android va devenir une plateforme ferm\u00e9e au mois de septembre",
+                "last_post_date": "2026-03-26 12:42",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35380/posts/?page=1&results_per_page=40",
+                        "count": 11
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "merise2",
+                        "tns3": "mesdiscussions-1207239.jpg"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "muzah",
+                        "tns3": "mesdiscussions-34850.png"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35380/"
+            },
+            {
+                "id": 35295,
+                "title": "[Topic Unique] Migration d'iOs \u00e0 Android",
+                "last_post_date": "2026-03-04 09:37",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35295/posts/?page=1&results_per_page=40",
+                        "count": 83
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "myzt",
+                        "tns3": "mesdiscussions-834445.jpg"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "Kerjou"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35295/"
+            },
+            {
+                "id": 34406,
+                "title": "[TU] [Feedback] NextGP : App Android d\u00e9di\u00e9 au racing (F1 x MotoGP)",
+                "last_post_date": "2026-02-06 16:12",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/34406/posts/?page=1&results_per_page=40",
+                        "count": 56
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "bixibu",
+                        "tns3": "mesdiscussions-114687.png"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "bixibu",
+                        "tns3": "mesdiscussions-114687.png"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/34406/"
+            },
+            {
+                "id": 35331,
+                "title": "autoradio android probl\u00e8me CANBUS",
+                "last_post_date": "2026-01-15 14:36",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35331/posts/?page=1&results_per_page=40",
+                        "count": 2
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "absolumentpasbultom",
+                        "tns3": "mesdiscussions-1056359.jpg"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "loweib"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35331/"
+            },
+            {
+                "id": 35357,
+                "title": "comment envoyer un ptit fichier .RAR par bluetooth avec FICHIERS ?",
+                "last_post_date": "2026-01-13 07:59",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35357/posts/?page=1&results_per_page=40",
+                        "count": 2
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "amiens2019"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "amiens2019"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35357/"
+            },
+            {
+                "id": 35355,
+                "title": "R\u00e9solu - Gmail android plus de synchro plus de notification",
+                "last_post_date": "2026-01-09 19:16",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35355/posts/?page=1&results_per_page=40",
+                        "count": 1
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "nicotat"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "nicotat"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35355/"
+            },
+            {
+                "id": 35354,
+                "title": "site pour t\u00e9l\u00e9charger .apk sans passer par une appli tierce?",
+                "last_post_date": "2026-01-08 14:37",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35354/posts/?page=1&results_per_page=40",
+                        "count": 1
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "serrye"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "serrye"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35354/"
+            },
+            {
+                "id": 35332,
+                "title": "probl\u00e8me connexion internet / android auto",
+                "last_post_date": "2025-12-23 10:39",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35332/posts/?page=1&results_per_page=40",
+                        "count": 19
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "polux42"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "polux42"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35332/"
+            },
+            {
+                "id": 35337,
+                "title": "YouTube sur Android Auto ou Android Automovie",
+                "last_post_date": "2025-11-28 16:44",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35337/posts/?page=1&results_per_page=40",
+                        "count": 1
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "DiB91",
+                        "tns3": "mesdiscussions-58199.png"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "DiB91",
+                        "tns3": "mesdiscussions-58199.png"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35337/"
+            },
+            {
+                "id": 35231,
+                "title": "blocage num\u00e9ros t\u00e9l",
+                "last_post_date": "2025-11-08 15:04",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35231/posts/?page=1&results_per_page=40",
+                        "count": 7
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "merise2",
+                        "tns3": "mesdiscussions-1207239.jpg"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "hspyck"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35231/"
+            },
+            {
+                "id": 35325,
+                "title": "Transfert via usb sur android impossible",
+                "last_post_date": "2025-11-02 10:50",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35325/posts/?page=1&results_per_page=40",
+                        "count": 2
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "scalpatif",
+                        "tns3": "mesdiscussions-501259.jpg"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "scalpatif",
+                        "tns3": "mesdiscussions-501259.jpg"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35325/"
+            },
+            {
+                "id": 35313,
+                "title": "Android auto",
+                "last_post_date": "2025-09-26 19:17",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35313/posts/?page=1&results_per_page=40",
+                        "count": 2
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "b4tm4n",
+                        "tns3": "mesdiscussions-1211322.jpg"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "ananas74"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35313/"
+            },
+            {
+                "id": 35315,
+                "title": "ouverture diaphragme sur redmenote 14",
+                "last_post_date": "2025-09-26 19:09",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35315/posts/?page=1&results_per_page=40",
+                        "count": 2
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "b4tm4n",
+                        "tns3": "mesdiscussions-1211322.jpg"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "Sepamal"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35315/"
+            },
+            {
+                "id": 35312,
+                "title": "comment donner le droit autorisation miracast \u00e0 une appli ?",
+                "last_post_date": "2025-09-25 19:23",
+                "is_closed": false,
+                "is_sticky": false,
+                "links": {
+                    "forum": {
+                        "linked_type": "forum",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+                    },
+                    "category": {
+                        "linked_type": "forum_category",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/"
+                    },
+                    "subcategory": {
+                        "linked_type": "forum_subcategory",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/"
+                    },
+                    "posts": {
+                        "linked_type": "list",
+                        "type": "link",
+                        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35312/posts/?page=1&results_per_page=40",
+                        "count": 3
+                    },
+                    "last_author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "amiens2019"
+                    },
+                    "author": {
+                        "linked_type": "user",
+                        "type": "link",
+                        "href": null,
+                        "title": "amiens2019"
+                    }
+                },
+                "type": "topic",
+                "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/35312/"
+            }
+        ],
+        "list_type": "topic",
+        "type": "list",
+        "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/23/subcategories/550/topics/last/?page=1&results_per_page=25"
+    }
+}

--- a/core/parser/src/test/resources/fixtures/rest_topics_cat23_subcat550_p1.source.txt
+++ b/core/parser/src/test/resources/fixtures/rest_topics_cat23_subcat550_p1.source.txt
@@ -1,0 +1,25 @@
+Source: forum.hardware.fr — REST API
+Captured endpoint: GET /webservices/rest_api.php?uri=forums/hardwarefr/categories/23/subcategories/550/topics/last/&page=1&results_per_page=25
+Captured: 2026-05-01 (anonymous)
+Type: page 1 des 25 derniers topics de cat=23 (Tech Mobiles) / subcat=550 (Android)
+
+Champs par topic (anonymous):
+- id, title, last_post_date (format "YYYY-MM-DD HH:MM" — pas de secondes), is_closed, is_sticky
+- links.posts.count (= nb total posts du topic)
+- links.posts.href (URL pour lecture HTML — REST /posts/ est cassé HTTP 500)
+- links.author.{title, tns3} (pseudo + filename avatar)
+- links.last_author.{title, tns3}
+- href, type
+
+Champs MANQUANTS vs HTML forum1.php :
+- `views` (nombre de vues) — non exposé en JSON
+- `total_pages` du topic — déductible via links.posts.count / 40 (results_per_page par défaut HTML topic)
+- `is_unread` / drapeaux personnels — uniquement en mode authentifié
+
+Pagination wrapper:
+- results_count = total topics dans cette subcat (~1008 pour cat23/sub550)
+- page = page courante
+- results_per_page = 25 (peut être modifié via query param)
+- total_pages = ceil(results_count / results_per_page) — pas exposé directement
+
+Voir rest_cat23_participated.json pour le format authentifié (ajout de is_read, last_position, last_post_read_id, flag_owntopic, subcategory link).

--- a/docs/adr/003-api-rest-hfr-hybride.md
+++ b/docs/adr/003-api-rest-hfr-hybride.md
@@ -1,0 +1,105 @@
+---
+title: ADR-003
+parent: ADRs
+grand_parent: Spécifications
+nav_order: 3
+permalink: /adr/003-api-rest-hfr-hybride
+---
+
+# ADR-003 — Stratégie hybride REST + HTML pour la couche réseau HFR
+
+## Statut
+
+Proposé — 2026-05-02
+
+## Contexte
+
+L'hypothèse de travail historique du projet (et de la PR #102 en cours sur `feature/1c-a-forum-parser`) était que **HFR n'expose pas d'API REST structurée** et que toute la couche réseau devait scraper du HTML brut. Cette hypothèse est encodée explicitement dans [ADR-009](009-okhttp-5-3-plus.md) :
+
+> Redface 2 ne consomme pas une API REST structurée. L'application récupère principalement du HTML brut HFR, puis le parse.
+
+Cette hypothèse est **fausse**. La vérification empirique 2026-05-01 (200+ endpoints testés, fixtures JSON capturées, doc V1 MesDiscussions retrouvée sur Wayback Machine) a établi que :
+
+1. **HFR expose une vraie API REST/JSON** sur `https://forum.hardware.fr/webservices/rest_api.php?uri=<URI>`. Le hub `/api/` documenté en V1 renvoie 404 sur HFR (mod_rewrite jamais activé) — il faut réécrire les `href` HATEOAS en `?uri=` côté client.
+2. La portion exposée est **partielle mais cohérente** : forums, catégories, sous-catégories, topic listings, drapeaux personnels (lus/participés/favoris), et metadata d'un topic. Auth via les cookies `md_id`/`md_user`/`md_passs` issus de `login_validation.php`.
+3. La **lecture du contenu d'un post** (`/posts/`) est cassée serveur (HTTP 500 inconditionnel, 18+ variantes de CSRF/headers/path testées) et reste donc HTML-only.
+4. Les **MPs** ne sont **pas exposés** en REST (∼300 variantes scannées : path-style, slugs, fautes, brute force IDs 0-999, endpoints V1 `users/<X>/threads/`). Limitation structurelle confirmée sur 13+ ans (`hfr4droid` 2013 avait déjà un fallback HTML pour la cat MP).
+5. Les **mutations REST** sont partiellement exploitables : les POST de création topic / réponse ont été testés live avec succès, et `PUT topics/` est routé avec `hash_check`. En revanche la sémantique métier des drapeaux REST reste sous-documentée (downgrade `flag_owntopic` refusé, no-op refusé, valeurs hors-bornes silently ignored).
+6. Un **bench mesuré** (4 000 fetches × 8 endpoints, 120 000 itérations parser, depuis Pologne/WiFi — ratios invariants) donne pour une session simulée de 19 navigations : **−91% bytes, −71% temps, 3.45× speedup** vs scraping HTML. Topic header metadata : **220× plus petit, 5.47× plus rapide**.
+
+La synthèse utile à la décision est intégrée dans cette ADR. Les logs d'exploration et les raw CSV du bench restent des archives locales non normatives ; les fixtures JSON versionnées deviennent la preuve rejouable côté tests.
+
+La conséquence est qu'on doit décider **par domaine** entre REST et HTML, plutôt que d'imposer une seule source.
+
+## Décision
+
+Adopter une **stratégie hybride explicite REST + HTML**, formalisée par domaine dans la table ci-dessous. Cette table devient la référence pour toute la couche réseau de Redface 2 v1.
+
+| Domaine | Source v1 | Endpoint | Justification |
+|---|---|---|---|
+| Liste catégories / sous-catégories | **REST** | `forums/hardwarefr/categories/`, `categories/{cat}/subcategories/` | 3-3.7× speedup, JSON déjà structuré, ordre éditorial préservé |
+| Liste topics d'une (sous-)catégorie | **REST** | `categories/{cat}/[subcategories/{sub}/]topics/last/?page=N&results_per_page=50` | 2.6× speedup, drapeaux `is_read`/`flag_owntopic` natifs en auth. `25` est le défaut HATEOAS, `50` est la cible RF2 pour limiter les requêtes. |
+| Drapeaux personnels (cyan / rouge / favoris) | **REST** | `categories/{cat}/topics/{participated,read,favorites}/`, ou globaux `topics/{…}/` | Endpoints dédiés, format normalisé, retire le besoin de scraper `forum1f.php?owntopic=N`. Attention : le format global est groupé par catégorie, le format par-cat est plat. |
+| Topic header metadata (titre, sticky, count) | **REST** | `categories/{cat}/topics/{post}/` | Gain ×220 sur la taille (1 KB vs 220 KB pour la page HTML complète) |
+| Lecture posts d'un topic (contenu) | **HTML** | `forum2.php?cat=N&post=M&page=P` | REST `/posts/` HTTP 500 inconditionnel — voie morte côté serveur |
+| Liste MPs + lecture MP + envoi MP | **HTML** | `forum1.php?cat=prive`, `forum2.php?cat=prive&post=N`, `bddpost.php` | Aucun endpoint REST exposé (vérifié exhaustivement) |
+| Mutations drapeaux | **HTML** | `addflag.php` / `delflag.php` | REST `PUT topics/{id}/` trop fragile (sémantique downgrade/no-op opaque) |
+| Création topic / réponse à un topic | **HTML v1, REST candidat v2** | `bddpost.php` (v1) ou `POST topics/last/` + `POST topics/{id}/posts/` (validés live) | Garder HTML stable en v1, réévaluer REST quand on aura un cycle CI complet et un compte/topic de test dédié |
+| Login | **HTML** | `login_validation.php` | Pas d'`/api/auth.php` exposé sur HFR |
+
+Choix de design pour la couche REST :
+
+1. **Pas de Retrofit.** [ADR-009](009-okhttp-5-3-plus.md) reste valide : les endpoints REST consommés sont peu nombreux et les payloads sont parsés via `kotlinx.serialization`. Un `HfrApiClient` léger au-dessus d'OkHttp suffit. La séparation réseau / parsing reste nette.
+2. **Helper de rewrite HATEOAS obligatoire.** Tout `href` retourné dans un payload pointe vers `/api/<…>` qui renvoie 404 sur HFR. Une fonction validante réécrit uniquement les URLs `https://forum.hardware.fr/api/<path>` vers `https://forum.hardware.fr/webservices/rest_api.php?uri=<path>` au moment du déréférencement. Le rewrite vit dans la couche réseau, jamais exposé aux ViewModels.
+3. **Limite de parallélisme.** OkHttp `maxRequestsPerHost = 5` (default) reste en place. Bench montre une saturation TCP côté Apache LDLC à 20 parallèles ; ≤ 10 connexions simultanées est le seuil sain. Pas de tuning custom requis.
+4. **Pas de fallback runtime global.** Si un endpoint REST utilisé en v1 commence à renvoyer 500/404 en prod, on réintroduit une source HTML pour le domaine touché via une PR dédiée. Pas de double-source automatique côté happy path : on ne paye pas le coût d'un fallback systématique sur des endpoints qui marchent.
+5. **Fixtures canoniques.** Les 6 fixtures `core/parser/src/test/resources/fixtures/rest_*.json` capturées le 2026-05-01 (avec leurs `.source.txt` documentant la commande curl d'origine) deviennent les fixtures de référence pour les parsers REST. Comme pour les fixtures HTML, les captures authentifiées doivent avoir leurs données sensibles nettoyées avant commit.
+6. **Pas de mutation REST en v1.** Même si création topic / réponse ont été validées live, l'écriture reste en HTML v1 (`bddpost.php`, `addflag.php`, `delflag.php`). Pour les drapeaux, la sémantique de `PUT topics/` est trop opaque et le risque de marquer involontairement des drapeaux en prod (testé : downgrade refusé, no-op refusé, hors-bornes silently ignored) interdit un usage v1. À réévaluer post-v1 avec un compte de test dédié.
+7. **Frontières de modules.** `:core:network` porte le transport REST, la construction d'URL et le rewrite HATEOAS. Les DTO `@Serializable` et les mappings vers `:core:model` vivent dans `:core:data`, au plus près des repositories qui consomment les endpoints. `:core:parser` reste dédié aux formats HFR historiques nécessitant une transformation structurante (HTML posts/MPs, AST).
+
+## Conséquences
+
+### Sur la PR #102 et la branche `feature/1c-a-forum-parser`
+
+- La stratégie HTML-first de la PR #102 est **superseded** par cette ADR pour cats / subcats / topic-list / drapeaux. La PR peut être remplacée ou réécrite, mais le choix durable est REST-first pour ces domaines.
+- Les artefacts utiles déjà produits (notamment les 6 fixtures `rest_*.json` actuellement untracked) seront repris dans la PR REST-first.
+- La PR d'implémentation REST-first devrait être structurée en 4 commits reviewables : (1) `HfrApiClient` + helper rewrite HATEOAS + fixtures, (2) DTO/mappers REST + repos, (3) câblage MVI / écrans Phase 1C, (4) suppression du code de parser HTML rendu obsolète pour ces domaines.
+
+### Sur les ADRs existantes
+
+- [ADR-009](009-okhttp-5-3-plus.md) reste **Accepté** pour la décision OkHttp 5.3+ direct, sans Retrofit. Son contexte "pas d'API REST structurée" est partiellement superseded par la présente ADR : le motif devient HTML brut **+** JSON REST léger, mais le choix technique reste optimal pour ce volume d'endpoints.
+- Pas d'impact sur [ADR-002](002-credentials-option-a.md) (credentials) ni [ADR-008](008-compose-navigation-3.md) (navigation) ni [ADR-011](011-postcontent-ast.md) (PostContent AST — concerne le rendu, pas la source).
+
+### Sur les specs canoniques
+
+- `docs/specs/protocol-hfr.md` : à enrichir d'une section REST (endpoints retenus, format JSON, helper HATEOAS, limites observées).
+- `docs/specs/architecture.md` : la couche `:core:network` accueille `HfrApiClient` à côté de l'OkHttp brut. Le diagramme des flux gagne une branche JSON parallèle à la branche HTML.
+- `docs/specs/stack.md` : documenter `kotlinx.serialization` comme dépendance directe déjà déclarée dans `libs.versions.toml`, à consommer explicitement par les modules qui parseront du JSON REST.
+- `docs/guides/contributing.md` : ajouter la convention de fixtures `rest_*.json` à côté des fixtures HTML existantes.
+
+### Sur la testabilité
+
+- Couverture **100%** sur les transformers JSON / mappers DTO REST, fixtures dictent l'exhaustivité — règle déjà appliquée aux parsers HTML, étendue aux données REST.
+- `MockWebServer` (mockwebserver3) déjà câblé via OkHttp 5 → utilisable directement pour les tests d'intégration `HfrApiClient`.
+- Tests d'intégration live HFR exclus de la CI (réseau réel + dépendance auth) — restent manuels via `hfr-mcp` au moment de capturer une fixture.
+
+### Sur la dette technique
+
+- La dépendance `Jsoup` reste nécessaire (HTML pour posts, MPs, mutations, login). Pas de gain de dépendance possible v1.
+- `kotlinx.serialization` est déjà déclaré dans `gradle/libs.versions.toml` et consommé par plusieurs modules. La PR REST devra l'ajouter explicitement au module consommateur si les DTO/mappers REST changent de module.
+- L'erreur d'analyse initiale (« HFR n'a pas de REST, basé sur la lecture de `hfr-mcp` ») est consignée dans la memory `reference_hfr_rest_api.md` § « Erreur à ne plus refaire » : la preuve qu'une API n'existe pas, c'est de tester l'endpoint, pas de lire un client tiers.
+
+## Alternatives considérées
+
+- **Statu quo 100% HTML scraping (continuer la PR #102 telle quelle)** — Rejeté. Laisse un facteur 3.45× de performance sur la table, et impose de continuer à parser des pages 220 KB pour récupérer des metadata 1 KB côté topic header. La partie HTML cats / subcats / topic-list de #102 ne doit pas devenir la base durable de 1C.
+- **100% REST** — Impossible. La lecture du contenu des posts (`/posts/`) est cassée côté serveur (HTTP 500 confirmé inconditionnel) et les MPs n'ont aucun endpoint REST. Impossible de couvrir le scope v1 sans HTML.
+- **REST first avec fallback HTML systématique** — Rejeté. Coût d'implémentation élevé (chaque appel REST a son équivalent HTML à maintenir et tester) pour une protection contre une panne hypothétique. Une bascule HTML peut être réintroduite au cas par cas par domaine si un endpoint REST se révèle instable en prod.
+- **Retrofit + interfaces typées sur la portion REST** — Rejeté. 6 endpoints justifient mal l'abstraction. ADR-009 reste applicable : OkHttp brut + parsing manuel via kotlinx.serialization. Le couplage faible avec le serveur (HFR peut couper la REST sans préavis) plaide aussi pour une couche client minimale qu'on peut facilement court-circuiter par domaine.
+- **Mutations drapeaux via REST PUT en v1** — Rejeté. Sémantique opaque (downgrade `flag_owntopic` refusé, no-op refusé, hors-bornes silently ignored) confirmée par test live. Le format `error_description` qui leak l'état serveur (`"forbidden{flag_courant} {lp_envoyée} ..."`) est pratique pour debug mais fragile à dépendre. À reconsidérer post-v1 sur un compte de test sans drapeaux préexistants.
+- **Création topic / réponse via REST POST en v1** — Reportée à v2. Endpoints routés (POST `topics/last/` et POST `topics/{id}/posts/` avec `hash_check`) testés live avec succès. Mais la suppression / rollback reste HTML (`DELETE` REST renvoie 501) et le risque opérationnel d'écriture est plus élevé qu'un simple GET. Garder `bddpost.php` en v1 minimise le risque ; basculer en v2 quand on a un cycle CI sandbox et un compte/topic de test dédié.
+
+## Sources
+
+- Sources versionnées : `core/parser/src/test/resources/fixtures/rest_*.json` (6 fixtures + `.source.txt`) et cette ADR, qui intègre la synthèse des mesures et des endpoints retenus.
+- Archives locales non normatives : `~/.claude/projects/-work-xaat/memory/reference_hfr_rest_api.md`, `tmp/redface2/drafts/hfr-rest-api_claude.md`, `tmp/redface2/drafts/hfr-rest-mp-doc-urls.md`, `tmp/redface2/bench-rest-vs-html-2026-05-01/results.md` (+ raw CSV + scripts rejouables).
+- Doc V1 MesDiscussions (Wayback Machine) : `https://web.archive.org/web/2018/help.mesdiscussions.net/pages/viewpage.action?pageId=5013586`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,7 +25,7 @@ Règles du repo :
 - statut simple : `Proposé`, `Accepté` ou `Superseded par ADR-XXX`
 - les pages canoniques de `docs/specs/` restent la source détaillée ; l'ADR capture le **pourquoi** et le **choix**
 
-Les numéros `003` à `007` sont volontairement laissés libres pour des décisions Phase 1 pressenties mais pas encore actées au moment où les ADR `008` à `010` ont été créées. Ils ne correspondent pas à des ADR supprimées.
+Les numéros `004` à `007` sont volontairement laissés libres pour des décisions Phase 1 pressenties mais pas encore actées au moment où les ADR `008` à `010` ont été créées. Ils ne correspondent pas à des ADR supprimées.
 
 ## Index initial
 
@@ -34,6 +34,7 @@ Les numéros `003` à `007` sont volontairement laissés libres pour des décisi
 | [ADR-000]({{ site.baseurl }}/adr/000-methodologie-triple-hybride) | Méthodologie triple-hybride SDD + Prototype + TDD |
 | [ADR-001]({{ site.baseurl }}/adr/001-modules-gradle-v1) | Découpage Gradle v1 : 15 modules avant les extensions |
 | [ADR-002]({{ site.baseurl }}/adr/002-credentials-option-a) | Credentials Option A : DataStore + Keystore, sans password stocké |
+| [ADR-003]({{ site.baseurl }}/adr/003-api-rest-hfr-hybride) | Stratégie hybride REST + HTML pour la couche réseau HFR |
 | [ADR-008]({{ site.baseurl }}/adr/008-compose-navigation-3) | Compose Navigation 3 retenu pour la navigation |
 | [ADR-009]({{ site.baseurl }}/adr/009-okhttp-5-3-plus) | OkHttp 5.3+ retenu comme client HTTP principal |
 | [ADR-010]({{ site.baseurl }}/adr/010-licence-client-android) | GPL-3.0-only retenue pour le client Android |


### PR DESCRIPTION
> Action par GPT-5 Codex (demandée par @XaaT)

## Summary

Ajoute ADR-003 pour acter la stratégie réseau hybride HFR : REST-first pour catégories / sous-catégories / listes topics / drapeaux / metadata topic, HTML conservé pour posts, MPs, login et mutations v1.

## Changes

- Ajout de `docs/adr/003-api-rest-hfr-hybride.md`.
- Mise à jour de l index ADR pour intégrer ADR-003.
- Ajout des fixtures REST JSON capturées le 2026-05-01 avec leurs `.source.txt`.

## Test plan

- `git diff --cached --check` avant commit.
- Relecture spec-check ciblée : incohérences restantes `protocol-hfr.md` / `stack.md` / `architecture.md` / `roadmap.md` listées comme conséquences de l ADR, à traiter dans la PR REST-first.

## Notes

Cette PR ne supprime pas `feature/1c-a-forum-parser`; elle isole seulement la décision ADR et les fixtures REST depuis une branche propre basée sur `main`.

Refs #102