### PR TITLE
ci(release): allow GHCR container pulls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,11 +54,12 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  # `contents: write` is the only scope needed — softprops/action-gh-release creates the
-  # GitHub Release + uploads assets via the REST API. We do not use OIDC tokens here
-  # (the Play Console upload uses a service-account JSON, not workload identity), so
-  # there is no `id-token: write/read` scope to grant.
+  # `contents: write` lets softprops/action-gh-release create the GitHub Release +
+  # upload assets via the REST API. `packages: read` is also required before checkout:
+  # the job itself runs inside a pinned GHCR container, and tag-triggered workflows do
+  # not get package read access once permissions are narrowed explicitly.
   contents: write
+  packages: read
 
 jobs:
   build:


### PR DESCRIPTION
> Action par GPT-5 Codex (demandée par @XaaT)

Hotfix release après échec du tag `app-v55` : le workflow `release.yml` restreint explicitement les permissions à `contents: write`, ce qui retire `packages: read`. Sur un tag, GitHub tente de se logger à `ghcr.io` pour tirer l’image job `ghcr.io/cirruslabs/android-sdk:36@sha256:...` avant checkout, puis échoue avec `Docker login for ghcr.io failed`.

Changement : ajout de `packages: read` aux permissions du workflow release.

Validation locale : `git diff --check`.

Après merge, je supprimerai/recréerai le tag `app-v55` sur le nouveau commit `main` corrigé, car le run échoué n’a pas atteint la construction ni l’upload Play.