### PR TITLE
fix(cache): hotfix Room schema v3 — rebuild flag_topics + AAB v29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,15 @@ Format inspiré de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/). Les
 
 ## [Unreleased]
 
-Phase 1B.1 livrée : login HFR utilisable de bout en bout avec cookies persistants (DataStore + `PersistentCookieJar`). AAB `0.1.0-phase1b.0` (build 14) sortira avec la PR `feature/1b-1-auth`.
+---
+
+## v0.7.0 — 2026-05-03
+
+Phase 1D livrée : drapeaux REST, lecture longue topic, cache Room (TTL + persistance + isolation par compte), prefetch anonyme. AAB `0.1.0-phase1d.1` (build 29).
+
+### Hotfix Phase 1D — Room schema v3
+
+Pendant la séquence de PRs Phase 1D, les fixes superpowers sur `flag_topics` (drop `views`, `firstUnreadPostId NOT NULL` → `lastPostReadId INTEGER nullable`) ont été appliqués sans bumper la version Room. Les builds intermédiaires (versionCode 25-28) ont donc écrit la table avec la forme legacy, et au passage à un build avec l'entité corrigée, Room throw `IllegalStateException: Room cannot verify the data integrity` (identityHash mismatch). Fix : bump @Database à v3 + `MIGRATION_2_3` qui drop-recrée `flag_topics` à la forme REST. Sûr car drapeaux = cache pur (re-fetch à l'observe suivant). `topic_pages` / `posts` non touchés.
 
 ### Phase 1D-4 — Prefetch anonyme (#108)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         // upload signing config).
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their phase / commit lineage to the user.
-        versionCode = 26
-        versionName = "0.1.0-phase1c.2"
+        versionCode = 29
+        versionName = "0.1.0-phase1d.1"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/core/database/schemas/fr.forumhfr.redface2.core.database.RedfaceDatabase/3.json
+++ b/core/database/schemas/fr.forumhfr.redface2.core.database.RedfaceDatabase/3.json
@@ -1,0 +1,318 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "21d61d3eb43568f3d9aaa651b39644d1",
+    "entities": [
+      {
+        "tableName": "topic_pages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cat` INTEGER NOT NULL, `post` INTEGER NOT NULL, `page` INTEGER NOT NULL, `title` TEXT NOT NULL, `totalPages` INTEGER NOT NULL, `isFirstPostOwner` INTEGER NOT NULL, `pollJson` TEXT, `numreponses` TEXT NOT NULL, `fetchedAt` INTEGER NOT NULL, `authMode` TEXT NOT NULL, PRIMARY KEY(`cat`, `post`, `page`))",
+        "fields": [
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "post",
+            "columnName": "post",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPages",
+            "columnName": "totalPages",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFirstPostOwner",
+            "columnName": "isFirstPostOwner",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pollJson",
+            "columnName": "pollJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "numreponses",
+            "columnName": "numreponses",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authMode",
+            "columnName": "authMode",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cat",
+            "post",
+            "page"
+          ]
+        }
+      },
+      {
+        "tableName": "posts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cat` INTEGER NOT NULL, `numreponse` INTEGER NOT NULL, `post` INTEGER NOT NULL, `author` TEXT NOT NULL, `date` INTEGER NOT NULL, `content` TEXT NOT NULL, `avatarUrl` TEXT, `isEditable` INTEGER NOT NULL, `isOwnPost` INTEGER NOT NULL, `quotedAuthors` TEXT NOT NULL, `postIndex` INTEGER, `fetchedAt` INTEGER NOT NULL, `authMode` TEXT NOT NULL, PRIMARY KEY(`cat`, `numreponse`))",
+        "fields": [
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numreponse",
+            "columnName": "numreponse",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "post",
+            "columnName": "post",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isEditable",
+            "columnName": "isEditable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOwnPost",
+            "columnName": "isOwnPost",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quotedAuthors",
+            "columnName": "quotedAuthors",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postIndex",
+            "columnName": "postIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authMode",
+            "columnName": "authMode",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cat",
+            "numreponse"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_posts_cat_post",
+            "unique": false,
+            "columnNames": [
+              "cat",
+              "post"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_posts_cat_post` ON `${TABLE_NAME}` (`cat`, `post`)"
+          }
+        ]
+      },
+      {
+        "tableName": "flag_topics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `type` TEXT NOT NULL, `cat` INTEGER NOT NULL, `subcat` INTEGER, `topicId` INTEGER NOT NULL, `title` TEXT NOT NULL, `totalPages` INTEGER NOT NULL, `replyCount` INTEGER NOT NULL, `hasUnread` INTEGER NOT NULL, `lastReadPage` INTEGER NOT NULL, `lastPostReadId` INTEGER, `firstPostAuthor` TEXT NOT NULL, `lastReplyAuthor` TEXT NOT NULL, `lastReplyAt` TEXT NOT NULL, `fetchedAt` INTEGER NOT NULL, `authMode` TEXT NOT NULL, PRIMARY KEY(`userId`, `type`, `cat`, `topicId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subcat",
+            "columnName": "subcat",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "topicId",
+            "columnName": "topicId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPages",
+            "columnName": "totalPages",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "replyCount",
+            "columnName": "replyCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasUnread",
+            "columnName": "hasUnread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadPage",
+            "columnName": "lastReadPage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPostReadId",
+            "columnName": "lastPostReadId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "firstPostAuthor",
+            "columnName": "firstPostAuthor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReplyAuthor",
+            "columnName": "lastReplyAuthor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReplyAt",
+            "columnName": "lastReplyAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authMode",
+            "columnName": "authMode",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "type",
+            "cat",
+            "topicId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_flag_topics_userId_type",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_flag_topics_userId_type` ON `${TABLE_NAME}` (`userId`, `type`)"
+          },
+          {
+            "name": "index_flag_topics_userId_fetchedAt",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "fetchedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_flag_topics_userId_fetchedAt` ON `${TABLE_NAME}` (`userId`, `fetchedAt`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '21d61d3eb43568f3d9aaa651b39644d1')"
+    ]
+  }
+}

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/RedfaceDatabase.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/RedfaceDatabase.kt
@@ -12,7 +12,7 @@ import fr.forumhfr.redface2.core.database.entities.TopicEntity
 
 @Database(
     entities = [TopicEntity::class, PostEntity::class, FlagTopicEntity::class],
-    version = 2,
+    version = 3,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/di/DatabaseModule.kt
@@ -11,6 +11,7 @@ import fr.forumhfr.redface2.core.database.RedfaceDatabase
 import fr.forumhfr.redface2.core.database.dao.FlagDao
 import fr.forumhfr.redface2.core.database.dao.TopicDao
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_1_2
+import fr.forumhfr.redface2.core.database.migrations.MIGRATION_2_3
 import javax.inject.Singleton
 
 @Module
@@ -25,7 +26,7 @@ object DatabaseModule {
         RedfaceDatabase::class.java,
         RedfaceDatabase.DATABASE_NAME,
     )
-        .addMigrations(MIGRATION_1_2)
+        .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
         .build()
 
     @Provides

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/migrations/Migrations.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/migrations/Migrations.kt
@@ -60,3 +60,60 @@ val MIGRATION_1_2: Migration = object : Migration(1, 2) {
         )
     }
 }
+
+/**
+ * v2 → v3 (Phase 1D hotfix):
+ *
+ * Rebuilds `flag_topics` to match the REST-aligned shape of [FlagTopicEntity] :
+ * - drops `views NOT NULL` (the REST API does not expose a view count),
+ * - replaces `firstUnreadPostId INTEGER NOT NULL` with `lastPostReadId INTEGER`
+ *   (REST exposes `last_post_read_id`, the **last** post the user has read,
+ *   nullable when omitted on a row).
+ *
+ * Devices that ran an intermediate Phase 1D AAB (v25-v28) wrote `flag_topics`
+ * with the legacy shape, then upgraded to a build whose entity expects the new
+ * shape — Room then fails with `IllegalStateException: Room cannot verify the
+ * data integrity` because the identity hash changed without a version bump.
+ * This migration drops the table and recreates it: `flag_topics` is pure cache
+ * (drapeaux are refetched at next observe), so destructive recreation is safe
+ * and avoids a column-by-column rewrite that would gain nothing for empty rows.
+ *
+ * `topic_pages` and `posts` are untouched : their schema didn't change between
+ * v2 and v3, only `flag_topics` did.
+ */
+val MIGRATION_2_3: Migration = object : Migration(2, 3) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("DROP TABLE IF EXISTS `flag_topics`")
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `flag_topics` (
+                `userId` TEXT NOT NULL,
+                `type` TEXT NOT NULL,
+                `cat` INTEGER NOT NULL,
+                `subcat` INTEGER,
+                `topicId` INTEGER NOT NULL,
+                `title` TEXT NOT NULL,
+                `totalPages` INTEGER NOT NULL,
+                `replyCount` INTEGER NOT NULL,
+                `hasUnread` INTEGER NOT NULL,
+                `lastReadPage` INTEGER NOT NULL,
+                `lastPostReadId` INTEGER,
+                `firstPostAuthor` TEXT NOT NULL,
+                `lastReplyAuthor` TEXT NOT NULL,
+                `lastReplyAt` TEXT NOT NULL,
+                `fetchedAt` INTEGER NOT NULL,
+                `authMode` TEXT NOT NULL,
+                PRIMARY KEY(`userId`, `type`, `cat`, `topicId`)
+            )
+            """.trimIndent(),
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_flag_topics_userId_type` " +
+                "ON `flag_topics` (`userId`, `type`)",
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_flag_topics_userId_fetchedAt` " +
+                "ON `flag_topics` (`userId`, `fetchedAt`)",
+        )
+    }
+}

--- a/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/migrations/MigrationTest.kt
+++ b/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/migrations/MigrationTest.kt
@@ -19,15 +19,10 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 /**
- * Robolectric-driven migration test for `MIGRATION_1_2`. Creates a v1 database with
- * the actual v1 schema (no `authMode`, no `flag_topics`), inserts a representative
- * row, runs the migration, then verifies the new shape on the same disk file by
- * opening it with the full Room database and reading back through the DAOs.
- *
- * Why this exists: the v1 → v2 migration is hand-written DDL. Without this test a
- * typo in `MIGRATION_1_2` (missing column, wrong index name, wrong default) would
- * only crash on a real upgrade-in-place install, where the diagnostic loop is days
- * long. The test takes seconds.
+ * Robolectric-driven migration tests for `MIGRATION_1_2` and `MIGRATION_2_3`. Both
+ * migrations are hand-written DDL ; without these tests a typo (missing column,
+ * wrong index name, wrong default) would only crash on a real upgrade-in-place
+ * install, where the diagnostic loop is days long. The tests take seconds.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, sdk = [33])
@@ -51,8 +46,8 @@ class MigrationTest {
     }
 
     @Test
-    fun migrate_1_to_2_adds_authMode_with_AUTHENTICATED_default_and_creates_flag_topics() {
-        val dbName = "redface-test-migration.db"
+    fun migrate_1_to_3_chains_both_migrations_and_keeps_topic_pages_data() {
+        val dbName = "redface-test-migration-1-to-3.db"
 
         // 1. Build the v1 DB and insert a `topic_pages` + `posts` row that pre-dates
         //    `authMode`. We write through the raw SQLite helper because the v1
@@ -93,22 +88,23 @@ class MigrationTest {
             )
         }
 
-        // 2. Run the migration against the v1 fixture DB. `validateDroppedTables = true`
-        //    asserts every Room-known table matches the v2 schema exactly — so a typo
-        //    in MIGRATION_1_2 would surface here (column type, NOT NULL flag, index).
-        helper.runMigrationsAndValidate(dbName, 2, true, MIGRATION_1_2).close()
+        // 2. Run both migrations in chain against the v1 fixture DB. Target version 3
+        //    is the current @Database version. `validateDroppedTables = true` asserts
+        //    every Room-known table matches the v3 schema exactly — so a typo in
+        //    MIGRATION_1_2 or MIGRATION_2_3 would surface here.
+        helper.runMigrationsAndValidate(dbName, 3, true, MIGRATION_1_2, MIGRATION_2_3).close()
 
-        // 3. Open the upgraded DB via Room (forbidding any further migration, since
-        //    we already migrated to the latest). Read back through the DAOs and
-        //    confirm the shape. The migration backfilled `authMode = AUTHENTICATED`
-        //    on the pre-existing row, and the new `flag_topics` table is callable.
+        // 3. Open the upgraded DB via Room (already at the latest version). Read back
+        //    through the DAOs and confirm the shape: `authMode` was backfilled to
+        //    AUTHENTICATED on the pre-existing rows, `flag_topics` is queryable with
+        //    the v3 shape (no `views`, `lastPostReadId` nullable).
         val migrated = Room.databaseBuilder(
             ApplicationProvider.getApplicationContext(),
             RedfaceDatabase::class.java,
             dbName,
         )
             .allowMainThreadQueries()
-            .addMigrations(MIGRATION_1_2)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
             .build()
 
         try {
@@ -126,10 +122,10 @@ class MigrationTest {
                 assertEquals("AUTHENTICATED", cursor.getString(0))
             }
 
-            // The new flag_topics table is created with the v2 shape: queries on the
-            // REST-aligned columns (no `views`, `lastPostReadId` instead of
-            // `firstUnreadPostId`) compile against the migrated DB. If anyone
-            // re-introduced a legacy column, this query would throw.
+            // The flag_topics table reaches v3 shape after the chain: REST-aligned
+            // columns (no `views`, `lastPostReadId` nullable) compile against the
+            // migrated DB. If anyone re-introduced a legacy column, this query would
+            // throw.
             migrated.openHelper.readableDatabase.query(
                 "SELECT lastPostReadId FROM flag_topics LIMIT 1",
             ).use { cursor ->
@@ -144,6 +140,123 @@ class MigrationTest {
                 assertEquals(0, cursor.getInt(0))
             }
             assertNotNull(migrated.flagDao())
+        } finally {
+            migrated.close()
+        }
+    }
+
+    @Test
+    fun migrate_2_to_3_rebuilds_flag_topics_with_REST_shape_and_keeps_topic_pages_intact() {
+        val dbName = "redface-test-migration-2-to-3.db"
+
+        // 1. Build a v2 DB with the LEGACY flag_topics shape — what intermediate
+        //    Phase 1D AABs (v25-v28) actually wrote on real devices. Cooking the v2
+        //    fixture by hand instead of running MIGRATION_1_2 because the v2 schema
+        //    JSON exported by Room reflects the FIXED shape, not the legacy one.
+        helper.createDatabase(dbName, 2).use { v2 ->
+            v2.execSQL("DROP TABLE IF EXISTS `flag_topics`")
+            v2.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `flag_topics` (
+                    `userId` TEXT NOT NULL,
+                    `type` TEXT NOT NULL,
+                    `cat` INTEGER NOT NULL,
+                    `subcat` INTEGER,
+                    `topicId` INTEGER NOT NULL,
+                    `title` TEXT NOT NULL,
+                    `totalPages` INTEGER NOT NULL,
+                    `replyCount` INTEGER NOT NULL,
+                    `views` INTEGER NOT NULL,
+                    `hasUnread` INTEGER NOT NULL,
+                    `lastReadPage` INTEGER NOT NULL,
+                    `firstUnreadPostId` INTEGER NOT NULL,
+                    `firstPostAuthor` TEXT NOT NULL,
+                    `lastReplyAuthor` TEXT NOT NULL,
+                    `lastReplyAt` TEXT NOT NULL,
+                    `fetchedAt` INTEGER NOT NULL,
+                    `authMode` TEXT NOT NULL,
+                    PRIMARY KEY(`userId`, `type`, `cat`, `topicId`)
+                )
+                """.trimIndent(),
+            )
+            // Insert a row with the legacy NOT NULL columns to prove the migration
+            // doesn't choke on existing data — the destructive recreate is safe.
+            v2.insert(
+                "flag_topics",
+                android.database.sqlite.SQLiteDatabase.CONFLICT_REPLACE,
+                ContentValues().apply {
+                    put("userId", "alice")
+                    put("type", "CYAN")
+                    put("cat", 23)
+                    putNull("subcat")
+                    put("topicId", 35395)
+                    put("title", "legacy topic")
+                    put("totalPages", 1)
+                    put("replyCount", 0)
+                    put("views", 9_999)
+                    put("hasUnread", 0)
+                    put("lastReadPage", 1)
+                    put("firstUnreadPostId", 555_000_100L)
+                    put("firstPostAuthor", "alice")
+                    put("lastReplyAuthor", "bob")
+                    put("lastReplyAt", "2026-04-01 10:00")
+                    put("fetchedAt", 1_700_000_000_000L)
+                    put("authMode", "AUTHENTICATED")
+                },
+            )
+            // Touch topic_pages so we can prove MIGRATION_2_3 leaves it alone.
+            v2.insert(
+                "topic_pages",
+                android.database.sqlite.SQLiteDatabase.CONFLICT_REPLACE,
+                ContentValues().apply {
+                    put("cat", 23)
+                    put("post", 35395)
+                    put("page", 1)
+                    put("title", "kept across migration")
+                    put("totalPages", 1)
+                    put("isFirstPostOwner", 0)
+                    putNull("pollJson")
+                    put("numreponses", "[\"100\"]")
+                    put("fetchedAt", 1_700_000_000_000L)
+                    put("authMode", "AUTHENTICATED")
+                },
+            )
+        }
+
+        // 2. Run MIGRATION_2_3 and validate against the v3 schema.
+        helper.runMigrationsAndValidate(dbName, 3, true, MIGRATION_2_3).close()
+
+        // 3. flag_topics legacy row is gone (drapeaux are pure cache, refetched at
+        //    next observe), topic_pages survives.
+        val migrated = Room.databaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            RedfaceDatabase::class.java,
+            dbName,
+        )
+            .allowMainThreadQueries()
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+            .build()
+
+        try {
+            migrated.openHelper.readableDatabase.query(
+                "SELECT COUNT(*) FROM flag_topics",
+            ).use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals("flag_topics must be empty after destructive rebuild", 0, cursor.getInt(0))
+            }
+            migrated.openHelper.readableDatabase.query(
+                "SELECT title FROM topic_pages WHERE cat = 23 AND post = 35395 AND page = 1",
+            ).use { cursor ->
+                assertTrue("topic_pages row must survive MIGRATION_2_3", cursor.moveToFirst())
+                assertEquals("kept across migration", cursor.getString(0))
+            }
+            // Querying the new column name compiles, querying the legacy ones throws —
+            // proving the rebuild took effect.
+            migrated.openHelper.readableDatabase.query(
+                "SELECT lastPostReadId FROM flag_topics LIMIT 1",
+            ).use { cursor ->
+                assertEquals(0, cursor.count)
+            }
         } finally {
             migrated.close()
         }


### PR DESCRIPTION
## Bug

Sur device réel avec un AAB Phase 1D intermédiaire (versionCode 25-28) déjà installé, l'app **crash au démarrage** au passage à v28 :

\`\`\`
java.lang.IllegalStateException: Room cannot verify the data integrity.
Looks like you've changed schema but forgot to update the version number.
\`\`\`

**Cause** : pendant la séquence de PRs Phase 1D, les fixes superpowers sur \`flag_topics\` (drop \`views\`, \`firstUnreadPostId NOT NULL\` → \`lastPostReadId INTEGER nullable\`) ont été appliqués sans bumper la version Room. La table sur disque a la forme legacy ; l'entité Kotlin attend la forme REST ; Room calcule un identityHash compile-time différent de celui inséré en DB → mismatch.

\"Clear cache\" Android n'efface pas la DB — d'où le crash persistant.

## Fix

- \`@Database(version = 2 → 3)\` sur \`RedfaceDatabase\`
- Nouvelle \`MIGRATION_2_3\` qui drop-recrée \`flag_topics\` à la forme REST. Sûr car drapeaux = cache pur (re-fetch à l'observe suivant). \`topic_pages\` et \`posts\` ne sont pas touchés.
- \`DatabaseModule.addMigrations(MIGRATION_1_2, MIGRATION_2_3)\`
- \`MigrationTest\` étendu :
  - test v1→v3 chaîne les deux migrations
  - nouveau test v2→v3 qui crée une table v2 avec la forme legacy (\`views NOT NULL\`, \`firstUnreadPostId NOT NULL\`) + un row, puis vérifie que la migration drop la table, recrée la nouvelle forme et préserve \`topic_pages\`
- Bump \`versionCode 26 → 29\`, \`versionName \"0.1.0-phase1c.2\" → \"0.1.0-phase1d.1\"\`. v27/v28 sautés car déjà consommés par des builds buggés.
- \`CHANGELOG.md\` : section \`v0.7.0 — 2026-05-03\` datée et documentant le hotfix.

## AAB

\`redface2-v29-20260503-be8c712.aab\` (9.9 MB), signé via init-script keystore upload.

Build : \`./scripts/docker-dev.sh ./gradlew :app:bundleRelease --init-script .gradle-user/signing/signing.init.gradle\` ✅

## Tests

\`:core:database:testDebugUnitTest --rerun-tasks\` → 12 tests, 0 failure, dont :

- \`migrate_1_to_3_chains_both_migrations_and_keeps_topic_pages_data\` (nouveau)
- \`migrate_2_to_3_rebuilds_flag_topics_with_REST_shape_and_keeps_topic_pages_intact\` (nouveau)
- les 11 tests \`FlagDaoTest\` + \`TopicDaoTest\` existants (sort cross-year, isolation par compte, anti-overwrite)

## Replaces

PR #118 (qui livrait v28). À fermer.

> Action par Claude Opus 4.7 (demandée par @XaaT)