### PR TITLE
fix(auth): add autofill hints to login fields

### DIFF
--- a/feature/auth/src/main/kotlin/fr/forumhfr/redface2/feature/auth/LoginScreen.kt
+++ b/feature/auth/src/main/kotlin/fr/forumhfr/redface2/feature/auth/LoginScreen.kt
@@ -23,8 +23,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.ContentType
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentType
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -96,7 +99,9 @@ internal fun LoginContent(
                     keyboardType = KeyboardType.Text,
                     imeAction = ImeAction.Next,
                 ),
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentType = ContentType.Username },
             )
 
             OutlinedTextField(
@@ -113,7 +118,9 @@ internal fun LoginContent(
                 keyboardActions = KeyboardActions(
                     onDone = { if (canSubmit) submitAction() },
                 ),
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentType = ContentType.Password },
             )
 
             val errorMode = state.mode as? LoginUiState.Mode.Error


### PR DESCRIPTION
> Action par GPT-5 Codex (demandée par @XaaT)

## Résumé

Corrige #170 en exposant les semantics Autofill Android sur les deux champs de `LoginScreen` :

- pseudo → `ContentType.Username` ;
- mot de passe → `ContentType.Password`.

Le fix est volontairement minimal : aucun changement ViewModel, réseau, stockage ou rendu visuel.

## Validation

- `./scripts/docker-dev.sh ./gradlew :feature:auth:compileDebugKotlin :feature:auth:testDebugUnitTest detektAll lintDebug --console=plain --no-daemon` ✅
- `m3-check` manuel sur `LoginScreen.kt` ✅ : pas de Material 2, pas de couleur/typo/shape hardcodée, pas d'API M3 dépréciée.

## Limite

Le comportement exact d'un password manager doit être confirmé par smoke test manuel sur device avec Proton Pass / Bitwarden / Google Password Manager. La PR corrige le contrat Android Autofill côté Compose, mais je ne peux pas valider l'UX réelle du service Autofill depuis CI.