### PR TITLE
chore(release): prepare app v58

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -19,6 +19,25 @@ Workflow : bumper `versionCode` + `versionName` dans `app/build.gradle.kts`, ajo
 
 ---
 
+## v58 — `0.3.18` — 2026-05-24
+
+**Statut** : `closed`
+**Commit** : tag `app-v58` après merge PR #204
+**Fichier** : artefact CD `app-v58`
+
+Phase 2 finish — rechargement du topic après publication.
+
+### Fixed
+- Reply / quote / edit / edit FP : après une soumission acceptée par HFR, l'écran topic force maintenant le rafraîchissement de la page cible au lieu de réafficher un cache stale.
+- Reply simple : retour en bas de la page fraîchement rechargée quand HFR renvoie l'ancre `#bas`.
+- Quote / edit / edit FP : extraction de `#t{numreponse}` depuis l'URL de succès HFR pour revenir directement au post créé ou modifié.
+- Échec de rafraîchissement post-submit : feedback utilisateur explicite via Toast, avec fallback sur le cache existant plutôt qu'un écran cassé.
+
+### Changed
+- `app/build.gradle.kts` : `versionCode = 58`, `versionName = "0.3.18"`.
+
+---
+
 ## v57 — `0.3.17` — 2026-05-24
 
 **Statut** : `closed`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         // track (alpha) and in the GitHub Release flag, not in versionName itself.
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
-        versionCode = 57
-        versionName = "0.3.17"
+        versionCode = 58
+        versionName = "0.3.18"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.


### PR DESCRIPTION
> Action par GPT-5 Codex (demandée par @XaaT)

## Summary

Prépare la release `app-v58` après merge de #204 :

- bump `versionCode = 58`
- bump `versionName = "0.3.18"`
- ajoute l’entrée `v58` dans `app/CHANGELOG.md`

## Validation

```bash
git diff --check
./scripts/docker-dev.sh ./gradlew :app:assembleDebug --console=plain --no-daemon
```

## Release

Après merge : tag `app-v58` sur `main`, ce qui déclenche le workflow release vers le track Play `alpha`.