### PR TITLE
test(core/ui): pin MediaCounter set-symmetry on a non-trivial AST

### DIFF
--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineTest.kt
@@ -208,6 +208,119 @@ class PostRendererInlineTest {
     }
 
     @Test
+    fun `non-trivial AST keeps inlineContentIds and media keys in lockstep`() {
+        // Issue #139 (suite #83): the existing tests cover the symmetry one container at a time
+        // (`MediaCounter recursion is symmetric across every PostInline container`) plus a
+        // 3-smiley flat case. They do not exercise a deep mix of containers + smileys (with and
+        // without `imageUrl`) + inline images all in one AST, which is how a real HFR post looks.
+        // A drift between `appendInline` and `walkInlinesForMedia` (e.g. a future container that
+        // recurses in one walk and not the other) would slip past the per-container tests but
+        // not this composite one — the set equality is the contract MediaCounter's KDoc spells
+        // out: "do not break that symmetry".
+        val inlines = listOf(
+            PostInline.Strong(
+                children = listOf(
+                    PostInline.Text("intro "),
+                    PostInline.Underline(
+                        children = listOf(
+                            PostInline.Smiley(
+                                kind = SmileyKind.Builtin(":jap:"),
+                                imageUrl = "https://forum-images.hardware.fr/icones/smilies/jap.gif",
+                            ),
+                        ),
+                    ),
+                    // Smiley without imageUrl: must NOT advance the smiley counter and must NOT
+                    // appear in the media map. Asymmetry trap if either walk forgets the gate.
+                    PostInline.Smiley(kind = SmileyKind.Builtin(":notapic"), imageUrl = null),
+                ),
+            ),
+            PostInline.Color(
+                colorHex = "#FF0000",
+                children = listOf(
+                    PostInline.InlineImage(
+                        url = "https://forum.hardware.fr/images/foo.png",
+                        description = "foo",
+                    ),
+                    PostInline.Smiley(
+                        kind = SmileyKind.Perso("cosmoschtroumpf"),
+                        imageUrl = "https://forum-images.hardware.fr/images/perso/cosmoschtroumpf.gif",
+                    ),
+                ),
+            ),
+            PostInline.LineBreak,
+            PostInline.Link(
+                url = "https://example.com",
+                children = listOf(
+                    PostInline.Emphasis(
+                        children = listOf(
+                            PostInline.Strike(
+                                children = listOf(
+                                    PostInline.Smiley(
+                                        kind = SmileyKind.Perso("rofl"),
+                                        imageUrl = "https://forum-images.hardware.fr/images/perso/rofl.gif",
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            PostInline.InlineImage(
+                url = "https://forum.hardware.fr/images/bar.png",
+                description = "bar",
+            ),
+        )
+
+        val annotated = buildInlineText(inlines, emptyLinkStyles, imageAlt = "img")
+        val media = collectInlineMedia(inlines)
+
+        // Set equality: every appendInlineContent placeholder must have an InlineTextContent and
+        // vice versa. A drift here is the orphan-placeholder bug the MediaCounter KDoc warns
+        // against ("do not break that symmetry").
+        assertEquals(annotated.inlineContentIds(), media.keys)
+        // Belt-and-braces: the count must also reflect what we constructed (3 smileys with
+        // imageUrl + 2 inline images = 5 placeholders, the no-imageUrl smiley contributes 0).
+        assertEquals("3 smileys + 2 inline images expected", 5, media.size)
+    }
+
+    @Test
+    fun `inline content IDs are zero-indexed and contiguous per media kind`() {
+        // The MediaCounter is created fresh per Text per its KDoc, so every paragraph restarts
+        // at 0. Pin both indexings so a future change that, say, switched to a shared mutable
+        // counter or a UUID-based ID would fail loudly here.
+        val inlines = listOf(
+            PostInline.Smiley(
+                kind = SmileyKind.Builtin(":jap:"),
+                imageUrl = "https://forum-images.hardware.fr/icones/smilies/jap.gif",
+            ),
+            PostInline.InlineImage(url = "https://forum.hardware.fr/images/a.png", description = "a"),
+            PostInline.Smiley(
+                kind = SmileyKind.Perso("rofl"),
+                imageUrl = "https://forum-images.hardware.fr/images/perso/rofl.gif",
+            ),
+            PostInline.InlineImage(url = "https://forum.hardware.fr/images/b.png", description = "b"),
+            PostInline.Smiley(
+                kind = SmileyKind.Builtin(":o"),
+                imageUrl = "https://forum-images.hardware.fr/icones/smilies/o.gif",
+            ),
+        )
+
+        val media = collectInlineMedia(inlines)
+
+        // Smiley counter: 3 distinct entries, zero-indexed, no gap.
+        assertEquals(
+            setOf("post-smiley-0", "post-smiley-1", "post-smiley-2"),
+            media.keys.filter { it.startsWith("post-smiley-") }.toSet(),
+        )
+        // Image counter: 2 distinct entries, zero-indexed, no gap. The two counters are
+        // independent — image-0 does not skip ahead because of smiley-0/1/2.
+        assertEquals(
+            setOf("post-image-0", "post-image-1"),
+            media.keys.filter { it.startsWith("post-image-") }.toSet(),
+        )
+    }
+
+    @Test
     fun `inline image uses the bounded 240x180 placeholder centred`() {
         // Pre-#109 the inline image placeholder was 240×180 but the inner Modifier was
         // fillMaxWidth() — meaningless inside InlineTextContent (the placeholder dictates the

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineTest.kt
@@ -229,9 +229,19 @@ class PostRendererInlineTest {
                             ),
                         ),
                     ),
+                    // Inline image directly under `Strong` covers the BBCode `[b][img]…[/img][/b]`
+                    // shape — without this case, deletion of the `is PostInline.Strong` branch in
+                    // `walkInlinesForMedia` (or its `appendInline` counterpart) would still leave
+                    // every per-container test green.
+                    PostInline.InlineImage(
+                        url = "https://forum.hardware.fr/images/inside-strong.png",
+                        description = "inside-strong",
+                    ),
                     // Smiley without imageUrl: must NOT advance the smiley counter and must NOT
                     // appear in the media map. Asymmetry trap if either walk forgets the gate.
-                    PostInline.Smiley(kind = SmileyKind.Builtin(":notapic"), imageUrl = null),
+                    // Reuse a real HFR builtin (`:o`) — AGENTS.md prohibits inventing smiley codes
+                    // even in tests; the assertion only cares about the `imageUrl == null` branch.
+                    PostInline.Smiley(kind = SmileyKind.Builtin(":o"), imageUrl = null),
                 ),
             ),
             PostInline.Color(
@@ -276,18 +286,24 @@ class PostRendererInlineTest {
 
         // Set equality: every appendInlineContent placeholder must have an InlineTextContent and
         // vice versa. A drift here is the orphan-placeholder bug the MediaCounter KDoc warns
-        // against ("do not break that symmetry").
-        assertEquals(annotated.inlineContentIds(), media.keys)
+        // against ("do not break that symmetry"). `media.keys` is the contract value (what
+        // `collectInlineMedia` produces), `annotated.inlineContentIds()` is the observed value
+        // (what `buildInlineText` emitted) — keep that ordering for failure-message clarity, in
+        // line with the sibling assertions earlier in this file.
+        assertEquals(media.keys, annotated.inlineContentIds())
         // Belt-and-braces: the count must also reflect what we constructed (3 smileys with
-        // imageUrl + 2 inline images = 5 placeholders, the no-imageUrl smiley contributes 0).
-        assertEquals("3 smileys + 2 inline images expected", 5, media.size)
+        // imageUrl + 3 inline images = 6 placeholders, the no-imageUrl smiley contributes 0).
+        assertEquals("3 smileys + 3 inline images expected", 6, media.size)
     }
 
     @Test
     fun `inline content IDs are zero-indexed and contiguous per media kind`() {
         // The MediaCounter is created fresh per Text per its KDoc, so every paragraph restarts
-        // at 0. Pin both indexings so a future change that, say, switched to a shared mutable
-        // counter or a UUID-based ID would fail loudly here.
+        // at 0. Pin both sides of the symmetry — the AnnotatedString placeholder IDs AND the
+        // map keys — so a future change that, say, switched to a shared mutable counter or a
+        // UUID-based ID would fail loudly here. Pinning only `media.keys` would miss the case
+        // where `appendInline` drifts to a different scheme while `walkInlinesForMedia` keeps
+        // the counter, which is precisely the asymmetry MediaCounter's KDoc warns against.
         val inlines = listOf(
             PostInline.Smiley(
                 kind = SmileyKind.Builtin(":jap:"),
@@ -305,19 +321,28 @@ class PostRendererInlineTest {
             ),
         )
 
+        val annotated = buildInlineText(inlines, emptyLinkStyles, imageAlt = "img")
         val media = collectInlineMedia(inlines)
 
-        // Smiley counter: 3 distinct entries, zero-indexed, no gap.
+        val expectedSmileyIds = setOf("post-smiley-0", "post-smiley-1", "post-smiley-2")
+        val expectedImageIds = setOf("post-image-0", "post-image-1")
+
+        // Smiley counter on the map side: 3 distinct entries, zero-indexed, no gap.
         assertEquals(
-            setOf("post-smiley-0", "post-smiley-1", "post-smiley-2"),
+            expectedSmileyIds,
             media.keys.filter { it.startsWith("post-smiley-") }.toSet(),
         )
-        // Image counter: 2 distinct entries, zero-indexed, no gap. The two counters are
-        // independent — image-0 does not skip ahead because of smiley-0/1/2.
+        // Image counter on the map side: 2 distinct entries, zero-indexed, no gap. The two
+        // counters are independent — image-0 does not skip ahead because of smiley-0/1/2.
         assertEquals(
-            setOf("post-image-0", "post-image-1"),
+            expectedImageIds,
             media.keys.filter { it.startsWith("post-image-") }.toSet(),
         )
+        // And on the AnnotatedString side: same expected sets, otherwise `appendInline` and
+        // `walkInlinesForMedia` are out of sync on the ID scheme even when the count matches.
+        val annotatedIds = annotated.inlineContentIds()
+        assertEquals(expectedSmileyIds, annotatedIds.filter { it.startsWith("post-smiley-") }.toSet())
+        assertEquals(expectedImageIds, annotatedIds.filter { it.startsWith("post-image-") }.toSet())
     }
 
     @Test


### PR DESCRIPTION
> Action par Claude Opus 4.7 (1M context, demandée par @xaat)

Closes #139.

## Pourquoi

Suite directe de #138 / #83. Les tests existants couvraient la symétrie entre `appendInline` (qui émet `appendInlineContent("post-smiley-N")` / `"post-image-N"`) et `walkInlinesForMedia` (qui peuple le `Map<String, InlineTextContent>`) **un container à la fois** (`MediaCounter recursion is symmetric across every PostInline container`) plus une trace flat de 3 smileys. Ce qui manquait : un mix profond de containers + smileys (avec/sans `imageUrl`) + inline images dans **un seul AST** — la forme typique d'un post HFR réel.

Une drift entre les deux walks (par ex. un nouveau container `PostInline.Subscript` qui recurse dans un seul des deux) passerait à travers les tests per-container mais pas un test composite. Le KDoc de `MediaCounter` ([core/ui/src/main/.../PostRenderer.kt](https://github.com/ForumHFR/redface2/blob/main/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt)) le dit explicitement : *"do not break that symmetry"*.

## Tests ajoutés (PostRendererInlineTest.kt)

### 1. `non-trivial AST keeps inlineContentIds and media keys in lockstep`

AST construit pour exercer **chaque** type de container PostInline + le piège `imageUrl == null` :

```
Strong(
  Text + Underline(Smiley builtin imageUrl) + Smiley builtin null
)
Color(InlineImage + Smiley perso imageUrl)
LineBreak
Link(Emphasis(Strike(Smiley perso imageUrl)))
InlineImage
```

Vérifie `assertEquals(annotated.inlineContentIds(), media.keys)` + count (3 smileys avec imageUrl + 2 inline images = 5 entries ; le smiley sans imageUrl ne compte pas).

### 2. `inline content IDs are zero-indexed and contiguous per media kind`

Pin la propriété "compteurs indépendants par type" : 3 smileys + 2 images interleaved → `post-smiley-{0,1,2}` et `post-image-{0,1}` sans gap. Régression-bait si quelqu'un passait à un compteur partagé ou des UUIDs.

## Tests

```
$ ./scripts/docker-dev.sh ./gradlew :core:ui:testDebugUnitTest --no-daemon
BUILD SUCCESSFUL in 12s
```

`:core:ui` post-PR : **31 tests / 0 failure** (13 + 5 + 10 + 3).

## Hors scope

- Test du reset `quoteDepth = 0` après reveal dans `CollapsedQuoteBlock` — demande Robolectric, suivi sous #130.

## Merge en --admin

CODEOWNERS = `* @XaaT`, projet sous pseudonyme — voie nominale clarifiée dans #134.