### PR TITLE
chore(release): bump app to v36 + configurable Play status

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,18 @@ on:
         required: false
         default: false
         type: boolean
+      play_release_status:
+        description: |
+          Play Console release status. `completed` = publish immediately on the chosen track
+          (testers see it without manual intervention). `draft` = upload as draft, requires
+          manual activation in the Play Console UI (final guardrail before users see it).
+          `inProgress` = upload + start a staged rollout (rollout fraction is set via Play
+          Console UI afterwards). Leave empty to use the smart default: `completed` for
+          testing tracks (alpha/beta/internal/closed), `draft` for `production` (so an
+          accidental prod tag can never auto-publish to real users).
+        required: false
+        default: ''
+        type: string
 
 concurrency:
   # Allow concurrent releases on different tags / refs but coalesce repeated dispatches on
@@ -60,6 +72,15 @@ jobs:
       # The historical comment here mentioned `gradle-play-publisher` which was retired in
       # the initial Codex review on this PR — the upload now goes through r0adkll directly.
       PLAY_TRACK: ${{ inputs.play_track || 'alpha' }}
+      # Smart default for the Play Console release status:
+      #   - explicit `play_release_status` input wins when non-empty
+      #   - otherwise: `draft` for production track (mandatory manual UI activation as a
+      #     final guardrail against accidental prod releases)
+      #   - otherwise: `completed` for any testing track (alpha/beta/internal/closed/none)
+      # On a tag push, `inputs.play_track` is empty so the default `completed` applies —
+      # tag = ship to alpha testers immediately. To target production, dispatch manually
+      # with `play_track: production` (which keeps the `draft` default unless overridden).
+      PLAY_RELEASE_STATUS: ${{ inputs.play_release_status != '' && inputs.play_release_status || (inputs.play_track == 'production' && 'draft' || 'completed') }}
 
     steps:
       - name: Checkout
@@ -111,7 +132,7 @@ jobs:
           echo "short_sha=${short_sha}" >>"$GITHUB_OUTPUT"
           echo "release_kind=${release_kind}" >>"$GITHUB_OUTPUT"
           echo "release_tag=${release_tag}" >>"$GITHUB_OUTPUT"
-          echo "::notice title=Release plan::kind=${release_kind} versionCode=${version_code} versionName=${version_name} sha=${short_sha} tag=${release_tag} track=${{ env.PLAY_TRACK }}"
+          echo "::notice title=Release plan::kind=${release_kind} versionCode=${version_code} versionName=${version_name} sha=${short_sha} tag=${release_tag} track=${{ env.PLAY_TRACK }} status=${{ env.PLAY_RELEASE_STATUS }}"
 
       - name: Setup Gradle
         # Pinned to v5 in lockstep with .github/workflows/ci.yml to keep both workflows on
@@ -220,9 +241,12 @@ jobs:
       - name: Publish to Play Console
         # gradle-play-publisher 4.0.0 had broken compat with our AGP 9.2 (project in
         # maintenance mode since April 2026), so we delegate the upload to the more focused
-        # r0adkll action that talks to the Play Developer API directly. status=draft means
-        # the maintainer activates the release in Play Console UI; releaseFiles points to
-        # the staged AAB; whatsNewDirectory pulls per-locale release-notes from the repo.
+        # r0adkll action that talks to the Play Developer API directly. The release status
+        # is configurable per run (`PLAY_RELEASE_STATUS`): `completed` publishes immediately
+        # on testing tracks (default for alpha/beta/internal), `draft` requires manual UI
+        # activation (default for production, override available via the dispatch input).
+        # `releaseFiles` points to the staged AAB; `whatsNewDirectory` pulls per-locale
+        # release-notes from the repo.
         if: ${{ env.PLAY_TRACK != 'none' && steps.service_account.outputs.path != '' }}
         # Pinned to a commit sha rather than the floating `v1` tag — this step pushes to
         # Play Console using the project's service account credentials, so we want a
@@ -239,7 +263,7 @@ jobs:
           # neither is deprecated as of v1.1.5 (verified against action.yml). We use `tracks`
           # to leave the door open for multi-track promotion later without renaming the input.
           tracks: ${{ env.PLAY_TRACK }}
-          status: draft
+          status: ${{ env.PLAY_RELEASE_STATUS }}
           # Action expects `whatsnew-<LOCALE>` files placed flat in this directory.
           whatsNewDirectory: app/src/main/play/whatsnew
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ Format inspiré de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/). Les
 
 ---
 
+## v0.8.4 — 2026-05-10
+
+Itération CD : la pipeline `release.yml` rendait obligatoire l'activation manuelle du draft Play Console après chaque upload (`status: draft` câblé en dur). Cette PR rend le statut configurable et choisit un défaut intelligent selon le track ciblé. Le `versionCode = 35` ayant été consommé sur Play, le build final passe en `v36 / 0.1.0-phase1.5`.
+
+### Changed
+- `.github/workflows/release.yml` ajoute un input `play_release_status` au `workflow_dispatch` (`completed` / `draft` / `inProgress` / vide) et un défaut intelligent : `completed` (publish immédiat) pour les tracks de test (`alpha`, `beta`, `internal`, closed track), `draft` (activation UI obligatoire) pour `production`. Sur tag push, le défaut s'applique aussi → `git tag app-v36 && git push --tags` envoie directement aux testeurs alpha sans intervention UI.
+- `app/build.gradle.kts` bump `versionCode = 36`, `versionName = "0.1.0-phase1.5"`. Le slot `v35` est marqué `closed` (uploadé manuellement sur le track alpha avant la mise en place du push API).
+- `docs/specs/roadmap.md` et footer Jekyll alignés sur specs v0.8.4 / AAB `0.1.0-phase1.5`.
+
+### Notes
+- Pas de modification fonctionnelle de l'app — c'est un patch de tooling release.
+- La garde-fou production reste actif par défaut : un éventuel dispatch sur `production` sans override explicite continuera à produire un draft.
+
+---
+
 ## v0.8.3 — 2026-05-08
 
 Patch dogfood guidé par le crawl exhaustif `wikismilies.php` : le bucket carré `56×56` rendait les micro-smileys lisibles, mais ne respectait pas la forme dominante réelle des smileys perso HFR (`70×50`, puis variantes `W×50`). Le build final passe en `v35 / 0.1.0-phase1.4`; `v34` est considéré brûlé.

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -15,11 +15,25 @@ Workflow : bumper `versionCode` + `versionName` dans `app/build.gradle.kts`, ajo
 
 ---
 
-## v35 — `0.1.0-phase1.4` — 2026-05-08
+## v36 — `0.1.0-phase1.5` — 2026-05-10
 
 **Statut** : `local`
 **Commit** : à venir
-**Fichier** : `redface2-v35-<date>-<sha>.aab`
+**Fichier** : `redface2-v36-<date>-<sha>.aab`
+
+Premier build CD avec auto-publish sur le track alpha. Pas de changement fonctionnel de l'app — c'est l'AAB qui valide bout-en-bout le nouveau pipeline avec `status: completed` (par défaut sur les tracks de test), pour ne plus avoir à activer le draft manuellement dans la Play Console après chaque upload.
+
+### Changed
+- `.github/workflows/release.yml` : ajout d'un input `play_release_status` au `workflow_dispatch` et d'un défaut intelligent (`completed` pour testing tracks, `draft` pour production).
+- `app/build.gradle.kts` bump `versionCode = 36`, `versionName = "0.1.0-phase1.5"`. Le slot `v35` est marqué `closed` (uploadé manuellement sur le track alpha avant la mise en place du push API).
+
+---
+
+## v35 — `0.1.0-phase1.4` — 2026-05-08
+
+**Statut** : `closed`
+**Commit** : `4bc6210`
+**Fichier** : `redface2-v35-4bc6210.aab`
 
 Patch dogfood après extraction exhaustive du wikismilies HFR : le bucket carré `56sp × 56sp` de v34 rendait les petits smileys lisibles, mais ne respectait pas la forme dominante réelle du corpus. Sur 34 139 smileys perso, la première taille est `70×50` (8047 occurrences), suivie de `50×50` (2811), `67×50` (1142), puis de nombreuses variantes `W×50`.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         // upload signing config).
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their phase / commit lineage to the user.
-        versionCode = 35
-        versionName = "0.1.0-phase1.4"
+        versionCode = 36
+        versionName = "0.1.0-phase1.5"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -18,7 +18,7 @@ mermaid:
 
 nav_sort: order
 
-footer_content: "Redface 2 &mdash; Specs v0.8.3 &mdash; Un projet communautaire pour Hardware.fr"
+footer_content: "Redface 2 &mdash; Specs v0.8.4 &mdash; Un projet communautaire pour Hardware.fr"
 
 back_to_top: true
 back_to_top_text: "Haut de page"

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -25,7 +25,7 @@ Pour la liste des capabilities et des non-goals, voir le [scope fonctionnel]({{ 
 | Phase | Objectif | Taille | Dépend de | Statut |
 |---|---|---|---|---|
 | **0 — Bootstrap** | Squelette qui compile, CI, thème, navigation | S | — | ✅ Livrée |
-| **1 — Core** | Lecture du forum (drapeaux, topics, forum, deep links) | XL | Phase 0 | ✅ Livrée (AAB `0.1.0-phase1.4` / specs v0.8.3) |
+| **1 — Core** | Lecture du forum (drapeaux, topics, forum, deep links) | XL | Phase 0 | ✅ Livrée (AAB `0.1.0-phase1.5` / specs v0.8.4) |
 | **2 — Écriture** | Post / edit / quote / create topic / recherche | L | Phase 1 | À faire |
 | **3 — Messages** | MPs classiques + MultiMPs avec sync | M | Phase 2 + **MPStorage2** (hfr-redkit) | À faire |
 | **4 — Extensions** | Bookmarks, Blacklist, Qualitay, Redflag | L | Phase 3 + **hfr-redflag Worker** | À faire |


### PR DESCRIPTION
> Action par Claude Opus 4.7 (1M context, demandée par @xaat)

## Pourquoi

Le pipeline CD livré par #133 hardcodait `status: draft` pour l'upload Play Console. Conséquence : après chaque push sur le track alpha, il fallait passer dans la Play Console UI pour activer manuellement la release. Pour un dogfood en boucle courte (testeurs internes), ça frottait inutilement.

## Ce que la PR change

### Workflow `release.yml`

1. Nouvel input `play_release_status` au `workflow_dispatch` :
   - `completed` → publish immédiat sur le track choisi
   - `draft` → upload + draft, activation UI manuelle requise
   - `inProgress` → publish + staged rollout (rollout fraction réglable via UI ensuite)
   - vide → défaut intelligent (voir ci-dessous)

2. Défaut intelligent par track (quand l'input est vide ou absent) :
   - `production` → `draft` (garde-fou contre une release prod accidentelle)
   - tous les autres tracks (`alpha`, `beta`, `internal`, closed track) → `completed`

3. Sur tag push (`app-v*`), l'input est null et le track default est `alpha` → le défaut `completed` s'applique → `git tag app-v36 && git push --tags` envoie directement aux testeurs alpha sans intervention UI. **C'est ce qu'on va tester avec ce bump.**

### Bump v36

- `app/build.gradle.kts` : `versionCode = 36`, `versionName = \"0.1.0-phase1.5\"`. Le slot v35 a déjà été uploadé manuellement sur le track alpha avant que l'API service-account soit branchée — il faut donc bumper.
- `app/CHANGELOG.md` : nouvelle entrée v36 ; v35 passe de `local` à `closed` (consommé sur Play).
- `CHANGELOG.md` (specs) : entrée v0.8.4 documentant la modif workflow.
- `docs/_config.yml` + `docs/specs/roadmap.md` alignés sur specs v0.8.4 / AAB `0.1.0-phase1.5`.

## Pas de changement fonctionnel

Aucun fichier Kotlin / Compose modifié. L'AAB v36 est binairement équivalent à v35 — c'est le tooling release qui change.

## Test plan

- [x] CI verte sur cette branche (workflow CI standard, le workflow release ne déclenche pas en PR)
- [ ] Après merge, `git tag app-v36 && git push --tags` doit produire un upload Play Console en `status: completed` sur le track `alpha` → testeurs voient la nouvelle version sans geste UI
- [ ] Le notice du step *Resolve refs* doit afficher `status=completed track=alpha`

## Merge en --admin

Cf. AGENTS.md `Review en mono-maintainer` clarifié dans #134 — projet sous pseudonyme, CODEOWNERS = `* @XaaT`, voie nominale.