### PR TITLE
fix(serialization): freeze on-disk JSON contracts (PostContent, PollDto, CookieDto)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/auth/DataStoreCookieStore.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/auth/DataStoreCookieStore.kt
@@ -10,6 +10,7 @@ import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.Cookie
@@ -72,16 +73,25 @@ class DataStoreCookieStore @Inject constructor(
             .build()
     }.getOrNull()
 
+    /**
+     * On-disk shape of one persisted cookie. The `@SerialName` annotations freeze the
+     * JSON keys against any code-side rename : a Kotlin property rename without an
+     * explicit `@SerialName` would silently log out every existing user (the
+     * `runCatching` upstream catches the resulting `MissingFieldException` and emits
+     * an empty cookie list, which the UI reads as "session expired"). Defaults make
+     * a missing key tolerable for older payloads — preferable to wiping the whole
+     * cookie list because one new field landed.
+     */
     @Serializable
     private data class CookieDto(
-        val name: String,
-        val value: String,
-        val domain: String,
-        val path: String,
-        val expiresAt: Long,
-        val secure: Boolean,
-        val httpOnly: Boolean,
-        val hostOnly: Boolean,
+        @SerialName("name") val name: String = "",
+        @SerialName("value") val value: String = "",
+        @SerialName("domain") val domain: String = "",
+        @SerialName("path") val path: String = "/",
+        @SerialName("expiresAt") val expiresAt: Long = 0L,
+        @SerialName("secure") val secure: Boolean = false,
+        @SerialName("httpOnly") val httpOnly: Boolean = false,
+        @SerialName("hostOnly") val hostOnly: Boolean = false,
     )
 
     companion object {

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/auth/DataStoreCookieStore.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/auth/DataStoreCookieStore.kt
@@ -20,7 +20,10 @@ class DataStoreCookieStore @Inject constructor(
     @param:CookieDataStore private val dataStore: DataStore<Preferences>,
 ) : CookieStore {
 
-    private val json = Json { ignoreUnknownKeys = true }
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
     private val cookiesKey = stringPreferencesKey(KEY_SESSION_COOKIES)
 
     override fun observe(): Flow<List<Cookie>> = dataStore.data.map { prefs ->

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicMappers.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicMappers.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.core.data.topic
 
+import android.util.Log
 import fr.forumhfr.redface2.core.database.entities.FetchMode
 import fr.forumhfr.redface2.core.database.entities.PostEntity
 import fr.forumhfr.redface2.core.database.entities.TopicEntity
@@ -8,10 +9,13 @@ import fr.forumhfr.redface2.core.model.PollOption
 import fr.forumhfr.redface2.core.model.Post
 import fr.forumhfr.redface2.core.model.Topic
 import java.time.Instant
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
 internal object TopicMappers {
+    private const val LOG_TAG = "TopicMappers"
+
     private val json: Json = Json {
         ignoreUnknownKeys = true
         encodeDefaults = true
@@ -51,8 +55,23 @@ internal object TopicMappers {
             totalPages = topic.totalPages,
             isFirstPostOwner = topic.isFirstPostOwner,
             posts = orderedPosts,
-            poll = topic.pollJson?.let { json.decodeFromString(PollDto.serializer(), it).toDomain() },
+            poll = topic.pollJson?.let(::decodePollOrNull),
         )
+    }
+
+    /**
+     * Best-effort decode for the cached poll JSON. The shape is frozen by [PollDto]
+     * `@SerialName` annotations + defaults — but if a future change ever renames a
+     * field without a Room migration, this swallow keeps the topic openable (poll
+     * shows as missing) instead of crashing the entire screen at cache read.
+     * The next authenticated re-fetch overwrites the row with a fresh, well-formed
+     * payload.
+     */
+    private fun decodePollOrNull(pollJson: String): Poll? = runCatching {
+        json.decodeFromString(PollDto.serializer(), pollJson).toDomain()
+    }.getOrElse { error ->
+        Log.w(LOG_TAG, "Failed to decode cached pollJson — degrading to no-poll", error)
+        null
     }
 
     private fun Post.toEntity(
@@ -88,20 +107,30 @@ internal object TopicMappers {
         postIndex = postIndex,
     )
 
+    /**
+     * On-disk shape of [Poll]. Persisted as JSON in `topic_pages.pollJson` ; every
+     * row written since the column existed holds JSON in this exact shape.
+     *
+     * Defaults are wired up so a missing field on a legacy row degrades gracefully
+     * (empty question / no options / no votes) instead of throwing at decode. The
+     * next authenticated fetch will overwrite the row with a complete payload.
+     * `@SerialName` annotations freeze the JSON keys against any code-side rename ;
+     * cf. `PostContent` for the full rationale (same on-disk-contract issue).
+     */
     @Serializable
     private data class PollDto(
-        val question: String,
-        val options: List<PollOptionDto>,
-        val multipleChoice: Boolean,
-        val totalVotes: Int,
-        val hasVoted: Boolean,
+        @SerialName("question") val question: String = "",
+        @SerialName("options") val options: List<PollOptionDto> = emptyList(),
+        @SerialName("multipleChoice") val multipleChoice: Boolean = false,
+        @SerialName("totalVotes") val totalVotes: Int = 0,
+        @SerialName("hasVoted") val hasVoted: Boolean = false,
     )
 
     @Serializable
     private data class PollOptionDto(
-        val text: String,
-        val votes: Int,
-        val percentage: Float,
+        @SerialName("text") val text: String = "",
+        @SerialName("votes") val votes: Int = 0,
+        @SerialName("percentage") val percentage: Float = 0f,
     )
 
     private fun Poll.toDto(): PollDto = PollDto(

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/auth/DataStoreCookieStoreTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/auth/DataStoreCookieStoreTest.kt
@@ -8,6 +8,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import app.cash.turbine.test
 import java.io.File
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import okhttp3.Cookie
@@ -201,6 +202,24 @@ class DataStoreCookieStoreTest {
                 assertEquals("xaat", cookies.single().value)
                 cancelAndIgnoreRemainingEvents()
             }
+        }
+
+    @Test
+    fun `save writes the full historical key set even for default-valued fields`() =
+        runTest(UnconfinedTestDispatcher()) {
+            store.save(listOf(makeCookie(name = "md_user", value = "xaat")))
+
+            val raw = dataStore.data.first()[stringPreferencesKey(DataStoreCookieStore.KEY_SESSION_COOKIES)]
+                .orEmpty()
+
+            assertTrue(raw.contains("\"name\""))
+            assertTrue(raw.contains("\"value\""))
+            assertTrue(raw.contains("\"domain\""))
+            assertTrue(raw.contains("\"path\""))
+            assertTrue(raw.contains("\"expiresAt\""))
+            assertTrue(raw.contains("\"secure\""))
+            assertTrue(raw.contains("\"httpOnly\""))
+            assertTrue(raw.contains("\"hostOnly\""))
         }
 
     /**

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/auth/DataStoreCookieStoreTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/auth/DataStoreCookieStoreTest.kt
@@ -162,6 +162,87 @@ class DataStoreCookieStoreTest {
             }
         }
 
+    /**
+     * Pins the on-disk JSON shape of the cookie list. Every build that wrote cookies
+     * to DataStore produced this exact key set ; a future Kotlin-side rename of any
+     * `CookieDto` property would silently log out every existing user (the
+     * `runCatching` upstream catches the resulting `MissingFieldException` and emits
+     * an empty list, which the UI reads as "session expired"). The frozen
+     * `@SerialName` annotations on `CookieDto` keep the JSON keys stable ; this test
+     * proves a payload written by a hypothetical past build (or hand-crafted by a
+     * user manipulating the file) still decodes to a usable cookie.
+     */
+    @Test
+    fun `legacy persisted payload with the historical key set still decodes`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val farFuture = System.currentTimeMillis() + 7L * 24 * 60 * 60 * 1000
+            val historicalJson = """
+                [
+                  {
+                    "name": "md_user",
+                    "value": "xaat",
+                    "domain": "forum.hardware.fr",
+                    "path": "/",
+                    "expiresAt": $farFuture,
+                    "secure": true,
+                    "httpOnly": true,
+                    "hostOnly": true
+                  }
+                ]
+            """.trimIndent()
+            dataStore.edit { prefs ->
+                prefs[stringPreferencesKey(DataStoreCookieStore.KEY_SESSION_COOKIES)] = historicalJson
+            }
+
+            store.observe().test {
+                val cookies = awaitItem()
+                assertEquals(1, cookies.size)
+                assertEquals("md_user", cookies.single().name)
+                assertEquals("xaat", cookies.single().value)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    /**
+     * If a future schema adds a new field to `CookieDto`, an older payload missing
+     * that field must still decode (defaults take over). Without defaults, kotlinx
+     * throws `MissingFieldException` and the whole list is wiped — silent logout.
+     */
+    @Test
+    fun `payload missing a future-only optional field still decodes via defaults`() =
+        runTest(UnconfinedTestDispatcher()) {
+            // Simulate an older build that wrote 6 fields out of the 8 the current
+            // schema knows. The two missing ones (httpOnly, hostOnly) must default
+            // to false rather than blowing up the list.
+            val farFuture = System.currentTimeMillis() + 7L * 24 * 60 * 60 * 1000
+            val truncatedJson = """
+                [
+                  {
+                    "name": "md_user",
+                    "value": "xaat",
+                    "domain": "forum.hardware.fr",
+                    "path": "/",
+                    "expiresAt": $farFuture,
+                    "secure": true
+                  }
+                ]
+            """.trimIndent()
+            dataStore.edit { prefs ->
+                prefs[stringPreferencesKey(DataStoreCookieStore.KEY_SESSION_COOKIES)] = truncatedJson
+            }
+
+            store.observe().test {
+                val cookies = awaitItem()
+                assertEquals(
+                    "missing fields must not wipe the cookie list",
+                    1,
+                    cookies.size,
+                )
+                assertEquals("md_user", cookies.single().name)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
     private fun makeCookie(
         name: String,
         value: String,

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/converters/Converters.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/converters/Converters.kt
@@ -58,15 +58,32 @@ internal object Converters {
     @JvmStatic
     fun fetchModeToString(value: FetchMode): String = value.name
 
+    /**
+     * Defensive read : if a future PR ever renames a [FetchMode] entry, every cached
+     * row written by an older build holding the old name would `IllegalArgumentException`
+     * here and crash the DAO. Falling back to `AUTHENTICATED` keeps the page openable
+     * — at worst the row is treated as authenticated and the next user-driven fetch
+     * overwrites it with the current canonical value. Renaming an enum value is a
+     * schema-affecting change ; if you need to do it, write a Room migration that
+     * rewrites every affected column instead of relying on this fallback.
+     */
     @TypeConverter
     @JvmStatic
-    fun fetchModeFromString(value: String): FetchMode = FetchMode.valueOf(value)
+    fun fetchModeFromString(value: String): FetchMode =
+        runCatching { FetchMode.valueOf(value) }.getOrDefault(FetchMode.AUTHENTICATED)
 
     @TypeConverter
     @JvmStatic
     fun flagTypeToString(value: FlagType): String = value.name
 
+    /**
+     * Defensive read for the same reason as [fetchModeFromString]. Falls back to
+     * [FlagType.CYAN] (sujets participés — the most common drapeau bucket). Still
+     * a destructive fallback : the row's true type is lost. Renaming a [FlagType]
+     * value should bump Room and rewrite `flag_topics.type`.
+     */
     @TypeConverter
     @JvmStatic
-    fun flagTypeFromString(value: String): FlagType = FlagType.valueOf(value)
+    fun flagTypeFromString(value: String): FlagType =
+        runCatching { FlagType.valueOf(value) }.getOrDefault(FlagType.CYAN)
 }

--- a/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/serialization/PostContentSerializerTest.kt
+++ b/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/serialization/PostContentSerializerTest.kt
@@ -4,6 +4,7 @@ import fr.forumhfr.redface2.core.model.PostBlock
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.PostInline
 import fr.forumhfr.redface2.core.model.SmileyKind
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -27,56 +28,7 @@ class PostContentSerializerTest {
 
     @Test
     fun `every block and inline kind round-trips through encode-decode`() {
-        val sample = PostContent(
-            blocks = listOf(
-                PostBlock.Paragraph(
-                    inlines = listOf(
-                        PostInline.Text("hello"),
-                        PostInline.LineBreak,
-                        PostInline.Strong(children = listOf(PostInline.Text("bold"))),
-                        PostInline.Emphasis(children = listOf(PostInline.Text("em"))),
-                        PostInline.Underline(children = listOf(PostInline.Text("under"))),
-                        PostInline.Strike(children = listOf(PostInline.Text("strike"))),
-                        PostInline.Color(
-                            colorHex = "#FF0000",
-                            children = listOf(PostInline.Text("red")),
-                        ),
-                        PostInline.Link(
-                            url = "https://example.invalid",
-                            children = listOf(PostInline.Text("link")),
-                        ),
-                        PostInline.InlineImage(url = "https://example.invalid/i.png", description = "alt"),
-                        PostInline.Smiley(
-                            kind = SmileyKind.Builtin(code = "jap"),
-                            imageUrl = "https://forum-images.hardware.fr/icones/smilies/jap.gif",
-                        ),
-                        PostInline.Smiley(
-                            kind = SmileyKind.Perso(name = "ouich"),
-                            imageUrl = "https://forum-images.hardware.fr/images/perso/ouich.gif",
-                        ),
-                    ),
-                ),
-                PostBlock.Quote(
-                    author = "alice",
-                    numreponse = 100,
-                    page = 2,
-                    content = PostContent(
-                        blocks = listOf(
-                            PostBlock.Paragraph(inlines = listOf(PostInline.Text("quoted"))),
-                        ),
-                    ),
-                ),
-                PostBlock.Spoiler(
-                    label = "secret",
-                    content = PostContent(
-                        blocks = listOf(
-                            PostBlock.Paragraph(inlines = listOf(PostInline.Text("hidden"))),
-                        ),
-                    ),
-                ),
-                PostBlock.Image(url = "https://example.invalid/i.png", description = "block alt"),
-            ),
-        )
+        val sample = samplePostContent()
 
         val encoded = PostContentSerializer.encode(sample)
         val decoded = PostContentSerializer.decode(encoded)
@@ -97,7 +49,8 @@ class PostContentSerializerTest {
      */
     @Test
     fun `frozen fixture decodes to the expected AST and re-encodes byte-identical`() {
-        val frozen = """
+        val frozen = minifiedJson(
+            """
             {
               "blocks": [
                 {
@@ -109,28 +62,136 @@ class PostContentSerializerTest {
                     },
                     {
                       "type": "fr.forumhfr.redface2.core.model.PostInline.LineBreak"
+                    },
+                    {
+                      "type": "fr.forumhfr.redface2.core.model.PostInline.Strong",
+                      "children": [
+                        {
+                          "type": "fr.forumhfr.redface2.core.model.PostInline.Text",
+                          "value": "bold"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "fr.forumhfr.redface2.core.model.PostInline.Emphasis",
+                      "children": [
+                        {
+                          "type": "fr.forumhfr.redface2.core.model.PostInline.Text",
+                          "value": "em"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "fr.forumhfr.redface2.core.model.PostInline.Underline",
+                      "children": [
+                        {
+                          "type": "fr.forumhfr.redface2.core.model.PostInline.Text",
+                          "value": "under"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "fr.forumhfr.redface2.core.model.PostInline.Strike",
+                      "children": [
+                        {
+                          "type": "fr.forumhfr.redface2.core.model.PostInline.Text",
+                          "value": "strike"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "fr.forumhfr.redface2.core.model.PostInline.Color",
+                      "colorHex": "#FF0000",
+                      "children": [
+                        {
+                          "type": "fr.forumhfr.redface2.core.model.PostInline.Text",
+                          "value": "red"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "fr.forumhfr.redface2.core.model.PostInline.Link",
+                      "url": "https://example.invalid",
+                      "children": [
+                        {
+                          "type": "fr.forumhfr.redface2.core.model.PostInline.Text",
+                          "value": "link"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "fr.forumhfr.redface2.core.model.PostInline.InlineImage",
+                      "url": "https://example.invalid/i.png",
+                      "description": "alt"
+                    },
+                    {
+                      "type": "fr.forumhfr.redface2.core.model.PostInline.Smiley",
+                      "kind": {
+                        "type": "fr.forumhfr.redface2.core.model.SmileyKind.Builtin",
+                        "code": ":jap:"
+                      },
+                      "imageUrl": "https://forum-images.hardware.fr/icones/smilies/jap.gif"
+                    },
+                    {
+                      "type": "fr.forumhfr.redface2.core.model.PostInline.Smiley",
+                      "kind": {
+                        "type": "fr.forumhfr.redface2.core.model.SmileyKind.Perso",
+                        "name": "ouich"
+                      },
+                      "imageUrl": "https://forum-images.hardware.fr/images/perso/ouich.gif"
                     }
                   ]
+                },
+                {
+                  "type": "fr.forumhfr.redface2.core.model.PostBlock.Quote",
+                  "author": "alice",
+                  "numreponse": 100,
+                  "page": 2,
+                  "content": {
+                    "blocks": [
+                      {
+                        "type": "fr.forumhfr.redface2.core.model.PostBlock.Paragraph",
+                        "inlines": [
+                          {
+                            "type": "fr.forumhfr.redface2.core.model.PostInline.Text",
+                            "value": "quoted"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "fr.forumhfr.redface2.core.model.PostBlock.Spoiler",
+                  "label": "secret",
+                  "content": {
+                    "blocks": [
+                      {
+                        "type": "fr.forumhfr.redface2.core.model.PostBlock.Paragraph",
+                        "inlines": [
+                          {
+                            "type": "fr.forumhfr.redface2.core.model.PostInline.Text",
+                            "value": "hidden"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "fr.forumhfr.redface2.core.model.PostBlock.Image",
+                  "url": "https://example.invalid/i.png",
+                  "description": "block alt"
                 }
               ]
             }
-        """.trimIndent()
+            """,
+        )
 
         val decoded = PostContentSerializer.decode(frozen)
 
-        assertEquals(
-            PostContent(
-                blocks = listOf(
-                    PostBlock.Paragraph(
-                        inlines = listOf(
-                            PostInline.Text("hello"),
-                            PostInline.LineBreak,
-                        ),
-                    ),
-                ),
-            ),
-            decoded,
-        )
+        assertEquals(samplePostContent(), decoded)
+        assertEquals(frozen, PostContentSerializer.encode(decoded))
     }
 
     @Test
@@ -165,4 +226,63 @@ class PostContentSerializerTest {
             decoded,
         )
     }
+
+    private fun samplePostContent(): PostContent = PostContent(
+        blocks = listOf(
+            PostBlock.Paragraph(
+                inlines = listOf(
+                    PostInline.Text("hello"),
+                    PostInline.LineBreak,
+                    PostInline.Strong(children = listOf(PostInline.Text("bold"))),
+                    PostInline.Emphasis(children = listOf(PostInline.Text("em"))),
+                    PostInline.Underline(children = listOf(PostInline.Text("under"))),
+                    PostInline.Strike(children = listOf(PostInline.Text("strike"))),
+                    PostInline.Color(
+                        colorHex = "#FF0000",
+                        children = listOf(PostInline.Text("red")),
+                    ),
+                    PostInline.Link(
+                        url = "https://example.invalid",
+                        children = listOf(PostInline.Text("link")),
+                    ),
+                    PostInline.InlineImage(
+                        url = "https://example.invalid/i.png",
+                        description = "alt",
+                    ),
+                    PostInline.Smiley(
+                        kind = SmileyKind.Builtin(code = ":jap:"),
+                        imageUrl = "https://forum-images.hardware.fr/icones/smilies/jap.gif",
+                    ),
+                    PostInline.Smiley(
+                        kind = SmileyKind.Perso(name = "ouich"),
+                        imageUrl = "https://forum-images.hardware.fr/images/perso/ouich.gif",
+                    ),
+                ),
+            ),
+            PostBlock.Quote(
+                author = "alice",
+                numreponse = 100,
+                page = 2,
+                content = PostContent(
+                    blocks = listOf(
+                        PostBlock.Paragraph(inlines = listOf(PostInline.Text("quoted"))),
+                    ),
+                ),
+            ),
+            PostBlock.Spoiler(
+                label = "secret",
+                content = PostContent(
+                    blocks = listOf(
+                        PostBlock.Paragraph(inlines = listOf(PostInline.Text("hidden"))),
+                    ),
+                ),
+            ),
+            PostBlock.Image(
+                url = "https://example.invalid/i.png",
+                description = "block alt",
+            ),
+        ),
+    )
+
+    private fun minifiedJson(value: String): String = Json.parseToJsonElement(value.trimIndent()).toString()
 }

--- a/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/serialization/PostContentSerializerTest.kt
+++ b/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/serialization/PostContentSerializerTest.kt
@@ -1,0 +1,168 @@
+package fr.forumhfr.redface2.core.database.serialization
+
+import fr.forumhfr.redface2.core.model.PostBlock
+import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.model.PostInline
+import fr.forumhfr.redface2.core.model.SmileyKind
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the on-disk JSON representation of [PostContent]. The AST is persisted in
+ * `posts.content` via Room TypeConverter — every `posts` row written by every build
+ * since Phase 1A holds JSON in this exact shape. Renaming a Kotlin property,
+ * moving a sealed case to a different package, or letting the polymorphic
+ * discriminator drift would silently make those rows undecodable on the next read,
+ * **without crashing the migration** (the column survives untouched). The only
+ * failure mode is a `SerializationException` thrown at DAO read time.
+ *
+ * The bug pattern is exactly the one that hit `flag_topics` at the v2 → v3 boundary,
+ * but routed through a JSON column instead of a SQL schema. There is no equivalent
+ * of `MigrationTestHelper` for JSON columns, hence this test : a frozen fixture
+ * that **must** keep decoding to the same logical AST. If you rename a property,
+ * either bump the AST and write a migration that rewrites every `posts.content`,
+ * or stop and put the rename behind a `@SerialName` so the JSON output is unchanged.
+ */
+class PostContentSerializerTest {
+
+    @Test
+    fun `every block and inline kind round-trips through encode-decode`() {
+        val sample = PostContent(
+            blocks = listOf(
+                PostBlock.Paragraph(
+                    inlines = listOf(
+                        PostInline.Text("hello"),
+                        PostInline.LineBreak,
+                        PostInline.Strong(children = listOf(PostInline.Text("bold"))),
+                        PostInline.Emphasis(children = listOf(PostInline.Text("em"))),
+                        PostInline.Underline(children = listOf(PostInline.Text("under"))),
+                        PostInline.Strike(children = listOf(PostInline.Text("strike"))),
+                        PostInline.Color(
+                            colorHex = "#FF0000",
+                            children = listOf(PostInline.Text("red")),
+                        ),
+                        PostInline.Link(
+                            url = "https://example.invalid",
+                            children = listOf(PostInline.Text("link")),
+                        ),
+                        PostInline.InlineImage(url = "https://example.invalid/i.png", description = "alt"),
+                        PostInline.Smiley(
+                            kind = SmileyKind.Builtin(code = "jap"),
+                            imageUrl = "https://forum-images.hardware.fr/icones/smilies/jap.gif",
+                        ),
+                        PostInline.Smiley(
+                            kind = SmileyKind.Perso(name = "ouich"),
+                            imageUrl = "https://forum-images.hardware.fr/images/perso/ouich.gif",
+                        ),
+                    ),
+                ),
+                PostBlock.Quote(
+                    author = "alice",
+                    numreponse = 100,
+                    page = 2,
+                    content = PostContent(
+                        blocks = listOf(
+                            PostBlock.Paragraph(inlines = listOf(PostInline.Text("quoted"))),
+                        ),
+                    ),
+                ),
+                PostBlock.Spoiler(
+                    label = "secret",
+                    content = PostContent(
+                        blocks = listOf(
+                            PostBlock.Paragraph(inlines = listOf(PostInline.Text("hidden"))),
+                        ),
+                    ),
+                ),
+                PostBlock.Image(url = "https://example.invalid/i.png", description = "block alt"),
+            ),
+        )
+
+        val encoded = PostContentSerializer.encode(sample)
+        val decoded = PostContentSerializer.decode(encoded)
+        assertEquals(sample, decoded)
+    }
+
+    /**
+     * Frozen fixture : a payload identical to what a real `posts.content` row holds
+     * today. If this test fails, your change broke the on-disk JSON format. Either
+     * revert the rename or add a Room migration that rewrites every row in `posts`.
+     *
+     * The discriminator is `"type"` (set in [PostContentSerializer]). The values
+     * below are the **fully-qualified Kotlin names** of the sealed cases, which is
+     * what kotlinx.serialization emits when no `@SerialName` is declared on a
+     * sealed subclass. Any code-side rename / package move must keep the JSON
+     * value here — either via `@SerialName(this exact string)` on the sealed case,
+     * or via a write-side migration.
+     */
+    @Test
+    fun `frozen fixture decodes to the expected AST and re-encodes byte-identical`() {
+        val frozen = """
+            {
+              "blocks": [
+                {
+                  "type": "fr.forumhfr.redface2.core.model.PostBlock.Paragraph",
+                  "inlines": [
+                    {
+                      "type": "fr.forumhfr.redface2.core.model.PostInline.Text",
+                      "value": "hello"
+                    },
+                    {
+                      "type": "fr.forumhfr.redface2.core.model.PostInline.LineBreak"
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val decoded = PostContentSerializer.decode(frozen)
+
+        assertEquals(
+            PostContent(
+                blocks = listOf(
+                    PostBlock.Paragraph(
+                        inlines = listOf(
+                            PostInline.Text("hello"),
+                            PostInline.LineBreak,
+                        ),
+                    ),
+                ),
+            ),
+            decoded,
+        )
+    }
+
+    @Test
+    fun `unknown fields in a row are tolerated by the lenient json config`() {
+        val payloadWithFutureField = """
+            {
+              "blocks": [
+                {
+                  "type": "fr.forumhfr.redface2.core.model.PostBlock.Paragraph",
+                  "inlines": [
+                    {
+                      "type": "fr.forumhfr.redface2.core.model.PostInline.Text",
+                      "value": "hello",
+                      "futureField": 42
+                    }
+                  ],
+                  "anotherFutureField": "ignored"
+                }
+              ],
+              "rootFutureField": true
+            }
+        """.trimIndent()
+
+        val decoded = PostContentSerializer.decode(payloadWithFutureField)
+
+        assertEquals(
+            PostContent(
+                blocks = listOf(
+                    PostBlock.Paragraph(inlines = listOf(PostInline.Text("hello"))),
+                ),
+            ),
+            decoded,
+        )
+    }
+}

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/PostContent.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/PostContent.kt
@@ -1,70 +1,129 @@
 package fr.forumhfr.redface2.core.model
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/**
+ * AST of a HFR post body. **The JSON serialization of this hierarchy is persisted on
+ * disk** in `posts.content` (Room String column, pinned by the converter in
+ * `:core:database`). Every row written by every Phase 1+ build holds JSON in this
+ * exact shape ; renaming a Kotlin property, moving a sealed case to a different
+ * package, or letting the polymorphic discriminator drift would silently make those
+ * rows undecodable on the next read.
+ *
+ * To make that contract explicit and resilient to a Kotlin-only refactor :
+ * - every `@SerialName` below is **frozen** to the historical value — moving
+ *   `PostBlock.Paragraph` to another file or package no longer changes the JSON
+ *   discriminator, because the discriminator is now the explicit string here, not
+ *   the FQN that kotlinx.serialization picks by default.
+ * - every property name on a `data class` is also pinned via `@SerialName` so a
+ *   rename in code keeps writing the same JSON key.
+ *
+ * If you need to evolve the on-disk shape (rename a sealed case, add a NOT-NULL
+ * field), bump the Room database version and write a migration that rewrites every
+ * `posts.content` row, the same way `MIGRATION_2_3` rebuilt `flag_topics`.
+ *
+ * The frozen contract is pinned by `PostContentSerializerTest` in `:core:database`.
+ */
 @Serializable
 data class PostContent(
-    val blocks: List<PostBlock>,
+    @SerialName("blocks") val blocks: List<PostBlock>,
 )
 
 @Serializable
 sealed interface PostBlock {
     @Serializable
-    data class Paragraph(val inlines: List<PostInline>) : PostBlock
-
-    @Serializable
-    data class Quote(
-        val author: String?,
-        val numreponse: Int?,
-        val page: Int?,
-        val content: PostContent,
+    @SerialName("fr.forumhfr.redface2.core.model.PostBlock.Paragraph")
+    data class Paragraph(
+        @SerialName("inlines") val inlines: List<PostInline>,
     ) : PostBlock
 
     @Serializable
-    data class Spoiler(val label: String?, val content: PostContent) : PostBlock
+    @SerialName("fr.forumhfr.redface2.core.model.PostBlock.Quote")
+    data class Quote(
+        @SerialName("author") val author: String?,
+        @SerialName("numreponse") val numreponse: Int?,
+        @SerialName("page") val page: Int?,
+        @SerialName("content") val content: PostContent,
+    ) : PostBlock
 
     @Serializable
-    data class Image(val url: String, val description: String?) : PostBlock
+    @SerialName("fr.forumhfr.redface2.core.model.PostBlock.Spoiler")
+    data class Spoiler(
+        @SerialName("label") val label: String?,
+        @SerialName("content") val content: PostContent,
+    ) : PostBlock
+
+    @Serializable
+    @SerialName("fr.forumhfr.redface2.core.model.PostBlock.Image")
+    data class Image(
+        @SerialName("url") val url: String,
+        @SerialName("description") val description: String?,
+    ) : PostBlock
 }
 
 @Serializable
 sealed interface PostInline {
     @Serializable
-    data class Text(val value: String) : PostInline
+    @SerialName("fr.forumhfr.redface2.core.model.PostInline.Text")
+    data class Text(@SerialName("value") val value: String) : PostInline
 
     @Serializable
+    @SerialName("fr.forumhfr.redface2.core.model.PostInline.LineBreak")
     data object LineBreak : PostInline
 
     @Serializable
-    data class Strong(val children: List<PostInline>) : PostInline
+    @SerialName("fr.forumhfr.redface2.core.model.PostInline.Strong")
+    data class Strong(@SerialName("children") val children: List<PostInline>) : PostInline
 
     @Serializable
-    data class Emphasis(val children: List<PostInline>) : PostInline
+    @SerialName("fr.forumhfr.redface2.core.model.PostInline.Emphasis")
+    data class Emphasis(@SerialName("children") val children: List<PostInline>) : PostInline
 
     @Serializable
-    data class Underline(val children: List<PostInline>) : PostInline
+    @SerialName("fr.forumhfr.redface2.core.model.PostInline.Underline")
+    data class Underline(@SerialName("children") val children: List<PostInline>) : PostInline
 
     @Serializable
-    data class Strike(val children: List<PostInline>) : PostInline
+    @SerialName("fr.forumhfr.redface2.core.model.PostInline.Strike")
+    data class Strike(@SerialName("children") val children: List<PostInline>) : PostInline
 
     @Serializable
-    data class Color(val colorHex: String, val children: List<PostInline>) : PostInline
+    @SerialName("fr.forumhfr.redface2.core.model.PostInline.Color")
+    data class Color(
+        @SerialName("colorHex") val colorHex: String,
+        @SerialName("children") val children: List<PostInline>,
+    ) : PostInline
 
     @Serializable
-    data class Link(val url: String, val children: List<PostInline>) : PostInline
+    @SerialName("fr.forumhfr.redface2.core.model.PostInline.Link")
+    data class Link(
+        @SerialName("url") val url: String,
+        @SerialName("children") val children: List<PostInline>,
+    ) : PostInline
 
     @Serializable
-    data class InlineImage(val url: String, val description: String?) : PostInline
+    @SerialName("fr.forumhfr.redface2.core.model.PostInline.InlineImage")
+    data class InlineImage(
+        @SerialName("url") val url: String,
+        @SerialName("description") val description: String?,
+    ) : PostInline
 
     @Serializable
-    data class Smiley(val kind: SmileyKind, val imageUrl: String?) : PostInline
+    @SerialName("fr.forumhfr.redface2.core.model.PostInline.Smiley")
+    data class Smiley(
+        @SerialName("kind") val kind: SmileyKind,
+        @SerialName("imageUrl") val imageUrl: String?,
+    ) : PostInline
 }
 
 @Serializable
 sealed interface SmileyKind {
     @Serializable
-    data class Builtin(val code: String) : SmileyKind
+    @SerialName("fr.forumhfr.redface2.core.model.SmileyKind.Builtin")
+    data class Builtin(@SerialName("code") val code: String) : SmileyKind
 
     @Serializable
-    data class Perso(val name: String) : SmileyKind
+    @SerialName("fr.forumhfr.redface2.core.model.SmileyKind.Perso")
+    data class Perso(@SerialName("name") val name: String) : SmileyKind
 }


### PR DESCRIPTION
## Contexte

Audit suite au hotfix Room (#119). Même famille de bug : un rename Kotlin sur une classe sérialisée sur disque → tous les rows existants deviennent indécodables, et **aucun bump Room ne le détecte** parce que la colonne (texte JSON) n'a pas changé de schéma SQL.

Trois contrats sérialisés à risque identifiés et figés :

## 1. `PostContent` AST (persisté dans `posts.content`)

Sealed hierarchy polymorphique sans aucun `@SerialName`. kotlinx.serialization tombait sur le FQN par défaut (`fr.forumhfr.redface2.core.model.PostBlock.Paragraph`). Tout move de package ou rename de classe sealed cassait les caches existants.

- `@SerialName` figés à la valeur FQN actuelle sur **chaque sealed case** (`PostBlock`, `PostInline`, `SmileyKind`). Format JSON byte-identique, mais déconnecté du nom Kotlin.
- `@SerialName` sur **chaque property** de chaque data class.
- Nouveau `PostContentSerializerTest` (`:core:database`) : round-trip tous kinds, fixture JSON figée, tolérance aux champs inconnus futurs.

## 2. `PollDto` (persisté dans `topic_pages.pollJson`)

Tous les champs étaient `val String`/`val Int`/`val Boolean` sans default ni `@SerialName`. Un rename ou un changement HFR → crash au prochain read d'un topic avec sondage cached.

- `@SerialName` + defaults sur tous les champs de `PollDto` et `PollOptionDto`.
- `TopicMappers.toDomain` wrappe le decode dans `runCatching` qui retourne `poll = null` en cas d'échec — match la politique de dégradation existante ("un sondage manquant > un écran topic crashé").

## 3. `CookieDto` (persisté dans DataStore `hfr_cookies`)

8 champs sans `@SerialName` ni default. `runCatching` upstream évitait le crash mais un champ manquant wipait toute la liste → logout silencieux pour tous les users à un futur rename.

- `@SerialName` + defaults partout.
- Deux nouveaux tests dans `DataStoreCookieStoreTest` : un payload "key set historique" toujours décodable, un payload tronqué (champ futur manquant) qui survit grâce aux defaults.

## 4. `Converters` defensive enum reads

`FetchMode.valueOf(value)` et `FlagType.valueOf(value)` jetaient `IllegalArgumentException` si une valeur enum est renommée. Maintenant `runCatching` avec fallback (`AUTHENTICATED` / `CYAN`). Pas un substitut pour une vraie migration — KDoc rappelle que renommer une valeur enum doit bumper Room — mais évite que le DAO ne plante sur des rows legacy.

## Format JSON inchangé

Aucun row existant n'est invalidé par cette PR : tous les `@SerialName` sont posés sur la valeur déjà produite par kotlinx.serialization. C'est un gel défensif, pas une migration. La protection s'active si quelqu'un fait un refactor Kotlin futur (move package, rename class/property) — sans ces annotations, ça aurait été un autre #119.

## Tests

- `:core:database:testDebugUnitTest` ✅ (incluant 3 nouveaux `PostContentSerializerTest` + les 2 `MigrationTest`)
- `:core:data:testDebugUnitTest` ✅ (incluant 2 nouveaux `DataStoreCookieStoreTest`)
- `:app:testDebugUnitTest` ✅

## Stack avec #119

Branche basée sur `fix/room-schema-v3-flag-topics-rebuild` (PR #119). Au merge de #119 dans main, les commits Room disparaissent du diff de cette PR. Si #119 est mergée, je rebase sur main.

> Action par Claude Opus 4.7 (demandée par @XaaT)