### PR TITLE
feat(editor): Phase 2C reply MVP (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,18 @@ Format inspiré de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/). Les
 
 ---
 
-## v0.10.1 — 2026-05-18
+## v0.10.2 — 2026-05-18
 
-App patch 0.3.1 (build v41) — instrumente le flow reply via le canal
-`DiagnosticsLog` existant pour permettre aux testeurs alpha de remonter
-les détails d'un échec du GET form ou d'un POST classifié `Unknown`.
+App patch 0.3.2 (build v42) — élargit l'instrumentation alpha au cas où
+l'exception est levée **dans** `HfrClient` (HTTP non-2xx, IO, session
+expirée) plutôt que dans le parser. Sur v41 le test alpha n'a vu que les
+`INFO` du GET sans aucun `WARN` derrière → l'exception sortait avant le
+parse. Cette version log la classe + le message à la frontière transport,
+puis logue à nouveau le mapping `SubmitError` côté ViewModel.
 
 ### Added
-- `DefaultReplyRepository` enregistre chaque GET `message.php` (cat / subcat / post / page), le résultat du parsing (`hiddenFields.size`, `isAnonymous`, `sujet`), chaque POST `bddpost.php` (incl. `bbcode.length`), et le verdict du parser réponse. Sur échec parser ou retour `Unknown`, dump un extrait HTML de 600 caractères avec `hash_check=…` masqué, plus la liste des `<form action="…">` détectés — utile pour diagnostiquer un changement de structure HFR sans capturer la session.
-- Visible dans l'écran Diagnostics (Messages → Outils alpha → Diagnostics).
-- `hash_check` toujours redacté (regex `hash_check[=:][^"&\s]+` → `<REDACTED>`).
+- `DefaultReplyRepository` wrappe les appels `hfrClient.getReplyForm` et `hfrClient.submitReply` dans un try/catch qui enregistre un `WARN` `GET reply form FAILED: <ClassName>: <message>` (resp. `POST reply FAILED…`) avant de propager l'exception. `SessionExpiredException` est tracée séparément, `CancellationException` passe sans log.
+- `PostEditorViewModel.handleFetchFailure` / `handleSubmitFailure` enregistrent un `WARN` `PostEditorVM` indiquant l'exception reçue et le `SubmitError` dans lequel elle a été mappée (`Network` / `SessionExpired` / `Hfr(Unknown)`).
 
 Premier flux de mutation HFR réelle livré : depuis un topic, l'utilisateur peut composer un BBCode et le poster via `bddpost.php`, avec gestion typée des 5 erreurs HFR observées et anti-double-submit. App bump à `0.3.0` (semver MINOR pour la première mutation HFR). 2 rounds de reviews croisées (4 flavors × 2 = 8 rapports) ont validé l'absence de blocker critique et corrigé 2 bugs latents avant tag : (1) le filtre `password` du `ReplyFormParser` était documenté mais inopérant car `<input type="password">` n'est pas hidden — corrigé en itérant sur `input[name]` avec deny rules explicites ; (2) `Topic.hasSubcat` acceptait `subcat = 0` (wire shape moderator-space HFR `cat=0` family) sans fixture utilisateur qui prouve la validité — durci à `subcat > 0`. Migration Room v3 → v4 ajoute `subcat` à `topic_pages` avec sentinel `-1`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Format inspiré de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/). Les
 
 ## [Unreleased]
 
+---
+
+## v0.10.0 — 2026-05-18
+
+Premier flux de mutation HFR réelle livré : depuis un topic, l'utilisateur peut composer un BBCode et le poster via `bddpost.php`, avec gestion typée des 5 erreurs HFR observées et anti-double-submit. App bump à `0.3.0` (semver MINOR pour la première mutation HFR). 2 rounds de reviews croisées (4 flavors × 2 = 8 rapports) ont validé l'absence de blocker critique et corrigé 2 bugs latents avant tag : (1) le filtre `password` du `ReplyFormParser` était documenté mais inopérant car `<input type="password">` n'est pas hidden — corrigé en itérant sur `input[name]` avec deny rules explicites ; (2) `Topic.hasSubcat` acceptait `subcat = 0` (wire shape moderator-space HFR `cat=0` family) sans fixture utilisateur qui prouve la validité — durci à `subcat > 0`. Migration Room v3 → v4 ajoute `subcat` à `topic_pages` avec sentinel `-1`.
+
 ### Added
 - Phase 2C — Reply MVP (#145) : première mutation HFR réelle livrée. `PostEditorViewModel` reçoit `ReplyRepository` (interface `:core:domain/write/`, impl `DefaultReplyRepository` dans `:core:data/write/`). En mode Reply, le ViewModel fetch `message.php` au démarrage pour obtenir `hash_check`, puis sur `SubmitClicked` POSTe `bddpost.php?config=hfr.inc` avec le formulaire HFR complet (`verifrequet=1100`, `content_form`, `cat`, `subcat`, `post`, `page`, etc.).
 - `:core:parser/write/ReplyFormParser` extrait les hidden fields HFR (sans `password`, sans `pseudo` anonyme) ; `ReplySubmitResponseParser` classifie les 5 retours observés (succès, `empty_message`, `invalid_token`, `antiflood`, `locked_topic`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Format inspiré de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/). Les
 
 ## [Unreleased]
 
+### Added
+- Phase 2C — Reply MVP (#145) : première mutation HFR réelle livrée. `PostEditorViewModel` reçoit `ReplyRepository` (interface `:core:domain/write/`, impl `DefaultReplyRepository` dans `:core:data/write/`). En mode Reply, le ViewModel fetch `message.php` au démarrage pour obtenir `hash_check`, puis sur `SubmitClicked` POSTe `bddpost.php?config=hfr.inc` avec le formulaire HFR complet (`verifrequet=1100`, `content_form`, `cat`, `subcat`, `post`, `page`, etc.).
+- `:core:parser/write/ReplyFormParser` extrait les hidden fields HFR (sans `password`, sans `pseudo` anonyme) ; `ReplySubmitResponseParser` classifie les 5 retours observés (succès, `empty_message`, `invalid_token`, `antiflood`, `locked_topic`).
+- `:core:network/HfrClient` ajoute `getReplyForm()` (GET `message.php`) et `submitReply()` (POST `bddpost.php`). Cookies réutilisés via l'`AuthenticatedClient` existant ; `hash_check` jamais loggué.
+- Navigation : `PostEditorRoute` reçoit maintenant `page` et `subcat` ; `TopicScreen.onReply` capture ces deux valeurs depuis le topic chargé. `PostEditorScreen` expose `onSubmitSucceeded(targetPage)` qui pop l'éditeur et recharge la page topic cible (la nav `NavBackStack` remplace l'entrée `TopicRoute` par `topicEntry.copy(page = targetPage ?: topicEntry.page)`).
+- Anti-double-submit : `submitJob.isActive` bloque les clics répétés pendant le POST.
+- `Topic.subcat: Int` + `TopicEntity.subcat: Int` (sentinel `-1` = `SUBCAT_UNKNOWN`) parsés depuis `input[name=subcat]` du HTML topic. Migration Room v3 → v4 (`ALTER TABLE topic_pages ADD COLUMN subcat INTEGER NOT NULL DEFAULT -1`). Le bouton « Répondre » est désactivé si `topic.hasSubcat == false` (cache pré-v4) — la valeur `-1` n'est jamais transmise à HFR.
+
+### Changed
+- `docs/specs/mvi.md` § Editor : actualisé pour le state submit + effets one-shot.
+- `docs/specs/navigation.md` : `PostEditorRoute` étendu, callbacks de TopicScreen et signature `PostEditorScreen` mis à jour.
+- `docs/specs/roadmap.md` : Phase 2 Reply MVP cochée.
+
 ---
 
 ## v0.9.0 — 2026-05-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,16 @@ Format inspiré de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/). Les
 
 ---
 
-## v0.10.0 — 2026-05-18
+## v0.10.1 — 2026-05-18
+
+App patch 0.3.1 (build v41) — instrumente le flow reply via le canal
+`DiagnosticsLog` existant pour permettre aux testeurs alpha de remonter
+les détails d'un échec du GET form ou d'un POST classifié `Unknown`.
+
+### Added
+- `DefaultReplyRepository` enregistre chaque GET `message.php` (cat / subcat / post / page), le résultat du parsing (`hiddenFields.size`, `isAnonymous`, `sujet`), chaque POST `bddpost.php` (incl. `bbcode.length`), et le verdict du parser réponse. Sur échec parser ou retour `Unknown`, dump un extrait HTML de 600 caractères avec `hash_check=…` masqué, plus la liste des `<form action="…">` détectés — utile pour diagnostiquer un changement de structure HFR sans capturer la session.
+- Visible dans l'écran Diagnostics (Messages → Outils alpha → Diagnostics).
+- `hash_check` toujours redacté (regex `hash_check[=:][^"&\s]+` → `<REDACTED>`).
 
 Premier flux de mutation HFR réelle livré : depuis un topic, l'utilisateur peut composer un BBCode et le poster via `bddpost.php`, avec gestion typée des 5 erreurs HFR observées et anti-double-submit. App bump à `0.3.0` (semver MINOR pour la première mutation HFR). 2 rounds de reviews croisées (4 flavors × 2 = 8 rapports) ont validé l'absence de blocker critique et corrigé 2 bugs latents avant tag : (1) le filtre `password` du `ReplyFormParser` était documenté mais inopérant car `<input type="password">` n'est pas hidden — corrigé en itérant sur `input[name]` avec deny rules explicites ; (2) `Topic.hasSubcat` acceptait `subcat = 0` (wire shape moderator-space HFR `cat=0` family) sans fixture utilisateur qui prouve la validité — durci à `subcat > 0`. Migration Room v3 → v4 ajoute `subcat` à `topic_pages` avec sentinel `-1`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,22 @@ puis logue à nouveau le mapping `SubmitError` côté ViewModel.
 - `DefaultReplyRepository` wrappe les appels `hfrClient.getReplyForm` et `hfrClient.submitReply` dans un try/catch qui enregistre un `WARN` `GET reply form FAILED: <ClassName>: <message>` (resp. `POST reply FAILED…`) avant de propager l'exception. `SessionExpiredException` est tracée séparément, `CancellationException` passe sans log.
 - `PostEditorViewModel.handleFetchFailure` / `handleSubmitFailure` enregistrent un `WARN` `PostEditorVM` indiquant l'exception reçue et le `SubmitError` dans lequel elle a été mappée (`Network` / `SessionExpired` / `Hfr(Unknown)`).
 
+---
+
+## v0.10.1 — 2026-05-18
+
+App patch 0.3.1 (build v41) — instrumente le flow Phase 2C reply via le canal `DiagnosticsLog` existant pour permettre aux testeurs alpha de remonter les détails d'un échec à un mainteneur sans capturer la session.
+
+### Added
+- `DefaultReplyRepository` injecte `DiagnosticsLog` et enregistre `INFO` sur chaque GET `message.php` (cat / subcat / post / page) et POST `bddpost.php`, `DEBUG` sur le parsing réussi du formulaire, `WARN` sur tout échec parser ou retour `Unknown`.
+- Sur échec parser, dump d'un extrait HTML (max 600 chars) avec `hash_check=…` masqué via regex, plus la liste des `<form action="…">` détectés — utile pour diagnostiquer un changement de structure HFR sans capturer la session.
+- Visible dans l'écran Diagnostics (Messages → Outils alpha → Diagnostics).
+- `hash_check` jamais sérialisé dans un message log natif Android.
+
+---
+
+## v0.10.0 — 2026-05-18
+
 Premier flux de mutation HFR réelle livré : depuis un topic, l'utilisateur peut composer un BBCode et le poster via `bddpost.php`, avec gestion typée des 5 erreurs HFR observées et anti-double-submit. App bump à `0.3.0` (semver MINOR pour la première mutation HFR). 2 rounds de reviews croisées (4 flavors × 2 = 8 rapports) ont validé l'absence de blocker critique et corrigé 2 bugs latents avant tag : (1) le filtre `password` du `ReplyFormParser` était documenté mais inopérant car `<input type="password">` n'est pas hidden — corrigé en itérant sur `input[name]` avec deny rules explicites ; (2) `Topic.hasSubcat` acceptait `subcat = 0` (wire shape moderator-space HFR `cat=0` family) sans fixture utilisateur qui prouve la validité — durci à `subcat > 0`. Migration Room v3 → v4 ajoute `subcat` à `topic_pages` avec sentinel `-1`.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ Format inspiré de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/). Les
 
 ---
 
+## v0.10.3 — 2026-05-18
+
+App patch 0.3.3 (build v43) — fix `NetworkOnMainThreadException`
+sur le flow Phase 2C reply, identifié grâce à l'instrumentation
+diagnostics v42.
+
+### Fixed
+- `DefaultReplyRepository.fetchReplyForm` et `submitReply` n'utilisaient pas le dispatcher IO injecté — les appels `hfrClient.getReplyForm` / `hfrClient.submitReply` tournaient donc sur `Dispatchers.Main.immediate` (le défaut de `viewModelScope.launch`), et OkHttp `.execute()` (blocking) levait `NetworkOnMainThreadException` avant même que la requête parte. Les autres repositories (`DefaultForumRepository`, …) wrappent déjà leurs appels HfrClient avec `withContext(ioDispatcher)` ; alignement maintenu.
+- L'erreur se manifestait côté utilisateur par « HFR a renvoyé une réponse inattendue » à l'ouverture de l'éditeur ET à chaque clic « Envoyer », sans aucun GET ni POST réellement émis vers HFR.
+
+---
+
 ## v0.10.2 — 2026-05-18
 
 App patch 0.3.2 (build v42) — élargit l'instrumentation alpha au cas où

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         // track (alpha) and in the GitHub Release flag, not in versionName itself.
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
-        versionCode = 41
-        versionName = "0.3.1"
+        versionCode = 42
+        versionName = "0.3.2"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         // track (alpha) and in the GitHub Release flag, not in versionName itself.
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
-        versionCode = 40
-        versionName = "0.3.0"
+        versionCode = 41
+        versionName = "0.3.1"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         // track (alpha) and in the GitHub Release flag, not in versionName itself.
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
-        versionCode = 39
-        versionName = "0.2.0"
+        versionCode = 40
+        versionName = "0.3.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         // track (alpha) and in the GitHub Release flag, not in versionName itself.
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
-        versionCode = 42
-        versionName = "0.3.2"
+        versionCode = 43
+        versionName = "0.3.3"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -78,6 +78,18 @@ data class PostEditorRoute(
     val cat: Int,
     val topicId: Int? = null,
     val numreponse: Int? = null,
+    /**
+     * Page index of the topic the user is replying to. Required by HFR's
+     * `message.php` reply form URL (cf. `docs/specs/protocol-hfr.md` § POST `bddpost.php`)
+     * — Phase 2C captures the value from the active topic state.
+     */
+    val page: Int? = null,
+    /**
+     * Sub-category id of the topic. Required by HFR's reply contract; carried
+     * over from `Topic.subcat` parsed from the loaded topic page. Phase 2C-A
+     * refuses to open the editor when this is null.
+     */
+    val subcat: Int? = null,
 ) : RedfaceNavKey
 
 @Serializable
@@ -275,12 +287,14 @@ private fun RedfaceNavHost(backStack: NavBackStack<NavKey>) {
                         page = route.page,
                         scrollTo = route.scrollTo,
                     ),
-                    onReply = { topicId ->
+                    onReply = { subcat, page ->
                         backStack.add(
                             PostEditorRoute(
                                 mode = PostEditorMode.Reply,
                                 cat = route.cat,
-                                topicId = topicId,
+                                topicId = route.post,
+                                page = page,
+                                subcat = subcat,
                             ),
                         )
                     },
@@ -304,7 +318,25 @@ private fun RedfaceNavHost(backStack: NavBackStack<NavKey>) {
                         cat = route.cat,
                         topicId = route.topicId,
                         numreponse = route.numreponse,
+                        page = route.page,
+                        subcat = route.subcat,
                     ),
+                    onSubmitSucceeded = { targetPage ->
+                        // Pop the editor and refresh the topic page. Phase 2C-A always
+                        // pops back to the topic; targetPage informs which page to
+                        // reload — null falls back to the page we replied from.
+                        backStack.removeAt(backStack.lastIndex)
+                        val topicEntry = backStack.lastOrNull() as? TopicRoute
+                        if (topicEntry != null) {
+                            backStack.removeAt(backStack.lastIndex)
+                            backStack.add(
+                                topicEntry.copy(
+                                    page = targetPage ?: topicEntry.page,
+                                    scrollTo = null,
+                                ),
+                            )
+                        }
+                    },
                 )
             }
             entry<TopicFormRoute> { route ->

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -325,7 +325,11 @@ private fun RedfaceNavHost(backStack: NavBackStack<NavKey>) {
                         // Pop the editor and refresh the topic page. Phase 2C-A always
                         // pops back to the topic; targetPage informs which page to
                         // reload — null falls back to the page we replied from.
-                        backStack.removeAt(backStack.lastIndex)
+                        // Guard the pop the same way the global `onBack` lambda does:
+                        // never collapse the back stack below the tab root.
+                        if (backStack.size > 1) {
+                            backStack.removeAt(backStack.lastIndex)
+                        }
                         val topicEntry = backStack.lastOrNull() as? TopicRoute
                         if (topicEntry != null) {
                             backStack.removeAt(backStack.lastIndex)

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicMappers.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicMappers.kt
@@ -37,6 +37,7 @@ internal object TopicMappers {
             numreponses = topic.posts.map { it.numreponse },
             fetchedAt = fetchedAt,
             authMode = authMode,
+            subcat = topic.subcat,
         )
         val postEntities = topic.posts.map { post ->
             post.toEntity(topic.cat, topic.post, fetchedAt, authMode)
@@ -50,6 +51,7 @@ internal object TopicMappers {
         return Topic(
             cat = topic.cat,
             post = topic.post,
+            subcat = topic.subcat,
             page = topic.page,
             title = topic.title,
             totalPages = topic.totalPages,

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultReplyRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultReplyRepository.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.core.data.write
 
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
 import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
 import fr.forumhfr.redface2.core.domain.write.ReplyRepository
 import fr.forumhfr.redface2.core.model.write.ReplyContext
@@ -14,6 +15,8 @@ import fr.forumhfr.redface2.core.parser.write.ReplySubmitResponseParser
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
 import okhttp3.FormBody
 
 /**
@@ -35,6 +38,7 @@ class DefaultReplyRepository @Inject constructor(
     private val replyFormParser: ReplyFormParser,
     private val replySubmitResponseParser: ReplySubmitResponseParser,
     private val diagnostics: DiagnosticsLog,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ReplyRepository {
 
     override suspend fun fetchReplyForm(context: ReplyContext): ReplyForm {
@@ -45,12 +49,18 @@ class DefaultReplyRepository @Inject constructor(
                 "post=${context.topicId} page=${context.page}",
         )
         val html = try {
-            hfrClient.getReplyForm(
-                cat = context.cat,
-                subcat = context.subcat,
-                post = context.topicId,
-                page = context.page,
-            )
+            // OkHttp `.execute()` is blocking IO ; hop off the main thread or the
+            // ViewModel's `viewModelScope.launch {}` (Dispatchers.Main.immediate by
+            // default) throws NetworkOnMainThreadException. Mirrors what the other
+            // repositories already do (DefaultForumRepository, …).
+            withContext(ioDispatcher) {
+                hfrClient.getReplyForm(
+                    cat = context.cat,
+                    subcat = context.subcat,
+                    post = context.topicId,
+                    page = context.page,
+                )
+            }
         } catch (cancel: CancellationException) {
             throw cancel
         } catch (error: SessionExpiredException) {
@@ -134,7 +144,7 @@ class DefaultReplyRepository @Inject constructor(
         )
         val formBody = buildFormBody(context, form, bbcodeContent)
         val responseHtml = try {
-            hfrClient.submitReply(formBody)
+            withContext(ioDispatcher) { hfrClient.submitReply(formBody) }
         } catch (cancel: CancellationException) {
             throw cancel
         } catch (error: SessionExpiredException) {

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultReplyRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultReplyRepository.kt
@@ -48,17 +48,54 @@ class DefaultReplyRepository @Inject constructor(
             "GET reply form cat=${context.cat} subcat=${context.subcat} " +
                 "post=${context.topicId} page=${context.page}",
         )
-        val html = try {
-            // OkHttp `.execute()` is blocking IO ; hop off the main thread or the
-            // ViewModel's `viewModelScope.launch {}` (Dispatchers.Main.immediate by
-            // default) throws NetworkOnMainThreadException. Mirrors what the other
-            // repositories already do (DefaultForumRepository, …).
+        // `HfrClient` already wraps its OkHttp call in `withContext(ioDispatcher)` (PR #162 round 3
+        // round-trip), but we keep `withContext` here so the Jsoup parse (CPU-bound, ~30 KB HTML)
+        // also runs off the main thread — aligned with `TopicRepositoryImpl.fetchAndPersist` which
+        // brackets `client.get* + parser.parse*` as a single IO block.
+        return try {
             withContext(ioDispatcher) {
-                hfrClient.getReplyForm(
+                val html = hfrClient.getReplyForm(
                     cat = context.cat,
                     subcat = context.subcat,
                     post = context.topicId,
                     page = context.page,
+                )
+                replyFormParser.parse(html).fold(
+                    onSuccess = { form ->
+                        diagnostics.record(
+                            DiagnosticsLog.Level.DEBUG,
+                            LOG_TAG,
+                            "reply form parsed: hiddenFields=${form.hiddenFields.size} " +
+                                "anonymous=${form.isAnonymous} sujet=\"${form.sujet}\"",
+                        )
+                        form
+                    },
+                    onFailure = { error ->
+                        // Alpha-only diagnostic snapshot: when the parser refuses the HTML
+                        // HFR returned, we dump a redacted excerpt to the in-app diagnostics
+                        // panel so a tester can copy/paste it back to a maintainer. The
+                        // excerpt is post-processed to mask `hash_check` in both KV and HTML
+                        // input forms (see `redactHashCheck`).
+                        diagnostics.record(
+                            DiagnosticsLog.Level.WARN,
+                            LOG_TAG,
+                            "reply form parse FAILED: ${error.message ?: error::class.simpleName}",
+                        )
+                        val redactedHead = redactHashCheckForDiagnostics(
+                            html.take(DIAG_HTML_HEAD),
+                        )
+                        diagnostics.record(
+                            DiagnosticsLog.Level.WARN,
+                            LOG_TAG,
+                            "html.length=${html.length}; head=$redactedHead",
+                        )
+                        diagnostics.record(
+                            DiagnosticsLog.Level.WARN,
+                            LOG_TAG,
+                            "form actions=${extractFormActions(html)}",
+                        )
+                        throw error
+                    },
                 )
             }
         } catch (cancel: CancellationException) {
@@ -82,41 +119,6 @@ class DefaultReplyRepository @Inject constructor(
             )
             throw error
         }
-        return replyFormParser.parse(html).fold(
-            onSuccess = { form ->
-                diagnostics.record(
-                    DiagnosticsLog.Level.DEBUG,
-                    LOG_TAG,
-                    "reply form parsed: hiddenFields=${form.hiddenFields.size} " +
-                        "anonymous=${form.isAnonymous} sujet=\"${form.sujet}\"",
-                )
-                form
-            },
-            onFailure = { error ->
-                // Alpha-only diagnostic snapshot: when the parser refuses the HTML
-                // HFR returned, we dump a redacted excerpt to the in-app diagnostics
-                // panel so a tester can copy/paste it back to a maintainer. The
-                // excerpt is post-processed to mask any `hash_check=...` value that
-                // might appear in the markup (even though the typical "form not
-                // found" case fires before we read one).
-                diagnostics.record(
-                    DiagnosticsLog.Level.WARN,
-                    LOG_TAG,
-                    "reply form parse FAILED: ${error.message ?: error::class.simpleName}",
-                )
-                diagnostics.record(
-                    DiagnosticsLog.Level.WARN,
-                    LOG_TAG,
-                    "html.length=${html.length}; head=${html.take(DIAG_HTML_HEAD).redactHashCheck()}",
-                )
-                diagnostics.record(
-                    DiagnosticsLog.Level.WARN,
-                    LOG_TAG,
-                    "form actions=${extractFormActions(html)}",
-                )
-                throw error
-            },
-        )
     }
 
     override suspend fun submitReply(
@@ -143,8 +145,37 @@ class DefaultReplyRepository @Inject constructor(
                 "post=${context.topicId} page=${context.page} bbcode.length=${bbcodeContent.length}",
         )
         val formBody = buildFormBody(context, form, bbcodeContent)
-        val responseHtml = try {
-            withContext(ioDispatcher) { hfrClient.submitReply(formBody) }
+        // Same rationale as `fetchReplyForm` : keep network + Jsoup parse in a single IO block.
+        return try {
+            withContext(ioDispatcher) {
+                val responseHtml = hfrClient.submitReply(formBody)
+                val outcome = replySubmitResponseParser.parse(responseHtml)
+                when (outcome) {
+                    is ReplySubmitResult.Success ->
+                        diagnostics.record(
+                            DiagnosticsLog.Level.INFO,
+                            LOG_TAG,
+                            "POST reply Success refreshUrl=${outcome.refreshUrl} " +
+                                "targetPage=${outcome.targetPage}",
+                        )
+                    is ReplySubmitResult.Failure -> {
+                        diagnostics.record(
+                            DiagnosticsLog.Level.WARN,
+                            LOG_TAG,
+                            "POST reply Failure reason=${outcome.reason::class.simpleName}",
+                        )
+                        if (outcome.reason == ReplyFailureReason.Unknown) {
+                            diagnostics.record(
+                                DiagnosticsLog.Level.WARN,
+                                LOG_TAG,
+                                "Unknown response head=" +
+                                    redactHashCheckForDiagnostics(responseHtml.take(DIAG_HTML_HEAD)),
+                            )
+                        }
+                    }
+                }
+                outcome
+            }
         } catch (cancel: CancellationException) {
             throw cancel
         } catch (error: SessionExpiredException) {
@@ -162,31 +193,6 @@ class DefaultReplyRepository @Inject constructor(
             )
             throw error
         }
-        val outcome = replySubmitResponseParser.parse(responseHtml)
-        when (outcome) {
-            is ReplySubmitResult.Success ->
-                diagnostics.record(
-                    DiagnosticsLog.Level.INFO,
-                    LOG_TAG,
-                    "POST reply Success refreshUrl=${outcome.refreshUrl} targetPage=${outcome.targetPage}",
-                )
-            is ReplySubmitResult.Failure -> {
-                diagnostics.record(
-                    DiagnosticsLog.Level.WARN,
-                    LOG_TAG,
-                    "POST reply Failure reason=${outcome.reason::class.simpleName}",
-                )
-                if (outcome.reason == ReplyFailureReason.Unknown) {
-                    diagnostics.record(
-                        DiagnosticsLog.Level.WARN,
-                        LOG_TAG,
-                        "Unknown response head=" +
-                            responseHtml.take(DIAG_HTML_HEAD).redactHashCheck(),
-                    )
-                }
-            }
-        }
-        return outcome
     }
 
     private fun guardAgainstInvalidSubmission(
@@ -248,16 +254,13 @@ class DefaultReplyRepository @Inject constructor(
             .mapNotNull { it.groupValues.getOrNull(1) }
             .take(MAX_FORM_ACTIONS_DUMP)
             .toList()
-        return if (matches.isEmpty()) "(none)" else matches.joinToString(", ")
+        // Defense-in-depth : HFR's reply form action is the bare endpoint URL today, but if a
+        // future page ever inlined `hash_check` into the action URL (legacy HFR forms have been
+        // observed doing so on neighbouring endpoints), we'd leak it through this diagnostic
+        // line. Pipe the join result through the same redactor that already covers HTML input
+        // and KV / JS forms.
+        return if (matches.isEmpty()) "(none)" else redactHashCheckForDiagnostics(matches.joinToString(", "))
     }
-
-    /**
-     * Masks any `hash_check=<value>` substring with `hash_check=<REDACTED>`. Diagnostic
-     * snapshots are user-visible in the alpha diagnostics screen, so we strip the
-     * token even though the typical "form not found" branch fires before reaching it.
-     */
-    private fun String.redactHashCheck(): String =
-        HASH_CHECK_REGEX.replace(this) { "hash_check=<REDACTED>" }
 
     private companion object {
         private const val LOG_TAG = "ReplyRepository"
@@ -267,9 +270,54 @@ class DefaultReplyRepository @Inject constructor(
             """<form[^>]*action="([^"]+)"""",
             RegexOption.IGNORE_CASE,
         )
-        private val HASH_CHECK_REGEX: Regex = Regex(
-            """hash_check[=:][^"&\s]+""",
-            RegexOption.IGNORE_CASE,
-        )
     }
 }
+
+/**
+ * Strips every observed `hash_check` carrier from a diagnostic snapshot before it lands in
+ * `DiagnosticsLog`. Public-to-the-module so the unit test in `DefaultReplyRepositoryDiagnosticsTest`
+ * can pin the contract without going through the full repository plumbing. Patterns covered :
+ *
+ *  - query / KV : `hash_check=abc`, `hash_check:abc`, `&hash_check=abc`
+ *  - JS literal : `var hash_check = "abc";` (covered by the KV form once the literal opens)
+ *  - HTML input, attribute order `name` then `value`
+ *    (`<input ... name="hash_check" ... value="abc" ...>`)
+ *  - HTML input, attribute order `value` then `name`
+ *    (`<input ... value="abc" ... name="hash_check" ...>`)
+ *
+ * Never logs or returns the raw value ; failure to redact is the canonical regression to test.
+ */
+internal fun redactHashCheckForDiagnostics(input: String): String {
+    var output = HASH_CHECK_KV_REGEX.replace(input) { match ->
+        // `hash_check=abc` / `hash_check:abc` — preserve the separator the caller used.
+        val separator = match.value[match.value.indexOf("hash_check") + "hash_check".length]
+        "hash_check${separator}<REDACTED>"
+    }
+    output = HASH_CHECK_INPUT_NAME_FIRST_REGEX.replace(output) { match ->
+        match.value.replace(match.groupValues[1], "<REDACTED>")
+    }
+    output = HASH_CHECK_INPUT_VALUE_FIRST_REGEX.replace(output) { match ->
+        match.value.replace(match.groupValues[1], "<REDACTED>")
+    }
+    return output
+}
+
+private val HASH_CHECK_KV_REGEX: Regex = Regex(
+    """hash_check[=:][^"&\s<>]+""",
+    RegexOption.IGNORE_CASE,
+)
+
+// `<input ... name="hash_check" ... value="VALUE" ...>`. We allow arbitrary other attributes
+// between `name` and `value`. The inner `[^>]*?` stays non-greedy so we don't swallow a closing
+// `>` of another tag.
+private val HASH_CHECK_INPUT_NAME_FIRST_REGEX: Regex = Regex(
+    """<input\b[^>]*?\bname=["']hash_check["'][^>]*?\bvalue=["']([^"']*)["'][^>]*>""",
+    RegexOption.IGNORE_CASE,
+)
+
+// `<input ... value="VALUE" ... name="hash_check" ...>`. Symmetric form for templates that
+// emit `value` before `name`.
+private val HASH_CHECK_INPUT_VALUE_FIRST_REGEX: Regex = Regex(
+    """<input\b[^>]*?\bvalue=["']([^"']*)["'][^>]*?\bname=["']hash_check["'][^>]*>""",
+    RegexOption.IGNORE_CASE,
+)

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultReplyRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultReplyRepository.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.core.data.write
 
+import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
 import fr.forumhfr.redface2.core.domain.write.ReplyRepository
 import fr.forumhfr.redface2.core.model.write.ReplyContext
 import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
@@ -31,16 +32,57 @@ class DefaultReplyRepository @Inject constructor(
     private val hfrClient: HfrClient,
     private val replyFormParser: ReplyFormParser,
     private val replySubmitResponseParser: ReplySubmitResponseParser,
+    private val diagnostics: DiagnosticsLog,
 ) : ReplyRepository {
 
     override suspend fun fetchReplyForm(context: ReplyContext): ReplyForm {
+        diagnostics.record(
+            DiagnosticsLog.Level.INFO,
+            LOG_TAG,
+            "GET reply form cat=${context.cat} subcat=${context.subcat} " +
+                "post=${context.topicId} page=${context.page}",
+        )
         val html = hfrClient.getReplyForm(
             cat = context.cat,
             subcat = context.subcat,
             post = context.topicId,
             page = context.page,
         )
-        return replyFormParser.parse(html).getOrThrow()
+        return replyFormParser.parse(html).fold(
+            onSuccess = { form ->
+                diagnostics.record(
+                    DiagnosticsLog.Level.DEBUG,
+                    LOG_TAG,
+                    "reply form parsed: hiddenFields=${form.hiddenFields.size} " +
+                        "anonymous=${form.isAnonymous} sujet=\"${form.sujet}\"",
+                )
+                form
+            },
+            onFailure = { error ->
+                // Alpha-only diagnostic snapshot: when the parser refuses the HTML
+                // HFR returned, we dump a redacted excerpt to the in-app diagnostics
+                // panel so a tester can copy/paste it back to a maintainer. The
+                // excerpt is post-processed to mask any `hash_check=...` value that
+                // might appear in the markup (even though the typical "form not
+                // found" case fires before we read one).
+                diagnostics.record(
+                    DiagnosticsLog.Level.WARN,
+                    LOG_TAG,
+                    "reply form parse FAILED: ${error.message ?: error::class.simpleName}",
+                )
+                diagnostics.record(
+                    DiagnosticsLog.Level.WARN,
+                    LOG_TAG,
+                    "html.length=${html.length}; head=${html.take(DIAG_HTML_HEAD).redactHashCheck()}",
+                )
+                diagnostics.record(
+                    DiagnosticsLog.Level.WARN,
+                    LOG_TAG,
+                    "form actions=${extractFormActions(html)}",
+                )
+                throw error
+            },
+        )
     }
 
     override suspend fun submitReply(
@@ -51,11 +93,48 @@ class DefaultReplyRepository @Inject constructor(
         // Defence in depth — the ViewModel is supposed to gate on these but we
         // re-check here so any bug upstream surfaces as a typed failure rather
         // than a malformed POST to HFR.
-        guardAgainstInvalidSubmission(form, bbcodeContent)?.let { return it }
+        guardAgainstInvalidSubmission(form, bbcodeContent)?.let { early ->
+            diagnostics.record(
+                DiagnosticsLog.Level.WARN,
+                LOG_TAG,
+                "POST short-circuited: ${early.reason::class.simpleName}",
+            )
+            return early
+        }
 
+        diagnostics.record(
+            DiagnosticsLog.Level.INFO,
+            LOG_TAG,
+            "POST reply cat=${context.cat} subcat=${context.subcat} " +
+                "post=${context.topicId} page=${context.page} bbcode.length=${bbcodeContent.length}",
+        )
         val formBody = buildFormBody(context, form, bbcodeContent)
         val responseHtml = hfrClient.submitReply(formBody)
-        return replySubmitResponseParser.parse(responseHtml)
+        val outcome = replySubmitResponseParser.parse(responseHtml)
+        when (outcome) {
+            is ReplySubmitResult.Success ->
+                diagnostics.record(
+                    DiagnosticsLog.Level.INFO,
+                    LOG_TAG,
+                    "POST reply Success refreshUrl=${outcome.refreshUrl} targetPage=${outcome.targetPage}",
+                )
+            is ReplySubmitResult.Failure -> {
+                diagnostics.record(
+                    DiagnosticsLog.Level.WARN,
+                    LOG_TAG,
+                    "POST reply Failure reason=${outcome.reason::class.simpleName}",
+                )
+                if (outcome.reason == ReplyFailureReason.Unknown) {
+                    diagnostics.record(
+                        DiagnosticsLog.Level.WARN,
+                        LOG_TAG,
+                        "Unknown response head=" +
+                            responseHtml.take(DIAG_HTML_HEAD).redactHashCheck(),
+                    )
+                }
+            }
+        }
+        return outcome
     }
 
     private fun guardAgainstInvalidSubmission(
@@ -110,5 +189,35 @@ class DefaultReplyRepository @Inject constructor(
             emitted += key
         }
         return builder.build()
+    }
+
+    private fun extractFormActions(html: String): String {
+        val matches = FORM_ACTION_REGEX.findAll(html)
+            .mapNotNull { it.groupValues.getOrNull(1) }
+            .take(MAX_FORM_ACTIONS_DUMP)
+            .toList()
+        return if (matches.isEmpty()) "(none)" else matches.joinToString(", ")
+    }
+
+    /**
+     * Masks any `hash_check=<value>` substring with `hash_check=<REDACTED>`. Diagnostic
+     * snapshots are user-visible in the alpha diagnostics screen, so we strip the
+     * token even though the typical "form not found" branch fires before reaching it.
+     */
+    private fun String.redactHashCheck(): String =
+        HASH_CHECK_REGEX.replace(this) { "hash_check=<REDACTED>" }
+
+    private companion object {
+        private const val LOG_TAG = "ReplyRepository"
+        private const val DIAG_HTML_HEAD = 600
+        private const val MAX_FORM_ACTIONS_DUMP = 6
+        private val FORM_ACTION_REGEX: Regex = Regex(
+            """<form[^>]*action="([^"]+)"""",
+            RegexOption.IGNORE_CASE,
+        )
+        private val HASH_CHECK_REGEX: Regex = Regex(
+            """hash_check[=:][^"&\s]+""",
+            RegexOption.IGNORE_CASE,
+        )
     }
 }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultReplyRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultReplyRepository.kt
@@ -6,6 +6,7 @@ import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
 import fr.forumhfr.redface2.core.model.write.ReplyForm
 import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
 import fr.forumhfr.redface2.core.network.HfrClient
+import fr.forumhfr.redface2.core.network.HfrConstants
 import fr.forumhfr.redface2.core.parser.write.ReplyFormParser
 import fr.forumhfr.redface2.core.parser.write.ReplySubmitResponseParser
 import javax.inject.Inject
@@ -82,7 +83,7 @@ class DefaultReplyRepository @Inject constructor(
         val builder = FormBody.Builder(Charsets.UTF_8)
         val overrides = mapOf(
             "hash_check" to form.hashCheck,
-            "verifrequet" to "1100",
+            "verifrequet" to HfrConstants.VERIF_REQUET,
             "content_form" to bbcodeContent,
             // numreponse / numrep are empty for a simple reply (no quote, no edit).
             "numreponse" to "",

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultReplyRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultReplyRepository.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.core.data.write
 
+import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
 import fr.forumhfr.redface2.core.domain.write.ReplyRepository
 import fr.forumhfr.redface2.core.model.write.ReplyContext
@@ -12,6 +13,7 @@ import fr.forumhfr.redface2.core.parser.write.ReplyFormParser
 import fr.forumhfr.redface2.core.parser.write.ReplySubmitResponseParser
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CancellationException
 import okhttp3.FormBody
 
 /**
@@ -42,12 +44,34 @@ class DefaultReplyRepository @Inject constructor(
             "GET reply form cat=${context.cat} subcat=${context.subcat} " +
                 "post=${context.topicId} page=${context.page}",
         )
-        val html = hfrClient.getReplyForm(
-            cat = context.cat,
-            subcat = context.subcat,
-            post = context.topicId,
-            page = context.page,
-        )
+        val html = try {
+            hfrClient.getReplyForm(
+                cat = context.cat,
+                subcat = context.subcat,
+                post = context.topicId,
+                page = context.page,
+            )
+        } catch (cancel: CancellationException) {
+            throw cancel
+        } catch (error: SessionExpiredException) {
+            diagnostics.record(
+                DiagnosticsLog.Level.WARN,
+                LOG_TAG,
+                "GET reply form SessionExpired: ${error.message ?: "(no message)"}",
+            )
+            throw error
+        } catch (@Suppress("TooGenericExceptionCaught") error: Throwable) {
+            // Alpha diagnostic : surface every transport-level failure (OkHttp IOException,
+            // HFR returning non-2xx, body decoding error…) with class + message before
+            // rethrowing. The VM still maps to a user-facing SubmitError downstream, but
+            // we want the tester to see *which* class actually fired.
+            diagnostics.record(
+                DiagnosticsLog.Level.WARN,
+                LOG_TAG,
+                "GET reply form FAILED: ${error::class.simpleName}: ${error.message ?: "(no message)"}",
+            )
+            throw error
+        }
         return replyFormParser.parse(html).fold(
             onSuccess = { form ->
                 diagnostics.record(
@@ -109,7 +133,25 @@ class DefaultReplyRepository @Inject constructor(
                 "post=${context.topicId} page=${context.page} bbcode.length=${bbcodeContent.length}",
         )
         val formBody = buildFormBody(context, form, bbcodeContent)
-        val responseHtml = hfrClient.submitReply(formBody)
+        val responseHtml = try {
+            hfrClient.submitReply(formBody)
+        } catch (cancel: CancellationException) {
+            throw cancel
+        } catch (error: SessionExpiredException) {
+            diagnostics.record(
+                DiagnosticsLog.Level.WARN,
+                LOG_TAG,
+                "POST reply SessionExpired: ${error.message ?: "(no message)"}",
+            )
+            throw error
+        } catch (@Suppress("TooGenericExceptionCaught") error: Throwable) {
+            diagnostics.record(
+                DiagnosticsLog.Level.WARN,
+                LOG_TAG,
+                "POST reply FAILED: ${error::class.simpleName}: ${error.message ?: "(no message)"}",
+            )
+            throw error
+        }
         val outcome = replySubmitResponseParser.parse(responseHtml)
         when (outcome) {
             is ReplySubmitResult.Success ->

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultReplyRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultReplyRepository.kt
@@ -1,0 +1,113 @@
+package fr.forumhfr.redface2.core.data.write
+
+import fr.forumhfr.redface2.core.domain.write.ReplyRepository
+import fr.forumhfr.redface2.core.model.write.ReplyContext
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
+import fr.forumhfr.redface2.core.model.write.ReplyForm
+import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
+import fr.forumhfr.redface2.core.network.HfrClient
+import fr.forumhfr.redface2.core.parser.write.ReplyFormParser
+import fr.forumhfr.redface2.core.parser.write.ReplySubmitResponseParser
+import javax.inject.Inject
+import javax.inject.Singleton
+import okhttp3.FormBody
+
+/**
+ * Default [ReplyRepository] implementation. Orchestrates the two-step HFR write
+ * dance for Phase 2C-A (#145) :
+ *
+ * 1. GET `message.php` to obtain the per-session `hash_check` and the hidden
+ *    fields HFR expects to receive verbatim.
+ * 2. Build a `FormBody` from those fields + the user's BBCode content, then POST
+ *    `bddpost.php` and classify the response.
+ *
+ * The repository deliberately does not retry — HFR's anti-flood is per-account
+ * and a transparent retry would burn the rate limit. The UI handles retry on
+ * user input. `hash_check` is never logged at any point.
+ */
+@Singleton
+class DefaultReplyRepository @Inject constructor(
+    private val hfrClient: HfrClient,
+    private val replyFormParser: ReplyFormParser,
+    private val replySubmitResponseParser: ReplySubmitResponseParser,
+) : ReplyRepository {
+
+    override suspend fun fetchReplyForm(context: ReplyContext): ReplyForm {
+        val html = hfrClient.getReplyForm(
+            cat = context.cat,
+            subcat = context.subcat,
+            post = context.topicId,
+            page = context.page,
+        )
+        return replyFormParser.parse(html).getOrThrow()
+    }
+
+    override suspend fun submitReply(
+        context: ReplyContext,
+        form: ReplyForm,
+        bbcodeContent: String,
+    ): ReplySubmitResult {
+        // Defence in depth — the ViewModel is supposed to gate on these but we
+        // re-check here so any bug upstream surfaces as a typed failure rather
+        // than a malformed POST to HFR.
+        guardAgainstInvalidSubmission(form, bbcodeContent)?.let { return it }
+
+        val formBody = buildFormBody(context, form, bbcodeContent)
+        val responseHtml = hfrClient.submitReply(formBody)
+        return replySubmitResponseParser.parse(responseHtml)
+    }
+
+    private fun guardAgainstInvalidSubmission(
+        form: ReplyForm,
+        bbcodeContent: String,
+    ): ReplySubmitResult.Failure? = when {
+        form.isAnonymous -> ReplySubmitResult.Failure(ReplyFailureReason.LoginRequired)
+        form.hashCheck.isBlank() -> ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)
+        bbcodeContent.isBlank() -> ReplySubmitResult.Failure(ReplyFailureReason.EmptyMessage)
+        else -> null
+    }
+
+    /**
+     * Assembles the POST payload. `hash_check`, `verifrequet` and `content_form`
+     * are the three fields HFR validates ; everything else is forwarded verbatim
+     * from the parsed form. Any local override (notably `content_form`,
+     * `numreponse`, `numrep`) wins over the parsed value to keep simple-reply
+     * semantics — see the `numrep` / `numreponse` notes in `protocol-hfr.md`.
+     */
+    private fun buildFormBody(
+        context: ReplyContext,
+        form: ReplyForm,
+        bbcodeContent: String,
+    ): FormBody {
+        val builder = FormBody.Builder(Charsets.UTF_8)
+        val overrides = mapOf(
+            "hash_check" to form.hashCheck,
+            "verifrequet" to "1100",
+            "content_form" to bbcodeContent,
+            // numreponse / numrep are empty for a simple reply (no quote, no edit).
+            "numreponse" to "",
+            "numrep" to "",
+            // Re-assert the (cat, subcat, post, page) tuple to match HFR's contract
+            // even if the form ever forgets to echo them.
+            "cat" to context.cat.toString(),
+            "subcat" to context.subcat.toString(),
+            "post" to context.topicId.toString(),
+            "page" to context.page.toString(),
+            "sujet" to form.sujet,
+        )
+        val emitted = mutableSetOf<String>()
+        overrides.forEach { (key, value) ->
+            builder.add(key, value)
+            emitted += key
+        }
+        form.hiddenFields.forEach { (key, value) ->
+            if (key in emitted) return@forEach
+            // Belt-and-braces : even though `ReplyFormParser` already filters
+            // `password` and anonymous `pseudo`, never relay them here.
+            if (key == "password") return@forEach
+            builder.add(key, value)
+            emitted += key
+        }
+        return builder.build()
+    }
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/ReplyRepositoryModule.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/ReplyRepositoryModule.kt
@@ -1,0 +1,35 @@
+package fr.forumhfr.redface2.core.data.write
+
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import fr.forumhfr.redface2.core.domain.write.ReplyRepository
+import fr.forumhfr.redface2.core.parser.write.ReplyFormParser
+import fr.forumhfr.redface2.core.parser.write.ReplySubmitResponseParser
+import javax.inject.Singleton
+
+/**
+ * Hilt wiring for the Phase 2C reply repository. Mirrors the (`@Binds` interface,
+ * `@Provides` parsers) split adopted by `FlagRepositoryModule` and friends.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ReplyRepositoryModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindReplyRepository(impl: DefaultReplyRepository): ReplyRepository
+
+    companion object {
+        @Provides
+        @Singleton
+        fun provideReplyFormParser(): ReplyFormParser = ReplyFormParser()
+
+        @Provides
+        @Singleton
+        fun provideReplySubmitResponseParser(): ReplySubmitResponseParser =
+            ReplySubmitResponseParser()
+    }
+}

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -52,6 +52,7 @@ class TopicRepositoryImplTest {
             authenticated = okHttp,
             anonymous = okHttp,
             baseUrl = server.url("/"),
+            ioDispatcher = Dispatchers.Unconfined,
         )
     }
 

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/write/DefaultReplyRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/write/DefaultReplyRepositoryTest.kt
@@ -7,6 +7,7 @@ import fr.forumhfr.redface2.core.network.HfrClient
 import fr.forumhfr.redface2.core.parser.write.ReplyFormParser
 import fr.forumhfr.redface2.core.parser.write.ReplySubmitResponseParser
 import java.net.URLDecoder
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -39,6 +40,7 @@ class DefaultReplyRepositoryTest {
             replyFormParser = ReplyFormParser(),
             replySubmitResponseParser = ReplySubmitResponseParser(),
             diagnostics = fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog(),
+            ioDispatcher = Dispatchers.Unconfined,
         )
     }
 

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/write/DefaultReplyRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/write/DefaultReplyRepositoryTest.kt
@@ -38,6 +38,7 @@ class DefaultReplyRepositoryTest {
             hfrClient = client,
             replyFormParser = ReplyFormParser(),
             replySubmitResponseParser = ReplySubmitResponseParser(),
+            diagnostics = fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog(),
         )
     }
 

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/write/DefaultReplyRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/write/DefaultReplyRepositoryTest.kt
@@ -1,0 +1,215 @@
+package fr.forumhfr.redface2.core.data.write
+
+import fr.forumhfr.redface2.core.model.write.ReplyContext
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
+import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
+import fr.forumhfr.redface2.core.network.HfrClient
+import fr.forumhfr.redface2.core.parser.write.ReplyFormParser
+import fr.forumhfr.redface2.core.parser.write.ReplySubmitResponseParser
+import java.net.URLDecoder
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class DefaultReplyRepositoryTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: HfrClient
+    private lateinit var repository: DefaultReplyRepository
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().apply { start() }
+        val okHttp = OkHttpClient.Builder().build()
+        client = HfrClient(
+            authenticated = okHttp,
+            anonymous = okHttp,
+            baseUrl = server.url("/"),
+        )
+        repository = DefaultReplyRepository(
+            hfrClient = client,
+            replyFormParser = ReplyFormParser(),
+            replySubmitResponseParser = ReplySubmitResponseParser(),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `fetchReplyForm hits message_php with the full HFR contract URL`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("write_reply_form_open_topic.html")))
+
+        val context = ReplyContext(cat = 23, subcat = 550, topicId = 35395, page = 20)
+        val form = repository.fetchReplyForm(context)
+
+        assertFalse(form.isAnonymous)
+        assertEquals("REDACTED_HASH_CHECK", form.hashCheck)
+
+        val recorded = server.takeRequest()
+        val url = recorded.requestUrl
+        assertNotNull(url)
+        requireNotNull(url)
+        assertEquals("message.php", url.pathSegments.first())
+        assertEquals("hfr.inc", url.queryParameter("config"))
+        assertEquals("23", url.queryParameter("cat"))
+        assertEquals("550", url.queryParameter("subcat"))
+        assertEquals("35395", url.queryParameter("post"))
+        assertEquals("20", url.queryParameter("page"))
+        assertEquals("1", url.queryParameter("p"))
+        assertEquals("0", url.queryParameter("sondage"))
+        assertEquals("0", url.queryParameter("owntopic"))
+        assertEquals("0", url.queryParameter("new"))
+    }
+
+    @Test
+    fun `submitReply posts the full form body to bddpost_php and parses success`() = runTest {
+        // GET form ; then success response.
+        server.enqueue(MockResponse().setBody(fixture("write_reply_form_open_topic.html")))
+        server.enqueue(MockResponse().setBody(fixture("write_reply_success_response.html")))
+
+        val context = ReplyContext(cat = 23, subcat = 550, topicId = 35395, page = 20)
+        val form = repository.fetchReplyForm(context)
+        val result = repository.submitReply(context, form, bbcodeContent = "Hello world.")
+
+        assertTrue("Expected success, got $result", result is ReplySubmitResult.Success)
+        val success = result as ReplySubmitResult.Success
+        assertEquals(20, success.targetPage)
+
+        // First request was the GET — drop it before inspecting the POST.
+        server.takeRequest()
+        val recorded = server.takeRequest()
+        assertEquals("POST", recorded.method)
+        val postUrl = recorded.requestUrl
+        assertNotNull(postUrl)
+        requireNotNull(postUrl)
+        assertEquals("bddpost.php", postUrl.pathSegments.first())
+        assertEquals("hfr.inc", postUrl.queryParameter("config"))
+
+        val body = parseFormBody(recorded.body.readUtf8())
+        assertEquals("REDACTED_HASH_CHECK", body["hash_check"])
+        assertEquals("1100", body["verifrequet"])
+        assertEquals("Hello world.", body["content_form"])
+        assertEquals("23", body["cat"])
+        assertEquals("550", body["subcat"])
+        assertEquals("35395", body["post"])
+        assertEquals("20", body["page"])
+        // Simple reply: numreponse / numrep stay empty.
+        assertEquals("", body["numreponse"])
+        assertEquals("", body["numrep"])
+        // password must never reach HFR.
+        assertFalse("password must never be transmitted", body.containsKey("password"))
+        // sujet is part of the contract.
+        assertEquals("Redface 2 — PHASE 2 @ ALPHA", body["sujet"])
+    }
+
+    @Test
+    fun `submitReply classifies empty message error`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("write_reply_form_open_topic.html")))
+        server.enqueue(MockResponse().setBody(fixture("write_empty_message_error.html")))
+        val context = ReplyContext(cat = 23, subcat = 550, topicId = 35395, page = 20)
+        val form = repository.fetchReplyForm(context)
+        val result = repository.submitReply(context, form, bbcodeContent = "non-blank content from user")
+        assertEquals(
+            ReplySubmitResult.Failure(ReplyFailureReason.EmptyMessage),
+            result,
+        )
+    }
+
+    @Test
+    fun `submitReply classifies invalid hash check`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("write_reply_form_open_topic.html")))
+        server.enqueue(MockResponse().setBody(fixture("write_invalid_token_error.html")))
+        val context = ReplyContext(cat = 23, subcat = 550, topicId = 35395, page = 20)
+        val form = repository.fetchReplyForm(context)
+        val result = repository.submitReply(context, form, bbcodeContent = "Hello.")
+        assertEquals(
+            ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck),
+            result,
+        )
+    }
+
+    @Test
+    fun `submitReply classifies anti-flood`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("write_reply_form_open_topic.html")))
+        server.enqueue(MockResponse().setBody(fixture("write_antiflood_error.html")))
+        val context = ReplyContext(cat = 23, subcat = 550, topicId = 35395, page = 20)
+        val form = repository.fetchReplyForm(context)
+        val result = repository.submitReply(context, form, bbcodeContent = "Hello.")
+        assertEquals(
+            ReplySubmitResult.Failure(ReplyFailureReason.AntiFlood),
+            result,
+        )
+    }
+
+    @Test
+    fun `submitReply classifies locked topic`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("write_reply_form_open_topic.html")))
+        server.enqueue(MockResponse().setBody(fixture("write_locked_topic_error.html")))
+        val context = ReplyContext(cat = 23, subcat = 550, topicId = 35395, page = 20)
+        val form = repository.fetchReplyForm(context)
+        val result = repository.submitReply(context, form, bbcodeContent = "Hello.")
+        assertEquals(
+            ReplySubmitResult.Failure(ReplyFailureReason.TopicLocked),
+            result,
+        )
+    }
+
+    @Test
+    fun `submitReply refuses to POST when the form is anonymous`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("write_reply_anonymous_form.html")))
+        val context = ReplyContext(cat = 23, subcat = 550, topicId = 35395, page = 20)
+        val form = repository.fetchReplyForm(context)
+        assertTrue("Anonymous form must be detected", form.isAnonymous)
+
+        // Only the GET should have been issued so far.
+        assertEquals(1, server.requestCount)
+
+        val result = repository.submitReply(context, form, bbcodeContent = "Hello.")
+        assertEquals(
+            ReplySubmitResult.Failure(ReplyFailureReason.LoginRequired),
+            result,
+        )
+        // No POST should have been issued.
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `submitReply refuses to POST a blank body, no network call`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("write_reply_form_open_topic.html")))
+        val context = ReplyContext(cat = 23, subcat = 550, topicId = 35395, page = 20)
+        val form = repository.fetchReplyForm(context)
+        assertEquals(1, server.requestCount)
+        val result = repository.submitReply(context, form, bbcodeContent = "    ")
+        assertEquals(
+            ReplySubmitResult.Failure(ReplyFailureReason.EmptyMessage),
+            result,
+        )
+        assertEquals(1, server.requestCount)
+    }
+
+    private fun fixture(name: String): String {
+        val stream = requireNotNull(
+            DefaultReplyRepositoryTest::class.java.classLoader?.getResourceAsStream("fixtures/$name"),
+        ) { "Fixture not found: fixtures/$name" }
+        return stream.bufferedReader().use { it.readText() }
+    }
+
+    private fun parseFormBody(body: String): Map<String, String> =
+        body.split('&')
+            .filter { it.isNotEmpty() }
+            .associate { pair ->
+                val (key, value) = pair.split('=', limit = 2).let { it[0] to (it.getOrNull(1) ?: "") }
+                URLDecoder.decode(key, "UTF-8") to URLDecoder.decode(value, "UTF-8")
+            }
+}

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/write/DefaultReplyRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/write/DefaultReplyRepositoryTest.kt
@@ -34,6 +34,7 @@ class DefaultReplyRepositoryTest {
             authenticated = okHttp,
             anonymous = okHttp,
             baseUrl = server.url("/"),
+            ioDispatcher = Dispatchers.Unconfined,
         )
         repository = DefaultReplyRepository(
             hfrClient = client,

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/write/RedactHashCheckForDiagnosticsTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/write/RedactHashCheckForDiagnosticsTest.kt
@@ -1,0 +1,116 @@
+package fr.forumhfr.redface2.core.data.write
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the redaction contract of [redactHashCheckForDiagnostics]. Coverage matrix mirrors
+ * the patterns the helper KDoc promises to mask :
+ *
+ *  - URL query / form-encoded KV (`hash_check=…`)
+ *  - JS literal (`var hash_check = "…"`) — falls back on the KV path once the literal opens
+ *  - HTML hidden input with `name` before `value`
+ *  - HTML hidden input with `value` before `name`
+ *  - mixed payload (KV + HTML inputs in the same blob, as observed when the alpha tester
+ *    dumps the first 600 chars of HFR's `message.php` response)
+ *
+ * Each test asserts both that the literal `hash_check` token stays in place (the redactor
+ * must not erase the field name — diagnostic value comes from seeing *that* HFR returned
+ * a `hash_check`) AND that the secret value never makes it through.
+ */
+class RedactHashCheckForDiagnosticsTest {
+
+    private val secret = "AbCdEfGhIjKlMnOp1234567890"
+
+    @Test
+    fun `KV form hash_check=value is masked`() {
+        val redacted = redactHashCheckForDiagnostics("hash_check=$secret&other=1")
+        assertEquals("hash_check=<REDACTED>&other=1", redacted)
+        assertFalse(secret in redacted)
+    }
+
+    @Test
+    fun `KV form hash_check colon value is masked`() {
+        val redacted = redactHashCheckForDiagnostics("hash_check:$secret")
+        assertEquals("hash_check:<REDACTED>", redacted)
+        assertFalse(secret in redacted)
+    }
+
+    @Test
+    fun `JS literal var hash_check is masked via the KV path`() {
+        val input = """var hash_check = "&hash_check=$secret";"""
+        val redacted = redactHashCheckForDiagnostics(input)
+        assertFalse("JS literal secret must not survive", secret in redacted)
+        assertTrue("hash_check label remains for diagnostic context", "hash_check" in redacted)
+    }
+
+    @Test
+    fun `HTML input name then value is masked`() {
+        val input = """<input type="hidden" name="hash_check" value="$secret" />"""
+        val redacted = redactHashCheckForDiagnostics(input)
+        assertFalse("HTML input value must not survive", secret in redacted)
+        assertTrue("redaction marker present", "<REDACTED>" in redacted)
+        assertTrue("input still recognisable as hash_check", """name="hash_check"""" in redacted)
+    }
+
+    @Test
+    fun `HTML input value then name is masked`() {
+        val input = """<input type="hidden" value="$secret" name="hash_check" />"""
+        val redacted = redactHashCheckForDiagnostics(input)
+        assertFalse("HTML input value must not survive when value comes first", secret in redacted)
+        assertTrue("redaction marker present", "<REDACTED>" in redacted)
+    }
+
+    @Test
+    fun `HTML input with single quotes is masked`() {
+        val input = """<input type='hidden' name='hash_check' value='$secret' />"""
+        val redacted = redactHashCheckForDiagnostics(input)
+        assertFalse("single-quoted attribute value must not survive", secret in redacted)
+    }
+
+    @Test
+    fun `mixed payload KV plus HTML input masks both sites`() {
+        val input = buildString {
+            append("Status: 200 OK\n")
+            append("Set-Cookie: PHPSESSID=zzz\n")
+            append("...hash_check=$secret&other=1...")
+            append("""<form action="bddpost.php?cat=23&page=1">""")
+            append("""<input type="hidden" name="hash_check" value="$secret" />""")
+            append("</form>")
+        }
+        val redacted = redactHashCheckForDiagnostics(input)
+        assertFalse(
+            "Neither carrier of the secret must survive the redactor",
+            secret in redacted,
+        )
+        // Sanity : we did not nuke the rest of the diagnostic context.
+        assertTrue("status line preserved", "200 OK" in redacted)
+        assertTrue("form tag preserved", """<form action="bddpost.php""" in redacted)
+    }
+
+    @Test
+    fun `payload without hash_check is left untouched`() {
+        val input = """<form action="bdd.php"><input name="content_form" value="hello"/></form>"""
+        val redacted = redactHashCheckForDiagnostics(input)
+        assertEquals(input, redacted)
+    }
+
+    @Test
+    fun `redactor never echoes the secret in its output`() {
+        val variants = listOf(
+            "hash_check=$secret",
+            "hash_check:$secret",
+            """<input name="hash_check" value="$secret">""",
+            """<input value="$secret" name="hash_check">""",
+            """<input type="hidden" name="hash_check"  value="$secret"   class="x">""",
+        )
+        variants.forEach { input ->
+            assertFalse(
+                "Secret leaked through variant: $input",
+                secret in redactHashCheckForDiagnostics(input),
+            )
+        }
+    }
+}

--- a/core/data/src/test/resources/fixtures/write_antiflood_error.html
+++ b/core/data/src/test/resources/fixtures/write_antiflood_error.html
@@ -1,0 +1,31 @@
+	<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+	<html>
+	<head>
+	<title>FORUM HardWare.fr</title>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta http-equiv="Pragma" content="no-cache" />
+	<meta http-equiv="Cache-Control" content="no-cache, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+	<meta http-equiv="Imagetoolbar" content="no" />
+	<meta name="Robots" content="noindex, follow" />
+	<link rel="stylesheet" type="text/css" href="/include/the_style1.php?color_key=FFFFFF/DEDFDF/000080/C2C3F4/001932/FFFFFF/FFFFFF/000000/000080/000000/000080/F7F7F7/DEDFDF/F7F7F7/DEDFDF/C0C0C0/C0C0C0/FFFFFF/000000/000000/0000FF/EEEEFF/DDDDEE/000000/FFEEEE/000000/FFFFFF/FF0000/FFFFFF/0/1/https%3A%40%40forum-images.hardware.fr/NULL/&amp;abs_img_path=%40data%40sites%40forum%40www%40static%40&amp;hide_bg_onglet=0&amp;v=11102781422" />
+	<link type="text/css" rel="stylesheet" href="https://forum-images.hardware.fr/compressed/the_style.css?v=11102781422" />	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+		<style type="text/css">
+	.hop{			background-color: #F7F7F7;
+			color: #000000;
+			margin:auto;
+			text-align: center;
+			width:50%;
+			border: 1px solid #C0C0C0;}
+	</style>
+	</head>
+
+	<body>
+			<div class="container">
+	<div class="mesdiscussions" id="mesdiscussions">
+	<br /><br />
+	<div class="hop">
+	Afin de prevenir les tentatives de flood, vous ne pouvez poster plus de 3 réponses consécutives dans un intervalle de 10 minutes	<br /><br /><a href="javascript:history.back(1)" class="Topic"><b>Retour à la page précédente</b></a>	</div>
+	</div>
+	</div>
+	</body></html>

--- a/core/data/src/test/resources/fixtures/write_antiflood_error.source.txt
+++ b/core/data/src/test/resources/fixtures/write_antiflood_error.source.txt
@@ -1,0 +1,6 @@
+Source: forum.hardware.fr
+Captured: 2026-05-17
+URL: POST https://forum.hardware.fr/bddpost.php?config=hfr.inc
+Notes: Fourth consecutive reply within 10 minutes; HFR anti-flood rejection, no post created.
+Sanitization: hash_check/codehex redacted; MP unread target id and MP count redacted when present; no cookies stored.
+Test context: Authenticated XaTelitte session, anti-flood test post 4/4 after three consecutive replies; no post created.

--- a/core/data/src/test/resources/fixtures/write_empty_message_error.html
+++ b/core/data/src/test/resources/fixtures/write_empty_message_error.html
@@ -1,0 +1,31 @@
+	<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+	<html>
+	<head>
+	<title>FORUM HardWare.fr</title>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta http-equiv="Pragma" content="no-cache" />
+	<meta http-equiv="Cache-Control" content="no-cache, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+	<meta http-equiv="Imagetoolbar" content="no" />
+	<meta name="Robots" content="noindex, follow" />
+	<link rel="stylesheet" type="text/css" href="/include/the_style1.php?color_key=FFFFFF/DEDFDF/000080/C2C3F4/001932/FFFFFF/FFFFFF/000000/000080/000000/000080/F7F7F7/DEDFDF/F7F7F7/DEDFDF/C0C0C0/C0C0C0/FFFFFF/000000/000000/0000FF/EEEEFF/DDDDEE/000000/FFEEEE/000000/FFFFFF/FF0000/FFFFFF/0/1/https%3A%40%40forum-images.hardware.fr/NULL/&amp;abs_img_path=%40data%40sites%40forum%40www%40static%40&amp;hide_bg_onglet=0&amp;v=11102781422" />
+	<link type="text/css" rel="stylesheet" href="https://forum-images.hardware.fr/compressed/the_style.css?v=11102781422" />	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+		<style type="text/css">
+	.hop{			background-color: #F7F7F7;
+			color: #000000;
+			margin:auto;
+			text-align: center;
+			width:50%;
+			border: 1px solid #C0C0C0;}
+	</style>
+	</head>
+
+	<body>
+	<form action="/message.php?config=hfr.inc&amp;cat=23&amp;post=35395&amp;page=20&amp;p=1&amp;subcat=550&amp;sondage=0&amp;owntopic=0&amp;new=0" method="post"><input type="hidden" name="hash_check" value="REDACTED_HASH_CHECK" /><input type="hidden" name="config" value="hfr.inc" /><input type="hidden" name="hash_check" value="REDACTED_HASH_CHECK" /><input type="hidden" name="subcat" value="550" /><input type="hidden" name="parents" value="" /><input type="hidden" name="post" value="35395" /><input type="hidden" name="stickold" value="0" /><input type="hidden" name="new" value="0" /><input type="hidden" name="cat" value="23" /><input type="hidden" name="numreponse" value="" /><input type="hidden" name="numrep" value="" /><input type="hidden" name="page" value="20" /><input type="hidden" name="verifrequet" value="1100" /><input type="hidden" name="p" value="1" /><input type="hidden" name="sondage" value="0" /><input type="hidden" name="sond" value="0" /><input type="hidden" name="cache" value="cache" /><input type="hidden" name="owntopic" value="0" /><input type="hidden" name="sujet" value="Redface 2 — PHASE 2 @ ALPHA" /><input type="hidden" name="pseudo" value="xatelitte" /><input type="hidden" name="password" value="" /><input type="hidden" name="MsgIcon" value="1" /><input type="hidden" name="search_smilies" value="" /><input type="hidden" name="ColorUsedMem" value="" /><input type="hidden" name="content_form" value="" /><input type="hidden" name="wysiwyg" value="0" /><input type="hidden" name="submit" value="Valider votre message" />		<div class="container">
+	<div class="mesdiscussions" id="mesdiscussions">
+	<br /><br />
+	<div class="hop">
+	Vous devez remplir tous les champs avant de poster ce message	<br /><br /><input type="submit" value="Retour à la page précédente" /></form>	</div>
+	</div>
+	</div>
+	</body></html>

--- a/core/data/src/test/resources/fixtures/write_empty_message_error.source.txt
+++ b/core/data/src/test/resources/fixtures/write_empty_message_error.source.txt
@@ -1,0 +1,6 @@
+Source: forum.hardware.fr
+Captured: 2026-05-17
+URL: POST https://forum.hardware.fr/bddpost.php?config=hfr.inc
+Notes: POST bddpost.php with valid hash_check and empty content_form; HFR validation error, no post created.
+Sanitization: hash_check/codehex redacted; MP unread target id and MP count redacted when present; no cookies stored.
+Test context: Authenticated XaTelitte session, Redface 2 topic cat=23 post=35395 page=20 subcat=550.

--- a/core/data/src/test/resources/fixtures/write_invalid_token_error.html
+++ b/core/data/src/test/resources/fixtures/write_invalid_token_error.html
@@ -1,0 +1,1 @@
+Une erreur est survenue lors de l'envoi des données. Essayez de vider le cache de votre navigateur

--- a/core/data/src/test/resources/fixtures/write_invalid_token_error.source.txt
+++ b/core/data/src/test/resources/fixtures/write_invalid_token_error.source.txt
@@ -1,0 +1,6 @@
+Source: forum.hardware.fr
+Captured: 2026-05-17
+URL: POST https://forum.hardware.fr/bddpost.php?config=hfr.inc
+Notes: POST bddpost.php with invalid hash_check and non-empty content; HFR rejects before posting. HFR returned this as the complete response body, with no HTML wrapper in the captured payload.
+Sanitization: hash_check/codehex redacted; MP unread target id and MP count redacted when present; no cookies stored.
+Test context: Authenticated XaTelitte session, Redface 2 topic cat=23 post=35395 page=20 subcat=550.

--- a/core/data/src/test/resources/fixtures/write_locked_topic_error.html
+++ b/core/data/src/test/resources/fixtures/write_locked_topic_error.html
@@ -1,0 +1,31 @@
+	<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+	<html>
+	<head>
+	<title>FORUM HardWare.fr</title>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta http-equiv="Pragma" content="no-cache" />
+	<meta http-equiv="Cache-Control" content="no-cache, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+	<meta http-equiv="Imagetoolbar" content="no" />
+	<meta name="Robots" content="noindex, follow" />
+	<link rel="stylesheet" type="text/css" href="/include/the_style1.php?color_key=FFFFFF/DEDFDF/000080/C2C3F4/001932/FFFFFF/FFFFFF/000000/000080/000000/000080/F7F7F7/DEDFDF/F7F7F7/DEDFDF/C0C0C0/C0C0C0/FFFFFF/000000/000000/0000FF/EEEEFF/DDDDEE/000000/FFEEEE/000000/FFFFFF/FF0000/FFFFFF/0/1/https%3A%40%40forum-images.hardware.fr/NULL/&amp;abs_img_path=%40data%40sites%40forum%40www%40static%40&amp;hide_bg_onglet=0&amp;v=11102781422" />
+	<link type="text/css" rel="stylesheet" href="https://forum-images.hardware.fr/compressed/the_style.css?v=11102781422" />	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+		<style type="text/css">
+	.hop{			background-color: #F7F7F7;
+			color: #000000;
+			margin:auto;
+			text-align: center;
+			width:50%;
+			border: 1px solid #C0C0C0;}
+	</style>
+	</head>
+
+	<body>
+			<div class="container">
+	<div class="mesdiscussions" id="mesdiscussions">
+	<br /><br />
+	<div class="hop">
+	Désolé ce sujet a été fermé...	<br /><br /><a href="javascript:history.back(1)" class="Topic"><b>Retour à la page précédente</b></a>	</div>
+	</div>
+	</div>
+	</body></html>

--- a/core/data/src/test/resources/fixtures/write_locked_topic_error.source.txt
+++ b/core/data/src/test/resources/fixtures/write_locked_topic_error.source.txt
@@ -1,0 +1,6 @@
+Source: forum.hardware.fr
+Captured: 2026-05-17
+URL: POST https://forum.hardware.fr/bddpost.php?config=hfr.inc
+Notes: POST bddpost.php on locked topic rejects with closed-topic error; no post created.
+Sanitization: hash_check/codehex redacted; MP unread target id and MP count redacted when present; no cookies stored.
+Test context: Authenticated XaTelitte session, forced POST attempt on locked topic cat=23 post=14227; no post created.

--- a/core/data/src/test/resources/fixtures/write_reply_anonymous_form.html
+++ b/core/data/src/test/resources/fixtures/write_reply_anonymous_form.html
@@ -1,0 +1,477 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+	<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr" lang="fr">
+	<head>
+	<title>FORUM HardWare.fr - Répondre / éditer un message</title><link type="text/css" rel="stylesheet" href="/include/the_style1.php?color_key=FFFFFF/DEDFDF/000080/C2C3F4/001932/FFFFFF/FFFFFF/000000/000080/000000/000080/F7F7F7/DEDFDF/F7F7F7/DEDFDF/C0C0C0/C0C0C0/FFFFFF/000000/000000/0000FF/EEEEFF/DDDDEE/000000/FFEEEE/000000/FFFFFF/FF0000/FFFFFF/0/1/https%3A%40%40forum-images.hardware.fr/NULL/&amp;abs_img_path=%40data%40sites%40forum%40www%40static%40&amp;hide_bg_onglet=0&amp;v=11102781422" /><style type="text/css">
+<!--
+.fastsearchMain{ width: 330px; }
+.fastsearchInput{ width: 70px; border: 1px solid black; }
+.fastsearchSubmit{ background-color: ; border: 0px;}
+.header2 { background-image: url(/img/forum3_1.gif);background-repeat: repeat-x; }
+.menuExt { font-family: Arial, Helvetica, sans-serif; font-size: 10px; color:#000; }
+.menuExt a { color:#000;text-decoration:none; }
+.menuExt a:hover { color:#000;text-decoration:underline; }
+form { display: inline; }
+.header { background-image: url(//forum-images.hardware.fr/img/header-bg.gif); background-repeat: repeat-x; }
+.tdmenu { width: 1px;height: 1px;color: #000000; }
+.hfrheadmenu { font-family: Arial, Helvetica, sans-serif;font-size:13px;font-weight:bold; }
+.hfrheadmenu span {color:;}
+.hfrheadmenu a { color:;text-decoration: none; }
+.hfrheadmenu a:hover { color:;text-decoration: underline; }
+.concours { font-family: Arial, Helvetica, sans-serif;color:;font-size: 16px;text-decoration: none;font-weight: bold;}
+.concours:hover { font-family: Arial, Helvetica, sans-serif;color:;font-size: 16px;text-decoration: underline;font-weight: bold; }
+.searchmenu { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: none;font-weight: bold; }
+.fastsearch { display: none; }
+.fastsearchHeader { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: none;font-weight: bold; }
+.fastsearchHeader:hover { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: underline;font-weight: bold; }
+-->
+</style>
+<script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+<script>
+  window.googletag = window.googletag || {cmd: []};
+  googletag.cmd.push(function() {
+    googletag.defineSlot('/2172442/forum_discussions_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-11').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-12').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-13').addService(googletag.pubads());
+    googletag.pubads().enableSingleRequest();
+    googletag.enableServices();
+  });
+</script>
+<script type='text/javascript'>
+     (function(){
+       var loc = window.location.href;
+       var dd = document.createElement('script');
+       dd.type = 'text/javascript'; dd.src = '//static.digidip.net/hardware.js?loc=' + loc;
+       var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(dd, s);
+     })();
+</script><script type="text/javascript">
+
+var hash_check = "&hash_check=";
+var _adresseRecherche = "/user/message-aj.php";
+var adresseFindSmiley = "/message-smi-mp-aj.php";
+var tempo_smilies= 0;
+
+var img_path= "https://forum-images.hardware.fr";
+
+function verif_join_form() {
+	if ((document.getElementById('submit_upload')) && (document.getElementById('submit_upload').style.fontWeight == 'bold')) {
+		return confirm('Attention : vous n\'avez pas joint l\'image que vous avez sélectionnée');
+	}
+	return true;
+}
+
+function verif_not_empty() {
+	if (document.getElementById('delete').checked == true) {
+		return true;
+	}
+	if (document.hop.sujet && trim(document.hop.sujet.value) =='') {
+		alert('Vous devez remplir tous les champs avant de poster ce message');
+		return false;
+	}
+	if (document.hop.content_form && trim(document.hop.content_form.value) == '') {
+		alert('Vous devez remplir tous les champs avant de poster ce message');
+		return false;
+	}
+	if (document.hop.codecaptcha && trim(document.hop.codecaptcha.value) == '') {
+		alert('Vous devez remplir tous les champs avant de poster ce message');
+		return false;
+	}
+	if (document.getElementById('have_sondage') && document.getElementById('have_sondage').checked == true && document.getElementById('annee').value && document.getElementById('annee').value.length != 4) {
+		alert('L\'année du sondage doit être sur 4 chiffres');
+		return false;
+	}
+
+	return true;
+}
+
+function trim(string) {
+	return string.replace(/(^\s*)|(\s*$)/g,"");
+}
+</script><script language="javascript" type="text/javascript">
+	<!--
+ var opera=0;
+	function putSmiley(tt,src) {
+TAinsert(" "+tt+" ","");
+}
+	//-->
+	</script><link type="text/css" rel="stylesheet" href="https://forum-images.hardware.fr/compressed/the_style.css?v=11102781422" />
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta http-equiv="Pragma" content="no-cache" />
+	<meta http-equiv="Cache-Control" content="no-cache, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+	<meta http-equiv="Imagetoolbar" content="no" />
+	<meta name="Robots" content="noindex, nofollow" />
+<script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/editPost.js?v=11102781422"></script><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/message.js?v=11102781422"></script><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/common.js?v=11102781422"></script></head><body id="category__redaction_form__form_message"  ><script language="JavaScript" type="text/javascript" src="/js/cookiechoices.js"></script>
+<script language="javascript" type="text/javascript" src="/js/jquery-1.11.1.min.js"></script>
+<script language="JavaScript" type="text/javascript" src="/js/cnil.js"></script>
+<script>
+ document.addEventListener('DOMContentLoaded', function(event) {
+    cookieChoices.showCookieConsentBar('HardWare.fr utilise des cookies pour une navigation optimale et des cookies tiers pour l\'analyse du trafic et la publicité',
+      'Fermer', 'En savoir plus', 'https://www.hardware.fr/html/donnees_personnelles/');
+  });
+</script>
+<style>
+#cookieChoiceInfo span
+,#cookieChoiceDismiss
+,#PlusCookieChoice{
+	font-family:Tahoma,Arial,Helvetica,sans-serif;
+}
+#cookieChoiceDismiss
+,#PlusCookieChoice
+{
+	color:black;
+	text-decoration:none;
+}
+#cookieChoiceDismiss:hover
+,#PlusCookieChoice:hover
+{
+	color:#cc6908;
+}
+</style>
+ <table cellspacing="0" cellpadding="0" width="98%" bgcolor="#000000" border="0" align="center" class="hfrheadmenu" style="border:1px solid #000;border-top:0;">
+        <tr>
+          <td style="vertical-align: top">
+            <table cellspacing="0" cellpadding="0" width="100%" border="0">
+              <tr>
+                <td style="width: 100%" align="left" valign="middle" colspan="2" class="header2"><span class="md_cryptlink45CBCBC0C22D1F1FCCCCCC19454AC14BCC4AC1431944C1"><img src="/img/forum_logo.gif" width="900" height="71" border="0" alt="" /></span></td>
+              </tr>
+              <tr>
+                <td style="background-color:#001932">
+                  <table cellspacing="0" cellpadding="2" width="100%" border="0">
+                    <tr>
+                      <td>&nbsp;<a class="cHeader" href="/">Forum</a>&nbsp;|&nbsp;
+<a class="cHeader" href="https://www.hardware.fr/">HardWare.fr</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/html/news/">News</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/html/articles/">Articles</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/articles/786-1/guide-pc-hardware-fr.html">PC</a>&nbsp;|&nbsp;<span class="md_cryptlink1F484F4C464919C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">S'identifier</span>&nbsp;|&nbsp;<span class="md_cryptlink1F4649C242C146C0CB464F4919C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">S'inscrire</span>&nbsp;|&nbsp;<a class="cHeader" href="https://shop.hardware.fr/" target="_blank" style="position: relative; padding: 0 21px 0 0;display: inline-block;">Shop <img src="/img/shop.png" style="height: 17px; display: inline; position: absolute; right: 0; top: -2px; "></a></td>
+<td align="right"><a class="cHeader" href="/search.php?config=hardwarefr.inc&cat=23&subcat=550">Recherche <img src="//forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif"></a></td>
+                    </tr>
+                    </table></td></tr></table>
+</td></tr></table><div style="width: 99%" align="right">
+<span class="s2Ext menuExt"><span class="md_cryptlink1F4F494846494319C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">4675 connect&eacute;s&nbsp;</span></span></div><br /><div class="container"><div class="mesdiscussions" id="mesdiscussions"><div class="arbo">
+<span  id="md_arbo_tree_1" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/" class="Ext">FORUM HardWare.fr</a></span>
+<br />
+<span  id="md_arbo_tree_2" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/hfr/gsmgpspda/liste_sujet-1.htm" class="Ext">Technologies&nbsp;Mobiles</a></span>
+<br />
+<span  id="md_arbo_tree_3" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline3.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/hfr/gsmgpspda/android/liste_sujet-1.htm" class="Ext">Android</a></span>
+<br />
+<h1  id="md_arbo_tree_4" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline4.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/hfr/gsmgpspda/android/redface-phase-alpha-sujet_35395_20.htm" class="Ext">Redface 2 — PHASE 2 @ ALPHA</a></h1>
+</div><div class="rightbutton fastsearch"><table class="main fastsearchMain" cellspacing="0" cellpadding="2"><tr class="cBackHeader fondForumDescription"><th><form method="post" id="fastsearch" action="/forum1.php"><input type="hidden" name="hash_check" value="REDACTED_HASH_CHECK" /><label for="fastsearchinputid"><a rel="nofollow" href="/search.php?config=hfr.inc&amp;cat=23&amp;subcat=550" class="cHeader fastsearchHeader">Recherche :</a>&nbsp;<input type="text" name="search" id="fastsearchinputid" value="" class="fastsearchInput" alt="Search string" /></label><input type="hidden" name="recherches" value="1" /><input type="hidden" name="searchtype" value="1" /><input type="hidden" name="titre" value="3" /><input type="hidden" name="resSearch" value="200" /><input type="hidden" name="orderSearch" value="1" /><input type="hidden" name="config" value="hfr.inc" /><input type="hidden" name="cat" value="23" /><input type="hidden" name="subcat" value="550" />&nbsp;<input type="image" src="https://forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif" class="fastsearchSubmit" title="Lancer une recherche" alt="Lancer une recherche" /></form></th></tr></table></div><div class="spacer">&nbsp;</div><br /><div></div><br /><table class="main" style="margin:auto;" cellspacing="0" cellpadding="4">
+				<tr class="cBackHeader">
+				<th colspan="2">Dernière réponse</th>
+			</tr>
+			<tr class="reponse">
+				<th colspan="2">
+					Sujet : Redface 2 — PHASE 2 @ ALPHA</th>
+			</tr><tr class="reponse">
+				<td class="messCase1bis" width="160" valign="top">XaTriX</td>
+				<td>Vu qu'on a du taf similaire on aurait pu mutualiser :o
+<br />Mais je pense qu'après avoir bien bossé sur RF2 on doit pouvoir générer quelque chose d'utile à n'importe quel client<div style="clear: both;"> </div></td>
+			</tr>
+			</table><br /><a name="formulaire"></a><form name="hop" id="hop" action="/bddpost.php?config=hfr.inc" method="post" onsubmit="
+	return verif_join_form();
+	document.hop.submit.style.visibility='hidden';"><input type="hidden" name="hash_check" value="REDACTED_HASH_CHECK" />	<input type="hidden" name="subcat" value="550" />
+<input type="hidden" name="parents" value="" />
+<input type="hidden" name="post" value="35395" />
+<input type="hidden" name="stickold" value="0" />
+<input type="hidden" name="new" value="0" />
+<input type="hidden" name="cat" id="catid" value="23" />
+<input type="hidden" name="numreponse" value="" />
+<input type="hidden" name="numrep" value="" />
+<input type="hidden" name="page" value="20" />
+<input type="hidden" name="verifrequet" value="1100" />
+<input type="hidden" name="p" value="1" />
+<input type="hidden" name="sondage" value="0" />
+<input type="hidden" name="sond" value="0" />
+<input type="hidden" name="cache" value="cache" />
+<input type="hidden" name="owntopic" value="0" />
+<input type="hidden" name="config" id="configid" value="hfr.inc" />
+<input type="hidden" name="sujet" value="Redface 2 — PHASE 2 @ ALPHA" /><table class="main" cellspacing="0" cellpadding="4" width="100%">
+	<tr class="cBackHeader">
+		<th colspan="2" style="text-align:center">Votre réponse</th>
+	</tr>
+	<tr class="reponse pseudoform" id="pseudoform">
+		<th class="repCase1">Nom d'utilisateur</th>
+		<td class="repCase2">
+			<input maxlength="25" accesskey="p" size="25" name="pseudo" value="" onfocus="passfocus()" />		&nbsp;&nbsp; <a href="/inscription.php?config=hfr.inc" class="Topic">Pour poster, vous devez être inscrit sur ce forum .... si ce n'est pas le cas, cliquez ici !</a>	</td>
+	</tr><tr class="reponse" style="display:none; display:none; " id="passf">
+		<th class="repCase1">Mot de passe</th>
+		<td class="repCase2">			<input type="password" maxlength="40" size="25" name="password" value="" />
+			&nbsp;&nbsp; <a href="/password.php?config=hfr.inc" class="Topic">Vous avez perdu votre mot de passe ? Cliquez ici !</a>
+		</td>
+	</tr><tr class="reponse">
+				<th class="repCase1">Le ton de votre message</th>
+					<td class="repCase2"><input id="icone1" type="radio" value="1" name="MsgIcon" checked="checked" />
+					&nbsp;<label for="icone1"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></label>&nbsp;<input id="icone2" type="radio" value="2" name="MsgIcon" />
+					&nbsp;<label for="icone2"><img src="https://forum-images.hardware.fr/icones/message/icon2.gif" alt="" /></label>&nbsp;<input id="icone3" type="radio" value="3" name="MsgIcon" />
+					&nbsp;<label for="icone3"><img src="https://forum-images.hardware.fr/icones/message/icon3.gif" alt="" /></label>&nbsp;<input id="icone4" type="radio" value="4" name="MsgIcon" />
+					&nbsp;<label for="icone4"><img src="https://forum-images.hardware.fr/icones/message/icon4.gif" alt="" /></label>&nbsp;<input id="icone5" type="radio" value="5" name="MsgIcon" />
+					&nbsp;<label for="icone5"><img src="https://forum-images.hardware.fr/icones/message/icon5.gif" alt="" /></label>&nbsp;<input id="icone6" type="radio" value="6" name="MsgIcon" />
+					&nbsp;<label for="icone6"><img src="https://forum-images.hardware.fr/icones/message/icon6.gif" alt="" /></label>&nbsp;<input id="icone7" type="radio" value="7" name="MsgIcon" />
+					&nbsp;<label for="icone7"><img src="https://forum-images.hardware.fr/icones/message/icon7.gif" alt="" /></label>&nbsp;<input id="icone8" type="radio" value="8" name="MsgIcon" />
+					&nbsp;<label for="icone8"><img src="https://forum-images.hardware.fr/icones/message/icon8.gif" alt="" /></label>&nbsp;<br /><input id="icone9" type="radio" value="9" name="MsgIcon" />
+					&nbsp;<label for="icone9"><img src="https://forum-images.hardware.fr/icones/message/icon9.gif" alt="" /></label>&nbsp;<input id="icone10" type="radio" value="10" name="MsgIcon" />
+					&nbsp;<label for="icone10"><img src="https://forum-images.hardware.fr/icones/message/icon10.gif" alt="" /></label>&nbsp;<input id="icone11" type="radio" value="11" name="MsgIcon" />
+					&nbsp;<label for="icone11"><img src="https://forum-images.hardware.fr/icones/message/icon11.gif" alt="" /></label>&nbsp;<input id="icone12" type="radio" value="12" name="MsgIcon" />
+					&nbsp;<label for="icone12"><img src="https://forum-images.hardware.fr/icones/message/icon12.gif" alt="" /></label>&nbsp;<input id="icone13" type="radio" value="13" name="MsgIcon" />
+					&nbsp;<label for="icone13"><img src="https://forum-images.hardware.fr/icones/message/icon13.gif" alt="" /></label>&nbsp;<input id="icone14" type="radio" value="14" name="MsgIcon" />
+					&nbsp;<label for="icone14"><img src="https://forum-images.hardware.fr/icones/message/icon14.gif" alt="" /></label>&nbsp;<input id="icone15" type="radio" value="15" name="MsgIcon" />
+					&nbsp;<label for="icone15"><img src="https://forum-images.hardware.fr/icones/message/icon15.gif" alt="" /></label>&nbsp;<input id="icone16" type="radio" value="16" name="MsgIcon" />
+					&nbsp;<label for="icone16"><img src="https://forum-images.hardware.fr/icones/message/icon16.gif" alt="" /></label>&nbsp;</td>
+			</tr><tr class="reponse">
+		<th class="repCase1">Votre réponse<br /><br /><br />
+			<div><div class="center">	<a target="_blank" href="/smilies.php?config=hfr.inc" class="s1Topic">Smilies</a>
+				<br />&nbsp;
+				<div class="smiley">
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/smilies/pfff.gif" alt=":pfff:" title=":pfff:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/ange.gif" alt=":ange:" title=":ange:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/non.gif" alt=":non:" title=":non:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/bounce.gif" alt=":bounce:" title=":bounce:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/smile.gif" alt=":)" title=":)" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/frown.gif" alt=":(" title=":(" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/biggrin.gif" alt=":D" title=":D" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/wink.gif" alt=";)" title=";)" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/ouch.gif" alt=":ouch:" title=":ouch:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/redface.gif" alt=":o" title=":o" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/confused.gif" alt=":??:" title=":??:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/tongue.gif" alt=":p" title=":p" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/na.gif" alt=":na:" title=":na:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/sarcastic.gif" alt=":sarcastic:" title=":sarcastic:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/smilies/fou.gif" alt=":fou:" title=":fou:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/jap.gif" alt=":jap:" title=":jap:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/lol.gif" alt=":lol:" title=":lol:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/wahoo.gif" alt=":wahoo:" title=":wahoo:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/kaola.gif" alt=":kaola:" title=":kaola:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/smilies/love.gif" alt=":love:" title=":love:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/heink.gif" alt=":heink:" title=":heink:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/cry.gif" alt=":cry:" title=":cry:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/whistle.gif" alt=":whistle:" title=":whistle:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/sol.gif" alt=":sol:" title=":sol:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/smilies/pt1cable.gif" alt=":pt1cable:" title=":pt1cable:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/sleep.gif" alt=":sleep:" title=":sleep:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/sweat.gif" alt=":sweat:" title=":sweat:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/hello.gif" alt=":hello:" title=":hello:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+				</div>
+				<div class="spacer">&nbsp;</div>
+				<br /><a href="/wikismilies.php?config=hfr.inc&amp;threecol=1" target="_blank" class="s1Topic">Liste des smilies perso</a><br /><a target="_blank" href="/wikismilies.php?config=hfr.inc" class="s1Topic">Wiki smilies</a><br /><span class="small">Chercher un smiley<br /><div id="dynamic_smilies"></div></div></div></th><td class="repCase2" valign="top">		<div class="left">
+				<img style="cursor:pointer" class="text_bold" onclick="TAinsert('[b]','[/b]');" title="Mettre en gras le texte. Syntaxe : [b]texte[/b]" alt="[b]" src="https://forum-images.hardware.fr/icones/message/bold.gif" width="27" height="28" /><img
+				style="cursor:pointer" class="text_ita" onclick="TAinsert('[i]','[/i]');" title="Mettre en italique le texte. Syntaxe : [i]texte[/i]" alt="[i]" src="https://forum-images.hardware.fr/icones/message/italic.gif" width="25" height="28" /><img
+				style="cursor:pointer" class="text_under" onclick="TAinsert('[u]','[/u]');" title="Souligner le texte. Syntaxe : [u]texte[/u]" alt="[u]" src="https://forum-images.hardware.fr/icones/message/underline.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_strike" onclick="TAinsert('[strike]','[/strike]');" title="Barrer le texte. Syntaxe : [strike]texte[/strike]" alt="[strike]" src="https://forum-images.hardware.fr/icones/message/strike.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_spoiler" onclick="TAinsert('[spoiler]','[/spoiler]');" title="Masquer le texte. Syntaxe : [spoiler]texte[/spoiler]" alt="[spoiler]" src="https://forum-images.hardware.fr/icones/message/spoiler.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_fixed" onclick="TAinsert('[fixed]','[/fixed]');" title="Ecrire avec une police de taille fixe. Syntaxe : [fixed]texte[/fixed]" alt="[fixed]" src="https://forum-images.hardware.fr/icones/message/fixe.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="cpp" onclick="TAinsert('[cpp]','[/cpp]');" title="Insérer du code C/C++. Syntaxe : [cpp]texte[/cpp]" alt="[cpp]" src="https://forum-images.hardware.fr/icones/message/c.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_url" onclick="TAinsert('[url]','[/url]');" title="Insérer une URL. Syntaxe : [url]texte[/url]" alt="[url]" src="https://forum-images.hardware.fr/icones/message/url.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_email" onclick="TAinsert('[email]','[/email]');" title="Insérer une adresse email. Syntaxe : [email]email@hostname.com[/email]" alt="[email]" src="https://forum-images.hardware.fr/icones/message/email.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="image" onclick="TAinsert('[img]','[/img]');" title="Insérer une image. Syntaxe : [img]http://www.exemple.com/exemple.jpg[/img]" alt="[img]" src="https://forum-images.hardware.fr/icones/message/image.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_puce" onclick="TAinsert('[*]','');" title="Insérer une puce. Syntaxe : [*]texte" alt="[*]" src="https://forum-images.hardware.fr/icones/message/puce.gif" width="23" height="28" />
+				&nbsp;&nbsp;
+			</div>
+			<div class="left" style="width:270px;">
+				<table class="none" style="margin-top:6px; border:0px" id="ColorPanel" cellspacing="0" cellpadding="0">
+					<tr>
+						<td style="margin:0; padding:0; line-height:10px; cursor:pointer; width:15px; border:1px solid #000000" id="ColorUsed" title="Dernière couleur sélectionnée"><img src="https://forum-images.hardware.fr/icones/trans.gif" alt="" width="15" height="17" onclick="TAinsert('['+document.getElementById('ColorUsed').bgColor+']','[/'+document.getElementById('ColorUsed').bgColor+']');" style="padding:0; margin:0" /><input type="hidden" value="" name="ColorUsedMem" id="ColorUsedMem" /></td>
+						<td width="5" style="margin:0; padding:0">&nbsp;
+							<script language="JavaScript" type="text/javascript">
+								rgb(0,col0,0,'https://forum-images.hardware.fr/icones/trans.gif','Mettre du texte en couleur');
+								rgb(18,col1,50,'https://forum-images.hardware.fr/icones/trans.gif','Mettre du texte en couleur');
+								rgb(36,col2,100,'https://forum-images.hardware.fr/icones/trans.gif','Mettre du texte en couleur');
+								rgb(0,col3,150,'https://forum-images.hardware.fr/icones/trans.gif','Mettre du texte en couleur');
+							</script>
+						</td>
+					</tr>
+				</table>
+			</div>
+			<div class="left">
+				&nbsp;&nbsp;
+				<img style="cursor:pointer" onclick="TAinsert('[quote]','[/quote]');" title="Insérer une citation. Syntaxe : [quote]texte[/quote]" alt="[quote]" src="https://forum-images.hardware.fr/icones/message/citation.gif" width="69" height="28" />
+			</div>
+			<div class="spacer">&nbsp;</div>
+	<br /><textarea cols="75" rows="14" class="contenu" name="content_form" id="content_form" accesskey="c"></textarea><input type="hidden" name="wysiwyg" value="0" />
+<input onclick=" return verif_not_empty()" type="submit" accesskey="s" value="Valider votre message" name="submit" /><input type="button" accesskey="a" value="Aperçu" onclick="apercevoir();" />		<div id="addCommentMessage"></div>
+		</td>
+	</tr>
+	<tr class="reponse">
+		<th class="repCase1">Options</th>
+		<td class="repCase2" style="font-weight:bold">	<input class="checkbox opt" type="checkbox" value="1" name="signature" id="signature" /><label for="signature">Activer votre signature</label>
+	<br /><input class="checkbox opt" type="checkbox" value="1" name="smiley" id="smiley" /><label for="smiley">Désactiver les smilies</label>
+	<br /><input class="checkbox opt" type="checkbox" value="1" name="emaill" id="emaill" /><label for="emaill">Activer la notification par email du sujet</label>
+	&nbsp;</td></tr></table></form><table class="main" cellspacing="0" cellpadding="4" width="100%">		<tr style="display:none" id="apercu" class="reponse">
+			<th class="repCase1">Aperçu</th>
+			<th class="repCase2"><iframe name="apercu_frame" id="apercu_frame" style="border:0px" src=""></iframe></th>
+		</tr>
+	</table><form action="/apercu.php" target="apercu_frame" method="post" name="apercu_form" id="apercu_form">
+<input type="hidden" name="hash_check" value="REDACTED_HASH_CHECK" /><input type="hidden" name="apercu_contenu" id="apercu_contenu" value="" />
+<input type="hidden" name="apercu_smiley" id="apercu_smiley" value="" />
+<input type="hidden" name="config" value="hfr.inc" />
+</form>
+<a href="/password.php?config=hfr.inc" class="s2Ext">Vous avez perdu votre mot de passe ?</a>
+<br />
+<br />
+
+<br /><table class="main" cellspacing="0" cellpadding="4" width="100%">
+			<tr class="cBackHeader">
+				<th class="padding">Vue Rapide de la discussion</th>
+			</tr>
+		</table>		<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#DEDFDF">
+						<td class="messCase1bis" width="160" valign="top">XaTriX</td>
+			<td>Vu qu'on a du taf similaire on aurait pu mutualiser :o
+<br />Mais je pense qu'après avoir bien bossé sur RF2 on doit pouvoir générer quelque chose d'utile à n'importe quel client<div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+			<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#F7F7F7">
+						<td class="messCase1bis" width="160" valign="top">ezzz</td>
+			<td>bah perso c’est écrire les specs qui me prend du temps pour lui dire comment faire &nbsp;<br />En général le gros du boulot est trivial mais dès que tu veux affiner dans un sens particulier ou qu’il faut gérer des cas particuliers liés au HTML du forum c’est moi qui m’y colle
+<br />Y aurait sans doute moyen de déléguer plus à l’IA mais c’est fatiguant aussi d’y réfléchir &nbsp;:o <div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+			<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#DEDFDF">
+						<td class="messCase1bis" width="160" valign="top">xatelitte</td>
+			<td>Test technique Redface2 #81 : capture des formulaires reply/edit/quote pour préparer la Phase 2 écriture.</p>&nbsp;<p>Édition technique : formulaire edit validé.</p>&nbsp;<p><em>Post par GPT-5 Codex</em><div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+			<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#F7F7F7">
+						<td class="messCase1bis" width="160" valign="top">XaTriX</td>
+			<td>J'avais la flemme de faire les fixtures moi même (définir quelle page sauvegarder, y aller, la sauvegarder en html, noter url/bouton/état dans un txt à côté, rince &amp; repeat) donc j'ai demandé au LLM d'apprendre à le faire :o
+<br />Même si je passe plus de temps à le driver/vérifier que de les faire moi même :o
+<br />&nbsp;<br />Tellement rébarbatif les tâches manuelles :o<div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+			<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#DEDFDF">
+						<td class="messCase1bis" width="160" valign="top">ezzz</td>
+			<td>En plus y a eu reset des tokens codex hier soir. Faut en profiter &nbsp;[:catalonix:10] <div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+			<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#F7F7F7">
+						<td class="messCase1bis" width="160" valign="top">XaTriX</td>
+			<td></p><div class="container"><table class="citation"><tr class="none"><td><b class="s1"><a href="/hfr/gsmgpspda/android/redface-phase-alpha-sujet_35395_20.htm#t2784589" class="Topic">Ayuget a écrit :</a></b><br /><br /><p>Punaise, j'ai l'impression que le nouveau développeur est aussi feignant que l'ancien &nbsp;:fou: <br /></p></td></tr></table></div><p><br />[:rofl]<div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+			<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#DEDFDF">
+						<td class="messCase1bis" width="160" valign="top">Shinseiki</td>
+			<td>Il a encore de la marge avant de te rattraper :o<div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+			<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#F7F7F7">
+						<td class="messCase1bis" width="160" valign="top">Ayuget</td>
+			<td>Punaise, j'ai l'impression que le nouveau développeur est aussi feignant que l'ancien &nbsp;:fou: <div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+			<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#DEDFDF">
+						<td class="messCase1bis" width="160" valign="top">Colonel MythO</td>
+			<td>Ah ben aujourd'hui il veut pas actualiser mes favoris déjà lus... [:henri gaud l'eau:5] <br />C'est dimanche !<div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+			<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#F7F7F7">
+						<td class="messCase1bis" width="160" valign="top">antiseptiqueIncolore</td>
+			<td></p><div class="container"><table class="citation"><tr class="none"><td><b class="s1"><a href="/hfr/gsmgpspda/android/redface-phase-alpha-sujet_35395_19.htm#t2784549" class="Topic">XaTriX a écrit :</a></b><br /><br /><p>J'attends les dons :o<br /></p></td></tr></table></div><p><br />T'as donné ton paypal?<div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+			<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#DEDFDF">
+						<td class="messCase1bis" width="160" valign="top">DP59</td>
+			<td></p><div class="container"><table class="citation"><tr class="none"><td><b class="s1"><a href="/hfr/gsmgpspda/android/redface-phase-alpha-sujet_35395_19.htm#t2784549" class="Topic">XaTriX a écrit :</a></b><br /><br /><p>J'attends les dons :o<br /></p></td></tr></table></div>&nbsp;<p> [:elie_cohbeet:10] <div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+
+<div class="copyright">
+<br /><a href="http://www.mesdiscussions.net" target="_blank" class="copyright">Forum MesDiscussions.Net</a>, Version 2010.2 <br />(c) 2000-2011 Doctissimo<br /></div>
+</div>
+</div>
+<center><font color="#000000" size="1" face="Arial, Helvetica, sans-serif"><br />Copyright © 1997-2025 Groupe <a href="https://www.ldlc.com" title="Achat de materiel Informatique">LDLC</a> (<a href="https://www.hardware.fr/html/donnees_personnelles/">Signaler un contenu illicite / Données personnelles</a>)</font></center>
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://tracking.groupe-ldlc.com/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '26']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<noscript><p><img src="https://tracking.groupe-ldlc.com/matomo.php?idsite=26&rec=1" style="border:0;" alt="" /></p></noscript>
+<!-- End Matomo Code --><script type="text/javascript">
+md_forum_decryptlink.init();
+</script>
+<script type="text/javascript">
+md_forum_decryptlink.init();
+</script>
+<script type="text/javascript">
+
+		window.onload = function(){aff_add_img_js();};
+
+	function warning() {
+		if (alert('Vous devez spécifier une sous-catégorie !')) {
+			return false;
+		} else {
+			return false;
+		}
+	}
+	function add_join_img() {
+	var addform= 0;
+	for (i=0;i<10;i++) {
+		if ((!document.getElementById('add_image'+i)) && (addform == 0)) {
+			//var inner_add_form= document.getElementById('add_image_form').innerHTML;
+			//document.getElementById('add_image_form').innerHTML= inner_add_form+ '<br /><input type="file" name="add_image'+i+'" id="add_image'+i+'" onchange="document.join_form.sub.style.fontWeight=\'bold\'" />';
+			addform= 1;
+			var addFile=document.createElement("DIV");
+			addFile.innerHTML= '<input type="file" name="add_image'+i+'" id="add_image'+i+'" onchange="document.join_form.sub.style.fontWeight=\'bold\'" />';
+		    document.getElementById('add_image_form').appendChild(addFile)
+			if (i == 9) {
+				document.getElementById('add_img_js').style.display= 'none';
+			}
+		}
+	}
+}
+
+function aff_add_img_js() {
+	if (document.getElementById('add_img_js')) {
+		document.getElementById('add_img_js').style.display= 'block';
+	}
+}
+function message_upload_img() {
+	no_image= 1;
+	for (i=0;i<10;i++) {
+		if ((document.getElementById('add_image'+i)) && (document.getElementById('add_image'+i).value != '')) {
+			no_image= 0;
+		}
+	}
+	if (no_image == 1) {
+		alert('Vous n\'avez pas choisi d\'image à joindre');
+		return false;
+	}
+	document.getElementById('add_img_js').style.display= 'none';
+	document.getElementById('add_image_form').style.display= 'none';
+	document.getElementById('submit_upload').style.display= 'none';
+	document.getElementById('join_form').action= '/user/join_image_b.php?config=hfr.inc';
+	document.getElementById('upload_frame').style.display= '';
+	document.getElementById('join_form').target= 'upload_frame';
+	document.getElementById('img_wait_upload_img').style.display= '';
+	document.getElementById('join_form').submit();
+	document.getElementById('submit_upload').style.fontWeight= 'normal';
+}
+</script>
+</body>
+</html>

--- a/core/data/src/test/resources/fixtures/write_reply_anonymous_form.source.txt
+++ b/core/data/src/test/resources/fixtures/write_reply_anonymous_form.source.txt
@@ -1,0 +1,6 @@
+Source: forum.hardware.fr
+Captured: 2026-05-17
+URL: https://forum.hardware.fr/message.php?config=hfr.inc&cat=23&post=35395&page=20&p=1&subcat=550&sondage=0&owntopic=0&new=0
+Notes: Anonymous GET reply form: HFR serves the composer with pseudo/password fields instead of redirecting immediately.
+Sanitization: hash_check/codehex redacted; MP unread target id and MP count redacted when present; no cookies stored.
+Test context: Anonymous session, Redface 2 topic cat=23 post=35395 page=20 subcat=550.

--- a/core/data/src/test/resources/fixtures/write_reply_form_open_topic.html
+++ b/core/data/src/test/resources/fixtures/write_reply_form_open_topic.html
@@ -1,0 +1,451 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+	<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr" lang="fr">
+	<head>
+	<title>FORUM HardWare.fr - Répondre / éditer un message</title><link type="text/css" rel="stylesheet" href="/include/the_style1.php?color_key=FFFFFF/DEDFDF/000080/C2C3F4/001932/FFFFFF/FFFFFF/000000/000080/000000/000080/F7F7F7/DEDFDF/F7F7F7/DEDFDF/C0C0C0/C0C0C0/FFFFFF/000000/000000/0000FF/EEEEFF/DDDDEE/000000/FFEEEE/000000/FFFFFF/FF0000/FFFFFF/0/1/https%3A%40%40forum-images.hardware.fr/NULL/&amp;abs_img_path=%40data%40sites%40forum%40www%40static%40&amp;hide_bg_onglet=0&amp;v=11102781422" /><style type="text/css">
+<!--
+.fastsearchMain{ width: 330px; }
+.fastsearchInput{ width: 70px; border: 1px solid black; }
+.fastsearchSubmit{ background-color: ; border: 0px;}
+.header2 { background-image: url(/img/forum3_1.gif);background-repeat: repeat-x; }
+.menuExt { font-family: Arial, Helvetica, sans-serif; font-size: 10px; color:#000; }
+.menuExt a { color:#000;text-decoration:none; }
+.menuExt a:hover { color:#000;text-decoration:underline; }
+form { display: inline; }
+.header { background-image: url(//forum-images.hardware.fr/img/header-bg.gif); background-repeat: repeat-x; }
+.tdmenu { width: 1px;height: 1px;color: #000000; }
+.hfrheadmenu { font-family: Arial, Helvetica, sans-serif;font-size:13px;font-weight:bold; }
+.hfrheadmenu span {color:;}
+.hfrheadmenu a { color:;text-decoration: none; }
+.hfrheadmenu a:hover { color:;text-decoration: underline; }
+.concours { font-family: Arial, Helvetica, sans-serif;color:;font-size: 16px;text-decoration: none;font-weight: bold;}
+.concours:hover { font-family: Arial, Helvetica, sans-serif;color:;font-size: 16px;text-decoration: underline;font-weight: bold; }
+.searchmenu { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: none;font-weight: bold; }
+.fastsearch { display: none; }
+.fastsearchHeader { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: none;font-weight: bold; }
+.fastsearchHeader:hover { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: underline;font-weight: bold; }
+-->
+</style>
+<script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+<script>
+  window.googletag = window.googletag || {cmd: []};
+  googletag.cmd.push(function() {
+    googletag.defineSlot('/2172442/forum_discussions_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-11').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-12').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-13').addService(googletag.pubads());
+    googletag.pubads().enableSingleRequest();
+    googletag.enableServices();
+  });
+</script>
+<script type='text/javascript'>
+     (function(){
+       var loc = window.location.href;
+       var dd = document.createElement('script');
+       dd.type = 'text/javascript'; dd.src = '//static.digidip.net/hardware.js?loc=' + loc;
+       var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(dd, s);
+     })();
+</script><script type="text/javascript">
+
+var hash_check = "&hash_check=REDACTED_HASH_CHECK";
+var _adresseRecherche = "/user/message-aj.php";
+var adresseFindSmiley = "/message-smi-mp-aj.php";
+var tempo_smilies= 0;
+
+var img_path= "https://forum-images.hardware.fr";
+
+function verif_join_form() {
+	if ((document.getElementById('submit_upload')) && (document.getElementById('submit_upload').style.fontWeight == 'bold')) {
+		return confirm('Attention : vous n\'avez pas joint l\'image que vous avez sélectionnée');
+	}
+	return true;
+}
+
+function verif_not_empty() {
+	if (document.getElementById('delete').checked == true) {
+		return true;
+	}
+	if (document.hop.sujet && trim(document.hop.sujet.value) =='') {
+		alert('Vous devez remplir tous les champs avant de poster ce message');
+		return false;
+	}
+	if (document.hop.content_form && trim(document.hop.content_form.value) == '') {
+		alert('Vous devez remplir tous les champs avant de poster ce message');
+		return false;
+	}
+	if (document.hop.codecaptcha && trim(document.hop.codecaptcha.value) == '') {
+		alert('Vous devez remplir tous les champs avant de poster ce message');
+		return false;
+	}
+	if (document.getElementById('have_sondage') && document.getElementById('have_sondage').checked == true && document.getElementById('annee').value && document.getElementById('annee').value.length != 4) {
+		alert('L\'année du sondage doit être sur 4 chiffres');
+		return false;
+	}
+
+	return true;
+}
+
+function trim(string) {
+	return string.replace(/(^\s*)|(\s*$)/g,"");
+}
+</script><script language="javascript" type="text/javascript">
+	<!--
+ var opera=0;
+	function putSmiley(tt,src) {
+TAinsert(" "+tt+" ","");
+}
+	//-->
+	</script><link type="text/css" rel="stylesheet" href="https://forum-images.hardware.fr/compressed/the_style.css?v=11102781422" />
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta http-equiv="Pragma" content="no-cache" />
+	<meta http-equiv="Cache-Control" content="no-cache, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+	<meta http-equiv="Imagetoolbar" content="no" />
+	<meta name="Robots" content="noindex, nofollow" />
+<script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/editPost.js?v=11102781422"></script><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/message.js?v=11102781422"></script><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/common.js?v=11102781422"></script></head><body id="category__redaction_form__form_message"  > <table cellspacing="0" cellpadding="0" width="98%" bgcolor="#000000" border="0" align="center" class="hfrheadmenu" style="border:1px solid #000;border-top:0;">
+        <tr>
+          <td style="vertical-align: top">
+            <table cellspacing="0" cellpadding="0" width="100%" border="0">
+              <tr>
+                <td style="width: 100%" align="left" valign="middle" colspan="2" class="header2"><span class="md_cryptlink45CBCBC0C22D1F1FCCCCCC19454AC14BCC4AC1431944C1"><img src="/img/forum_logo.gif" width="900" height="71" border="0" alt="" /></span></td>
+              </tr>
+              <tr>
+                <td style="background-color:#001932">
+                  <table cellspacing="0" cellpadding="2" width="100%" border="0">
+                    <tr>
+                      <td>&nbsp;<a class="cHeader" href="/">Forum</a>&nbsp;|&nbsp;
+<a class="cHeader" href="https://www.hardware.fr/">HardWare.fr</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/html/news/">News</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/html/articles/">Articles</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/articles/786-1/guide-pc-hardware-fr.html">PC</a>&nbsp;|&nbsp;<span class="md_cryptlink1FC349484F4C19C045C02F424F4944464C2E454AC14BCC4AC14344C11946494214424F4B434543C52E2443252B234A232C4B24254B4B2B254B2B252B2A43444B2A442B252420212C20">Se d&eacute;connecter</span>&nbsp;|&nbsp;<span class="md_cryptlink1FC3C243C11F434B46CBC0C14F44464819C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">Profil</span>&nbsp;|&nbsp;<a class="cHeader" href="https://shop.hardware.fr/" target="_blank" style="position: relative; padding: 0 21px 0 0;display: inline-block;">Shop <img src="/img/shop.png" style="height: 17px; display: inline; position: absolute; right: 0; top: -2px; "></a></td>
+<td align="right"><a class="cHeader" href="/search.php?config=hardwarefr.inc&cat=23&subcat=550">Recherche <img src="//forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif"></a></td>
+                    </tr>
+                    </table></td></tr></table>
+</td></tr></table><div style="width: 99%" align="right">
+<span class="s2Ext menuExt"><span class="md_cryptlink1F4F494846494319C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">3848 connect&eacute;s&nbsp;</span></span></div><br /><script language="javascript" type="text/javascript">
+			<!--
+			writeCookie('md_users_res');
+			//-->
+			</script><div class="container"><div class="mesdiscussions" id="mesdiscussions"><div class="arbo">
+<span  id="md_arbo_tree_1" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/" class="Ext">FORUM HardWare.fr</a></span>
+<br />
+<span  id="md_arbo_tree_2" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/hfr/gsmgpspda/liste_sujet-1.htm" class="Ext">Technologies&nbsp;Mobiles</a></span>
+<br />
+<span  id="md_arbo_tree_3" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline3.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/hfr/gsmgpspda/android/liste_sujet-1.htm" class="Ext">Android</a></span>
+<br />
+<h1  id="md_arbo_tree_4" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline4.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/hfr/gsmgpspda/android/redface-phase-alpha-sujet_35395_20.htm" class="Ext">Redface 2 — PHASE 2 @ ALPHA</a></h1>
+</div><div class="rightbutton fastsearch"><table class="main fastsearchMain" cellspacing="0" cellpadding="2"><tr class="cBackHeader fondForumDescription"><th><form method="post" id="fastsearch" action="/forum1.php"><input type="hidden" name="hash_check" value="REDACTED_HASH_CHECK" /><label for="fastsearchinputid"><a rel="nofollow" href="/search.php?config=hfr.inc&amp;cat=23&amp;subcat=550" class="cHeader fastsearchHeader">Recherche :</a>&nbsp;<input type="text" name="search" id="fastsearchinputid" value="" class="fastsearchInput" alt="Search string" /></label><input type="hidden" name="recherches" value="1" /><input type="hidden" name="searchtype" value="1" /><input type="hidden" name="titre" value="3" /><input type="hidden" name="resSearch" value="200" /><input type="hidden" name="orderSearch" value="1" /><input type="hidden" name="config" value="hfr.inc" /><input type="hidden" name="cat" value="23" /><input type="hidden" name="subcat" value="550" />&nbsp;<input type="image" src="https://forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif" class="fastsearchSubmit" title="Lancer une recherche" alt="Lancer une recherche" /></form></th></tr></table></div><div class="spacer">&nbsp;</div><br /><div></div><br /><table class="main" style="margin:auto;" cellspacing="0" cellpadding="4">
+				<tr class="cBackHeader">
+				<th colspan="2">Dernière réponse</th>
+			</tr>
+			<tr class="reponse">
+				<th colspan="2">
+					Sujet : Redface 2 — PHASE 2 @ ALPHA</th>
+			</tr><tr class="reponse">
+				<td class="messCase1bis" width="160" valign="top">ezzz</td>
+				<td>bah perso c’est écrire les specs qui me prend du temps pour lui dire comment faire &nbsp;<br />En général le gros du boulot est trivial mais dès que tu veux affiner dans un sens particulier ou qu’il faut gérer des cas particuliers liés au HTML du forum c’est moi qui m’y colle
+<br />Y aurait sans doute moyen de déléguer plus à l’IA mais c’est fatiguant aussi d’y réfléchir &nbsp;:o <div style="clear: both;"> </div></td>
+			</tr>
+			</table><br /><a name="formulaire"></a><form name="hop" id="hop" action="/bddpost.php?config=hfr.inc" method="post" onsubmit="
+	return verif_join_form();
+	document.hop.submit.style.visibility='hidden';"><input type="hidden" name="hash_check" value="REDACTED_HASH_CHECK" />	<input type="hidden" name="subcat" value="550" />
+<input type="hidden" name="parents" value="" />
+<input type="hidden" name="post" value="35395" />
+<input type="hidden" name="stickold" value="0" />
+<input type="hidden" name="new" value="0" />
+<input type="hidden" name="cat" id="catid" value="23" />
+<input type="hidden" name="numreponse" value="" />
+<input type="hidden" name="numrep" value="" />
+<input type="hidden" name="page" value="20" />
+<input type="hidden" name="verifrequet" value="1100" />
+<input type="hidden" name="p" value="1" />
+<input type="hidden" name="sondage" value="0" />
+<input type="hidden" name="sond" value="0" />
+<input type="hidden" name="cache" value="cache" />
+<input type="hidden" name="owntopic" value="0" />
+<input type="hidden" name="config" id="configid" value="hfr.inc" />
+<input type="hidden" name="sujet" value="Redface 2 — PHASE 2 @ ALPHA" /><table class="main" cellspacing="0" cellpadding="4" width="100%">
+	<tr class="cBackHeader">
+		<th colspan="2" style="text-align:center">Votre réponse</th>
+	</tr>
+	<tr class="reponse pseudoform" id="pseudoform">
+		<th class="repCase1">Nom d'utilisateur</th>
+		<td class="repCase2">
+			<input maxlength="25" accesskey="p" size="25" name="pseudo" value="xatelitte" onfocus="passfocus()" />		&nbsp;&nbsp; <a href="/inscription.php?config=hfr.inc" class="Topic">Pour poster, vous devez être inscrit sur ce forum .... si ce n'est pas le cas, cliquez ici !</a>	</td>
+	</tr><tr class="reponse" style="display:none; display:none; " id="passf">
+		<th class="repCase1">Mot de passe</th>
+		<td class="repCase2">			<input type="password" maxlength="40" size="25" name="password" value="" />
+			&nbsp;&nbsp; <a href="/password.php?config=hfr.inc" class="Topic">Vous avez perdu votre mot de passe ? Cliquez ici !</a>
+		</td>
+	</tr><tr class="reponse">
+				<th class="repCase1">Le ton de votre message</th>
+					<td class="repCase2"><input id="icone1" type="radio" value="1" name="MsgIcon" checked="checked" />
+					&nbsp;<label for="icone1"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></label>&nbsp;<input id="icone2" type="radio" value="2" name="MsgIcon" />
+					&nbsp;<label for="icone2"><img src="https://forum-images.hardware.fr/icones/message/icon2.gif" alt="" /></label>&nbsp;<input id="icone3" type="radio" value="3" name="MsgIcon" />
+					&nbsp;<label for="icone3"><img src="https://forum-images.hardware.fr/icones/message/icon3.gif" alt="" /></label>&nbsp;<input id="icone4" type="radio" value="4" name="MsgIcon" />
+					&nbsp;<label for="icone4"><img src="https://forum-images.hardware.fr/icones/message/icon4.gif" alt="" /></label>&nbsp;<input id="icone5" type="radio" value="5" name="MsgIcon" />
+					&nbsp;<label for="icone5"><img src="https://forum-images.hardware.fr/icones/message/icon5.gif" alt="" /></label>&nbsp;<input id="icone6" type="radio" value="6" name="MsgIcon" />
+					&nbsp;<label for="icone6"><img src="https://forum-images.hardware.fr/icones/message/icon6.gif" alt="" /></label>&nbsp;<input id="icone7" type="radio" value="7" name="MsgIcon" />
+					&nbsp;<label for="icone7"><img src="https://forum-images.hardware.fr/icones/message/icon7.gif" alt="" /></label>&nbsp;<input id="icone8" type="radio" value="8" name="MsgIcon" />
+					&nbsp;<label for="icone8"><img src="https://forum-images.hardware.fr/icones/message/icon8.gif" alt="" /></label>&nbsp;<br /><input id="icone9" type="radio" value="9" name="MsgIcon" />
+					&nbsp;<label for="icone9"><img src="https://forum-images.hardware.fr/icones/message/icon9.gif" alt="" /></label>&nbsp;<input id="icone10" type="radio" value="10" name="MsgIcon" />
+					&nbsp;<label for="icone10"><img src="https://forum-images.hardware.fr/icones/message/icon10.gif" alt="" /></label>&nbsp;<input id="icone11" type="radio" value="11" name="MsgIcon" />
+					&nbsp;<label for="icone11"><img src="https://forum-images.hardware.fr/icones/message/icon11.gif" alt="" /></label>&nbsp;<input id="icone12" type="radio" value="12" name="MsgIcon" />
+					&nbsp;<label for="icone12"><img src="https://forum-images.hardware.fr/icones/message/icon12.gif" alt="" /></label>&nbsp;<input id="icone13" type="radio" value="13" name="MsgIcon" />
+					&nbsp;<label for="icone13"><img src="https://forum-images.hardware.fr/icones/message/icon13.gif" alt="" /></label>&nbsp;<input id="icone14" type="radio" value="14" name="MsgIcon" />
+					&nbsp;<label for="icone14"><img src="https://forum-images.hardware.fr/icones/message/icon14.gif" alt="" /></label>&nbsp;<input id="icone15" type="radio" value="15" name="MsgIcon" />
+					&nbsp;<label for="icone15"><img src="https://forum-images.hardware.fr/icones/message/icon15.gif" alt="" /></label>&nbsp;<input id="icone16" type="radio" value="16" name="MsgIcon" />
+					&nbsp;<label for="icone16"><img src="https://forum-images.hardware.fr/icones/message/icon16.gif" alt="" /></label>&nbsp;</td>
+			</tr><tr class="reponse">
+		<th class="repCase1">Votre réponse<br /><br /><br />
+			<div><div class="center">	<a target="_blank" href="/smilies.php?config=hfr.inc" class="s1Topic">Smilies</a>
+				<br />&nbsp;
+				<div class="smiley">
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/smilies/pfff.gif" alt=":pfff:" title=":pfff:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/ange.gif" alt=":ange:" title=":ange:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/non.gif" alt=":non:" title=":non:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/bounce.gif" alt=":bounce:" title=":bounce:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/smile.gif" alt=":)" title=":)" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/frown.gif" alt=":(" title=":(" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/biggrin.gif" alt=":D" title=":D" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/wink.gif" alt=";)" title=";)" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/ouch.gif" alt=":ouch:" title=":ouch:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/redface.gif" alt=":o" title=":o" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/confused.gif" alt=":??:" title=":??:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/tongue.gif" alt=":p" title=":p" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/na.gif" alt=":na:" title=":na:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/sarcastic.gif" alt=":sarcastic:" title=":sarcastic:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/smilies/fou.gif" alt=":fou:" title=":fou:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/jap.gif" alt=":jap:" title=":jap:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/lol.gif" alt=":lol:" title=":lol:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/wahoo.gif" alt=":wahoo:" title=":wahoo:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/kaola.gif" alt=":kaola:" title=":kaola:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/smilies/love.gif" alt=":love:" title=":love:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/heink.gif" alt=":heink:" title=":heink:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/cry.gif" alt=":cry:" title=":cry:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/whistle.gif" alt=":whistle:" title=":whistle:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/sol.gif" alt=":sol:" title=":sol:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/smilies/pt1cable.gif" alt=":pt1cable:" title=":pt1cable:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/sleep.gif" alt=":sleep:" title=":sleep:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/sweat.gif" alt=":sweat:" title=":sweat:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/hello.gif" alt=":hello:" title=":hello:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+				</div>
+				<div class="spacer">&nbsp;</div>
+				<br /><a href="/wikismilies.php?config=hfr.inc&amp;threecol=1" target="_blank" class="s1Topic">Liste des smilies perso</a><br /><a target="_blank" href="/wikismilies.php?config=hfr.inc" class="s1Topic">Wiki smilies</a><br /><span class="small">Chercher un smiley<br /><input type="text" value="" name="search_smilies" id="search_smilies" size="10" onkeyup="find_smilies_timer('hfr.inc',1214571)"/></span><br /><div id="dynamic_smilies"></div></div></div></th><td class="repCase2" valign="top">		<div class="left">
+				<img style="cursor:pointer" class="text_bold" onclick="TAinsert('[b]','[/b]');" title="Mettre en gras le texte. Syntaxe : [b]texte[/b]" alt="[b]" src="https://forum-images.hardware.fr/icones/message/bold.gif" width="27" height="28" /><img
+				style="cursor:pointer" class="text_ita" onclick="TAinsert('[i]','[/i]');" title="Mettre en italique le texte. Syntaxe : [i]texte[/i]" alt="[i]" src="https://forum-images.hardware.fr/icones/message/italic.gif" width="25" height="28" /><img
+				style="cursor:pointer" class="text_under" onclick="TAinsert('[u]','[/u]');" title="Souligner le texte. Syntaxe : [u]texte[/u]" alt="[u]" src="https://forum-images.hardware.fr/icones/message/underline.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_strike" onclick="TAinsert('[strike]','[/strike]');" title="Barrer le texte. Syntaxe : [strike]texte[/strike]" alt="[strike]" src="https://forum-images.hardware.fr/icones/message/strike.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_spoiler" onclick="TAinsert('[spoiler]','[/spoiler]');" title="Masquer le texte. Syntaxe : [spoiler]texte[/spoiler]" alt="[spoiler]" src="https://forum-images.hardware.fr/icones/message/spoiler.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_fixed" onclick="TAinsert('[fixed]','[/fixed]');" title="Ecrire avec une police de taille fixe. Syntaxe : [fixed]texte[/fixed]" alt="[fixed]" src="https://forum-images.hardware.fr/icones/message/fixe.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="cpp" onclick="TAinsert('[cpp]','[/cpp]');" title="Insérer du code C/C++. Syntaxe : [cpp]texte[/cpp]" alt="[cpp]" src="https://forum-images.hardware.fr/icones/message/c.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_url" onclick="TAinsert('[url]','[/url]');" title="Insérer une URL. Syntaxe : [url]texte[/url]" alt="[url]" src="https://forum-images.hardware.fr/icones/message/url.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_email" onclick="TAinsert('[email]','[/email]');" title="Insérer une adresse email. Syntaxe : [email]email@hostname.com[/email]" alt="[email]" src="https://forum-images.hardware.fr/icones/message/email.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="image" onclick="TAinsert('[img]','[/img]');" title="Insérer une image. Syntaxe : [img]http://www.exemple.com/exemple.jpg[/img]" alt="[img]" src="https://forum-images.hardware.fr/icones/message/image.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_puce" onclick="TAinsert('[*]','');" title="Insérer une puce. Syntaxe : [*]texte" alt="[*]" src="https://forum-images.hardware.fr/icones/message/puce.gif" width="23" height="28" />
+				&nbsp;&nbsp;
+			</div>
+			<div class="left" style="width:270px;">
+				<table class="none" style="margin-top:6px; border:0px" id="ColorPanel" cellspacing="0" cellpadding="0">
+					<tr>
+						<td style="margin:0; padding:0; line-height:10px; cursor:pointer; width:15px; border:1px solid #000000" id="ColorUsed" title="Dernière couleur sélectionnée"><img src="https://forum-images.hardware.fr/icones/trans.gif" alt="" width="15" height="17" onclick="TAinsert('['+document.getElementById('ColorUsed').bgColor+']','[/'+document.getElementById('ColorUsed').bgColor+']');" style="padding:0; margin:0" /><input type="hidden" value="" name="ColorUsedMem" id="ColorUsedMem" /></td>
+						<td width="5" style="margin:0; padding:0">&nbsp;
+							<script language="JavaScript" type="text/javascript">
+								rgb(0,col0,0,'https://forum-images.hardware.fr/icones/trans.gif','Mettre du texte en couleur');
+								rgb(18,col1,50,'https://forum-images.hardware.fr/icones/trans.gif','Mettre du texte en couleur');
+								rgb(36,col2,100,'https://forum-images.hardware.fr/icones/trans.gif','Mettre du texte en couleur');
+								rgb(0,col3,150,'https://forum-images.hardware.fr/icones/trans.gif','Mettre du texte en couleur');
+							</script>
+						</td>
+					</tr>
+				</table>
+			</div>
+			<div class="left">
+				&nbsp;&nbsp;
+				<img style="cursor:pointer" onclick="TAinsert('[quote]','[/quote]');" title="Insérer une citation. Syntaxe : [quote]texte[/quote]" alt="[quote]" src="https://forum-images.hardware.fr/icones/message/citation.gif" width="69" height="28" />
+			</div>
+			<div class="spacer">&nbsp;</div>
+	<br /><textarea cols="75" rows="14" class="contenu" name="content_form" id="content_form" accesskey="c"></textarea><input type="hidden" name="wysiwyg" value="0" />
+<input onclick=" return verif_not_empty()" type="submit" accesskey="s" value="Valider votre message" name="submit" /><input type="button" accesskey="a" value="Aperçu" onclick="apercevoir();" />		<div id="addCommentMessage"></div>
+		</td>
+	</tr>
+	<tr class="reponse">
+		<th class="repCase1">Options</th>
+		<td class="repCase2" style="font-weight:bold">	<input class="checkbox opt" type="checkbox" value="1" name="signature" id="signature" /><label for="signature">Activer votre signature</label>
+	<br /><input class="checkbox opt" type="checkbox" value="1" name="smiley" id="smiley" /><label for="smiley">Désactiver les smilies</label>
+	<br /><input class="checkbox opt" type="checkbox" value="1" name="emaill" id="emaill" /><label for="emaill">Activer la notification par email du sujet</label>
+	&nbsp;</td></tr></table></form><table class="main" cellspacing="0" cellpadding="4" width="100%">		<tr style="display:none" id="apercu" class="reponse">
+			<th class="repCase1">Aperçu</th>
+			<th class="repCase2"><iframe name="apercu_frame" id="apercu_frame" style="border:0px" src=""></iframe></th>
+		</tr>
+	</table><form action="/apercu.php" target="apercu_frame" method="post" name="apercu_form" id="apercu_form">
+<input type="hidden" name="hash_check" value="REDACTED_HASH_CHECK" /><input type="hidden" name="apercu_contenu" id="apercu_contenu" value="" />
+<input type="hidden" name="apercu_smiley" id="apercu_smiley" value="" />
+<input type="hidden" name="config" value="hfr.inc" />
+</form>
+<a href="/password.php?config=hfr.inc" class="s2Ext">Vous avez perdu votre mot de passe ?</a>
+<br />
+<br />
+
+<br /><table class="main" cellspacing="0" cellpadding="4" width="100%">
+			<tr class="cBackHeader">
+				<th class="padding">Vue Rapide de la discussion</th>
+			</tr>
+		</table>		<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#DEDFDF">
+						<td class="messCase1bis" width="160" valign="top">ezzz</td>
+			<td>bah perso c’est écrire les specs qui me prend du temps pour lui dire comment faire &nbsp;<br />En général le gros du boulot est trivial mais dès que tu veux affiner dans un sens particulier ou qu’il faut gérer des cas particuliers liés au HTML du forum c’est moi qui m’y colle
+<br />Y aurait sans doute moyen de déléguer plus à l’IA mais c’est fatiguant aussi d’y réfléchir &nbsp;:o <div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+			<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#F7F7F7">
+						<td class="messCase1bis" width="160" valign="top">xatelitte</td>
+			<td>Test technique Redface2 #81 : capture des formulaires reply/edit/quote pour préparer la Phase 2 écriture.</p>&nbsp;<p>Édition technique : formulaire edit validé.</p>&nbsp;<p><em>Post par GPT-5 Codex</em><div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+			<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#DEDFDF">
+						<td class="messCase1bis" width="160" valign="top">XaTriX</td>
+			<td>J'avais la flemme de faire les fixtures moi même (définir quelle page sauvegarder, y aller, la sauvegarder en html, noter url/bouton/état dans un txt à côté, rince &amp; repeat) donc j'ai demandé au LLM d'apprendre à le faire :o
+<br />Même si je passe plus de temps à le driver/vérifier que de les faire moi même :o
+<br />&nbsp;<br />Tellement rébarbatif les tâches manuelles :o<div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+			<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#F7F7F7">
+						<td class="messCase1bis" width="160" valign="top">ezzz</td>
+			<td>En plus y a eu reset des tokens codex hier soir. Faut en profiter &nbsp;[:catalonix:10] <div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+			<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#DEDFDF">
+						<td class="messCase1bis" width="160" valign="top">XaTriX</td>
+			<td></p><div class="container"><table class="citation"><tr class="none"><td><b class="s1"><a href="/hfr/gsmgpspda/android/redface-phase-alpha-sujet_35395_20.htm#t2784589" class="Topic">Ayuget a écrit :</a></b><br /><br /><p>Punaise, j'ai l'impression que le nouveau développeur est aussi feignant que l'ancien &nbsp;:fou: <br /></p></td></tr></table></div><p><br />[:rofl]<div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+			<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#F7F7F7">
+						<td class="messCase1bis" width="160" valign="top">Shinseiki</td>
+			<td>Il a encore de la marge avant de te rattraper :o<div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+			<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#DEDFDF">
+						<td class="messCase1bis" width="160" valign="top">Ayuget</td>
+			<td>Punaise, j'ai l'impression que le nouveau développeur est aussi feignant que l'ancien &nbsp;:fou: <div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+			<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#F7F7F7">
+						<td class="messCase1bis" width="160" valign="top">Colonel MythO</td>
+			<td>Ah ben aujourd'hui il veut pas actualiser mes favoris déjà lus... [:henri gaud l'eau:5] <br />C'est dimanche !<div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+			<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#DEDFDF">
+						<td class="messCase1bis" width="160" valign="top">antiseptiqueIncolore</td>
+			<td></p><div class="container"><table class="citation"><tr class="none"><td><b class="s1"><a href="/hfr/gsmgpspda/android/redface-phase-alpha-sujet_35395_19.htm#t2784549" class="Topic">XaTriX a écrit :</a></b><br /><br /><p>J'attends les dons :o<br /></p></td></tr></table></div><p><br />T'as donné ton paypal?<div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+			<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#F7F7F7">
+						<td class="messCase1bis" width="160" valign="top">DP59</td>
+			<td></p><div class="container"><table class="citation"><tr class="none"><td><b class="s1"><a href="/hfr/gsmgpspda/android/redface-phase-alpha-sujet_35395_19.htm#t2784549" class="Topic">XaTriX a écrit :</a></b><br /><br /><p>J'attends les dons :o<br /></p></td></tr></table></div>&nbsp;<p> [:elie_cohbeet:10] <div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+
+<div class="copyright">
+<br /><a href="http://www.mesdiscussions.net" target="_blank" class="copyright">Forum MesDiscussions.Net</a>, Version 2010.2 <br />(c) 2000-2011 Doctissimo<br /></div>
+</div>
+</div>
+<center><font color="#000000" size="1" face="Arial, Helvetica, sans-serif"><br />Copyright © 1997-2025 Groupe <a href="https://www.ldlc.com" title="Achat de materiel Informatique">LDLC</a> (<a href="https://www.hardware.fr/html/donnees_personnelles/">Signaler un contenu illicite / Données personnelles</a>)</font></center>
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://tracking.groupe-ldlc.com/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '26']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<noscript><p><img src="https://tracking.groupe-ldlc.com/matomo.php?idsite=26&rec=1" style="border:0;" alt="" /></p></noscript>
+<!-- End Matomo Code --><script type="text/javascript">
+md_forum_decryptlink.init();
+</script>
+<script type="text/javascript">
+md_forum_decryptlink.init();
+</script>
+<script type="text/javascript">
+var md_url_img_shadow= 'https://forum-images.hardware.fr';
+var md_tabs_menu_shadow= 1;
+</script>
+<script type="text/javascript">
+
+		window.onload = function(){aff_add_img_js();};
+
+	function warning() {
+		if (alert('Vous devez spécifier une sous-catégorie !')) {
+			return false;
+		} else {
+			return false;
+		}
+	}
+	function add_join_img() {
+	var addform= 0;
+	for (i=0;i<10;i++) {
+		if ((!document.getElementById('add_image'+i)) && (addform == 0)) {
+			//var inner_add_form= document.getElementById('add_image_form').innerHTML;
+			//document.getElementById('add_image_form').innerHTML= inner_add_form+ '<br /><input type="file" name="add_image'+i+'" id="add_image'+i+'" onchange="document.join_form.sub.style.fontWeight=\'bold\'" />';
+			addform= 1;
+			var addFile=document.createElement("DIV");
+			addFile.innerHTML= '<input type="file" name="add_image'+i+'" id="add_image'+i+'" onchange="document.join_form.sub.style.fontWeight=\'bold\'" />';
+		    document.getElementById('add_image_form').appendChild(addFile)
+			if (i == 9) {
+				document.getElementById('add_img_js').style.display= 'none';
+			}
+		}
+	}
+}
+
+function aff_add_img_js() {
+	if (document.getElementById('add_img_js')) {
+		document.getElementById('add_img_js').style.display= 'block';
+	}
+}
+function message_upload_img() {
+	no_image= 1;
+	for (i=0;i<10;i++) {
+		if ((document.getElementById('add_image'+i)) && (document.getElementById('add_image'+i).value != '')) {
+			no_image= 0;
+		}
+	}
+	if (no_image == 1) {
+		alert('Vous n\'avez pas choisi d\'image à joindre');
+		return false;
+	}
+	document.getElementById('add_img_js').style.display= 'none';
+	document.getElementById('add_image_form').style.display= 'none';
+	document.getElementById('submit_upload').style.display= 'none';
+	document.getElementById('join_form').action= '/user/join_image_b.php?config=hfr.inc';
+	document.getElementById('upload_frame').style.display= '';
+	document.getElementById('join_form').target= 'upload_frame';
+	document.getElementById('img_wait_upload_img').style.display= '';
+	document.getElementById('join_form').submit();
+	document.getElementById('submit_upload').style.fontWeight= 'normal';
+}
+</script>
+</body>
+</html>

--- a/core/data/src/test/resources/fixtures/write_reply_form_open_topic.source.txt
+++ b/core/data/src/test/resources/fixtures/write_reply_form_open_topic.source.txt
@@ -1,0 +1,6 @@
+Source: forum.hardware.fr
+Captured: 2026-05-17 with authenticated XaTelitte session
+URL: https://forum.hardware.fr/message.php?config=hfr.inc&cat=23&post=35395&page=20&p=1&subcat=550&sondage=0&owntopic=0&new=0
+Notes: GET reply form for Redface 2 topic page 20.
+Sanitization: hash_check/codehex redacted; MP unread target id and MP count redacted when present; no cookies stored.
+Test context: Redface 2 topic cat=23 post=35395 subcat=550; controlled test post numreponse=2784595.

--- a/core/data/src/test/resources/fixtures/write_reply_success_response.html
+++ b/core/data/src/test/resources/fixtures/write_reply_success_response.html
@@ -1,0 +1,31 @@
+	<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+	<html>
+	<head>
+	<title>FORUM HardWare.fr</title>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta http-equiv="Pragma" content="no-cache" />
+	<meta http-equiv="Cache-Control" content="no-cache, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+	<meta http-equiv="Imagetoolbar" content="no" />
+	<meta name="Robots" content="noindex, follow" />
+	<link rel="stylesheet" type="text/css" href="/include/the_style1.php?color_key=FFFFFF/DEDFDF/000080/C2C3F4/001932/FFFFFF/FFFFFF/000000/000080/000000/000080/F7F7F7/DEDFDF/F7F7F7/DEDFDF/C0C0C0/C0C0C0/FFFFFF/000000/000000/0000FF/EEEEFF/DDDDEE/000000/FFEEEE/000000/FFFFFF/FF0000/FFFFFF/0/1/https%3A%40%40forum-images.hardware.fr/NULL/&amp;abs_img_path=%40data%40sites%40forum%40www%40static%40&amp;hide_bg_onglet=0&amp;v=11102781422" />
+	<link type="text/css" rel="stylesheet" href="https://forum-images.hardware.fr/compressed/the_style.css?v=11102781422" />	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta http-equiv="Refresh" content="1; url=/hfr/gsmgpspda/android/redface-phase-alpha-sujet_35395_20.htm#bas" />	<style type="text/css">
+	.hop{			background-color: #F7F7F7;
+			color: #000000;
+			margin:auto;
+			text-align: center;
+			width:50%;
+			border: 1px solid #C0C0C0;}
+	</style>
+	</head>
+
+	<body>
+			<div class="container">
+	<div class="mesdiscussions" id="mesdiscussions">
+	<br /><br />
+	<div class="hop">
+	Votre réponse a été postée avec succès !		</div>
+	</div>
+	</div>
+	</body></html>

--- a/core/data/src/test/resources/fixtures/write_reply_success_response.source.txt
+++ b/core/data/src/test/resources/fixtures/write_reply_success_response.source.txt
@@ -1,0 +1,6 @@
+Source: forum.hardware.fr
+Captured: 2026-05-17
+URL: POST https://forum.hardware.fr/bddpost.php?config=hfr.inc
+Notes: POST bddpost.php success response after controlled reply on Redface 2 topic.
+Sanitization: hash_check/codehex redacted; MP unread target id and MP count redacted when present; no cookies stored.
+Test context: Authenticated XaTelitte session, anti-flood test post 1/4, created numreponse=2784599.

--- a/core/database/schemas/fr.forumhfr.redface2.core.database.RedfaceDatabase/4.json
+++ b/core/database/schemas/fr.forumhfr.redface2.core.database.RedfaceDatabase/4.json
@@ -1,0 +1,324 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "daee81657b300fb58a74c54ab54448a0",
+    "entities": [
+      {
+        "tableName": "topic_pages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cat` INTEGER NOT NULL, `post` INTEGER NOT NULL, `page` INTEGER NOT NULL, `title` TEXT NOT NULL, `totalPages` INTEGER NOT NULL, `isFirstPostOwner` INTEGER NOT NULL, `pollJson` TEXT, `numreponses` TEXT NOT NULL, `fetchedAt` INTEGER NOT NULL, `authMode` TEXT NOT NULL, `subcat` INTEGER NOT NULL, PRIMARY KEY(`cat`, `post`, `page`))",
+        "fields": [
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "post",
+            "columnName": "post",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPages",
+            "columnName": "totalPages",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFirstPostOwner",
+            "columnName": "isFirstPostOwner",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pollJson",
+            "columnName": "pollJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "numreponses",
+            "columnName": "numreponses",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authMode",
+            "columnName": "authMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subcat",
+            "columnName": "subcat",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cat",
+            "post",
+            "page"
+          ]
+        }
+      },
+      {
+        "tableName": "posts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cat` INTEGER NOT NULL, `numreponse` INTEGER NOT NULL, `post` INTEGER NOT NULL, `author` TEXT NOT NULL, `date` INTEGER NOT NULL, `content` TEXT NOT NULL, `avatarUrl` TEXT, `isEditable` INTEGER NOT NULL, `isOwnPost` INTEGER NOT NULL, `quotedAuthors` TEXT NOT NULL, `postIndex` INTEGER, `fetchedAt` INTEGER NOT NULL, `authMode` TEXT NOT NULL, PRIMARY KEY(`cat`, `numreponse`))",
+        "fields": [
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numreponse",
+            "columnName": "numreponse",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "post",
+            "columnName": "post",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isEditable",
+            "columnName": "isEditable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOwnPost",
+            "columnName": "isOwnPost",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quotedAuthors",
+            "columnName": "quotedAuthors",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postIndex",
+            "columnName": "postIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authMode",
+            "columnName": "authMode",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cat",
+            "numreponse"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_posts_cat_post",
+            "unique": false,
+            "columnNames": [
+              "cat",
+              "post"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_posts_cat_post` ON `${TABLE_NAME}` (`cat`, `post`)"
+          }
+        ]
+      },
+      {
+        "tableName": "flag_topics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `type` TEXT NOT NULL, `cat` INTEGER NOT NULL, `subcat` INTEGER, `topicId` INTEGER NOT NULL, `title` TEXT NOT NULL, `totalPages` INTEGER NOT NULL, `replyCount` INTEGER NOT NULL, `hasUnread` INTEGER NOT NULL, `lastReadPage` INTEGER NOT NULL, `lastPostReadId` INTEGER, `firstPostAuthor` TEXT NOT NULL, `lastReplyAuthor` TEXT NOT NULL, `lastReplyAt` TEXT NOT NULL, `fetchedAt` INTEGER NOT NULL, `authMode` TEXT NOT NULL, PRIMARY KEY(`userId`, `type`, `cat`, `topicId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subcat",
+            "columnName": "subcat",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "topicId",
+            "columnName": "topicId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPages",
+            "columnName": "totalPages",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "replyCount",
+            "columnName": "replyCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasUnread",
+            "columnName": "hasUnread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadPage",
+            "columnName": "lastReadPage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPostReadId",
+            "columnName": "lastPostReadId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "firstPostAuthor",
+            "columnName": "firstPostAuthor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReplyAuthor",
+            "columnName": "lastReplyAuthor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReplyAt",
+            "columnName": "lastReplyAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authMode",
+            "columnName": "authMode",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "type",
+            "cat",
+            "topicId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_flag_topics_userId_type",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_flag_topics_userId_type` ON `${TABLE_NAME}` (`userId`, `type`)"
+          },
+          {
+            "name": "index_flag_topics_userId_fetchedAt",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "fetchedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_flag_topics_userId_fetchedAt` ON `${TABLE_NAME}` (`userId`, `fetchedAt`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'daee81657b300fb58a74c54ab54448a0')"
+    ]
+  }
+}

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/RedfaceDatabase.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/RedfaceDatabase.kt
@@ -12,7 +12,7 @@ import fr.forumhfr.redface2.core.database.entities.TopicEntity
 
 @Database(
     entities = [TopicEntity::class, PostEntity::class, FlagTopicEntity::class],
-    version = 3,
+    version = 4,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/di/DatabaseModule.kt
@@ -12,6 +12,7 @@ import fr.forumhfr.redface2.core.database.dao.FlagDao
 import fr.forumhfr.redface2.core.database.dao.TopicDao
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_1_2
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_2_3
+import fr.forumhfr.redface2.core.database.migrations.MIGRATION_3_4
 import javax.inject.Singleton
 
 @Module
@@ -26,7 +27,7 @@ object DatabaseModule {
         RedfaceDatabase::class.java,
         RedfaceDatabase.DATABASE_NAME,
     )
-        .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+        .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
         .build()
 
     @Provides

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/entities/TopicEntity.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/entities/TopicEntity.kt
@@ -29,7 +29,10 @@ data class TopicEntity(
      * HFR's write endpoints (`message.php` / `bddpost.php`). Defaults to `-1` for rows
      * persisted before the v3 → v4 migration; the value `-1` is a sentinel meaning
      * "unknown, refresh required" and is **never** sent to HFR — write flows check
-     * `subcat >= 0` before posting.
+     * `subcat > 0` before posting. The `> 0` (instead of `>= 0`) is intentional :
+     * HFR's `cat=0` / `cat=prive` moderator-space wire shape emits `subcat=0` and
+     * Phase 2C has no fixture proving it would be accepted, so write paths treat
+     * `subcat=0` exactly like the missing-subcat sentinel.
      */
     val subcat: Int = -1,
 )

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/entities/TopicEntity.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/entities/TopicEntity.kt
@@ -24,4 +24,12 @@ data class TopicEntity(
      * v1 rows keep their richer auth-derived fields after the v1→v2 migration.
      */
     val authMode: FetchMode,
+    /**
+     * Sub-category id captured from the topic page HTML (Phase 2C, #145). Required by
+     * HFR's write endpoints (`message.php` / `bddpost.php`). Defaults to `-1` for rows
+     * persisted before the v3 → v4 migration; the value `-1` is a sentinel meaning
+     * "unknown, refresh required" and is **never** sent to HFR — write flows check
+     * `subcat >= 0` before posting.
+     */
+    val subcat: Int = -1,
 )

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/migrations/Migrations.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/migrations/Migrations.kt
@@ -81,29 +81,6 @@ val MIGRATION_1_2: Migration = object : Migration(1, 2) {
  * `topic_pages` and `posts` are untouched : their schema didn't change between
  * v2 and v3, only `flag_topics` did.
  */
-/**
- * v3 → v4 (Phase 2C, #145):
- *
- * Adds `subcat` to `topic_pages`. Phase 2C requires the sub-category id to build a
- * valid `message.php` GET form and a valid `bddpost.php` POST (cf.
- * `docs/specs/protocol-hfr.md` § POST `bddpost.php`). The parser extracts the value
- * from the topic page HTML (`input[name=subcat]`), the entity stores it next to
- * `cat`, `post`, `page`.
- *
- * Existing v3 rows are backfilled to `-1`, a sentinel that means "unknown, must be
- * refreshed before any write flow". Write paths refuse to POST when `subcat < 0` —
- * the value is *never* transmitted to HFR. Setting the column NOT NULL via the
- * `-1` default keeps Room's schema verification happy without forcing a row rewrite
- * (topic pages are short-lived cache, the next live fetch replaces the sentinel).
- */
-val MIGRATION_3_4: Migration = object : Migration(3, 4) {
-    override fun migrate(db: SupportSQLiteDatabase) {
-        db.execSQL(
-            "ALTER TABLE topic_pages ADD COLUMN subcat INTEGER NOT NULL DEFAULT -1",
-        )
-    }
-}
-
 val MIGRATION_2_3: Migration = object : Migration(2, 3) {
     override fun migrate(db: SupportSQLiteDatabase) {
         db.execSQL("DROP TABLE IF EXISTS `flag_topics`")
@@ -137,6 +114,29 @@ val MIGRATION_2_3: Migration = object : Migration(2, 3) {
         db.execSQL(
             "CREATE INDEX IF NOT EXISTS `index_flag_topics_userId_fetchedAt` " +
                 "ON `flag_topics` (`userId`, `fetchedAt`)",
+        )
+    }
+}
+
+/**
+ * v3 → v4 (Phase 2C, #145):
+ *
+ * Adds `subcat` to `topic_pages`. Phase 2C requires the sub-category id to build a
+ * valid `message.php` GET form and a valid `bddpost.php` POST (cf.
+ * `docs/specs/protocol-hfr.md` § POST `bddpost.php`). The parser extracts the value
+ * from the topic page HTML (`input[name=subcat]`), the entity stores it next to
+ * `cat`, `post`, `page`.
+ *
+ * Existing v3 rows are backfilled to `-1`, a sentinel that means "unknown, must be
+ * refreshed before any write flow". Write paths refuse to POST when `subcat < 0` —
+ * the value is *never* transmitted to HFR. Setting the column NOT NULL via the
+ * `-1` default keeps Room's schema verification happy without forcing a row rewrite
+ * (topic pages are short-lived cache, the next live fetch replaces the sentinel).
+ */
+val MIGRATION_3_4: Migration = object : Migration(3, 4) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "ALTER TABLE topic_pages ADD COLUMN subcat INTEGER NOT NULL DEFAULT -1",
         )
     }
 }

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/migrations/Migrations.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/migrations/Migrations.kt
@@ -81,6 +81,29 @@ val MIGRATION_1_2: Migration = object : Migration(1, 2) {
  * `topic_pages` and `posts` are untouched : their schema didn't change between
  * v2 and v3, only `flag_topics` did.
  */
+/**
+ * v3 → v4 (Phase 2C, #145):
+ *
+ * Adds `subcat` to `topic_pages`. Phase 2C requires the sub-category id to build a
+ * valid `message.php` GET form and a valid `bddpost.php` POST (cf.
+ * `docs/specs/protocol-hfr.md` § POST `bddpost.php`). The parser extracts the value
+ * from the topic page HTML (`input[name=subcat]`), the entity stores it next to
+ * `cat`, `post`, `page`.
+ *
+ * Existing v3 rows are backfilled to `-1`, a sentinel that means "unknown, must be
+ * refreshed before any write flow". Write paths refuse to POST when `subcat < 0` —
+ * the value is *never* transmitted to HFR. Setting the column NOT NULL via the
+ * `-1` default keeps Room's schema verification happy without forcing a row rewrite
+ * (topic pages are short-lived cache, the next live fetch replaces the sentinel).
+ */
+val MIGRATION_3_4: Migration = object : Migration(3, 4) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "ALTER TABLE topic_pages ADD COLUMN subcat INTEGER NOT NULL DEFAULT -1",
+        )
+    }
+}
+
 val MIGRATION_2_3: Migration = object : Migration(2, 3) {
     override fun migrate(db: SupportSQLiteDatabase) {
         db.execSQL("DROP TABLE IF EXISTS `flag_topics`")

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/migrations/Migrations.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/migrations/Migrations.kt
@@ -128,10 +128,13 @@ val MIGRATION_2_3: Migration = object : Migration(2, 3) {
  * `cat`, `post`, `page`.
  *
  * Existing v3 rows are backfilled to `-1`, a sentinel that means "unknown, must be
- * refreshed before any write flow". Write paths refuse to POST when `subcat < 0` —
- * the value is *never* transmitted to HFR. Setting the column NOT NULL via the
- * `-1` default keeps Room's schema verification happy without forcing a row rewrite
- * (topic pages are short-lived cache, the next live fetch replaces the sentinel).
+ * refreshed before any write flow". Write paths refuse to POST when `subcat <= 0` —
+ * the value is *never* transmitted to HFR. The strict `<= 0` (instead of `< 0`) also
+ * excludes the `cat=0` / `cat=prive` moderator-space wire shape (HFR emits
+ * `subcat=0` there) for which Phase 2C has no validated fixture. Setting the column
+ * NOT NULL via the `-1` default keeps Room's schema verification happy without
+ * forcing a row rewrite (topic pages are short-lived cache, the next live fetch
+ * replaces the sentinel).
  */
 val MIGRATION_3_4: Migration = object : Migration(3, 4) {
     override fun migrate(db: SupportSQLiteDatabase) {

--- a/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/migrations/MigrationTest.kt
+++ b/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/migrations/MigrationTest.kt
@@ -19,10 +19,11 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 /**
- * Robolectric-driven migration tests for `MIGRATION_1_2` and `MIGRATION_2_3`. Both
- * migrations are hand-written DDL ; without these tests a typo (missing column,
- * wrong index name, wrong default) would only crash on a real upgrade-in-place
- * install, where the diagnostic loop is days long. The tests take seconds.
+ * Robolectric-driven migration tests for `MIGRATION_1_2`, `MIGRATION_2_3` and
+ * `MIGRATION_3_4`. The migrations are hand-written DDL ; without these tests a typo
+ * (missing column, wrong index name, wrong default) would only crash on a real
+ * upgrade-in-place install, where the diagnostic loop is days long. The tests take
+ * seconds.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, sdk = [33])
@@ -104,7 +105,7 @@ class MigrationTest {
             dbName,
         )
             .allowMainThreadQueries()
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
             .build()
 
         try {
@@ -234,7 +235,7 @@ class MigrationTest {
             dbName,
         )
             .allowMainThreadQueries()
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
             .build()
 
         try {

--- a/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/migrations/MigrationTest.kt
+++ b/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/migrations/MigrationTest.kt
@@ -268,7 +268,9 @@ class MigrationTest {
      * the sentinel default `-1`, that pre-existing rows are preserved and that the
      * new column is queryable as a real `INTEGER`. The sentinel value is the
      * "unknown, must be refreshed before any write flow" marker; write paths gate
-     * on `subcat >= 0` so the value is never transmitted to HFR.
+     * on `subcat > 0` (excluding both the sentinel and HFR's `cat=0` /
+     * `cat=prive` moderator-space wire shape) so the value is never transmitted
+     * to HFR.
      */
     @Test
     fun migrate_3_to_4_adds_subcat_with_sentinel_default_to_topic_pages() {

--- a/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/migrations/MigrationTest.kt
+++ b/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/migrations/MigrationTest.kt
@@ -262,4 +262,65 @@ class MigrationTest {
             migrated.close()
         }
     }
+
+    /**
+     * Phase 2C (#145) — proves `MIGRATION_3_4` adds `subcat` to `topic_pages` with
+     * the sentinel default `-1`, that pre-existing rows are preserved and that the
+     * new column is queryable as a real `INTEGER`. The sentinel value is the
+     * "unknown, must be refreshed before any write flow" marker; write paths gate
+     * on `subcat >= 0` so the value is never transmitted to HFR.
+     */
+    @Test
+    fun migrate_3_to_4_adds_subcat_with_sentinel_default_to_topic_pages() {
+        val dbName = "redface-test-migration-3-to-4.db"
+
+        // 1. Build the v3 DB and insert a topic_pages row that pre-dates `subcat`.
+        helper.createDatabase(dbName, 3).use { v3 ->
+            v3.insert(
+                "topic_pages",
+                android.database.sqlite.SQLiteDatabase.CONFLICT_REPLACE,
+                ContentValues().apply {
+                    put("cat", 23)
+                    put("post", 35395)
+                    put("page", 1)
+                    put("title", "v3 cached topic")
+                    put("totalPages", 1)
+                    put("isFirstPostOwner", 0)
+                    putNull("pollJson")
+                    put("numreponses", "[\"100\"]")
+                    put("fetchedAt", 1_700_000_000_000L)
+                    put("authMode", "AUTHENTICATED")
+                },
+            )
+        }
+
+        // 2. Run MIGRATION_3_4 and validate against the v4 schema.
+        helper.runMigrationsAndValidate(dbName, 4, true, MIGRATION_3_4).close()
+
+        // 3. Open the production Room database (which chains every migration) so
+        //    the post-migration schema is what real users land on.
+        val migrated = Room.databaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            RedfaceDatabase::class.java,
+            dbName,
+        )
+            .allowMainThreadQueries()
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
+            .build()
+
+        try {
+            migrated.openHelper.readableDatabase.query(
+                "SELECT subcat FROM topic_pages WHERE cat = 23 AND post = 35395 AND page = 1",
+            ).use { cursor ->
+                assertTrue("v3 row must survive MIGRATION_3_4", cursor.moveToFirst())
+                assertEquals(
+                    "subcat must default to the SUBCAT_UNKNOWN sentinel for pre-v4 rows",
+                    -1,
+                    cursor.getInt(0),
+                )
+            }
+        } finally {
+            migrated.close()
+        }
+    }
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/write/ReplyRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/write/ReplyRepository.kt
@@ -1,0 +1,33 @@
+package fr.forumhfr.redface2.core.domain.write
+
+import fr.forumhfr.redface2.core.model.write.ReplyContext
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
+import fr.forumhfr.redface2.core.model.write.ReplyForm
+import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
+
+/**
+ * Repository surface for posting a reply to an HFR topic. Phase 2C-A (#145) only
+ * covers the simple-reply path (no quote pre-fill, no edit, no FP); the same shape
+ * will be reused later for `:feature:editor`'s edit and create-topic flows.
+ *
+ * Implementations live in `:core:data` and chain a GET on `message.php` (to grab
+ * the per-session `hash_check`) followed by a POST on `bddpost.php`. The contract
+ * is intentionally narrow:
+ *
+ * - [fetchReplyForm] returns a [ReplyForm] even when HFR served the anonymous
+ *   composer (caller inspects [ReplyForm.isAnonymous] before calling [submitReply]).
+ *   Transport / session-expiry failures are raised as exceptions.
+ * - [submitReply] returns a [ReplySubmitResult] for every recognised response
+ *   (success + the documented [ReplyFailureReason] modes). It raises only on
+ *   transport-level issues.
+ */
+interface ReplyRepository {
+
+    suspend fun fetchReplyForm(context: ReplyContext): ReplyForm
+
+    suspend fun submitReply(
+        context: ReplyContext,
+        form: ReplyForm,
+        bbcodeContent: String,
+    ): ReplySubmitResult
+}

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/Topic.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/Topic.kt
@@ -18,7 +18,14 @@ data class Topic(
     val isFirstPostOwner: Boolean,
     val poll: Poll?,
 ) {
-    val hasSubcat: Boolean get() = subcat != SUBCAT_UNKNOWN
+    /**
+     * True only when [subcat] is a strictly positive HFR identifier. Excludes both
+     * the [SUBCAT_UNKNOWN] sentinel and `0` — the latter is the same wire shape HFR
+     * uses for its moderator-only space (`cat=0` family) and we have no captured
+     * fixture proving it is a valid value for a user-visible topic. Read flows can
+     * still surface the topic ; only write flows gate on `hasSubcat`.
+     */
+    val hasSubcat: Boolean get() = subcat > 0
 
     companion object {
         const val SUBCAT_UNKNOWN: Int = -1

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/Topic.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/Topic.kt
@@ -3,13 +3,27 @@ package fr.forumhfr.redface2.core.model
 data class Topic(
     val cat: Int,
     val post: Int,
+    /**
+     * Sub-category id. Required by HFR's `message.php` / `bddpost.php` write endpoints
+     * (cf. `docs/specs/protocol-hfr.md` § POST `bddpost.php`). Sentinel value [SUBCAT_UNKNOWN]
+     * means the row was read from a v3 cache that pre-dates subcat persistence; the topic
+     * is then read-only until a live refresh produces a real id. It is never transmitted
+     * to HFR — write flows guard against it via [hasSubcat].
+     */
+    val subcat: Int,
     val title: String,
     val posts: List<Post>,
     val page: Int,
     val totalPages: Int,
     val isFirstPostOwner: Boolean,
     val poll: Poll?,
-)
+) {
+    val hasSubcat: Boolean get() = subcat != SUBCAT_UNKNOWN
+
+    companion object {
+        const val SUBCAT_UNKNOWN: Int = -1
+    }
+}
 
 data class Poll(
     val question: String,

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/write/ReplyContext.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/write/ReplyContext.kt
@@ -16,7 +16,9 @@ data class ReplyContext(
 ) {
     init {
         require(cat >= 0) { "cat must be >= 0, was $cat" }
-        require(subcat >= 0) { "subcat must be >= 0 (sentinel reached), was $subcat" }
+        // Refuse both the SUBCAT_UNKNOWN sentinel (-1) and the moderator-space wire
+        // shape (0). Mirrors `Topic.hasSubcat` — see its KDoc.
+        require(subcat > 0) { "subcat must be > 0 (sentinel or moderator space), was $subcat" }
         require(topicId >= 0) { "topicId must be >= 0, was $topicId" }
         require(page >= 1) { "page must be >= 1, was $page" }
     }

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/write/ReplyContext.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/write/ReplyContext.kt
@@ -1,0 +1,23 @@
+package fr.forumhfr.redface2.core.model.write
+
+/**
+ * Identifies the topic page the user is about to reply to. Built from a loaded
+ * `Topic` (Phase 2C: only opens once `Topic.hasSubcat` is true) and passed to the
+ * reply repository so the repository can build the HFR `message.php` GET URL.
+ *
+ * All four ids come from the same parsed HTML page — there is no implicit default.
+ * The repository will refuse to operate if [subcat] is negative.
+ */
+data class ReplyContext(
+    val cat: Int,
+    val subcat: Int,
+    val topicId: Int,
+    val page: Int,
+) {
+    init {
+        require(cat >= 0) { "cat must be >= 0, was $cat" }
+        require(subcat >= 0) { "subcat must be >= 0 (sentinel reached), was $subcat" }
+        require(topicId >= 0) { "topicId must be >= 0, was $topicId" }
+        require(page >= 1) { "page must be >= 1, was $page" }
+    }
+}

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/write/ReplyForm.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/write/ReplyForm.kt
@@ -1,0 +1,26 @@
+package fr.forumhfr.redface2.core.model.write
+
+/**
+ * Parsed view of HFR's `message.php` reply form. Carries the volatile bits that the
+ * subsequent `bddpost.php` POST has to echo back — chiefly the per-session CSRF
+ * token `hash_check` — plus the static hidden fields HFR expects to receive
+ * verbatim (`cat`, `subcat`, `post`, `page`, `verifrequet=1100`, `sujet`, `cache`,
+ * `sond`, `owntopic`, `config`, `MsgIcon`, `signature`, `wysiwyg`, …).
+ *
+ * The model is intentionally a `Map<String, String>` rather than a typed bag: HFR
+ * adds and removes hidden fields freely between deploys and we'd rather forward
+ * them all than dropdown one and silently break the contract. Sensitive fields
+ * (`password`, `pseudo` for an anonymous form) are filtered out at parse time —
+ * see [ReplyForm.hiddenFields] — so the repository never re-posts them.
+ *
+ * [isAnonymous] is true when the parsed form exposes an editable `pseudo`/`password`
+ * pair, which HFR serves whenever the session cookie is missing or expired. The
+ * reply repository refuses to use such a form and surfaces a "login required" error
+ * to the UI instead.
+ */
+data class ReplyForm(
+    val hashCheck: String,
+    val sujet: String,
+    val hiddenFields: Map<String, String>,
+    val isAnonymous: Boolean,
+)

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/write/ReplySubmitResult.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/write/ReplySubmitResult.kt
@@ -48,6 +48,12 @@ sealed interface ReplyFailureReason {
      */
     data object LoginRequired : ReplyFailureReason
 
-    /** Unrecognised response. The repository preserves the raw text for diagnostics only — never logged. */
+    /**
+     * Unrecognised response. The UI surfaces a generic "unexpected response" message
+     * and keeps the user's draft intact. No raw text is carried — the response body
+     * is intentionally dropped to avoid leaking `hash_check` or session metadata
+     * into a snapshot or a log. If we ever need to ship diagnostics, add a dedicated,
+     * pre-redacted field rather than storing the full body here.
+     */
     data object Unknown : ReplyFailureReason
 }

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/write/ReplySubmitResult.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/write/ReplySubmitResult.kt
@@ -1,0 +1,53 @@
+package fr.forumhfr.redface2.core.model.write
+
+/**
+ * Outcome of a POST to `bddpost.php`. Every variant is derived from a real HFR
+ * response (cf. fixtures `core/parser/src/test/resources/fixtures/write_*_response.html`
+ * and friends) — no inferred error states.
+ */
+sealed interface ReplySubmitResult {
+
+    /**
+     * HFR replied with the success page. [refreshUrl] is the value carried by the
+     * `<meta http-equiv="Refresh" content="N; url=…">` header — exactly the URL HFR
+     * wants the client to land on (typically `…/sujet_X_PAGE.htm#bas`). Callers
+     * should treat it as opaque and just navigate there, optionally extracting
+     * [targetPage] from the URL when they need to refresh a known cache.
+     */
+    data class Success(
+        val refreshUrl: String?,
+        val targetPage: Int?,
+    ) : ReplySubmitResult
+
+    /** HFR refused to post and surfaced one of the known reasons. */
+    data class Failure(val reason: ReplyFailureReason) : ReplySubmitResult
+}
+
+/**
+ * Classified failure reasons. Each variant maps to a literal HFR error string we
+ * have observed in the Phase 2A captures. [Unknown] is the safety net when HFR
+ * returns a page we don't recognise — the UI surfaces a generic error and keeps
+ * the user's draft intact.
+ */
+sealed interface ReplyFailureReason {
+    /** « Vous devez remplir tous les champs avant de poster ce message » */
+    data object EmptyMessage : ReplyFailureReason
+
+    /** « Une erreur est survenue lors de l'envoi des données » */
+    data object InvalidHashCheck : ReplyFailureReason
+
+    /** « vous ne pouvez poster plus de 3 réponses consécutives… » */
+    data object AntiFlood : ReplyFailureReason
+
+    /** « Désolé ce sujet a été fermé » */
+    data object TopicLocked : ReplyFailureReason
+
+    /**
+     * HFR served the anonymous `pseudo`/`password` composer, which Redface 2 refuses
+     * to use. Surface a "login required" CTA in the UI.
+     */
+    data object LoginRequired : ReplyFailureReason
+
+    /** Unrecognised response. The repository preserves the raw text for diagnostics only — never logged. */
+    data object Unknown : ReplyFailureReason
+}

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
@@ -9,6 +9,7 @@ import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 import okhttp3.Call
+import okhttp3.FormBody
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -83,6 +84,60 @@ class HfrClient @Inject constructor(
             .build()
 
         val request = Request.Builder().url(url).get().build()
+        return authenticated.newCall(request).executeAuthenticatedHtml()
+    }
+
+    /**
+     * Phase 2C (#145) — GET the HFR reply form for a `(cat, subcat, post, page)`
+     * tuple. The returned HTML carries the per-session `hash_check` plus all the
+     * hidden inputs the subsequent POST must echo back. The URL shape mirrors what
+     * HFR's web UI hits when a logged-in user clicks « Répondre » (cf.
+     * `docs/specs/protocol-hfr.md` § POST `bddpost.php` and the Phase 2A fixture
+     * `write_reply_form_open_topic.html`).
+     *
+     * Always uses the authenticated client : a session-expired GET surfaces
+     * [SessionExpiredException] via [executeAuthenticatedHtml] rather than
+     * silently returning the anonymous composer.
+     */
+    suspend fun getReplyForm(
+        cat: Int,
+        subcat: Int,
+        post: Int,
+        page: Int,
+    ): String {
+        val url = baseUrl.newBuilder()
+            .addPathSegment("message.php")
+            .addQueryParameter("config", "hfr.inc")
+            .addQueryParameter("cat", cat.toString())
+            .addQueryParameter("post", post.toString())
+            .addQueryParameter("page", page.toString())
+            .addQueryParameter("p", "1")
+            .addQueryParameter("subcat", subcat.toString())
+            .addQueryParameter("sondage", "0")
+            .addQueryParameter("owntopic", "0")
+            .addQueryParameter("new", "0")
+            .build()
+        val request = Request.Builder().url(url).get().build()
+        return authenticated.newCall(request).executeAuthenticatedHtml()
+    }
+
+    /**
+     * Phase 2C (#145) — POST the reply payload to `bddpost.php`. The [formBody]
+     * is built by the repository from the parsed [ReplyForm] (hidden fields +
+     * `hash_check` + the user's BBCode `content_form`). HFR never returns a
+     * proper HTTP error code on failure: success and the four documented error
+     * variants (`empty`, `invalid_token`, `antiflood`, `locked`) all come back as
+     * HTTP 200 with distinct body text — see `ReplySubmitResponseParser` for the
+     * classification.
+     *
+     * `hash_check` is **never** logged, including on transport errors.
+     */
+    suspend fun submitReply(formBody: FormBody): String {
+        val url = baseUrl.newBuilder()
+            .addPathSegment("bddpost.php")
+            .addQueryParameter("config", "hfr.inc")
+            .build()
+        val request = Request.Builder().url(url).post(formBody).build()
         return authenticated.newCall(request).executeAuthenticatedHtml()
     }
 

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
@@ -2,12 +2,15 @@ package fr.forumhfr.redface2.core.network
 
 import androidx.tracing.trace
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
 import fr.forumhfr.redface2.core.network.qualifiers.AnonymousClient
 import fr.forumhfr.redface2.core.network.qualifiers.AuthenticatedClient
 import fr.forumhfr.redface2.core.network.qualifiers.HfrBaseUrl
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
 import okhttp3.Call
 import okhttp3.FormBody
 import okhttp3.HttpUrl
@@ -20,6 +23,7 @@ class HfrClient @Inject constructor(
     @param:AuthenticatedClient private val authenticated: OkHttpClient,
     @param:AnonymousClient private val anonymous: OkHttpClient,
     @param:HfrBaseUrl private val baseUrl: HttpUrl,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
     suspend fun getTopicPage(
         cat: Int,
@@ -49,13 +53,18 @@ class HfrClient @Inject constructor(
             // pull from the response body. Splitting them lets a profiler tell a slow handshake
             // apart from a slow body download. The auth branch above wires the same prefix into
             // `executeAuthenticatedHtml`.
-            trace("$TOPIC_TRACE_PREFIX.network") {
-                anonymous.newCall(request).execute()
-            }.use { response ->
-                if (!response.isSuccessful) {
-                    throw IOException("HFR returned ${response.code} for $url")
+            // `withContext(ioDispatcher)` ensures we never call OkHttp `.execute()` on the main
+            // thread, regardless of the caller's coroutine context (cf. PR #162 v43 — repository
+            // layer forgot the hop and triggered `NetworkOnMainThreadException`).
+            withContext(ioDispatcher) {
+                trace("$TOPIC_TRACE_PREFIX.network") {
+                    anonymous.newCall(request).execute()
+                }.use { response ->
+                    if (!response.isSuccessful) {
+                        throw IOException("HFR returned ${response.code} for $url")
+                    }
+                    trace("$TOPIC_TRACE_PREFIX.body_read") { response.body.string() }
                 }
-                trace("$TOPIC_TRACE_PREFIX.body_read") { response.body.string() }
             }
         }
     }
@@ -147,32 +156,39 @@ class HfrClient @Inject constructor(
      * inline. When [tracePrefix] is non-null, the OkHttp call up to headers is wrapped in
      * `<prefix>.network` and the body pull in `<prefix>.body_read` (cf. `docs/guides/profiling.md`).
      * Callers that don't belong to the topic parcours pass `null` to stay out of `rf2.topic.*`.
+     *
+     * Wraps the blocking OkHttp `.execute()` in `withContext(ioDispatcher)` so callers can safely
+     * invoke `HfrClient.*` from any coroutine context, including `viewModelScope.launch {}`'s
+     * default `Dispatchers.Main.immediate`. Repositories may keep their own `withContext` for
+     * defense in depth (notably to cover CPU-bound parsers in the same IO block), but they are
+     * not required to do so to avoid `NetworkOnMainThreadException`.
      */
-    private fun Call.executeAuthenticatedHtml(tracePrefix: String? = null): String {
-        val response: Response = if (tracePrefix != null) {
-            trace("$tracePrefix.network") { execute() }
-        } else {
-            execute()
-        }
-        return response.use {
-            if (!response.isSuccessful) {
-                throw IOException("HFR returned ${response.code} for ${response.request.url}")
-            }
-            val html = if (tracePrefix != null) {
-                // Session-expiry detection (login redirect / login form sniff) runs after the body
-                // is in memory, so its cost is negligible relative to body_read; not worth a third
-                // section.
-                trace("$tracePrefix.body_read") { response.body.string() }
+    private suspend fun Call.executeAuthenticatedHtml(tracePrefix: String? = null): String =
+        withContext(ioDispatcher) {
+            val response: Response = if (tracePrefix != null) {
+                trace("$tracePrefix.network") { execute() }
             } else {
-                response.body.string()
+                execute()
             }
-            val finalUrl = response.request.url
-            if (finalUrl.isLoginUrl() || html.looksLikeLoginPage()) {
-                throw SessionExpiredException(finalUrl.toString())
+            response.use {
+                if (!response.isSuccessful) {
+                    throw IOException("HFR returned ${response.code} for ${response.request.url}")
+                }
+                val html = if (tracePrefix != null) {
+                    // Session-expiry detection (login redirect / login form sniff) runs after the
+                    // body is in memory, so its cost is negligible relative to body_read; not
+                    // worth a third section.
+                    trace("$tracePrefix.body_read") { response.body.string() }
+                } else {
+                    response.body.string()
+                }
+                val finalUrl = response.request.url
+                if (finalUrl.isLoginUrl() || html.looksLikeLoginPage()) {
+                    throw SessionExpiredException(finalUrl.toString())
+                }
+                html
             }
-            html
         }
-    }
 
     private companion object {
         // Prefix consumed by `docs/guides/profiling.md` — keep in lockstep with the catalogue.

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrConstants.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrConstants.kt
@@ -10,6 +10,14 @@ object HfrConstants {
     /** Query string `config` value present on every HFR endpoint touched by Redface 2. */
     const val CONFIG: String = "hfr.inc"
 
+    /**
+     * Anti-bot value HFR expects on `bddpost.php` POSTs (Phase 2C, #145). Captured
+     * verbatim from the Phase 2A reply / quote / edit / create-topic fixtures —
+     * see `docs/specs/protocol-hfr.md` § POST `bddpost.php`. Centralised here so the
+     * upcoming quote / edit / create flows share the same literal.
+     */
+    const val VERIF_REQUET: String = "1100"
+
     val ConnectTimeout: Duration = Duration.ofSeconds(15)
     val ReadTimeout: Duration = Duration.ofSeconds(20)
     val WriteTimeout: Duration = Duration.ofSeconds(20)

--- a/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/HfrClientTest.kt
+++ b/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/HfrClientTest.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.core.network
 
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -24,6 +25,7 @@ class HfrClientTest {
             authenticated = okHttp,
             anonymous = okHttp,
             baseUrl = server.url("/"),
+            ioDispatcher = Dispatchers.Unconfined,
         )
     }
 

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/TopicPageParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/TopicPageParser.kt
@@ -23,6 +23,7 @@ class TopicPageParser(
         return Topic(
             cat = requireInputValue(document, HfrSelectors.CATEGORY_ID_INPUT),
             post = requireInputValue(document, HfrSelectors.TOPIC_ID_INPUT),
+            subcat = requireInputValue(document, HfrSelectors.SUBCATEGORY_ID_INPUT),
             title = document.selectFirst(HfrSelectors.TOPIC_TITLE)?.text()?.trim()
                 ?: error("Topic title not found"),
             posts = posts,

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/TopicPageParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/TopicPageParser.kt
@@ -23,7 +23,15 @@ class TopicPageParser(
         return Topic(
             cat = requireInputValue(document, HfrSelectors.CATEGORY_ID_INPUT),
             post = requireInputValue(document, HfrSelectors.TOPIC_ID_INPUT),
-            subcat = requireInputValue(document, HfrSelectors.SUBCATEGORY_ID_INPUT),
+            // subcat is required by Phase 2C's write contract but the Phase 1
+            // read flow is older — falling back to the SUBCAT_UNKNOWN sentinel
+            // keeps a topic readable even if HFR ever stops emitting the field,
+            // at the cost of disabling reply until a future capture surfaces a
+            // real id. Several HFR widgets render `input[name=subcat]` on the
+            // same page (fast-search header, reply form, …), so we explicitly
+            // pick the last occurrence which is the one that lives next to the
+            // reply form.
+            subcat = optionalSubcat(document),
             title = document.selectFirst(HfrSelectors.TOPIC_TITLE)?.text()?.trim()
                 ?: error("Topic title not found"),
             posts = posts,
@@ -32,6 +40,17 @@ class TopicPageParser(
             isFirstPostOwner = false,
             poll = parsePoll(document),
         )
+    }
+
+    private fun optionalSubcat(document: Document): Int {
+        val inputs = document.select(HfrSelectors.SUBCATEGORY_ID_INPUT)
+        if (inputs.isEmpty()) return Topic.SUBCAT_UNKNOWN
+        // Several HFR widgets ship a subcat hidden input on the same page (search
+        // header, reply form, …) — they all carry the same value in practice. We
+        // pick the last occurrence because the reply form (Phase 2C write target)
+        // is rendered after the search widget, so the last write is the most
+        // trustworthy from the write-contract perspective.
+        return inputs.last()?.attr("value")?.toIntOrNull() ?: Topic.SUBCAT_UNKNOWN
     }
 
     private fun parsePosts(

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/common/HfrSelectors.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/common/HfrSelectors.kt
@@ -2,6 +2,7 @@ package fr.forumhfr.redface2.core.parser.common
 
 object HfrSelectors {
     const val CATEGORY_ID_INPUT = "input[name=cat]"
+    const val SUBCATEGORY_ID_INPUT = "input[name=subcat]"
     const val TOPIC_ID_INPUT = "input[name=post]"
     const val TOPIC_TITLE = "tr.fondForum2Title h3"
     const val TOP_PAGER = "tr.fondForum2PagesHaut"

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/write/ReplyFormParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/write/ReplyFormParser.kt
@@ -2,7 +2,6 @@ package fr.forumhfr.redface2.core.parser.write
 
 import fr.forumhfr.redface2.core.model.write.ReplyForm
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
 
 /**
  * Parses HFR's `message.php` reply form. The page returned by HFR contains many
@@ -34,7 +33,14 @@ class ReplyFormParser {
         val replyForm = document.selectFirst("form[action*=bddpost.php]")
             ?: return Result.failure(IllegalStateException("Reply form not found"))
 
-        val hiddenInputs = replyForm.select("input[type=hidden]")
+        // Iterate every <input> below the reply form (hidden, text, password, …) so
+        // we can apply the explicit allow/deny rules below regardless of the input
+        // type HFR uses. Restricting to `input[type=hidden]` would silently drop the
+        // user-typed pseudo field (which HFR renders as `type=text` even when the
+        // user is authenticated) and would *not* protect against password input
+        // either (which has `type=password`, not hidden) — both deny rules are
+        // necessary, and both come from a single pass over the full input list.
+        val allInputs = replyForm.select("input[name]")
         val pseudoInput = replyForm.selectFirst("input[name=pseudo]")
         val sujetInput = replyForm.selectFirst("input[name=sujet]")
 
@@ -43,20 +49,30 @@ class ReplyFormParser {
 
         val collected = mutableMapOf<String, String>()
         var hashCheck: String? = null
-        hiddenInputs.forEach { input ->
+        allInputs.forEach { input ->
             val name = input.attr("name")
             if (name.isEmpty()) return@forEach
+            val type = input.attr("type").lowercase()
+            // Hard deny: password is never echoed back to HFR (HFR's hidden composer
+            // fallback would re-authenticate over an existing cookie — never the path
+            // we want). The `password` *name* check is belt-and-braces in case HFR
+            // ever ships a non-`type=password` element with that name.
+            if (type == "password" || name == "password") return@forEach
             val value = input.attr("value")
             when (name) {
                 "hash_check" -> {
-                    // Keep the first non-empty hash_check we see; HFR sometimes renders
-                    // it twice (search widget + reply form). The reply form copy comes
-                    // after the search one, so the last-write-wins behaviour below also
-                    // works, but pin the contract explicitly here.
+                    // HFR sometimes renders hash_check twice (search widget + reply
+                    // form). Last non-empty write wins; the reply form copy appears
+                    // after the search one in the document, so this picks up the
+                    // authoritative value naturally.
                     if (value.isNotEmpty()) hashCheck = value
                 }
-                // We forward the static hidden inputs verbatim — keeps Phase 2C honest
-                // against future HFR additions without code change.
+                "pseudo" -> {
+                    // Only forward when authenticated (non-empty value). On the
+                    // anonymous composer, HFR re-types the same field as an editable
+                    // text input — we still skip it.
+                    if (!isAnonymous && pseudoValue.isNotEmpty()) collected[name] = pseudoValue
+                }
                 else -> collected[name] = value
             }
         }
@@ -64,13 +80,6 @@ class ReplyFormParser {
         val resolvedHashCheck = hashCheck
         if (resolvedHashCheck.isNullOrBlank()) {
             return Result.failure(IllegalStateException("hash_check missing from reply form"))
-        }
-
-        // Pseudo: only forward when authenticated (non-empty). Password is always
-        // dropped: HFR's hidden composer is the one we never want to use.
-        if (!isAnonymous && pseudoInput != null) {
-            val name = pseudoInput.attr("name")
-            if (name.isNotEmpty() && pseudoValue.isNotEmpty()) collected[name] = pseudoValue
         }
 
         // Sujet is part of the form contract but lives outside the hidden inputs in
@@ -86,8 +95,4 @@ class ReplyFormParser {
             ),
         )
     }
-
-    @Suppress("unused")
-    private fun Element.hiddenInputValue(name: String): String? =
-        selectFirst("input[type=hidden][name=$name]")?.attr("value")?.takeIf { it.isNotEmpty() }
 }

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/write/ReplyFormParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/write/ReplyFormParser.kt
@@ -1,0 +1,93 @@
+package fr.forumhfr.redface2.core.parser.write
+
+import fr.forumhfr.redface2.core.model.write.ReplyForm
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+
+/**
+ * Parses HFR's `message.php` reply form. The page returned by HFR contains many
+ * `<form>` elements (search box, navigation widgets, …); the reply form is the
+ * one whose `action` ends with `bddpost.php` — see fixture
+ * `core/parser/src/test/resources/fixtures/write_reply_form_open_topic.html`.
+ *
+ * The parser captures every hidden input under that form. The list of fields HFR
+ * sends is not fully stable, so we forward them all rather than allow-listing —
+ * with two exceptions:
+ *
+ * - `password` is filtered out unconditionally. Even in an authenticated session
+ *   HFR injects a (blank) `password` field for the legacy composer fallback; we
+ *   never want to re-POST it.
+ * - `pseudo` is filtered out as well when the form is anonymous. When the form is
+ *   authenticated the field carries the user's pseudo and we forward it, matching
+ *   what HFR's web composer does.
+ *
+ * [ReplyForm.isAnonymous] is true when the form has an editable `<input
+ * name="pseudo">` with an empty `value=""` and a sibling `<input
+ * name="password">`. Both shapes come straight from
+ * `write_reply_anonymous_form.html`.
+ */
+class ReplyFormParser {
+
+    @Suppress("ReturnCount") // Guard clauses for hash_check / form absent / etc.
+    fun parse(html: String): Result<ReplyForm> {
+        val document = Jsoup.parse(html)
+        val replyForm = document.selectFirst("form[action*=bddpost.php]")
+            ?: return Result.failure(IllegalStateException("Reply form not found"))
+
+        val hiddenInputs = replyForm.select("input[type=hidden]")
+        val pseudoInput = replyForm.selectFirst("input[name=pseudo]")
+        val sujetInput = replyForm.selectFirst("input[name=sujet]")
+
+        val pseudoValue = pseudoInput?.attr("value").orEmpty()
+        val isAnonymous = pseudoInput != null && pseudoValue.isEmpty()
+
+        val collected = mutableMapOf<String, String>()
+        var hashCheck: String? = null
+        hiddenInputs.forEach { input ->
+            val name = input.attr("name")
+            if (name.isEmpty()) return@forEach
+            val value = input.attr("value")
+            when (name) {
+                "hash_check" -> {
+                    // Keep the first non-empty hash_check we see; HFR sometimes renders
+                    // it twice (search widget + reply form). The reply form copy comes
+                    // after the search one, so the last-write-wins behaviour below also
+                    // works, but pin the contract explicitly here.
+                    if (value.isNotEmpty()) hashCheck = value
+                }
+                // We forward the static hidden inputs verbatim — keeps Phase 2C honest
+                // against future HFR additions without code change.
+                else -> collected[name] = value
+            }
+        }
+
+        val resolvedHashCheck = hashCheck
+        if (resolvedHashCheck.isNullOrBlank()) {
+            return Result.failure(IllegalStateException("hash_check missing from reply form"))
+        }
+
+        // Pseudo: only forward when authenticated (non-empty). Password is always
+        // dropped: HFR's hidden composer is the one we never want to use.
+        if (!isAnonymous && pseudoInput != null) {
+            val name = pseudoInput.attr("name")
+            if (name.isNotEmpty() && pseudoValue.isNotEmpty()) collected[name] = pseudoValue
+        }
+
+        // Sujet is part of the form contract but lives outside the hidden inputs in
+        // some HFR renderings (it can be either visible or hidden depending on layout).
+        val sujet = sujetInput?.attr("value").orEmpty()
+
+        return Result.success(
+            ReplyForm(
+                hashCheck = resolvedHashCheck,
+                sujet = sujet,
+                hiddenFields = collected.toMap(),
+                isAnonymous = isAnonymous,
+            ),
+        )
+    }
+
+    @Suppress("unused")
+    private fun Element.hiddenInputValue(name: String): String? =
+        selectFirst("input[type=hidden][name=$name]")?.attr("value")?.takeIf { it.isNotEmpty() }
+}

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/write/ReplySubmitResponseParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/write/ReplySubmitResponseParser.kt
@@ -1,0 +1,91 @@
+package fr.forumhfr.redface2.core.parser.write
+
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
+import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
+import org.jsoup.Jsoup
+
+/**
+ * Parses the response HFR returns after a POST to `bddpost.php`.
+ *
+ * Success and failure are surfaced by a literal French sentence in the body, plus
+ * a `<meta http-equiv="Refresh" content="N; url=…">` header on success that
+ * carries the URL HFR wants the client to land on. We match on substrings because
+ * HFR wraps the message in styled `<div class="hop">` markup that varies between
+ * deploys ; the underlying text doesn't.
+ *
+ * Each match maps to a concrete fixture under
+ * `core/parser/src/test/resources/fixtures/write_*` ; pinned by tests in
+ * `ReplySubmitResponseParserTest`.
+ */
+class ReplySubmitResponseParser {
+
+    fun parse(html: String): ReplySubmitResult {
+        // Fast path: HFR's "invalid token" path returns a bare text/plain payload
+        // (~99 bytes, no HTML envelope). Match first to avoid relying on Jsoup for
+        // body-less inputs.
+        val trimmedHead = html.trimStart().take(MAX_HEAD_PROBE)
+        if (looksLikeInvalidTokenPlainText(trimmedHead)) {
+            return ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)
+        }
+
+        // Other paths land on a full HFR-styled HTML page — let Jsoup normalise it.
+        val document = Jsoup.parse(html)
+        val body = document.body().text()
+
+        return when {
+            INVALID_TOKEN_PATTERNS.any { body.contains(it, ignoreCase = true) } ->
+                ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)
+
+            body.contains(EMPTY_MESSAGE_MARKER, ignoreCase = true) ->
+                ReplySubmitResult.Failure(ReplyFailureReason.EmptyMessage)
+
+            body.contains(ANTI_FLOOD_MARKER, ignoreCase = true) ->
+                ReplySubmitResult.Failure(ReplyFailureReason.AntiFlood)
+
+            body.contains(TOPIC_LOCKED_MARKER, ignoreCase = true) ->
+                ReplySubmitResult.Failure(ReplyFailureReason.TopicLocked)
+
+            body.contains(SUCCESS_MARKER, ignoreCase = true) -> parseSuccess(html)
+
+            else -> ReplySubmitResult.Failure(ReplyFailureReason.Unknown)
+        }
+    }
+
+    private fun parseSuccess(html: String): ReplySubmitResult.Success {
+        // Use the raw HTML rather than Jsoup so we keep the literal `1; url=…`
+        // structure intact ; Jsoup normalises the attribute order in older releases.
+        val refresh = META_REFRESH_REGEX.find(html)?.groupValues?.getOrNull(1)?.trim()
+        val page = refresh?.let { url -> PAGE_NUMBER_REGEX.find(url)?.groupValues?.getOrNull(1)?.toIntOrNull() }
+        return ReplySubmitResult.Success(refreshUrl = refresh, targetPage = page)
+    }
+
+    private fun looksLikeInvalidTokenPlainText(head: String): Boolean {
+        if (head.isEmpty()) return false
+        val lower = head.lowercase()
+        // Plain-text payload : no opening tag, just the literal HFR sentence.
+        return !lower.startsWith("<") &&
+            INVALID_TOKEN_PATTERNS.any { lower.contains(it, ignoreCase = true) }
+    }
+
+    private companion object {
+        private const val MAX_HEAD_PROBE = 256
+
+        // Substrings of the literal HFR messages. Lower-cased for case-insensitive match.
+        private val INVALID_TOKEN_PATTERNS: List<String> = listOf(
+            "une erreur est survenue lors de l'envoi des données",
+        )
+        private const val EMPTY_MESSAGE_MARKER: String =
+            "remplir tous les champs avant de poster"
+        private const val ANTI_FLOOD_MARKER: String =
+            "consécutives dans un intervalle de 10 minutes"
+        private const val TOPIC_LOCKED_MARKER: String = "sujet a été fermé"
+        private const val SUCCESS_MARKER: String = "votre réponse a été postée avec succès"
+
+        private val META_REFRESH_REGEX: Regex =
+            Regex("""<meta[^>]*http-equiv="Refresh"[^>]*content="\d+\s*;\s*url=([^"]+)""", RegexOption.IGNORE_CASE)
+
+        // HFR's success refresh URLs look like `…/sujet_35395_20.htm#bas` — the second
+        // integer between underscores is the page.
+        private val PAGE_NUMBER_REGEX: Regex = Regex("""sujet_\d+_(\d+)""", RegexOption.IGNORE_CASE)
+    }
+}

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/TopicPageParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/TopicPageParserTest.kt
@@ -2,6 +2,7 @@ package fr.forumhfr.redface2.core.parser
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -122,6 +123,38 @@ class TopicPageParserTest {
         val topic = parser.parse(fixture("topic_khakha_page_2.html"))
 
         assertNull(topic.posts.first().postIndex)
+    }
+
+    @Test
+    fun `parse extracts the subcat from the HFR topic page so Phase 2C can build a reply URL`() {
+        // `input[name=subcat]` appears multiple times on a HFR topic page (fast-search
+        // header + reply form). The parser must pick a real value, not the
+        // SUBCAT_UNKNOWN sentinel — Phase 2C's reply flow refuses to open the editor
+        // when the topic carries the sentinel (cache pre-dating MIGRATION_3_4).
+        val topic = parser.parse(fixture("topic_khakha_page_1.html"))
+
+        assertEquals(432, topic.subcat)
+        assertTrue(topic.hasSubcat)
+    }
+
+    @Test
+    fun `parse falls back to SUBCAT_UNKNOWN when the topic HTML drops the subcat input`() {
+        // Stripped-down topic page : cat + post + title + page are present so Phase 1
+        // read keeps working ; subcat input is intentionally missing. Phase 2C must
+        // tolerate this gracefully — the topic stays openable, only reply is disabled.
+        val html = """
+            <html><body>
+              <input type="hidden" name="cat" value="13" />
+              <input type="hidden" name="post" value="84540" />
+              <table><tbody>
+                <tr class="fondForum2Title"><td><h3>Stripped topic</h3></td></tr>
+                <tr class="fondForum2PagesHaut"><td class="left"><b>1</b></td></tr>
+              </tbody></table>
+            </body></html>
+        """.trimIndent()
+        val topic = parser.parse(html)
+        assertEquals(fr.forumhfr.redface2.core.model.Topic.SUBCAT_UNKNOWN, topic.subcat)
+        assertFalse(topic.hasSubcat)
     }
 
     private fun fixture(name: String): String {

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/TopicPageParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/TopicPageParserTest.kt
@@ -139,9 +139,15 @@ class TopicPageParserTest {
 
     @Test
     fun `parse falls back to SUBCAT_UNKNOWN when the topic HTML drops the subcat input`() {
-        // Stripped-down topic page : cat + post + title + page are present so Phase 1
-        // read keeps working ; subcat input is intentionally missing. Phase 2C must
-        // tolerate this gracefully — the topic stays openable, only reply is disabled.
+        // Synthetic HTML is **explicitly** allowed for this regression check :
+        // CLAUDE.md § Fixtures HTML requires real HFR captures via hfr-mcp for
+        // anything that exercises the production parser path on a representative
+        // page. Here we only exercise the *missing-input fallback branch* of
+        // `optionalSubcat`, which by definition cannot be captured live (every
+        // real HFR topic ships a `subcat` input). Building the minimal valid
+        // shape locally is the cheapest way to pin the contract — if HFR ever
+        // changes the topic layout to drop subcat altogether, real fixtures will
+        // overtake this test.
         val html = """
             <html><body>
               <input type="hidden" name="cat" value="13" />
@@ -155,6 +161,32 @@ class TopicPageParserTest {
         val topic = parser.parse(html)
         assertEquals(fr.forumhfr.redface2.core.model.Topic.SUBCAT_UNKNOWN, topic.subcat)
         assertFalse(topic.hasSubcat)
+    }
+
+    @Test
+    fun `parse picks the last subcat occurrence when multiple widgets share the field`() {
+        // HFR ships `input[name=subcat]` in several widgets on a single topic page
+        // (fast-search header + reply form). The reply form occurrence is the one
+        // we want — it's emitted after the search widget. This regression test
+        // synthesises two occurrences with different values to prove the
+        // `optionalSubcat` `last()` choice is wired the way the KDoc claims.
+        val html = """
+            <html><body>
+              <input type="hidden" name="cat" value="13" />
+              <input type="hidden" name="post" value="84540" />
+              <input type="hidden" name="subcat" value="111" />
+              <table><tbody>
+                <tr class="fondForum2Title"><td><h3>Topic with two subcat inputs</h3></td></tr>
+                <tr class="fondForum2PagesHaut"><td class="left"><b>1</b></td></tr>
+              </tbody></table>
+              <form action="/bddpost.php?config=hfr.inc">
+                <input type="hidden" name="subcat" value="432" />
+              </form>
+            </body></html>
+        """.trimIndent()
+        val topic = parser.parse(html)
+        assertEquals(432, topic.subcat)
+        assertTrue(topic.hasSubcat)
     }
 
     private fun fixture(name: String): String {

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/write/ReplyFormParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/write/ReplyFormParserTest.kt
@@ -1,0 +1,93 @@
+package fr.forumhfr.redface2.core.parser.write
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReplyFormParserTest {
+
+    private val parser = ReplyFormParser()
+
+    @Test
+    fun `extracts hash_check, hidden fields and sujet from the authenticated reply form`() {
+        val html = readFixture("write_reply_form_open_topic.html")
+        val form = parser.parse(html).getOrThrow()
+
+        assertFalse("Authenticated form must not be flagged as anonymous", form.isAnonymous)
+        assertEquals("REDACTED_HASH_CHECK", form.hashCheck)
+        assertEquals("Redface 2 — PHASE 2 @ ALPHA", form.sujet)
+
+        // Static contract fields HFR expects to receive verbatim on POST.
+        assertEquals("23", form.hiddenFields["cat"])
+        assertEquals("550", form.hiddenFields["subcat"])
+        assertEquals("35395", form.hiddenFields["post"])
+        assertEquals("20", form.hiddenFields["page"])
+        assertEquals("1100", form.hiddenFields["verifrequet"])
+        assertEquals("hfr.inc", form.hiddenFields["config"])
+        assertEquals("cache", form.hiddenFields["cache"])
+        assertEquals("0", form.hiddenFields["sond"])
+        assertEquals("0", form.hiddenFields["owntopic"])
+        assertEquals("0", form.hiddenFields["new"])
+
+        // numreponse / numrep are empty in a simple reply.
+        assertEquals("", form.hiddenFields["numreponse"])
+        assertEquals("", form.hiddenFields["numrep"])
+
+        // Authenticated form carries the user's pseudo as a visible field — we forward it.
+        assertEquals("xatelitte", form.hiddenFields["pseudo"])
+
+        // Sensitive: password must never be forwarded, even when blank in source.
+        assertFalse("password must be stripped from hiddenFields", form.hiddenFields.containsKey("password"))
+    }
+
+    @Test
+    fun `flags the anonymous composer and skips the pseudo field`() {
+        val html = readFixture("write_reply_anonymous_form.html")
+        val form = parser.parse(html).getOrThrow()
+
+        assertTrue("Anonymous form must be flagged", form.isAnonymous)
+        assertFalse("pseudo must be skipped on anonymous form", form.hiddenFields.containsKey("pseudo"))
+        assertFalse("password must be skipped on anonymous form", form.hiddenFields.containsKey("password"))
+
+        // hash_check still present even on anonymous form — we just refuse to use it.
+        assertNotNull(form.hashCheck)
+        assertEquals("REDACTED_HASH_CHECK", form.hashCheck)
+    }
+
+    @Test
+    fun `forced-form on locked topic still parses but the post will be refused server-side`() {
+        // HFR serves the composer when you craft message.php URL on a locked topic, but
+        // the POST is rejected. The parser must still produce a usable form (so the
+        // caller can attempt the POST and surface the typed "TopicLocked" error).
+        val html = readFixture("write_reply_locked_topic_forced_form.html")
+        val form = parser.parse(html).getOrThrow()
+        assertNotNull(form.hashCheck)
+        assertEquals("REDACTED_HASH_CHECK", form.hashCheck)
+    }
+
+    @Test
+    fun `fails fast when hash_check is missing`() {
+        val html = """<html><body><form action="/bddpost.php?config=hfr.inc" method="post">
+            <input type="hidden" name="cat" value="23" />
+            <input type="hidden" name="post" value="1" />
+        </form></body></html>"""
+        val result = parser.parse(html)
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun `fails when no bddpost form is present at all`() {
+        val html = """<html><body><p>unrelated page</p></body></html>"""
+        val result = parser.parse(html)
+        assertTrue(result.isFailure)
+    }
+
+    private fun readFixture(name: String): String {
+        val stream = requireNotNull(
+            ReplyFormParserTest::class.java.classLoader?.getResourceAsStream("fixtures/$name"),
+        ) { "Fixture not found: fixtures/$name" }
+        return stream.bufferedReader().use { it.readText() }
+    }
+}

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/write/ReplySubmitResponseParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/write/ReplySubmitResponseParserTest.kt
@@ -1,0 +1,102 @@
+package fr.forumhfr.redface2.core.parser.write
+
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
+import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReplySubmitResponseParserTest {
+
+    private val parser = ReplySubmitResponseParser()
+
+    @Test
+    fun `success response extracts refresh URL and target page`() {
+        val html = readFixture("write_reply_success_response.html")
+        val result = parser.parse(html)
+        assertTrue("Expected success, got $result", result is ReplySubmitResult.Success)
+        val success = result as ReplySubmitResult.Success
+        val refreshUrl = success.refreshUrl
+        assertNotNull("Refresh URL must be parsed", refreshUrl)
+        requireNotNull(refreshUrl)
+        // The fixture refreshes to …/sujet_35395_20.htm#bas — page 20.
+        assertEquals(20, success.targetPage)
+        assertTrue(refreshUrl.contains("sujet_35395_20"))
+        assertTrue(refreshUrl.endsWith("#bas"))
+    }
+
+    @Test
+    fun `empty message error is classified`() {
+        val html = readFixture("write_empty_message_error.html")
+        val result = parser.parse(html)
+        assertEquals(
+            ReplySubmitResult.Failure(ReplyFailureReason.EmptyMessage),
+            result,
+        )
+    }
+
+    @Test
+    fun `invalid hash check is classified, even on the bare text response variant`() {
+        val html = readFixture("write_invalid_token_error.html")
+        val result = parser.parse(html)
+        assertEquals(
+            ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck),
+            result,
+        )
+    }
+
+    @Test
+    fun `anti-flood error is classified`() {
+        val html = readFixture("write_antiflood_error.html")
+        val result = parser.parse(html)
+        assertEquals(
+            ReplySubmitResult.Failure(ReplyFailureReason.AntiFlood),
+            result,
+        )
+    }
+
+    @Test
+    fun `locked topic error is classified`() {
+        val html = readFixture("write_locked_topic_error.html")
+        val result = parser.parse(html)
+        assertEquals(
+            ReplySubmitResult.Failure(ReplyFailureReason.TopicLocked),
+            result,
+        )
+    }
+
+    @Test
+    fun `unknown response falls back to Unknown reason`() {
+        val html = "<html><body>Page non documentée</body></html>"
+        val result = parser.parse(html)
+        assertEquals(
+            ReplySubmitResult.Failure(ReplyFailureReason.Unknown),
+            result,
+        )
+    }
+
+    @Test
+    fun `success without parsable page leaves targetPage null but keeps refreshUrl`() {
+        // Stripped-down success: meta refresh present but URL does not match the
+        // sujet_X_Y pattern (HFR sometimes returns the front page after a flood).
+        val html = """
+            <html><head>
+              <meta http-equiv="Refresh" content="1; url=/hfr/Programmation/Divers-6/liste_sujet-1.htm" />
+            </head><body>
+              <div class="hop">Votre réponse a été postée avec succès !</div>
+            </body></html>
+        """.trimIndent()
+        val result = parser.parse(html) as ReplySubmitResult.Success
+        assertNotNull(result.refreshUrl)
+        assertNull(result.targetPage)
+    }
+
+    private fun readFixture(name: String): String {
+        val stream = requireNotNull(
+            ReplySubmitResponseParserTest::class.java.classLoader?.getResourceAsStream("fixtures/$name"),
+        ) { "Fixture not found: fixtures/$name" }
+        return stream.bufferedReader().use { it.readText() }
+    }
+}

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -18,7 +18,7 @@ mermaid:
 
 nav_sort: order
 
-footer_content: "Redface 2 &mdash; Specs v0.9.0 &mdash; Un projet communautaire pour Hardware.fr"
+footer_content: "Redface 2 &mdash; Specs v0.10.0 &mdash; Un projet communautaire pour Hardware.fr"
 
 back_to_top: true
 back_to_top_text: "Haut de page"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -18,7 +18,7 @@ mermaid:
 
 nav_sort: order
 
-footer_content: "Redface 2 &mdash; Specs v0.10.1 &mdash; Un projet communautaire pour Hardware.fr"
+footer_content: "Redface 2 &mdash; Specs v0.10.2 &mdash; Un projet communautaire pour Hardware.fr"
 
 back_to_top: true
 back_to_top_text: "Haut de page"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -18,7 +18,7 @@ mermaid:
 
 nav_sort: order
 
-footer_content: "Redface 2 &mdash; Specs v0.10.2 &mdash; Un projet communautaire pour Hardware.fr"
+footer_content: "Redface 2 &mdash; Specs v0.10.3 &mdash; Un projet communautaire pour Hardware.fr"
 
 back_to_top: true
 back_to_top_text: "Haut de page"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -18,7 +18,7 @@ mermaid:
 
 nav_sort: order
 
-footer_content: "Redface 2 &mdash; Specs v0.10.0 &mdash; Un projet communautaire pour Hardware.fr"
+footer_content: "Redface 2 &mdash; Specs v0.10.1 &mdash; Un projet communautaire pour Hardware.fr"
 
 back_to_top: true
 back_to_top_text: "Haut de page"

--- a/docs/specs/models.md
+++ b/docs/specs/models.md
@@ -225,7 +225,7 @@ enum class FlagType {
 data class Topic(
     val cat: Int,
     val post: Int,
-    val subcat: Int,                 // Phase 2C : sous-cat HFR, requis par message.php/bddpost.php. Sentinel SUBCAT_UNKNOWN=-1 pour les caches pré-MIGRATION_3_4 (lecture autorisée, écriture désactivée). Jamais transmis tel quel à HFR.
+    val subcat: Int,                 // Phase 2C : sous-cat HFR, requis par message.php/bddpost.php. Sentinel SUBCAT_UNKNOWN=-1 pour les caches pré-MIGRATION_3_4 (lecture autorisée, écriture désactivée). Le wire shape moderator-space HFR (`cat=0`) émet aussi `subcat=0` sans fixture utilisateur valide pour Phase 2C — donc traité comme « unknown » côté écriture. Jamais transmis tel quel à HFR.
     val title: String,
     val posts: List<Post>,
     val page: Int,
@@ -233,7 +233,8 @@ data class Topic(
     val isFirstPostOwner: Boolean,   // Phase 1 : figé à false par TopicPageParser tant que parseEditPage n'est pas livrée (Phase 2). Renseigné côté serveur via la page d'édition du FP.
     val poll: Poll?,
 ) {
-    val hasSubcat: Boolean get() = subcat != SUBCAT_UNKNOWN
+    // Strictement > 0 : exclut le sentinel (-1) ET la wire shape moderator-space (0).
+    val hasSubcat: Boolean get() = subcat > 0
 
     companion object { const val SUBCAT_UNKNOWN: Int = -1 }
 }
@@ -405,7 +406,7 @@ plus tard pour Edit / Quote / Edit FP / Create.
 ```kotlin
 data class ReplyContext(
     val cat: Int,
-    val subcat: Int,                 // requis ≥ 0 ; ReplyContext.init refuse le sentinel SUBCAT_UNKNOWN
+    val subcat: Int,                 // requis > 0 ; `ReplyContext.init` refuse à la fois le sentinel `SUBCAT_UNKNOWN` (-1) et la wire shape moderator-space HFR (0, cat=0/cat=prive)
     val topicId: Int,
     val page: Int,                   // page topic depuis laquelle l'utilisateur a cliqué "Répondre"
 )

--- a/docs/specs/models.md
+++ b/docs/specs/models.md
@@ -225,13 +225,18 @@ enum class FlagType {
 data class Topic(
     val cat: Int,
     val post: Int,
+    val subcat: Int,                 // Phase 2C : sous-cat HFR, requis par message.php/bddpost.php. Sentinel SUBCAT_UNKNOWN=-1 pour les caches pré-MIGRATION_3_4 (lecture autorisée, écriture désactivée). Jamais transmis tel quel à HFR.
     val title: String,
     val posts: List<Post>,
     val page: Int,
     val totalPages: Int,
     val isFirstPostOwner: Boolean,   // Phase 1 : figé à false par TopicPageParser tant que parseEditPage n'est pas livrée (Phase 2). Renseigné côté serveur via la page d'édition du FP.
     val poll: Poll?,
-)
+) {
+    val hasSubcat: Boolean get() = subcat != SUBCAT_UNKNOWN
+
+    companion object { const val SUBCAT_UNKNOWN: Int = -1 }
+}
 
 data class Post(
     val numreponse: Int,                 // unique par (cat), PAS globalement — clé composite (cat, numreponse) au niveau base
@@ -388,6 +393,49 @@ data class TopicListPage(
 ```
 
 **Champs absents en REST** : `views` n'est pas exposé en JSON — ne pas inventer `0`, ne pas l'afficher. Le calcul de pages côté topic (`TopicSummary.totalPages`) utilise le `results_per_page` exposé par `links.posts.href` (typiquement 40 dans les fixtures, mais c'est l'API qui décide — `40` n'est pas une constante globale, cf. [protocol-hfr.md § postsPerPage configurable]({{ site.baseurl }}/specs/protocol-hfr#postsperpage-configurable) pour la pagination HTML). Le `results_per_page` du wrapper REST englobe la **liste de topics**, distinct de celui imbriqué dans `links.posts.href` qui pagine les **posts** d'un topic.
+
+---
+
+## Écriture HFR
+
+Types vivant dans `:core:model/write/` ; consommés par `:core:parser/write/`,
+`:core:data/write/` et `:feature:editor`. Livrés en Phase 2C (#145) ; étendus
+plus tard pour Edit / Quote / Edit FP / Create.
+
+```kotlin
+data class ReplyContext(
+    val cat: Int,
+    val subcat: Int,                 // requis ≥ 0 ; ReplyContext.init refuse le sentinel SUBCAT_UNKNOWN
+    val topicId: Int,
+    val page: Int,                   // page topic depuis laquelle l'utilisateur a cliqué "Répondre"
+)
+
+data class ReplyForm(
+    val hashCheck: String,           // CSRF token HFR, jamais loggué
+    val sujet: String,
+    val hiddenFields: Map<String, String>,   // password filtré au parse ; pseudo anonyme filtré
+    val isAnonymous: Boolean,
+)
+
+sealed interface ReplySubmitResult {
+    data class Success(
+        val refreshUrl: String?,     // <meta http-equiv="Refresh" content="N; url=…">
+        val targetPage: Int?,        // dérivé du shape sujet_X_Y.htm
+    ) : ReplySubmitResult
+    data class Failure(val reason: ReplyFailureReason) : ReplySubmitResult
+}
+
+sealed interface ReplyFailureReason {
+    data object EmptyMessage : ReplyFailureReason
+    data object InvalidHashCheck : ReplyFailureReason
+    data object AntiFlood : ReplyFailureReason
+    data object TopicLocked : ReplyFailureReason
+    data object LoginRequired : ReplyFailureReason   // form anonyme servi par HFR
+    data object Unknown : ReplyFailureReason         // réponse non reconnue ; pas de raw body conservé (cf. KDoc)
+}
+```
+
+Le contrat HFR sous-jacent est documenté dans [`protocol-hfr.md` § POST `bddpost.php`]({{ site.baseurl }}/specs/protocol-hfr). Les `ReplyFailureReason` mappent un-à-un sur les fixtures `write_*_error.html` / `write_*_response.html` capturées en Phase 2A.
 
 ---
 

--- a/docs/specs/mvi.md
+++ b/docs/specs/mvi.md
@@ -223,7 +223,7 @@ sealed interface TopicEffect {
 
 ## Écran Editor (post-level reply / edit) + formulaire de topic
 
-Phase 2B-A (#86 + #144) sépare l'éditeur en **deux familles** plutôt qu'en un mode unique. Le post-level editor (`PostEditorScreen`) gère le contenu BBCode pour Reply / Edit ; le formulaire de topic (`TopicFormScreen`) gérera New / Edit FP — pour l'instant placeholder en attendant #148 / #149.
+Phase 2B-A (#86 + #144) a séparé l'éditeur en **deux familles** plutôt qu'en un mode unique. Phase 2C (#145) ajoute la première mutation HFR utile : le submit reply via `bddpost.php`. Le formulaire de topic (`TopicFormScreen`) reste placeholder en attendant #148 / #149.
 
 ```kotlin
 // Post-level editor — édition de niveau post (contenu BBCode seulement)
@@ -237,20 +237,32 @@ data class PostEditorState(
     val cat: Int,
     val topicId: Int?,
     val numreponse: Int?,
+    val page: Int?,                 // (Phase 2C) page topic en cours
+    val subcat: Int?,               // (Phase 2C) sous-cat HFR, requis pour reply
     val draft: TextFieldValue = TextFieldValue(),
     val preview: PostContent = PostContent(blocks = emptyList()),
     val isPreviewVisible: Boolean = false,
     val validation: BbcodeValidation = BbcodeValidation.Idle,
+    val isLoadingForm: Boolean = false,  // GET message.php avant submit
+    val isSubmitting: Boolean = false,   // POST bddpost.php en cours
+    val submitError: SubmitError? = null,
 )
 
 sealed interface PostEditorIntent {
     data class ContentChanged(val value: TextFieldValue) : PostEditorIntent
     data class ToolbarActionClicked(val action: BbcodeAction) : PostEditorIntent
     data object TogglePreview : PostEditorIntent
+    data object SubmitClicked : PostEditorIntent       // (Phase 2C)
+    data object ErrorDismissed : PostEditorIntent      // (Phase 2C)
+}
+
+// Effets one-shot bypassant le state (jamais rejoués sur recomposition)
+sealed interface PostEditorEffect {
+    data class SubmitSucceeded(val targetPage: Int?) : PostEditorEffect
 }
 ```
 
-> **Statut Phase 2B-A — éditeur local, pas d'envoi HFR** : `PostEditorViewModel` est livré et tient la draft BBCode + la preview locale. Aucune mutation réseau (`bddpost.php`, `apercu.php`) n'est branchée ; reply/edit réels arrivent avec #145 / #146 / #147. `TopicFormScreen` est un placeholder explicite jusqu'à #148 (Edit FP) / #149 (Create topic).
+> **Statut Phase 2C — reply MVP livré** : `PostEditorViewModel` injecte `ReplyRepository` (interface `:core:domain/write/`, impl `:core:data/write/`). Sur init en mode Reply, il fetch `message.php` pour obtenir `hash_check` + les hidden fields HFR, puis sur `SubmitClicked` POSTe `bddpost.php?config=hfr.inc`. Anti-double-submit via `submitJob.isActive`. Errors typées via `ReplyFailureReason` (empty / invalid_token / antiflood / locked / login_required / unknown) + `SubmitError.Network` / `SessionExpired` / `MissingSubcat`. Sur succès, effet `SubmitSucceeded(targetPage)` → la navigation pop l'éditeur et recharge la page topic. Edit / Quote / Edit FP / Create restent dans #146 / #147 / #148 / #149. `TopicFormScreen` reste placeholder.
 >
 > Les deux écrans partagent leurs **capacités** via composables `:core:ui` (`BbcodeTextField`, `BbcodeToolbar`, `BbcodePreview`, et plus tard `PollEditor`, `CatSubcatPicker`). `BbcodePreview` reçoit un `PostContent` déjà parsé — il **ne parse pas lui-même**, ce qui garde `:core:ui` libre de toute logique métier. Le parsing BBCode reste une responsabilité `:core:parser` (`parsePostContentFromBbcode`) exposée aux features via une interface `BbcodePreviewParser` (`:core:domain`) injectée par Hilt, afin de préserver la frontière `:feature:*` → `:core:domain` + `:core:ui` (les ViewModels appellent le use case et passent le `PostContent` résultant à `BbcodePreview`). Pas de duplication, juste deux contrats de formulaire distincts. Rationale : l'endpoint HFR n'est pas une bonne frontière UI (`Reply` et `NewTopic` passent tous deux par `bddpost.php` mais leurs formulaires diffèrent ; `EditFirstPost` et `NewTopic` partagent presque toute la structure malgré des endpoints différents). La frontière utile est **post-level** vs **topic-level**.
 

--- a/docs/specs/navigation.md
+++ b/docs/specs/navigation.md
@@ -214,8 +214,10 @@ Implémentation via **Compose Navigation 3** (1.1.0+, stable depuis 08/04/2026).
 @Serializable data class PostEditorRoute(
     val mode: PostEditorMode,
     val cat: Int,
-    val topicId: Int? = null,             // requis à terme pour Reply, attendu par TopicScreen.onReply
+    val topicId: Int? = null,             // requis pour Reply (Phase 2C)
     val numreponse: Int? = null,          // requis à terme pour Edit
+    val page: Int? = null,                // page topic en cours, requis Reply (#145)
+    val subcat: Int? = null,              // sous-cat HFR, requis Reply (#145) — TopicScreen ne pousse PostEditorRoute que si topic.hasSubcat
 ) : RedfaceNavKey
 
 @Serializable data class TopicFormRoute(
@@ -284,8 +286,19 @@ private fun RedfaceNavHost(backStack: NavBackStack<NavKey>) {
             entry<TopicRoute> { route ->
                 TopicScreen(
                     request = TopicRequest(route.cat, route.post, route.page, route.scrollTo),
-                    onReply = { topicId ->
-                        backStack.add(PostEditorRoute(PostEditorMode.Reply, route.cat, topicId = topicId))
+                    // Phase 2C (#145): TopicScreen exposes subcat from the parsed topic
+                    // page; the reply button is disabled when `topic.hasSubcat` is false
+                    // (cached row from before the v3 → v4 Room migration).
+                    onReply = { subcat, page ->
+                        backStack.add(
+                            PostEditorRoute(
+                                PostEditorMode.Reply,
+                                route.cat,
+                                topicId = route.post,
+                                page = page,
+                                subcat = subcat,
+                            ),
+                        )
                     },
                     onOpenPage = { targetPage ->
                         backStack.removeAt(backStack.lastIndex)
@@ -295,7 +308,25 @@ private fun RedfaceNavHost(backStack: NavBackStack<NavKey>) {
             }
             entry<PostEditorRoute> { route ->
                 PostEditorScreen(
-                    request = PostEditorRequest(route.mode, route.cat, route.topicId, route.numreponse),
+                    request = PostEditorRequest(
+                        route.mode,
+                        route.cat,
+                        route.topicId,
+                        route.numreponse,
+                        route.page,
+                        route.subcat,
+                    ),
+                    // Phase 2C (#145): pop editor + replace topic entry to refresh the
+                    // target page (defaults to the page the user replied from when HFR
+                    // does not surface a different one in the meta refresh URL).
+                    onSubmitSucceeded = { targetPage ->
+                        backStack.removeAt(backStack.lastIndex)
+                        val topicEntry = backStack.lastOrNull() as? TopicRoute
+                        if (topicEntry != null) {
+                            backStack.removeAt(backStack.lastIndex)
+                            backStack.add(topicEntry.copy(page = targetPage ?: topicEntry.page, scrollTo = null))
+                        }
+                    },
                 )
             }
             entry<TopicFormRoute> { route ->
@@ -420,7 +451,7 @@ Manifest requis : `android:enableOnBackInvokedCallback="true"` sur `<application
 > **Statut Phase 5+** — multi-pane n'est pas livré en Phase 1. Dans le snippet ci-dessous :
 >
 > - le **pattern de composition** (`NavDisplay` + `ListDetailPaneScaffold` sur le même back stack, switch `WindowSizeClass`) est **illustratif** — c'est ce qui sera implémenté Phase 5+ ;
-> - les **signatures de screens** appelées (`FlagsRoute(onOpenFlag, onLoginRequested)`, `MessagesScreen(versionName, versionCode, onLoginRequested, onOpenDiagnostics)`, `SearchScreen()`, `TopicScreen(request: TopicRequest, onReply, onOpenPage)`, `PostEditorScreen(request: PostEditorRequest)`, `TopicFormScreen(mode, cat?, subcat?, topicId?)`) sont les signatures **réelles** livrées dans le repo (cf. `feature/topic/.../TopicScreen.kt`, `feature/flags/.../FlagsRoute.kt`, `feature/messages/.../MessagesScreen.kt`, `feature/search/.../SearchScreen.kt`, `feature/editor/.../PostEditorScreen.kt`, `feature/editor/.../TopicFormScreen.kt`).
+> - les **signatures de screens** appelées (`FlagsRoute(onOpenFlag, onLoginRequested)`, `MessagesScreen(versionName, versionCode, onLoginRequested, onOpenDiagnostics)`, `SearchScreen()`, `TopicScreen(request: TopicRequest, onReply: (subcat, page) -> Unit, onOpenPage)`, `PostEditorScreen(request: PostEditorRequest, onSubmitSucceeded: (targetPage?) -> Unit)`, `TopicFormScreen(mode, cat?, subcat?, topicId?)`) sont les signatures **réelles** livrées dans le repo (cf. `feature/topic/.../TopicScreen.kt`, `feature/flags/.../FlagsRoute.kt`, `feature/messages/.../MessagesScreen.kt`, `feature/search/.../SearchScreen.kt`, `feature/editor/.../PostEditorScreen.kt`, `feature/editor/.../TopicFormScreen.kt`).
 >
 > Le call-site `onOpenFlag = { flag -> backStack.add(TopicRoute(flag.cat, flag.topicId, flag.lastReadPage, scrollTo = ...)) }` passe désormais le topic concerné — Phase 1B.4 a remplacé le placeholder mock par la liste réelle des drapeaux.
 
@@ -458,8 +489,8 @@ fun AdaptiveNavHost(backStack: NavBackStack<NavKey>) {
                             page = current.page,
                             scrollTo = current.scrollTo,
                         ),
-                        onReply = { topicId ->
-                            backStack.add(PostEditorRoute(PostEditorMode.Reply, current.cat, topicId = topicId))
+                        onReply = { subcat, page ->
+                            backStack.add(PostEditorRoute(PostEditorMode.Reply, current.cat, topicId = current.post, page = page, subcat = subcat))
                         },
                         onOpenPage = { targetPage ->
                             backStack.removeAt(backStack.lastIndex)
@@ -467,7 +498,8 @@ fun AdaptiveNavHost(backStack: NavBackStack<NavKey>) {
                         },
                     )
                     is PostEditorRoute -> PostEditorScreen(
-                        request = PostEditorRequest(current.mode, current.cat, current.topicId, current.numreponse),
+                        request = PostEditorRequest(current.mode, current.cat, current.topicId, current.numreponse, current.page, current.subcat),
+                        onSubmitSucceeded = { /* multi-pane refresh handled by parent observer */ },
                     )
                     is TopicFormRoute -> TopicFormScreen(
                         mode = current.mode,

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -124,7 +124,7 @@ Le PostRenderer sera développé de manière incrémentale : texte brut d'abord,
 - [x] **2A — Reality check protocole d'écriture HFR (#81) + références écosystème (#32)** — fixtures live, spec écriture alignée HFR, page `docs/guides/references.md` consolidée. Mergé via PR #159 (writes) + PR #160 (références).
 - [x] **2B-A — Socle éditeur local (#86, refs #144)** — `PostEditorRoute` / `TopicFormRoute`, `PostEditorScreen` + ViewModel, toolbar BBCode complète (gras / italique / souligné / barré / quote / code / cpp / fixed / spoiler / url / image), preview locale via `parsePostContentFromBbcode`. Pas encore d'envoi HFR — local seulement.
 - [ ] Recherche — titres de topics et contenu de posts, filtres par catégorie/auteur/date
-- [ ] Reply — répondre à un topic
+- [x] **2C — Reply MVP (#145)** — POST réel `bddpost.php` via `ReplyRepository` (`:core:domain/write/` + `:core:data/write/`), `PostEditorViewModel` wire submit + erreurs typées (`empty`, `invalid_token`, `antiflood`, `locked`, `login_required`). Migration Room v3 → v4 ajoute `subcat` à `topic_pages` ; HFR write contract recapturé sur fixtures Phase 2A.
 - [ ] Quote — citer un post → reply pré-rempli
 - [ ] Edit — éditer son propre post
 - [ ] Edit FP — éditer le first post (sujet, contenu, sondage)

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorIntent.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorIntent.kt
@@ -4,11 +4,29 @@ import androidx.compose.ui.text.input.TextFieldValue
 import fr.forumhfr.redface2.core.ui.editor.BbcodeAction
 
 /**
- * MVI intents emitted by `PostEditorScreen`. Phase 2B-A keeps the surface tight: no
- * submit intent yet (no network call), no preview-fetch intent (no `apercu.php`).
+ * MVI intents emitted by `PostEditorScreen`. Phase 2C (#145) adds the reply submit
+ * surface ; quote / edit / create-topic surface in #146 / #147 / #148 / #149.
  */
 sealed interface PostEditorIntent {
     data class ContentChanged(val value: TextFieldValue) : PostEditorIntent
     data class ToolbarActionClicked(val action: BbcodeAction) : PostEditorIntent
     data object TogglePreview : PostEditorIntent
+
+    /** User asked to send the reply to HFR (Phase 2C, [PostEditorMode.Reply] only). */
+    data object SubmitClicked : PostEditorIntent
+
+    /** User dismissed an in-flight error banner. Clears [PostEditorState.submitError]. */
+    data object ErrorDismissed : PostEditorIntent
+}
+
+/**
+ * One-shot effects emitted by [PostEditorViewModel]. These bypass [PostEditorState]
+ * so they are never replayed across recompositions / process death.
+ */
+sealed interface PostEditorEffect {
+    /**
+     * The reply was accepted by HFR. The receiver navigates back to the topic and
+     * refreshes the page if [targetPage] is known.
+     */
+    data class SubmitSucceeded(val targetPage: Int?) : PostEditorEffect
 }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorRequest.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorRequest.kt
@@ -2,13 +2,21 @@ package fr.forumhfr.redface2.feature.editor
 
 /**
  * Plain request payload assisted-injected into [PostEditorViewModel]. Mirrors the
- * `PostEditorRoute` NavKey from `:app/navigation` without leaking Navigation 3 types
- * into the feature module. Phase 2B-A only renders the local editor — actual
- * HFR-side reply / edit submission arrive with #145 / #147.
+ * `PostEditorRoute` NavKey from `:app/navigation` without leaking Navigation 3
+ * types into the feature module.
+ *
+ * Phase 2C-A (#145) extends the payload with [page] and [subcat] : both are
+ * required by HFR's `message.php` reply form contract (cf.
+ * `docs/specs/protocol-hfr.md` § POST `bddpost.php`). The caller (TopicScreen)
+ * is responsible for supplying real values; passing `null` here implies "Phase
+ * 2C wiring not yet ready for this entry point" and the editor stays in a
+ * read-only / local-preview-only mode for that session.
  */
 data class PostEditorRequest(
     val mode: PostEditorMode,
     val cat: Int,
     val topicId: Int?,
     val numreponse: Int?,
+    val page: Int?,
+    val subcat: Int?,
 )

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -3,44 +3,60 @@ package fr.forumhfr.redface2.feature.editor
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
 import fr.forumhfr.redface2.core.ui.editor.BbcodePreview
 import fr.forumhfr.redface2.core.ui.editor.BbcodeTextField
 import fr.forumhfr.redface2.core.ui.editor.BbcodeToolbar
 
 /**
- * Phase 2B-A post-level editor screen. Local-only: text field + toolbar + preview.
- * No HFR POST, no `apercu.php` round-trip — those land in #145 / #146 / #147.
+ * Post-level editor screen. Phase 2C (#145) adds a Submit button that posts the
+ * reply via [PostEditorViewModel.submit]. Successful submissions raise a one-shot
+ * [PostEditorEffect.SubmitSucceeded] which the navigation host translates into a
+ * back navigation + topic refresh.
  */
 @Composable
 fun PostEditorScreen(
     request: PostEditorRequest,
+    onSubmitSucceeded: (targetPage: Int?) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: PostEditorViewModel = hiltViewModel<PostEditorViewModel, PostEditorViewModel.Factory>(
         creationCallback = { factory -> factory.create(request) },
     ),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    LaunchedEffect(viewModel) {
+        viewModel.effects.collect { effect ->
+            when (effect) {
+                is PostEditorEffect.SubmitSucceeded -> onSubmitSucceeded(effect.targetPage)
+            }
+        }
+    }
     PostEditorContent(
         state = state,
         onIntent = remember(viewModel) { { intent: PostEditorIntent -> viewModel.submit(intent) } },
@@ -99,11 +115,49 @@ private fun PostEditorContent(
                 BbcodePreview(content = state.preview)
             }
 
-            Text(
-                text = stringResource(R.string.editor_submit_disabled),
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            state.submitError?.let { error ->
+                Text(
+                    text = stringResource(error.bannerResId),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                )
+                TextButton(onClick = { onIntent(PostEditorIntent.ErrorDismissed) }) {
+                    Text(text = stringResource(R.string.editor_error_dismiss))
+                }
+            }
+
+            if (state.mode == PostEditorMode.Reply) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    if (state.isLoadingForm) {
+                        CircularProgressIndicator(modifier = Modifier.size(20.dp))
+                    }
+                    Button(
+                        enabled = state.canSubmit,
+                        onClick = { onIntent(PostEditorIntent.SubmitClicked) },
+                    ) {
+                        if (state.isSubmitting) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(18.dp),
+                                color = MaterialTheme.colorScheme.onPrimary,
+                            )
+                        } else {
+                            Text(text = stringResource(R.string.editor_submit))
+                        }
+                    }
+                }
+            } else {
+                // Edit / Quote / Create flows arrive later — keep the placeholder
+                // language as a reminder this surface is not yet wired up.
+                Text(
+                    text = stringResource(R.string.editor_submit_disabled),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
     }
 }
@@ -112,4 +166,19 @@ private val PostEditorMode.titleResId: Int
     get() = when (this) {
         PostEditorMode.Reply -> R.string.editor_post_reply_title
         PostEditorMode.Edit -> R.string.editor_post_edit_title
+    }
+
+private val SubmitError.bannerResId: Int
+    get() = when (this) {
+        is SubmitError.Hfr -> when (reason) {
+            ReplyFailureReason.EmptyMessage -> R.string.editor_error_empty
+            ReplyFailureReason.InvalidHashCheck -> R.string.editor_error_invalid_hash
+            ReplyFailureReason.AntiFlood -> R.string.editor_error_anti_flood
+            ReplyFailureReason.TopicLocked -> R.string.editor_error_topic_locked
+            ReplyFailureReason.LoginRequired -> R.string.editor_error_login_required
+            ReplyFailureReason.Unknown -> R.string.editor_error_unknown
+        }
+        SubmitError.Network -> R.string.editor_error_network
+        SubmitError.SessionExpired -> R.string.editor_error_session_expired
+        SubmitError.MissingSubcat -> R.string.editor_error_missing_subcat
     }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
@@ -39,9 +39,9 @@ data class PostEditorState(
     val canSubmit: Boolean
         get() = mode == PostEditorMode.Reply &&
             page != null &&
-            // Reject both the "unknown" null and the v3-cache sentinel `-1` —
-            // the latter would silently fail `ReplyContext.init` later.
-            (subcat != null && subcat >= 0) &&
+            // Reject the `null` unknown, the `-1` SUBCAT_UNKNOWN sentinel and the `0`
+            // moderator-space wire shape (`Topic.hasSubcat` uses the same rule).
+            (subcat != null && subcat > 0) &&
             topicId != null &&
             draft.text.isNotBlank() &&
             !isSubmitting &&

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
@@ -39,7 +39,9 @@ data class PostEditorState(
     val canSubmit: Boolean
         get() = mode == PostEditorMode.Reply &&
             page != null &&
-            subcat != null &&
+            // Reject both the "unknown" null and the v3-cache sentinel `-1` —
+            // the latter would silently fail `ReplyContext.init` later.
+            (subcat != null && subcat >= 0) &&
             topicId != null &&
             draft.text.isNotBlank() &&
             !isSubmitting &&

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
@@ -4,28 +4,78 @@ import androidx.compose.ui.text.input.TextFieldValue
 import fr.forumhfr.redface2.core.domain.editor.BbcodeValidation
 import fr.forumhfr.redface2.core.domain.editor.validateBbcodeDraft
 import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
 
 /**
- * MVI state of a Phase 2B-A post-level editor session. Holds the current BBCode
- * draft, the parsed preview AST, and the user-visible toggles — but **no** network
- * effect yet. Submission, draft persistence and form fetching arrive later in Phase
- * 2C-D (#145, #146, #147).
+ * MVI state of the post-level editor. Local draft + parsed preview AST + the Phase
+ * 2C (#145) submit lifecycle. Submission for Edit / Edit FP / Create / Quote arrives
+ * later (#146, #147, #148, #149).
  */
 data class PostEditorState(
     val mode: PostEditorMode,
     val cat: Int,
     val topicId: Int?,
     val numreponse: Int?,
+    /** Page index of the topic for the reply form GET (Phase 2C). Null when unknown. */
+    val page: Int?,
+    /** Sub-category id required by HFR's write contract. Null when unknown — reply disabled. */
+    val subcat: Int?,
     val draft: TextFieldValue = TextFieldValue(),
     val preview: PostContent = PostContent(blocks = emptyList()),
     val isPreviewVisible: Boolean = false,
     val validation: BbcodeValidation = BbcodeValidation.Idle,
+    /** True while we GET the reply form to grab `hash_check`. */
+    val isLoadingForm: Boolean = false,
+    /** True while we POST `bddpost.php`. Guards against double submit. */
+    val isSubmitting: Boolean = false,
+    /** Surfaces an HFR-classified failure to the UI. Null means "no error to show". */
+    val submitError: SubmitError? = null,
 ) {
-    val isSubmitEnabled: Boolean get() = draft.text.isNotBlank()
+    /**
+     * Reply submission is allowed when : we know the routing context (page + subcat),
+     * the user has typed something non-blank, the editor is not already submitting,
+     * and we are not still fetching the form.
+     */
+    val canSubmit: Boolean
+        get() = mode == PostEditorMode.Reply &&
+            page != null &&
+            subcat != null &&
+            topicId != null &&
+            draft.text.isNotBlank() &&
+            !isSubmitting &&
+            !isLoadingForm
+
+    val isSubmitEnabled: Boolean get() = canSubmit
+}
+
+/**
+ * UI-facing error envelope. The repository's [ReplyFailureReason] is the canonical
+ * type — we wrap it here so transport-level failures (IO, session) can land alongside
+ * the HFR-classified reasons without leaking exception types into the View.
+ */
+sealed interface SubmitError {
+    /** A classified failure surfaced verbatim by HFR (see fixtures). */
+    data class Hfr(val reason: ReplyFailureReason) : SubmitError
+
+    /** Network / IO error. The draft is preserved ; the user can retry. */
+    data object Network : SubmitError
+
+    /** Auth cookie was rejected mid-flow. The UI prompts a fresh login. */
+    data object SessionExpired : SubmitError
+
+    /**
+     * The active topic page does not carry a `subcat` yet (cache pre-dates Phase 2C).
+     * The UI tells the user to refresh the topic first.
+     */
+    data object MissingSubcat : SubmitError
 }
 
 internal fun PostEditorState.withDraft(updated: TextFieldValue): PostEditorState =
     copy(
         draft = updated,
         validation = validateBbcodeDraft(updated.text),
+        // Clear an error as soon as the user mutates the draft — they have implicitly
+        // accepted that we will try again. Keep it on toolbar-only mutations though
+        // (caller resets `submitError` directly when needed).
+        submitError = if (updated.text != draft.text) null else submitError,
     )

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -248,7 +248,9 @@ class PostEditorViewModel @AssistedInject constructor(
         val page = snapshot.page ?: return null
         val subcat = snapshot.subcat ?: return null
         val topicId = snapshot.topicId ?: return null
-        if (subcat < 0) return null
+        // Mirror the `Topic.hasSubcat` / `ReplyContext.init` rule : reject both the
+        // sentinel (-1) and the moderator-space wire shape (0).
+        if (subcat <= 0) return null
         return ReplyContext(cat = snapshot.cat, subcat = subcat, topicId = topicId, page = page)
     }
 

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -3,31 +3,52 @@ package fr.forumhfr.redface2.feature.editor
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
+import fr.forumhfr.redface2.core.domain.write.ReplyRepository
+import fr.forumhfr.redface2.core.model.write.ReplyContext
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
+import fr.forumhfr.redface2.core.model.write.ReplyForm
+import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
 import fr.forumhfr.redface2.core.ui.editor.BbcodeAction
 import fr.forumhfr.redface2.core.ui.editor.applyBbcodeAction
+import java.io.IOException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 /**
- * ViewModel backing the Phase 2B-A post-level editor. Owns the BBCode draft
- * (`TextFieldValue` so the selection survives rotations), the parsed preview AST
- * and the preview-visibility toggle.
+ * ViewModel backing the post-level editor. Owns the BBCode draft, the parsed
+ * preview AST, the preview-visibility toggle, and the Phase 2C (#145) reply
+ * submission lifecycle :
  *
- * No network effect, no draft persistence — those land in Phase 2C-D (#145, #146,
- * #147). The ViewModel keeps the draft alive across recompositions / rotations by
- * holding it in [_state]; process-death persistence is intentionally out of scope.
+ * 1. On init, when the request is a reply with a known `(page, subcat, topicId)`,
+ *    fetches the HFR reply form (`message.php`) to grab the per-session
+ *    `hash_check` and the hidden contract fields.
+ * 2. On [PostEditorIntent.SubmitClicked], POSTs `bddpost.php` via the repository
+ *    and emits a one-shot [PostEditorEffect.SubmitSucceeded] on success.
+ *
+ * Anti-double-submit is enforced via [PostEditorState.isSubmitting] + a single
+ * [submitJob] reference that ignores re-entry while in flight. Errors classified
+ * by the repository are surfaced via [SubmitError]; the draft is preserved.
  */
 @HiltViewModel(assistedFactory = PostEditorViewModel.Factory::class)
 class PostEditorViewModel @AssistedInject constructor(
     @Assisted private val request: PostEditorRequest,
     private val previewParser: BbcodePreviewParser,
+    private val replyRepository: ReplyRepository,
 ) : ViewModel() {
 
     private val _state: MutableStateFlow<PostEditorState> = MutableStateFlow(
@@ -36,15 +57,36 @@ class PostEditorViewModel @AssistedInject constructor(
             cat = request.cat,
             topicId = request.topicId,
             numreponse = request.numreponse,
+            page = request.page,
+            subcat = request.subcat,
         ),
     )
     val state: StateFlow<PostEditorState> = _state.asStateFlow()
+
+    private val _effects: Channel<PostEditorEffect> = Channel(capacity = Channel.BUFFERED)
+    val effects: Flow<PostEditorEffect> = _effects.receiveAsFlow()
+
+    /**
+     * Cached form pulled lazily on [PostEditorMode.Reply]. Keeping it on the
+     * ViewModel rather than the [PostEditorState] avoids leaking `hash_check`
+     * through Compose snapshot tooling / state restoration.
+     */
+    private var loadedForm: ReplyForm? = null
+    private var submitJob: Job? = null
+
+    init {
+        if (request.mode == PostEditorMode.Reply) {
+            loadReplyFormIfPossible()
+        }
+    }
 
     fun submit(intent: PostEditorIntent) {
         when (intent) {
             is PostEditorIntent.ContentChanged -> onContentChanged(intent.value)
             is PostEditorIntent.ToolbarActionClicked -> onToolbarActionClicked(intent.action)
             PostEditorIntent.TogglePreview -> onTogglePreview()
+            PostEditorIntent.SubmitClicked -> onSubmitClicked()
+            PostEditorIntent.ErrorDismissed -> _state.update { it.copy(submitError = null) }
         }
     }
 
@@ -90,6 +132,121 @@ class PostEditorViewModel @AssistedInject constructor(
                 preview = if (nextVisible) previewParser.parsePreview(current.draft.text) else current.preview,
             )
         }
+    }
+
+    private fun loadReplyFormIfPossible() {
+        val context = buildReplyContext() ?: run {
+            _state.update { it.copy(submitError = SubmitError.MissingSubcat) }
+            return
+        }
+        _state.update { it.copy(isLoadingForm = true, submitError = null) }
+        viewModelScope.launch {
+            val outcome = runCatching { replyRepository.fetchReplyForm(context) }
+            outcome.fold(
+                onSuccess = { form ->
+                    loadedForm = form
+                    _state.update { current ->
+                        current.copy(
+                            isLoadingForm = false,
+                            submitError = if (form.isAnonymous) {
+                                SubmitError.Hfr(ReplyFailureReason.LoginRequired)
+                            } else {
+                                current.submitError
+                            },
+                        )
+                    }
+                },
+                onFailure = { error -> handleFetchFailure(error) },
+            )
+        }
+    }
+
+    private fun handleFetchFailure(error: Throwable) {
+        if (error is CancellationException) throw error
+        val mapped = when (error) {
+            is SessionExpiredException -> SubmitError.SessionExpired
+            is IOException -> SubmitError.Network
+            else -> throw error
+        }
+        _state.update { it.copy(isLoadingForm = false, submitError = mapped) }
+    }
+
+    @Suppress("ReturnCount") // guard clauses are the natural shape of the dispatcher
+    private fun onSubmitClicked() {
+        val snapshot = _state.value
+        if (!snapshot.canSubmit) return
+        val context = buildReplyContext() ?: run {
+            _state.update { it.copy(submitError = SubmitError.MissingSubcat) }
+            return
+        }
+        val form = loadedForm ?: run {
+            // Form not loaded yet — fetch it then bail out; user re-clicks once ready.
+            loadReplyFormIfPossible()
+            return
+        }
+        if (form.isAnonymous) {
+            _state.update { it.copy(submitError = SubmitError.Hfr(ReplyFailureReason.LoginRequired)) }
+            return
+        }
+        if (submitJob?.isActive == true) return
+
+        _state.update { it.copy(isSubmitting = true, submitError = null) }
+        submitJob = viewModelScope.launch {
+            val outcome = runCatching {
+                replyRepository.submitReply(
+                    context = context,
+                    form = form,
+                    bbcodeContent = snapshot.draft.text,
+                )
+            }
+            outcome.fold(
+                onSuccess = ::handleSubmitOutcome,
+                onFailure = ::handleSubmitFailure,
+            )
+        }
+    }
+
+    private fun handleSubmitOutcome(result: ReplySubmitResult) {
+        when (result) {
+            is ReplySubmitResult.Success -> {
+                _effects.trySend(PostEditorEffect.SubmitSucceeded(targetPage = result.targetPage))
+                _state.update { it.copy(isSubmitting = false, submitError = null) }
+            }
+            is ReplySubmitResult.Failure -> {
+                // InvalidHashCheck typically means the cached form has expired ;
+                // refetch silently and let the user re-submit.
+                if (result.reason == ReplyFailureReason.InvalidHashCheck) {
+                    loadedForm = null
+                    loadReplyFormIfPossible()
+                }
+                _state.update {
+                    it.copy(isSubmitting = false, submitError = SubmitError.Hfr(result.reason))
+                }
+            }
+        }
+    }
+
+    private fun handleSubmitFailure(error: Throwable) {
+        if (error is CancellationException) {
+            _state.update { it.copy(isSubmitting = false) }
+            throw error
+        }
+        val mapped = when (error) {
+            is SessionExpiredException -> SubmitError.SessionExpired
+            is IOException -> SubmitError.Network
+            else -> throw error
+        }
+        _state.update { it.copy(isSubmitting = false, submitError = mapped) }
+    }
+
+    @Suppress("ReturnCount") // Each guard returns null with a distinct reason
+    private fun buildReplyContext(): ReplyContext? {
+        val snapshot = state.value
+        val page = snapshot.page ?: return null
+        val subcat = snapshot.subcat ?: return null
+        val topicId = snapshot.topicId ?: return null
+        if (subcat < 0) return null
+        return ReplyContext(cat = snapshot.cat, subcat = subcat, topicId = topicId, page = page)
     }
 
     @AssistedFactory

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -9,6 +9,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
 import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
 import fr.forumhfr.redface2.core.domain.write.ReplyRepository
 import fr.forumhfr.redface2.core.model.write.ReplyContext
@@ -49,6 +50,7 @@ class PostEditorViewModel @AssistedInject constructor(
     @Assisted private val request: PostEditorRequest,
     private val previewParser: BbcodePreviewParser,
     private val replyRepository: ReplyRepository,
+    private val diagnostics: DiagnosticsLog,
 ) : ViewModel() {
 
     private val _state: MutableStateFlow<PostEditorState> = MutableStateFlow(
@@ -171,6 +173,12 @@ class PostEditorViewModel @AssistedInject constructor(
             is IOException -> SubmitError.Network
             else -> SubmitError.Hfr(ReplyFailureReason.Unknown)
         }
+        diagnostics.record(
+            DiagnosticsLog.Level.WARN,
+            LOG_TAG_VM,
+            "fetch bubbled: ${error::class.simpleName}: ${error.message ?: "(no message)"} " +
+                "→ ${mapped::class.simpleName}",
+        )
         _state.update { it.copy(isLoadingForm = false, submitError = mapped) }
     }
 
@@ -239,6 +247,12 @@ class PostEditorViewModel @AssistedInject constructor(
             is IOException -> SubmitError.Network
             else -> SubmitError.Hfr(ReplyFailureReason.Unknown)
         }
+        diagnostics.record(
+            DiagnosticsLog.Level.WARN,
+            LOG_TAG_VM,
+            "submit bubbled: ${error::class.simpleName}: ${error.message ?: "(no message)"} " +
+                "→ ${mapped::class.simpleName}",
+        )
         _state.update { it.copy(isSubmitting = false, submitError = mapped) }
     }
 
@@ -257,5 +271,11 @@ class PostEditorViewModel @AssistedInject constructor(
     @AssistedFactory
     interface Factory {
         fun create(request: PostEditorRequest): PostEditorViewModel
+    }
+
+    private companion object {
+        // Distinct from the repository's "ReplyRepository" tag so the diagnostics
+        // panel makes it obvious which layer recorded an entry.
+        private const val LOG_TAG_VM = "PostEditorVM"
     }
 }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -164,7 +164,13 @@ class PostEditorViewModel @AssistedInject constructor(
     }
 
     private fun handleFetchFailure(error: Throwable) {
-        if (error is CancellationException) throw error
+        if (error is CancellationException) {
+            // Symmetry with `handleSubmitFailure` : reset the in-flight flag before the throw so
+            // a parent ViewModel that survives the cancellation (or any state observer reading
+            // the snapshot before death) does not see `isLoadingForm = true` forever.
+            _state.update { it.copy(isLoadingForm = false) }
+            throw error
+        }
         // Map known transport-level failures to a typed SubmitError ; classify the
         // rest as Unknown rather than letting the exception bubble up and crash the
         // process. The UI surfaces the same "unexpected response" message either way.

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -163,10 +163,13 @@ class PostEditorViewModel @AssistedInject constructor(
 
     private fun handleFetchFailure(error: Throwable) {
         if (error is CancellationException) throw error
+        // Map known transport-level failures to a typed SubmitError ; classify the
+        // rest as Unknown rather than letting the exception bubble up and crash the
+        // process. The UI surfaces the same "unexpected response" message either way.
         val mapped = when (error) {
             is SessionExpiredException -> SubmitError.SessionExpired
             is IOException -> SubmitError.Network
-            else -> throw error
+            else -> SubmitError.Hfr(ReplyFailureReason.Unknown)
         }
         _state.update { it.copy(isLoadingForm = false, submitError = mapped) }
     }
@@ -234,7 +237,7 @@ class PostEditorViewModel @AssistedInject constructor(
         val mapped = when (error) {
             is SessionExpiredException -> SubmitError.SessionExpired
             is IOException -> SubmitError.Network
-            else -> throw error
+            else -> SubmitError.Hfr(ReplyFailureReason.Unknown)
         }
         _state.update { it.copy(isSubmitting = false, submitError = mapped) }
     }

--- a/feature/editor/src/main/res/values/strings.xml
+++ b/feature/editor/src/main/res/values/strings.xml
@@ -7,7 +7,18 @@
     <string name="editor_field_placeholder">Saisissez votre message…</string>
     <string name="editor_preview_show">Afficher l\'aperçu</string>
     <string name="editor_preview_hide">Masquer l\'aperçu</string>
-    <string name="editor_submit_disabled">L\'envoi HFR arrive en Phase 2C — éditeur local seulement pour l\'instant.</string>
+    <string name="editor_submit">Envoyer</string>
+    <string name="editor_submit_disabled">L\'envoi HFR arrive avec les autres modes — éditeur local seulement pour l\'instant.</string>
     <string name="editor_validation_empty">Message vide</string>
     <string name="editor_topic_form_placeholder">Le formulaire de création / édition de sujet arrive en Phase 2D-2E (#148, #149). Cette tranche 2B-A ne livre que l\'éditeur post-level.</string>
+    <string name="editor_error_dismiss">Masquer</string>
+    <string name="editor_error_empty">Message vide. HFR refuse les réponses sans contenu.</string>
+    <string name="editor_error_invalid_hash">Session HFR expirée pendant la saisie. Réessayez ; le formulaire est rechargé en arrière-plan.</string>
+    <string name="editor_error_anti_flood">Anti-flood HFR : pas plus de 3 réponses consécutives par tranche de 10 minutes. Réessayez plus tard.</string>
+    <string name="editor_error_topic_locked">Ce sujet a été fermé. Impossible de poster une réponse.</string>
+    <string name="editor_error_login_required">Vous devez être connecté pour répondre. Reconnectez-vous depuis l\'onglet Messages.</string>
+    <string name="editor_error_unknown">HFR a renvoyé une réponse inattendue. Réessayez ou actualisez l\'app.</string>
+    <string name="editor_error_network">Erreur réseau. Vérifiez votre connexion et réessayez.</string>
+    <string name="editor_error_session_expired">Votre session HFR a expiré. Reconnectez-vous.</string>
+    <string name="editor_error_missing_subcat">La page de sujet en cache ne contient pas la sous-catégorie HFR. Actualisez le sujet avant de répondre.</string>
 </resources>

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -310,6 +310,7 @@ class PostEditorViewModelTest {
             ),
             previewParser = previewParser,
             replyRepository = replyRepository,
+            diagnostics = fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog(),
         )
 
     private fun authenticatedForm(): ReplyForm = ReplyForm(

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -223,18 +223,7 @@ class PostEditorViewModelTest {
 
     @Test
     fun `submit refuses when subcat is null and surfaces MissingSubcat`() = runTest {
-        val viewModel = PostEditorViewModel(
-            request = PostEditorRequest(
-                mode = PostEditorMode.Reply,
-                cat = SAMPLE_CAT,
-                topicId = SAMPLE_TOPIC_ID,
-                numreponse = null,
-                page = SAMPLE_PAGE,
-                subcat = null, // sentinel reached
-            ),
-            previewParser = previewParser,
-            replyRepository = replyRepository,
-        )
+        val viewModel = newReplyViewModel(subcat = null)
         viewModel.state.test {
             val settled = expectMostRecentItem()
             assertEquals(SubmitError.MissingSubcat, settled.submitError)
@@ -244,18 +233,84 @@ class PostEditorViewModelTest {
         assertEquals(0, replyRepository.formFetches)
     }
 
-    private fun newReplyViewModel(): PostEditorViewModel = PostEditorViewModel(
-        request = PostEditorRequest(
-            mode = PostEditorMode.Reply,
-            cat = SAMPLE_CAT,
-            topicId = SAMPLE_TOPIC_ID,
-            numreponse = null,
-            page = SAMPLE_PAGE,
-            subcat = SAMPLE_SUBCAT,
-        ),
-        previewParser = previewParser,
-        replyRepository = replyRepository,
-    )
+    @Test
+    fun `submit refuses when subcat is the SUBCAT_UNKNOWN sentinel`() = runTest {
+        // Distinct from `subcat = null` : a v3-cache row carries the -1 sentinel,
+        // which is non-null but must be treated as "unknown, refresh required".
+        val viewModel = newReplyViewModel(subcat = -1)
+        viewModel.state.test {
+            val settled = expectMostRecentItem()
+            assertEquals(SubmitError.MissingSubcat, settled.submitError)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(0, replyRepository.formFetches)
+    }
+
+    @Test
+    fun `submit refuses when subcat is zero (HFR moderator-space wire shape)`() = runTest {
+        // 0 is HFR's wire shape for the moderator-only space (cf. cat=0 family).
+        // No fixture exercises subcat=0 on a user topic, so write flows refuse it
+        // to avoid sending a malformed POST.
+        val viewModel = newReplyViewModel(subcat = 0)
+        viewModel.state.test {
+            val settled = expectMostRecentItem()
+            assertEquals(SubmitError.MissingSubcat, settled.submitError)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(0, replyRepository.formFetches)
+    }
+
+    @Test
+    fun `init form fetch surfaces SessionExpired when HFR redirects to login`() = runTest {
+        replyRepository.formException = fr.forumhfr.redface2.core.domain.auth.SessionExpiredException(
+            "https://forum.hardware.fr/login.php",
+        )
+        val viewModel = newReplyViewModel()
+        viewModel.state.test {
+            val settled = expectMostRecentItem()
+            assertFalse(settled.isLoadingForm)
+            assertEquals(SubmitError.SessionExpired, settled.submitError)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `init form fetch surfaces Network error on IOException`() = runTest {
+        replyRepository.formException = java.io.IOException("disconnected")
+        val viewModel = newReplyViewModel()
+        viewModel.state.test {
+            val settled = expectMostRecentItem()
+            assertFalse(settled.isLoadingForm)
+            assertEquals(SubmitError.Network, settled.submitError)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `init form fetch maps unexpected exceptions to Hfr(Unknown) instead of crashing`() = runTest {
+        replyRepository.formException = IllegalStateException("HFR returned a 500 page we don't know")
+        val viewModel = newReplyViewModel()
+        viewModel.state.test {
+            val settled = expectMostRecentItem()
+            assertFalse(settled.isLoadingForm)
+            assertEquals(SubmitError.Hfr(ReplyFailureReason.Unknown), settled.submitError)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private fun newReplyViewModel(subcat: Int? = SAMPLE_SUBCAT): PostEditorViewModel =
+        PostEditorViewModel(
+            request = PostEditorRequest(
+                mode = PostEditorMode.Reply,
+                cat = SAMPLE_CAT,
+                topicId = SAMPLE_TOPIC_ID,
+                numreponse = null,
+                page = SAMPLE_PAGE,
+                subcat = subcat,
+            ),
+            previewParser = previewParser,
+            replyRepository = replyRepository,
+        )
 
     private fun authenticatedForm(): ReplyForm = ReplyForm(
         hashCheck = "FAKE_HASH",
@@ -297,6 +352,7 @@ class PostEditorViewModelTest {
         var submitResult: ReplySubmitResult? = null
         var submitException: Throwable? = null
         var submitGate: CompletableDeferred<Unit>? = null
+        var formException: Throwable? = null
 
         var formFetches: Int = 0
             private set
@@ -305,6 +361,7 @@ class PostEditorViewModelTest {
 
         override suspend fun fetchReplyForm(context: ReplyContext): ReplyForm {
             formFetches += 1
+            formException?.let { throw it }
             return formResult.getOrThrow()
         }
 

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -5,10 +5,17 @@ import androidx.compose.ui.text.input.TextFieldValue
 import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
 import fr.forumhfr.redface2.core.domain.editor.BbcodeValidation
+import fr.forumhfr.redface2.core.domain.write.ReplyRepository
 import fr.forumhfr.redface2.core.model.PostBlock
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.PostInline
+import fr.forumhfr.redface2.core.model.write.ReplyContext
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
+import fr.forumhfr.redface2.core.model.write.ReplyForm
+import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
 import fr.forumhfr.redface2.core.ui.editor.BbcodeAction
+import java.io.IOException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -18,6 +25,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -26,6 +34,7 @@ import org.junit.Test
 class PostEditorViewModelTest {
 
     private val previewParser = FakePreviewParser()
+    private val replyRepository = FakeReplyRepository()
 
     @Before
     fun setUp() {
@@ -39,18 +48,17 @@ class PostEditorViewModelTest {
 
     @Test
     fun `initial state mirrors the request and starts with an empty draft`() = runTest {
-        val viewModel = newViewModel()
+        val viewModel = newReplyViewModel()
         viewModel.state.test {
             val initial = awaitItem()
             assertEquals(PostEditorMode.Reply, initial.mode)
-            assertEquals(23, initial.cat)
-            assertEquals(35395, initial.topicId)
+            assertEquals(SAMPLE_CAT, initial.cat)
+            assertEquals(SAMPLE_TOPIC_ID, initial.topicId)
+            assertEquals(SAMPLE_PAGE, initial.page)
+            assertEquals(SAMPLE_SUBCAT, initial.subcat)
             assertEquals("", initial.draft.text)
             assertFalse(initial.isPreviewVisible)
             assertEquals(PostContent(blocks = emptyList()), initial.preview)
-            // Initial state: the user has not typed anything yet, so we stay Idle rather
-            // than flagging an empty draft. The transition to EmptyDraft happens only
-            // after a real ContentChanged intent leaves the draft blank.
             assertEquals(BbcodeValidation.Idle, initial.validation)
             cancelAndIgnoreRemainingEvents()
         }
@@ -58,34 +66,24 @@ class PostEditorViewModelTest {
 
     @Test
     fun `content changes update the draft and clear the empty-validation hint`() = runTest {
-        val viewModel = newViewModel()
-        viewModel.submit(
-            PostEditorIntent.ContentChanged(
-                TextFieldValue(text = "hello", selection = TextRange(5)),
-            ),
-        )
+        val viewModel = newReplyViewModel()
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("hello", TextRange(5))))
         viewModel.state.test {
             val state = awaitItem()
             assertEquals("hello", state.draft.text)
             assertEquals(BbcodeValidation.Idle, state.validation)
-            assertTrue(state.isSubmitEnabled)
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
     fun `toolbar action wraps the current selection`() = runTest {
-        val viewModel = newViewModel()
-        viewModel.submit(
-            PostEditorIntent.ContentChanged(
-                TextFieldValue(text = "hello", selection = TextRange(0, 5)),
-            ),
-        )
+        val viewModel = newReplyViewModel()
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("hello", TextRange(0, 5))))
         viewModel.submit(PostEditorIntent.ToolbarActionClicked(BbcodeAction.Bold))
         viewModel.state.test {
             val state = awaitItem()
             assertEquals("[b]hello[/b]", state.draft.text)
-            // Selection should still wrap the inserted content.
             assertEquals(3, state.draft.selection.start)
             assertEquals(8, state.draft.selection.end)
             cancelAndIgnoreRemainingEvents()
@@ -94,64 +92,183 @@ class PostEditorViewModelTest {
 
     @Test
     fun `toggling preview parses the current draft and shows it`() = runTest {
-        val viewModel = newViewModel()
-        viewModel.submit(
-            PostEditorIntent.ContentChanged(
-                TextFieldValue(text = "[b]hi[/b]", selection = TextRange(9)),
-            ),
-        )
+        val viewModel = newReplyViewModel()
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("[b]hi[/b]", TextRange(9))))
         viewModel.submit(PostEditorIntent.TogglePreview)
         viewModel.state.test {
             val state = awaitItem()
             assertTrue(state.isPreviewVisible)
-            // FakePreviewParser returns a deterministic content keyed on the input text.
             assertEquals(previewParser.contentFor("[b]hi[/b]"), state.preview)
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `subsequent content edits re-parse the preview while it stays visible`() = runTest {
-        val viewModel = newViewModel()
-        viewModel.submit(PostEditorIntent.TogglePreview)
-        viewModel.submit(
-            PostEditorIntent.ContentChanged(
-                TextFieldValue(text = "first", selection = TextRange(5)),
-            ),
-        )
-        viewModel.submit(
-            PostEditorIntent.ContentChanged(
-                TextFieldValue(text = "second", selection = TextRange(6)),
-            ),
-        )
+    fun `preview hidden mode does not re-parse on every keystroke`() = runTest {
+        val viewModel = newReplyViewModel()
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("hello", TextRange(5))))
+        assertEquals(0, previewParser.callCount)
+    }
+
+    @Test
+    fun `reply VM fetches the form on init and clears the loading flag`() = runTest {
+        replyRepository.formResult = Result.success(authenticatedForm())
+        val viewModel = newReplyViewModel()
         viewModel.state.test {
-            val state = awaitItem()
-            assertTrue(state.isPreviewVisible)
-            assertEquals(previewParser.contentFor("second"), state.preview)
+            // Skip the transient `isLoadingForm = true` state if any, settle on final.
+            val settled = expectMostRecentItem()
+            assertFalse(settled.isLoadingForm)
+            assertNull(settled.submitError)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(1, replyRepository.formFetches)
+    }
+
+    @Test
+    fun `reply VM surfaces login required when form is anonymous`() = runTest {
+        replyRepository.formResult = Result.success(anonymousForm())
+        val viewModel = newReplyViewModel()
+        viewModel.state.test {
+            val settled = expectMostRecentItem()
+            assertEquals(
+                SubmitError.Hfr(ReplyFailureReason.LoginRequired),
+                settled.submitError,
+            )
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `preview hidden mode does not re-parse on every keystroke`() = runTest {
-        val viewModel = newViewModel()
-        viewModel.submit(
-            PostEditorIntent.ContentChanged(
-                TextFieldValue(text = "hello", selection = TextRange(5)),
-            ),
-        )
-        // Preview is hidden — parser must not be hit.
-        assertEquals(0, previewParser.callCount)
+    fun `submit blank content does not POST`() = runTest {
+        replyRepository.formResult = Result.success(authenticatedForm())
+        val viewModel = newReplyViewModel()
+        viewModel.submit(PostEditorIntent.SubmitClicked)
+        assertEquals(0, replyRepository.submitCalls)
     }
 
-    private fun newViewModel(): PostEditorViewModel = PostEditorViewModel(
+    @Test
+    fun `submit happy path emits SubmitSucceeded with targetPage`() = runTest {
+        replyRepository.formResult = Result.success(authenticatedForm())
+        replyRepository.submitResult = ReplySubmitResult.Success(
+            refreshUrl = "/hfr/.../sujet_X_20.htm#bas",
+            targetPage = 20,
+        )
+        val viewModel = newReplyViewModel()
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("Hello!", TextRange(6))))
+        viewModel.effects.test {
+            viewModel.submit(PostEditorIntent.SubmitClicked)
+            val effect = awaitItem()
+            assertEquals(PostEditorEffect.SubmitSucceeded(targetPage = 20), effect)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(1, replyRepository.submitCalls)
+    }
+
+    @Test
+    fun `submit anti-flood preserves the draft and exposes the error`() = runTest {
+        replyRepository.formResult = Result.success(authenticatedForm())
+        replyRepository.submitResult = ReplySubmitResult.Failure(ReplyFailureReason.AntiFlood)
+        val viewModel = newReplyViewModel()
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("Hello!", TextRange(6))))
+        viewModel.submit(PostEditorIntent.SubmitClicked)
+        viewModel.state.test {
+            val settled = expectMostRecentItem()
+            assertFalse(settled.isSubmitting)
+            assertEquals(
+                SubmitError.Hfr(ReplyFailureReason.AntiFlood),
+                settled.submitError,
+            )
+            // Draft survives.
+            assertEquals("Hello!", settled.draft.text)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `submit network error keeps the draft and surfaces Network error`() = runTest {
+        replyRepository.formResult = Result.success(authenticatedForm())
+        replyRepository.submitException = IOException("disconnected")
+        val viewModel = newReplyViewModel()
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("Hello!", TextRange(6))))
+        viewModel.submit(PostEditorIntent.SubmitClicked)
+        viewModel.state.test {
+            val settled = expectMostRecentItem()
+            assertFalse(settled.isSubmitting)
+            assertEquals(SubmitError.Network, settled.submitError)
+            assertEquals("Hello!", settled.draft.text)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `double submit only triggers one POST when the first call is still in flight`() = runTest {
+        replyRepository.formResult = Result.success(authenticatedForm())
+        // Hold the first submit pending until the test releases it. This is the only
+        // realistic shape of "double submit": with UnconfinedTestDispatcher every
+        // launch completes synchronously, so without a suspension point the second
+        // click would observe submitJob as already-done and re-fire.
+        val gate = CompletableDeferred<Unit>()
+        replyRepository.submitGate = gate
+        replyRepository.submitResult = ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
+
+        val viewModel = newReplyViewModel()
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("Hello!", TextRange(6))))
+
+        viewModel.submit(PostEditorIntent.SubmitClicked) // launches the first submit; suspends on gate
+        viewModel.submit(PostEditorIntent.SubmitClicked) // must be a no-op (job already active)
+
+        gate.complete(Unit)
+        assertEquals(1, replyRepository.submitCalls)
+    }
+
+    @Test
+    fun `submit refuses when subcat is null and surfaces MissingSubcat`() = runTest {
+        val viewModel = PostEditorViewModel(
+            request = PostEditorRequest(
+                mode = PostEditorMode.Reply,
+                cat = SAMPLE_CAT,
+                topicId = SAMPLE_TOPIC_ID,
+                numreponse = null,
+                page = SAMPLE_PAGE,
+                subcat = null, // sentinel reached
+            ),
+            previewParser = previewParser,
+            replyRepository = replyRepository,
+        )
+        viewModel.state.test {
+            val settled = expectMostRecentItem()
+            assertEquals(SubmitError.MissingSubcat, settled.submitError)
+            cancelAndIgnoreRemainingEvents()
+        }
+        // No fetch attempted because we never had a valid ReplyContext.
+        assertEquals(0, replyRepository.formFetches)
+    }
+
+    private fun newReplyViewModel(): PostEditorViewModel = PostEditorViewModel(
         request = PostEditorRequest(
             mode = PostEditorMode.Reply,
-            cat = 23,
-            topicId = 35395,
+            cat = SAMPLE_CAT,
+            topicId = SAMPLE_TOPIC_ID,
             numreponse = null,
+            page = SAMPLE_PAGE,
+            subcat = SAMPLE_SUBCAT,
         ),
         previewParser = previewParser,
+        replyRepository = replyRepository,
+    )
+
+    private fun authenticatedForm(): ReplyForm = ReplyForm(
+        hashCheck = "FAKE_HASH",
+        sujet = "Fake Topic",
+        hiddenFields = mapOf("cat" to "23", "subcat" to "550", "post" to "35395", "page" to "20"),
+        isAnonymous = false,
+    )
+
+    private fun anonymousForm(): ReplyForm = ReplyForm(
+        hashCheck = "FAKE_HASH",
+        sujet = "Fake Topic",
+        hiddenFields = mapOf("cat" to "23", "subcat" to "550", "post" to "35395", "page" to "20"),
+        isAnonymous = true,
     )
 
     private class FakePreviewParser : BbcodePreviewParser {
@@ -163,9 +280,50 @@ class PostEditorViewModelTest {
             return contentFor(bbcode)
         }
 
-        /** Deterministic content keyed on the input for assertion convenience. */
         fun contentFor(bbcode: String): PostContent = PostContent(
             blocks = listOf(PostBlock.Paragraph(listOf(PostInline.Text(bbcode)))),
         )
+    }
+
+    private class FakeReplyRepository : ReplyRepository {
+        var formResult: Result<ReplyForm> = Result.success(
+            ReplyForm(
+                hashCheck = "FAKE_HASH",
+                sujet = "Fake Topic",
+                hiddenFields = mapOf("cat" to "23", "subcat" to "550", "post" to "35395", "page" to "20"),
+                isAnonymous = false,
+            ),
+        )
+        var submitResult: ReplySubmitResult? = null
+        var submitException: Throwable? = null
+        var submitGate: CompletableDeferred<Unit>? = null
+
+        var formFetches: Int = 0
+            private set
+        var submitCalls: Int = 0
+            private set
+
+        override suspend fun fetchReplyForm(context: ReplyContext): ReplyForm {
+            formFetches += 1
+            return formResult.getOrThrow()
+        }
+
+        override suspend fun submitReply(
+            context: ReplyContext,
+            form: ReplyForm,
+            bbcodeContent: String,
+        ): ReplySubmitResult {
+            submitCalls += 1
+            submitGate?.await()
+            submitException?.let { throw it }
+            return submitResult ?: error("submitResult not set")
+        }
+    }
+
+    private companion object {
+        const val SAMPLE_CAT = 23
+        const val SAMPLE_TOPIC_ID = 35_395
+        const val SAMPLE_PAGE = 20
+        const val SAMPLE_SUBCAT = 550
     }
 }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -56,7 +56,14 @@ import kotlinx.coroutines.flow.first
 @Composable
 fun TopicScreen(
     request: TopicRequest,
-    onReply: (Int) -> Unit,
+    /**
+     * Open the reply editor for this topic. The lambda receives the topic's
+     * sub-category id (parsed from the loaded page) and the current page number ;
+     * cat and topicId are derived from [request]. Phase 2C-A only invokes this
+     * callback when the topic carries a valid `subcat` (otherwise the reply button
+     * stays disabled to avoid passing a sentinel value to the HFR write contract).
+     */
+    onReply: (subcat: Int, page: Int) -> Unit,
     onOpenPage: (Int) -> Unit,
 ) {
     val viewModel = hiltViewModel<TopicViewModel, TopicViewModel.Factory>(
@@ -97,7 +104,7 @@ fun TopicScreen(
         state = state,
         listState = lazyListState,
         onIntent = viewModel::send,
-        onReply = { onReply(request.post) },
+        onReply = onReply,
         onOpenPage = onOpenPage,
     )
 }
@@ -107,7 +114,7 @@ internal fun TopicContent(
     state: TopicUiState,
     listState: LazyListState,
     onIntent: (TopicIntent) -> Unit,
-    onReply: () -> Unit,
+    onReply: (subcat: Int, page: Int) -> Unit,
     onOpenPage: (Int) -> Unit,
 ) {
     Surface(
@@ -167,7 +174,7 @@ internal fun TopicContent(
 private fun TopicLoadedContent(
     state: TopicUiState,
     topic: Topic,
-    onReply: () -> Unit,
+    onReply: (subcat: Int, page: Int) -> Unit,
     onOpenPage: (Int) -> Unit,
     listState: LazyListState,
 ) {
@@ -205,7 +212,7 @@ private fun TopicLoadedContent(
 private fun TopicHeaderCard(
     topic: Topic,
     state: TopicUiState,
-    onReply: () -> Unit,
+    onReply: (subcat: Int, page: Int) -> Unit,
     onOpenPage: (Int) -> Unit,
 ) {
     Card {
@@ -247,7 +254,13 @@ private fun TopicHeaderCard(
             topic.poll?.let { poll ->
                 TopicPollCard(poll)
             }
-            Button(onClick = onReply) {
+            Button(
+                onClick = { onReply(topic.subcat, topic.page) },
+                // Topic pages cached before Phase 2C have `subcat = SUBCAT_UNKNOWN`. We
+                // refuse to open the editor in that state — the next live refresh of
+                // the topic will populate a real subcat and the button comes back.
+                enabled = topic.hasSubcat,
+            ) {
                 Text(text = stringResource(R.string.topic_reply))
             }
         }

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -323,6 +323,7 @@ class TopicViewModelTest {
     ): Topic = Topic(
         cat = SAMPLE_CAT,
         post = SAMPLE_POST,
+        subcat = SAMPLE_SUBCAT,
         title = title,
         posts = posts,
         page = page,
@@ -352,6 +353,7 @@ class TopicViewModelTest {
     companion object {
         private const val SAMPLE_CAT = 13
         private const val SAMPLE_POST = 84_540
+        private const val SAMPLE_SUBCAT = 432
         private const val CANCEL_TIMEOUT_MS = 2_000L
     }
 }


### PR DESCRIPTION
> Action par Claude Opus 4.7 (demandée par @XaaT)

## Summary

Phase 2C — Reply MVP. Closes #145.

Première mutation HFR réelle livrée. Depuis un `TopicScreen`, le bouton « Répondre » ouvre l'éditeur en mode Reply, l'utilisateur tape du BBCode, le ViewModel pré-fetch `message.php` pour récupérer le `hash_check`, puis sur Submit POST `bddpost.php?config=hfr.inc` avec les fields HFR observés (`verifrequet=1100`, `content_form`, `cat`, `subcat`, `post`, `page`, `numreponse=""`, `numrep=""`, etc.). Erreurs HFR classifiées et préservation de la draft sur erreur. Anti-double-submit.

## Architecture

- **`:core:model/write/`** — `ReplyContext`, `ReplyForm`, `ReplySubmitResult`, `ReplyFailureReason`. Pure data, accessible aux parsers et au repository.
- **`:core:domain/write/`** — `ReplyRepository` interface. Seul accès depuis `:feature:editor` (frontière Konsist préservée).
- **`:core:parser/write/`** — `ReplyFormParser` (extrait hash_check + hidden fields, filtre `password` et `pseudo` anonyme), `ReplySubmitResponseParser` (classifie les 5 retours observés, gère le payload `invalid_token` text/plain spécifique).
- **`:core:network/HfrClient`** — `getReplyForm()` GET `message.php` avec URL HFR exacte, `submitReply()` POST `bddpost.php` via `FormBody`. `hash_check` **jamais loggué**.
- **`:core:data/write/DefaultReplyRepository`** — orchestre GET form → POST. Defense-in-depth: refuse anonymous form, hash_check vide, body blank sans réseau.
- **`:feature:editor`** — `PostEditorViewModel` injecte `ReplyRepository` (interface), fetch form au init, submit sur intent, anti-double-submit via `submitJob.isActive`, draft préservée sur erreur. UI: bouton Submit + spinner + bannière d'erreur dismissable.

## Topic subcat plumbing

Le contrat HFR exige `subcat` dans l'URL `message.php`. Ajouté :

- `Topic.subcat: Int` + `Topic.hasSubcat` (sentinel `SUBCAT_UNKNOWN = -1` pour les rows pré-migration).
- `HfrSelectors.SUBCATEGORY_ID_INPUT` + extraction `TopicPageParser`.
- `TopicEntity.subcat` + migration Room v3→v4 (`ALTER TABLE topic_pages ADD COLUMN subcat INTEGER NOT NULL DEFAULT -1`).
- Le bouton Reply est **désactivé** si `topic.hasSubcat == false`. La valeur `-1` n'est **jamais** envoyée à HFR.
- Aucun `subcat = 0` magique nulle part.

## Navigation post-submit

`PostEditorScreen.onSubmitSucceeded(targetPage)` →
- pop `PostEditorRoute` du back stack ;
- remplace l'entrée `TopicRoute` par `topicEntry.copy(page = targetPage ?: topicEntry.page)` ;
- `TopicViewModel` re-fetch la page cible.

Pas de scroll vers le nouveau `numreponse` — HFR ne le surface pas dans la réponse, juste `#bas`. Documenté.

## Erreurs HFR couvertes

| Fixture | Classification |
|---|---|
| `write_reply_success_response.html` | `Success(refreshUrl, targetPage)` |
| `write_empty_message_error.html` | `Failure(EmptyMessage)` |
| `write_invalid_token_error.html` | `Failure(InvalidHashCheck)` — re-fetch silencieux du form |
| `write_antiflood_error.html` | `Failure(AntiFlood)` |
| `write_locked_topic_error.html` | `Failure(TopicLocked)` |
| `write_reply_anonymous_form.html` (au GET) | `Failure(LoginRequired)`, pas de POST |

Plus errors transport : `SessionExpiredException` → `SubmitError.SessionExpired`, `IOException` → `SubmitError.Network`.

## Tests exécutés (container `cirruslabs/android-sdk:36`)

- `:core:parser:test` — `ReplyFormParserTest` (5 cas) + `ReplySubmitResponseParserTest` (6 cas) verts.
- `:core:data:testDebugUnitTest` — `DefaultReplyRepositoryTest` MockWebServer (8 cas dont contract GET URL, contract POST body field-by-field, 4 error variants, anonymous refusal sans réseau, body blank refusal sans réseau).
- `:feature:editor:testDebugUnitTest` — `PostEditorViewModelTest` (13 cas dont submit happy path, anti-flood preserve draft, network error preserve draft, double-submit gate avec `CompletableDeferred` pour bloquer le 1er call, MissingSubcat refusal).
- `:feature:topic:testDebugUnitTest` — `fakeTopic` carry `subcat`.
- `:app:testDebugUnitTest` — `DocsConsistencyTest` + `ArchitectureKonsistTest` inchangés (la frontière `:feature:editor ↛ :core:parser` tient : le nouveau parser est consommé via `ReplyRepository` dans `:core:domain`).
- `detektAll` + `lintDebug` verts.

**Pas de POST live HFR en CI.** Le tag `app-v40` produit un AAB qu'on teste manuellement sur le track alpha.

## Hors scope (#146, #147, #148, #149, #11)

- Quote préremplie (#146)
- Edit post (#147)
- Edit FP (#148)
- Create topic (#149)
- Aperçu serveur `apercu.php`
- Brouillons Room persistants
- Smiley picker / color picker / listes avancées

## Auto-review (checklist du prompt)

- [x] Aucun `subcat=0` magique
- [x] Aucun POST sans `hash_check`
- [x] Aucun log du `hash_check`
- [x] Aucun stockage / préremplissage password
- [x] Aucun chemin quote/edit/create topic ajouté
- [x] Aucune dépendance directe `:feature:editor → :core:parser` ou `:core:network`
- [x] Toutes les erreurs HFR observées ont un test
- [x] La draft est préservée sur erreur réseau/HFR
- [x] Anti-double-submit testé avec `CompletableDeferred`
- [x] Navigation post-submit honnête (pas de scroll vers `numreponse` inconnu)
- [x] `docs/specs/*` n'a pas de claim non testé

🤖 Generated with [Claude Code](https://claude.com/claude-code)
