### PR TITLE
test(core/ui): pin quote-depth contract from issue #3

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -55,11 +55,15 @@ import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.PostInline
 import fr.forumhfr.redface2.core.model.SmileyKind
 
-// Issue #3 explicit contract: "Max N=3 niveaux visibles, reste collapsible". Beyond that the
-// quote tail collapses to a "Afficher les citations imbriquées" Card so the user can opt in.
-// Exposed as `internal` (not `private`) so the JVM unit test in `PostRendererQuoteDepthTest`
-// can pin both the constant value and the depth predicate behaviour without instantiating the
-// `@Composable` `QuoteBlock` (which would require Robolectric — see #130 for that path).
+/**
+ * Maximum number of nested quote levels that render expanded inline. Issue #3 explicit
+ * contract: "Max N=3 niveaux visibles, reste collapsible". Beyond that the quote tail
+ * collapses to an "Afficher les citations imbriquées" Card so the user can opt in.
+ *
+ * Exposed `internal` (not `private`) so the JVM unit test in [PostRendererQuoteDepthTest] can
+ * pin both the value and the depth predicate without instantiating the `@Composable`
+ * [QuoteBlock] (which would require Robolectric — see issue #130 for that path).
+ */
 internal const val MAX_VISIBLE_QUOTE_DEPTH = 3
 
 /**

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -55,7 +55,19 @@ import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.PostInline
 import fr.forumhfr.redface2.core.model.SmileyKind
 
-private const val MAX_VISIBLE_QUOTE_DEPTH = 3
+// Issue #3 explicit contract: "Max N=3 niveaux visibles, reste collapsible". Beyond that the
+// quote tail collapses to a "Afficher les citations imbriquées" Card so the user can opt in.
+// Exposed as `internal` (not `private`) so the JVM unit test in `PostRendererQuoteDepthTest`
+// can pin both the constant value and the depth predicate behaviour without instantiating the
+// `@Composable` `QuoteBlock` (which would require Robolectric — see #130 for that path).
+internal const val MAX_VISIBLE_QUOTE_DEPTH = 3
+
+/**
+ * Returns true when a `Quote` block at the given recursion depth must render as
+ * `CollapsedQuoteBlock` instead of expanding inline. Pure decision so the rule is testable
+ * without entering Compose; `QuoteBlock` is the only call site.
+ */
+internal fun isCollapsedQuoteDepth(depth: Int): Boolean = depth >= MAX_VISIBLE_QUOTE_DEPTH
 
 @Composable
 fun PostRenderer(
@@ -117,7 +129,7 @@ private fun ParagraphBlock(inlines: List<PostInline>) {
 
 @Composable
 private fun QuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
-    if (quoteDepth >= MAX_VISIBLE_QUOTE_DEPTH) {
+    if (isCollapsedQuoteDepth(quoteDepth)) {
         CollapsedQuoteBlock(block)
         return
     }

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteDepthTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteDepthTest.kt
@@ -43,10 +43,11 @@ class PostRendererQuoteDepthTest {
     }
 
     @Test
-    fun `quote depth at and beyond the limit collapse to opt-in reveal`() {
-        // Depth 3 is the first level that crosses the issue #3 threshold, so it collapses to
-        // `CollapsedQuoteBlock`. Anything deeper stays collapsed too — the recursion never
-        // re-expands by accident.
+    fun `quote depth at and beyond the limit must collapse`() {
+        // Depth 3 is the first level that crosses the issue #3 threshold, so the predicate
+        // returns true and `QuoteBlock` will branch to `CollapsedQuoteBlock` at the call site.
+        // The reveal/reset behaviour of `CollapsedQuoteBlock` itself (clicking re-expands with
+        // depth reset to 0) lives inside the `@Composable` and is tracked under issue #130.
         assertTrue(
             "depth 3 (4th nested quote) must collapse to the 'Afficher' card per issue #3",
             isCollapsedQuoteDepth(3),

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteDepthTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteDepthTest.kt
@@ -1,0 +1,57 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the quote-recursion-depth contract spelled out in issue #3
+ * (https://github.com/ForumHFR/redface2/issues/3) — "Max N=3 niveaux visibles, reste collapsible
+ * ('Afficher les citations imbriquées'). Au-delà, HFR est illisible de toute façon. Évite
+ * l'explosion de stack et limite la récursion d'UI."
+ *
+ * The actual rendering branch lives in the `@Composable` `QuoteBlock`, which needs Robolectric
+ * to drive — that's tracked separately under issue #130 alongside the `fillMaxSize()` /
+ * `fontScale` invariants. The decision predicate `isCollapsedQuoteDepth` was extracted out of
+ * `QuoteBlock` so the contract can be locked in a pure JVM test today and any later change
+ * (e.g. lowering N to 2 or raising it to 4) becomes a deliberate review step rather than a
+ * silent drift.
+ */
+class PostRendererQuoteDepthTest {
+
+    @Test
+    fun `MAX_VISIBLE_QUOTE_DEPTH stays at the issue 3 contract value`() {
+        assertEquals(
+            "Issue #3 mandates N=3 visible quote levels — bumping this constant must be a " +
+                "deliberate review step, not a silent change.",
+            3,
+            MAX_VISIBLE_QUOTE_DEPTH,
+        )
+    }
+
+    @Test
+    fun `quote depths below the limit render expanded`() {
+        // The first three nesting levels (0, 1, 2) must render as a regular `Card` quote so the
+        // typical 1- and 2-level quote chains found in HFR threads stay readable.
+        assertFalse("depth 0 (top-level quote) must render expanded", isCollapsedQuoteDepth(0))
+        assertFalse("depth 1 (quote-in-quote) must render expanded", isCollapsedQuoteDepth(1))
+        assertFalse(
+            "depth 2 (quote-in-quote-in-quote) must render expanded",
+            isCollapsedQuoteDepth(2),
+        )
+    }
+
+    @Test
+    fun `quote depth at and beyond the limit collapse to opt-in reveal`() {
+        // Depth 3 is the first level that crosses the issue #3 threshold, so it collapses to
+        // `CollapsedQuoteBlock`. Anything deeper stays collapsed too — the recursion never
+        // re-expands by accident.
+        assertTrue(
+            "depth 3 (4th nested quote) must collapse to the 'Afficher' card per issue #3",
+            isCollapsedQuoteDepth(3),
+        )
+        assertTrue("depth 4 must collapse", isCollapsedQuoteDepth(4))
+        assertTrue("very deep quotes must keep collapsing", isCollapsedQuoteDepth(99))
+    }
+}


### PR DESCRIPTION
> Action par Claude Opus 4.7 (1M context, demandée par @xaat)

Closes #83.

## État de la couverture avant cette PR

L'issue #83 listait 4 tests à écrire. Au fil des PR Phase 1D les 3 premiers ont été couverts incrementally :

| Test | Couverture | Fichier |
|---|---|---|
| 1. `LineBreak` dans `Strong` → `\n` dans l'AnnotatedString | ✅ couvert | `PostRendererInlineTest.kt:18-33` |
| 2. Synchronisation `appendInline` IDs ↔ `collectInlineMedia` keys | ✅ couvert (+ recursion symmetric across containers) | `PostRendererInlineTest.kt:35-106` |
| 3. `parseColor` sur longueurs valides / invalides | ✅ couvert (5 cas) | `PostRendererColorTest.kt` |
| 4. Quote depth ≥ 3 → collapse | ❌ non couvert | _cette PR_ |

## Cette PR — Test 4 uniquement

### Pourquoi ce n'est pas un test Compose direct

`QuoteBlock` est `@Composable`. Tester la branche `quoteDepth >= MAX_VISIBLE_QUOTE_DEPTH` directement demanderait Robolectric / Compose UI test — pas encore consommé dans le projet (suivi sous #130, qui groupera la première vague de tests UI Phase 2 incluant aussi le `fillMaxSize()` / `fontScale` invariant). Le coût d'introduction de Robolectric pour un seul test est disproportionné tant que la décision elle-même est triviale.

### Approche

1. Extraction de la décision dans une fonction pure `internal fun isCollapsedQuoteDepth(depth: Int): Boolean = depth >= MAX_VISIBLE_QUOTE_DEPTH`
2. Élévation de `MAX_VISIBLE_QUOTE_DEPTH` de `private` à `internal` (plus accessible aux tests, toujours dans le module)
3. `QuoteBlock` appelle la fonction au lieu de comparer directement (refacto sémantique nulle)
4. `PostRendererQuoteDepthTest` (3 tests) :
   - constante = 3 (verrouille le contrat #3 « Max N=3 niveaux visibles »)
   - depth 0/1/2 → expanded
   - depth 3/4/99 → collapsed

Quand #130 livrera Robolectric, un test de rendu pourra compléter (pas remplacer) ce filet — la constante restera utile pour empêcher un changement silencieux du contrat.

### Diff

- `core/ui/src/main/kotlin/.../post/PostRenderer.kt` (+13/-2)
- `core/ui/src/test/kotlin/.../post/PostRendererQuoteDepthTest.kt` (+58, nouveau)

### Tests

```
$ ./scripts/docker-dev.sh ./gradlew :core:ui:testDebugUnitTest --no-daemon
BUILD SUCCESSFUL in 33s
```

Ventilation `:core:ui` : **29 tests, 0 failure** (13 `PostMediaDisplayPolicyTest` + 5 `PostRendererColorTest` + 8 `PostRendererInlineTest` + 3 `PostRendererQuoteDepthTest`).

## Note Context7

PR ne touche aucune API Compose moderne (fonction pure + `internal const val` + JUnit 4 standard). Aucune surface où Context7 apporterait un check utile au-delà des tests existants — le tag annotation `androidx.compose.foundation.text.inlineContent` consommé par `inlineContentIds()` dans les tests existants (vérifié stable de longue date) n'est pas modifié par cette PR.

## Merge en --admin

CODEOWNERS = `* @XaaT`, projet sous pseudonyme — voie nominale clarifiée dans #134.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>