### PR TITLE
refactor(forum): cleanup post-PR #106 — FlagPalette + dedup helper + isRefreshing tests (#111)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/FlagPalette.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/FlagPalette.kt
@@ -1,7 +1,5 @@
 package fr.forumhfr.redface2.core.ui.theme
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.graphics.Color
 import fr.forumhfr.redface2.core.model.FlagType
 
@@ -27,11 +25,12 @@ object FlagPalette {
     val Favorite: Color = Color(0xFFF9A825)
 
     /**
-     * Resolves the bucket color for a non-null [FlagType]. Composable + read-only so
-     * it can sit inside `remember`/`derivedStateOf` blocks without recomposition cost.
+     * Resolves the bucket color for a non-null [FlagType]. Plain Kotlin function — not
+     * `@Composable` — so it can be called from `remember { ... }` / `derivedStateOf { ... }`
+     * blocks (whose lambdas reject composable calls) as well as from a regular
+     * `@Composable` body. The returned [Color] is a constant; theme branching, if ever
+     * needed, would introduce a parallel `@Composable` accessor.
      */
-    @Composable
-    @ReadOnlyComposable
     fun colorFor(type: FlagType): Color = when (type) {
         FlagType.CYAN -> Cyan
         FlagType.RED -> Red

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/FlagPalette.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/FlagPalette.kt
@@ -1,0 +1,40 @@
+package fr.forumhfr.redface2.core.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.graphics.Color
+import fr.forumhfr.redface2.core.model.FlagType
+
+/**
+ * Drapeau bucket palette. The colors mirror the legacy HFR palette
+ * (`flag1.gif` cyan / `flag0.gif` red / `favoris.gif` yellow) so a user reading the
+ * forum on the web and on Redface 2 sees the same visual mapping :
+ *
+ * - [FlagType.CYAN] → cyan, sujets participés
+ * - [FlagType.RED] → rouge, lus uniquement
+ * - [FlagType.FAVORITE] → jaune, favoris
+ *
+ * Kept distinct from the Material 3 `error` / `tertiary` roles on purpose : mapping
+ * the buckets to roles would either introduce ambiguity (red flag ↔ error state) or
+ * lose the third axis (no neutral M3 role for a yellow favorite). The values are the
+ * same in light, dark and AMOLED schemes — drapeau identity is a content marker, not
+ * a surface affordance, so it stays anchored to the legacy hue regardless of theme.
+ */
+object FlagPalette {
+
+    val Cyan: Color = Color(0xFF00BCD4)
+    val Red: Color = Color(0xFFD32F2F)
+    val Favorite: Color = Color(0xFFF9A825)
+
+    /**
+     * Resolves the bucket color for a non-null [FlagType]. Composable + read-only so
+     * it can sit inside `remember`/`derivedStateOf` blocks without recomposition cost.
+     */
+    @Composable
+    @ReadOnlyComposable
+    fun colorFor(type: FlagType): Color = when (type) {
+        FlagType.CYAN -> Cyan
+        FlagType.RED -> Red
+        FlagType.FAVORITE -> Favorite
+    }
+}

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModel.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModel.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.stateIn
@@ -247,32 +246,6 @@ class CategoryViewModel @AssistedInject constructor(
 
     private companion object {
         const val STOP_TIMEOUT_MS: Long = 5_000L
-    }
-}
-
-/**
- * Hides a transient `Loading` re-emitted by a repository's `refresh*()` broadcast
- * when there is already a prior `Content` to keep showing. The first cold-start
- * `Loading` passes through (so the screen still renders its initial spinner) and
- * `Error` always passes through (so a failed refresh surfaces the "Réessayer"
- * button instead of silently keeping stale data).
- */
-private fun <T : Any> Flow<T>.keepContentDuringRefresh(
-    isLoading: (T) -> Boolean,
-    isContent: (T) -> Boolean,
-): Flow<T> = flow {
-    var lastContent: T? = null
-    collect { value ->
-        when {
-            isContent(value) -> {
-                lastContent = value
-                emit(value)
-            }
-            isLoading(value) && lastContent != null -> {
-                // Suppress: keep showing the previous Content under a refresh spinner.
-            }
-            else -> emit(value)
-        }
     }
 }
 

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -45,6 +44,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.SubCategory
 import fr.forumhfr.redface2.core.model.TopicSummary
+import fr.forumhfr.redface2.core.ui.theme.FlagPalette
 
 /**
  * Per-category screen: chip row of subcategories ("Toutes" + each subcat) on top, list
@@ -348,11 +348,7 @@ private fun FlagIndicator(flagType: FlagType?) {
         Spacer(modifier = gutter)
         return
     }
-    val color = when (flagType) {
-        FlagType.CYAN -> Color(0xFF00BCD4)
-        FlagType.RED -> Color(0xFFD32F2F)
-        FlagType.FAVORITE -> Color(0xFFF9A825)
-    }
+    val color = FlagPalette.colorFor(flagType)
     val description = stringResource(
         when (flagType) {
             FlagType.CYAN -> R.string.category_flag_cyan

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumViewModel.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumViewModel.kt
@@ -7,11 +7,9 @@ import fr.forumhfr.redface2.core.domain.forum.ForumRepository
 import fr.forumhfr.redface2.core.domain.forum.ForumResult
 import fr.forumhfr.redface2.core.model.Category
 import javax.inject.Inject
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -35,10 +33,10 @@ class ForumViewModel @Inject constructor(
 
     val uiState: StateFlow<ForumUiState> = forumRepository.observeCategories()
         .map { it.toUiState() }
-        // Suppress transient `Loading` re-emitted by refreshCategories() once we have
-        // a Content to keep showing — see CategoryViewModel.keepContentDuringRefresh
-        // for the same pattern at the per-category screen level.
-        .keepContentDuringRefresh()
+        .keepContentDuringRefresh(
+            isLoading = { it is ForumUiState.Loading },
+            isContent = { it is ForumUiState.Content },
+        )
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS),
@@ -62,24 +60,6 @@ class ForumViewModel @Inject constructor(
             is ForumResult.Success -> ForumUiState.Content(value)
             is ForumResult.Failure -> ForumUiState.Error(cause.message)
         }
-
-    private fun Flow<ForumUiState>.keepContentDuringRefresh(): Flow<ForumUiState> = flow {
-        var lastContent: ForumUiState.Content? = null
-        collect { value ->
-            when (value) {
-                is ForumUiState.Content -> {
-                    lastContent = value
-                    emit(value)
-                }
-                ForumUiState.Loading -> if (lastContent != null) {
-                    // Skip — keep showing the previous content under a refresh spinner.
-                } else {
-                    emit(value)
-                }
-                is ForumUiState.Error -> emit(value)
-            }
-        }
-    }
 
     private companion object {
         const val STOP_TIMEOUT_MS: Long = 5_000L

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/RefreshUiHelpers.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/RefreshUiHelpers.kt
@@ -1,0 +1,43 @@
+package fr.forumhfr.redface2.feature.forum
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+/**
+ * Suppresses a transient `Loading` re-emitted by a repository's `refresh*()` broadcast
+ * when there is already a prior `Content` to keep showing. Shared between the Forum
+ * and Category view models — both screens render a `PullToRefreshBox` that expects
+ * the body to stay visible while the refresh round-trip is in flight, instead of
+ * blanking back to a cold spinner.
+ *
+ * Behaviour pinned by `ForumViewModelTest` and `CategoryViewModelTest` :
+ *
+ * - first emission of `Loading` (cold start, no prior Content) **passes through** so
+ *   the screen renders its initial spinner ;
+ * - any later `Loading` while a prior `Content` exists is **suppressed** so the
+ *   list stays visible under the refresh indicator ;
+ * - `Error` always passes through (a failed refresh must surface the "Réessayer"
+ *   button instead of silently keeping stale data).
+ *
+ * `T` is intentionally constrained to the screen's UI state sealed type ; the caller
+ * supplies the two predicates because this helper does not depend on any specific
+ * `*UiState` shape.
+ */
+internal fun <T : Any> Flow<T>.keepContentDuringRefresh(
+    isLoading: (T) -> Boolean,
+    isContent: (T) -> Boolean,
+): Flow<T> = flow {
+    var lastContent: T? = null
+    collect { value ->
+        when {
+            isContent(value) -> {
+                lastContent = value
+                emit(value)
+            }
+            isLoading(value) && lastContent != null -> {
+                // Suppress: keep showing the previous Content under a refresh spinner.
+            }
+            else -> emit(value)
+        }
+    }
+}

--- a/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/ForumViewModelTest.kt
+++ b/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/ForumViewModelTest.kt
@@ -6,6 +6,7 @@ import fr.forumhfr.redface2.core.domain.forum.ForumResult
 import fr.forumhfr.redface2.core.model.Category
 import fr.forumhfr.redface2.core.model.SubCategory
 import fr.forumhfr.redface2.core.model.TopicListPage
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -70,6 +71,44 @@ class ForumViewModelTest {
         assertTrue(repo.refreshCategoriesCalled)
     }
 
+    @Test
+    fun `isRefreshing stays false on cold start before any user-triggered refresh`() = runTest {
+        // Pins the contract that `isRefreshing` is reserved for user-driven refreshes —
+        // initial cold-start fetch goes through `uiState.Loading`, not `isRefreshing=true`.
+        val repo = FakeForumRepository()
+        val vm = ForumViewModel(repo)
+
+        vm.isRefreshing.test {
+            assertEquals(false, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `isRefreshing flips true during refresh and false after`() = runTest {
+        val repo = FakeForumRepository()
+        val vm = ForumViewModel(repo)
+
+        vm.isRefreshing.test {
+            assertEquals(false, awaitItem())
+
+            // Gate refreshCategories so the launched refresh coroutine suspends
+            // mid-way. The flag must be true while the gate holds.
+            val gate = CompletableDeferred<Unit>()
+            repo.suspendRefreshCategoriesUntil = gate
+
+            vm.refresh()
+
+            assertEquals(true, awaitItem())
+
+            // Release the gate → finally branch flips the flag back off.
+            gate.complete(Unit)
+            assertEquals(false, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+
     private companion object {
         val SAMPLE_CATEGORIES: List<Category> = listOf(
             Category(id = 13, name = "Discussions", forceSubcat = true, subcategoryCount = 15),
@@ -82,12 +121,14 @@ class ForumViewModelTest {
             MutableSharedFlow(replay = 1, extraBufferCapacity = 4)
         var refreshCategoriesCalled: Boolean = false
             private set
+        var suspendRefreshCategoriesUntil: CompletableDeferred<Unit>? = null
 
         override fun observeCategories(): Flow<ForumResult<List<Category>>> =
             categories.asSharedFlow()
 
         override suspend fun refreshCategories() {
             refreshCategoriesCalled = true
+            suspendRefreshCategoriesUntil?.await()
         }
 
         override fun observeSubcategories(cat: Int): Flow<ForumResult<List<SubCategory>>> =

--- a/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/RefreshUiHelpersTest.kt
+++ b/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/RefreshUiHelpersTest.kt
@@ -1,0 +1,115 @@
+package fr.forumhfr.redface2.feature.forum
+
+import app.cash.turbine.test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pin the contract of [keepContentDuringRefresh] directly. The two ViewModel
+ * tests cover the helper indirectly via their refresh flows, but only this
+ * test asserts the suppression rule in isolation — no dispatcher, no scope,
+ * no Hilt — so a regression cannot hide behind ViewModel orchestration.
+ *
+ * Test fixture is a tiny sealed type that mirrors the project's UI-state
+ * shape (`Loading` / `Content` / `Error`) without dragging in the real
+ * Forum/Category states.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class RefreshUiHelpersTest {
+
+    private sealed interface FakeState {
+        data object Loading : FakeState
+        data class Content(val payload: String) : FakeState
+        data class Error(val message: String) : FakeState
+    }
+
+    private val isLoading: (FakeState) -> Boolean = { it is FakeState.Loading }
+    private val isContent: (FakeState) -> Boolean = { it is FakeState.Content }
+
+    @Test
+    fun `cold-start Loading passes through when no prior Content`() = runTest {
+        val source = MutableSharedFlow<FakeState>(replay = 0, extraBufferCapacity = 4)
+
+        source.asSharedFlow().keepContentDuringRefresh(isLoading, isContent).test {
+            source.emit(FakeState.Loading)
+            assertEquals(FakeState.Loading, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `Loading after Content is suppressed so the screen keeps the prior content`() = runTest {
+        val source = MutableSharedFlow<FakeState>(replay = 0, extraBufferCapacity = 4)
+        val content = FakeState.Content("topics-page-1")
+
+        source.asSharedFlow().keepContentDuringRefresh(isLoading, isContent).test {
+            // First Loading gets through — cold start.
+            source.emit(FakeState.Loading)
+            assertEquals(FakeState.Loading, awaitItem())
+
+            // Content lands and is replayed downstream.
+            source.emit(content)
+            assertEquals(content, awaitItem())
+
+            // Refresh: the repository's broadcast re-emits Loading. The helper
+            // must swallow it so the UI keeps rendering `content` under the
+            // PullToRefresh indicator instead of bouncing through a spinner.
+            source.emit(FakeState.Loading)
+            expectNoEvents()
+
+            // The refreshed Content arrives and propagates as the new value.
+            val refreshed = FakeState.Content("topics-page-1-refreshed")
+            source.emit(refreshed)
+            assertEquals(refreshed, awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `Error after Content propagates so the Reessayer button can surface`() = runTest {
+        val source = MutableSharedFlow<FakeState>(replay = 0, extraBufferCapacity = 4)
+        val content = FakeState.Content("topics-page-1")
+        val error = FakeState.Error("HFR éteint")
+
+        source.asSharedFlow().keepContentDuringRefresh(isLoading, isContent).test {
+            source.emit(content)
+            assertEquals(content, awaitItem())
+
+            // A refresh failure must NOT be silenced — keeping stale data forever
+            // would mask network outages indefinitely.
+            source.emit(error)
+            assertEquals(error, awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `Loading immediately after Error is suppressed only if Content was seen earlier`() = runTest {
+        val source = MutableSharedFlow<FakeState>(replay = 0, extraBufferCapacity = 4)
+        val content = FakeState.Content("topics-page-1")
+
+        source.asSharedFlow().keepContentDuringRefresh(isLoading, isContent).test {
+            // Establish the "lastContent" anchor.
+            source.emit(content)
+            assertEquals(content, awaitItem())
+
+            // Error propagates …
+            source.emit(FakeState.Error("boom"))
+            awaitItem()
+
+            // … but the next Loading is still suppressed because lastContent is set.
+            // (The helper only resets lastContent on a new Content; an Error in the
+            // middle does not invalidate the anchor.)
+            source.emit(FakeState.Loading)
+            expectNoEvents()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}


### PR DESCRIPTION
## Résumé

Cleanup court post-merge #106 avant d'attaquer les gros chantiers Phase 1D (#110, #107, #26, #108). Pas de changement réseau, cache ou navigation.

## F1 — Theming `FlagIndicator`

`feature/forum/.../ForumCategoryScreen.kt::FlagIndicator` hardcodait ses couleurs en `Color(0xFF...)` inline. Ces valeurs sont maintenant dans un objet `FlagPalette` côté `:core:ui/theme/`.

- `FlagPalette.Cyan` / `Red` / `Favorite` exposés en constantes Compose.
- `FlagPalette.colorFor(FlagType)` pour le call-site existant.
- Mapping conservé : CYAN = sujets participés, RED = lus uniquement, FAVORITE = favoris.
- Pas de basculement vers les roles M3 (`error` / `tertiary`) — cela rendrait les buckets ambigus (red flag ↔ error state, pas de neutral M3 role pour favorite).
- Mêmes valeurs en light / dark / AMOLED — l'identité drapeau est un content marker, pas une surface affordance.

## F2 — Dédup `keepContentDuringRefresh`

Le même helper était dupliqué entre `ForumViewModel` (sans paramètres, scellé sur `ForumUiState`) et `CategoryViewModel` (avec deux prédicats `isLoading` / `isContent`). Factorisé dans `:feature:forum/RefreshUiHelpers.kt` avec la signature paramétrée du second (plus générique). `ForumViewModel` passe désormais ses propres prédicats.

Sémantique pinned :
- premier `Loading` cold-start passe (cold spinner initial) ;
- `Loading` ultérieur suppressed quand un `Content` existe (pull-to-refresh ne wipe pas la liste) ;
- `Error` toujours surfacée (un refresh raté doit montrer "Réessayer", pas garder du stale silencieusement).

Helper gardé local au module `:feature:forum` — pas réutilisé ailleurs, pas de raison de l'exposer plus haut (#106 review note : ne pas créer un module shared/core pour un helper local).

## F3 — Aligner `isRefreshing`

`CategoryViewModelTest` couvrait déjà la transition `isRefreshing false → true → false` via une `suspendRefreshSubcategoriesUntil` gate. `ForumViewModelTest` n'avait que le test "refresh forwards to repo" (smoke). Ajout de :

- `isRefreshing stays false on cold start before any user-triggered refresh` — pin l'invariant que `isRefreshing` est réservé au pull-to-refresh utilisateur (le cold-start passe par `uiState.Loading`).
- `isRefreshing flips true during refresh and false after` — même pattern que la couverture Category, avec un `CompletableDeferred` qui gate `refreshCategories()`.

`ForumViewModel.isRefreshing` et `CategoryViewModel.uiState.isRefreshing` exposent la même sémantique — le `try/finally` garantit le flip-back même sur erreur réseau (vérifié statiquement, le test runtime du throw est trop dépendant du dispatcher pour être stable).

## Tests exécutés

```
./scripts/docker-dev.sh ./gradlew detektAll lintDebug testDebugUnitTest :app:assembleDebug
```

Tous verts, sans warning nouveau.

## Hors scope

- Migration `:feature:flags` REST (#110)
- Cache Room / persistance drapeaux (#26)
- Prefetch anonyme (#108)
- Lecture longue topic (#107)

## Issues liées

`Closes #111`

> Action par Claude Opus 4.7 (1M context) (demandée par @XaaT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)