### PR TITLE
test(perf): add androidx.tracing sections for topic read flow

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -32,6 +32,10 @@ dependencies {
     implementation(platform(libs.okhttp.bom))
     implementation(libs.okhttp)
 
+    // androidx.tracing for `rf2.topic.parse_html`, `rf2.topic.map_domain`, `rf2.topic.room_read`,
+    // `rf2.topic.room_write` markers around the topic-page repository pipeline (#117).
+    implementation(libs.androidx.tracing)
+
     testImplementation(libs.junit4)
     testImplementation(libs.mockk)
     testImplementation(libs.robolectric)

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.core.data.topic
 
 import android.util.Log
+import androidx.tracing.trace
 import fr.forumhfr.redface2.core.data.cache.CachePolicy
 import fr.forumhfr.redface2.core.database.dao.TopicDao
 import fr.forumhfr.redface2.core.database.entities.FetchMode
@@ -96,15 +97,20 @@ class TopicRepositoryImpl @Inject constructor(
         page: Int,
         authMode: FetchMode,
     ): Topic = withContext(ioDispatcher) {
+        // The `rf2.topic.network` and `rf2.topic.body_read` sections live inside `HfrClient`
+        // (same coroutine, same IO dispatcher). The remaining phases — parse, map, persist —
+        // are wrapped here. Section names match `docs/guides/profiling.md`.
         val html = client.getTopicPage(
             cat = cat,
             post = post,
             page = page,
             useAuth = authMode == FetchMode.AUTHENTICATED,
         )
-        val topic = parser.parseTopicPage(html)
-        val (topicEntity, postEntities) = TopicMappers.toEntities(topic, clock.instant(), authMode)
-        persist(topicEntity, postEntities, authMode)
+        val topic = trace("rf2.topic.parse_html") { parser.parseTopicPage(html) }
+        val (topicEntity, postEntities) = trace("rf2.topic.map_domain") {
+            TopicMappers.toEntities(topic, clock.instant(), authMode)
+        }
+        trace("rf2.topic.room_write") { persist(topicEntity, postEntities, authMode) }
         topic
     }
 
@@ -142,15 +148,16 @@ class TopicRepositoryImpl @Inject constructor(
         }
     }
 
-    private suspend fun loadFromCache(cat: Int, post: Int, page: Int): CachedTopic? {
-        val topicEntity = topicDao.getTopicPage(cat, post, page) ?: return null
-        val postEntities = topicDao.getPostsByNumreponse(cat, topicEntity.numreponses)
-        return CachedTopic(
-            topic = TopicMappers.toDomain(topicEntity, postEntities),
-            fetchedAt = topicEntity.fetchedAt,
-            authMode = topicEntity.authMode,
-        )
-    }
+    private suspend fun loadFromCache(cat: Int, post: Int, page: Int): CachedTopic? =
+        trace("rf2.topic.room_read") {
+            val topicEntity = topicDao.getTopicPage(cat, post, page) ?: return@trace null
+            val postEntities = topicDao.getPostsByNumreponse(cat, topicEntity.numreponses)
+            CachedTopic(
+                topic = TopicMappers.toDomain(topicEntity, postEntities),
+                fetchedAt = topicEntity.fetchedAt,
+                authMode = topicEntity.authMode,
+            )
+        }
 
     private data class CachedTopic(
         val topic: Topic,

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImpl.kt
@@ -2,6 +2,7 @@ package fr.forumhfr.redface2.core.data.topic
 
 import android.util.Log
 import androidx.tracing.trace
+import androidx.tracing.traceAsync
 import fr.forumhfr.redface2.core.data.cache.CachePolicy
 import fr.forumhfr.redface2.core.database.dao.TopicDao
 import fr.forumhfr.redface2.core.database.entities.FetchMode
@@ -13,6 +14,7 @@ import fr.forumhfr.redface2.core.model.Topic
 import fr.forumhfr.redface2.core.network.HfrClient
 import fr.forumhfr.redface2.core.parser.HfrParser
 import java.time.Clock
+import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CancellationException
@@ -100,6 +102,12 @@ class TopicRepositoryImpl @Inject constructor(
         // The `rf2.topic.network` and `rf2.topic.body_read` sections live inside `HfrClient`
         // (same coroutine, same IO dispatcher). The remaining phases — parse, map, persist —
         // are wrapped here. Section names match `docs/guides/profiling.md`.
+        //
+        // `parse_html` and `map_domain` use the synchronous `trace { … }` helper because both
+        // wrapped calls are non-suspend and run to completion on a single thread. `room_write`
+        // wraps a `suspend` Room transaction that may resume on Room's executor thread, so the
+        // synchronous per-thread `Trace.beginSection`/`endSection` would leak — we use the async
+        // variant with a process-wide cookie instead.
         val html = client.getTopicPage(
             cat = cat,
             post = post,
@@ -110,7 +118,9 @@ class TopicRepositoryImpl @Inject constructor(
         val (topicEntity, postEntities) = trace("rf2.topic.map_domain") {
             TopicMappers.toEntities(topic, clock.instant(), authMode)
         }
-        trace("rf2.topic.room_write") { persist(topicEntity, postEntities, authMode) }
+        traceAsync(ROOM_WRITE_SECTION, asyncCookie.incrementAndGet()) {
+            persist(topicEntity, postEntities, authMode)
+        }
         topic
     }
 
@@ -149,8 +159,11 @@ class TopicRepositoryImpl @Inject constructor(
     }
 
     private suspend fun loadFromCache(cat: Int, post: Int, page: Int): CachedTopic? =
-        trace("rf2.topic.room_read") {
-            val topicEntity = topicDao.getTopicPage(cat, post, page) ?: return@trace null
+        // Async section : the wrapped DAO calls are `suspend` and Room may resume the coroutine
+        // on its own executor, breaking the same-thread invariant of synchronous trace sections.
+        // `traceAsync` from `androidx.tracing` handles begin/end across suspend boundaries.
+        traceAsync(ROOM_READ_SECTION, asyncCookie.incrementAndGet()) {
+            val topicEntity = topicDao.getTopicPage(cat, post, page) ?: return@traceAsync null
             val postEntities = topicDao.getPostsByNumreponse(cat, topicEntity.numreponses)
             CachedTopic(
                 topic = TopicMappers.toDomain(topicEntity, postEntities),
@@ -167,5 +180,14 @@ class TopicRepositoryImpl @Inject constructor(
 
     private companion object {
         const val LOG_TAG = "TopicRepository"
+        const val ROOM_READ_SECTION = "rf2.topic.room_read"
+        const val ROOM_WRITE_SECTION = "rf2.topic.room_write"
+
+        // Process-wide monotonic cookie source for async trace sections. AndroidX requires
+        // cookies to be unique only among overlapping events sharing the same section name;
+        // a single shared `AtomicInteger` is enough and survives `@Singleton` boundaries
+        // (same JVM = same counter). Wraps around at `Int.MAX_VALUE` after ~2B sections,
+        // which is several orders of magnitude above any realistic process lifetime.
+        private val asyncCookie = AtomicInteger(0)
     }
 }

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -24,6 +24,11 @@ dependencies {
     api(libs.okhttp)
     implementation(libs.okhttp.logging)
 
+    // androidx.tracing for `Trace.beginSection`/`endSection` and the `trace { … }` extension
+    // used by `HfrClient` to mark `rf2.topic.network` and `rf2.topic.body_read` phases. See
+    // #117 / `docs/guides/profiling.md` for the section-name catalogue.
+    implementation(libs.androidx.tracing)
+
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.android)
 

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
@@ -38,21 +38,23 @@ class HfrClient @Inject constructor(
         return if (useAuth) {
             // Authenticated read: an expired session would otherwise be parsed silently as an
             // empty topic. executeAuthenticatedHtml() raises SessionExpiredException so the
-            // caller can surface a reconnect CTA instead of a misleading empty screen.
-            authenticated.newCall(request).executeAuthenticatedHtml()
+            // caller can surface a reconnect CTA instead of a misleading empty screen. The
+            // `rf2.topic` prefix scopes the trace sections to the topic feature only — other
+            // callers (MP list, …) opt out of tracing by omitting the prefix.
+            authenticated.newCall(request).executeAuthenticatedHtml(tracePrefix = TOPIC_TRACE_PREFIX)
         } else {
             // `rf2.topic.network` covers DNS + connect + TLS + headers (the part OkHttp returns
             // before we touch the body). `rf2.topic.body_read` covers the bytes-on-the-wire
             // pull from the response body. Splitting them lets a profiler tell a slow handshake
-            // apart from a slow body download. The same split lives in
-            // `executeAuthenticatedHtml` for the auth path.
-            trace("rf2.topic.network") {
+            // apart from a slow body download. The auth branch above wires the same prefix into
+            // `executeAuthenticatedHtml`.
+            trace("$TOPIC_TRACE_PREFIX.network") {
                 anonymous.newCall(request).execute()
             }.use { response ->
                 if (!response.isSuccessful) {
                     throw IOException("HFR returned ${response.code} for $url")
                 }
-                trace("rf2.topic.body_read") { response.body.string() }
+                trace("$TOPIC_TRACE_PREFIX.body_read") { response.body.string() }
             }
         }
     }
@@ -84,23 +86,42 @@ class HfrClient @Inject constructor(
         return authenticated.newCall(request).executeAuthenticatedHtml()
     }
 
-    private fun Call.executeAuthenticatedHtml(): String {
-        // Same split as the anonymous branch in `getTopicPage` — `rf2.topic.network` for the
-        // OkHttp call up to headers, `rf2.topic.body_read` for the body pull. The session-expiry
-        // detection (login redirect / login form sniff) runs after the body is already in
-        // memory, so it has no measurable cost worth a third section.
-        val response: Response = trace("rf2.topic.network") { execute() }
+    /**
+     * Executes the call, returns the body as a UTF-8 string, and raises
+     * [SessionExpiredException] if HFR redirected to the login page or returned the login form
+     * inline. When [tracePrefix] is non-null, the OkHttp call up to headers is wrapped in
+     * `<prefix>.network` and the body pull in `<prefix>.body_read` (cf. `docs/guides/profiling.md`).
+     * Callers that don't belong to the topic parcours pass `null` to stay out of `rf2.topic.*`.
+     */
+    private fun Call.executeAuthenticatedHtml(tracePrefix: String? = null): String {
+        val response: Response = if (tracePrefix != null) {
+            trace("$tracePrefix.network") { execute() }
+        } else {
+            execute()
+        }
         return response.use {
             if (!response.isSuccessful) {
                 throw IOException("HFR returned ${response.code} for ${response.request.url}")
             }
-            val html = trace("rf2.topic.body_read") { response.body.string() }
+            val html = if (tracePrefix != null) {
+                // Session-expiry detection (login redirect / login form sniff) runs after the body
+                // is in memory, so its cost is negligible relative to body_read; not worth a third
+                // section.
+                trace("$tracePrefix.body_read") { response.body.string() }
+            } else {
+                response.body.string()
+            }
             val finalUrl = response.request.url
             if (finalUrl.isLoginUrl() || html.looksLikeLoginPage()) {
                 throw SessionExpiredException(finalUrl.toString())
             }
             html
         }
+    }
+
+    private companion object {
+        // Prefix consumed by `docs/guides/profiling.md` — keep in lockstep with the catalogue.
+        private const val TOPIC_TRACE_PREFIX = "rf2.topic"
     }
 
     private fun HttpUrl.isLoginUrl(): Boolean =

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.core.network
 
+import androidx.tracing.trace
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.network.qualifiers.AnonymousClient
 import fr.forumhfr.redface2.core.network.qualifiers.AuthenticatedClient
@@ -11,6 +12,7 @@ import okhttp3.Call
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.Response
 
 @Singleton
 class HfrClient @Inject constructor(
@@ -39,11 +41,18 @@ class HfrClient @Inject constructor(
             // caller can surface a reconnect CTA instead of a misleading empty screen.
             authenticated.newCall(request).executeAuthenticatedHtml()
         } else {
-            anonymous.newCall(request).execute().use { response ->
+            // `rf2.topic.network` covers DNS + connect + TLS + headers (the part OkHttp returns
+            // before we touch the body). `rf2.topic.body_read` covers the bytes-on-the-wire
+            // pull from the response body. Splitting them lets a profiler tell a slow handshake
+            // apart from a slow body download. The same split lives in
+            // `executeAuthenticatedHtml` for the auth path.
+            trace("rf2.topic.network") {
+                anonymous.newCall(request).execute()
+            }.use { response ->
                 if (!response.isSuccessful) {
                     throw IOException("HFR returned ${response.code} for $url")
                 }
-                response.body.string()
+                trace("rf2.topic.body_read") { response.body.string() }
             }
         }
     }
@@ -75,16 +84,23 @@ class HfrClient @Inject constructor(
         return authenticated.newCall(request).executeAuthenticatedHtml()
     }
 
-    private fun Call.executeAuthenticatedHtml(): String = execute().use { response ->
-        if (!response.isSuccessful) {
-            throw IOException("HFR returned ${response.code} for ${response.request.url}")
+    private fun Call.executeAuthenticatedHtml(): String {
+        // Same split as the anonymous branch in `getTopicPage` — `rf2.topic.network` for the
+        // OkHttp call up to headers, `rf2.topic.body_read` for the body pull. The session-expiry
+        // detection (login redirect / login form sniff) runs after the body is already in
+        // memory, so it has no measurable cost worth a third section.
+        val response: Response = trace("rf2.topic.network") { execute() }
+        return response.use {
+            if (!response.isSuccessful) {
+                throw IOException("HFR returned ${response.code} for ${response.request.url}")
+            }
+            val html = trace("rf2.topic.body_read") { response.body.string() }
+            val finalUrl = response.request.url
+            if (finalUrl.isLoginUrl() || html.looksLikeLoginPage()) {
+                throw SessionExpiredException(finalUrl.toString())
+            }
+            html
         }
-        val html = response.body.string()
-        val finalUrl = response.request.url
-        if (finalUrl.isLoginUrl() || html.looksLikeLoginPage()) {
-            throw SessionExpiredException(finalUrl.toString())
-        }
-        html
     }
 
     private fun HttpUrl.isLoginUrl(): Boolean =

--- a/docs/guides/profiling.md
+++ b/docs/guides/profiling.md
@@ -15,17 +15,19 @@ Issue tracker : [#117](https://github.com/ForumHFR/redface2/issues/117) (instrum
 
 Toutes les sections sont préfixées `rf2.topic.` pour faciliter le filtrage côté Perfetto / `TraceSectionMetric`. Le préfixe est stable : un bump de phase ne le renomme pas. Tout changement de nom doit être reflété simultanément ici et dans la (future) configuration `TraceSectionMetric` du macrobenchmark.
 
-| Section | Module / fichier | Phase mesurée |
-|---|---|---|
-| `rf2.topic.network` | `core/network/.../HfrClient.kt` | Appel OkHttp `execute()` jusqu'aux headers (DNS + connect + TLS + send + receive headers). Émise sur les deux paths (auth + anon). |
-| `rf2.topic.body_read` | `core/network/.../HfrClient.kt` | `response.body.string()` — lecture des bytes du body. Mesure isolée du téléchargement, distincte du handshake. |
-| `rf2.topic.parse_html` | `core/data/.../TopicRepositoryImpl.kt` | `HfrParser.parseTopicPage(html)` — coût CPU pur du parsing Jsoup → AST `PostContent`. |
-| `rf2.topic.map_domain` | `core/data/.../TopicRepositoryImpl.kt` | `TopicMappers.toEntities(...)` — conversion modèles domaine → entités Room. |
-| `rf2.topic.room_read` | `core/data/.../TopicRepositoryImpl.kt` | `loadFromCache(...)` — lecture cache-aside (hit ou miss). |
-| `rf2.topic.room_write` | `core/data/.../TopicRepositoryImpl.kt` | `persist(...)` — écriture transactionnelle Room (auth ou anon prefetch). |
-| `rf2.topic.first_content` | `feature/topic/.../TopicViewModel.kt` | Section **asynchrone** : commence quand `loadCurrentPage()` démarre, finit au premier emit `Mode.Loaded` ou `Mode.Error`. Mesure le ressenti utilisateur entre intent et premier contenu, qu'il vienne du cache ou du réseau. |
+| Section | Type | Module / fichier | Phase mesurée |
+|---|---|---|---|
+| `rf2.topic.network` | sync | `core/network/.../HfrClient.kt` | Appel OkHttp `execute()` jusqu'aux headers (DNS + connect + TLS + send + receive headers). Émise sur les deux paths du parcours topic (auth + anon) — `executeAuthenticatedHtml` reçoit le préfixe `rf2.topic` uniquement quand `getTopicPage(useAuth=true)` l'appelle, donc `getPrivateMessageListPage` et tout autre appelant restent hors namespace. |
+| `rf2.topic.body_read` | sync | `core/network/.../HfrClient.kt` | `response.body.string()` — lecture des bytes du body. Mesure isolée du téléchargement, distincte du handshake. Même conditionnel d'émission que `network`. |
+| `rf2.topic.parse_html` | sync | `core/data/.../TopicRepositoryImpl.kt` | `HfrParser.parseTopicPage(html)` — coût CPU pur du parsing Jsoup → AST `PostContent`. |
+| `rf2.topic.map_domain` | sync | `core/data/.../TopicRepositoryImpl.kt` | `TopicMappers.toEntities(...)` — conversion modèles domaine → entités Room. |
+| `rf2.topic.room_read` | async | `core/data/.../TopicRepositoryImpl.kt` | `loadFromCache(...)` — lecture cache-aside (hit ou miss). Wrap `traceAsync` car les `suspend` DAO Room peuvent reprendre sur un thread différent de celui qui a émis le begin. |
+| `rf2.topic.room_write` | async | `core/data/.../TopicRepositoryImpl.kt` | `persist(...)` — écriture transactionnelle Room (auth ou anon prefetch). Async pour la même raison que `room_read`. |
+| `rf2.topic.first_content` | async | `feature/topic/.../TopicViewModel.kt` | Commence quand `loadCurrentPage()` démarre, finit au premier emit `Mode.Loaded` ou `Mode.Error`. Mesure le ressenti utilisateur entre intent et premier contenu, qu'il vienne du cache ou du réseau. |
 
-`first_content` est la seule section asynchrone — elle traverse plusieurs threads (UI → IO → UI) et utilise `Trace.beginAsyncSection` / `endAsyncSection` avec un cookie incrémenté à chaque retry / re-load. Les autres sections sont synchrones (un seul thread pendant leur durée).
+Sections **synchrones** (`Trace.beginSection` / `Trace.endSection` via le helper `trace { … }`) : begin et end doivent se produire sur le même thread. C'est garanti ici parce que `network`, `body_read`, `parse_html` et `map_domain` enrobent du code non-`suspend` qui ne peut pas changer de thread pendant son exécution.
+
+Sections **asynchrones** (`Trace.beginAsyncSection` / `Trace.endAsyncSection` via le helper `traceAsync(name, cookie) { … }`) : tolèrent les changements de thread (begin sur thread A, end sur thread B). Utilisées pour tout code qui suspend ou qui peut être resumé sur un dispatcher différent — `room_read`, `room_write` (DAO Room `suspend`) et `first_content` (UI → IO → UI). Le cookie est un entier monotone (un par scope : compteur process-wide pour les sections Room, compteur par-VM pour `first_content`) — il garantit qu'un retry mid-load ferme la section précédente avant qu'une nouvelle commence.
 
 ## Visualiser les sections en local
 

--- a/docs/guides/profiling.md
+++ b/docs/guides/profiling.md
@@ -1,0 +1,67 @@
+---
+layout: default
+title: Profiling et tracing
+parent: Guides
+nav_order: 6
+---
+
+# Profiling et tracing
+
+Comment instrumenter et mesurer les performances du parcours « ouvrir un topic et commencer à lire ». Cette page documente le **catalogue stable des sections de trace** et la procédure pour les visualiser dans Android Studio Profiler ou Perfetto.
+
+Issue tracker : [#117](https://github.com/ForumHFR/redface2/issues/117) (instrumentation initiale, livrée), suites éventuelles à ouvrir si une trace montre un goulot.
+
+## Catalogue des sections `rf2.topic.*`
+
+Toutes les sections sont préfixées `rf2.topic.` pour faciliter le filtrage côté Perfetto / `TraceSectionMetric`. Le préfixe est stable : un bump de phase ne le renomme pas. Tout changement de nom doit être reflété simultanément ici et dans la (future) configuration `TraceSectionMetric` du macrobenchmark.
+
+| Section | Module / fichier | Phase mesurée |
+|---|---|---|
+| `rf2.topic.network` | `core/network/.../HfrClient.kt` | Appel OkHttp `execute()` jusqu'aux headers (DNS + connect + TLS + send + receive headers). Émise sur les deux paths (auth + anon). |
+| `rf2.topic.body_read` | `core/network/.../HfrClient.kt` | `response.body.string()` — lecture des bytes du body. Mesure isolée du téléchargement, distincte du handshake. |
+| `rf2.topic.parse_html` | `core/data/.../TopicRepositoryImpl.kt` | `HfrParser.parseTopicPage(html)` — coût CPU pur du parsing Jsoup → AST `PostContent`. |
+| `rf2.topic.map_domain` | `core/data/.../TopicRepositoryImpl.kt` | `TopicMappers.toEntities(...)` — conversion modèles domaine → entités Room. |
+| `rf2.topic.room_read` | `core/data/.../TopicRepositoryImpl.kt` | `loadFromCache(...)` — lecture cache-aside (hit ou miss). |
+| `rf2.topic.room_write` | `core/data/.../TopicRepositoryImpl.kt` | `persist(...)` — écriture transactionnelle Room (auth ou anon prefetch). |
+| `rf2.topic.first_content` | `feature/topic/.../TopicViewModel.kt` | Section **asynchrone** : commence quand `loadCurrentPage()` démarre, finit au premier emit `Mode.Loaded` ou `Mode.Error`. Mesure le ressenti utilisateur entre intent et premier contenu, qu'il vienne du cache ou du réseau. |
+
+`first_content` est la seule section asynchrone — elle traverse plusieurs threads (UI → IO → UI) et utilise `Trace.beginAsyncSection` / `endAsyncSection` avec un cookie incrémenté à chaque retry / re-load. Les autres sections sont synchrones (un seul thread pendant leur durée).
+
+## Visualiser les sections en local
+
+### Android Studio Profiler — System Trace (recommandé pour le dev quotidien)
+
+1. Lancer l'app debug sur device ou émulateur (API ≥ 29 — minSdk du projet).
+2. **View → Tool Windows → Profiler**.
+3. Sélectionner le process `fr.forumhfr.redface2`.
+4. **CPU** → choisir l'onglet **System Trace** → Record.
+5. Ouvrir un topic depuis l'app pendant que l'enregistrement tourne.
+6. Stopper l'enregistrement, chercher `rf2.topic.*` dans la barre de recherche : les sections apparaissent dans la lane du process.
+
+### Perfetto (pour analyse plus fine)
+
+1. Activer le développeur trace : `adb shell perfetto -c - --txt -o /data/misc/perfetto-traces/trace.pb` avec une config personnalisée (ou utiliser le UI Perfetto sur https://ui.perfetto.dev/ qui sait piloter `record_android_trace`).
+2. Reproduire le scénario topic.
+3. Pull le trace : `adb pull /data/misc/perfetto-traces/trace.pb`.
+4. Drag-and-drop dans https://ui.perfetto.dev/ → search bar → `rf2.topic`.
+
+Perfetto sait grouper les sections par nom et calculer p50 / p95 sur plusieurs runs, ce que System Trace ne fait pas.
+
+## Conventions
+
+- **Toujours préfixer `rf2.topic.`** pour les nouvelles sections du parcours topic. Pour d'autres parcours (forum, drapeaux, MPs), utiliser `rf2.<feature>.` afin de garder un namespace lisible.
+- **Pas de format / pas d'emoji** dans les noms de sections — ils sont consommés par des outils qui comparent par chaîne exacte.
+- **Sections instantanées (durée ≈ 0)** : préférer un nom qui finit par `.tick` ou `.event` (e.g. `rf2.topic.cache_hit_event`) pour les distinguer des phases de durée. Aucun de ce type n'est utilisé aujourd'hui.
+- **Modifier un nom de section = casser un consommateur potentiel** (macrobenchmark, dashboard externe). Toute modification doit mettre à jour ce fichier dans la même PR.
+
+## Hors scope de cette première instrumentation
+
+- **Microbenchmark parser** (`androidx.benchmark.junit4`) — module dédié pour mesurer `HfrParser.parseTopicPage` en isolation. Suivi sous une issue fille ouverte avec `#117`. Déclencheur : une trace montre `rf2.topic.parse_html` dominant le temps avant premier contenu, ou un changement structurel du parser.
+- **Macrobenchmark parcours topic** (`androidx.benchmark.macro.junit4`) — module séparé pour mesurer `FrameTimingMetric` et `TraceSectionMetric` sur un scénario complet. Suivi sous une issue fille. Déclencheur : optimisation envisagée sur le parcours, ou ralentissement ressenti remonté en dogfood.
+- **OkHttp `EventListener` debug** — séparation fine DNS / connect / TLS / request / response / body. Pas livré ici, peut être ajouté à `HfrClient` si une trace montre que `rf2.topic.network` mérite d'être décomposée plus finement.
+
+## Référence
+
+- AndroidX Tracing 1.3.0 (catégorie `androidx.tracing:tracing`) — la version 1.3 a fusionné `tracing-ktx` dans le module principal. La 2.0.0-alpha introduit `TraceSink` / `TraceDriver` ; non consommée tant qu'elle n'est pas stable.
+- [Documentation officielle Android — System tracing overview](https://developer.android.com/topic/performance/tracing) pour le format `Trace.beginSection` / `endSection` et les async sections.
+- [Documentation `TraceSectionMetric`](https://developer.android.com/reference/kotlin/androidx/benchmark/macro/TraceSectionMetric) pour la consommation de ces sections par un macrobenchmark.

--- a/feature/topic/build.gradle.kts
+++ b/feature/topic/build.gradle.kts
@@ -5,6 +5,17 @@ plugins {
 
 android {
     namespace = "fr.forumhfr.redface2.feature.topic"
+
+    testOptions {
+        unitTests {
+            // `androidx.tracing.Trace` delegates to `android.os.Trace`, which is unavailable
+            // in JVM unit tests. The default-values stub returns no-ops for void methods, so
+            // the tracing calls in `TopicViewModel.{begin,end}FirstContentSection` become
+            // no-ops in JVM tests instead of throwing "not mocked". Same convention as
+            // :core:network and :core:data.
+            isReturnDefaultValues = true
+        }
+    }
 }
 
 dependencies {
@@ -17,6 +28,10 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.kotlinx.coroutines.android)
+
+    // androidx.tracing for the `rf2.topic.first_content` marker emitted on the first state
+    // transition into `Mode.Loaded` (#117).
+    implementation(libs.androidx.tracing)
 
     testImplementation(libs.junit4)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -2,6 +2,7 @@ package fr.forumhfr.redface2.feature.topic
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.tracing.Trace
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -55,6 +56,17 @@ class TopicViewModel @AssistedInject constructor(
      */
     private var scrollEffectEmitted: Boolean = false
 
+    /**
+     * Async-trace cookie for the `rf2.topic.first_content` section. The section starts when
+     * [loadCurrentPage] kicks off and ends on the first emission that lands in
+     * [TopicUiState.Mode.Loaded] (cache hit or first network reply, whichever comes first).
+     * The cookie is monotonically incremented on each retry / re-load so a previous in-flight
+     * section can be ended cleanly before a new one starts; without this the trace would show
+     * an open-ended section that never closes when the user retries mid-load.
+     */
+    private var firstContentCookie: Int = 0
+    private var firstContentInFlight: Boolean = false
+
     init {
         loadCurrentPage()
     }
@@ -65,10 +77,33 @@ class TopicViewModel @AssistedInject constructor(
         }
     }
 
+    override fun onCleared() {
+        // Close the in-flight async trace section if the ViewModel dies before the first
+        // emission lands — leaving an open async section in the trace would skew the next
+        // measurement window and Perfetto would draw a never-ending sliver.
+        endFirstContentSectionIfNeeded()
+        super.onCleared()
+    }
+
+    private fun beginFirstContentSection() {
+        endFirstContentSectionIfNeeded()
+        firstContentCookie++
+        Trace.beginAsyncSection(FIRST_CONTENT_SECTION, firstContentCookie)
+        firstContentInFlight = true
+    }
+
+    private fun endFirstContentSectionIfNeeded() {
+        if (firstContentInFlight) {
+            Trace.endAsyncSection(FIRST_CONTENT_SECTION, firstContentCookie)
+            firstContentInFlight = false
+        }
+    }
+
     private fun loadCurrentPage() {
         loadJob?.cancel()
         prefetchJob?.cancel()
         prefetchedPage = null
+        beginFirstContentSection()
         _state.update { it.copy(mode = TopicUiState.Mode.Loading) }
         loadJob = viewModelScope.launch {
             topicRepository
@@ -83,6 +118,9 @@ class TopicViewModel @AssistedInject constructor(
                         if (current.mode is TopicUiState.Mode.Loaded) current
                         else current.copy(mode = TopicUiState.Mode.Error(error.message ?: "Unknown error"))
                     }
+                    // Close the async trace section even on the error path so the trace
+                    // still draws a bounded sliver from intent to terminal state.
+                    endFirstContentSectionIfNeeded()
                 }
                 .collect { topic ->
                     _state.update {
@@ -91,6 +129,10 @@ class TopicViewModel @AssistedInject constructor(
                             availablePages = (1..topic.totalPages).toList(),
                         )
                     }
+                    // First content visible — close the async section. Subsequent emissions
+                    // (stale-cache then refresh) already see `firstContentInFlight = false`
+                    // and the helper short-circuits.
+                    endFirstContentSectionIfNeeded()
                     maybeEmitScroll(topic.posts.map { it.numreponse })
                     maybeSchedulePrefetch(totalPages = topic.totalPages)
                 }
@@ -140,5 +182,12 @@ class TopicViewModel @AssistedInject constructor(
     @AssistedFactory
     interface Factory {
         fun create(request: TopicRequest): TopicViewModel
+    }
+
+    private companion object {
+        // Keep the section-name catalogue in lockstep with `docs/guides/profiling.md` so a
+        // `TraceSectionMetric("rf2.topic.first_content")` consumer (future macrobenchmark
+        // under #117 follow-up) keeps matching after refactors.
+        private const val FIRST_CONTENT_SECTION = "rf2.topic.first_content"
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ robolectric = "4.16.1"
 turbine = "1.2.1"
 konsist = "0.17.3"
 javax-inject = "1"
+androidx-tracing = "1.3.0"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -46,6 +47,11 @@ ksp-gradle-plugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.
 hilt-android-gradle-plugin = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt" }
 
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
+# `tracing-ktx` was merged into the main `tracing` module in 1.3.0 (extension `trace { … }` is now
+# in the same artefact). Used to mark named sections around the topic-read flow so Android Studio
+# Profiler / Perfetto can show the cost of each phase. Kept stable to avoid the 2.x alpha churn
+# (TraceSink + TraceDriver APIs).
+androidx-tracing = { module = "androidx.tracing:tracing", version.ref = "androidx-tracing" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test-core" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }


### PR DESCRIPTION
## Contexte

Closes #117. Instrumente le parcours « ouvrir un topic et commencer à lire » avec des sections [`androidx.tracing`](https://developer.android.com/topic/performance/tracing) nommées (`rf2.topic.*`) pour permettre une analyse granulaire du temps passé entre l'intent utilisateur et le premier contenu visible, via Android Studio Profiler, Perfetto ou un futur `TraceSectionMetric` macrobenchmark.

## Approche : option A (Codex verdict)

Discussion préalable avec Codex sur la décomposition de #117 → option A retenue : **livrer uniquement l'instrumentation `androidx.tracing` + le catalogue stable**, sans microbench parser ni macrobench, ces deux derniers tracés en follow-ups :

- #141 — microbenchmark `HfrParser.parseTopicPage` (déclencheur : trace montre `parse_html` dominant)
- #142 — macrobenchmark `FrameTimingMetric` + `TraceSectionMetric` parcours topic (déclencheur : optimisation envisagée ou ralentissement remonté)

Rationale : l'instrumentation est la fondation indépendante. Sans données réelles d'un trace, choisir entre micro et macro relève de la spéculation — le catalogue de sections stable permet d'attaquer chaque axe quand un signal le justifie, pas avant.

## Catalogue des sections

| Section | Module | Phase mesurée |
|---|---|---|
| `rf2.topic.network` | `core/network/HfrClient.kt` | OkHttp `execute()` jusqu'aux headers (DNS + connect + TLS + send + receive headers). Émise sur les deux paths (auth + anon). |
| `rf2.topic.body_read` | `core/network/HfrClient.kt` | `response.body.string()` — bytes du body. |
| `rf2.topic.parse_html` | `core/data/TopicRepositoryImpl.kt` | `HfrParser.parseTopicPage(html)` — coût CPU pur. |
| `rf2.topic.map_domain` | `core/data/TopicRepositoryImpl.kt` | `TopicMappers.toEntities(...)` → entités Room. |
| `rf2.topic.room_read` | `core/data/TopicRepositoryImpl.kt` | `loadFromCache(...)` — hit ou miss. |
| `rf2.topic.room_write` | `core/data/TopicRepositoryImpl.kt` | `persist(...)` — Room transactionnelle. |
| `rf2.topic.first_content` | `feature/topic/TopicViewModel.kt` | **Async** — intent → premier emit `Mode.Loaded` ou `Mode.Error` (cache hit ou réseau). |

## Détails techniques

- **Async section + cookie monotone** : `Trace.beginAsyncSection` / `endAsyncSection` avec un cookie incrémenté à chaque retry / re-load. Sans cookie, un retry mid-load laisserait une section ouverte que Perfetto dessinerait comme un sliver infini. `onCleared` ferme proprement toute section en cours si le ViewModel meurt avant la première émission.
- **JVM tests** : `feature/topic/build.gradle.kts` active `unitTests.isReturnDefaultValues = true` car `androidx.tracing.Trace.{begin,end}AsyncSection` délègue à `android.os.Trace` non mocké en tests JVM. Même convention que `:core:network` et `:core:data`.
- **Pas de dépendance nouvelle côté runtime applicatif** — `androidx.tracing` 1.3.0 est zero-cost en release sans System Trace actif.

## Documentation

`docs/guides/profiling.md` (nouveau, +67 lignes) — catalogue stable, procédure Android Studio Profiler + Perfetto, conventions de nommage (`rf2.<feature>.`), hors-scope explicite (microbench, macrobench, OkHttp `EventListener` debug).

## Tests

- ✅ `:app:assembleDebug` — BUILD SUCCESSFUL
- ✅ `:feature:topic:testDebugUnitTest` — 12 tests verts après ajout de `isReturnDefaultValues = true`
- ⚠️ Pas de test unitaire qui asserte les noms de sections — les wrappers `trace { … }` sont triviaux et un test JVM ne vérifierait que la chaîne littérale, pas le câblage System Trace réel. Validation visuelle dans Android Studio System Trace prévue à la prochaine session de profiling.

## Suivi

Le catalogue est **stable** — toute modification de nom de section doit mettre à jour `docs/guides/profiling.md` dans la même PR (cf. § Conventions). Un `TraceSectionMetric("rf2.topic.first_content")` futur (#142) doit continuer à matcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)