### PR TITLE
fix(release): trust workspace for git in container job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,16 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
 
+      - name: Trust workspace for git
+        # `actions/checkout` configures `safe.directory` for the runner user, but this job
+        # runs inside the `cirruslabs/android-sdk` container under a different uid. Without
+        # this step, every subsequent `git` call (rev-parse here, plus implicit calls inside
+        # `gradle/actions/setup-gradle` for cache fingerprinting) fails with
+        # `fatal: detected dubious ownership in repository at '/__w/redface2/redface2'`.
+        # Scoped to GITHUB_WORKSPACE to avoid trusting unrelated paths.
+        shell: bash
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Resolve refs and version metadata
         id: meta
         shell: bash


### PR DESCRIPTION
> Action par Claude Opus 4.7 (1M context, demandée par @xaat)

## Symptôme

Le run [25613069512](https://github.com/ForumHFR/redface2/actions/runs/25613069512) (premier dispatch manuel de la CD sur main, 2026-05-09 22:10) a planté au step *Resolve refs and version metadata* :

```
fatal: detected dubious ownership in repository at '/__w/redface2/redface2'
To add an exception for this directory, call:
    git config --global --add safe.directory /__w/redface2/redface2
##[error]Process completed with exit code 128.
```

Source : `git rev-parse --short HEAD` à la ligne `short_sha=$(...)` du step.

## Cause

Le job tourne `inside the` container `ghcr.io/cirruslabs/android-sdk:36` sous un uid différent de celui du runner GitHub. `actions/checkout@v6` configure `safe.directory` pour le user du runner mais pas pour l'user dans le container, donc tout appel `git` côté steps suivants échoue avec ce message — comportement documenté côté actions/checkout (cf. [actions/checkout#766](https://github.com/actions/checkout/issues/766) et issues dérivées sur le pattern container-job + uid mismatch).

Pas de souci pour le step `Checkout` lui-même (il extrait via tarball, pas via git natif). Mais `git rev-parse` et probablement `gradle/actions/setup-gradle` (qui fingerprint le cache via git) échouent en aval.

## Fix

Un step `Trust workspace for git` après le checkout qui ajoute `$GITHUB_WORKSPACE` à `safe.directory` global :

```yaml
- name: Trust workspace for git
  shell: bash
  run: git config --global --add safe.directory \"\$GITHUB_WORKSPACE\"
```

Scope au workspace plutôt qu'à `*` pour ne pas faire confiance aveugle à n'importe quel path.

## Test

- [ ] CI verte sur cette PR
- [ ] Après merge, relancer un `workflow_dispatch` manuel sur main avec `play_track: none` et vérifier que le step *Resolve refs and version metadata* passe et que les outputs `version_code` / `version_name` / `short_sha` sont bien produits

## Merge en --admin

Cf. AGENTS.md clause `Review en mono-maintainer` — config CODEOWNERS `* @XaaT` sur projet sous pseudonyme, pas de second compte associable, pas de communauté → admin justifié.