### PR TITLE
chore(release): bump app to v52

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -15,6 +15,31 @@ Workflow : bumper `versionCode` + `versionName` dans `app/build.gradle.kts`, ajo
 
 ---
 
+## v52 — `0.3.12` — 2026-05-22
+
+**Statut** : `closed`
+**Commit** : à venir (tag `app-v52` après merge de la PR de release)
+**Fichier** : artefact CD `app-v52`
+
+Phase 2G-A — recherche réelle de topics HFR par titre.
+
+### Added
+- Onglet Recherche branché sur l'endpoint HFR réel `forum1.php?recherches=1`.
+- Recherche par titre en mode toutes catégories, avec pivots de catégories quand HFR renvoie plusieurs familles de résultats.
+- Recherche scoped par catégorie depuis les pivots HFR.
+- Fixtures réelles et tests parser / repository / ViewModel pour les quatre formes observées : aucun résultat, pivot unique, pivot multiple, catégorie explicite.
+
+### Fixed
+- Les résultats d'une recherche en vol ne peuvent plus remplacer l'état après saisie d'une nouvelle query.
+- Les lignes de résultats malformées échouent explicitement au parser au lieu d'être silencieusement ignorées.
+- La construction de l'URL `searchTopics()` est maintenant couverte par MockWebServer, y compris le mode anonyme.
+
+### Changed
+- `app/build.gradle.kts` : `versionCode = 52`, `versionName = "0.3.12"`.
+- Notes Play Console mises à jour pour le track alpha.
+
+---
+
 ## v51 — `0.3.11` — 2026-05-22
 
 **Statut** : `closed`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         // track (alpha) and in the GitHub Release flag, not in versionName itself.
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
-        versionCode = 51
-        versionName = "0.3.11"
+        versionCode = 52
+        versionName = "0.3.12"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,9 +1,9 @@
-Redface 2 alpha build — editor smiley picker.
+Redface 2 alpha build — real HFR search.
 
 New:
-- Smileys button in the Reply / Quote / Edit editor.
-- Standard tab with bundled HFR smileys.
-- Wiki tab with live search for custom smileys.
-- Raw BBCode insertion with HFR-style surrounding spaces.
+- Search tab now uses HFR's real title-search endpoint.
+- Real results with author, counters, latest reply and category.
+- Category pivots when HFR returns several result families.
+- Hardened stale-result races and unexpected HTML responses.
 
 Please report bugs via the alpha channel or the GitHub repository.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,9 +1,9 @@
-Build alpha Redface 2 — picker smileys éditeur.
+Build alpha Redface 2 — recherche HFR réelle.
 
 Nouveautés :
-- Bouton Smileys dans l'éditeur Reply / Quote / Edit.
-- Onglet Standard avec les smileys HFR intégrés.
-- Onglet Wiki avec recherche live des smileys perso.
-- Insertion BBCode brute avec la convention d'espaces HFR.
+- Onglet Recherche branché sur la recherche HFR par titre.
+- Résultats réels avec auteur, compteur, dernier message et catégorie.
+- Pivots de catégories quand HFR renvoie plusieurs familles de résultats.
+- Durcissement des cas de course et des réponses HTML inattendues.
 
 Merci de remonter tout bug via le canal alpha ou le dépôt GitHub.


### PR DESCRIPTION
> Action par GPT-5 Codex (demandée par @XaaT)

Release alpha v52 / 0.3.12 après merge de #180.

Contenu :
- bump `versionCode = 52`, `versionName = 0.3.12` ;
- entrée `app/CHANGELOG.md` pour Phase 2G-A ;
- notes Play Console FR/EN mises à jour pour la recherche réelle HFR.

Validation locale :
- `./scripts/docker-dev.sh ./gradlew :app:assembleDebug --console=plain --no-daemon` ✅

Après merge : tag `app-v52` pour déclencher la CD Release vers le track alpha.