### PR TITLE
feat(parser): support [fixed] and [code] block kinds (#79)

### DIFF
--- a/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/serialization/PostContentSerializerTest.kt
+++ b/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/serialization/PostContentSerializerTest.kt
@@ -182,6 +182,20 @@ class PostContentSerializerTest {
                   "type": "fr.forumhfr.redface2.core.model.PostBlock.Image",
                   "url": "https://example.invalid/i.png",
                   "description": "block alt"
+                },
+                {
+                  "type": "fr.forumhfr.redface2.core.model.PostBlock.Fixed",
+                  "text": "indented line\nsecond line"
+                },
+                {
+                  "type": "fr.forumhfr.redface2.core.model.PostBlock.CodeBlock",
+                  "text": "println(\"hi\")",
+                  "language": "kotlin"
+                },
+                {
+                  "type": "fr.forumhfr.redface2.core.model.PostBlock.CodeBlock",
+                  "text": "no lang here",
+                  "language": null
                 }
               ]
             }
@@ -281,6 +295,9 @@ class PostContentSerializerTest {
                 url = "https://example.invalid/i.png",
                 description = "block alt",
             ),
+            PostBlock.Fixed(text = "indented line\nsecond line"),
+            PostBlock.CodeBlock(text = "println(\"hi\")", language = "kotlin"),
+            PostBlock.CodeBlock(text = "no lang here", language = null),
         ),
     )
 

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/PostContent.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/PostContent.kt
@@ -60,6 +60,19 @@ sealed interface PostBlock {
         @SerialName("url") val url: String,
         @SerialName("description") val description: String?,
     ) : PostBlock
+
+    @Serializable
+    @SerialName("fr.forumhfr.redface2.core.model.PostBlock.Fixed")
+    data class Fixed(
+        @SerialName("text") val text: String,
+    ) : PostBlock
+
+    @Serializable
+    @SerialName("fr.forumhfr.redface2.core.model.PostBlock.CodeBlock")
+    data class CodeBlock(
+        @SerialName("text") val text: String,
+        @SerialName("language") val language: String?,
+    ) : PostBlock
 }
 
 @Serializable

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
@@ -112,9 +112,11 @@ class PostContentParser {
         // HFR renders [quotemsg=...] as <table class="citation"> (with author anchor) and
         // [quote] (anonymous) as <table class="quote"> — both map to the same Quote block.
         element.selectFirst("table.citation, table.quote") != null -> NodeKind.QUOTE
-        // Defensive: most quotes are wrapped in <div class="container">, but if a future skin
-        // change drops the wrapper for fixed/code (the same way quotes already are sometimes
-        // emitted), we still want to catch them here before falling through to PARAGRAPH.
+        // Speculative defense: every fixture captured so far emits [fixed] / [code] as a <table>
+        // child direct of <div id="paraN"> (handled by classifyTable above), never wrapped in a
+        // <div class="container">. If a future HFR skin starts wrapping these blocks the way it
+        // already wraps quotes, this branch keeps the body out of the surrounding paragraph
+        // instead of falling through to PARAGRAPH_CONTAINER. Not exercised by any current test.
         element.selectFirst("table.fixed") != null -> NodeKind.FIXED_BLOCK
         element.selectFirst("table.code") != null -> NodeKind.CODE_BLOCK
         element.attr("style").contains("clear: both") -> NodeKind.IGNORE
@@ -247,12 +249,17 @@ class PostContentParser {
 
     /**
      * Extracts the visible source text from a `[fixed]` / `[code]` table cell. The clone is
-     * mutated in place: each `<br>` becomes a literal newline so single-line authoring survives,
+     * mutated in place:
+     *   - each `<br>` becomes a literal newline so single-line authoring survives ;
+     *   - each `<p>` is suffixed with a newline so a multi-paragraph `[fixed]` body keeps its
+     *     paragraph separations — `wholeText()` does not insert whitespace between sibling block
+     *     elements, so `<p>A</p><p>B</p>` would otherwise collapse into `AB` ;
      * then `wholeText()` walks the DOM preserving whitespace so indentation inside `<pre>` stays
      * intact (unlike `text()`, which collapses runs of whitespace to a single space).
      */
     private fun extractCellText(element: Element): String {
         element.select("br").forEach { it.replaceWith(TextNode("\n")) }
+        element.select("p").forEach { it.appendChild(TextNode("\n")) }
         return element.wholeText().trim()
     }
 

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
@@ -112,11 +112,10 @@ class PostContentParser {
         // HFR renders [quotemsg=...] as <table class="citation"> (with author anchor) and
         // [quote] (anonymous) as <table class="quote"> — both map to the same Quote block.
         element.selectFirst("table.citation, table.quote") != null -> NodeKind.QUOTE
-        // Speculative defense: every fixture captured so far emits [fixed] / [code] as a <table>
-        // child direct of <div id="paraN"> (handled by classifyTable above), never wrapped in a
-        // <div class="container">. If a future HFR skin starts wrapping these blocks the way it
-        // already wraps quotes, this branch keeps the body out of the surrounding paragraph
-        // instead of falling through to PARAGRAPH_CONTAINER. Not exercised by any current test.
+        // Defensive wrapper support: every fixture captured so far emits [fixed] / [code] as a
+        // <table> child direct of <div id="paraN"> (handled by classifyTable above), but quotes
+        // use <div class="container"> wrappers. Synthetic tests pin this fallback so a future HFR
+        // skin wrapping monospace blocks would still keep them out of the surrounding paragraph.
         element.selectFirst("table.fixed") != null -> NodeKind.FIXED_BLOCK
         element.selectFirst("table.code") != null -> NodeKind.CODE_BLOCK
         element.attr("style").contains("clear: both") -> NodeKind.IGNORE
@@ -255,12 +254,22 @@ class PostContentParser {
      *     paragraph separations — `wholeText()` does not insert whitespace between sibling block
      *     elements, so `<p>A</p><p>B</p>` would otherwise collapse into `AB` ;
      * then `wholeText()` walks the DOM preserving whitespace so indentation inside `<pre>` stays
-     * intact (unlike `text()`, which collapses runs of whitespace to a single space).
+     * intact (unlike `text()`, which collapses runs of whitespace to a single space). Only empty
+     * boundary lines injected by the HTML structure are trimmed; leading spaces on real content
+     * lines are part of the `[fixed]` / `[code]` contract and must survive.
      */
     private fun extractCellText(element: Element): String {
         element.select("br").forEach { it.replaceWith(TextNode("\n")) }
         element.select("p").forEach { it.appendChild(TextNode("\n")) }
-        return element.wholeText().trim()
+        return element.wholeText().trimStructuralBlankLines()
+    }
+
+    private fun String.trimStructuralBlankLines(): String {
+        val lines = replace("\r\n", "\n").replace('\r', '\n').split('\n')
+        val firstContentLine = lines.indexOfFirst { it.isNotBlank() }
+        if (firstContentLine == -1) return ""
+        val lastContentLine = lines.indexOfLast { it.isNotBlank() }
+        return lines.subList(firstContentLine, lastContentLine + 1).joinToString("\n")
     }
 
     /**

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
@@ -68,6 +68,16 @@ class PostContentParser {
                     parseImageBlock(node as Element)?.let(blocks::add)
                 }
 
+                NodeKind.FIXED_BLOCK -> {
+                    flushParagraph()
+                    parseFixedBlock(node as Element)?.let(blocks::add)
+                }
+
+                NodeKind.CODE_BLOCK -> {
+                    flushParagraph()
+                    parseCodeBlock(node as Element)?.let(blocks::add)
+                }
+
                 NodeKind.INLINE -> paragraph += parseInline(node)
 
                 NodeKind.PARAGRAPH_CONTAINER -> {
@@ -88,6 +98,11 @@ class PostContentParser {
             "div" -> classifyDiv(element)
             "p" -> NodeKind.PARAGRAPH_CONTAINER
             "img" -> if (isStandaloneImage(element)) NodeKind.IMAGE_BLOCK else NodeKind.INLINE
+            // HFR emits [fixed] / [code] as <table> children direct of <div id="paraN">, with no
+            // wrapping <div class="container"> like quotes have. The classifyDiv path therefore
+            // never sees them; recognising them at the top level here is what keeps the body
+            // out of the surrounding paragraph (see classifyTable for the per-class dispatch).
+            "table" -> classifyTable(element)
             else -> NodeKind.INLINE
         }
     }
@@ -97,8 +112,21 @@ class PostContentParser {
         // HFR renders [quotemsg=...] as <table class="citation"> (with author anchor) and
         // [quote] (anonymous) as <table class="quote"> — both map to the same Quote block.
         element.selectFirst("table.citation, table.quote") != null -> NodeKind.QUOTE
+        // Defensive: most quotes are wrapped in <div class="container">, but if a future skin
+        // change drops the wrapper for fixed/code (the same way quotes already are sometimes
+        // emitted), we still want to catch them here before falling through to PARAGRAPH.
+        element.selectFirst("table.fixed") != null -> NodeKind.FIXED_BLOCK
+        element.selectFirst("table.code") != null -> NodeKind.CODE_BLOCK
         element.attr("style").contains("clear: both") -> NodeKind.IGNORE
         else -> NodeKind.PARAGRAPH_CONTAINER
+    }
+
+    private fun classifyTable(element: Element): NodeKind = when {
+        element.hasClass("spoiler") -> NodeKind.SPOILER
+        element.hasClass("citation") || element.hasClass("quote") -> NodeKind.QUOTE
+        element.hasClass("fixed") -> NodeKind.FIXED_BLOCK
+        element.hasClass("code") -> NodeKind.CODE_BLOCK
+        else -> NodeKind.INLINE
     }
 
     private fun isStandaloneImage(element: Element): Boolean {
@@ -114,7 +142,7 @@ class PostContentParser {
     }
 
     private fun parseQuote(element: Element): PostBlock.Quote? {
-        val table = element.selectFirst("table.citation, table.quote")
+        val table = resolveTable(element, "table.citation, table.quote")
         val cell = table?.selectFirst("td")?.clone()
         if (table == null || cell == null) return null
 
@@ -150,7 +178,7 @@ class PostContentParser {
     }
 
     private fun parseSpoiler(element: Element): PostBlock.Spoiler? {
-        val table = element.selectFirst("table.spoiler")
+        val table = resolveTable(element, "table.spoiler")
         val cell = table?.selectFirst("td")?.clone()
         if (table == null || cell == null) return null
 
@@ -182,6 +210,62 @@ class PostContentParser {
         val description = element.attr("alt").ifBlank { element.attr("title") }.takeIf(String::isNotBlank)
         return PostBlock.Image(url = url, description = description)
     }
+
+    private fun parseFixedBlock(element: Element): PostBlock.Fixed? {
+        val cell = resolveTable(element, "table.fixed")?.selectFirst("td")?.clone() ?: return null
+        // Defensive: HFR currently renders [fixed] without the "Code :" label, but if a future
+        // skin re-uses <b class="s1"> as a header here, drop it the same way parseCodeBlock does.
+        cell.select("b.s1").remove()
+        val text = extractCellText(cell)
+        return text.takeIf(String::isNotBlank)?.let { PostBlock.Fixed(it) }
+    }
+
+    private fun parseCodeBlock(element: Element): PostBlock.CodeBlock? {
+        val cell = resolveTable(element, "table.code")?.selectFirst("td")?.clone() ?: return null
+        cell.select("b.s1").remove()
+
+        // [code lang] renders the body inside <pre class="<lang>"> (e.g. <pre class="cpp">). The
+        // language hint sits on that element. Plain [code] uses <ol class="olcode"> directly under
+        // the <td> with no <pre>, hence language stays null.
+        val pre = cell.selectFirst("pre")
+        val language = pre?.classNames()?.firstOrNull()?.takeIf(String::isNotBlank)
+
+        // Both shapes ultimately wrap each source line in an <li>:
+        //   - plain:    <ol class="olcode"><li>line</li>...</ol>
+        //   - colored:  <pre class="cpp"><ol><li class="li1"><div class="de1">line</div></li>...</ol></pre>
+        // Joining li.wholeText() with \n flattens the syntax-highlight spans (kw3/me1/st0/de1)
+        // into raw source text — Phase 1 contract per issue #79; coloration is Phase 2 work.
+        val items = cell.select("li")
+        val text = if (items.isNotEmpty()) {
+            items.joinToString("\n") { extractCellText(it) }
+        } else {
+            extractCellText(cell)
+        }
+        return text.takeIf(String::isNotBlank)
+            ?.let { PostBlock.CodeBlock(text = it, language = language) }
+    }
+
+    /**
+     * Extracts the visible source text from a `[fixed]` / `[code]` table cell. The clone is
+     * mutated in place: each `<br>` becomes a literal newline so single-line authoring survives,
+     * then `wholeText()` walks the DOM preserving whitespace so indentation inside `<pre>` stays
+     * intact (unlike `text()`, which collapses runs of whitespace to a single space).
+     */
+    private fun extractCellText(element: Element): String {
+        element.select("br").forEach { it.replaceWith(TextNode("\n")) }
+        return element.wholeText().trim()
+    }
+
+    /**
+     * HFR can emit the same semantic block in two shapes:
+     *   - `<div class="container"><table class="<kind>">...</table></div>` (typical for quotes)
+     *   - `<table class="<kind>">...</table>` direct child of `<div id="paraN">` (typical for
+     *     `[fixed]` / `[code]`).
+     * The classifier dispatches both shapes to the same parse method; this helper resolves the
+     * table element regardless of whether [element] is the wrapping div or the table itself.
+     */
+    private fun resolveTable(element: Element, selector: String): Element? =
+        if (element.tagName() == "table") element else element.selectFirst(selector)
 
     private fun parseInline(node: Node): List<PostInline> = when (node) {
         is TextNode -> listOfNotNull(normalizeText(node.text())?.let(PostInline::Text))
@@ -350,6 +434,8 @@ class PostContentParser {
         QUOTE,
         SPOILER,
         IMAGE_BLOCK,
+        FIXED_BLOCK,
+        CODE_BLOCK,
         INLINE,
         PARAGRAPH_CONTAINER,
     }

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
@@ -492,6 +492,36 @@ class PostContentParserTest {
     }
 
     @Test
+    fun `fixed and code blocks preserve leading indentation`() {
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            """
+            <div id="para123">
+                <table class="fixed"><tr class="none"><td><p>    fixed indentation<br>  fixed second</p></td></tr></table>
+                <table class="code">
+                    <tr class="none">
+                        <td>
+                            <b class="s1">Code :</b><br>
+                            <ol id="code1" class="olcode">
+                                <li>    val value = 42</li>
+                                <li>        println(value)</li>
+                            </ol>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            """.trimIndent(),
+        )
+
+        val result = parser.parse(element)
+
+        val fixed = result.ast.allBlocks().filterIsInstance<PostBlock.Fixed>().single()
+        val code = result.ast.allBlocks().filterIsInstance<PostBlock.CodeBlock>().single()
+        assertEquals("    fixed indentation\n  fixed second", fixed.text)
+        assertEquals("    val value = 42\n        println(value)", code.text)
+    }
+
+    @Test
     fun `synthetic code table without pre wrapper has null language`() {
         val parser = PostContentParser()
         val element = jsoupBody(

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
@@ -425,6 +425,73 @@ class PostContentParserTest {
     }
 
     @Test
+    fun `witness fixture topic_page_multipage produces fixed and three code blocks`() {
+        // Issue #79 explicitly cites this fixture (line 218) as the original witness for
+        // [fixed] / [code] parsing. Asserting on its contents — not just on the richer
+        // topic_redface2_p16 — closes the issue's "Périmètre" checkbox literally and protects
+        // the historical baseline from silent regressions.
+        val topic = pageParser.parse(fixture("topic_page_multipage.html"))
+
+        val blocks = topic.posts.flatMap { post -> post.content.allBlocks() }
+        val fixedBlocks = blocks.filterIsInstance<PostBlock.Fixed>()
+        val codeBlocks = blocks.filterIsInstance<PostBlock.CodeBlock>()
+
+        assertEquals("witness fixture has exactly one [fixed] block", 1, fixedBlocks.size)
+        assertEquals("witness fixture has exactly three [code] blocks", 3, codeBlocks.size)
+
+        val fixed = fixedBlocks.first().text
+        assertTrue("fixed body must contain `Ceci est un test`, got=$fixed", fixed.contains("Ceci est un test"))
+        assertTrue("fixed body must contain `abcdefghi`, got=$fixed", fixed.contains("abcdefghi"))
+        assertTrue("fixed body must contain `123456789`, got=$fixed", fixed.contains("123456789"))
+
+        val javaBlock = codeBlocks.firstOrNull { it.language == "java" }
+        assertNotNull("expected one [code lang=java] block on the witness fixture", javaBlock)
+        // The colored cpp/java shape wraps the source in <pre class="java"><ol><li><div class="de1">…</div></li>…
+        // — wholeText() flattens the syntax-highlight spans so the body is the raw source line.
+        // HFR encodes ` );` (space before the closing paren) and decodes &quot; into ".
+        assertTrue(
+            "java code body must contain the println call, got=${javaBlock!!.text}",
+            javaBlock.text.contains("""System.out.println("Code Java" );"""),
+        )
+        assertEquals(
+            "two plain [code] blocks (no <pre lang>) must surface language=null",
+            2,
+            codeBlocks.count { it.language == null },
+        )
+    }
+
+    @Test
+    fun `multi paragraph fixed cell preserves a separator between paragraphs`() {
+        // Defensive coverage: HFR's current rendering wraps a single-paragraph [fixed] body in
+        // one <p>, but if a future skin emits multiple <p> siblings inside the cell, wholeText()
+        // would collapse them into a single line ("AB") because it does not insert whitespace
+        // between block-level elements. extractCellText counters that by suffixing each <p>
+        // with a newline before flattening.
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            """
+            <div id="para123">
+                <table class="fixed"><tr class="none"><td><p>line one</p><p>line two</p></td></tr></table>
+            </div>
+            """.trimIndent(),
+        )
+
+        val result = parser.parse(element)
+
+        val fixed = result.ast.allBlocks().filterIsInstance<PostBlock.Fixed>().firstOrNull()
+        assertNotNull("synthetic multi-paragraph [fixed] should still produce one Fixed block", fixed)
+        assertTrue(
+            "Fixed.text should keep paragraphs separated, got=${fixed!!.text}",
+            fixed.text.contains("line one") && fixed.text.contains("line two") &&
+                fixed.text.indexOf("line one") < fixed.text.indexOf("line two"),
+        )
+        assertTrue(
+            "Fixed.text should not collapse paragraphs into `line oneline two`",
+            !fixed.text.contains("line oneline two"),
+        )
+    }
+
+    @Test
     fun `synthetic code table without pre wrapper has null language`() {
         val parser = PostContentParser()
         val element = jsoupBody(

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
@@ -330,6 +330,133 @@ class PostContentParserTest {
     }
 
     @Test
+    fun `fixed and code tables are recognised as their own block kinds`() {
+        // Witness post on topic_redface2_p16 was authored explicitly to feed the parser:
+        // XaTriX posted a series of [fixed] / [code] blocks and re-quoted them. The fixture
+        // therefore contains 9 [fixed], 19 [code] (4 with a cpp language hint via <pre>).
+        val topic = pageParser.parse(fixture("topic_redface2_p16.html"))
+
+        val blocks = topic.posts.flatMap { post -> post.content.allBlocks() }
+        val fixedBlocks = blocks.filterIsInstance<PostBlock.Fixed>()
+        val codeBlocks = blocks.filterIsInstance<PostBlock.CodeBlock>()
+
+        assertTrue(
+            "page 16 fixture should expose [fixed] blocks; if 0 they fell back to inline text",
+            fixedBlocks.isNotEmpty(),
+        )
+        assertTrue(
+            "page 16 fixture should expose [code] blocks; if 0 they fell back to inline text",
+            codeBlocks.isNotEmpty(),
+        )
+        assertTrue(
+            "fixed text content should match what XaTriX posted (`Salut je suis un fixed`)",
+            fixedBlocks.any { it.text == "Salut je suis un fixed" },
+        )
+        assertTrue(
+            "default [code] body should be `je suis un truc de code`",
+            codeBlocks.any { it.text == "je suis un truc de code" && it.language == null },
+        )
+    }
+
+    @Test
+    fun `code block with explicit language hint surfaces the pre class as language`() {
+        val topic = pageParser.parse(fixture("topic_redface2_p16.html"))
+
+        val coloredCpp = topic.posts
+            .flatMap { post -> post.content.allBlocks() }
+            .filterIsInstance<PostBlock.CodeBlock>()
+            .firstOrNull { it.language == "cpp" }
+
+        assertNotNull("expected at least one [code lang=cpp] block on page 16", coloredCpp)
+        // HFR wraps the colored body in <pre class="cpp"><ol><li><div class="de1">...</div></li></ol></pre>.
+        // Phase 1 contract per issue #79: the syntax-highlight spans (kw3 / me1 / st0) collapse
+        // to raw source text — coloration is Phase 2 work.
+        assertEquals("là du code en cpp", coloredCpp!!.text)
+    }
+
+    @Test
+    fun `fixed and code blocks survive being nested inside a quote`() {
+        // XaTriX re-quoted his own [fixed] / [code] dump — the quote walker must descend into the
+        // citation and surface the wrapped blocks as Fixed/CodeBlock, not as flattened paragraphs.
+        val topic = pageParser.parse(fixture("topic_redface2_p16.html"))
+
+        val nestedFixed = topic.posts
+            .flatMap { post -> post.content.allBlocks() }
+            .filterIsInstance<PostBlock.Quote>()
+            .flatMap { it.content.blocks.filterIsInstance<PostBlock.Fixed>() }
+        val nestedCode = topic.posts
+            .flatMap { post -> post.content.allBlocks() }
+            .filterIsInstance<PostBlock.Quote>()
+            .flatMap { it.content.blocks.filterIsInstance<PostBlock.CodeBlock>() }
+
+        assertTrue(
+            "at least one quote on page 16 wraps a [fixed] block — got=${nestedFixed.size}",
+            nestedFixed.isNotEmpty(),
+        )
+        assertTrue(
+            "at least one quote on page 16 wraps a [code] block — got=${nestedCode.size}",
+            nestedCode.isNotEmpty(),
+        )
+    }
+
+    @Test
+    fun `synthetic fixed table is parsed as a single Fixed block`() {
+        // Boundary check decoupled from the live capture: confirms the classifier picks
+        // <table class="fixed"> before <table class="code"> falls through and prevents the
+        // legacy regression where a [fixed] body was flattened into the surrounding paragraph.
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            """
+            <div id="para123">
+                <p>before</p>
+                <div class="container">
+                    <table class="fixed"><tr class="none"><td><p>line one<br>line two</p></td></tr></table>
+                </div>
+                <p>after</p>
+            </div>
+            """.trimIndent(),
+        )
+
+        val result = parser.parse(element)
+
+        val fixed = result.ast.allBlocks().filterIsInstance<PostBlock.Fixed>()
+        assertEquals("exactly one Fixed block expected", 1, fixed.size)
+        assertEquals("line one\nline two", fixed.first().text)
+    }
+
+    @Test
+    fun `synthetic code table without pre wrapper has null language`() {
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            """
+            <div id="para123">
+                <div class="container">
+                    <table class="code">
+                        <tr class="none">
+                            <td>
+                                <b class="s1">Code :</b><br>
+                                <ol id="code1" class="olcode">
+                                    <li>line one</li>
+                                    <li>line two</li>
+                                </ol>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+            """.trimIndent(),
+        )
+
+        val result = parser.parse(element)
+
+        val code = result.ast.allBlocks().filterIsInstance<PostBlock.CodeBlock>()
+        assertEquals("exactly one CodeBlock expected", 1, code.size)
+        assertEquals(null, code.first().language)
+        // The "Code :" header is dropped; <li> children are joined with newlines.
+        assertEquals("line one\nline two", code.first().text)
+    }
+
+    @Test
     fun `non-http schemes other than data and javascript are also rejected`() {
         val parser = PostContentParser()
         val element = jsoupBody(
@@ -408,6 +535,8 @@ private fun walkBlocks(blocks: List<PostBlock>, out: MutableList<PostInline>) {
             is PostBlock.Quote -> walkBlocks(block.content.blocks, out)
             is PostBlock.Spoiler -> walkBlocks(block.content.blocks, out)
             is PostBlock.Image -> Unit
+            is PostBlock.Fixed -> Unit
+            is PostBlock.CodeBlock -> Unit
         }
     }
 }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -1,12 +1,14 @@
 package fr.forumhfr.redface2.core.ui.post
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.material3.Card
@@ -30,6 +32,7 @@ import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
@@ -70,6 +73,8 @@ private fun PostBlocksRenderer(
                 is PostBlock.Quote -> QuoteBlock(block, quoteDepth)
                 is PostBlock.Spoiler -> SpoilerBlock(block, quoteDepth)
                 is PostBlock.Image -> ImageBlock(block)
+                is PostBlock.Fixed -> FixedBlock(block)
+                is PostBlock.CodeBlock -> CodeBlockBlock(block)
             }
         }
     }
@@ -245,6 +250,61 @@ private fun ImageBlock(block: PostBlock.Image) {
         contentDescription = block.description,
         modifier = Modifier.fillMaxWidth(),
     )
+}
+
+@Composable
+private fun FixedBlock(block: PostBlock.Fixed) {
+    MonospaceContainer {
+        Text(
+            text = block.text,
+            style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+@Composable
+private fun CodeBlockBlock(block: PostBlock.CodeBlock) {
+    MonospaceContainer {
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            block.language?.let { lang ->
+                Text(
+                    text = lang,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Text(
+                text = block.text,
+                style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+    }
+}
+
+/**
+ * Wraps a `[fixed]` / `[code]` body in a tinted card with horizontal scroll. Long lines (raw URL,
+ * indented snippets, syntax-highlighted source) overflow horizontally instead of wrapping — wrap
+ * would mangle indentation and break the visual contract of a monospace block.
+ */
+@Composable
+private fun MonospaceContainer(content: @Composable () -> Unit) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+        ),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState())
+                .padding(12.dp),
+        ) {
+            content()
+        }
+    }
 }
 
 internal fun buildInlineText(

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -259,6 +259,7 @@ private fun FixedBlock(block: PostBlock.Fixed) {
             text = block.text,
             style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
             color = MaterialTheme.colorScheme.onSurface,
+            softWrap = false,
         )
     }
 }
@@ -278,6 +279,7 @@ private fun CodeBlockBlock(block: PostBlock.CodeBlock) {
                 text = block.text,
                 style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
                 color = MaterialTheme.colorScheme.onSurface,
+                softWrap = false,
             )
         }
     }
@@ -285,8 +287,15 @@ private fun CodeBlockBlock(block: PostBlock.CodeBlock) {
 
 /**
  * Wraps a `[fixed]` / `[code]` body in a tinted card with horizontal scroll. Long lines (raw URL,
- * indented snippets, syntax-highlighted source) overflow horizontally instead of wrapping — wrap
- * would mangle indentation and break the visual contract of a monospace block.
+ * indented snippets, syntax-highlighted source) must overflow horizontally instead of wrapping —
+ * wrap would mangle indentation and break the visual contract of a monospace block.
+ *
+ * Modifier order matters here: the **outer** [Card] carries [Modifier.fillMaxWidth] so the card
+ * itself spans the parent. The **inner** [Column] must NOT carry [Modifier.fillMaxWidth] before
+ * [Modifier.horizontalScroll] — that would clamp the children's measured width to the card's
+ * width and turn the scroll into a no-op. [Modifier.padding] sits before the scroll modifier so
+ * the inset is fixed and the children scroll inside it (otherwise the left padding would slide
+ * out of view on overflow). The monospace [Text] children opt out of soft wrap explicitly.
  */
 @Composable
 private fun MonospaceContainer(content: @Composable () -> Unit) {
@@ -298,9 +307,8 @@ private fun MonospaceContainer(content: @Composable () -> Unit) {
     ) {
         Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .horizontalScroll(rememberScrollState())
-                .padding(12.dp),
+                .padding(12.dp)
+                .horizontalScroll(rememberScrollState()),
         ) {
             content()
         }

--- a/docs/adr/011-postcontent-ast.md
+++ b/docs/adr/011-postcontent-ast.md
@@ -58,7 +58,7 @@ L'AST est sémantique, pas une copie de DOM HTML. Elle représente des blocs et 
 - smileys HFR builtin (`:code:`) et perso (`[:name]`) sans heuristique côté renderer ;
 - citations récursives avec auteur, `numreponse` et page quand connus ;
 - spoilers ;
-- blocs monospace `[fixed]` ;
+- blocs monospace `[fixed]` et `[code]` (avec hint langue optionnel pour `[code lang]`) ;
 - images et médias, en bloc ou inline selon le contexte HTML ou BBCode source ;
 - paragraphes et sauts de ligne.
 

--- a/docs/specs/models.md
+++ b/docs/specs/models.md
@@ -258,9 +258,9 @@ sealed interface PostBlock {
         val content: PostContent,
     ) : PostBlock
     data class Spoiler(val label: String?, val content: PostContent) : PostBlock
-    // Les blocs monospace [fixed] / [code] sont prévus par ADR-011 mais pas encore produits par le
-    // parser HTML de Phase 1 ; ils arrivent via [#79](https://github.com/ForumHFR/redface2/issues/79).
     data class Image(val url: String, val description: String?) : PostBlock
+    data class Fixed(val text: String) : PostBlock                           // BBCode [fixed], rendu monospace plein largeur
+    data class CodeBlock(val text: String, val language: String?) : PostBlock // BBCode [code], language depuis <pre class="<lang>"> ; null si [code] sans hint. Phase 1 : aplatissement de la coloration syntaxique HFR (kw3/me1/st0/de1) en texte brut, coloration reportée Phase 2.
 }
 
 sealed interface PostInline {
@@ -282,7 +282,7 @@ sealed interface SmileyKind {
 }
 ```
 
-`PostContent` est le contrat cible décrit par [ADR-011]({{ site.baseurl }}/adr/011-postcontent-ast). La dette de fragment HTML brut dans le slice topic fixe est résorbée par [#80](https://github.com/ForumHFR/redface2/pull/80) ; les blocs monospace `[fixed]` / `[code]` restent suivis par [#79](https://github.com/ForumHFR/redface2/issues/79). `PostInline.Color.colorHex` conserve la couleur sous forme textuelle normalisée (`#RRGGBB` ou `#AARRGGBB`) pour préserver le round-trip BBCode HFR.
+`PostContent` est le contrat cible décrit par [ADR-011]({{ site.baseurl }}/adr/011-postcontent-ast). La dette de fragment HTML brut dans le slice topic fixe est résorbée par [#80](https://github.com/ForumHFR/redface2/pull/80) ; les blocs monospace `[fixed]` / `[code]` sont parsés depuis Phase 1 via [#79](https://github.com/ForumHFR/redface2/issues/79). `PostInline.Color.colorHex` conserve la couleur sous forme textuelle normalisée (`#RRGGBB` ou `#AARRGGBB`) pour préserver le round-trip BBCode HFR.
 
 ---
 

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -94,7 +94,7 @@ Les dépôts en cylindre (`MPStorage2`, `hfr-redflag`) sont des **dépendances e
 - [x] Deep linking (URLs HFR → app) — `parseHfrDeepLink` corrigé (mapping `forum1.php` ↔ `forum2.php` inversé, fixé en 1C-A) et branché sur les écrans réels Forum/Category/Topic
 - [x] **Prefetch pages suivantes Phase 1D-4 (#108)** — topic `page + 1` persisté en `ANONYMOUS` sans écraser l'authentifié, listing forum `page + 1` warm-up anonyme sans exposer le payload ; annulation au changement de page / sortie d'écran
 - [ ] Images + smileys (Coil 3 — split fetcher déjà câblé via `coil-network-okhttp`)
-- [ ] Blocs monospace `[fixed]` / `[code]` — restent suivis par [#79](https://github.com/ForumHFR/redface2/issues/79) et arriveront avec une fixture réelle
+- [x] **Blocs monospace `[fixed]` / `[code]` (#79)** — `PostBlock.Fixed(text)` et `PostBlock.CodeBlock(text, language?)` parsés depuis `<table class="fixed">` / `<table class="code">` ; `PostRenderer` rend chaque bloc dans une `Card surfaceContainerHighest` à police monospace avec scroll horizontal sur overflow. Coloration syntaxique aplatie en texte brut (Phase 2).
 
 **Livrable :** une app utilisable pour **lire** le forum au quotidien. Pas encore de possibilité d'écrire.
 


### PR DESCRIPTION
> Action par Claude Opus 4.7 (1M context, demandée par @XaTriX) + correctif GPT-5 Codex demandé par @XaTriX

## Résumé

Avant cette PR, `<table class="fixed">` et `<table class="code">` tombaient dans `NodeKind.INLINE` du `PostContentParser` : leur contenu était aplati dans le paragraphe environnant, et le hint langue HFR (`<pre class="cpp">` pour `[code lang=cpp]`) était silencieusement perdu.

Closes #79.

## Modèle

```kotlin
sealed interface PostBlock {
    // …
    data class Fixed(val text: String) : PostBlock
    data class CodeBlock(val text: String, val language: String?) : PostBlock
}
```

`@SerialName` figé au FQN historique + `@SerialName` sur chaque property — leçon PR #120, un rename Kotlin ultérieur ne pourra plus corrompre des `posts.content` déjà persistées par Phase 1D.

## Parser

Diagnostic clé : HFR émet `[quote]` dans un `<div class="container">`, mais les fixtures réelles montrent `[fixed]` / `[code]` comme enfants directs du `<div id="paraN">`. Il manquait donc la branche `"table"` dans `classifyNode`.

- `classifyNode` ajoute `"table" -> classifyTable(element)` ; `classifyTable` dispatche par classe (spoiler / citation / quote / fixed / code).
- `parseQuote`, `parseSpoiler`, `parseFixedBlock`, `parseCodeBlock` acceptent soit le wrapper `<div>`, soit la `<table>` directe via `resolveTable`.
- `parseCodeBlock` extrait la langue depuis `<pre class="<lang>">` (`cpp`, `java`, etc.) et joint les `<li>` source avec `\n`. Couvre la forme plain (`<ol class="olcode"><li>…</li></ol>`) et la forme colorée (`<pre class="<lang>"><ol><li><div class="de1">…</div></li></ol></pre>`). Phase 1 : la coloration syntaxique HFR (spans `kw3` / `me1` / `st0` / `de1`) est aplatie en texte brut — coloration reportée en Phase 2.
- `extractCellText` conserve les espaces significatifs en début de ligne : seules les lignes vides structurelles de bordure sont retirées.

## Rendu

`PostRenderer` ajoute `FixedBlock` et `CodeBlockBlock` : `Card surfaceContainerHighest` à police monospace avec scroll horizontal sur overflow. Le `Card` porte `fillMaxWidth`, mais le `Column` interne ne force plus `fillMaxWidth` avant `horizontalScroll`, sinon le scroll serait un no-op. Les `Text` monospace utilisent `softWrap = false`.

## Tests

| Test | Couvre |
|---|---|
| `fixed and code tables are recognised as their own block kinds` | live `topic_redface2_p16.html` — 9 `[fixed]` + 19 `[code]` parsés |
| `code block with explicit language hint surfaces the pre class as language` | hint `cpp` extrait depuis `<pre class="cpp">` |
| `fixed and code blocks survive being nested inside a quote` | quote walker descend bien dans les blocs monospace imbriqués |
| `synthetic fixed table is parsed as a single Fixed block` | fallback wrapper `<div class="container"><table class="fixed">…` |
| `witness fixture topic_page_multipage produces fixed and three code blocks` | fixture témoin historique de #79 : 1 `[fixed]`, 3 `[code]`, dont `language="java"` |
| `multi paragraph fixed cell preserves a separator between paragraphs` | garde un séparateur entre `<p>` successifs dans une cellule monospace |
| `fixed and code blocks preserve leading indentation` | préserve les espaces significatifs en début de ligne |
| `synthetic code table without pre wrapper has null language` | forme plain `[code]` sans hint langue |
| `PostContentSerializerTest` extended | round-trip encode/decode pour `Fixed`, `CodeBlock(language="kotlin")` et `CodeBlock(language=null)` ; frozen fixture étendue |

## Specs

- `docs/specs/models.md` : nouveaux cases `Fixed` / `CodeBlock` dans le code Kotlin canonique de `PostBlock`. La note "pas encore produits" est retirée.
- `docs/adr/011-postcontent-ast.md` : `[code]` ajouté à côté de `[fixed]` dans la liste des nœuds attendus.
- `docs/specs/roadmap.md` : Phase 1 case "Blocs monospace" flip ☐ → ✅.

## Test plan

- [x] `./scripts/docker-dev.sh ./gradlew :core:parser:test --rerun-tasks` → BUILD SUCCESSFUL
- [x] `./scripts/docker-dev.sh ./gradlew :core:database:testDebugUnitTest :core:ui:testDebugUnitTest --rerun-tasks` → BUILD SUCCESSFUL
- [x] `./scripts/docker-dev.sh ./gradlew detektAll` → BUILD SUCCESSFUL
- [x] CI GitHub `Build, lint and test` verte sur `6a9288a`
- [ ] Smoke test sur AAB (post #2783631 du topic Redface 2 : afficher les 3 blocs [fixed]/[code]/[code lang=cpp]) — à faire après merge
