### PR TITLE
feat(forum): Phase 1C-B — pull-to-refresh + drapeaux REST + recherche locale

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         // upload signing config).
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their phase / commit lineage to the user.
-        versionCode = 24
-        versionName = "0.1.0-phase1b.10"
+        versionCode = 26
+        versionName = "0.1.0-phase1c.2"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/forum/RestForumMappers.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/forum/RestForumMappers.kt
@@ -96,7 +96,10 @@ internal object RestForumMappers {
             ceil(postsCount.toDouble() / postsResultsPerPage).toInt().coerceAtLeast(1)
         }
         val subcatFromHref = dto.links.subcategory?.href?.let(::extractSubcatId)
-        val isAuthenticatedRow = dto.isRead != null || dto.lastPosition != null || dto.lastPostReadId != null
+        val isAuthenticatedRow = dto.isRead != null ||
+            dto.lastPosition != null ||
+            dto.lastPostReadId != null ||
+            dto.flagOwntopic != null
         val lastReadPage = if (isAuthenticatedRow) {
             postsHref
                 ?.let { extractQueryParam(it, "page") }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/forum/RestForumMappers.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/forum/RestForumMappers.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.core.data.forum
 
 import fr.forumhfr.redface2.core.model.Category
+import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.SubCategory
 import fr.forumhfr.redface2.core.model.TopicListPage
 import fr.forumhfr.redface2.core.model.TopicSummary
@@ -120,7 +121,23 @@ internal object RestForumMappers {
             hasUnread = dto.isRead?.let { !it },
             lastReadPage = lastReadPage,
             lastPostReadId = dto.lastPostReadId,
+            flagType = toFlagType(dto.flagOwntopic),
         )
+    }
+
+    /**
+     * REST `flag_owntopic` mirrors the legacy HTML `owntopic` query param :
+     * `1 → CYAN` (sujets participés), `2 → RED` (lus uniquement),
+     * `3 → FAVORITE` (favoris). Anything else (null, 0, future bucket numbers,
+     * negative values) maps to `null` instead of throwing — the UI degrades
+     * to "no badge" for unknown buckets so an HFR-side rollout that adds a
+     * 4th flag type doesn't crash the app.
+     */
+    private fun toFlagType(rawFlagOwntopic: Int?): FlagType? = when (rawFlagOwntopic) {
+        1 -> FlagType.CYAN
+        2 -> FlagType.RED
+        3 -> FlagType.FAVORITE
+        else -> null
     }
 
     private fun extractSubcatId(href: String): Int? =

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/forum/RestForumMappersTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/forum/RestForumMappersTest.kt
@@ -188,6 +188,45 @@ class RestForumMappersTest {
     }
 
     @Test
+    fun `flag_owntopic alone counts as an authenticated row — lastReadPage parsed from posts href`() {
+        // Synthetic: only flag_owntopic + links.posts.href?page=2. No is_read, no
+        // last_position, no last_post_read_id. Before the fix, isAuthenticatedRow
+        // looked only at is_read / last_position / last_post_read_id, so lastReadPage
+        // would have been null even though the auth-only flag_owntopic field was
+        // populated. Pin the relaxed predicate.
+        val payload = """
+            {
+              "resource": {
+                "page": 1,
+                "results_count": 1,
+                "results_per_page": 1,
+                "resources": [
+                  {
+                    "id": 77,
+                    "title": "auth via flag only",
+                    "flag_owntopic": 1,
+                    "links": {
+                      "posts": {
+                        "href": "https://forum.hardware.fr/api/forums/x/categories/1/topics/77/posts/?page=2&results_per_page=40",
+                        "count": 60
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+        """.trimIndent()
+        val envelope = json.decodeFromString<RestListEnvelope<RestTopic>>(payload)
+
+        val topic = RestForumMappers.toTopicListPage(envelope, cat = 1, subcat = null).topics.single()
+
+        assertEquals(2, topic.lastReadPage)
+        assertEquals(FlagType.CYAN, topic.flagType)
+        // hasUnread is still null — `is_read` was not in the payload.
+        assertNull(topic.hasUnread)
+    }
+
+    @Test
     fun `flagType is independent from hasUnread — read CYAN topic still surfaces both`() {
         // is_read = true (drapeau lu), flag_owntopic = 1 (cyan participé).
         val payload = """

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/forum/RestForumMappersTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/forum/RestForumMappersTest.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.core.data.forum
 
 import fr.forumhfr.redface2.core.model.Category
+import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.SubCategory
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
@@ -90,10 +91,11 @@ class RestForumMappersTest {
         assertEquals(189, tmListTopic.replyCount)
         assertEquals(5, tmListTopic.totalPages)
         assertFalse(tmListTopic.isLocked)
-        // Anonymous response → hasUnread / lastReadPage / lastPostReadId stay null
+        // Anonymous response → hasUnread / lastReadPage / lastPostReadId / flagType stay null
         assertNull(tmListTopic.hasUnread)
         assertNull(tmListTopic.lastReadPage)
         assertNull(tmListTopic.lastPostReadId)
+        assertNull(tmListTopic.flagType)
         // Authors are mapped from links.author / links.last_author
         assertEquals("Wolfman", marcTopic.author)
         assertEquals("Wolfman", marcTopic.lastReplyAuthor)
@@ -142,6 +144,74 @@ class RestForumMappersTest {
         assertNotEquals(479, topic.lastReadPage)
         // subcat extracted from links.subcategory.href
         assertEquals(550, topic.subcat)
+        // flag_owntopic = 1 → CYAN (sujet participé). Captured fixture is the participated bucket.
+        assertEquals(FlagType.CYAN, topic.flagType)
+    }
+
+    @Test
+    fun `flag_owntopic 1, 2, 3 map to CYAN, RED, FAVORITE — anything else maps to null`() {
+        // Synthetic payloads — one resource per flag_owntopic value we care to assert.
+        // The tuple lists the expected mapping; null covers anonymous (absent), 0/4/-1
+        // (unknown buckets HFR may add or rename without warning).
+        val cases: List<Pair<Int?, FlagType?>> = listOf(
+            1 to FlagType.CYAN,
+            2 to FlagType.RED,
+            3 to FlagType.FAVORITE,
+            null to null,
+            0 to null,
+            4 to null,
+            -1 to null,
+        )
+
+        cases.forEach { (raw, expected) ->
+            val payload = """
+                {
+                  "resource": {
+                    "page": 1,
+                    "results_count": 1,
+                    "results_per_page": 1,
+                    "resources": [
+                      {
+                        "id": 99,
+                        "title": "synthetic",
+                        ${if (raw != null) "\"flag_owntopic\": $raw," else ""}
+                        "links": { "posts": { "count": 1 } }
+                      }
+                    ]
+                  }
+                }
+            """.trimIndent()
+            val envelope = json.decodeFromString<RestListEnvelope<RestTopic>>(payload)
+            val topic = RestForumMappers.toTopicListPage(envelope, cat = 1, subcat = null).topics.single()
+            assertEquals("flag_owntopic=$raw expected $expected", expected, topic.flagType)
+        }
+    }
+
+    @Test
+    fun `flagType is independent from hasUnread — read CYAN topic still surfaces both`() {
+        // is_read = true (drapeau lu), flag_owntopic = 1 (cyan participé).
+        val payload = """
+            {
+              "resource": {
+                "page": 1,
+                "results_count": 1,
+                "results_per_page": 1,
+                "resources": [
+                  {
+                    "id": 42,
+                    "title": "read but cyan",
+                    "is_read": true,
+                    "flag_owntopic": 1,
+                    "links": { "posts": { "count": 1 } }
+                  }
+                ]
+              }
+            }
+        """.trimIndent()
+        val envelope = json.decodeFromString<RestListEnvelope<RestTopic>>(payload)
+        val topic = RestForumMappers.toTopicListPage(envelope, cat = 1, subcat = null).topics.single()
+        assertEquals(FlagType.CYAN, topic.flagType)
+        assertEquals(false, topic.hasUnread)
     }
 
     @Test

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/TopicSummary.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/TopicSummary.kt
@@ -46,6 +46,18 @@ data class TopicSummary(
      * deep link). Distinct from "first unread", which is one post further.
      */
     val lastPostReadId: Int?,
+    /**
+     * Authenticated-only flag bucket inferred from REST `flag_owntopic` :
+     * - `1 → FlagType.CYAN`     (« Mes sujets » — sujets participés)
+     * - `2 → FlagType.RED`      (« Lus uniquement »)
+     * - `3 → FlagType.FAVORITE` (favoris)
+     *
+     * `null` quand le payload est anonyme (champ absent) ou que la valeur est
+     * inconnue (HFR ajoutera peut-être 4 demain — on dégrade silencieusement
+     * plutôt que de planter). Distinct de [hasUnread] qui est l'axe lu/non-lu :
+     * un sujet drapeau cyan peut être lu ou non lu.
+     */
+    val flagType: FlagType?,
 )
 
 /**

--- a/docs/specs/models.md
+++ b/docs/specs/models.md
@@ -372,6 +372,7 @@ data class TopicSummary(
     val hasUnread: Boolean?,          // !is_read si présent en auth, null sinon
     val lastReadPage: Int?,           // page extraite de `links.posts.href?page=N` (auth uniquement). PAS `last_position` qui est l'index intra-page.
     val lastPostReadId: Int?,         // mirrors `last_post_read_id` si présent — id du dernier post lu, ancre pour le scroll.
+    val flagType: FlagType?,          // dérivé de REST `flag_owntopic` : 1→CYAN, 2→RED, 3→FAVORITE, sinon null. Indépendant de `hasUnread`.
 )
 
 data class TopicListPage(

--- a/docs/specs/protocol-hfr.md
+++ b/docs/specs/protocol-hfr.md
@@ -404,6 +404,17 @@ Implémenté de façon validante (host + scheme + préfixe `/api/` enforcés) da
 - `views` (compteur de vues) : absent du JSON. Si on a besoin du chiffre, c'est HTML uniquement.
 - `total_pages` (topic) : déductible via `ceil(links.posts.count / N)`, où `N` est la valeur du query param `results_per_page` exposé par `links.posts.href` du payload (typiquement 40 dans les fixtures actuelles, mais ne **jamais** le hardcoder — c'est l'API qui décide). C'est différent du réglage HTML utilisateur `postsPerPage` (cf. § *postsPerPage configurable*) qui s'applique au rendu de `forum2.php`, pas à la liste de topics REST.
 - `last_position` ≠ page : `last_position` est l'**index/offset du dernier post lu dans le topic global** (et non un numéro de page). La page de reprise est exposée séparément, encodée dans `links.posts.href?page=N` du même topic auth ; c'est cette valeur qu'il faut consommer pour `TopicSummary.lastReadPage`.
+- `flag_owntopic` (auth uniquement) : numéro de bucket drapeau côté HFR — `1` = sujets participés (cyan), `2` = lus uniquement (rouge), `3` = favoris (jaune). Mapping canonique :
+
+  | `flag_owntopic` | `FlagType` (côté Redface 2) | Bucket HFR (legacy `forum1f.php?owntopic=N`) |
+  |---|---|---|
+  | `1` | `CYAN` | « Mes sujets » (sujets participés) |
+  | `2` | `RED` | « Lus uniquement » |
+  | `3` | `FAVORITE` | « Favoris » |
+  | `null` / absent | `null` | payload anonyme |
+  | autre (`0`, `4`, négatif…) | `null` | bucket inconnu — l'UI dégrade silencieusement, pas de crash |
+
+  Indépendant de `is_read` : un sujet drapeau cyan peut être lu (`is_read = true`, `hasUnread = false`) ou non lu — les deux axes coexistent dans `TopicSummary`.
 - `tns3` filename avatar : nom du fichier, le préfixe d'URL est à reconstituer côté UI.
 
 ---

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -89,7 +89,7 @@ Les dépôts en cylindre (`MPStorage2`, `hfr-redflag`) sont des **dépendances e
 - [x] **Écran Topic réel** — `TopicRepository` cache-aside (OkHttp + parser + Room) livré ([PR #88](https://github.com/ForumHFR/redface2/pull/88)) puis branché sur `TopicScreen` (1A-bind), `TopicFixtureRepository` supprimé
 - [ ] Écran Topic — pagination, scroll vers `numreponse` cible, navigation entre pages
 - [x] **Écran Forum 1C-A REST-first** — `:feature:forum.ForumScreen` (19 catégories) + `ForumCategoryScreen` (subcats + topics paginés). Source REST `/webservices/rest_api.php` via `HfrApiClient` (`:core:network`) et `ForumRepository` (`:core:data`), cf. [ADR-003]({{ site.baseurl }}/adr/003-api-rest-hfr-hybride)
-- [ ] Écran Forum 1C-B — pull-to-refresh, drapeaux REST, recherche locale dans la liste
+- [x] **Écran Forum 1C-B** — Material 3 `PullToRefreshBox` sur `ForumScreen` / `ForumCategoryScreen` (contenu préservé pendant le refresh, pas de `SwipeRefresh` Accompanist), badge drapeau par topic dérivé du REST `flag_owntopic` (CYAN / RED / FAVORITE), recherche locale dans la page courante (titre / auteur / dernier réponseur, accent-insensitive)
 - [ ] Cache Room — topics et drapeaux
 - [x] Deep linking (URLs HFR → app) — `parseHfrDeepLink` corrigé (mapping `forum1.php` ↔ `forum2.php` inversé, fixé en 1C-A) et branché sur les écrans réels Forum/Category/Topic
 - [ ] Prefetch pages suivantes (avec `@AnonymousClient`, cf. [protocol-hfr.md]({{ site.baseurl }}/specs/protocol-hfr#règle-critique--prefetch-non-authentifié))

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModel.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModel.kt
@@ -11,12 +11,15 @@ import fr.forumhfr.redface2.core.domain.forum.ForumResult
 import fr.forumhfr.redface2.core.model.Category
 import fr.forumhfr.redface2.core.model.SubCategory
 import fr.forumhfr.redface2.core.model.TopicListPage
+import fr.forumhfr.redface2.core.model.TopicSummary
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -37,6 +40,12 @@ import kotlinx.coroutines.launch
  * Switching subcategories is a local UI state change — it does not push a new nav entry,
  * so the deep link `(cat, initialSubcat)` survives across switches and the back button
  * still brings the user up to the parent stack.
+ *
+ * `refresh()` toggles [isRefreshing] for the duration of the network round-trip so a
+ * PullToRefresh indicator stays anchored over the existing content. While a refresh is
+ * in flight the [TopicsUiState] / [SubcategoriesUiState] sub-states keep showing the
+ * previous `Content` (via [keepContentDuringRefresh]) instead of bouncing through
+ * `Loading` and wiping the list.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel(assistedFactory = CategoryViewModel.Factory::class)
@@ -47,6 +56,8 @@ class CategoryViewModel @AssistedInject constructor(
 
     private val selectedSubcat: MutableStateFlow<Int?> = MutableStateFlow(request.initialSubcat)
     private val page: MutableStateFlow<Int> = MutableStateFlow(request.initialPage.coerceAtLeast(1))
+    private val searchQuery: MutableStateFlow<String> = MutableStateFlow("")
+    private val isRefreshing: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     private val categoryNameState: StateFlow<String?> =
         forumRepository.observeCategories()
@@ -60,6 +71,10 @@ class CategoryViewModel @AssistedInject constructor(
     private val subcategoriesState: StateFlow<SubcategoriesUiState> =
         forumRepository.observeSubcategories(request.cat)
             .map { it.toSubcategoriesUiState() }
+            .keepContentDuringRefresh(
+                isLoading = { it is SubcategoriesUiState.Loading },
+                isContent = { it is SubcategoriesUiState.Content },
+            )
             .stateIn(
                 scope = viewModelScope,
                 started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS),
@@ -70,9 +85,18 @@ class CategoryViewModel @AssistedInject constructor(
         selectedSubcat,
         page,
     ) { subcat, currentPage -> subcat to currentPage }
+        // flatMapLatest gives us a fresh upstream every time (cat, subcat, page) shifts —
+        // the new flow restarts at Loading, which is the right semantics: the topics
+        // we were showing are for a different (subcat, page) tuple. The refresh-keeps-
+        // content trick (keepContentDuringRefresh) is applied *inside* the new upstream
+        // so that a refresh of the same key keeps showing the prior topics.
         .flatMapLatest { (subcat, currentPage) ->
             forumRepository.observeTopicList(cat = request.cat, subcat = subcat, page = currentPage)
                 .map { it.toTopicsUiState() }
+                .keepContentDuringRefresh(
+                    isLoading = { it is TopicsUiState.Loading },
+                    isContent = { it is TopicsUiState.Content },
+                )
         }
         .stateIn(
             scope = viewModelScope,
@@ -80,22 +104,37 @@ class CategoryViewModel @AssistedInject constructor(
             initialValue = TopicsUiState.Loading,
         )
 
-    val uiState: StateFlow<CategoryUiState> = combine(
+    // 7 source flows total (5 core + searchQuery + isRefreshing). Kotlin's typed
+    // `combine` overloads cap at 5, so we layer a second `combine` on top of the core
+    // one to fold in the search query and refresh indicator. Keeps the lambda typed
+    // and avoids `Array<*>` casts at the use site.
+    private val coreState: Flow<CoreCategoryState> = combine(
         selectedSubcat,
         page,
         categoryNameState,
         subcategoriesState,
         topicsState,
     ) { subcat, currentPage, categoryName, subcategories, topics ->
+        CoreCategoryState(subcat, currentPage, categoryName, subcategories, topics)
+    }
+
+    val uiState: StateFlow<CategoryUiState> = combine(
+        coreState,
+        searchQuery,
+        isRefreshing,
+    ) { core, query, refreshing ->
         CategoryUiState(
             cat = request.cat,
-            categoryName = categoryName,
+            categoryName = core.categoryName,
             initialSubcat = request.initialSubcat,
-            selectedSubcat = subcat,
-            page = currentPage,
-            pageCount = topics.pageCount(),
-            subcategories = subcategories,
-            topics = topics,
+            selectedSubcat = core.subcat,
+            page = core.page,
+            pageCount = core.topics.pageCount(),
+            subcategories = core.subcategories,
+            topics = core.topics,
+            searchQuery = query,
+            filteredTopics = core.topics.filterTopics(query),
+            isRefreshing = refreshing,
         )
     }.stateIn(
         scope = viewModelScope,
@@ -109,6 +148,9 @@ class CategoryViewModel @AssistedInject constructor(
             pageCount = 1,
             subcategories = SubcategoriesUiState.Loading,
             topics = TopicsUiState.Loading,
+            searchQuery = "",
+            filteredTopics = emptyList(),
+            isRefreshing = false,
         ),
     )
 
@@ -116,6 +158,7 @@ class CategoryViewModel @AssistedInject constructor(
         if (selectedSubcat.value == subcat) return
         selectedSubcat.value = subcat
         page.value = 1
+        // searchQuery preserved deliberately — see CategoryUiState.searchQuery KDoc.
     }
 
     fun selectPage(newPage: Int) {
@@ -123,14 +166,30 @@ class CategoryViewModel @AssistedInject constructor(
         page.value = newPage
     }
 
+    fun updateSearchQuery(query: String) {
+        searchQuery.value = query
+    }
+
+    /**
+     * Triggers a network refresh of the subcategories AND the current topic list.
+     * Toggles [isRefreshing] for the duration so the PullToRefresh indicator stays
+     * anchored. The repository's refresh* methods broadcast `Loading` then the
+     * fresh result through their respective shared flows; [keepContentDuringRefresh]
+     * collapses the transient `Loading` so the list does not blank.
+     */
     fun refresh() {
         viewModelScope.launch {
-            forumRepository.refreshSubcategories(request.cat)
-            forumRepository.refreshTopicList(
-                cat = request.cat,
-                subcat = selectedSubcat.value,
-                page = page.value,
-            )
+            isRefreshing.value = true
+            try {
+                forumRepository.refreshSubcategories(request.cat)
+                forumRepository.refreshTopicList(
+                    cat = request.cat,
+                    subcat = selectedSubcat.value,
+                    page = page.value,
+                )
+            } finally {
+                isRefreshing.value = false
+            }
         }
     }
 
@@ -161,13 +220,52 @@ class CategoryViewModel @AssistedInject constructor(
         else -> 1
     }
 
+    private fun TopicsUiState.filterTopics(query: String): List<TopicSummary> = when (this) {
+        is TopicsUiState.Content -> page.topics.filter { matchesTopicQuery(it, query) }
+        else -> emptyList()
+    }
+
     @AssistedFactory
     interface Factory {
         fun create(request: CategoryRequest): CategoryViewModel
     }
 
+    private data class CoreCategoryState(
+        val subcat: Int?,
+        val page: Int,
+        val categoryName: String?,
+        val subcategories: SubcategoriesUiState,
+        val topics: TopicsUiState,
+    )
+
     private companion object {
         const val STOP_TIMEOUT_MS: Long = 5_000L
+    }
+}
+
+/**
+ * Hides a transient `Loading` re-emitted by a repository's `refresh*()` broadcast
+ * when there is already a prior `Content` to keep showing. The first cold-start
+ * `Loading` passes through (so the screen still renders its initial spinner) and
+ * `Error` always passes through (so a failed refresh surfaces the "Réessayer"
+ * button instead of silently keeping stale data).
+ */
+private fun <T : Any> Flow<T>.keepContentDuringRefresh(
+    isLoading: (T) -> Boolean,
+    isContent: (T) -> Boolean,
+): Flow<T> = flow {
+    var lastContent: T? = null
+    collect { value ->
+        when {
+            isContent(value) -> {
+                lastContent = value
+                emit(value)
+            }
+            isLoading(value) && lastContent != null -> {
+                // Suppress: keep showing the previous Content under a refresh spinner.
+            }
+            else -> emit(value)
+        }
     }
 }
 

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModel.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModel.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -59,9 +60,15 @@ class CategoryViewModel @AssistedInject constructor(
     private val searchQuery: MutableStateFlow<String> = MutableStateFlow("")
     private val isRefreshing: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
+    // scan keeps the last non-null name across `Loading` / `Failure` re-emissions so a
+    // global refreshCategories() round-trip does not reflash the screen title back to
+    // "Catégorie <id>". The seed `null` lets the screen render its fallback before the
+    // first successful fetch.
     private val categoryNameState: StateFlow<String?> =
         forumRepository.observeCategories()
-            .map { result -> result.toCategoryName(request.cat) }
+            .scan(null as String?) { previous, result ->
+                result.toCategoryName(request.cat) ?: previous
+            }
             .stateIn(
                 scope = viewModelScope,
                 started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS),

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -35,6 +36,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -333,10 +336,16 @@ private fun TopicRow(
 
 @Composable
 private fun FlagIndicator(flagType: FlagType?) {
+    // Reserve the same gutter width on every row, flagged or not, so titles stay
+    // left-aligned across rows in mixed (auth) listings. When flagType is null the
+    // gutter is an empty Spacer; when it is non-null we paint the colored dot inside
+    // the same gutter and attach a contentDescription so screen readers and color-
+    // blind users get the bucket name (color is otherwise the only signal).
+    val gutter = Modifier
+        .padding(end = 12.dp)
+        .size(10.dp)
     if (flagType == null) {
-        // No badge for anonymous payloads or unknown buckets — keeps the row aligned
-        // with the no-flag visual but doesn't reserve space (we want the title to flow
-        // left-aligned in the common public case).
+        Spacer(modifier = gutter)
         return
     }
     val color = when (flagType) {
@@ -344,12 +353,18 @@ private fun FlagIndicator(flagType: FlagType?) {
         FlagType.RED -> Color(0xFFD32F2F)
         FlagType.FAVORITE -> Color(0xFFF9A825)
     }
+    val description = stringResource(
+        when (flagType) {
+            FlagType.CYAN -> R.string.category_flag_cyan
+            FlagType.RED -> R.string.category_flag_red
+            FlagType.FAVORITE -> R.string.category_flag_favorite
+        },
+    )
     Box(
-        modifier = Modifier
-            .padding(end = 12.dp)
-            .size(10.dp)
+        modifier = gutter
             .clip(CircleShape)
-            .background(color),
+            .background(color)
+            .semantics { contentDescription = description },
     )
 }
 

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.feature.forum
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -9,28 +10,36 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.SubCategory
 import fr.forumhfr.redface2.core.model.TopicSummary
 
@@ -40,7 +49,13 @@ import fr.forumhfr.redface2.core.model.TopicSummary
  * fires [onOpenTopic] with the right `(cat, post, page, scrollTo)` triple — when the
  * authenticated payload exposes `lastPostReadId`, the user lands directly on their last
  * read position; otherwise [onOpenTopic] is called with `page = 1` and no scroll target.
+ *
+ * Phase 1C-B additions:
+ * - Material 3 [PullToRefreshBox] anchored over the topic body.
+ * - Local in-page search field, filtering on title / author / last reply author.
+ * - Per-row flag badge driven by the auth-only `flag_owntopic` REST field.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ForumCategoryScreen(
     request: CategoryRequest,
@@ -79,16 +94,46 @@ fun ForumCategoryScreen(
 
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
 
-            TopicsBody(
-                state = state.topics,
-                onOpenTopic = onOpenTopic,
-                onRetry = viewModel::refresh,
-                onSelectPage = viewModel::selectPage,
-                currentPage = state.page,
-                pageCount = state.pageCount,
+            SearchField(
+                query = state.searchQuery,
+                onQueryChange = viewModel::updateSearchQuery,
             )
+
+            PullToRefreshBox(
+                isRefreshing = state.isRefreshing,
+                onRefresh = viewModel::refresh,
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                TopicsBody(
+                    state = state.topics,
+                    filteredTopics = state.filteredTopics,
+                    searchQuery = state.searchQuery,
+                    onOpenTopic = onOpenTopic,
+                    onRetry = viewModel::refresh,
+                    onSelectPage = viewModel::selectPage,
+                    currentPage = state.page,
+                    pageCount = state.pageCount,
+                )
+            }
         }
     }
+}
+
+@Composable
+private fun SearchField(
+    query: String,
+    onQueryChange: (String) -> Unit,
+) {
+    OutlinedTextField(
+        value = query,
+        onValueChange = onQueryChange,
+        singleLine = true,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        label = { Text(stringResource(R.string.category_search_label)) },
+        placeholder = { Text(stringResource(R.string.category_search_placeholder)) },
+    )
 }
 
 @Composable
@@ -147,7 +192,7 @@ private fun SubcategoryChips(
 
 /**
  * Compose composables idiomatically take many small focused params (state slice +
- * callbacks + a pager position). 6 args here is below most Material 3 composable
+ * callbacks + a pager position). 8 args here is below most Material 3 composable
  * signatures' real-world threshold, but detekt's default `functionThreshold = 6`
  * fires on equality. Suppressing locally rather than relaxing the project rule.
  */
@@ -155,6 +200,8 @@ private fun SubcategoryChips(
 @Composable
 private fun TopicsBody(
     state: TopicsUiState,
+    filteredTopics: List<TopicSummary>,
+    searchQuery: String,
     onOpenTopic: (TopicSummary) -> Unit,
     onRetry: () -> Unit,
     onSelectPage: (Int) -> Unit,
@@ -195,11 +242,17 @@ private fun TopicsBody(
         }
 
         is TopicsUiState.Content -> {
-            val topics = state.page.topics
+            // The PagerRow always shows the underlying `state.page` total — a search
+            // filter only narrows the visible rows in the current page; switching
+            // page or subcat is what actually re-fetches.
             LazyColumn(modifier = Modifier.fillMaxWidth()) {
-                items(topics, key = TopicSummary::topicId) { topic ->
-                    TopicRow(topic = topic, onClick = { onOpenTopic(topic) })
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                if (filteredTopics.isEmpty()) {
+                    item { TopicsEmpty(searchQuery = searchQuery) }
+                } else {
+                    items(filteredTopics, key = TopicSummary::topicId) { topic ->
+                        TopicRow(topic = topic, onClick = { onOpenTopic(topic) })
+                        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                    }
                 }
                 item {
                     PagerRow(
@@ -210,6 +263,26 @@ private fun TopicsBody(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun TopicsEmpty(searchQuery: String) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = if (searchQuery.isBlank()) {
+                stringResource(R.string.category_topics_empty)
+            } else {
+                stringResource(R.string.category_topics_empty_search, searchQuery)
+            },
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 
@@ -225,6 +298,7 @@ private fun TopicRow(
             .padding(horizontal = 24.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        FlagIndicator(flagType = topic.flagType)
         Column(modifier = Modifier.fillMaxWidth()) {
             Text(
                 text = topic.title,
@@ -255,6 +329,28 @@ private fun TopicRow(
             }
         }
     }
+}
+
+@Composable
+private fun FlagIndicator(flagType: FlagType?) {
+    if (flagType == null) {
+        // No badge for anonymous payloads or unknown buckets — keeps the row aligned
+        // with the no-flag visual but doesn't reserve space (we want the title to flow
+        // left-aligned in the common public case).
+        return
+    }
+    val color = when (flagType) {
+        FlagType.CYAN -> Color(0xFF00BCD4)
+        FlagType.RED -> Color(0xFFD32F2F)
+        FlagType.FAVORITE -> Color(0xFFF9A825)
+    }
+    Box(
+        modifier = Modifier
+            .padding(end = 12.dp)
+            .size(10.dp)
+            .clip(CircleShape)
+            .background(color),
+    )
 }
 
 @Composable

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumScreen.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumScreen.kt
@@ -14,11 +14,13 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -36,15 +38,21 @@ import fr.forumhfr.redface2.core.model.Category
  * Forum home tab. Lists the 19 public HFR categories from the REST API. Tapping a row
  * delegates to [onOpenCategory] which lifts the user into the per-category screen.
  *
- * No SwipeRefresh / Accompanist — Phase 1C-A keeps the same minimal "Réessayer" /
- * "Actualiser" affordance the Drapeaux screen ships with, per ADR-003 § "UI" guidance.
+ * Refresh UX is `PullToRefreshBox` (Material 3 stable). Accompanist `SwipeRefresh` is
+ * forbidden in this codebase; the legacy "Actualiser" inline button is kept as a
+ * secondary affordance for accessibility / non-touch input. While a refresh is in
+ * flight the categories list is **not** wiped — `ForumViewModel.uiState` collapses
+ * the transient `Loading` re-emitted by `refreshCategories()` (cf. ADR-003 §
+ * "UI guidance" + the keepContentDuringRefresh helper there).
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ForumScreen(
     onOpenCategory: (Category) -> Unit,
 ) {
     val viewModel: ForumViewModel = hiltViewModel()
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
 
     Surface(
         modifier = Modifier.fillMaxSize(),
@@ -63,18 +71,24 @@ fun ForumScreen(
                 modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
             )
 
-            when (val current = state) {
-                ForumUiState.Loading -> ForumLoading()
-                is ForumUiState.Error -> ForumError(
-                    message = current.message,
-                    onRetry = viewModel::refresh,
-                )
+            PullToRefreshBox(
+                isRefreshing = isRefreshing,
+                onRefresh = viewModel::refresh,
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                when (val current = state) {
+                    ForumUiState.Loading -> ForumLoading()
+                    is ForumUiState.Error -> ForumError(
+                        message = current.message,
+                        onRetry = viewModel::refresh,
+                    )
 
-                is ForumUiState.Content -> ForumContent(
-                    categories = current.categories,
-                    onOpenCategory = onOpenCategory,
-                    onRefresh = viewModel::refresh,
-                )
+                    is ForumUiState.Content -> ForumContent(
+                        categories = current.categories,
+                        onOpenCategory = onOpenCategory,
+                        onRefresh = viewModel::refresh,
+                    )
+                }
             }
         }
     }

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumUiState.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumUiState.kt
@@ -3,7 +3,9 @@ package fr.forumhfr.redface2.feature.forum
 import fr.forumhfr.redface2.core.model.Category
 import fr.forumhfr.redface2.core.model.SubCategory
 import fr.forumhfr.redface2.core.model.TopicListPage
+import fr.forumhfr.redface2.core.model.TopicSummary
 import kotlin.math.ceil
+import java.text.Normalizer
 
 /**
  * UI state for the Forum home screen (list of HFR top-level categories). The state
@@ -39,7 +41,60 @@ data class CategoryUiState(
     val pageCount: Int,
     val subcategories: SubcategoriesUiState,
     val topics: TopicsUiState,
+    /**
+     * Local search filter. The query never hits the network — it filters the
+     * currently loaded `topics.page` (when [topics] is `Content`). The
+     * predicate matches the topic title, the original author, and the last
+     * reply author, accent- and case-insensitively (cf. [matchesTopicQuery]).
+     * Empty / blank query disables the filter and `filteredTopics` mirrors
+     * the full page.
+     *
+     * The query is preserved across page / subcat changes by design (it is a
+     * filtering preference, not a per-page search) — when the new page yields
+     * 0 matches the screen renders an explicit empty state.
+     */
+    val searchQuery: String,
+    /** Filtered view over `topics.page.topics` per [searchQuery]. */
+    val filteredTopics: List<TopicSummary>,
+    /**
+     * `true` while a user-driven refresh (PullToRefresh, "Réessayer") is in
+     * flight. Independent of the underlying [topics] / [subcategories] state
+     * machines: the indicator stays on top of the existing content while the
+     * refresh round-trip resolves, and the list is **not** wiped during that
+     * window.
+     */
+    val isRefreshing: Boolean,
 )
+
+/**
+ * Pure helper kept top-level so it can be tested without spinning up a ViewModel.
+ *
+ * The matcher is :
+ * - case-insensitive (`Foo` matches `foo bar`)
+ * - accent-insensitive — Unicode NFD-decomposes both sides then strips combining
+ *   marks, so `electronique` matches `Electronique` and `CŒUR` matches `cœur`
+ *   without pulling a heavy dependency
+ * - matches against `title`, `author` and `lastReplyAuthor` only — listing
+ *   payloads do not currently expose subcategory names per topic, so we keep
+ *   the surface narrow and predictable.
+ *
+ * Returns `true` for blank queries so callers can use it as an unconditional
+ * predicate.
+ */
+internal fun matchesTopicQuery(topic: TopicSummary, query: String): Boolean {
+    if (query.isBlank()) return true
+    val needle = query.foldForSearch()
+    return topic.title.foldForSearch().contains(needle) ||
+        topic.author.foldForSearch().contains(needle) ||
+        topic.lastReplyAuthor.foldForSearch().contains(needle)
+}
+
+private fun String.foldForSearch(): String =
+    Normalizer.normalize(this, Normalizer.Form.NFD)
+        .replace(COMBINING_MARKS, "")
+        .lowercase()
+
+private val COMBINING_MARKS = Regex("\\p{InCombiningDiacriticalMarks}+")
 
 /**
  * Pure helper kept top-level so it can be exercised in isolation. Falls back to `1`

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumViewModel.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumViewModel.kt
@@ -5,9 +5,13 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.forum.ForumRepository
 import fr.forumhfr.redface2.core.domain.forum.ForumResult
+import fr.forumhfr.redface2.core.model.Category
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -16,14 +20,25 @@ import kotlinx.coroutines.launch
  * ViewModel for the Forum home tab — exposes the list of HFR top-level categories.
  * The repository is REST-backed (ADR-003); the home tab itself only needs the public
  * categories list, so we use the anonymous fetch path indirectly via the repository.
+ *
+ * `isRefreshing` is toggled around the user-driven refresh round-trip so a Material 3
+ * PullToRefresh indicator can stay anchored over the existing content without wiping
+ * the list back to a cold spinner.
  */
 @HiltViewModel
 class ForumViewModel @Inject constructor(
     private val forumRepository: ForumRepository,
 ) : ViewModel() {
 
+    private val _isRefreshing: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean> = _isRefreshing
+
     val uiState: StateFlow<ForumUiState> = forumRepository.observeCategories()
         .map { it.toUiState() }
+        // Suppress transient `Loading` re-emitted by refreshCategories() once we have
+        // a Content to keep showing — see CategoryViewModel.keepContentDuringRefresh
+        // for the same pattern at the per-category screen level.
+        .keepContentDuringRefresh()
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS),
@@ -31,15 +46,40 @@ class ForumViewModel @Inject constructor(
         )
 
     fun refresh() {
-        viewModelScope.launch { forumRepository.refreshCategories() }
+        viewModelScope.launch {
+            _isRefreshing.value = true
+            try {
+                forumRepository.refreshCategories()
+            } finally {
+                _isRefreshing.value = false
+            }
+        }
     }
 
-    private fun ForumResult<List<fr.forumhfr.redface2.core.model.Category>>.toUiState(): ForumUiState =
+    private fun ForumResult<List<Category>>.toUiState(): ForumUiState =
         when (this) {
             ForumResult.Loading -> ForumUiState.Loading
             is ForumResult.Success -> ForumUiState.Content(value)
             is ForumResult.Failure -> ForumUiState.Error(cause.message)
         }
+
+    private fun Flow<ForumUiState>.keepContentDuringRefresh(): Flow<ForumUiState> = flow {
+        var lastContent: ForumUiState.Content? = null
+        collect { value ->
+            when (value) {
+                is ForumUiState.Content -> {
+                    lastContent = value
+                    emit(value)
+                }
+                ForumUiState.Loading -> if (lastContent != null) {
+                    // Skip — keep showing the previous content under a refresh spinner.
+                } else {
+                    emit(value)
+                }
+                is ForumUiState.Error -> emit(value)
+            }
+        }
+    }
 
     private companion object {
         const val STOP_TIMEOUT_MS: Long = 5_000L

--- a/feature/forum/src/main/res/values/strings.xml
+++ b/feature/forum/src/main/res/values/strings.xml
@@ -17,4 +17,9 @@
     <string name="category_pager_previous">Précédent</string>
     <string name="category_pager_next">Suivant</string>
     <string name="category_pager_position">page %1$d / %2$d</string>
+
+    <string name="category_search_label">Rechercher dans cette page</string>
+    <string name="category_search_placeholder">Titre, auteur, dernier réponseur</string>
+    <string name="category_topics_empty">Aucun topic à afficher.</string>
+    <string name="category_topics_empty_search">Aucun topic ne contient « %1$s » dans cette page.</string>
 </resources>

--- a/feature/forum/src/main/res/values/strings.xml
+++ b/feature/forum/src/main/res/values/strings.xml
@@ -22,4 +22,8 @@
     <string name="category_search_placeholder">Titre, auteur, dernier réponseur</string>
     <string name="category_topics_empty">Aucun topic à afficher.</string>
     <string name="category_topics_empty_search">Aucun topic ne contient « %1$s » dans cette page.</string>
+
+    <string name="category_flag_cyan">Drapeau mes sujets</string>
+    <string name="category_flag_red">Drapeau lu uniquement</string>
+    <string name="category_flag_favorite">Favori</string>
 </resources>

--- a/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModelTest.kt
+++ b/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModelTest.kt
@@ -204,6 +204,135 @@ class CategoryViewModelTest {
     }
 
     @Test
+    fun `refresh forwards the current page and selectedSubcat after the user moved`() = runTest {
+        val repo = FakeForumRepository()
+        val vm = CategoryViewModel(
+            request = CategoryRequest(cat = 23, initialSubcat = null, initialPage = 1),
+            forumRepository = repo,
+        )
+
+        // Move state to (subcat=550, page=2) before the user pulls to refresh.
+        vm.selectSubcategory(550)
+        vm.selectPage(2)
+
+        vm.refresh()
+
+        assertTrue(repo.refreshSubcategoriesCalls.contains(23))
+        assertEquals(listOf(Triple(23, 550, 2)), repo.refreshTopicListCalls)
+    }
+
+    @Test
+    fun `isRefreshing flips true during refresh and false after`() = runTest {
+        val repo = FakeForumRepository()
+        val vm = CategoryViewModel(
+            request = CategoryRequest(cat = 23, initialSubcat = 550),
+            forumRepository = repo,
+        )
+
+        // Repository's refresh* methods are simple stubs (Unit) — they suspend zero
+        // work, so isRefreshing flips on then off in a single dispatch cycle. We
+        // still assert the false state at rest, plus the on-the-fly tracking exposed
+        // by `repo.refreshTopicListCalls`.
+        assertEquals(false, vm.uiState.value.isRefreshing)
+        vm.refresh()
+        assertEquals(false, vm.uiState.value.isRefreshing)
+        assertTrue(repo.refreshTopicListCalls.isNotEmpty())
+    }
+
+    @Test
+    fun `searchQuery filters by title author and lastReplyAuthor case- and accent-insensitively`() = runTest {
+        val repo = FakeForumRepository()
+        val vm = CategoryViewModel(
+            request = CategoryRequest(cat = 23, initialSubcat = 550),
+            forumRepository = repo,
+        )
+
+        val topics = listOf(
+            topicSummary(id = 1, title = "Android et iOS", author = "alice", lastAuthor = "bob"),
+            topicSummary(id = 2, title = "Réflexion sur la batterie", author = "Charlie", lastAuthor = "dave"),
+            topicSummary(id = 3, title = "Câble USB-C", author = "Eve", lastAuthor = "Frédéric"),
+        )
+
+        vm.uiState.test {
+            awaitItem() // initial Loading
+            repo.emitSubcategories(ForumResult.Success(emptyList()))
+            repo.emitTopicList(
+                cat = 23,
+                subcat = 550,
+                page = 1,
+                result = ForumResult.Success(EMPTY_PAGE.copy(topics = topics, totalTopics = topics.size)),
+            )
+
+            val withAll = awaitContent { it.topics is TopicsUiState.Content && it.filteredTopics.size == 3 }
+            assertEquals(3, withAll.filteredTopics.size)
+
+            // Title match — case-insensitive
+            vm.updateSearchQuery("ANDROID")
+            val byTitle = awaitContent { it.searchQuery == "ANDROID" && it.filteredTopics.size == 1 }
+            assertEquals(setOf(1), byTitle.filteredTopics.map(TopicSummary::topicId).toSet())
+
+            // Title match — accent-insensitive
+            vm.updateSearchQuery("reflexion")
+            val byAccent = awaitContent { it.searchQuery == "reflexion" && it.filteredTopics.size == 1 }
+            assertEquals(setOf(2), byAccent.filteredTopics.map(TopicSummary::topicId).toSet())
+
+            // Last reply author — accent-insensitive
+            vm.updateSearchQuery("frederic")
+            val byLastAuthor = awaitContent { it.searchQuery == "frederic" && it.filteredTopics.size == 1 }
+            assertEquals(setOf(3), byLastAuthor.filteredTopics.map(TopicSummary::topicId).toSet())
+
+            // Author match — case-insensitive substring
+            vm.updateSearchQuery("CHAR")
+            val byAuthor = awaitContent { it.searchQuery == "CHAR" && it.filteredTopics.size == 1 }
+            assertEquals(setOf(2), byAuthor.filteredTopics.map(TopicSummary::topicId).toSet())
+
+            // No match — empty list
+            vm.updateSearchQuery("zzz")
+            val noMatch = awaitContent { it.searchQuery == "zzz" }
+            assertTrue(noMatch.filteredTopics.isEmpty())
+
+            // Empty query — full list back
+            vm.updateSearchQuery("")
+            val cleared = awaitContent { it.searchQuery == "" && it.filteredTopics.size == 3 }
+            assertEquals(3, cleared.filteredTopics.size)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `searchQuery is preserved across subcategory switches`() = runTest {
+        val repo = FakeForumRepository()
+        val vm = CategoryViewModel(
+            request = CategoryRequest(cat = 23, initialSubcat = null),
+            forumRepository = repo,
+        )
+
+        vm.uiState.test {
+            awaitItem() // initial Loading
+            repo.emitSubcategories(ForumResult.Success(listOf(SUBCAT_550)))
+            repo.emitTopicList(
+                cat = 23,
+                subcat = null,
+                page = 1,
+                result = ForumResult.Success(EMPTY_PAGE.copy(subcat = null, totalTopics = 0)),
+            )
+            awaitContent { it.subcategories is SubcategoriesUiState.Content }
+
+            vm.updateSearchQuery("hello")
+            awaitContent { it.searchQuery == "hello" }
+
+            vm.selectSubcategory(550)
+            // After subcat switch the page resets to 1 — but the searchQuery stays.
+            val afterSwitch = awaitContent { it.selectedSubcat == 550 }
+            assertEquals("hello", afterSwitch.searchQuery)
+            assertEquals(1, afterSwitch.page)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `failure from observeSubcategories surfaces as SubcategoriesUiState Error`() = runTest {
         val repo = FakeForumRepository()
         val vm = CategoryViewModel(
@@ -236,6 +365,29 @@ class CategoryViewModelTest {
             topics = emptyList<TopicSummary>(),
         )
         const val AWAIT_CONTENT_TIMEOUT_MS = 2_000L
+
+        fun topicSummary(
+            id: Int,
+            title: String,
+            author: String = "anon",
+            lastAuthor: String = author,
+        ): TopicSummary = TopicSummary(
+            cat = 23,
+            subcat = 550,
+            topicId = id,
+            title = title,
+            author = author,
+            lastReplyAuthor = lastAuthor,
+            lastReplyAt = "2026-05-02 10:00",
+            replyCount = 0,
+            totalPages = 1,
+            isSticky = false,
+            isLocked = false,
+            hasUnread = null,
+            lastReadPage = null,
+            lastPostReadId = null,
+            flagType = null,
+        )
     }
 
     /**

--- a/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModelTest.kt
+++ b/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModelTest.kt
@@ -7,6 +7,7 @@ import fr.forumhfr.redface2.core.model.Category
 import fr.forumhfr.redface2.core.model.SubCategory
 import fr.forumhfr.redface2.core.model.TopicListPage
 import fr.forumhfr.redface2.core.model.TopicSummary
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -229,14 +230,65 @@ class CategoryViewModelTest {
             forumRepository = repo,
         )
 
-        // Repository's refresh* methods are simple stubs (Unit) — they suspend zero
-        // work, so isRefreshing flips on then off in a single dispatch cycle. We
-        // still assert the false state at rest, plus the on-the-fly tracking exposed
-        // by `repo.refreshTopicListCalls`.
-        assertEquals(false, vm.uiState.value.isRefreshing)
-        vm.refresh()
-        assertEquals(false, vm.uiState.value.isRefreshing)
-        assertTrue(repo.refreshTopicListCalls.isNotEmpty())
+        // Force at least one collector on uiState so the underlying combine starts
+        // observing isRefreshing — without this, vm.uiState.value would stay frozen
+        // on the StateFlow's initialValue and we couldn't observe the transient flip.
+        vm.uiState.test {
+            awaitItem() // initial Loading
+            assertEquals(false, vm.uiState.value.isRefreshing)
+
+            // Gate refreshSubcategories so the launched refresh() coroutine suspends
+            // mid-way. We can then assert isRefreshing == true while the gate holds.
+            val gate = CompletableDeferred<Unit>()
+            repo.suspendRefreshSubcategoriesUntil = gate
+
+            vm.refresh()
+
+            // While the repository is suspended the flag has flipped on. Drain
+            // intermediate emissions until the indicator reaches true.
+            val whileRefreshing = awaitContent { it.isRefreshing }
+            assertEquals(true, whileRefreshing.isRefreshing)
+
+            // Release the gate — refresh() resumes, runs refreshTopicList, returns,
+            // and isRefreshing flips back off.
+            gate.complete(Unit)
+            val afterRefresh = awaitContent { !it.isRefreshing }
+            assertEquals(false, afterRefresh.isRefreshing)
+            assertTrue(repo.refreshTopicListCalls.isNotEmpty())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `categoryName is preserved across Loading and Failure broadcasts`() = runTest {
+        val repo = FakeForumRepository()
+        val vm = CategoryViewModel(
+            request = CategoryRequest(cat = 23, initialSubcat = null),
+            forumRepository = repo,
+        )
+
+        vm.uiState.test {
+            awaitItem() // initial — categoryName == null
+            repo.emitCategories(
+                ForumResult.Success(
+                    listOf(
+                        Category(id = 23, name = "Technologies Mobiles", forceSubcat = false, subcategoryCount = 5),
+                    ),
+                ),
+            )
+            val withName = awaitContent { it.categoryName == "Technologies Mobiles" }
+            assertEquals("Technologies Mobiles", withName.categoryName)
+
+            // A subsequent Loading (e.g. user pulled-to-refresh on Forum tab) must NOT
+            // wipe the title back to "Catégorie 23". Same for a transient Failure.
+            repo.emitCategories(ForumResult.Loading)
+            assertEquals("Technologies Mobiles", vm.uiState.value.categoryName)
+
+            repo.emitCategories(ForumResult.Failure(IllegalStateException("transient")))
+            assertEquals("Technologies Mobiles", vm.uiState.value.categoryName)
+
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     @Test
@@ -420,6 +472,13 @@ class CategoryViewModelTest {
         var refreshTopicListCalls: List<Triple<Int, Int?, Int>> = emptyList()
             private set
 
+        /**
+         * Optional gate consumed by [refreshSubcategories] — when set, the suspending
+         * stub awaits the gate before recording the call and returning. Lets a test
+         * pin the in-flight state of [CategoryViewModel.isRefreshing].
+         */
+        var suspendRefreshSubcategoriesUntil: CompletableDeferred<Unit>? = null
+
         override fun observeCategories(): Flow<ForumResult<List<Category>>> =
             categories.asSharedFlow()
 
@@ -429,6 +488,7 @@ class CategoryViewModelTest {
             subcategories.asSharedFlow()
 
         override suspend fun refreshSubcategories(cat: Int) {
+            suspendRefreshSubcategoriesUntil?.await()
             refreshSubcategoriesCalls = refreshSubcategoriesCalls + cat
         }
 

--- a/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/MatchesTopicQueryTest.kt
+++ b/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/MatchesTopicQueryTest.kt
@@ -1,0 +1,71 @@
+package fr.forumhfr.redface2.feature.forum
+
+import fr.forumhfr.redface2.core.model.TopicSummary
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-helper tests for [matchesTopicQuery]. The local search field calls into this
+ * helper for every visible topic on every keystroke, so we pin its semantics here.
+ */
+class MatchesTopicQueryTest {
+
+    @Test
+    fun `blank query matches every topic`() {
+        assertTrue(matchesTopicQuery(topic("Android", "alice", "bob"), ""))
+        assertTrue(matchesTopicQuery(topic("Android", "alice", "bob"), "   "))
+    }
+
+    @Test
+    fun `case-insensitive title match`() {
+        val t = topic(title = "Android et iOS")
+        assertTrue(matchesTopicQuery(t, "ANDROID"))
+        assertTrue(matchesTopicQuery(t, "android"))
+        assertTrue(matchesTopicQuery(t, "AnDrOiD"))
+    }
+
+    @Test
+    fun `accent-insensitive title match folds NFD then strips combining marks`() {
+        val t = topic(title = "Réflexion sur la batterie")
+        assertTrue(matchesTopicQuery(t, "reflexion"))
+        assertTrue(matchesTopicQuery(t, "RÉFLEXION"))
+        assertTrue(matchesTopicQuery(t, "Réflexion"))
+    }
+
+    @Test
+    fun `matches author and lastReplyAuthor`() {
+        val t = topic(title = "fixed", author = "Charlie", lastAuthor = "Frédéric")
+        assertTrue(matchesTopicQuery(t, "char"))
+        assertTrue(matchesTopicQuery(t, "frederic"))
+    }
+
+    @Test
+    fun `no match returns false`() {
+        val t = topic(title = "Android", author = "alice", lastAuthor = "bob")
+        assertFalse(matchesTopicQuery(t, "windows"))
+        assertFalse(matchesTopicQuery(t, "zzz"))
+    }
+
+    private fun topic(
+        title: String = "ignored",
+        author: String = "ignored",
+        lastAuthor: String = "ignored",
+    ): TopicSummary = TopicSummary(
+        cat = 23,
+        subcat = null,
+        topicId = 1,
+        title = title,
+        author = author,
+        lastReplyAuthor = lastAuthor,
+        lastReplyAt = "",
+        replyCount = 0,
+        totalPages = 1,
+        isSticky = false,
+        isLocked = false,
+        hasUnread = null,
+        lastReadPage = null,
+        lastPostReadId = null,
+        flagType = null,
+    )
+}


### PR DESCRIPTION
> Action par Claude Opus 4.7 (1M context) (demandée par @XaaT)

Phase 1C-B du chantier Forum, suite directe de la PR #105 (1C-A). Refs #100.

## Bloc 1 — Refresh UX

- `PullToRefreshBox` Material 3 (stable) sur `ForumScreen` et `ForumCategoryScreen`. Pas de `SwipeRefresh` Accompanist.
- `ForumViewModel.isRefreshing` et `CategoryViewModel.isRefreshing` exposés en `StateFlow<Boolean>`, togglés autour du round-trip `refresh*()`.
- Helper `keepContentDuringRefresh` qui collapse le `Loading` transient ré-émis par les `categoriesRefresh` / `subcategoriesRefresh` / `topicListRefresh` flows quand on a déjà un `Content` à montrer. La liste ne flashe plus pendant un pull-to-refresh manuel. `Error` passe toujours pour conserver le bouton « Réessayer ».
- Boutons inline « Actualiser » / « Réessayer » conservés (affordance secondaire).

## Bloc 2 — Drapeaux REST dans la liste

- Nouveau champ `TopicSummary.flagType: FlagType?` dérivé de REST `flag_owntopic` :
  - `1 → FlagType.CYAN` (« Mes sujets » — sujets participés)
  - `2 → FlagType.RED` (« Lus uniquement »)
  - `3 → FlagType.FAVORITE` (favoris)
  - `null` / autre → `null` (dégrade silencieusement, pas de crash sur valeur inattendue).
- `TopicRow` affiche un petit point coloré en début de ligne quand `flagType != null`. `hasUnread` reste un axe séparé (font weight).
- Pas de migration de `:feature:flags` HTML vers REST dans cette PR.
- Pas de mutation drapeau (issue #99, Phase 2).
- Pas de nouvel endpoint dédié drapeau : `flag_owntopic` exposé par `/topics/last/` suffit pour l'UI 1C-B.

## Bloc 3 — Recherche locale dans la page

- Champ `OutlinedTextField` au-dessus de la liste (label « Rechercher dans cette page »).
- Filtre **local** sur la page courante uniquement, pas de requête réseau à chaque frappe.
- Helper pur `matchesTopicQuery` : case-insensitive et accent-insensitive (Unicode NFD + strip combining marks). Match sur `title`, `author`, `lastReplyAuthor`.
- Query conservée entre changements de subcategory et de page (filtrage de préférence, pas search par page).
- Aucun résultat : état vide dédié, pas un `Error`.

## Hors scope (conservé)

- Pas de mutations drapeaux REST.
- Pas de migration `:feature:flags`.
- Pas de Room / cache disque pour Forum.
- Pas de prefetch pages suivantes.
- Pas de REST posts (HTML reste canonique).
- Pas de fallback runtime REST → HTML.
- Pas de refonte visuelle.

## Validation

Exécutée via `./scripts/docker-dev.sh` :

- `./gradlew :core:network:testDebugUnitTest :core:data:testDebugUnitTest :feature:forum:testDebugUnitTest :app:testDebugUnitTest` — **OK** (47s)
- `./gradlew detektAll lintDebug test :app:assembleDebug` — **OK** (1m10s)

Tests ajoutés / mis à jour :
- `RestForumMappersTest` : 7 cas `flag_owntopic` (1/2/3/null/0/4/-1) + `flagType` indépendant de `hasUnread`.
- `CategoryViewModelTest` : `refresh()` forwarde `selectedSubcat` + `page` courants, `isRefreshing` toggle, recherche case+accent-insensitive multi-champs, query survit au switch subcat.
- `MatchesTopicQueryTest` : helper pur isolé.

## Documentation

- `docs/specs/roadmap.md` : case 1C-B cochée.
- `docs/specs/models.md` : `TopicSummary.flagType` documenté.
- `docs/specs/protocol-hfr.md` : table de mapping `flag_owntopic` ↔ `FlagType` ajoutée.

## Test plan

- [ ] CI verte sur la PR.
- [ ] Smoke test manuel après merge : pull-to-refresh sur Forum + Category, recherche locale dans une catégorie active, drapeau cyan visible sur un sujet participé après login.