### PR TITLE
chore(release): bump app to v38

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -15,6 +15,25 @@ Workflow : bumper `versionCode` + `versionName` dans `app/build.gradle.kts`, ajo
 
 ---
 
+## v38 — `0.1.0-phase1.7` — 2026-05-11
+
+**Statut** : `closed`
+**Commit** : à venir
+**Fichier** : `redface2-v38-<sha>.aab`
+
+Build de polish pré-Phase 2 pour le track alpha Play. L'objectif est de présenter une app de lecture cohérente pendant la revue manuelle Play, sans faux boutons laissant croire que Recherche ou Messages sont déjà livrés.
+
+### Changed
+- Écran Drapeaux recentré sur la lecture : footer alpha retiré, liste + refresh + login/reconnect gardés.
+- Les sujets CYAN déjà lus (`hasUnread = false`) sont masqués par défaut, avec un toggle « Afficher les sujets participés déjà lus ».
+- Écran Messages transformé en surface temporaire « Compte + Outils alpha » : login/logout, version, diagnostics et signalement.
+- Écran Recherche remplacé par une annonce sobre de la future recherche HFR Phase 2, sans bouton de topic démo.
+
+### Docs
+- Specs `architecture.md`, `mvi.md`, `navigation.md` et `roadmap.md` alignées avec le polish #154.
+
+---
+
 ## v37 — `0.1.0-phase1.6` — 2026-05-10
 
 **Statut** : `closed`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         // upload signing config).
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their phase / commit lineage to the user.
-        versionCode = 37
-        versionName = "0.1.0-phase1.6"
+        versionCode = 38
+        versionName = "0.1.0-phase1.7"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,7 +1,9 @@
-Test build — Redface 2 (community client for the French HFR forum).
+Alpha build Redface 2 — pre-Phase 2 polish.
 
-Full changelog: see the repo CHANGELOG.md
-https://github.com/ForumHFR/redface2/blob/main/CHANGELOG.md
+Changes:
+- Flags tab is now focused on reading.
+- Read participated topics are hidden by default, with a toggle to show them again.
+- Search and Messages tabs now explain the upcoming features instead of showing fake demo actions.
+- Diagnostics, reporting and account details moved to Messages.
 
-Please report any bug via the testing channel tools or by opening an
-issue on the repository.
+Please report bugs via the alpha channel or the GitHub repository.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,7 +1,9 @@
-Build de test — Redface 2 (client communautaire pour HFR).
+Build alpha Redface 2 — polish pré-Phase 2.
 
-Détail des changements : voir CHANGELOG.md du dépôt
-https://github.com/ForumHFR/redface2/blob/main/CHANGELOG.md
+Nouveautés :
+- Drapeaux recentrés sur la lecture.
+- Sujets participés déjà lus masqués par défaut, avec option pour les réafficher.
+- Onglets Recherche et Messages clarifiés en attendant les vraies features Phase 2/3.
+- Diagnostics, signalement et infos de compte déplacés dans Messages.
 
-Merci de remonter tout bug via les outils du canal de test ou en
-ouvrant une issue sur le dépôt.
+Merci de remonter tout bug via le canal alpha ou le dépôt GitHub.


### PR DESCRIPTION
> Action par GPT-5 Codex (demandée par @XaaT)

## Résumé

Bump release alpha après merge de #155.

- `versionCode = 38`
- `versionName = 0.1.0-phase1.7`
- `app/CHANGELOG.md` documente le polish pré-Phase 2
- notes Play `whatsnew-fr-FR` / `whatsnew-en-US` alignées avec le build alpha

## Validation

- `git diff --check` OK
- CI GitHub attendue sur cette PR

## Suite après merge

Créer le tag `app-v38` sur le merge commit puis le pousser pour déclencher `.github/workflows/release.yml` : AAB/APK signés, GitHub Release, upload Play Console track `alpha`.

Refs #154