### PR TITLE
chore(release): bump app to v48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ Format inspiré de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/). Les
 
 ## [Unreleased]
 
-Follow-up Codex review de #165 (Phase 2D-B Edit FP) — trois risques résiduels durcis, pas de bump version ni de release.
+(rien pour le moment)
+
+---
+
+## v0.10.8 — 2026-05-21
+
+App patch 0.3.8 (build v48) — follow-up Codex review de #165 (Phase 2D-B Edit FP) : trois risques résiduels durcis avant de poursuivre Phase 2E. Pas de nouvelle feature utilisateur ; build alpha de stabilisation.
 
 ### Changed
 - `TopicFormViewModel` hydrate désormais `subject` et `draft` indépendamment via `subjectHydratedFromServer` + `draftHydratedFromServer` (au lieu d'un unique `formHydratedFromServer` all-or-nothing). Sur un fetch lent, modifier un seul des deux champs avant la réponse n'empêche plus l'autre d'être hydraté depuis le form HFR. Anti-clobber `InvalidHashCheck` toujours préservé.
@@ -19,8 +25,6 @@ Follow-up Codex review de #165 (Phase 2D-B Edit FP) — trois risques résiduels
 - `TopicFormViewModelTest` : trois cas ajoutés via `formGate` — saisie sujet pré-fetch, saisie draft pré-fetch, et refetch silencieux après `InvalidHashCheck` qui ne clobber ni le sujet ni le draft.
 - `TopicFormParserTest` : pin l'absence des noms poll dans `hiddenFields` sur la fixture sans sondage ; deux cas synthétiques pour le subcat fail-safe (aucune option `selected`, « Aucune » sélectionnée) ; un cas synthétique pour le passthrough poll actif via `TopicPollForm.fields`.
 - `DefaultTopicFormRepositoryTest` : pin l'absence de tout champ poll sur le wire quand `have_sondage` est unchecked ; nouveau cas synthétique qui prouve qu'un sondage actif est forwardé exactement une fois (pas zéro, pas deux).
-
----
 
 ---
 
@@ -50,8 +54,6 @@ App patch 0.3.7 (build v47) — Phase 2D-B : édition du premier post d'un topic
 - `DefaultTopicFormRepositoryTest` : GET URL contient `numreponse`, POST sur `bdd.php` avec `sujet`/`subcat`/`content_form`/`numreponse`/`numrep=""`, `delete`/`password` jamais transmis, poll fields préservés.
 - `TopicPageParserTest` : `isFirstPostOwner = true` sur synthétique page=1 + premier post editable ; `false` sur page=2 même avec edit link.
 - `TopicFormViewModelTest` : init hydrate sujet + draft + options ; refetch silencieux ne clobber pas saisie utilisateur ; submit appelle repository avec valeurs courantes ; success émet `SubmitSucceeded(targetPage, scrollTo = numreponse)`.
-
----
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         // track (alpha) and in the GitHub Release flag, not in versionName itself.
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
-        versionCode = 47
-        versionName = "0.3.7"
+        versionCode = 48
+        versionName = "0.3.8"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,9 +1,8 @@
-Alpha build Redface 2 — pre-Phase 2 polish.
+Redface 2 alpha build — first-post edit hardening.
 
 Changes:
-- Flags tab is now focused on reading.
-- Read participated topics are hidden by default, with a toggle to show them again.
-- Search and Messages tabs now explain the upcoming features instead of showing fake demo actions.
-- Diagnostics, reporting and account details moved to Messages.
+- First-post editing hardened after review.
+- More robust subject/content hydration on slow networks.
+- Safer subcategory and poll-field handling to avoid implicit changes.
 
 Please report bugs via the alpha channel or the GitHub repository.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,9 +1,8 @@
-Build alpha Redface 2 — polish pré-Phase 2.
+Build alpha Redface 2 — stabilisation édition FP.
 
 Nouveautés :
-- Drapeaux recentrés sur la lecture.
-- Sujets participés déjà lus masqués par défaut, avec option pour les réafficher.
-- Onglets Recherche et Messages clarifiés en attendant les vraies features Phase 2/3.
-- Diagnostics, signalement et infos de compte déplacés dans Messages.
+- Édition du premier message durcie après review.
+- Hydratation sujet/contenu plus robuste sur réseau lent.
+- Sous-catégorie et champs sondage sécurisés pour éviter les changements implicites.
 
 Merci de remonter tout bug via le canal alpha ou le dépôt GitHub.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -18,7 +18,7 @@ mermaid:
 
 nav_sort: order
 
-footer_content: "Redface 2 &mdash; Specs v0.10.7 &mdash; Un projet communautaire pour Hardware.fr"
+footer_content: "Redface 2 &mdash; Specs v0.10.8 &mdash; Un projet communautaire pour Hardware.fr"
 
 back_to_top: true
 back_to_top_text: "Haut de page"


### PR DESCRIPTION
> Action par GPT-5 Codex (demandée par @XaaT)

Prépare la release alpha `app-v48` après merge de #166.

Changements :
- app `versionCode=48`, `versionName=0.3.8` ;
- specs `v0.10.8` + CHANGELOG ;
- notes Play `whatsnew-fr-FR` / `whatsnew-en-US` orientées stabilisation édition FP.

Validation locale :
- `./scripts/docker-dev.sh ./gradlew detektAll lintDebug testDebugUnitTest --console=plain --no-daemon` ✅

Après merge : tag annoté `app-v48` pour déclencher la CD Play alpha.