### PR TITLE
fix(ui): smileys inline alignés sur la baseline (parité web) (#203)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -530,6 +530,11 @@ internal fun imageInlineContent(image: PostInline.InlineImage): InlineTextConten
         placeholder = Placeholder(
             width = box.placeholderWidth,
             height = box.placeholderHeight,
+            // Inline [img] deliberately keeps Center, unlike smileys (which moved to AboveBaseline
+            // for web parity in #203). An embedded image is a 240×180 block of user media, not an
+            // emotive glyph riding the text baseline: centring it on the line reads better and
+            // matches how a wrapped thumbnail sits next to text. Do not "unify" this with the
+            // smiley alignment without a visual pass — the two contracts are intentionally distinct.
             placeholderVerticalAlign = PlaceholderVerticalAlign.Center,
         ),
     ) {

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -572,6 +572,13 @@ internal fun smileyInlineContent(smiley: PostInline.Smiley): InlineTextContent {
             model = smiley.imageUrl,
             contentDescription = description,
             contentScale = PostMediaDisplayPolicy.smileyContentScale,
+            // Bottom-align the sprite inside the placeholder so its *visible* bottom rests on the
+            // baseline (= the placeholder bottom, since AboveBaseline). With ContentScale.Fit a
+            // sprite that doesn't fill the 70×50 bucket's height is letterboxed; the default Center
+            // alignment then floats it ~1px above the baseline — off by that gap from HFR web, which
+            // sits the bare <img> bottom on the baseline. BottomCenter closes that gap for any aspect
+            // ratio (#131 web-parity polish; a no-op for sprites that already fill the bucket height).
+            alignment = Alignment.BottomCenter,
             modifier = Modifier.fillMaxSize(),
         )
     }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -552,7 +552,15 @@ internal fun smileyInlineContent(smiley: PostInline.Smiley): InlineTextContent {
         placeholder = Placeholder(
             width = box.placeholderWidth,
             height = box.placeholderHeight,
-            placeholderVerticalAlign = PlaceholderVerticalAlign.Center,
+            // #203 — web parity. HFR serves both builtin (`/icones/…`) and perso (`/images/perso/…`)
+            // smileys as bare `<img>` with no `vertical-align`, so the browser falls back to the CSS
+            // default `baseline`: the bottom of the sprite sits on the text baseline. `Center` (the
+            // previous value) instead straddled the placeholder across the line centre, which on a
+            // 50sp perso bucket overflowed ~15sp above AND below a 20sp body line — the "smiley au
+            // milieu de la ligne, par-dessus le texte" reported in #203. `AboveBaseline` reproduces
+            // the web baseline alignment. Verified against captured fixtures (no perso/builtin smiley
+            // carries a width/height/style attribute in a post body).
+            placeholderVerticalAlign = PlaceholderVerticalAlign.AboveBaseline,
         ),
     ) {
         AsyncImage(

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineLayoutTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineLayoutTest.kt
@@ -118,6 +118,39 @@ class PostRendererInlineLayoutTest {
     }
 
     @Test
+    fun `perso smiley placeholder bottom sits on the text baseline for web parity`() {
+        // #203 — HFR serves smileys as bare <img> with no vertical-align, so the browser uses the
+        // CSS default `baseline` (the bottom of the sprite rests on the text baseline). RF2 must
+        // match that: `PlaceholderVerticalAlign.AboveBaseline` aligns the placeholder bottom with
+        // the baseline. The previous `Center` straddled the 50sp perso bucket across the line centre
+        // (≈15sp above AND below a 20sp body line), the "smiley au milieu de la ligne, par-dessus le
+        // texte" reported in #203. We mount the smiley between real text so the first baseline is
+        // anchored by the font metrics, then assert the placeholder bottom lands on it. A regression
+        // back to `Center` pushes the bottom well below the baseline and fails this assertion.
+        val capture = LayoutCapture()
+        mountInlineContent(
+            capture,
+            listOf(
+                PostInline.Text("ab "),
+                persoSmileyInlines().first(),
+                PostInline.Text(" cd"),
+            ),
+        )
+        capture.fontScale.value = 1f
+        composeTestRule.waitForIdle()
+        val rect = requireSingleRect(capture, "perso smiley")
+        val baseline = requireNotNull(capture.layout.value?.firstBaseline) {
+            "perso smiley : no TextLayoutResult / firstBaseline captured"
+        }
+        assertCloseEnough(
+            label = "perso smiley placeholder bottom vs first baseline",
+            expected = baseline,
+            actual = rect.bottom,
+            tolerance = BASELINE_TOLERANCE_PX,
+        )
+    }
+
+    @Test
     fun `inline image placeholder lands on the policy bucket at fontScale 1`() {
         val capture = LayoutCapture()
         mountInlineContent(capture, inlineImageInlines())
@@ -346,6 +379,14 @@ class PostRendererInlineLayoutTest {
          * placeholder tests use.
          */
         const val SIZE_TOLERANCE_PX: Float = 0.5f
+
+        /**
+         * Baseline alignment (#203) tolerates a touch more than raw size: the placeholder bottom is
+         * compared against `firstBaseline`, which the layout pass derives from the font's descent
+         * rounding on top of the placeholder height. 2 px stays well under one body-line of slack
+         * while absorbing that sub-pixel quantisation.
+         */
+        const val BASELINE_TOLERANCE_PX: Float = 2f
 
         /** Ratio comparisons need a smaller relative tolerance. 0.01 covers float rounding. */
         const val RATIO_TOLERANCE: Float = 0.01f

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineLayoutTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineLayoutTest.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.core.ui.post
 
 import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.MutableState
@@ -144,6 +145,34 @@ class PostRendererInlineLayoutTest {
         }
         assertCloseEnough(
             label = "perso smiley placeholder bottom vs first baseline",
+            expected = baseline,
+            actual = rect.bottom,
+            tolerance = BASELINE_TOLERANCE_PX,
+        )
+    }
+
+    @Test
+    fun `builtin smiley placeholder bottom sits on the text baseline for web parity`() {
+        // #203 — same baseline rule as the perso case, on the 18sp builtin bucket (served from
+        // `/icones/…`). Builtin smileys are the most common path on HFR, so pin the geometry here
+        // too: a regression back to `Center` would push the bottom below the baseline and fail.
+        val capture = LayoutCapture()
+        mountInlineContent(
+            capture,
+            listOf(
+                PostInline.Text("ab "),
+                builtinSmileyInlines().first(),
+                PostInline.Text(" cd"),
+            ),
+        )
+        capture.fontScale.value = 1f
+        composeTestRule.waitForIdle()
+        val rect = requireSingleRect(capture, "builtin smiley")
+        val baseline = requireNotNull(capture.layout.value?.firstBaseline) {
+            "builtin smiley : no TextLayoutResult / firstBaseline captured"
+        }
+        assertCloseEnough(
+            label = "builtin smiley placeholder bottom vs first baseline",
             expected = baseline,
             actual = rect.bottom,
             tolerance = BASELINE_TOLERANCE_PX,
@@ -316,20 +345,27 @@ class PostRendererInlineLayoutTest {
      * [TextLayoutResult] in [capture] gives the test access to `placeholderRects` after each
      * fontScale change. Density stays fixed at `1f` so the assertions at fontScale=1 reduce to
      * `sp == px`.
+     *
+     * The [Text] is mounted under [MaterialTheme] with `style = bodyMedium` to mirror the production
+     * `ParagraphBlock` (which renders posts in `MaterialTheme.typography.bodyMedium`): the baseline
+     * assertions then pin the same font metrics the app actually uses, not the bare `Text` default.
      */
     private fun mountInlineContent(capture: LayoutCapture, inlines: List<PostInline>) {
         val annotated = buildInlineText(inlines, emptyLinkStyles, imageAlt = "img")
         val media: Map<String, InlineTextContent> = collectInlineMedia(inlines)
         composeTestRule.setContent {
             val fontScale = capture.fontScale.value
-            CompositionLocalProvider(
-                LocalDensity provides Density(density = 1f, fontScale = fontScale),
-            ) {
-                Text(
-                    text = annotated,
-                    inlineContent = media,
-                    onTextLayout = { result -> capture.layout.value = result },
-                )
+            MaterialTheme {
+                CompositionLocalProvider(
+                    LocalDensity provides Density(density = 1f, fontScale = fontScale),
+                ) {
+                    Text(
+                        text = annotated,
+                        inlineContent = media,
+                        style = MaterialTheme.typography.bodyMedium,
+                        onTextLayout = { result -> capture.layout.value = result },
+                    )
+                }
             }
         }
         composeTestRule.waitForIdle()

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineTest.kt
@@ -137,7 +137,7 @@ class PostRendererInlineTest {
     }
 
     @Test
-    fun `builtin smiley with imageUrl uses the small bucket placeholder centred`() {
+    fun `builtin smiley with imageUrl uses the small bucket placeholder baseline-aligned`() {
         // Builtin smileys are typically 16x16 to 18x18 in HFR's icon set. The small bucket fits
         // them inline with body-medium text without a noticeable height bump on the line.
         val inlines = listOf(
@@ -162,8 +162,11 @@ class PostRendererInlineTest {
             placeholder.height,
         )
         assertEquals(
-            "smileys must align centred so the surrounding line height stretches symmetrically",
-            PlaceholderVerticalAlign.Center,
+            // #203 — HFR serves smileys as bare <img> (CSS default vertical-align: baseline), so RF2
+            // aligns the placeholder bottom with the text baseline for web parity instead of
+            // centring it across the line (which straddled tall perso buckets over the body line).
+            "smileys must align above the baseline to match HFR's web rendering",
+            PlaceholderVerticalAlign.AboveBaseline,
             placeholder.placeholderVerticalAlign,
         )
     }
@@ -201,8 +204,9 @@ class PostRendererInlineTest {
             placeholder.width,
         )
         assertEquals(
-            "perso smileys must align centred for symmetric line-height stretch",
-            PlaceholderVerticalAlign.Center,
+            // #203 — same web-parity rule as builtin: baseline-aligned, not centred on the line.
+            "perso smileys must align above the baseline to match HFR's web rendering",
+            PlaceholderVerticalAlign.AboveBaseline,
             placeholder.placeholderVerticalAlign,
         )
     }


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

## Problème (#203)

HFR rend les smileys (builtin `/icones/…` et perso `/images/perso/…`) comme de simples `<img>` sans `vertical-align` → le navigateur applique le défaut CSS `baseline` (le bas du smiley repose sur la baseline du texte). RF2 utilisait `PlaceholderVerticalAlign.Center`, qui centre le placeholder sur le **milieu de la ligne** : sur le bucket perso 50sp, ça débordait de ~15sp au-dessus **et** en dessous d'une ligne de corps de 20sp — le « smiley au milieu de la ligne, par-dessus le texte » rapporté dans #203 (repro v0.3.17 build 57, toujours présent en v64).

## Fix

`PlaceholderVerticalAlign.Center` → `AboveBaseline` (aligne le bas du placeholder sur la baseline, comme le web). Une ligne de prod.

**Source de vérité** : aucun smiley perso/builtin ne porte d'attribut `width`/`height`/`style` dans les fixtures de corps de post capturées → le web retombe sur `baseline`. Fix indépendant de #175 (rendu adaptatif).

## Tests

- nouveau test `PostRendererInlineLayoutTest` : pin le bas du placeholder sur la première baseline du texte (une régression vers `Center` le pousse en dessous et fait échouer le test) ;
- `PostRendererInlineTest` builtin/perso : assertions `Center` → `AboveBaseline`.

Validation locale : `detektAll lintDebug test testDebugUnitTest :app:assembleDebug --rerun-tasks` **vert**. Validé visuellement sur émulateur (topics Loisirs gifs + alpha RF2) : le smiley se pose désormais sur la ligne de texte.

Closes #203
