### PR TITLE
ci(release): shorten Play release notes

### DIFF
--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,12 +1,11 @@
-Redface 2 alpha build — expanded HFR search.
+Redface 2 alpha — expanded HFR search.
 
 New:
-- Default search now covers titles and message content.
-- Scope selector: titles + messages, titles only, messages only.
-- “Matching message” excerpt when HFR provides it.
-- Opens the exact matching post from content-search results when possible.
-- Category pivot is now a clearer horizontal scope selector.
-- Search screen wording now matches the actual behavior.
-- Changing the text scope keeps the selected HFR category.
+- Search titles and message content by default.
+- Scope: titles + messages, titles only, messages only.
+- Show HFR matching-message excerpts when available.
+- Open the exact post when HFR gives a reply id.
+- Clearer horizontal category selector.
+- Changing text scope keeps the selected category.
 
-Please report bugs via the alpha channel or the GitHub repository.
+Report bugs via alpha or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,12 +1,11 @@
-Build alpha Redface 2 — recherche HFR étendue.
+Alpha Redface 2 — recherche HFR étendue.
 
 Nouveautés :
-- Recherche par défaut dans les titres et les messages.
-- Choix Titres + messages / Titres seuls / Messages seuls.
-- Extrait « Dernier message correspondant » quand HFR le fournit.
-- Ouverture du post exact depuis les résultats contenu quand possible.
-- Pivot catégories clarifié en sélecteur horizontal.
-- Libellés Recherche réalignés avec le comportement réel.
-- Changer le champ recherché conserve la catégorie sélectionnée.
+- Recherche titres + contenu par défaut.
+- Scope : titres + messages, titres seuls, messages seuls.
+- Extrait HFR du message correspondant quand disponible.
+- Ouverture du post exact si HFR donne le numreponse.
+- Sélecteur horizontal de catégorie plus clair.
+- Changer le champ recherché conserve la catégorie.
 
-Merci de remonter tout bug via le canal alpha ou le dépôt GitHub.
+Bugs : alpha ou GitHub.


### PR DESCRIPTION
> Action par GPT-5 Codex (demandée par @XaaT)

Hotfix release après second échec du tag `app-v55` : l’AAB est construit et signé, mais l’upload Play Console refuse `whatsnew-en-US` car la note fait 543 caractères pour une limite Play à 500.

Changement : raccourcissement des notes `en-US` et `fr-FR` en conservant les points utilisateur essentiels.

Validation locale :
- `wc -m app/src/main/play/whatsnew/whatsnew-en-US app/src/main/play/whatsnew/whatsnew-fr-FR` → 376 / 391 caractères ;
- `git diff --check` OK.

Après merge, je redéplacerai `app-v55` sur le nouveau `main` et relancerai la release.