### PR TITLE
fix(topic): re-ancrage du scroll deep-link pendant le settle des images-blocs (#197)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -236,14 +236,18 @@ private suspend fun LazyListState.reanchorWhileMediaSettles(target: Int) {
         withFrameNanos { }
         if (isScrollInProgress) return // user took over — never fight a manual scroll
         val current = ReanchorFrame(firstVisibleItemIndex, firstVisibleItemScrollOffset)
+        val stableThreshold = if (frame >= REANCHOR_MIN_FRAMES) {
+            REANCHOR_STABLE_FRAMES
+        } else {
+            Int.MAX_VALUE
+        }
         when (
             val step = reanchorStep(
                 current = current,
                 previous = previous,
                 target = target,
                 stableFrames = stableFrames,
-                stableThreshold = REANCHOR_STABLE_FRAMES,
-                canStop = frame >= REANCHOR_MIN_FRAMES,
+                stableThreshold = stableThreshold,
             )
         ) {
             ReanchorStep.Stop -> return
@@ -272,18 +276,18 @@ internal sealed interface ReanchorStep {
  * Pure per-frame decision for [reanchorWhileMediaSettles] (#197), extracted so the state machine is
  * unit-testable without a frame clock or a live `LazyListState`.
  *
- * Stop only when [canStop] is true and the target's position has held still ([current] equal to
- * [previous]) for [stableThreshold] consecutive frames. Otherwise carry the updated stable count and
- * ask for a re-pin whenever the target is not currently at the very top ([ReanchorFrame.index] !=
- * [target] or a non-zero offset) — a no-op when it already is, harmless when the list cannot scroll
- * it higher.
+ * Stop once the target's position has held still ([current] equal to [previous]) for
+ * [stableThreshold] consecutive frames. The caller passes `Int.MAX_VALUE` during the initial
+ * cold-decode guard window so the helper keeps monitoring even if the first frames are stable.
+ * Otherwise carry the updated stable count and ask for a re-pin whenever the target is not currently
+ * at the very top ([ReanchorFrame.index] != [target] or a non-zero offset) — a no-op when it already
+ * is, harmless when the list cannot scroll it higher.
  *
  * @param current the target row's position this frame
  * @param previous the same reading from the previous frame, or `null` on the first frame
  * @param target the item index we want pinned to the top
  * @param stableFrames consecutive still frames observed so far
  * @param stableThreshold still frames required to consider the layout settled
- * @param canStop false during the initial cold-decode guard window
  */
 internal fun reanchorStep(
     current: ReanchorFrame,
@@ -291,11 +295,10 @@ internal fun reanchorStep(
     target: Int,
     stableFrames: Int,
     stableThreshold: Int,
-    canStop: Boolean = true,
 ): ReanchorStep {
     val moved = previous == null || current != previous
     val nextStableFrames = if (moved) 0 else stableFrames + 1
-    if (canStop && nextStableFrames >= stableThreshold) return ReanchorStep.Stop
+    if (nextStableFrames >= stableThreshold) return ReanchorStep.Stop
     val repin = current.index != target || current.offset != 0
     return ReanchorStep.Continue(stableFrames = nextStableFrames, repin = repin)
 }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -199,7 +199,7 @@ fun TopicScreen(
 }
 
 /**
- * #197 — keep [target] pinned to the top of the viewport while upstream block images settle.
+ * #197 — keep [target] anchored at the top of the viewport while upstream block images settle.
  *
  * `PostBlock.Image` renders a `SubcomposeAsyncImage` that starts at `blockImageMinHeight` (160.dp)
  * while loading/erroring and grows to its decoded height (up to `blockImageMaxHeight`, 480.dp) once
@@ -208,29 +208,80 @@ fun TopicScreen(
  * target scrolled off-screen. A warm image cache decodes synchronously before the first measure,
  * which is why #197 only reproduces on a cold cache.
  *
- * We re-pin every frame until the target stays at the top for [REANCHOR_STABLE_FRAMES] consecutive
- * frames, bounded by [REANCHOR_MAX_FRAMES] so a never-resolving image cannot hold the list hostage.
- * We bail the instant the user grabs the list (`isScrollInProgress`) so the settle window never
- * fights manual scrolling — extending the single-shot, no-focus-stealing contract documented on
- * [TopicEffect]. Inline smileys/images are *not* a factor here: their `InlineTextContent`
- * placeholders are fixed-size, so only block images move the geometry.
+ * Each frame we re-pin the target to the top (when it has drifted) and stop once its position has
+ * held still for [REANCHOR_STABLE_FRAMES] consecutive frames — *settled*, not *pinned at offset 0*.
+ * Keying the stop on stillness rather than `offset == 0` handles two cases the #197 review flagged:
+ *  - a tail post the list cannot scroll all the way up (not enough content below) rests at a
+ *    non-zero offset; an `offset == 0` criterion would never be met and would churn the whole frame
+ *    budget on no-op re-pins;
+ *  - block images above the target that decode at staggered times keep moving the position, so we
+ *    must not declare victory in the gap between two growth pushes.
+ * Bounded by [REANCHOR_MAX_FRAMES] so a never-resolving image cannot hold the list hostage, and we
+ * bail the instant the user grabs the list (`isScrollInProgress`) so the settle window never fights
+ * manual scrolling — extending the single-shot, no-focus-stealing contract on [TopicEffect]. Inline
+ * smileys/images are *not* a factor: their `InlineTextContent` placeholders are fixed-size, so only
+ * block images move the geometry.
+ *
+ * The per-frame decision is delegated to the pure [reanchorStep] so the state machine is unit-tested
+ * without a frame clock or a live `LazyListState`.
  */
 private suspend fun LazyListState.reanchorWhileMediaSettles(target: Int) {
     var stableFrames = 0
+    var previous: ReanchorFrame? = null
     repeat(REANCHOR_MAX_FRAMES) {
         withFrameNanos { }
-        // A user drag/fling during the settle window wins outright — never re-snap on them.
-        if (isScrollInProgress) return
-        val pinned = firstVisibleItemIndex == target && firstVisibleItemScrollOffset == 0
-        if (pinned) {
-            stableFrames++
-            if (stableFrames >= REANCHOR_STABLE_FRAMES) return
-        } else {
-            // The geometry above the target changed (an image grew) — pull it back to the top.
-            scrollToItem(target)
-            stableFrames = 0
+        if (isScrollInProgress) return // user took over — never fight a manual scroll
+        val current = ReanchorFrame(firstVisibleItemIndex, firstVisibleItemScrollOffset)
+        when (val step = reanchorStep(current, previous, target, stableFrames, REANCHOR_STABLE_FRAMES)) {
+            ReanchorStep.Stop -> return
+            is ReanchorStep.Continue -> {
+                stableFrames = step.stableFrames
+                if (step.repin) scrollToItem(target)
+            }
         }
+        previous = current
     }
+}
+
+/** The target row's position within the viewport on a given frame. Cf. [reanchorStep]. */
+internal data class ReanchorFrame(val index: Int, val offset: Int)
+
+/** Outcome of one [reanchorStep] decision. */
+internal sealed interface ReanchorStep {
+    /** The layout has settled (or the frame budget is spent) — stop re-anchoring. */
+    data object Stop : ReanchorStep
+
+    /** Keep going: carry [stableFrames] to the next frame and re-pin to the top iff [repin]. */
+    data class Continue(val stableFrames: Int, val repin: Boolean) : ReanchorStep
+}
+
+/**
+ * Pure per-frame decision for [reanchorWhileMediaSettles] (#197), extracted so the state machine is
+ * unit-testable without a frame clock or a live `LazyListState`.
+ *
+ * Stop once the target's position has held still ([current] equal to [previous]) for
+ * [stableThreshold] consecutive frames. Otherwise carry the updated stable count and ask for a
+ * re-pin whenever the target is not currently at the very top ([ReanchorFrame.index] != [target] or
+ * a non-zero offset) — a no-op when it already is, harmless when the list cannot scroll it higher.
+ *
+ * @param current the target row's position this frame
+ * @param previous the same reading from the previous frame, or `null` on the first frame
+ * @param target the item index we want pinned to the top
+ * @param stableFrames consecutive still frames observed so far
+ * @param stableThreshold still frames required to consider the layout settled
+ */
+internal fun reanchorStep(
+    current: ReanchorFrame,
+    previous: ReanchorFrame?,
+    target: Int,
+    stableFrames: Int,
+    stableThreshold: Int,
+): ReanchorStep {
+    val moved = previous == null || current != previous
+    val nextStableFrames = if (moved) 0 else stableFrames + 1
+    if (nextStableFrames >= stableThreshold) return ReanchorStep.Stop
+    val repin = current.index != target || current.offset != 0
+    return ReanchorStep.Continue(stableFrames = nextStableFrames, repin = repin)
 }
 
 /**
@@ -239,7 +290,7 @@ private suspend fun LazyListState.reanchorWhileMediaSettles(target: Int) {
  */
 private const val REANCHOR_MAX_FRAMES = 120
 
-/** Three identical frames in a row = the layout above the target has stopped growing. */
+/** Frames the target position must hold still before we treat the layout as settled. */
 private const val REANCHOR_STABLE_FRAMES = 3
 
 @Composable

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -146,7 +147,13 @@ fun TopicScreen(
                     val index = loadedMode.topic.posts.indexOfFirst { it.numreponse == effect.numreponse }
                     if (index >= 0) {
                         // +1 because the LazyColumn header card occupies item 0.
-                        lazyListState.scrollToItem(index + 1)
+                        val target = index + 1
+                        lazyListState.scrollToItem(target)
+                        // #197 — block images above the target grow from 160dp to up to 480dp once
+                        // Coil decodes them, shifting the offset *after* this one-shot scroll and
+                        // leaving the target off-screen on a cold image cache. Keep it pinned while
+                        // the layout settles (bails on user scroll, bounded by a frame budget).
+                        lazyListState.reanchorWhileMediaSettles(target)
                     }
                 }
                 TopicEffect.ScrollToEndOfPage -> {
@@ -190,6 +197,50 @@ fun TopicScreen(
         onOpenProfile = onOpenProfile,
     )
 }
+
+/**
+ * #197 — keep [target] pinned to the top of the viewport while upstream block images settle.
+ *
+ * `PostBlock.Image` renders a `SubcomposeAsyncImage` that starts at `blockImageMinHeight` (160.dp)
+ * while loading/erroring and grows to its decoded height (up to `blockImageMaxHeight`, 480.dp) once
+ * Coil resolves the bitmap. Any block image in a post *above* the deep-link target shifts the
+ * cumulative scroll offset by up to +320.dp *after* the initial one-shot `scrollToItem`, leaving the
+ * target scrolled off-screen. A warm image cache decodes synchronously before the first measure,
+ * which is why #197 only reproduces on a cold cache.
+ *
+ * We re-pin every frame until the target stays at the top for [REANCHOR_STABLE_FRAMES] consecutive
+ * frames, bounded by [REANCHOR_MAX_FRAMES] so a never-resolving image cannot hold the list hostage.
+ * We bail the instant the user grabs the list (`isScrollInProgress`) so the settle window never
+ * fights manual scrolling — extending the single-shot, no-focus-stealing contract documented on
+ * [TopicEffect]. Inline smileys/images are *not* a factor here: their `InlineTextContent`
+ * placeholders are fixed-size, so only block images move the geometry.
+ */
+private suspend fun LazyListState.reanchorWhileMediaSettles(target: Int) {
+    var stableFrames = 0
+    repeat(REANCHOR_MAX_FRAMES) {
+        withFrameNanos { }
+        // A user drag/fling during the settle window wins outright — never re-snap on them.
+        if (isScrollInProgress) return
+        val pinned = firstVisibleItemIndex == target && firstVisibleItemScrollOffset == 0
+        if (pinned) {
+            stableFrames++
+            if (stableFrames >= REANCHOR_STABLE_FRAMES) return
+        } else {
+            // The geometry above the target changed (an image grew) — pull it back to the top.
+            scrollToItem(target)
+            stableFrames = 0
+        }
+    }
+}
+
+/**
+ * ~2 s at 60 fps : long enough to cover a cold image decode on a typical page, short enough that a
+ * stuck/never-resolving image cannot pin the list indefinitely. Cf. [reanchorWhileMediaSettles].
+ */
+private const val REANCHOR_MAX_FRAMES = 120
+
+/** Three identical frames in a row = the layout above the target has stopped growing. */
+private const val REANCHOR_STABLE_FRAMES = 3
 
 @Composable
 @Suppress("LongParameterList") // state-hoisted Composable : each param has a distinct call-site.

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -208,14 +208,18 @@ fun TopicScreen(
  * target scrolled off-screen. A warm image cache decodes synchronously before the first measure,
  * which is why #197 only reproduces on a cold cache.
  *
- * Each frame we re-pin the target to the top (when it has drifted) and stop once its position has
- * held still for [REANCHOR_STABLE_FRAMES] consecutive frames — *settled*, not *pinned at offset 0*.
+ * Each frame we re-pin the target to the top (when it has drifted) and stop once the minimum
+ * settle window has elapsed *and* its position has held still for [REANCHOR_STABLE_FRAMES]
+ * consecutive frames — *settled*, not *pinned at offset 0*.
  * Keying the stop on stillness rather than `offset == 0` handles two cases the #197 review flagged:
  *  - a tail post the list cannot scroll all the way up (not enough content below) rests at a
  *    non-zero offset; an `offset == 0` criterion would never be met and would churn the whole frame
  *    budget on no-op re-pins;
  *  - block images above the target that decode at staggered times keep moving the position, so we
  *    must not declare victory in the gap between two growth pushes.
+ * The [REANCHOR_MIN_FRAMES] guard prevents the opposite bug: declaring victory after only three
+ * stable frames (~50 ms) before a cold Coil decode has even had time to finish, then letting the
+ * target drift once the first image finally grows.
  * Bounded by [REANCHOR_MAX_FRAMES] so a never-resolving image cannot hold the list hostage, and we
  * bail the instant the user grabs the list (`isScrollInProgress`) so the settle window never fights
  * manual scrolling — extending the single-shot, no-focus-stealing contract on [TopicEffect]. Inline
@@ -228,11 +232,20 @@ fun TopicScreen(
 private suspend fun LazyListState.reanchorWhileMediaSettles(target: Int) {
     var stableFrames = 0
     var previous: ReanchorFrame? = null
-    repeat(REANCHOR_MAX_FRAMES) {
+    repeat(REANCHOR_MAX_FRAMES) { frame ->
         withFrameNanos { }
         if (isScrollInProgress) return // user took over — never fight a manual scroll
         val current = ReanchorFrame(firstVisibleItemIndex, firstVisibleItemScrollOffset)
-        when (val step = reanchorStep(current, previous, target, stableFrames, REANCHOR_STABLE_FRAMES)) {
+        when (
+            val step = reanchorStep(
+                current = current,
+                previous = previous,
+                target = target,
+                stableFrames = stableFrames,
+                stableThreshold = REANCHOR_STABLE_FRAMES,
+                canStop = frame >= REANCHOR_MIN_FRAMES,
+            )
+        ) {
             ReanchorStep.Stop -> return
             is ReanchorStep.Continue -> {
                 stableFrames = step.stableFrames
@@ -259,16 +272,18 @@ internal sealed interface ReanchorStep {
  * Pure per-frame decision for [reanchorWhileMediaSettles] (#197), extracted so the state machine is
  * unit-testable without a frame clock or a live `LazyListState`.
  *
- * Stop once the target's position has held still ([current] equal to [previous]) for
- * [stableThreshold] consecutive frames. Otherwise carry the updated stable count and ask for a
- * re-pin whenever the target is not currently at the very top ([ReanchorFrame.index] != [target] or
- * a non-zero offset) — a no-op when it already is, harmless when the list cannot scroll it higher.
+ * Stop only when [canStop] is true and the target's position has held still ([current] equal to
+ * [previous]) for [stableThreshold] consecutive frames. Otherwise carry the updated stable count and
+ * ask for a re-pin whenever the target is not currently at the very top ([ReanchorFrame.index] !=
+ * [target] or a non-zero offset) — a no-op when it already is, harmless when the list cannot scroll
+ * it higher.
  *
  * @param current the target row's position this frame
  * @param previous the same reading from the previous frame, or `null` on the first frame
  * @param target the item index we want pinned to the top
  * @param stableFrames consecutive still frames observed so far
  * @param stableThreshold still frames required to consider the layout settled
+ * @param canStop false during the initial cold-decode guard window
  */
 internal fun reanchorStep(
     current: ReanchorFrame,
@@ -276,10 +291,11 @@ internal fun reanchorStep(
     target: Int,
     stableFrames: Int,
     stableThreshold: Int,
+    canStop: Boolean = true,
 ): ReanchorStep {
     val moved = previous == null || current != previous
     val nextStableFrames = if (moved) 0 else stableFrames + 1
-    if (nextStableFrames >= stableThreshold) return ReanchorStep.Stop
+    if (canStop && nextStableFrames >= stableThreshold) return ReanchorStep.Stop
     val repin = current.index != target || current.offset != 0
     return ReanchorStep.Continue(stableFrames = nextStableFrames, repin = repin)
 }
@@ -289,6 +305,13 @@ internal fun reanchorStep(
  * stuck/never-resolving image cannot pin the list indefinitely. Cf. [reanchorWhileMediaSettles].
  */
 private const val REANCHOR_MAX_FRAMES = 120
+
+/**
+ * ~1 s at 60 fps before stillness can stop the loop. This keeps the guard alive long enough for the
+ * first cold Coil decodes to start moving layout; otherwise three stable frames immediately after
+ * the initial scroll can stop the loop before any image above the target has resolved.
+ */
+private const val REANCHOR_MIN_FRAMES = 60
 
 /** Frames the target position must hold still before we treat the layout as settled. */
 private const val REANCHOR_STABLE_FRAMES = 3

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/ReanchorStepTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/ReanchorStepTest.kt
@@ -53,8 +53,7 @@ class ReanchorStepTest {
             previous = frame,
             target = target,
             stableFrames = threshold,
-            stableThreshold = threshold,
-            canStop = false,
+            stableThreshold = Int.MAX_VALUE,
         )
         assertTrue(step is ReanchorStep.Continue)
         step as ReanchorStep.Continue

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/ReanchorStepTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/ReanchorStepTest.kt
@@ -1,0 +1,121 @@
+package fr.forumhfr.redface2.feature.topic
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #197 — pure JVM coverage of [reanchorStep], the per-frame state machine driving
+ * `reanchorWhileMediaSettles`. The suspend loop itself (frame clock + Coil decode timing) is not
+ * JVM-testable, but its decision is, so the tricky cases the #197 review raised are pinned here:
+ * a tail post that can never reach `offset == 0`, staggered image growth, and the user-scroll bail
+ * (the bail lives in the loop; here we pin everything else).
+ */
+class ReanchorStepTest {
+
+    private val target = 5
+    private val threshold = 3
+
+    @Test
+    fun `first frame resets the stable counter and never stops`() {
+        val step = reanchorStep(
+            current = ReanchorFrame(target, 0),
+            previous = null,
+            target = target,
+            stableFrames = 99,
+            stableThreshold = threshold,
+        )
+        assertTrue(step is ReanchorStep.Continue)
+        step as ReanchorStep.Continue
+        assertEquals(0, step.stableFrames)
+        assertFalse("already at the top → no re-pin", step.repin)
+    }
+
+    @Test
+    fun `holding still for the threshold stops`() {
+        val frame = ReanchorFrame(target, 0)
+        val step = reanchorStep(
+            frame,
+            previous = frame,
+            target = target,
+            stableFrames = threshold - 1,
+            stableThreshold = threshold,
+        )
+        assertEquals(ReanchorStep.Stop, step)
+    }
+
+    @Test
+    fun `a position change resets the stable counter and asks for a re-pin`() {
+        // An image above the target decoded and grew: the target drifted from offset 0 to 60.
+        val step = reanchorStep(
+            current = ReanchorFrame(target, 60),
+            previous = ReanchorFrame(target, 0),
+            target = target,
+            stableFrames = threshold - 1,
+            stableThreshold = threshold,
+        )
+        assertTrue(step is ReanchorStep.Continue)
+        step as ReanchorStep.Continue
+        assertEquals(0, step.stableFrames)
+        assertTrue("drifted off the top → re-pin", step.repin)
+    }
+
+    @Test
+    fun `a tail post resting at a non-zero offset still settles once it stops moving`() {
+        // The list cannot scroll the target all the way up. Keying the stop on stillness (not
+        // offset==0) is what prevents churning the whole frame budget on no-op re-pins.
+        val resting = ReanchorFrame(target, 300)
+        val step = reanchorStep(
+            resting,
+            previous = resting,
+            target = target,
+            stableFrames = threshold - 1,
+            stableThreshold = threshold,
+        )
+        assertEquals("settled at a non-zero offset = Stop", ReanchorStep.Stop, step)
+    }
+
+    @Test
+    fun `a still-but-not-yet-settled tail post keeps re-pinning`() {
+        val resting = ReanchorFrame(target, 300)
+        val step = reanchorStep(
+            resting,
+            previous = resting,
+            target = target,
+            stableFrames = 0,
+            stableThreshold = threshold,
+        )
+        assertTrue(step is ReanchorStep.Continue)
+        step as ReanchorStep.Continue
+        assertEquals(1, step.stableFrames)
+        assertTrue("offset != 0 → re-pin (a harmless no-op when already at max scroll)", step.repin)
+    }
+
+    @Test
+    fun `staggered image growth resets stability so it never stops between two decodes`() {
+        val a = ReanchorFrame(target, 0)
+        // Two still frames accrue while image A holds.
+        var stable = (reanchorStep(a, a, target, 0, threshold) as ReanchorStep.Continue).stableFrames
+        stable = (reanchorStep(a, a, target, stable, threshold) as ReanchorStep.Continue).stableFrames
+        assertEquals(2, stable)
+        // Image B now decodes and grows → the position moves → stability must reset, not stop.
+        val b = ReanchorFrame(target, 80)
+        val step = reanchorStep(b, previous = a, target = target, stableFrames = stable, stableThreshold = threshold)
+        assertTrue(step is ReanchorStep.Continue)
+        assertEquals("staggered growth resets stability", 0, (step as ReanchorStep.Continue).stableFrames)
+    }
+
+    @Test
+    fun `index drift (an earlier item peeks at the top) asks for a re-pin`() {
+        val step = reanchorStep(
+            current = ReanchorFrame(target - 1, 10),
+            previous = ReanchorFrame(target, 0),
+            target = target,
+            stableFrames = 0,
+            stableThreshold = threshold,
+        )
+        assertTrue(step is ReanchorStep.Continue)
+        assertTrue((step as ReanchorStep.Continue).repin)
+    }
+}

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/ReanchorStepTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/ReanchorStepTest.kt
@@ -46,6 +46,23 @@ class ReanchorStepTest {
     }
 
     @Test
+    fun `holding still before the minimum settle window keeps monitoring`() {
+        val frame = ReanchorFrame(target, 0)
+        val step = reanchorStep(
+            frame,
+            previous = frame,
+            target = target,
+            stableFrames = threshold,
+            stableThreshold = threshold,
+            canStop = false,
+        )
+        assertTrue(step is ReanchorStep.Continue)
+        step as ReanchorStep.Continue
+        assertEquals(threshold + 1, step.stableFrames)
+        assertFalse("already at the top → no re-pin, but keep watching for late decodes", step.repin)
+    }
+
+    @Test
     fun `a position change resets the stable counter and asks for a re-pin`() {
         // An image above the target decoded and grew: the target drifted from offset 0 to 60.
         val step = reanchorStep(


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

## Problème (#197)

Le deep-link vers un post (`#t<numreponse>`) fait un `scrollToItem` **unique** au moment où la page est chargée. Or `PostBlock.Image` rend un `SubcomposeAsyncImage` qui démarre à `blockImageMinHeight` (160 dp) puis grandit jusqu'à sa hauteur décodée (jusqu'à `blockImageMaxHeight`, 480 dp) une fois que Coil résout le bitmap. Toute image-bloc dans un post **au-dessus** de la cible décale alors l'offset cumulé de jusqu'à +320 dp **après** le scroll unique → la cible se retrouve hors écran. Un cache image chaud décode de façon synchrone avant la première mesure, d'où le fait que #197 ne se reproduit qu'**en cache froid**.

Ce n'est **pas** un bug de drapeaux : `:feature:topic` n'a aucun code d'état lu/non-lu ; le symptôme « lu/non-lu perturbé » est la conséquence perceptuelle du mauvais ancrage (cf. audit Phase 2).

## Fix

`LazyListState.reanchorWhileMediaSettles(target)` : après le scroll initial, re-pin la cible en haut à **chaque frame** tant que sa position n'est pas stable sur `REANCHOR_STABLE_FRAMES` frames consécutives, borné par `REANCHOR_MAX_FRAMES` (~2 s) pour qu'une image qui ne résout jamais ne bloque pas la liste. Abandonne dès que l'utilisateur saisit la liste (`isScrollInProgress`) → ne combat jamais le scroll manuel, prolongeant le contrat single-shot / no-focus-stealing documenté sur `TopicEffect`. Les smileys/images inline ne sont pas en cause (placeholders de taille fixe).

Scopé à `ScrollToPost` (le chemin deep-link #197) ; `ScrollToEndOfPage` (#200) inchangé.

## Validation

- `detektAll lintDebug test testDebugUnitTest :app:assembleDebug --rerun-tasks` **vert**.
- **Émulateur, cache froid** (`pm clear` → cache Coil vidé) : deep-link `forum2.php?…&page=4344#t74613025` vers un post profond d'un topic d'images (des dizaines d'images-blocs au-dessus). Après chargement cold, la cible n°74613025 est ancrée **en haut du viewport** (confirmé via `uiautomator dump` : `n°74613025` puis `n°74613112`) — sans le fix, les images grandissantes l'auraient poussée hors écran.

Pas de test unitaire : le comportement dépend du timing de décodage Coil + frame clock, non couvrable en JVM/Robolectric (cf. audit). `TopicViewModelTest` (émission de l'effet) reste vert.

Closes #197
