### PR TITLE
chore(release): bump app to v30

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -15,6 +15,29 @@ Workflow : bumper `versionCode` + `versionName` dans `app/build.gradle.kts`, ajo
 
 ---
 
+## v30 — `0.1.0-phase1d.2` — 2026-05-04
+
+**Statut** : `local`
+**Commit** : à venir
+**Fichier** : `redface2-v30-<date>-<sha>.aab`
+
+Release Phase 1D après merge de [#123](https://github.com/ForumHFR/redface2/pull/123) : support natif des blocs monospace HFR `[fixed]` / `[code]`.
+
+### Added
+- **Parser PostContent** : `PostBlock.Fixed(text)` et `PostBlock.CodeBlock(text, language?)` sont produits depuis `<table class="fixed">` / `<table class="code">`, y compris quand les blocs sont imbriqués dans une citation.
+- **Hints langue `[code lang]`** : la classe `<pre class="<lang>">` est exposée via `CodeBlock.language` (`cpp`, `java`, etc.). La coloration syntaxique HFR est volontairement aplatie en texte brut en Phase 1.
+- **PostRenderer** : rendu Compose natif en `Card` monospace avec scroll horizontal et `softWrap = false`.
+
+### Fixed
+- **Indentation monospace** : le parser ne fait plus de `trim()` global sur les blocs `[fixed]` / `[code]`; seules les lignes vides structurelles en bordure sont retirées.
+- **Scroll horizontal** : le conteneur monospace ne clamp plus sa largeur interne avant `horizontalScroll`.
+
+### Tests
+- Tests parser sur les fixtures réelles `topic_page_multipage.html` et `topic_redface2_p16.html`.
+- Test de sérialisation JSON pour les nouveaux variants `Fixed` / `CodeBlock`.
+
+---
+
 ## v24 — `0.1.0-phase1b.10` — 2026-05-01
 
 **Statut** : `local`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         // upload signing config).
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their phase / commit lineage to the user.
-        versionCode = 29
-        versionName = "0.1.0-phase1d.1"
+        versionCode = 30
+        versionName = "0.1.0-phase1d.2"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.


### PR DESCRIPTION
> Action par GPT-5 Codex (demandée par @XaaT)

## Résumé

Bump applicatif pour générer un AAB Play signé après merge de #123.

- `versionCode = 30`
- `versionName = "0.1.0-phase1d.2"`
- entrée `app/CHANGELOG.md` v30 avec le support `[fixed]` / `[code]`

## Test plan

- [x] `git diff --check`
- [ ] CI GitHub
- [ ] `:app:bundleRelease` signé après merge sur `main`