### PR TITLE
chore(release): prepare app v65

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -17,14 +17,30 @@ Workflow : bumper `versionCode` + `versionName` dans `app/build.gradle.kts`, ajo
 
 ## Unreleased
 
+Aucun changement applicatif non distribué.
+
+---
+
+## v65 — `0.3.25` — 2026-05-30
+
+**Statut** : `closed`
+**Commit** : tag `app-v65` après merge des PR #215, #216 et #217
+**Fichier** : AAB uploadé sur le canal Play closed alpha + tag pour F-Droid
+
+Phase 2 finish — polish lecture topic après retours alpha : baseline smileys, stabilité du scroll deep-link pendant le chargement des images et régression de header après liens profil. Embarque aussi les corrections #206/#214 restées en *Unreleased* depuis v64.
+
 ### Added
 - **#206 — Highlight du topic fraîchement créé dans la liste (workaround).** La navigation directe vers le sujet créé étant impossible — HFR redirige vers la **liste de la catégorie** sans jamais renvoyer l'id du topic (confirmé live, cf. #214) — l'app **met en évidence le sujet fraîchement créé dans la liste sur laquelle elle atterrit**, par **correspondance exacte du titre** posté (titre trimé, insensible à la casse). Match exact (un `contains` highlighterait à tort un ancien sujet dont le titre est un préfixe) ; seul cas de sur-match résiduel : deux sujets au titre strictement identique seraient mis en évidence ensemble. La mise en évidence reste affichée uniquement sur la page/sous-catégorie d'arrivée ; elle disparaît dès que l'utilisateur change de page ou de sous-catégorie. Ligne accessible (`stateDescription` « Sujet que vous venez de créer ») et texte en `onSecondaryContainer` pour le contraste M3. Plumbing : l'effet `NewTopicCreated` porte désormais le `subject` saisi → propagé jusqu'à `CategoryRoute.highlightTitle` sur le path fallback (toujours le cas pour un create) → descendu jusqu'à la ligne de liste. Surbrillance sobre réutilisant le rôle M3 `secondaryContainer` (même style que le highlight d'un post cible dans `TopicScreen`, aucune couleur en dur). Dégrade proprement : `highlightTitle == null` sur tous les chemins de navigation normaux (forum, deep link, switch de sous-catégorie) → aucun highlight. C'est la version réalisable de #206.
 
 ### Fixed
 - **#214 — Création de topic : succès ne s'affiche plus en erreur.** Le submit create-topic réussit côté HFR mais l'app affichait « HFR a renvoyé une réponse inattendue » (le topic était pourtant créé → risque de doublons). Cause confirmée par capture live (`write_create_topic_success_response.html`) : HFR renvoie une phrase de succès propre au create — **« Votre message a été posté avec succès ! »** — que `ReplySubmitResponseParser` ne connaissait pas (il ne matchait que reply « réponse postée » et edit « message édité »). Fix : ajout du marker create. Validé contre la vraie fixture.
+- **#203 — Smileys inline alignés sur la baseline.** Le rendu Compose aligne désormais les smileys inline sur la baseline du texte, pour se rapprocher du rendu web HFR et limiter les sauts visuels entre texte et smileys.
+- **#197 — Re-ancrage du scroll deep-link pendant le chargement des images-blocs.** Quand un lien pointe vers un post précis, `TopicScreen` continue de surveiller la position pendant une fenêtre de décodage initiale afin de compenser les images qui gonflent au-dessus de la cible après le premier scroll. Le watcher reste annulable dès que l'utilisateur scrolle manuellement.
+- **Régression #208 — Header de post compact après liens profil.** Le pseudo cliquable n'étire plus le header du post : la zone tappable reste limitée à l'avatar/pseudo et le layout garde une hauteur stable.
 
 ### Changed
 - **Build debug** : le libellé du lanceur de la variante `debug` (installée côté-à-côté via `applicationIdSuffix=.debug`) devient **« Redface 2 ADB »** (au lieu de « Redface 2 ») pour distinguer l'install dogfood adb. La release garde `@string/app_name`.
+- `app/build.gradle.kts` : `versionCode = 65`, `versionName = "0.3.25"`.
 
 ### Known issues
 - **#206 — « Navigation directe vers le sujet créé » impossible (remplacée par le highlight, cf. *Added*).** La capture live montre qu'après un create réussi, HFR redirige vers la **liste de la catégorie** (`…/liste_sujet-1.htm`), **sans jamais renvoyer l'id du sujet créé** : `newTopicId`/`newNumreponse` sont toujours `null`. La fonctionnalité d'origine de #206 (ouvrir directement le topic) n'est donc pas réalisable. **Solution livrée** (voir *Added* ci-dessus) : l'app met en évidence le sujet fraîchement créé dans la liste par correspondance exacte du titre — le workaround validé « Exact post-création ». La branche `newTopicId != null` (jump direct) reste dans le code mais est morte pour le create ; conservée par sécurité si HFR se mettait un jour à ancrer un segment `sujet_`.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         // track (alpha) and in the GitHub Release flag, not in versionName itself.
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
-        versionCode = 64
-        versionName = "0.3.24"
+        versionCode = 65
+        versionName = "0.3.25"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,11 +1,9 @@
-Redface 2 alpha v62 — logged-in quotes fixed.
+Redface 2 alpha v65 — topic reading polish.
 
 Fixes:
-- Quotes now render correctly while logged in.
-- HFR `citation` and `oldcitation` variants are both parsed.
-
-v61 recap:
-- "Clear topic cache" maintenance action.
-- Alpha "Ignore topic cache" option for cache bug diagnostics.
+- Inline smileys align better with text.
+- More reliable jump-to-post while images load.
+- Compact post header after profile links.
+- New-topic success and list highlight.
 
 Report bugs via alpha or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,11 +1,9 @@
-Alpha Redface 2 v62 — citations connectées corrigées.
+Alpha Redface 2 v65 — polish lecture topic.
 
 Correctifs :
-- Les citations s’affichent correctement en étant connecté.
-- Les variantes HFR `citation` / `oldcitation` sont maintenant reconnues.
-
-Rappel v61 :
-- Bouton « Vider le cache des topics ».
-- Option alpha « Ignorer le cache topic » pour diagnostiquer les bugs de cache.
+- Smileys inline mieux alignés avec le texte.
+- Scroll vers un post plus fiable pendant le chargement des images.
+- Header de post compact après clic sur profil.
+- Création de topic : succès et mise en évidence dans la liste.
 
 Bugs : alpha ou GitHub.


### PR DESCRIPTION
> Action par GPT-5 Codex (demandée par @XaaT)

Prépare la release alpha v65 après merge des PR #215, #216 et #217.

Changements :
- bump `versionCode` 64 → 65 et `versionName` 0.3.24 → 0.3.25
- entrée `app/CHANGELOG.md` pour v65
- notes Play FR/EN mises à jour

Validation locale :
- `git diff --check`
- `./scripts/docker-dev.sh ./gradlew :app:assembleDebug --console=plain --no-daemon`

Après merge : tag `app-v65` pour déclencher la release Play alpha et le dispatch F-Droid.