### PR TITLE
docs(release): mark v37 closed after Play alpha upload

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -17,9 +17,9 @@ Workflow : bumper `versionCode` + `versionName` dans `app/build.gradle.kts`, ajo
 
 ## v37 — `0.1.0-phase1.6` — 2026-05-10
 
-**Statut** : `local` (sera `closed` après upload alpha automatique)
-**Commit** : à venir
-**Fichier** : `redface2-v37-<date>-<sha>.aab`
+**Statut** : `closed`
+**Commit** : `1832ed1`
+**Fichier** : `redface2-v37-1832ed1.aab`
 
 Build de finalisation Phase 1. Pas de changement fonctionnel visible utilisateur — uniquement de l'instrumentation perf et des tests qui figent les invariants du `PostRenderer` pour Phase 2.
 


### PR DESCRIPTION
Tag `app-v37` a déclenché [release.yml run 25636414200](https://github.com/ForumHFR/redface2/actions/runs/25636414200) ; build, sign, upload Play Console alpha et création de la [GitHub Release](https://github.com/ForumHFR/redface2/releases/tag/app-v37) tous verts.

Mise à jour du statut v37 dans `app/CHANGELOG.md` (`local` → `closed`) et du commit canonique (`1832ed1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)