### PR TITLE
chore(release): bump app to v50

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -15,11 +15,29 @@ Workflow : bumper `versionCode` + `versionName` dans `app/build.gradle.kts`, ajo
 
 ---
 
+## v50 — `0.3.10` — 2026-05-22
+
+**Statut** : `closed`
+**Commit** : à venir (tag `app-v50` après merge de la PR de release)
+**Fichier** : `redface2-v50-<sha>.aab`
+
+Hotfix alpha — amélioration du remplissage automatique sur l'écran de connexion.
+
+### Fixed
+- `LoginScreen` expose les hints Android Autofill corrects : pseudo en `ContentType.Username`, mot de passe en `ContentType.Password`.
+- Proton Pass, Bitwarden, Google Password Manager et les autres services Autofill ont maintenant un contrat explicite pour distinguer les deux champs.
+
+### Changed
+- `app/build.gradle.kts` : `versionCode = 50`, `versionName = "0.3.10"`.
+- Notes Play Console mises à jour pour le track alpha.
+
+---
+
 ## v49 — `0.3.9` — 2026-05-21
 
 **Statut** : `closed`
-**Commit** : à venir (tag `app-v49` après merge de la PR #169)
-**Fichier** : `redface2-v49-<sha>.aab`
+**Commit** : `c79789b`
+**Fichier** : artefact CD `app-v49`
 
 Phase 2E — création de topic depuis l'app. Un compte authentifié peut ouvrir le composer depuis une liste de catégorie, saisir un titre + contenu BBCode, choisir la sous-catégorie et poster via `bddpost.php` sans navigateur.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         // track (alpha) and in the GitHub Release flag, not in versionName itself.
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
-        versionCode = 49
-        versionName = "0.3.9"
+        versionCode = 50
+        versionName = "0.3.10"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,8 +1,8 @@
-Redface 2 alpha build — topic creation.
+Redface 2 alpha build — login hotfix.
 
-Changes:
-- New "New topic" button on category lists when signed in.
-- Dedicated composer: title, subcategory, BBCode content and HFR options.
-- If HFR does not expose the new topic link yet, the app falls back to the target category.
+Fixes:
+- Password managers now get explicit username/password Autofill hints.
+- Targeted fix for Proton Pass filling the password into the username field.
+- No functional change to reading or posting flows.
 
 Please report bugs via the alpha channel or the GitHub repository.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,8 +1,8 @@
-Build alpha Redface 2 — création de topic.
+Build alpha Redface 2 — hotfix connexion.
 
-Nouveautés :
-- Nouveau bouton "Nouveau topic" sur les listes de catégorie quand vous êtes connecté.
-- Composer dédié : titre, sous-catégorie, contenu BBCode et options HFR.
-- En cas de succès sans lien direct récupérable, retour sobre vers la sous-catégorie cible.
+Correctif :
+- Les gestionnaires de mots de passe reconnaissent mieux les champs pseudo et mot de passe.
+- Correction ciblée pour éviter que Proton Pass colle le mot de passe dans le champ pseudo.
+- Aucun changement fonctionnel sur le flux de lecture/écriture.
 
 Merci de remonter tout bug via le canal alpha ou le dépôt GitHub.


### PR DESCRIPTION
> Action par GPT-5 Codex (demandée par @XaaT)

## Résumé

Prépare la release alpha app v50 / `0.3.10` pour le hotfix Autofill login livré par #171.

Changements :
- `versionCode = 50`, `versionName = "0.3.10"` ;
- `app/CHANGELOG.md` ajoute v50 et corrige l'entrée v49 maintenant que `app-v49` est publié ;
- notes Play Console FR/EN mises à jour pour le track alpha.

## Validation

- `./scripts/docker-dev.sh ./gradlew :app:bundleRelease --console=plain --no-daemon` ✅

## Après merge

Créer et pousser le tag `app-v50` depuis `main` pour déclencher la CD release/Play Console.