### PR TITLE
chore(release): 0.1.0-phase1d.0 (build 28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ Format inspiré de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/). Les
 
 ## [Unreleased]
 
-Phase 1B.1 livrée : login HFR utilisable de bout en bout avec cookies persistants (DataStore + `PersistentCookieJar`). AAB `0.1.0-phase1b.0` (build 14) sortira avec la PR `feature/1b-1-auth`.
+---
+
+## v0.7.0 — 2026-05-03
+
+Phase 1D livrée : drapeaux REST, lecture longue topic, cache Room (TTL + persistance + isolation par compte), prefetch anonyme. AAB `0.1.0-phase1d.0` (build 28). Le `versionCode 27` a déjà été produit pour un build préliminaire pré-merge (sur la tête de PR #116 d'avant superpowers fixes) ; ce bump à 28 livre la version stampée sur main post-merge.
 
 ### Phase 1D-4 — Prefetch anonyme (#108)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         // upload signing config).
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their phase / commit lineage to the user.
-        versionCode = 26
-        versionName = "0.1.0-phase1c.2"
+        versionCode = 28
+        versionName = "0.1.0-phase1d.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -18,7 +18,7 @@ mermaid:
 
 nav_sort: order
 
-footer_content: "Redface 2 &mdash; Specs v0.6.0 &mdash; Un projet communautaire pour Hardware.fr"
+footer_content: "Redface 2 &mdash; Specs v0.7.0 &mdash; Un projet communautaire pour Hardware.fr"
 
 back_to_top: true
 back_to_top_text: "Haut de page"


### PR DESCRIPTION
## Résumé

Bump version pour la release Phase 1D :

- `app/build.gradle.kts` : `versionCode 26 → 28`, `versionName "0.1.0-phase1c.2" → "0.1.0-phase1d.0"`
- `docs/_config.yml` : footer specs `v0.6.0 → v0.7.0`
- `CHANGELOG.md` : section `[Unreleased]` archivée en `v0.7.0 — 2026-05-03`, regroupant les livraisons Phase 1D-1 à 1D-4 (PRs #112, #114, #115, #116) et la note Phase 1B.1 antérieure ; nouvelle `[Unreleased]` vide pour les prochains correctifs.

**Note** : `versionCode 27` a déjà été produit pour un build préliminaire pré-merge (sur la tête de PR #116 d'avant les superpowers fixes). Ce bump saute donc directement à 28 pour livrer la version stampée sur main post-merge.

## AAB

`redface2-v28-20260503-7831ab5.aab` (9.9 MB), stampé sur le commit de cette PR.

Build : `./scripts/docker-dev.sh ./gradlew :app:bundleRelease --init-script .gradle-user/signing/signing.init.gradle` ✅

## Tests

Pas de modification de code applicatif — pur version bump + doc.

> Action par Claude Opus 4.7 (demandée par @XaaT)