### PR TITLE
ci(release): trigger F-Droid repo update on tagged release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,3 +299,44 @@ jobs:
           prerelease: ${{ contains(steps.meta.outputs.version_name, 'phase') || contains(steps.meta.outputs.version_name, 'rc') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # ──────────────────────────────────────────────────────────────────────
+      # Cross-repo trigger : signal the redface2-fdroid repo to fetch the
+      # newly-uploaded APK and rebuild its F-Droid index. Uses a GitHub App
+      # (redface2-fdroid-publisher) installed only on redface2-fdroid ; the App
+      # generates a 1-hour token via JWT exchange — zero PAT, zero recurring
+      # maintenance. If the dispatch fails (App revoked, F-Droid repo down,
+      # GitHub API hiccup), we DON'T fail the whole release job : the APK is
+      # already on Play + GitHub Releases, the F-Droid mirror catching up
+      # later is a downstream concern. The publisher workflow has a manual
+      # workflow_dispatch fallback to recover.
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Generate F-Droid publisher App token
+        id: fdroid_app_token
+        if: ${{ steps.meta.outputs.release_kind == 'tag' || inputs.attach_release }}
+        continue-on-error: true
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RF2_FDROID_APP_ID }}
+          private-key: ${{ secrets.RF2_FDROID_APP_PRIVATE_KEY }}
+          owner: ForumHFR
+          repositories: redface2-fdroid
+
+      - name: Trigger F-Droid publish
+        if: ${{ steps.fdroid_app_token.outcome == 'success' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.fdroid_app_token.outputs.token }}
+        run: |
+          # The APK filename follows the `stamp_apk_name` convention
+          # established by `app/build.gradle.kts` (cf. ADR-0XX release
+          # filenames) : `redface2-v<vc>-<short_sha>.apk`. We rebuild it
+          # from the `meta` step outputs rather than scanning release
+          # assets, so we don't add another API roundtrip.
+          APK_FILENAME="redface2-v${{ steps.meta.outputs.version_code }}-${{ steps.meta.outputs.short_sha }}.apk"
+          echo "Triggering F-Droid publish for tag ${{ steps.meta.outputs.release_tag }} (apk=$APK_FILENAME)"
+          gh api repos/ForumHFR/redface2-fdroid/dispatches \
+            -f event_type=rf2_release \
+            -f "client_payload[tag]=${{ steps.meta.outputs.release_tag }}" \
+            -f "client_payload[apk_filename]=$APK_FILENAME" \
+            -f "client_payload[version_code]=${{ steps.meta.outputs.version_code }}"

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -1,0 +1,74 @@
+---
+title: Installation
+parent: Guides
+nav_order: 1
+---
+
+# Installer Redface 2
+
+Trois canaux de distribution sont disponibles. Ils utilisent des **clés de signature différentes**, donc l'app installée depuis l'un ne peut pas être mise à jour depuis un autre sans désinstallation préalable. Choisissez votre canal et restez dessus.
+
+## Google Play Store
+
+Canal le plus large, recommandé pour la plupart des utilisateurs.
+
+- Recherchez **« Redface 2 »** dans le Play Store.
+- Lien direct : à publier une fois la review Play terminée (l'app est actuellement en alpha closed-testing).
+- Mises à jour automatiques.
+
+Signature : générée par Google via le système **Play App Signing** (notre clé d'upload est utilisée pour signer le bundle envoyé à Play, puis Google re-signe l'APK distribué).
+
+## F-Droid (dépôt privé)
+
+Canal préféré pour les utilisateurs qui veulent rester loin des Google Play Services ou auditer chaque release.
+
+1. Installez un client F-Droid : [F-Droid officiel](https://f-droid.org/), [Neo Store](https://github.com/NeoApplications/Neo-Store), [Foxy Droid](https://github.com/kitsunyan/foxy-droid), ou équivalent.
+2. Dans le client, ouvrez **Paramètres → Dépôts → Ajouter un dépôt**.
+3. Entrez l'URL et le fingerprint suivants :
+
+   ```
+   URL         : https://forumhfr.github.io/redface2-fdroid/repo
+   Fingerprint : B0D265D6783596834715E6AB8C54C4A94A2642F6AD15E279F948A58DF174C8AB
+   ```
+
+   Certains clients permettent de coller l'URL et le fingerprint comme un seul lien : `https://forumhfr.github.io/redface2-fdroid/repo?fingerprint=B0D265D6783596834715E6AB8C54C4A94A2642F6AD15E279F948A58DF174C8AB`.
+
+4. Activez le dépôt. Redface 2 devrait apparaître dans la liste des applications disponibles.
+5. Installez. Les mises à jour seront proposées automatiquement à chaque nouvelle release (~1-2 min après publication sur Play).
+
+Signature : notre **clé d'upload d'origine** (la même que celle envoyée à Play avant le re-signing Google).
+
+> **Important** : si vous avez déjà installé Redface 2 via Google Play Store, **désinstallez-la d'abord** avant d'installer via F-Droid. Les deux APKs sont signés par des clés différentes et Android refuse les mises à jour cross-signature.
+
+## GitHub Releases (sideload direct)
+
+Pour un audit ponctuel ou un test d'une version spécifique sans passer par un client tiers.
+
+1. Allez sur la page [Releases du dépôt redface2](https://github.com/ForumHFR/redface2/releases).
+2. Choisissez la version souhaitée.
+3. Téléchargez le fichier `redface2-vNN-XXXXXXX.apk` (où `NN` est le version code, `XXXXXXX` le commit SHA court).
+4. Sur Android, ouvrez le fichier APK téléchargé et acceptez l'installation depuis des sources inconnues si demandé.
+
+Signature : identique à F-Droid (clé d'upload d'origine). Donc un utilisateur peut basculer GitHub Releases ↔ F-Droid sans désinstaller, contrairement à Play.
+
+Pas de mises à jour automatiques par ce canal. Refaire l'opération à chaque nouvelle version.
+
+## Comparaison des canaux
+
+| Canal | Mises à jour auto | Signature | Audit | Recommandation |
+|---|---|---|---|---|
+| Play Store | ✅ | Google (re-signé) | difficile | grand public |
+| F-Droid (dépôt privé) | ✅ | Clé d'upload | facile (HTML statique) | utilisateurs F-Droid / audit |
+| GitHub Releases sideload | ❌ | Clé d'upload | facile (hash + signature visibles) | test ponctuel |
+
+## Désinstaller proprement
+
+Si vous voulez changer de canal, désinstallez d'abord :
+
+```
+Paramètres Android → Applications → Redface 2 → Désinstaller
+```
+
+Ensuite installez via le nouveau canal.
+
+> **Vos données locales** (cookies de session HFR, préférences, cache Room) sont supprimées à la désinstallation. Il faudra vous reconnecter au forum après la réinstallation.


### PR DESCRIPTION
> Action par Claude Opus 4.7 (demandée par @XaaT)

## Summary

Implémente la voie 1 de l'issue [#137](https://github.com/ForumHFR/redface2/issues/137) (distribution F-Droid via dépôt privé) — bootstrap complet du repo \`ForumHFR/redface2-fdroid\` + automation cross-repo via GitHub App.

À chaque tag \`app-v*\`, après l'upload Play + la création du Release GitHub :

1. Le workflow récupère un token éphémère 1h via la GitHub App \`redface2-fdroid-publisher\` (App ID 3826088, installée uniquement sur \`redface2-fdroid\`).
2. Il POST un \`repository_dispatch\` event \`rf2_release\` vers \`redface2-fdroid\` avec le tag + le filename APK en payload.
3. \`redface2-fdroid/.github/workflows/publish.yml\` (déjà en place) consomme l'event, télécharge l'APK depuis ce Release, régénère l'index F-Droid et push sur sa branche \`gh-pages\`.
4. Le client F-Droid de l'utilisateur voit la nouvelle version ~1-2 min après le tag.

## Architecture

- **Zéro PAT** : GitHub App \`redface2-fdroid-publisher\`, tokens éphémères 1h, ne expire jamais, pas lié à un user humain. Setup une fois pour la vie du projet.
- **Repo séparé** \`ForumHFR/redface2-fdroid\` : sépare l'historique distribution vs code applicatif. Pas de \`.git\` polluante côté \`redface2\`.
- **\`continue-on-error: true\`** sur les nouveaux steps : un hiccup F-Droid (App revoked, repo down, API timeout) ne fait PAS échouer la release applicative. L'APK est déjà sur Play + Releases ; F-Droid catch-up en async.
- **Fallback manuel** : \`publish.yml\` a un \`workflow_dispatch\` qui permet de relancer une publication arbitraire sans re-tagger \`redface2\`.

## Setup déjà effectué (cette session)

- Repo \`ForumHFR/redface2-fdroid\` créé.
- Keystore F-Droid générée + 3 secrets injectés (\`FDROID_KEYSTORE_B64\`, \`FDROID_KEY_PASSWORD\`, \`FDROID_KEY_ALIAS\`) côté \`redface2-fdroid\`.
- GitHub App \`redface2-fdroid-publisher\` créée + installée sur \`redface2-fdroid\` + 2 secrets injectés (\`RF2_FDROID_APP_ID\`, \`RF2_FDROID_APP_PRIVATE_KEY\`) côté \`redface2\`.
- Branche orphan \`gh-pages\` bootstrappée avec un index F-Droid vide signé.
- GitHub Pages activée sur \`gh-pages\` → \`https://forumhfr.github.io/redface2-fdroid/\` (déjà LIVE).
- README + fingerprint repo F-Droid documentés (\`B0D265D6783596834715E6AB8C54C4A94A2642F6AD15E279F948A58DF174C8AB\`).

## Files

- \`.github/workflows/release.yml\` (+41 lignes) : 2 nouveaux steps en fin de job (App token + dispatch).
- \`docs/guides/installation.md\` (+74 lignes) : doc utilisateur des 3 canaux (Play, F-Droid, sideload).

## Test plan

- [ ] CI verte sur cette PR (lint workflow YAML).
- [ ] Après merge + push d'un tag \`app-v53\` test : vérifier que le step \`Trigger F-Droid publish\` passe vert.
- [ ] Vérifier que le workflow \`publish.yml\` côté \`redface2-fdroid\` se déclenche dans la minute qui suit.
- [ ] Vérifier que \`https://forumhfr.github.io/redface2-fdroid/repo/index-v2.json\` contient bien l'APK \`app-v53\`.
- [ ] Test installation sur device via client F-Droid (Neo Store / officiel).

## Refs

Refs #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)