### PR TITLE
feat(prefetch): Phase 1D-4 — prefetch anonyme topic + listing (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Format inspiré de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/). Les
 
 Phase 1B.1 livrée : login HFR utilisable de bout en bout avec cookies persistants (DataStore + `PersistentCookieJar`). AAB `0.1.0-phase1b.0` (build 14) sortira avec la PR `feature/1b-1-auth`.
 
+### Phase 1D-4 — Prefetch anonyme (#108)
+
+#### Added
+- `TopicRepository.prefetch(cat, post, page)` : fetch topic en client anonyme, persistance `ANONYMOUS`, erreurs swallowed. Le cache auth plus riche reste protégé par l'anti-écrasement `authMode`.
+- `ForumRepository.prefetchTopicList(cat, subcat, page)` : warm-up anonyme du listing suivant, payload jeté volontairement pour ne pas exposer de données sans champs per-user.
+- `TopicViewModel` et `CategoryViewModel` lancent un prefetch `page + 1` best-effort après émission `Content`, avec un seul prefetch en vol et annulation à la sortie d'écran.
+- Tests ViewModel/repository + règle Konsist : les chemins prefetch doivent utiliser les APIs dédiées et ne pas appeler les méthodes `refresh*` authentifiées.
+
+#### Changed
+- `docs/specs/architecture.md` explicite l'asymétrie : topic prefetch persiste une row `ANONYMOUS`, listing forum prefetch réchauffe seulement HFR/CDN.
+
 ### Phase 1D-3 — Cache Room (#26)
 
 #### Added

--- a/app/src/test/kotlin/fr/forumhfr/redface2/ArchitectureKonsistTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/ArchitectureKonsistTest.kt
@@ -122,9 +122,14 @@ class ArchitectureKonsistTest {
         // which both go to the @AnonymousClient. A ViewModel that calls
         // `refreshTopicPage()` or `refreshTopicList()` from a "prefetch" context
         // would fire an authenticated request and silently mark drapeaux as read
-        // (cf. ADR-003 § Prefetch). This test catches the mistake by enforcing
-        // that the substring "prefetch" only appears next to the repository's
-        // prefetch methods, never the auth-paying refresh ones.
+        // (cf. ADR-003 § Prefetch).
+        //
+        // We analyse at **function** granularity, not line-by-line. A naive
+        // line search misses the natural shape of the bug : a function named
+        // `maybeSchedulePrefetch(...)` calls `refreshTopicPage(...)` two lines
+        // below — the line search would not flag it because `prefetch` and
+        // `refreshTopicPage` live on different lines. Looking at the function
+        // text catches both same-line and multi-line forms.
         val viewModelFiles = Konsist
             .scopeFromProject()
             .slice { file ->
@@ -137,22 +142,19 @@ class ArchitectureKonsistTest {
 
         assertTrue("Konsist must scan feature ViewModels", viewModelFiles.isNotEmpty())
 
-        viewModelFiles.assertFalse { file ->
-            // Match patterns where a "prefetch"-named scope refers to refresh*().
-            // Naive but cheap: if a file mentions both "prefetch" and a refresh*()
-            // method invocation in any prefetch-tagged context, flag it.
-            val text = file.text.lowercase()
-            val prefetchContext = text.contains("prefetch")
-            val callsAuthenticatedRefresh = text.contains("refreshtopicpage") ||
-                text.contains("refreshtopiclist")
-            // Only flag if the file has BOTH and the refresh call lives near a
-            // prefetch label — same line or same block. We approximate "near"
-            // by looking at the lines that contain the refresh call.
-            prefetchContext && callsAuthenticatedRefresh && file.text.lineSequence().any { line ->
-                val lower = line.lowercase()
-                lower.contains("prefetch") && (
-                    lower.contains("refreshtopicpage") || lower.contains("refreshtopiclist")
-                    )
+        viewModelFiles.forEach { file ->
+            file.functions(includeNested = true, includeLocal = true).forEach { function ->
+                val nameSuggestsPrefetch = "prefetch" in function.name.lowercase()
+                val bodyMentionsPrefetch = "prefetch" in function.text.lowercase()
+                if (!nameSuggestsPrefetch && !bodyMentionsPrefetch) return@forEach
+                val body = function.text.lowercase()
+                val callsRefresh = "refreshtopicpage" in body || "refreshtopiclist" in body
+                org.junit.Assert.assertFalse(
+                    "Function ${file.path}:${function.name} mixes prefetch context " +
+                        "with an authenticated refresh* call. Anonymous prefetch must use " +
+                        "TopicRepository.prefetch / ForumRepository.prefetchTopicList only.",
+                    callsRefresh,
+                )
             }
         }
     }

--- a/app/src/test/kotlin/fr/forumhfr/redface2/ArchitectureKonsistTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/ArchitectureKonsistTest.kt
@@ -115,6 +115,48 @@ class ArchitectureKonsistTest {
         }
     }
 
+    @Test
+    fun `prefetch call sites use the prefetch entry points only`() {
+        // Phase 1D PR 4 — anonymous prefetch must funnel through the dedicated
+        // repository methods (`TopicRepository.prefetch`, `ForumRepository.prefetchTopicList`),
+        // which both go to the @AnonymousClient. A ViewModel that calls
+        // `refreshTopicPage()` or `refreshTopicList()` from a "prefetch" context
+        // would fire an authenticated request and silently mark drapeaux as read
+        // (cf. ADR-003 § Prefetch). This test catches the mistake by enforcing
+        // that the substring "prefetch" only appears next to the repository's
+        // prefetch methods, never the auth-paying refresh ones.
+        val viewModelFiles = Konsist
+            .scopeFromProject()
+            .slice { file ->
+                file.path.contains("/feature/") &&
+                    file.path.endsWith("ViewModel.kt") &&
+                    !file.path.contains("/src/test/") &&
+                    !file.path.contains("/build/")
+            }
+            .files
+
+        assertTrue("Konsist must scan feature ViewModels", viewModelFiles.isNotEmpty())
+
+        viewModelFiles.assertFalse { file ->
+            // Match patterns where a "prefetch"-named scope refers to refresh*().
+            // Naive but cheap: if a file mentions both "prefetch" and a refresh*()
+            // method invocation in any prefetch-tagged context, flag it.
+            val text = file.text.lowercase()
+            val prefetchContext = text.contains("prefetch")
+            val callsAuthenticatedRefresh = text.contains("refreshtopicpage") ||
+                text.contains("refreshtopiclist")
+            // Only flag if the file has BOTH and the refresh call lives near a
+            // prefetch label — same line or same block. We approximate "near"
+            // by looking at the lines that contain the refresh call.
+            prefetchContext && callsAuthenticatedRefresh && file.text.lineSequence().any { line ->
+                val lower = line.lowercase()
+                lower.contains("prefetch") && (
+                    lower.contains("refreshtopicpage") || lower.contains("refreshtopiclist")
+                    )
+            }
+        }
+    }
+
     private companion object {
         const val ANONYMOUS_CLIENT_PACKAGE =
             "fr.forumhfr.redface2.core.network.qualifiers"

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/forum/DefaultForumRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/forum/DefaultForumRepository.kt
@@ -113,6 +113,35 @@ class DefaultForumRepository @Inject constructor(
         flow.emit(fetchTopicList(cat, subcat, page))
     }
 
+    /**
+     * Fires an unauthenticated `getTopicList` request — no cookie sent — to
+     * warm HFR's edge cache for the next page the user is likely to visit.
+     * The response is intentionally **discarded**: writing it into the
+     * authenticated [topicListRefresh] flow would silently strip per-user
+     * fields like `is_read` and `last_post_read_id` that the screen relies on,
+     * which is exactly the failure mode ADR-003 § Prefetch warns against.
+     *
+     * Failures are swallowed (best-effort prefetch). [CancellationException]
+     * is rethrown so the caller's coroutine cancellation propagates.
+     */
+    override suspend fun prefetchTopicList(cat: Int, subcat: Int?, page: Int) {
+        withContext(ioDispatcher) {
+            try {
+                apiClient.getTopicList(
+                    cat = cat,
+                    subcat = subcat,
+                    page = page,
+                    resultsPerPage = DEFAULT_RESULTS_PER_PAGE,
+                    useAuth = false,
+                )
+            } catch (cancellation: kotlinx.coroutines.CancellationException) {
+                throw cancellation
+            } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
+                Log.w(LOG_TAG, "Prefetch failed for cat=$cat subcat=$subcat page=$page", error)
+            }
+        }
+    }
+
     private suspend fun fetchCategories(): ForumResult<List<Category>> = withContext(ioDispatcher) {
         runCatching {
             val body = apiClient.getCategories(useAuth = false)

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImpl.kt
@@ -35,7 +35,7 @@ class TopicRepositoryImpl @Inject constructor(
      * - Cache hit, **AUTHENTICATED** + fresh → emit and stop. No network. This is the
      *   snappy back-nav case: returning to a page within `CachePolicy.topicPage` does
      *   not refetch and does not silently mark drapeaux as read.
-     * - Cache hit, **ANONYMOUS** (warmed by [prefetchAnonymous]) → always emit cache
+     * - Cache hit, **ANONYMOUS** (warmed by [prefetch]) → always emit cache
      *   then re-fetch authenticated, regardless of TTL. The anon row is missing
      *   per-user fields (`isOwnPost`, `isEditable`, …) and reading without re-fetching
      *   would also skip the implicit "mark as read" the auth GET triggers server-side.

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImpl.kt
@@ -75,18 +75,20 @@ class TopicRepositoryImpl @Inject constructor(
         fetchAndPersist(cat, post, page, FetchMode.AUTHENTICATED)
 
     /**
-     * Background prefetch path used by the prefetch service (Phase 1D PR 4).
-     * Issues an unauthenticated fetch — see ADR-003 § Prefetch — and persists
-     * the result *only if* it does not overwrite an existing authenticated
-     * cache row. Returns the parsed [Topic] for the caller's discretion (the
-     * service typically discards it).
-     *
-     * Not declared on [TopicRepository] because consumers in `:feature:*`
-     * never need the anonymous variant; only the data-layer prefetch service
-     * does.
+     * Phase 1D PR 4 — anonymous prefetch. Issues an unauthenticated fetch (cf.
+     * ADR-003 § Prefetch) and persists the result *only if* it does not
+     * overwrite an existing authenticated cache row. Failures are logged and
+     * swallowed so a flaky prefetch never disturbs the user-facing flow.
      */
-    suspend fun prefetchAnonymous(cat: Int, post: Int, page: Int): Topic =
-        fetchAndPersist(cat, post, page, FetchMode.ANONYMOUS)
+    override suspend fun prefetch(cat: Int, post: Int, page: Int) {
+        try {
+            fetchAndPersist(cat, post, page, FetchMode.ANONYMOUS)
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
+            Log.w(LOG_TAG, "Prefetch failed for cat=$cat post=$post page=$page", error)
+        }
+    }
 
     private suspend fun fetchAndPersist(
         cat: Int,

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/forum/DefaultForumRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/forum/DefaultForumRepositoryTest.kt
@@ -95,6 +95,42 @@ class DefaultForumRepositoryTest {
     }
 
     @Test
+    fun `prefetchTopicList issues an unauthenticated REST request`() = runTest {
+        val apiClient = mockk<HfrApiClient> {
+            coEvery {
+                getTopicList(cat = 23, subcat = 550, page = 2, resultsPerPage = 50, useAuth = false)
+            } returns fixture("rest_topics_cat23_subcat550_p1.json")
+        }
+        val repo = repository(apiClient)
+
+        repo.prefetchTopicList(cat = 23, subcat = 550, page = 2)
+
+        // Cookie-bearing path must NOT be invoked. ADR-003 § Prefetch makes this
+        // the inviolable rule: a prefetch with `useAuth = true` would silently
+        // mark drapeaux as read on HFR.
+        coVerify(exactly = 1) {
+            apiClient.getTopicList(cat = 23, subcat = 550, page = 2, resultsPerPage = 50, useAuth = false)
+        }
+        coVerify(exactly = 0) {
+            apiClient.getTopicList(any(), any(), any(), any(), useAuth = true)
+        }
+    }
+
+    @Test
+    fun `prefetchTopicList swallows network failures`() = runTest {
+        val apiClient = mockk<HfrApiClient> {
+            coEvery {
+                getTopicList(any(), any(), any(), any(), useAuth = false)
+            } throws IllegalStateException("HFR éteint")
+        }
+        val repo = repository(apiClient)
+
+        // Best-effort prefetch — must not bubble up. The screen's authenticated
+        // observeTopicList will fail visibly later if HFR is really down.
+        repo.prefetchTopicList(cat = 23, subcat = 550, page = 2)
+    }
+
+    @Test
     fun `categories cache replays past CachePolicy categories TTL when stale`() = runTest {
         val apiClient = mockk<HfrApiClient> {
             coEvery { getCategories(any()) } returns fixture("rest_categories.json")

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -148,7 +148,7 @@ class TopicRepositoryImplTest {
     }
 
     @Test
-    fun `prefetchAnonymous does not overwrite an existing AUTHENTICATED row`() = runTest {
+    fun `prefetch does not overwrite an existing AUTHENTICATED row`() = runTest {
         // First request lands as authenticated and warms the cache with auth-derived
         // post fields (the fixture has isOwnPost=false but the row is tagged AUTH).
         server.enqueue(MockResponse().setBody(fixtureHtml("topic_page_single.html")))
@@ -163,7 +163,7 @@ class TopicRepositoryImplTest {
         // call; the assertion is on the persisted row's authMode.
         server.enqueue(MockResponse().setBody(fixtureHtml("topic_page_single.html")))
         val anonRepo = repository(now = Instant.parse("2026-04-26T18:00:30Z"))
-        anonRepo.prefetchAnonymous(1, 999_395, 1)
+        anonRepo.prefetch(1, 999_395, 1)
 
         val afterPrefetch = dao.getTopicPage(1, 999_395, 1)
         assertNotNull(afterPrefetch)
@@ -178,7 +178,7 @@ class TopicRepositoryImplTest {
     fun `observeTopicPage with a fresh ANONYMOUS cache still re-fetches authenticated`() = runTest {
         // Cold cache → anonymous prefetch lands an ANONYMOUS row at T0.
         server.enqueue(MockResponse().setBody(fixtureHtml("topic_page_single.html")))
-        repository(now = Instant.parse("2026-04-26T18:00:00Z")).prefetchAnonymous(1, 999_395, 1)
+        repository(now = Instant.parse("2026-04-26T18:00:00Z")).prefetch(1, 999_395, 1)
         val anonRow = dao.getTopicPage(1, 999_395, 1)
         assertEquals(FetchMode.ANONYMOUS, anonRow!!.authMode)
         assertEquals("warm-up should have issued exactly one network request", 1, server.requestCount)
@@ -207,7 +207,7 @@ class TopicRepositoryImplTest {
         // Cold cache → an anonymous prefetch writes an ANONYMOUS row.
         server.enqueue(MockResponse().setBody(fixtureHtml("topic_page_single.html")))
         val anonRepo = repository(now = Instant.parse("2026-04-26T18:00:00Z"))
-        anonRepo.prefetchAnonymous(1, 999_395, 1)
+        anonRepo.prefetch(1, 999_395, 1)
         val anonRow = dao.getTopicPage(1, 999_395, 1)
         assertNotNull(anonRow)
         assertEquals(FetchMode.ANONYMOUS, anonRow!!.authMode)
@@ -229,11 +229,11 @@ class TopicRepositoryImplTest {
     }
 
     @Test
-    fun `prefetchAnonymous on a cold cache writes an ANONYMOUS row`() = runTest {
+    fun `prefetch on a cold cache writes an ANONYMOUS row`() = runTest {
         server.enqueue(MockResponse().setBody(fixtureHtml("topic_page_single.html")))
         val anonRepo = repository(now = Instant.parse("2026-04-26T18:00:00Z"))
 
-        anonRepo.prefetchAnonymous(1, 999_395, 1)
+        anonRepo.prefetch(1, 999_395, 1)
 
         val row = dao.getTopicPage(1, 999_395, 1)
         assertNotNull(row)

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/forum/ForumRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/forum/ForumRepository.kt
@@ -37,15 +37,25 @@ interface ForumRepository {
 
     /**
      * Anonymous prefetch — unauthenticated REST request (cf. ADR-003 §
-     * Prefetch) that warms an in-memory cache of [page] for `(cat, subcat)`.
-     * The cached entry is **not** broadcast through the auth flow consumed by
-     * the screen, since the anon payload misses the per-user fields
-     * (`is_read`, `last_post_read_id`); the next user-driven
-     * [observeTopicList] still re-fetches authenticated.
+     * Prefetch) for `(cat, subcat, page)`. The response payload is
+     * **intentionally discarded** : there is no client-side cache populated
+     * by this method. Persisting an anonymous response would strip per-user
+     * fields (`is_read`, `last_post_read_id`) that the screen relies on, and
+     * `[observeTopicList]` will re-fetch authenticated on the next visit.
      *
-     * The benefit is purely network: the prefetch uses the anonymous client,
-     * so no cookie is sent and HFR does not mark anything as read. Failures
-     * are swallowed.
+     * The only benefit is **edge-cache warming on HFR / its CDN** : the next
+     * authenticated request for this `(cat, subcat, page)` lands warmer at
+     * the origin, shaving the connect/parse cost on HFR's side. The client
+     * does not see latency improvements unless HFR's CDN layer caches across
+     * authenticated and unauthenticated requests for the same URL — which
+     * is the documented behaviour of `forums/hardwarefr/categories/{cat}/
+     * topics/last/`.
+     *
+     * If a real client-side prefetch cache is needed in the future, it must
+     * be a **separate** persistence path that round-trips to authenticated
+     * before exposing the data — never feed this anonymous payload into the
+     * existing flow. Failures are swallowed (best-effort);
+     * [CancellationException] propagates.
      */
     suspend fun prefetchTopicList(cat: Int, subcat: Int?, page: Int)
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/forum/ForumRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/forum/ForumRepository.kt
@@ -34,6 +34,20 @@ interface ForumRepository {
     ): Flow<ForumResult<TopicListPage>>
 
     suspend fun refreshTopicList(cat: Int, subcat: Int?, page: Int)
+
+    /**
+     * Anonymous prefetch — unauthenticated REST request (cf. ADR-003 §
+     * Prefetch) that warms an in-memory cache of [page] for `(cat, subcat)`.
+     * The cached entry is **not** broadcast through the auth flow consumed by
+     * the screen, since the anon payload misses the per-user fields
+     * (`is_read`, `last_post_read_id`); the next user-driven
+     * [observeTopicList] still re-fetches authenticated.
+     *
+     * The benefit is purely network: the prefetch uses the anonymous client,
+     * so no cookie is sent and HFR does not mark anything as read. Failures
+     * are swallowed.
+     */
+    suspend fun prefetchTopicList(cat: Int, subcat: Int?, page: Int)
 }
 
 /**

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/topic/TopicRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/topic/TopicRepository.kt
@@ -20,4 +20,17 @@ interface TopicRepository {
      * The persisted row is tagged as authenticated.
      */
     suspend fun refreshTopicPage(cat: Int, post: Int, page: Int): Topic
+
+    /**
+     * Background prefetch — anonymous fetch (no HFR cookies, no
+     * mark-as-read side effect, cf. ADR-003 § Prefetch) that warms the Room
+     * cache for [page] without overwriting an existing authenticated row. The
+     * caller's coroutine context controls cancellation: when the consumer
+     * leaves the screen or moves on to a new page, the structured-concurrency
+     * scope it lives in propagates the cancel and stops the in-flight fetch.
+     *
+     * Failures are swallowed: a prefetch is best-effort by design and must
+     * never bubble up to the user-facing flow.
+     */
+    suspend fun prefetch(cat: Int, post: Int, page: Int)
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/topic/TopicRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/topic/TopicRepository.kt
@@ -23,9 +23,24 @@ interface TopicRepository {
 
     /**
      * Background prefetch — anonymous fetch (no HFR cookies, no
-     * mark-as-read side effect, cf. ADR-003 § Prefetch) that warms the Room
-     * cache for [page] without overwriting an existing authenticated row. The
-     * caller's coroutine context controls cancellation: when the consumer
+     * mark-as-read side effect, cf. ADR-003 § Prefetch).
+     *
+     * **Persists an `ANONYMOUS` row** in Room when [page] is not already cached
+     * as `AUTHENTICATED`. The next [observeTopicPage] call on the same `(cat, post,
+     * page)` reads that anon row immediately for snappy first paint, then triggers
+     * a foreground authenticated re-fetch to surface per-user fields (`isOwnPost`,
+     * `isEditable`) and let HFR mark drapeaux as read. The anti-overwrite rule is
+     * enforced atomically by the DAO `@Transaction` (cf.
+     * `TopicDao.upsertTopicPageWithPostsUnlessAuthenticated`), so a concurrent
+     * authenticated write cannot be clobbered by this prefetch.
+     *
+     * Note the asymmetry with [fr.forumhfr.redface2.core.domain.forum.ForumRepository.prefetchTopicList],
+     * which warms HFR's CDN only and **does not** populate any client-side cache —
+     * the listing payload would strip per-user fields the user-facing path needs.
+     * Topic pages are persisted because the `ANONYMOUS` shape of a topic page is
+     * still useful to render before the auth refresh lands ; listing pages are not.
+     *
+     * The caller's coroutine context controls cancellation: when the consumer
      * leaves the screen or moves on to a new page, the structured-concurrency
      * scope it lives in propagates the cancel and stops the in-flight fetch.
      *

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -387,18 +387,22 @@ Pour donner l'impression que le forum est local :
 
 ```
 Utilisateur lit la page 3 d'un topic
-  → Prefetch page 4 en arrière-plan
+  → Prefetch page 4 en arrière-plan (anonyme, écrit en cache ANONYMOUS)
   → Quand il scroll vers le bas, la page 4 est déjà prête
-
-Utilisateur ouvre ses drapeaux
-  → Prefetch les 3 premiers topics (ceux qu'il ouvre le plus souvent)
 ```
 
-Le prefetch respecte les conditions réseau : désactivé en mode économie de données ou réseau lent.
+Implémentation Phase 1D PR 4 (#108) :
+
+- **Topic page** : `TopicViewModel` déclenche `topicRepository.prefetch(cat, post, page+1)` après chaque émission `Loaded`. Le job est rattaché à `viewModelScope` ; sortir de l'écran ou changer de page propage le `cancel()` jusqu'à OkHttp.
+- **Topic listing** : `CategoryViewModel` déclenche `forumRepository.prefetchTopicList(cat, subcat, page+1)` à chaque transition vers `Content`. Le job est annulé à chaque changement de `(subcat, page)` via le pattern `combine + onEach + cancel` standard.
+- **Une seule page d'avance** par déclencheur. Pas de chaîne `n+2, n+3` — le coût ne paie pas le bénéfice et grossirait la facture pour des comportements rares.
+- **Échecs swallowed** : un prefetch flaky ne doit jamais perturber l'affichage. Erreurs loguées en `Log.w`, puis avalées.
 
 #### Règle critique : prefetch non-authentifié
 
 Les requêtes de prefetch ne doivent **jamais** inclure les cookies de session — sinon HFR marque silencieusement les topics comme lus. Implémentation avec deux instances `OkHttpClient` (`@AuthenticatedClient` / `@AnonymousClient`) et test Konsist d'enforcement : voir [protocol-hfr.md § Règle critique prefetch non-authentifié]({{ site.baseurl }}/specs/protocol-hfr#règle-critique--prefetch-non-authentifié).
+
+Côté cache disque, l'entrée est tagguée `authMode = ANONYMOUS` et **ne remplace pas** une row existante taguée `AUTHENTICATED` (cf. § Stratégie de cache).
 
 ---
 

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -393,8 +393,8 @@ Utilisateur lit la page 3 d'un topic
 
 Implémentation Phase 1D PR 4 (#108) :
 
-- **Topic page** : `TopicViewModel` déclenche `topicRepository.prefetch(cat, post, page+1)` après chaque émission `Loaded`. Le job est rattaché à `viewModelScope` ; sortir de l'écran ou changer de page propage le `cancel()` jusqu'à OkHttp.
-- **Topic listing** : `CategoryViewModel` déclenche `forumRepository.prefetchTopicList(cat, subcat, page+1)` à chaque transition vers `Content`. Le job est annulé à chaque changement de `(subcat, page)` via le pattern `combine + onEach + cancel` standard.
+- **Topic page** : `TopicViewModel` déclenche `topicRepository.prefetch(cat, post, page+1)` après chaque émission `Loaded`. Le job est rattaché à `viewModelScope` ; sortir de l'écran ou changer de page propage le `cancel()` jusqu'à OkHttp. **Le payload est persisté** comme row `ANONYMOUS` en Room — la prochaine `observeTopicPage` la lit immédiatement (paint snappy) puis re-fetch authentifié pour upgrader vers `AUTHENTICATED` (champs per-user).
+- **Topic listing** : `CategoryViewModel` déclenche `forumRepository.prefetchTopicList(cat, subcat, page+1)` à chaque transition vers `Content`. Le job est annulé à chaque changement de `(subcat, page)` via le pattern `combine + onEach + cancel` standard. **Le payload est volontairement jeté** — pas de cache client peuplé. Un payload anonyme stripperait `is_read` et `last_post_read_id` qui sont nécessaires côté écran ; on ne fait que chauffer le CDN HFR pour la prochaine requête authentifiée.
 - **Une seule page d'avance** par déclencheur. Pas de chaîne `n+2, n+3` — le coût ne paie pas le bénéfice et grossirait la facture pour des comportements rares.
 - **Échecs swallowed** : un prefetch flaky ne doit jamais perturber l'affichage. Erreurs loguées en `Log.w`, puis avalées.
 

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -92,7 +92,7 @@ Les dépôts en cylindre (`MPStorage2`, `hfr-redflag`) sont des **dépendances e
 - [x] **Écran Forum 1C-B** — Material 3 `PullToRefreshBox` sur `ForumScreen` / `ForumCategoryScreen` (contenu préservé pendant le refresh, pas de `SwipeRefresh` Accompanist), badge drapeau par topic dérivé du REST `flag_owntopic` (CYAN / RED / FAVORITE), recherche locale dans la page courante (titre / auteur / dernier réponseur, accent-insensitive)
 - [x] **Cache Room Phase 1D-3 (#26)** — pages topic + posts persistés avec TTL, `authMode` anti-écrasement, drapeaux REST persistés par compte dans `flag_topics`, purge logout / changement de pseudo via `CacheInvalidator`
 - [x] Deep linking (URLs HFR → app) — `parseHfrDeepLink` corrigé (mapping `forum1.php` ↔ `forum2.php` inversé, fixé en 1C-A) et branché sur les écrans réels Forum/Category/Topic
-- [ ] Prefetch pages suivantes (avec `@AnonymousClient`, cf. [protocol-hfr.md]({{ site.baseurl }}/specs/protocol-hfr#règle-critique--prefetch-non-authentifié))
+- [x] **Prefetch pages suivantes Phase 1D-4 (#108)** — topic `page + 1` persisté en `ANONYMOUS` sans écraser l'authentifié, listing forum `page + 1` warm-up anonyme sans exposer le payload ; annulation au changement de page / sortie d'écran
 - [ ] Images + smileys (Coil 3 — split fetcher déjà câblé via `coil-network-okhttp`)
 - [ ] Blocs monospace `[fixed]` / `[code]` — restent suivis par [#79](https://github.com/ForumHFR/redface2/issues/79) et arriveront avec une fixture réelle
 

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModel.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModel.kt
@@ -13,13 +13,16 @@ import fr.forumhfr.redface2.core.model.SubCategory
 import fr.forumhfr.redface2.core.model.TopicListPage
 import fr.forumhfr.redface2.core.model.TopicSummary
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -160,6 +163,49 @@ class CategoryViewModel @AssistedInject constructor(
         ),
     )
 
+    private var prefetchJob: Job? = null
+
+    init {
+        // Anonymous prefetch of `page + 1` whenever a content emission lands —
+        // see ADR-003 § Prefetch and the PR 4 prompt. The job is cancelled on
+        // every (subcat, page) change so we never have two prefetches in
+        // flight at once and never warm a page the user has already moved
+        // past. Using `is ContentTrigger` ignores Loading / Error transitions
+        // — only firm Content triggers a warm-up.
+        viewModelScope.launch {
+            combine(selectedSubcat, page, topicsState) { subcat, currentPage, topics ->
+                ContentTrigger(subcat, currentPage, topics.contentPageCount() ?: -1)
+            }
+                .distinctUntilChanged()
+                .onEach { trigger -> schedulePrefetch(trigger) }
+                .collect()
+        }
+    }
+
+    private suspend fun Flow<ContentTrigger>.collect() = collect { /* no-op, side-effect via onEach */ }
+
+    private fun schedulePrefetch(trigger: ContentTrigger) {
+        prefetchJob?.cancel()
+        val nextPage = trigger.currentPage + 1
+        // pageCount unknown (no Content yet) → -1 sentinel, skip.
+        if (trigger.pageCount <= 0 || nextPage > trigger.pageCount) return
+        prefetchJob = viewModelScope.launch {
+            forumRepository.prefetchTopicList(
+                cat = request.cat,
+                subcat = trigger.subcat,
+                page = nextPage,
+            )
+        }
+    }
+
+    private fun TopicsUiState.contentPageCount(): Int? = when (this) {
+        is TopicsUiState.Content -> listingPageCount(
+            totalTopics = page.totalTopics,
+            resultsPerPage = page.resultsPerPage,
+        )
+        else -> null
+    }
+
     fun selectSubcategory(subcat: Int?) {
         if (selectedSubcat.value == subcat) return
         selectedSubcat.value = subcat
@@ -242,6 +288,12 @@ class CategoryViewModel @AssistedInject constructor(
         val categoryName: String?,
         val subcategories: SubcategoriesUiState,
         val topics: TopicsUiState,
+    )
+
+    private data class ContentTrigger(
+        val subcat: Int?,
+        val currentPage: Int,
+        val pageCount: Int,
     )
 
     private companion object {

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModel.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModel.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.scan
@@ -172,23 +173,23 @@ class CategoryViewModel @AssistedInject constructor(
         // flight at once and never warm a page the user has already moved
         // past. Using `is ContentTrigger` ignores Loading / Error transitions
         // — only firm Content triggers a warm-up.
-        viewModelScope.launch {
-            combine(selectedSubcat, page, topicsState) { subcat, currentPage, topics ->
-                ContentTrigger(subcat, currentPage, topics.contentPageCount() ?: -1)
-            }
-                .distinctUntilChanged()
-                .onEach { trigger -> schedulePrefetch(trigger) }
-                .collect()
+        combine(selectedSubcat, page, topicsState) { subcat, currentPage, topics ->
+            ContentTrigger(subcat, currentPage, topics.contentPageCount() ?: -1)
         }
+            .distinctUntilChanged()
+            .onEach { trigger -> schedulePrefetch(trigger) }
+            .launchIn(viewModelScope)
     }
 
-    private suspend fun Flow<ContentTrigger>.collect() = collect { /* no-op, side-effect via onEach */ }
-
     private fun schedulePrefetch(trigger: ContentTrigger) {
-        prefetchJob?.cancel()
         val nextPage = trigger.currentPage + 1
-        // pageCount unknown (no Content yet) → -1 sentinel, skip.
+        // pageCount unknown (no Content yet) → -1 sentinel, skip without touching
+        // the in-flight prefetch. The previous shape cancelled the job before this
+        // guard, which would lose an already-running prefetch when a Loading or
+        // intermediate emission landed during a pull-to-refresh — the prefetch was
+        // dropped and not relaunched, leaving the user with a cold next page.
         if (trigger.pageCount <= 0 || nextPage > trigger.pageCount) return
+        prefetchJob?.cancel()
         prefetchJob = viewModelScope.launch {
             forumRepository.prefetchTopicList(
                 cat = request.cat,

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModel.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModel.kt
@@ -167,28 +167,38 @@ class CategoryViewModel @AssistedInject constructor(
     private var prefetchJob: Job? = null
 
     init {
-        // Anonymous prefetch of `page + 1` whenever a content emission lands —
-        // see ADR-003 § Prefetch and the PR 4 prompt. The job is cancelled on
-        // every (subcat, page) change so we never have two prefetches in
-        // flight at once and never warm a page the user has already moved
-        // past. Using `is ContentTrigger` ignores Loading / Error transitions
-        // — only firm Content triggers a warm-up.
-        combine(selectedSubcat, page, topicsState) { subcat, currentPage, topics ->
-            ContentTrigger(subcat, currentPage, topics.contentPageCount() ?: -1)
-        }
+        // Anonymous prefetch of `page + 1` whenever a Content lands. The trigger is
+        // derived **directly from the [TopicListPage] inside `Content`** — not from
+        // the separate `selectedSubcat` / `page` `MutableStateFlow`s. The earlier
+        // shape `combine(selectedSubcat, page, topicsState)` had a race : when the
+        // user switched subcat, the new `(subcat, page)` keys landed before the
+        // upstream `flatMapLatest` had time to emit the new `Content`, so the
+        // combine produced a trigger with **new keys + old Content payload** and
+        // tried to prefetch the wrong (subcat, page+1).
+        //
+        // Reading from the Content guarantees the trigger fields are coherent. On
+        // intermediate states (Loading / Error during a refresh or subcat switch)
+        // we cancel any in-flight prefetch so we never warm a page the user has
+        // moved past.
+        topicsState
+            .map { state -> state.toPrefetchTriggerOrNull() }
             .distinctUntilChanged()
-            .onEach { trigger -> schedulePrefetch(trigger) }
+            .onEach { trigger ->
+                if (trigger == null) {
+                    prefetchJob?.cancel()
+                } else {
+                    schedulePrefetch(trigger)
+                }
+            }
             .launchIn(viewModelScope)
     }
 
     private fun schedulePrefetch(trigger: ContentTrigger) {
         val nextPage = trigger.currentPage + 1
-        // pageCount unknown (no Content yet) → -1 sentinel, skip without touching
-        // the in-flight prefetch. The previous shape cancelled the job before this
-        // guard, which would lose an already-running prefetch when a Loading or
-        // intermediate emission landed during a pull-to-refresh — the prefetch was
-        // dropped and not relaunched, leaving the user with a cold next page.
-        if (trigger.pageCount <= 0 || nextPage > trigger.pageCount) return
+        // pageCount unknown is not possible here — the trigger is built from a
+        // Content payload that always carries a valid totalTopics / resultsPerPage.
+        // We still skip when the user is on the last page (or beyond, defensive).
+        if (nextPage > trigger.pageCount) return
         prefetchJob?.cancel()
         prefetchJob = viewModelScope.launch {
             forumRepository.prefetchTopicList(
@@ -199,10 +209,14 @@ class CategoryViewModel @AssistedInject constructor(
         }
     }
 
-    private fun TopicsUiState.contentPageCount(): Int? = when (this) {
-        is TopicsUiState.Content -> listingPageCount(
-            totalTopics = page.totalTopics,
-            resultsPerPage = page.resultsPerPage,
+    private fun TopicsUiState.toPrefetchTriggerOrNull(): ContentTrigger? = when (this) {
+        is TopicsUiState.Content -> ContentTrigger(
+            subcat = page.subcat,
+            currentPage = page.page,
+            pageCount = listingPageCount(
+                totalTopics = page.totalTopics,
+                resultsPerPage = page.resultsPerPage,
+            ),
         )
         else -> null
     }

--- a/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModelTest.kt
+++ b/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModelTest.kt
@@ -406,6 +406,54 @@ class CategoryViewModelTest {
         }
     }
 
+    @Test
+    fun `Content emission triggers anonymous prefetch of the next page`() = runTest {
+        val repo = FakeForumRepository()
+        val vm = CategoryViewModel(
+            request = CategoryRequest(cat = 23, initialSubcat = 550, initialPage = 1),
+            forumRepository = repo,
+        )
+        // Listings: 130 topics @ 50 per page → 3 pages total. Prefetch should fire for page 2.
+        val multiPage = EMPTY_PAGE.copy(totalTopics = 130, resultsPerPage = 50)
+
+        vm.uiState.test {
+            awaitItem() // initial state
+            repo.emitSubcategories(ForumResult.Success(listOf(SUBCAT_550)))
+            repo.emitTopicList(cat = 23, subcat = 550, page = 1, result = ForumResult.Success(multiPage))
+            awaitContent { it.topics is TopicsUiState.Content }
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        assertEquals(
+            "page 1 of a 3-page listing should fire one prefetch on page 2",
+            listOf(Triple(23, 550, 2)),
+            repo.prefetchTopicListCalls,
+        )
+    }
+
+    @Test
+    fun `last page does not trigger a prefetch`() = runTest {
+        val repo = FakeForumRepository()
+        val vm = CategoryViewModel(
+            request = CategoryRequest(cat = 23, initialSubcat = 550, initialPage = 3),
+            forumRepository = repo,
+        )
+        val multiPage = EMPTY_PAGE.copy(totalTopics = 130, resultsPerPage = 50, page = 3)
+
+        vm.uiState.test {
+            awaitItem()
+            repo.emitSubcategories(ForumResult.Success(listOf(SUBCAT_550)))
+            repo.emitTopicList(cat = 23, subcat = 550, page = 3, result = ForumResult.Success(multiPage))
+            awaitContent { it.topics is TopicsUiState.Content }
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        assertTrue(
+            "no prefetch on the final page",
+            repo.prefetchTopicListCalls.isEmpty(),
+        )
+    }
+
     private companion object {
         val SUBCAT_550 = SubCategory(id = 550, name = "Android", parentCategoryId = 23)
         val EMPTY_PAGE = TopicListPage(
@@ -471,6 +519,8 @@ class CategoryViewModelTest {
             private set
         var refreshTopicListCalls: List<Triple<Int, Int?, Int>> = emptyList()
             private set
+        var prefetchTopicListCalls: List<Triple<Int, Int?, Int>> = emptyList()
+            private set
 
         /**
          * Optional gate consumed by [refreshSubcategories] — when set, the suspending
@@ -501,6 +551,10 @@ class CategoryViewModelTest {
 
         override suspend fun refreshTopicList(cat: Int, subcat: Int?, page: Int) {
             refreshTopicListCalls = refreshTopicListCalls + Triple(cat, subcat, page)
+        }
+
+        override suspend fun prefetchTopicList(cat: Int, subcat: Int?, page: Int) {
+            prefetchTopicListCalls = prefetchTopicListCalls + Triple(cat, subcat, page)
         }
 
         suspend fun emitCategories(result: ForumResult<List<Category>>) {

--- a/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModelTest.kt
+++ b/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModelTest.kt
@@ -432,6 +432,59 @@ class CategoryViewModelTest {
     }
 
     @Test
+    fun `prefetch is cancelled when the screen is left (issue #108)`() = runTest {
+        // The prefetch coroutine lives on `viewModelScope`. Issue #108's acceptance
+        // criterion is "le prefetch est annulé quand l'utilisateur quitte la page".
+        // We simulate that by calling `ViewModel.clear()` (the API the framework
+        // uses on screen leave) and verifying the in-flight prefetch sees a
+        // [CancellationException].
+        val cancelObserved = kotlinx.coroutines.CompletableDeferred<Unit>()
+        val repo = FakeForumRepository().apply {
+            prefetchHook = { _, _, _ ->
+                try {
+                    kotlinx.coroutines.awaitCancellation()
+                } catch (cancellation: kotlinx.coroutines.CancellationException) {
+                    cancelObserved.complete(Unit)
+                    throw cancellation
+                }
+            }
+        }
+        val vm = CategoryViewModel(
+            request = CategoryRequest(cat = 23, initialSubcat = 550, initialPage = 1),
+            forumRepository = repo,
+        )
+        val multiPage = EMPTY_PAGE.copy(totalTopics = 130, resultsPerPage = 50)
+
+        vm.uiState.test {
+            awaitItem()
+            repo.emitSubcategories(ForumResult.Success(listOf(SUBCAT_550)))
+            repo.emitTopicList(cat = 23, subcat = 550, page = 1, result = ForumResult.Success(multiPage))
+            awaitContent { it.topics is TopicsUiState.Content }
+            cancelAndIgnoreRemainingEvents()
+        }
+        // Prefetch must have launched and be suspended on awaitCancellation().
+        assertEquals(listOf(Triple(23, 550, 2)), repo.prefetchTopicListCalls)
+
+        // Simulate the screen leaving by routing the existing ViewModel through a
+        // ViewModelStore. `ViewModelStore.clear()` is the public API the framework
+        // uses on screen leave : it walks every stored ViewModel and triggers the
+        // internal clear path that cancels `viewModelScope` and calls `onCleared()`.
+        val store = androidx.lifecycle.ViewModelStore()
+        androidx.lifecycle.ViewModelProvider(
+            store,
+            object : androidx.lifecycle.ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T = vm as T
+            },
+        ).get(CategoryViewModel::class.java)
+        store.clear()
+
+        kotlinx.coroutines.withTimeout(AWAIT_CONTENT_TIMEOUT_MS) {
+            cancelObserved.await()
+        }
+    }
+
+    @Test
     fun `last page does not trigger a prefetch`() = runTest {
         val repo = FakeForumRepository()
         val vm = CategoryViewModel(
@@ -553,8 +606,15 @@ class CategoryViewModelTest {
             refreshTopicListCalls = refreshTopicListCalls + Triple(cat, subcat, page)
         }
 
+        /**
+         * Optional hook that lets a test gate the prefetch coroutine — e.g. suspend
+         * forever to verify cancellation propagates from a parent scope cancel.
+         */
+        var prefetchHook: (suspend (cat: Int, subcat: Int?, page: Int) -> Unit)? = null
+
         override suspend fun prefetchTopicList(cat: Int, subcat: Int?, page: Int) {
             prefetchTopicListCalls = prefetchTopicListCalls + Triple(cat, subcat, page)
+            prefetchHook?.invoke(cat, subcat, page)
         }
 
         suspend fun emitCategories(result: ForumResult<List<Category>>) {

--- a/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/ForumViewModelTest.kt
+++ b/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/ForumViewModelTest.kt
@@ -145,6 +145,8 @@ class ForumViewModelTest {
 
         override suspend fun refreshTopicList(cat: Int, subcat: Int?, page: Int) = Unit
 
+        override suspend fun prefetchTopicList(cat: Int, subcat: Int?, page: Int) = Unit
+
         suspend fun emitCategories(result: ForumResult<List<Category>>) {
             categories.emit(result)
         }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -117,7 +117,11 @@ class TopicViewModel @AssistedInject constructor(
      * - Skip the call when already at the last page.
      * - Track [prefetchedPage] so we don't re-issue a request if the same
      *   page emits twice (cache + refresh emission of the stale path, or any
-     *   future intermediate emission).
+     *   future intermediate emission). The marker is set **before** the
+     *   coroutine runs, so a transient prefetch failure (network glitch) is
+     *   **not** retried for the same emission — prefetch is best-effort by
+     *   design and the next user-driven `observeTopicPage` on `page+1` will
+     *   re-fetch through the normal cache-miss path.
      * - Hang the job off [viewModelScope] so leaving the screen cancels the
      *   in-flight request — the structured-concurrency cancel propagates down
      *   to OkHttp.

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -43,6 +43,8 @@ class TopicViewModel @AssistedInject constructor(
     val effects: Flow<TopicEffect> = _effects.receiveAsFlow()
 
     private var loadJob: Job? = null
+    private var prefetchJob: Job? = null
+    private var prefetchedPage: Int? = null
 
     /**
      * Tracks whether the current value of [TopicRequest.scrollTo] has already been
@@ -65,6 +67,8 @@ class TopicViewModel @AssistedInject constructor(
 
     private fun loadCurrentPage() {
         loadJob?.cancel()
+        prefetchJob?.cancel()
+        prefetchedPage = null
         _state.update { it.copy(mode = TopicUiState.Mode.Loading) }
         loadJob = viewModelScope.launch {
             topicRepository
@@ -88,6 +92,7 @@ class TopicViewModel @AssistedInject constructor(
                         )
                     }
                     maybeEmitScroll(topic.posts.map { it.numreponse })
+                    maybeSchedulePrefetch(totalPages = topic.totalPages)
                 }
         }
     }
@@ -98,6 +103,33 @@ class TopicViewModel @AssistedInject constructor(
         if (shouldEmit) {
             _effects.send(TopicEffect.ScrollToPost(checkNotNull(target)))
             scrollEffectEmitted = true
+        }
+    }
+
+    /**
+     * Fires off an anonymous prefetch of `currentPage + 1` once per loaded
+     * page. We deliberately:
+     *
+     * - Run **only one** page ahead — multi-page prefetching is explicitly out
+     *   of scope (§ "Ne pas prefetch plusieurs pages d'avance" in the PR 4
+     *   prompt). Two-page-ahead would scale costs without matching real
+     *   reading patterns.
+     * - Skip the call when already at the last page.
+     * - Track [prefetchedPage] so we don't re-issue a request if the same
+     *   page emits twice (cache + refresh emission of the stale path, or any
+     *   future intermediate emission).
+     * - Hang the job off [viewModelScope] so leaving the screen cancels the
+     *   in-flight request — the structured-concurrency cancel propagates down
+     *   to OkHttp.
+     */
+    private fun maybeSchedulePrefetch(totalPages: Int) {
+        val nextPage = request.page + 1
+        if (nextPage > totalPages) return
+        if (prefetchedPage == nextPage) return
+        prefetchedPage = nextPage
+        prefetchJob?.cancel()
+        prefetchJob = viewModelScope.launch {
+            topicRepository.prefetch(request.cat, request.post, nextPage)
         }
     }
 

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -60,6 +60,57 @@ class TopicViewModelTest {
     }
 
     @Test
+    fun `prefetch is cancelled when the screen is left (issue #108)`() = runTest {
+        // Symmetric to CategoryViewModelTest's same-named case. Issue #108's
+        // acceptance criterion is "le prefetch est annulé quand l'utilisateur quitte
+        // la page". The topic-page prefetch is the more user-visible path of the two,
+        // so it deserves its own pin — without this test, only the listing path
+        // proves the cancellation chain. We suspend `prefetch` on awaitCancellation
+        // and verify the in-flight call observes [CancellationException] when the
+        // ViewModelStore is cleared (the public API the framework calls on screen
+        // leave).
+        val cancelObserved = kotlinx.coroutines.CompletableDeferred<Unit>()
+        val topic = fakeTopic(page = 2, totalPages = 5)
+        val repository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(topic) }))
+        repository.prefetchHook = { _, _, _ ->
+            try {
+                kotlinx.coroutines.awaitCancellation()
+            } catch (cancellation: kotlinx.coroutines.CancellationException) {
+                cancelObserved.complete(Unit)
+                throw cancellation
+            }
+        }
+        val vm = TopicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = repository,
+        )
+
+        vm.state.test {
+            assertMode<TopicUiState.Mode.Loaded>(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(
+            "prefetch should have been launched on Loaded(page=2)",
+            listOf(Triple(SAMPLE_CAT, SAMPLE_POST, 3)),
+            repository.prefetches,
+        )
+
+        val store = androidx.lifecycle.ViewModelStore()
+        androidx.lifecycle.ViewModelProvider(
+            store,
+            object : androidx.lifecycle.ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T = vm as T
+            },
+        ).get(TopicViewModel::class.java)
+        store.clear()
+
+        kotlinx.coroutines.withTimeout(CANCEL_TIMEOUT_MS) {
+            cancelObserved.await()
+        }
+    }
+
+    @Test
     fun `last page does not trigger an out-of-range prefetch`() = runTest {
         val topic = fakeTopic(page = 5, totalPages = 5)
         val repository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(topic) }))
@@ -301,6 +352,7 @@ class TopicViewModelTest {
     companion object {
         private const val SAMPLE_CAT = 13
         private const val SAMPLE_POST = 84_540
+        private const val CANCEL_TIMEOUT_MS = 2_000L
     }
 }
 
@@ -310,6 +362,14 @@ private class FakeTopicRepository(
     private val queue = ArrayDeque(flowsToReturn)
     val calls: MutableList<Triple<Int, Int, Int>> = mutableListOf()
     val prefetches: MutableList<Triple<Int, Int, Int>> = mutableListOf()
+
+    /**
+     * Optional hook to suspend or fail inside `prefetch(...)`. Tests that need to
+     * observe the in-flight prefetch (cancellation, hung network) install this
+     * to gate the suspend until they're ready to assert. Default keeps the fake
+     * fast: `prefetch` returns immediately after recording the call.
+     */
+    var prefetchHook: (suspend (cat: Int, post: Int, page: Int) -> Unit)? = null
 
     override fun observeTopicPage(cat: Int, post: Int, page: Int): Flow<Topic> {
         calls += Triple(cat, post, page)
@@ -322,6 +382,7 @@ private class FakeTopicRepository(
 
     override suspend fun prefetch(cat: Int, post: Int, page: Int) {
         prefetches += Triple(cat, post, page)
+        prefetchHook?.invoke(cat, post, page)
     }
 }
 

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -52,7 +52,29 @@ class TopicViewModelTest {
             cancelAndIgnoreRemainingEvents()
         }
         assertEquals(listOf(Triple(SAMPLE_CAT, SAMPLE_POST, 2)), repository.calls)
+        assertEquals(
+            "anonymous prefetch should fire on page+1 once the topic is loaded",
+            listOf(Triple(SAMPLE_CAT, SAMPLE_POST, 3)),
+            repository.prefetches,
+        )
     }
+
+    @Test
+    fun `last page does not trigger an out-of-range prefetch`() = runTest {
+        val topic = fakeTopic(page = 5, totalPages = 5)
+        val repository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(topic) }))
+
+        TopicViewModel(
+            request = topicRequest(page = 5),
+            topicRepository = repository,
+        ).state.test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        assertTrue("no prefetch on the final page", repository.prefetches.isEmpty())
+    }
+
 
     @Test
     fun `cache emission lands before fresh emission in observable state sequence`() = runTest {
@@ -287,6 +309,7 @@ private class FakeTopicRepository(
 ) : TopicRepository {
     private val queue = ArrayDeque(flowsToReturn)
     val calls: MutableList<Triple<Int, Int, Int>> = mutableListOf()
+    val prefetches: MutableList<Triple<Int, Int, Int>> = mutableListOf()
 
     override fun observeTopicPage(cat: Int, post: Int, page: Int): Flow<Topic> {
         calls += Triple(cat, post, page)
@@ -295,6 +318,10 @@ private class FakeTopicRepository(
 
     override suspend fun refreshTopicPage(cat: Int, post: Int, page: Int): Topic {
         error("refreshTopicPage not used by ViewModel under test")
+    }
+
+    override suspend fun prefetch(cat: Int, post: Int, page: Int) {
+        prefetches += Triple(cat, post, page)
     }
 }
 
@@ -305,5 +332,9 @@ private class FakeStreamingTopicRepository(
 
     override suspend fun refreshTopicPage(cat: Int, post: Int, page: Int): Topic {
         error("refreshTopicPage not used by ViewModel under test")
+    }
+
+    override suspend fun prefetch(cat: Int, post: Int, page: Int) {
+        // no-op for streaming tests
     }
 }


### PR DESCRIPTION
## Résumé

Phase 1D PR 4 (#108) : prefetch anonyme de la page suivante côté topic et côté listing forum, basé sur la séparation auth/anonyme livrée par #26 (PR #115).

**Dépend de #115** — la branche est ouverte avec `--base feature/1d-3-cache-room` pour que la diff reviewable ne montre que le delta. Une fois #115 mergée, GitHub re-base automatiquement sur `main`.

## Règle non négociable

Tout prefetch passe par le client `@AnonymousClient` (useAuth=false). Un prefetch authentifié marquerait silencieusement les drapeaux comme lus côté HFR (cf. ADR-003 § Prefetch).

## Changements

### Domain
- `TopicRepository.prefetch(cat, post, page)` — anonymous, persiste `ANONYMOUS` sans écraser un row `AUTHENTICATED` (PR3 garantit l'anti-écrasement).
- `ForumRepository.prefetchTopicList(cat, subcat, page)` — anonymous fetch, payload jeté (l'auth flow re-fetch les fields per-user).

### Data
- `TopicRepositoryImpl.prefetch` : délègue à `fetchAndPersist(..., FetchMode.ANONYMOUS)` + swallow errors hors `CancellationException`.
- `DefaultForumRepository.prefetchTopicList` : `apiClient.getTopicList(useAuth = false)`, payload jeté, swallow errors.

### Feature
- `TopicViewModel` : `prefetchJob` annulable, `prefetchedPage` pour idempotence, fired après chaque `Loaded`. `nextPage > totalPages` court-circuite. Pas de chaîne `n+2`.
- `CategoryViewModel` : `combine(selectedSubcat, page, topicsState).distinctUntilChanged()` → `schedulePrefetch` qui annule le job précédent et lance le nouveau. Pas de prefetch sur la dernière page.

### Tests
- `DefaultForumRepositoryTest` : `prefetchTopicList` enforce `useAuth=false` (et `useAuth=true` jamais appelé) ; failures swallowed.
- `TopicRepositoryImplTest` : `prefetch` n'écrase pas `AUTHENTICATED` (déjà couvert par PR3, renommage `prefetchAnonymous` → `prefetch`).
- `TopicViewModelTest` : page+1 fired après `Loaded` ; pas de prefetch sur la dernière page.
- `CategoryViewModelTest` : `Content` (130 topics, 3 pages) déclenche `prefetchTopicList(_, _, 2)` ; page=3/3 → 0 prefetch.
- Konsist `ArchitectureKonsistTest.kt` : un site labellisé "prefetch" qui appelle `refreshTopicPage`/`refreshTopicList` est rejeté au build.

### Doc
- `docs/specs/architecture.md` § Prefetch intelligent : détails Phase 1D PR 4 (page+1 only, cancel on page change, swallow errors, anti-écrasement disque).

## Validation

```
./scripts/docker-dev.sh ./gradlew detektAll lintDebug testDebugUnitTest :app:assembleDebug
BUILD SUCCESSFUL
```

## Test plan

- [x] `detektAll` vert
- [x] `lintDebug` vert
- [x] `testDebugUnitTest` vert (tous modules)
- [x] `:app:assembleDebug` vert
- [x] Konsist : prefetch ↔ refresh* segregated

## Hors scope

- Prefetch d'images / smileys / médias (#109).
- WorkManager / background polling : pas Phase 1D.
- Multi-page prefetch (n+2, n+3) : explicitement out of scope par le prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)