### PR TITLE
chore(docs): bump Jekyll footer to v0.7.0

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -18,7 +18,7 @@ mermaid:
 
 nav_sort: order
 
-footer_content: "Redface 2 &mdash; Specs v0.6.0 &mdash; Un projet communautaire pour Hardware.fr"
+footer_content: "Redface 2 &mdash; Specs v0.7.0 &mdash; Un projet communautaire pour Hardware.fr"
 
 back_to_top: true
 back_to_top_text: "Haut de page"


### PR DESCRIPTION
> Action par Claude Opus 4.7 (1M context, demandée par @XaTriX)

Sync du footer Jekyll sur la version canonique \`CHANGELOG.md\`. Drift d'une minor depuis le 2026-05-03 (Phase 1D + Room v3 + audit serialization + PR #123 \`[fixed]\`/\`[code]\` toutes documentées sous v0.7.0 mais le footer affichait encore **v0.6.0**).

Pure docs sync — aucun changement de contenu spec.