### PR TITLE
fix(topic): le pseudo cliquable ne gonfle plus le header de post (régression #208)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -639,19 +639,25 @@ private fun TopicPostCard(
                 Modifier
             }
             val pseudoModifier = if (onOpenProfile != null) {
-                Modifier
-                    .minimumInteractiveComponentSize()
-                    .clickable(
-                        onClick = onOpenProfile,
-                        role = Role.Button,
-                        onClickLabel = openProfileLabel,
-                    )
+                // No minimumInteractiveComponentSize() on the pseudo: it reserves a 48dp-tall box
+                // and centres the text inside it, which inflated the header Row and left the pseudo
+                // floating mid-height with the date pushed far below it. The avatar beside it is the
+                // 48dp-compliant touch target for the very same `onOpenProfile` action, so the pseudo
+                // stays a convenience tap at its natural text height without bloating the layout.
+                Modifier.clickable(
+                    onClick = onOpenProfile,
+                    role = Role.Button,
+                    onClickLabel = openProfileLabel,
+                )
             } else {
                 Modifier
             }
             Row(
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.Top,
+                // Centre the avatar against the name+date block so the identity line reads as one
+                // tidy unit (the previous Top alignment + the inflated pseudo made the pseudo look
+                // vertically centred while the date dropped well below the avatar).
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 RedfaceUserAvatar(
                     avatarUrl = post.avatarUrl,


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

## Problème (régression #208)

Le travail profil #208 (PR #211, commit `3b772f04`) a rendu le pseudo de l'auteur cliquable avec `minimumInteractiveComponentSize()`. Ce modifier réserve une boîte de **48dp de haut et y centre le texte** : dans la `Row` du header de post, ça gonflait la ligne d'identité — le pseudo flottait à mi-hauteur et la **date tombait loin sous l'avatar** au lieu d'être juste sous le nom.

## Fix

- retirer `minimumInteractiveComponentSize()` du pseudo : l'avatar voisin est déjà la cible tactile 48dp pour la **même action** `onOpenProfile`, donc le pseudo reste cliquable à sa hauteur naturelle (affordance) sans bloater le layout ;
- centrer l'avatar contre le bloc nom+date (`Alignment.Top` → `Alignment.CenterVertically`) → la ligne d'identité se lit comme un bloc compact aligné sur l'avatar.

## Validation

- `detektAll lintDebug :feature:topic:testDebugUnitTest --rerun-tasks` **vert** (aucune plainte lint a11y après le retrait du min-size).
- Validé visuellement sur émulateur : **avant** = pseudo centré + date décalée loin sous l'avatar ; **après** = `[avatar] pseudo • n°… / date` compact et aligné.

Régression introduite par #208 / #211 ; non liée aux autres PR Phase 2 finish en cours (#215 smiley, #216 scroll).
