### PR TITLE
feat(ui): dimensionnement intrinsèque des smileys inline (#175)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -21,6 +21,25 @@ Aucun changement applicatif non distribué.
 
 ---
 
+## v66 — `0.3.26` — 2026-05-30
+
+**Statut** : `closed`
+**Commit** : tag `app-v66` après merge de la PR #222
+**Fichier** : AAB uploadé sur le canal Play closed alpha + tag pour F-Droid
+
+Phase 2 finish — dogfood du rendu adaptatif des smileys inline (#175) après les retours sur les buckets fixes. Cette version garde les smileys builtin sur leur petite taille connue et mesure les smileys perso à leur taille intrinsèque pour éviter à la fois les micro-smileys agrandis et les gros smileys qui chevauchent le texte.
+
+### Changed
+- **#175 — Smileys inline à taille intrinsèque.** Les smileys perso ne passent plus par un bucket fixe unique `70×50` : l'app mesure leur taille native via Coil, applique un no-upscale, un cap absolu et un cap relatif de largeur façon RF1/HFR web. Les micro-smileys restent petits, les `70×50` dominants restent lisibles, et les très gros sprites sont réduits au lieu de déborder.
+- **Ligne de texte adaptative pour les smileys hauts.** Les paragraphes contenant des smileys inline retirent le `lineHeight` fixe pour laisser la ligne grandir autour du placeholder baseline-aligned. Objectif : zéro chevauchement avec les lignes voisines.
+- **Build / release** : `app/build.gradle.kts` passe à `versionCode = 66`, `versionName = "0.3.26"`.
+
+### Known issues
+- **#175 / #131 — Gate dogfood encore ouvert.** Les specs canoniques documentent encore la stratégie bucket fixe tant que ce rendu adaptatif n'est pas validé en alpha. Si le dogfood confirme le choix, `protocol-hfr.md`, `roadmap.md` et l'ADR de rendu smileys seront actés dans une PR dédiée.
+- **Cap relatif sous `fontScale > 1`.** Le cap de largeur relatif est exact au fontScale standard et légèrement permissif avec les grandes tailles de police. À calibrer si le dogfood accessibilité montre un débordement réel.
+
+---
+
 ## v65 — `0.3.25` — 2026-05-30
 
 **Statut** : `closed`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         // track (alpha) and in the GitHub Release flag, not in versionName itself.
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
-        versionCode = 65
-        versionName = "0.3.25"
+        versionCode = 66
+        versionName = "0.3.26"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,9 +1,9 @@
-Redface 2 alpha v65 — topic reading polish.
+Redface 2 alpha v66 — adaptive smileys.
 
-Fixes:
-- Inline smileys align better with text.
-- More reliable jump-to-post while images load.
-- Compact post header after profile links.
-- New-topic success and list highlight.
+Changes:
+- Perso smileys now render from their measured native size.
+- Tiny smileys stay tiny; large smileys are capped cleanly.
+- Text lines grow to avoid smiley overlap.
+- Builtin smileys keep their known small size.
 
 Report bugs via alpha or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,9 +1,9 @@
-Alpha Redface 2 v65 — polish lecture topic.
+Alpha Redface 2 v66 — smileys adaptatifs.
 
-Correctifs :
-- Smileys inline mieux alignés avec le texte.
-- Scroll vers un post plus fiable pendant le chargement des images.
-- Header de post compact après clic sur profil.
-- Création de topic : succès et mise en évidence dans la liste.
+Changements :
+- Smileys perso rendus à leur taille native mesurée.
+- Micro-smileys conservés petits, gros smileys réduits proprement.
+- Lignes de texte adaptées pour éviter le chevauchement.
+- Builtins gardés sur leur petite taille connue.
 
 Bugs : alpha ou GitHub.

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -52,6 +52,10 @@ dependencies {
     implementation(libs.coil.network.okhttp)
 
     testImplementation(libs.junit4)
+    // #175 — FakeImageLoaderEngine + ColorImage(width,height) give deterministic intrinsic-size
+    // measurements under Robolectric (no network/decode), and runTest drives the suspend measure.
+    testImplementation(libs.coil.test)
+    testImplementation(libs.kotlinx.coroutines.test)
     // #130 — Robolectric runtime hosts `createComposeRule()` on JVM ; the manifest is debug-only
     // and pulls the Activity surrogate the rule mounts internally ; the BOM platform aligns the
     // ui-test artifacts with the production Compose versions.

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeCache.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeCache.kt
@@ -8,10 +8,11 @@ import androidx.compose.ui.unit.IntSize
  * #175 — process-wide cache of measured intrinsic media sizes, keyed by image URL.
  *
  * The URL's native size is immutable, so we measure it once (via [measureIntrinsicMediaSize]) and
- * reuse it for every occurrence across posts/screens — the N copies of the same `:jap:` never
- * re-measure. Backed by a Compose `SnapshotStateMap` so a write (when a measurement lands) triggers
- * recomposition of the paragraphs reading that URL, which then rebuild their placeholders at the
- * final size.
+ * reuse it for every occurrence across posts/screens — the N copies of the same perso smiley do not
+ * re-measure once the first result has landed. Builtin HFR smileys bypass measurement entirely and
+ * use their known small size. Backed by a Compose `SnapshotStateMap` so a write (when a measurement
+ * lands) triggers recomposition of the paragraphs reading that URL, which then rebuild their
+ * placeholders at the final size.
  *
  * Failures are memoized too (with a TTL): a dead host / 404 must not be re-fetched on every
  * recomposition or LazyColumn re-entry — without this the cold-cache placeholder path would flood

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeCache.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeCache.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.core.ui.post
 
 import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.unit.IntSize
 
 /**
@@ -79,4 +80,20 @@ internal class DefaultIntrinsicMediaSizeCache(
         const val DEFAULT_MAX_ENTRIES = 1024
         const val DEFAULT_FAILURE_TTL_MILLIS = 60_000L
     }
+}
+
+/**
+ * Process-wide default cache instance. Survives recomposition and LazyColumn recycling (it lives
+ * above the composition); NOT process death — the Coil disk cache makes a cold re-measure cheap.
+ */
+internal object ProcessIntrinsicMediaSizeCache :
+    IntrinsicMediaSizeCache by DefaultIntrinsicMediaSizeCache()
+
+/**
+ * Exposes the [IntrinsicMediaSizeCache] to the post renderer. Defaults to the process-wide singleton
+ * so no wiring is required at the app entry point; tests override it with a pre-filled fake via
+ * `CompositionLocalProvider` to assert measured sizing deterministically.
+ */
+internal val LocalIntrinsicMediaSizeCache = staticCompositionLocalOf<IntrinsicMediaSizeCache> {
+    ProcessIntrinsicMediaSizeCache
 }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeCache.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeCache.kt
@@ -1,0 +1,82 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.ui.unit.IntSize
+
+/**
+ * #175 — process-wide cache of measured intrinsic media sizes, keyed by image URL.
+ *
+ * The URL's native size is immutable, so we measure it once (via [measureIntrinsicMediaSize]) and
+ * reuse it for every occurrence across posts/screens — the N copies of the same `:jap:` never
+ * re-measure. Backed by a Compose `SnapshotStateMap` so a write (when a measurement lands) triggers
+ * recomposition of the paragraphs reading that URL, which then rebuild their placeholders at the
+ * final size.
+ *
+ * Failures are memoized too (with a TTL): a dead host / 404 must not be re-fetched on every
+ * recomposition or LazyColumn re-entry — without this the cold-cache placeholder path would flood
+ * the network. After [failureTtlMillis] a failed URL may be retried (a transient outage recovers).
+ *
+ * Lives in `:core:ui` (no Hilt — the module has no DI) and is exposed via a process-wide singleton +
+ * a CompositionLocal so tests can inject a pre-filled fake. Not persisted (Room/DataStore): the
+ * Coil disk cache makes a cold-start re-measure cheap, and `PostContent` stays frozen.
+ */
+internal interface IntrinsicMediaSizeCache {
+    /** Measured native size for [url], or `null` if not yet measured (or only a failure is recorded). */
+    fun get(url: String): IntSize?
+
+    /** `true` when a measurement failure for [url] is still within [failureTtlMillis] of [nowMillis]. */
+    fun isFailureFresh(url: String, nowMillis: Long): Boolean
+
+    fun putSuccess(url: String, size: IntSize)
+
+    fun putFailure(url: String, nowMillis: Long)
+}
+
+/**
+ * Default [IntrinsicMediaSizeCache]: a `SnapshotStateMap` bounded to [maxEntries] with FIFO
+ * eviction (insertion order — native sizes are immutable and re-measure is cheap via the Coil disk
+ * cache, so true LRU is overkill). Thread-safe: the snapshot system guards concurrent map access
+ * (writes from the IO dispatcher, reads from the main thread); the auxiliary insertion-order queue
+ * is guarded by [lock].
+ */
+internal class DefaultIntrinsicMediaSizeCache(
+    private val maxEntries: Int = DEFAULT_MAX_ENTRIES,
+    private val failureTtlMillis: Long = DEFAULT_FAILURE_TTL_MILLIS,
+) : IntrinsicMediaSizeCache {
+
+    private sealed interface Entry {
+        data class Success(val size: IntSize) : Entry
+        data class Failure(val atMillis: Long) : Entry
+    }
+
+    private val entries = mutableStateMapOf<String, Entry>()
+    private val insertionOrder = ArrayDeque<String>()
+    private val lock = Any()
+
+    override fun get(url: String): IntSize? = (entries[url] as? Entry.Success)?.size
+
+    override fun isFailureFresh(url: String, nowMillis: Long): Boolean {
+        val failure = entries[url] as? Entry.Failure ?: return false
+        return nowMillis - failure.atMillis < failureTtlMillis
+    }
+
+    override fun putSuccess(url: String, size: IntSize) = put(url, Entry.Success(size))
+
+    override fun putFailure(url: String, nowMillis: Long) = put(url, Entry.Failure(nowMillis))
+
+    private fun put(url: String, entry: Entry) {
+        synchronized(lock) {
+            if (!entries.containsKey(url)) insertionOrder.addLast(url)
+            entries[url] = entry
+            while (insertionOrder.size > maxEntries) {
+                val evicted = insertionOrder.removeFirst()
+                entries.remove(evicted)
+            }
+        }
+    }
+
+    internal companion object {
+        const val DEFAULT_MAX_ENTRIES = 1024
+        const val DEFAULT_FAILURE_TTL_MILLIS = 60_000L
+    }
+}

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeMeasurer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeMeasurer.kt
@@ -1,0 +1,36 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import androidx.compose.ui.unit.IntSize
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.request.ImageRequest
+import coil3.request.SuccessResult
+import coil3.size.Size
+
+/**
+ * #175 — measure a media's **intrinsic** (native) pixel dimensions via Coil, off the main thread.
+ *
+ * Requests `Size.ORIGINAL` so Coil reports the SOURCE dimensions (not the display target), then
+ * reads `coil3.Image.width/height` (raw bitmap px, never screen-density scaled). The caller wraps
+ * this in `withContext(ioDispatcher)` and caches the result by URL.
+ *
+ * Returns `null` on error / non-positive dimensions so the caller falls back to a provisional size.
+ *
+ * NB (#175 conversion): the returned px are CSS/logical-pixel equivalents — they are fed to the
+ * placeholder as `.sp` directly (`70px → 70.sp`), NOT divided by screen density. See the design
+ * doc; dividing by density would render smileys ~`1/density` too small.
+ */
+internal suspend fun measureIntrinsicMediaSize(
+    url: String,
+    context: PlatformContext,
+    imageLoader: ImageLoader,
+): IntSize? {
+    val result = imageLoader.execute(
+        ImageRequest.Builder(context)
+            .data(url)
+            .size(Size.ORIGINAL)
+            .build(),
+    )
+    val image = (result as? SuccessResult)?.image ?: return null
+    return if (image.width > 0 && image.height > 0) IntSize(image.width, image.height) else null
+}

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeMeasurer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeMeasurer.kt
@@ -8,17 +8,22 @@ import coil3.request.SuccessResult
 import coil3.size.Size
 
 /**
- * #175 — measure a media's **intrinsic** (native) pixel dimensions via Coil, off the main thread.
+ * #175 — measure a media's **intrinsic** (native) pixel dimensions via Coil.
  *
- * Requests `Size.ORIGINAL` so Coil reports the SOURCE dimensions (not the display target), then
- * reads `coil3.Image.width/height` (raw bitmap px, never screen-density scaled). The caller wraps
- * this in `withContext(ioDispatcher)` and caches the result by URL.
+ * Requests `Size.ORIGINAL` so Coil decodes to the SOURCE dimensions (not the display target), then
+ * reads `coil3.Image.width/height` (raw bitmap px, never screen-density scaled). `execute()` is a
+ * main-safe suspend call (Coil dispatches its own I/O), so the caller invokes it directly from a
+ * `LaunchedEffect` and caches the result by URL. Returns `null` on error / non-positive dimensions so
+ * the caller can fall back to a provisional size.
  *
- * Returns `null` on error / non-positive dimensions so the caller falls back to a provisional size.
+ * Caveat: `Size.ORIGINAL` sets the request *target*, not Coil's `maxBitmapSize` (default 4096) — so
+ * the reported size equals the source only while the source is ≤ 4096 on each axis; a larger source
+ * is reported at the clamped decode size. Irrelevant for smileys (all well under 4096); it would only
+ * matter if this were reused to size arbitrary large inline images.
  *
- * NB (#175 conversion): the returned px are CSS/logical-pixel equivalents — they are fed to the
- * placeholder as `.sp` directly (`70px → 70.sp`), NOT divided by screen density. See the design
- * doc; dividing by density would render smileys ~`1/density` too small.
+ * NB (#175 conversion): the returned px are CSS/logical-pixel equivalents — fed to the placeholder as
+ * `.sp` directly (`70px → 70.sp`), NOT divided by screen density (which would render smileys
+ * ~`1/density` too small — the bug the design doc calls out).
  */
 internal suspend fun measureIntrinsicMediaSize(
     url: String,

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
@@ -10,29 +10,24 @@ import fr.forumhfr.redface2.core.model.SmileyKind
 import kotlin.math.roundToInt
 
 /**
- * Pure, JVM-testable mapping from a media inline node to the bucket size used by Compose's
- * [androidx.compose.foundation.text.InlineTextContent] `Placeholder`. The matching `AsyncImage`
- * fills the placeholder via `Modifier.fillMaxSize()` rather than carrying its own `dp` size — so
- * the image always tracks the `sp`-sized placeholder, even when `fontScale != 1` (accessibility).
+ * Pure, JVM-testable sizing for inline post media (smileys + inline images). The matching `AsyncImage`
+ * fills the placeholder via `Modifier.fillMaxSize()` rather than carrying its own `dp` size — so the
+ * image always tracks the `sp`-sized placeholder, even when `fontScale != 1` (accessibility).
  *
- * Why buckets and not measured intrinsic sizes (cf. arbitrage Codex on issue #109): Compose
- * `InlineTextContent` requires a **fixed** `Placeholder` size at the time the `AnnotatedString`
- * is built. Real HFR smileys range from 15×15 (`:tinostar:`, `:grilled:`) up to ~70×50 for the
- * common perso, with rare larger sprites. Async measurement via `ImageLoader.execute()` would
- * force a recomposition pass with a visible "size pop" on first scroll, plus a per-URL cache to
- * maintain. Phase 1 therefore picks two smiley buckets keyed on [SmileyKind] (the parser already
- * classifies the BBCode token via `alt`/`title`) plus one inline-image bucket.
+ * #175 — SMILEYS are sized by their **measured intrinsic** native dimensions (no-upscale + cap, see
+ * [intrinsicSmileyDisplaySize] + [capToWidth]), fed by an async Coil measurement cached per URL
+ * (`IntrinsicMediaSizeCache`, driven by `PostRenderer.ParagraphBlock`). The intrinsic px are treated
+ * as logical/CSS pixels (→ `.sp` directly, NOT `/density`), reproducing the web/RF1 rendering. The old
+ * fixed [builtinSmiley]/[persoSmiley] buckets now survive only as the **cold-cache fallback** shown
+ * while a smiley's size is in flight (and as the default `collectInlineMedia` resolver in tests).
  *
- * [smileyContentScale] is `ContentScale.Fit`: HFR perso smileys are expressive sprites, and tiny
- * 15×15 sources become unreadable on phones when left at native size. The line-height bug from the
- * initial 64×64 policy came from the old `Modifier.size(.dp)` child drifting from the `sp`
- * placeholder, plus an overly large bucket — not from scaling the sprite to the placeholder.
- * Keeping `Modifier.fillMaxSize()` makes the rendered smiley track the reserved text line under
- * `fontScale`, while the 70×50 bucket follows the dominant wikismilies corpus shape without
- * returning to the old broken 64sp line height.
+ * Inline `[img]` ([inlineImage]) is OUT of #175 scope and still uses its fixed 240×180 bucket with
+ * [inlineImageContentScale] (`Inside`) — a separate UX contract; revisit if dogfood shows it needs
+ * the same intrinsic treatment.
  *
- * Re-evaluate in Phase 2/4 if a fixed bucket still feels wrong on real corpora; intrinsic-size
- * measurement remains the open Phase 2/4 option.
+ * Why this took fixed buckets as a stopgap in #109: Compose `InlineTextContent` requires a **fixed**
+ * `Placeholder` size when the `AnnotatedString` is built, so intrinsic sizing needs async-measure →
+ * cache → recompose; a cold first paint can still reflow once before the measured size lands.
  */
 internal object PostMediaDisplayPolicy {
 

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
@@ -18,8 +18,9 @@ import kotlin.math.roundToInt
  * [intrinsicSmileyDisplaySize] + [capToWidth]), fed by an async Coil measurement cached per URL
  * (`IntrinsicMediaSizeCache`, driven by `PostRenderer.ParagraphBlock`). The intrinsic px are treated
  * as logical/CSS pixels (→ `.sp` directly, NOT `/density`), reproducing the web/RF1 rendering. The old
- * fixed [builtinSmiley]/[persoSmiley] buckets now survive only as the **cold-cache fallback** shown
- * while a smiley's size is in flight (and as the default `collectInlineMedia` resolver in tests).
+ * fixed [builtinSmiley]/[persoSmiley] buckets now survive only as fallbacks: builtins use their known
+ * small size directly, while perso smileys use the 70×50 cold-cache fallback while measurement is
+ * in flight (and as the default `collectInlineMedia` resolver in tests).
  *
  * Inline `[img]` ([inlineImage]) is OUT of #175 scope and still uses its fixed 240×180 bucket with
  * [inlineImageContentScale] (`Inside`) — a separate UX contract; revisit if dogfood shows it needs
@@ -180,9 +181,10 @@ internal const val SMILEY_MAX_WIDTH_SP = 240
 internal const val SMILEY_RELATIVE_MAX_WIDTH_FRACTION = 0.9f
 
 /**
- * #175 — provisional placeholder sizes used while a smiley's intrinsic size is still being measured
- * (cold cache), to minimise reflow when the real size lands. Builtins are pre-seeded at their known
- * ~16×16 (HFR icon set); perso falls back to the dominant 70×50 corpus size.
+ * #175 — provisional placeholder sizes used while a perso smiley's intrinsic size is still being
+ * measured (cold cache), to minimise reflow when the real size lands. Builtins are never measured:
+ * they use their known ~16×16 HFR icon size directly. Perso falls back to the dominant 70×50 corpus
+ * size until measurement completes.
  */
 internal val builtinPreseedSize = PixelSize(16, 16)
 internal val persoColdFallbackSize = PixelSize(70, 50)

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
@@ -32,9 +32,11 @@ import kotlin.math.roundToInt
 internal object PostMediaDisplayPolicy {
 
     /**
-     * Smileys are textual/emotive glyphs: fit them to the reserved bucket so even tiny historical
-     * perso sprites remain visible on high-density phones. Ratio is preserved; square smileys fill
-     * the bucket, wide/tall ones are letterboxed.
+     * #175 — the smiley placeholder is now sized to the smiley's measured intrinsic size (or a
+     * provisional cold-cache fallback), so [ContentScale.Fit] just maps the bitmap into that
+     * same-ratio box without distortion. It no longer upscales a tiny sprite to an oversized fixed
+     * bucket (the pre-#175 model): the size difference between a 15×15 and a 70×50 now comes from
+     * the source, matching web/RF1.
      */
     val smileyContentScale: ContentScale = ContentScale.Fit
 
@@ -45,8 +47,12 @@ internal object PostMediaDisplayPolicy {
     val inlineImageContentScale: ContentScale = ContentScale.Inside
 
     /**
+     * **Not the #175 production size** — since intrinsic sizing landed, this fixed box survives only
+     * as the default [collectInlineMedia] resolver used by tests (production sizes from the measured
+     * native px, see the object KDoc; the in-flight cold fallback is [builtinPreseedSize]).
+     *
      * Built-in HFR smileys (`:jap:`, `:o`, `:D`, `;)`, `:??:`, …) — served from `/icones/<x>.gif`
-     * and `/icones/smilies/<x>.gif`. HFR ships them at 16×16 historically; the 18-sp bucket is
+     * and `/icones/smilies/<x>.gif`. HFR ships them at 16×16 historically; the 18-sp box is
      * a tiny pad so a slightly taller variant doesn't get clipped at the baseline.
      */
     val builtinSmiley: InlineMediaBox = InlineMediaBox(
@@ -55,18 +61,17 @@ internal object PostMediaDisplayPolicy {
     )
 
     /**
+     * **Not the #175 production size** — since intrinsic sizing landed, this fixed box survives only
+     * as the default [collectInlineMedia] resolver used by tests (production sizes from the measured
+     * native px, see the object KDoc; the in-flight cold fallback is [persoColdFallbackSize]).
+     *
      * User-uploaded persona smileys (`[:cosmoschtroumpf]`, `[:rofl]`, …) — served from
      * `/images/perso/<x>.gif` or `/images/perso/<N>/<x>.gif`. Sizes are heterogeneous; the bulk
      * of the exhaustive wikismilies corpus lands on height 50 px, with width commonly ranging up
      * to 70 px. The top sizes found during dogfood were 70×50 (8047), 50×50 (2811), 67×50
      * (1142), then many W×50 variants; tiny historical sprites (15×15, 19×19, 16×16) exist too.
-     *
-     * 70×50 is a corpus-first bucket after dogfood on v32-v34:
-     * - 40×40 + Inside fixed overlap but made common perso unreadable on phones;
-     * - 56×56 + Fit made tiny sprites readable but letterboxed the dominant 70×50 shape;
-     * - 70×50 + Fit keeps common perso at their native HFR ratio while upscaling tiny ones to a
-     *   readable 50 px-high glyph;
-     * - placeholder height stays below the old broken 64sp line rhythm.
+     * 70×50 (the dominant corpus size) is therefore the natural provisional size to minimise reflow
+     * before the measured size lands.
      */
     val persoSmiley: InlineMediaBox = InlineMediaBox(
         placeholderWidth = 70.sp,
@@ -120,6 +125,11 @@ internal data class PixelSize(val width: Int, val height: Int)
 /**
  * Pure mirror of [ContentScale.Fit]: uniformly scale [source] so it fits inside [bucket] while
  * preserving aspect ratio. Returns the resulting size.
+ *
+ * #175 note: this is **no longer on the production smiley path** (which uses
+ * [intrinsicSmileyDisplaySize] + [capToWidth]); it is retained as a pure-JVM `Fit` reference and is
+ * still exercised by tests. Cross-referenced from [intrinsicSmileyDisplaySize] only for its shared
+ * anti-collapse clamp.
  *
  * The result is clamped to at least 1×1 to guard against extreme aspect ratios where rounding
  * would otherwise collapse one dimension to 0 (e.g. a 1×100 banner downscaled into a 70×50

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
@@ -152,3 +152,55 @@ internal fun fitScaledMediaSize(source: PixelSize, bucket: PixelSize): PixelSize
         height = (source.height * scale).roundToInt().coerceAtLeast(1),
     )
 }
+
+/**
+ * #175 — absolute caps for an inline smiley, in **sp** (the intrinsic native px are treated as
+ * logical/CSS px and fed to the placeholder as `.sp` directly — see [intrinsicSmileyDisplaySize]).
+ *
+ * Calibrated against the wikismilies corpus (dominant 70×50, then 50×50/67×50): the height cap of
+ * 70sp lets the dominant 70×50 pass through untouched (~3.5× a 20sp body line, like the web) and
+ * only clamps rare oversized sprites. The width cap is a coarse abuse guard; the *real* horizontal
+ * limit is the relative `0.9 × contentWidth` (RF1's `img { max-width: 90% }`) applied renderer-side
+ * where the container width is known. Values are starting points to calibrate in dogfood (#175).
+ */
+internal const val SMILEY_MAX_HEIGHT_SP = 70
+internal const val SMILEY_MAX_WIDTH_SP = 240
+
+/**
+ * #175 — provisional placeholder sizes used while a smiley's intrinsic size is still being measured
+ * (cold cache), to minimise reflow when the real size lands. Builtins are pre-seeded at their known
+ * ~16×16 (HFR icon set); perso falls back to the dominant 70×50 corpus size.
+ */
+internal val builtinPreseedSize = PixelSize(16, 16)
+internal val persoColdFallbackSize = PixelSize(70, 50)
+
+/**
+ * #175 — the no-upscale + cap policy that replaces the fixed [InlineMediaBox] buckets for smileys.
+ *
+ * Given a smiley's intrinsic native size [nativePx] (raw bitmap px from Coil, treated as logical/CSS
+ * px), returns the display size to feed the placeholder (as `.sp`):
+ *  - **no upscale**: never larger than native — a 15×15 stays 15×15 (the old `Fit` bucket blew it up
+ *    to 50×50), a 70×50 stays 70×50, a `:jap:` ~16×16 stays small. The builtin↔perso size difference
+ *    emerges from the source, matching RF1/web ;
+ *  - **cap down** to [maxWidthSp]×[maxHeightSp] preserving aspect ratio (a huge sprite shrinks) ;
+ *  - clamped ≥ 1 per axis (same anti-collapse guard as [fitScaledMediaSize]).
+ *
+ * The *relative* width cap (≈`0.9 × contentWidth`) is applied separately in the renderer, which is
+ * the only place the container width is known (BoxWithConstraints).
+ */
+internal fun intrinsicSmileyDisplaySize(
+    nativePx: PixelSize,
+    maxWidthSp: Int = SMILEY_MAX_WIDTH_SP,
+    maxHeightSp: Int = SMILEY_MAX_HEIGHT_SP,
+): PixelSize {
+    require(nativePx.width > 0 && nativePx.height > 0) { "nativePx must be positive" }
+    val scale = minOf(
+        maxWidthSp.toFloat() / nativePx.width.toFloat(),
+        maxHeightSp.toFloat() / nativePx.height.toFloat(),
+        1f,
+    )
+    return PixelSize(
+        width = (nativePx.width * scale).roundToInt().coerceAtLeast(1),
+        height = (nativePx.height * scale).roundToInt().coerceAtLeast(1),
+    )
+}

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
@@ -167,6 +167,14 @@ internal const val SMILEY_MAX_HEIGHT_SP = 70
 internal const val SMILEY_MAX_WIDTH_SP = 240
 
 /**
+ * #175 — RF1's `img { max-width: 90% }` ported to the smiley path: a smiley never occupies more than
+ * this fraction of the available content width. Applied renderer-side (the only place the container
+ * width is known, via `BoxWithConstraints`) so a large perso shrinks to fit instead of overflowing /
+ * overlapping the text in a narrow quote — and it stays correct as the width shrinks with quote depth.
+ */
+internal const val SMILEY_RELATIVE_MAX_WIDTH_FRACTION = 0.9f
+
+/**
  * #175 — provisional placeholder sizes used while a smiley's intrinsic size is still being measured
  * (cold cache), to minimise reflow when the real size lands. Builtins are pre-seeded at their known
  * ~16×16 (HFR icon set); perso falls back to the dominant 70×50 corpus size.
@@ -202,5 +210,19 @@ internal fun intrinsicSmileyDisplaySize(
     return PixelSize(
         width = (nativePx.width * scale).roundToInt().coerceAtLeast(1),
         height = (nativePx.height * scale).roundToInt().coerceAtLeast(1),
+    )
+}
+
+/**
+ * #175 — scale [size] down so its width fits [maxWidthSp] (the relative cap, ≈90% of the content
+ * width), preserving aspect ratio and clamping to ≥1 per axis. A no-op when it already fits or when
+ * [maxWidthSp] is non-positive (defensive: a zero-width container should not collapse the smiley).
+ */
+internal fun capToWidth(size: PixelSize, maxWidthSp: Int): PixelSize {
+    if (maxWidthSp <= 0 || size.width <= maxWidthSp) return size
+    val scale = maxWidthSp.toFloat() / size.width.toFloat()
+    return PixelSize(
+        width = maxWidthSp,
+        height = (size.height * scale).roundToInt().coerceAtLeast(1),
     )
 }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.SingletonImageLoader
@@ -157,21 +158,27 @@ private fun ParagraphBlock(inlines: List<PostInline>) {
         }
     }
 
-    if (annotated.text.isBlank() && !hasInlineMedia(inlines)) {
+    val hasMedia = remember(inlines) { hasInlineMedia(inlines) }
+    if (annotated.text.isBlank() && !hasMedia) {
         return
     }
-    // #175 — cap each smiley to RF1's `img { max-width: 90% }`: never wider than 90% of the content
-    // width. BoxWithConstraints exposes that width (it shrinks with quote depth via QuoteFrame), so a
-    // large perso no longer overflows / overlaps the surrounding text in a narrow quote.
+    // #175 — two guards against a tall/large inline smiley overlapping the text:
+    //  - width: cap each smiley to RF1's `img { max-width: 90% }` of the content width (read from
+    //    BoxWithConstraints, which shrinks with quote depth) so it never overflows a narrow quote;
+    //  - height: for media paragraphs drop bodyMedium's fixed `lineHeight` so the LINE GROWS to
+    //    contain the placeholder. With the clamp + Center, a 70sp sprite still overflowed upward onto
+    //    the line above (measured top y=-22→+7); unspecified lineHeight lets the line expand → zero
+    //    overlap. Plain-text paragraphs keep the bodyMedium rhythm.
     BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
         val maxSmileyWidthSp = (maxWidth.value * SMILEY_RELATIVE_MAX_WIDTH_FRACTION).roundToInt()
         val inlineContent = remember(inlines, measuredSizes, maxSmileyWidthSp) {
             collectInlineMedia(inlines) { smiley -> smileyDisplayBox(smiley, measuredSizes, maxSmileyWidthSp) }
         }
+        val baseStyle = MaterialTheme.typography.bodyMedium
         Text(
             text = annotated,
             inlineContent = inlineContent,
-            style = MaterialTheme.typography.bodyMedium,
+            style = if (hasMedia) baseStyle.copy(lineHeight = TextUnit.Unspecified) else baseStyle,
             color = MaterialTheme.colorScheme.onSurface,
         )
     }
@@ -667,28 +674,21 @@ internal fun smileyInlineContent(smiley: PostInline.Smiley, box: InlineMediaBox)
         placeholder = Placeholder(
             width = box.placeholderWidth,
             height = box.placeholderHeight,
-            // #203 — web parity. HFR serves both builtin (`/icones/…`) and perso (`/images/perso/…`)
-            // smileys as bare `<img>` with no `vertical-align`, so the browser falls back to the CSS
-            // default `baseline`: the bottom of the sprite sits on the text baseline. `Center` (the
-            // previous value) instead straddled the placeholder across the line centre, which on a
-            // 50sp perso bucket overflowed ~15sp above AND below a 20sp body line — the "smiley au
-            // milieu de la ligne, par-dessus le texte" reported in #203. `AboveBaseline` reproduces
-            // the web baseline alignment. Verified against captured fixtures (no perso/builtin smiley
-            // carries a width/height/style attribute in a post body).
-            placeholderVerticalAlign = PlaceholderVerticalAlign.AboveBaseline,
+            // #175 — `Center`, deliberately NOT `AboveBaseline`. AboveBaseline anchors the sprite's
+            // bottom to the baseline and extends it UPWARD *without growing the line*, so a tall perso
+            // overflows onto the line above (measured: a 70sp sprite reaches y=-22 over a 28sp first
+            // line — the overlap reported on the franzhermann post). Only Center/Top/Bottom make the
+            // line grow to contain the placeholder; Center grows it symmetrically → the line gets
+            // taller and there is ZERO overlap. The #203 "straddle" that pushed us to AboveBaseline
+            // came from the old 50sp bucket blowing up tiny sprites; with #175 intrinsic sizing a
+            // small smiley is ~line height, so Center sits it naturally on the line instead.
+            placeholderVerticalAlign = PlaceholderVerticalAlign.Center,
         ),
     ) {
         AsyncImage(
             model = smiley.imageUrl,
             contentDescription = description,
             contentScale = PostMediaDisplayPolicy.smileyContentScale,
-            // Bottom-align the sprite inside the placeholder so its *visible* bottom rests on the
-            // baseline (= the placeholder bottom, since AboveBaseline). With ContentScale.Fit a
-            // sprite that doesn't fill the 70×50 bucket's height is letterboxed; the default Center
-            // alignment then floats it ~1px above the baseline — off by that gap from HFR web, which
-            // sits the bare <img> bottom on the baseline. BottomCenter closes that gap for any aspect
-            // ratio (#131 web-parity polish; a no-op for sprites that already fill the bucket height).
-            alignment = Alignment.BottomCenter,
             modifier = Modifier.fillMaxSize(),
         )
     }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -134,18 +134,32 @@ private fun ParagraphBlock(inlines: List<PostInline>) {
     val annotated = remember(inlines, linkStyles, imageAlt) {
         buildInlineText(inlines, linkStyles, imageAlt)
     }
+    val hasMedia = remember(inlines) { hasInlineMedia(inlines) }
 
-    // #175 — adaptive smiley sizing. Read each smiley's measured native size from the URL cache;
-    // the reads are tracked snapshot reads, so when a measurement lands the SnapshotStateMap write
-    // recomposes this block and only the inline-content Map (not the AnnotatedString) is rebuilt at
-    // the final size. Cold/miss → a provisional fallback to minimise reflow (builtin ~16, perso 70×50).
+    // Plain-text paragraph (the common case): no inline media to size, so render directly with the
+    // bodyMedium rhythm and skip the whole #175 machinery — no cache reads, no measurement effect, no
+    // BoxWithConstraints/SubcomposeLayout wrapper.
+    if (!hasMedia) {
+        if (annotated.text.isBlank()) return
+        Text(
+            text = annotated,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        return
+    }
+
+    // #175 — media paragraph: adaptive smiley sizing. Read each smiley's measured native size from the
+    // URL cache; the reads are tracked snapshot reads, so when a measurement lands the SnapshotStateMap
+    // write recomposes this block and only the inline-content Map (not the AnnotatedString) is rebuilt
+    // at the final size. Cold/miss → a provisional fallback to minimise reflow (builtin ~16, perso 70×50).
     val sizeCache = LocalIntrinsicMediaSizeCache.current
     val smileyUrls = remember(inlines) { collectSmileyUrls(inlines) }
     val measuredSizes: Map<String, IntSize?> = smileyUrls.associateWith { sizeCache.get(it) }
 
     // Measure the not-yet-known URLs. Coil's execute() is a main-safe suspend call (it dispatches its
-    // own I/O), and reuses the shared SingletonImageLoader caches the rendering AsyncImage hits — so
-    // no double network fetch. A dead URL is recorded as a failure (TTL) so it is not re-fetched.
+    // own I/O), and reuses the shared SingletonImageLoader caches the rendering AsyncImage hits — so no
+    // double network fetch. A dead URL is recorded as a failure (TTL) so it is not re-fetched.
     val platformContext = LocalPlatformContext.current
     LaunchedEffect(smileyUrls) {
         val loader = SingletonImageLoader.get(platformContext)
@@ -158,27 +172,21 @@ private fun ParagraphBlock(inlines: List<PostInline>) {
         }
     }
 
-    val hasMedia = remember(inlines) { hasInlineMedia(inlines) }
-    if (annotated.text.isBlank() && !hasMedia) {
-        return
-    }
-    // #175 — two guards against a tall/large inline smiley overlapping the text:
+    // Two guards against a tall/large inline smiley overlapping the text:
     //  - width: cap each smiley to RF1's `img { max-width: 90% }` of the content width (read from
     //    BoxWithConstraints, which shrinks with quote depth) so it never overflows a narrow quote;
-    //  - height: for media paragraphs drop bodyMedium's fixed `lineHeight` so the LINE GROWS to
-    //    contain the (baseline-aligned) placeholder. With the clamp a tall sprite overflowed UP off
-    //    its line onto the line above (measured top y=-22 over a 28sp first line); unspecified
-    //    lineHeight lets the ascent expand → zero overlap. Plain-text paragraphs keep the bodyMedium rhythm.
+    //  - height: drop bodyMedium's fixed `lineHeight` so the LINE GROWS to contain the baseline-aligned
+    //    placeholder. With the clamp a tall sprite overflowed UP off its line onto the line above
+    //    (measured top y=-22 over a 28sp first line); unspecified lineHeight lets the ascent expand → zero overlap.
     BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
         val maxSmileyWidthSp = (maxWidth.value * SMILEY_RELATIVE_MAX_WIDTH_FRACTION).roundToInt()
         val inlineContent = remember(inlines, measuredSizes, maxSmileyWidthSp) {
             collectInlineMedia(inlines) { smiley -> smileyDisplayBox(smiley, measuredSizes, maxSmileyWidthSp) }
         }
-        val baseStyle = MaterialTheme.typography.bodyMedium
         Text(
             text = annotated,
             inlineContent = inlineContent,
-            style = if (hasMedia) baseStyle.copy(lineHeight = TextUnit.Unspecified) else baseStyle,
+            style = MaterialTheme.typography.bodyMedium.copy(lineHeight = TextUnit.Unspecified),
             color = MaterialTheme.colorScheme.onSurface,
         )
     }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -50,8 +51,12 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.SingletonImageLoader
 import coil3.compose.AsyncImage
+import coil3.compose.LocalPlatformContext
 import coil3.compose.SubcomposeAsyncImage
 import coil3.compose.SubcomposeAsyncImageContent
 import fr.forumhfr.redface2.core.ui.R
@@ -121,10 +126,38 @@ private fun ParagraphBlock(inlines: List<PostInline>) {
         )
     }
     val imageAlt = stringResource(R.string.post_inline_image_alt)
+    // The AnnotatedString is INVARIANT — it carries only the U+FFFC markers + IDs (via MediaCounter),
+    // never a size — so it is never rebuilt when a measurement lands (#175 stability pivot).
     val annotated = remember(inlines, linkStyles, imageAlt) {
         buildInlineText(inlines, linkStyles, imageAlt)
     }
-    val inlineContent = remember(inlines) { collectInlineMedia(inlines) }
+
+    // #175 — adaptive smiley sizing. Read each smiley's measured native size from the URL cache;
+    // the reads are tracked snapshot reads, so when a measurement lands the SnapshotStateMap write
+    // recomposes this block and only the inline-content Map (not the AnnotatedString) is rebuilt at
+    // the final size. Cold/miss → a provisional fallback to minimise reflow (builtin ~16, perso 70×50).
+    val sizeCache = LocalIntrinsicMediaSizeCache.current
+    val smileyUrls = remember(inlines) { collectSmileyUrls(inlines) }
+    val measuredSizes: Map<String, IntSize?> = smileyUrls.associateWith { sizeCache.get(it) }
+    val inlineContent = remember(inlines, measuredSizes) {
+        collectInlineMedia(inlines) { smiley -> smileyDisplayBox(smiley, measuredSizes) }
+    }
+
+    // Measure the not-yet-known URLs. Coil's execute() is a main-safe suspend call (it dispatches its
+    // own I/O), and reuses the shared SingletonImageLoader caches the rendering AsyncImage hits — so
+    // no double network fetch. A dead URL is recorded as a failure (TTL) so it is not re-fetched.
+    val platformContext = LocalPlatformContext.current
+    LaunchedEffect(smileyUrls) {
+        val loader = SingletonImageLoader.get(platformContext)
+        smileyUrls.forEach { url ->
+            val now = System.currentTimeMillis()
+            if (sizeCache.get(url) == null && !sizeCache.isFailureFresh(url, now)) {
+                val size = measureIntrinsicMediaSize(url, platformContext, loader)
+                if (size != null) sizeCache.putSuccess(url, size) else sizeCache.putFailure(url, now)
+            }
+        }
+    }
+
     if (annotated.text.isBlank() && inlineContent.isEmpty()) {
         return
     }
@@ -491,10 +524,19 @@ private fun AnnotatedString.Builder.appendInline(
     }
 }
 
-internal fun collectInlineMedia(inlines: List<PostInline>): Map<String, InlineTextContent> {
+/**
+ * Builds the `InlineTextContent` map keyed by the same IDs [buildInlineText] emits (the MediaCounter
+ * symmetry invariant). [smileyBox] resolves the placeholder size for each smiley: the production
+ * caller ([ParagraphBlock]) passes a cache-backed resolver (#175 intrinsic sizing), while tests can
+ * pass a stub. The default keeps the legacy fixed buckets as the cold fallback.
+ */
+internal fun collectInlineMedia(
+    inlines: List<PostInline>,
+    smileyBox: (PostInline.Smiley) -> InlineMediaBox = { PostMediaDisplayPolicy.smileyBox(it) },
+): Map<String, InlineTextContent> {
     val out = mutableMapOf<String, InlineTextContent>()
     val media = MediaCounter()
-    walkInlinesForMedia(inlines, out, media)
+    walkInlinesForMedia(inlines, out, media, smileyBox)
     return out
 }
 
@@ -502,6 +544,7 @@ private fun walkInlinesForMedia(
     inlines: List<PostInline>,
     out: MutableMap<String, InlineTextContent>,
     media: MediaCounter,
+    smileyBox: (PostInline.Smiley) -> InlineMediaBox,
 ) {
     inlines.forEach { inline ->
         when (inline) {
@@ -510,18 +553,57 @@ private fun walkInlinesForMedia(
 
             is PostInline.Smiley -> {
                 if (inline.imageUrl == null) return@forEach
-                out += media.nextSmiley() to smileyInlineContent(inline)
+                out += media.nextSmiley() to smileyInlineContent(inline, smileyBox(inline))
             }
 
-            is PostInline.Strong -> walkInlinesForMedia(inline.children, out, media)
-            is PostInline.Emphasis -> walkInlinesForMedia(inline.children, out, media)
-            is PostInline.Underline -> walkInlinesForMedia(inline.children, out, media)
-            is PostInline.Strike -> walkInlinesForMedia(inline.children, out, media)
-            is PostInline.Color -> walkInlinesForMedia(inline.children, out, media)
-            is PostInline.Link -> walkInlinesForMedia(inline.children, out, media)
+            is PostInline.Strong -> walkInlinesForMedia(inline.children, out, media, smileyBox)
+            is PostInline.Emphasis -> walkInlinesForMedia(inline.children, out, media, smileyBox)
+            is PostInline.Underline -> walkInlinesForMedia(inline.children, out, media, smileyBox)
+            is PostInline.Strike -> walkInlinesForMedia(inline.children, out, media, smileyBox)
+            is PostInline.Color -> walkInlinesForMedia(inline.children, out, media, smileyBox)
+            is PostInline.Link -> walkInlinesForMedia(inline.children, out, media, smileyBox)
             else -> Unit
         }
     }
+}
+
+/** Collects the distinct (non-null) smiley image URLs of [inlines], for #175 measurement. */
+private fun collectSmileyUrls(inlines: List<PostInline>): Set<String> {
+    val urls = LinkedHashSet<String>()
+    fun walk(list: List<PostInline>) {
+        list.forEach { inline ->
+            when (inline) {
+                is PostInline.Smiley -> inline.imageUrl?.let { urls += it }
+                is PostInline.Strong -> walk(inline.children)
+                is PostInline.Emphasis -> walk(inline.children)
+                is PostInline.Underline -> walk(inline.children)
+                is PostInline.Strike -> walk(inline.children)
+                is PostInline.Color -> walk(inline.children)
+                is PostInline.Link -> walk(inline.children)
+                else -> Unit
+            }
+        }
+    }
+    walk(inlines)
+    return urls
+}
+
+/**
+ * #175 — resolve a smiley's placeholder box: measured native size (no-upscale + cap) when known,
+ * else a provisional fallback (pre-seeded builtin / dominant 70×50 perso) to minimise reflow while
+ * the measurement is in flight.
+ */
+private fun smileyDisplayBox(smiley: PostInline.Smiley, measured: Map<String, IntSize?>): InlineMediaBox {
+    val size = smiley.imageUrl?.let { measured[it] }
+    if (size != null) {
+        val display = intrinsicSmileyDisplaySize(PixelSize(size.width, size.height))
+        return InlineMediaBox(display.width.sp, display.height.sp)
+    }
+    val fallback = when (smiley.kind) {
+        is SmileyKind.Builtin -> builtinPreseedSize
+        is SmileyKind.Perso -> persoColdFallbackSize
+    }
+    return InlineMediaBox(fallback.width.sp, fallback.height.sp)
 }
 
 internal fun imageInlineContent(image: PostInline.InlineImage): InlineTextContent {
@@ -550,8 +632,7 @@ internal fun imageInlineContent(image: PostInline.InlineImage): InlineTextConten
     }
 }
 
-internal fun smileyInlineContent(smiley: PostInline.Smiley): InlineTextContent {
-    val box = PostMediaDisplayPolicy.smileyBox(smiley)
+internal fun smileyInlineContent(smiley: PostInline.Smiley, box: InlineMediaBox): InlineTextContent {
     val description = smiley.kind.token()
     return InlineTextContent(
         placeholder = Placeholder(

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -166,9 +166,9 @@ private fun ParagraphBlock(inlines: List<PostInline>) {
     //  - width: cap each smiley to RF1's `img { max-width: 90% }` of the content width (read from
     //    BoxWithConstraints, which shrinks with quote depth) so it never overflows a narrow quote;
     //  - height: for media paragraphs drop bodyMedium's fixed `lineHeight` so the LINE GROWS to
-    //    contain the placeholder. With the clamp + Center, a 70sp sprite still overflowed upward onto
-    //    the line above (measured top y=-22→+7); unspecified lineHeight lets the line expand → zero
-    //    overlap. Plain-text paragraphs keep the bodyMedium rhythm.
+    //    contain the (baseline-aligned) placeholder. With the clamp a tall sprite overflowed UP off
+    //    its line onto the line above (measured top y=-22 over a 28sp first line); unspecified
+    //    lineHeight lets the ascent expand → zero overlap. Plain-text paragraphs keep the bodyMedium rhythm.
     BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
         val maxSmileyWidthSp = (maxWidth.value * SMILEY_RELATIVE_MAX_WIDTH_FRACTION).roundToInt()
         val inlineContent = remember(inlines, measuredSizes, maxSmileyWidthSp) {
@@ -674,15 +674,15 @@ internal fun smileyInlineContent(smiley: PostInline.Smiley, box: InlineMediaBox)
         placeholder = Placeholder(
             width = box.placeholderWidth,
             height = box.placeholderHeight,
-            // #175 — `Center`, deliberately NOT `AboveBaseline`. AboveBaseline anchors the sprite's
-            // bottom to the baseline and extends it UPWARD *without growing the line*, so a tall perso
-            // overflows onto the line above (measured: a 70sp sprite reaches y=-22 over a 28sp first
-            // line — the overlap reported on the franzhermann post). Only Center/Top/Bottom make the
-            // line grow to contain the placeholder; Center grows it symmetrically → the line gets
-            // taller and there is ZERO overlap. The #203 "straddle" that pushed us to AboveBaseline
-            // came from the old 50sp bucket blowing up tiny sprites; with #175 intrinsic sizing a
-            // small smiley is ~line height, so Center sits it naturally on the line instead.
-            placeholderVerticalAlign = PlaceholderVerticalAlign.Center,
+            // #175 — AboveBaseline: the sprite bottom sits on the text baseline, exactly like a bare
+            // <img> in the browser (web/RF1 parity, consistent with #203). The line's text stays on its
+            // baseline (aligned with neighbouring lines) and a tall smiley rises above it. This avoids
+            // overlap ONLY because media paragraphs drop bodyMedium's fixed lineHeight (see
+            // ParagraphBlock): with the clamp, AboveBaseline pushed a tall sprite UP off its line onto
+            // the line above (measured top y=-22 over a 28sp first line); letting the line grow lets the
+            // ascent expand to contain it → ZERO overlap. (Center was trialled — zero overlap too — but
+            // it floated the line's text at the smiley's mid-height, breaking its baseline vs neighbours.)
+            placeholderVerticalAlign = PlaceholderVerticalAlign.AboveBaseline,
         ),
     ) {
         AsyncImage(

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
@@ -64,6 +65,7 @@ import fr.forumhfr.redface2.core.model.PostBlock
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.PostInline
 import fr.forumhfr.redface2.core.model.SmileyKind
+import kotlin.math.roundToInt
 
 /**
  * Maximum number of nested quote levels that render expanded inline. Issue #3 explicit
@@ -139,9 +141,6 @@ private fun ParagraphBlock(inlines: List<PostInline>) {
     val sizeCache = LocalIntrinsicMediaSizeCache.current
     val smileyUrls = remember(inlines) { collectSmileyUrls(inlines) }
     val measuredSizes: Map<String, IntSize?> = smileyUrls.associateWith { sizeCache.get(it) }
-    val inlineContent = remember(inlines, measuredSizes) {
-        collectInlineMedia(inlines) { smiley -> smileyDisplayBox(smiley, measuredSizes) }
-    }
 
     // Measure the not-yet-known URLs. Coil's execute() is a main-safe suspend call (it dispatches its
     // own I/O), and reuses the shared SingletonImageLoader caches the rendering AsyncImage hits — so
@@ -158,15 +157,24 @@ private fun ParagraphBlock(inlines: List<PostInline>) {
         }
     }
 
-    if (annotated.text.isBlank() && inlineContent.isEmpty()) {
+    if (annotated.text.isBlank() && !hasInlineMedia(inlines)) {
         return
     }
-    Text(
-        text = annotated,
-        inlineContent = inlineContent,
-        style = MaterialTheme.typography.bodyMedium,
-        color = MaterialTheme.colorScheme.onSurface,
-    )
+    // #175 — cap each smiley to RF1's `img { max-width: 90% }`: never wider than 90% of the content
+    // width. BoxWithConstraints exposes that width (it shrinks with quote depth via QuoteFrame), so a
+    // large perso no longer overflows / overlaps the surrounding text in a narrow quote.
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val maxSmileyWidthSp = (maxWidth.value * SMILEY_RELATIVE_MAX_WIDTH_FRACTION).roundToInt()
+        val inlineContent = remember(inlines, measuredSizes, maxSmileyWidthSp) {
+            collectInlineMedia(inlines) { smiley -> smileyDisplayBox(smiley, measuredSizes, maxSmileyWidthSp) }
+        }
+        Text(
+            text = annotated,
+            inlineContent = inlineContent,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
 }
 
 @Composable
@@ -589,21 +597,42 @@ private fun collectSmileyUrls(inlines: List<PostInline>): Set<String> {
 }
 
 /**
- * #175 — resolve a smiley's placeholder box: measured native size (no-upscale + cap) when known,
- * else a provisional fallback (pre-seeded builtin / dominant 70×50 perso) to minimise reflow while
- * the measurement is in flight.
+ * #175 — resolve a smiley's placeholder box: measured native size (no-upscale + absolute cap) when
+ * known, else a provisional fallback (pre-seeded builtin / dominant 70×50 perso) to minimise reflow
+ * while the measurement is in flight. Finally clamped to [maxWidthSp] (RF1's relative `max-width:90%`)
+ * so a large perso cannot overflow a narrow quote line.
  */
-private fun smileyDisplayBox(smiley: PostInline.Smiley, measured: Map<String, IntSize?>): InlineMediaBox {
+private fun smileyDisplayBox(
+    smiley: PostInline.Smiley,
+    measured: Map<String, IntSize?>,
+    maxWidthSp: Int,
+): InlineMediaBox {
     val size = smiley.imageUrl?.let { measured[it] }
-    if (size != null) {
-        val display = intrinsicSmileyDisplaySize(PixelSize(size.width, size.height))
-        return InlineMediaBox(display.width.sp, display.height.sp)
+    val base = if (size != null) {
+        intrinsicSmileyDisplaySize(PixelSize(size.width, size.height))
+    } else {
+        when (smiley.kind) {
+            is SmileyKind.Builtin -> builtinPreseedSize
+            is SmileyKind.Perso -> persoColdFallbackSize
+        }
     }
-    val fallback = when (smiley.kind) {
-        is SmileyKind.Builtin -> builtinPreseedSize
-        is SmileyKind.Perso -> persoColdFallbackSize
+    val capped = capToWidth(base, maxWidthSp)
+    return InlineMediaBox(capped.width.sp, capped.height.sp)
+}
+
+/** True when [inlines] contains at least one renderable inline media (a smiley with a URL, or an image). */
+private fun hasInlineMedia(inlines: List<PostInline>): Boolean = inlines.any { inline ->
+    when (inline) {
+        is PostInline.InlineImage -> true
+        is PostInline.Smiley -> inline.imageUrl != null
+        is PostInline.Strong -> hasInlineMedia(inline.children)
+        is PostInline.Emphasis -> hasInlineMedia(inline.children)
+        is PostInline.Underline -> hasInlineMedia(inline.children)
+        is PostInline.Strike -> hasInlineMedia(inline.children)
+        is PostInline.Color -> hasInlineMedia(inline.children)
+        is PostInline.Link -> hasInlineMedia(inline.children)
+        else -> false
     }
-    return InlineMediaBox(fallback.width.sp, fallback.height.sp)
 }
 
 internal fun imageInlineContent(image: PostInline.InlineImage): InlineTextContent {

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -154,7 +154,7 @@ private fun ParagraphBlock(inlines: List<PostInline>) {
     // write recomposes this block and only the inline-content Map (not the AnnotatedString) is rebuilt
     // at the final size. Cold/miss → a provisional fallback to minimise reflow (builtin ~16, perso 70×50).
     val sizeCache = LocalIntrinsicMediaSizeCache.current
-    val smileyUrls = remember(inlines) { collectSmileyUrls(inlines) }
+    val smileyUrls = remember(inlines) { collectMeasurableSmileyUrls(inlines) }
     val measuredSizes: Map<String, IntSize?> = smileyUrls.associateWith { sizeCache.get(it) }
 
     // Measure the not-yet-known URLs. Coil's execute() is a main-safe suspend call (it dispatches its
@@ -590,25 +590,37 @@ private fun walkInlinesForMedia(
     }
 }
 
-/** Collects the distinct (non-null) smiley image URLs of [inlines], for #175 measurement. */
-private fun collectSmileyUrls(inlines: List<PostInline>): Set<String> {
+/**
+ * Collects distinct perso smiley image URLs of [inlines], for #175 intrinsic measurement.
+ *
+ * Builtin HFR smileys are intentionally skipped: their historical 16×16-ish size is known and stable,
+ * so measuring/fetching every `:jap:`/`:o` on a cold topic would contradict the pre-seed contract and
+ * add avoidable work to the common path.
+ */
+internal fun collectMeasurableSmileyUrls(inlines: List<PostInline>): Set<String> {
     val urls = LinkedHashSet<String>()
-    fun walk(list: List<PostInline>) {
-        list.forEach { inline ->
-            when (inline) {
-                is PostInline.Smiley -> inline.imageUrl?.let { urls += it }
-                is PostInline.Strong -> walk(inline.children)
-                is PostInline.Emphasis -> walk(inline.children)
-                is PostInline.Underline -> walk(inline.children)
-                is PostInline.Strike -> walk(inline.children)
-                is PostInline.Color -> walk(inline.children)
-                is PostInline.Link -> walk(inline.children)
-                else -> Unit
-            }
-        }
-    }
-    walk(inlines)
+    collectMeasurableSmileyUrlsInto(inlines, urls)
     return urls
+}
+
+private fun collectMeasurableSmileyUrlsInto(inlines: List<PostInline>, urls: MutableSet<String>) {
+    inlines.forEach { inline -> collectMeasurableSmileyUrl(inline, urls) }
+}
+
+private fun collectMeasurableSmileyUrl(inline: PostInline, urls: MutableSet<String>) {
+    when (inline) {
+        is PostInline.Smiley -> {
+            if (inline.kind is SmileyKind.Perso) inline.imageUrl?.let { urls += it }
+        }
+
+        is PostInline.Strong -> collectMeasurableSmileyUrlsInto(inline.children, urls)
+        is PostInline.Emphasis -> collectMeasurableSmileyUrlsInto(inline.children, urls)
+        is PostInline.Underline -> collectMeasurableSmileyUrlsInto(inline.children, urls)
+        is PostInline.Strike -> collectMeasurableSmileyUrlsInto(inline.children, urls)
+        is PostInline.Color -> collectMeasurableSmileyUrlsInto(inline.children, urls)
+        is PostInline.Link -> collectMeasurableSmileyUrlsInto(inline.children, urls)
+        else -> Unit
+    }
 }
 
 /**

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeCacheTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeCacheTest.kt
@@ -1,0 +1,72 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import androidx.compose.ui.unit.IntSize
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #175 — coverage of [DefaultIntrinsicMediaSizeCache], in particular the **failure memoization**
+ * (a dead URL must not be re-fetched on every recomposition) and FIFO eviction.
+ */
+class IntrinsicMediaSizeCacheTest {
+
+    @Test
+    fun `success is stored and returned by url`() {
+        val cache = DefaultIntrinsicMediaSizeCache()
+        cache.putSuccess("u", IntSize(70, 50))
+        assertEquals(IntSize(70, 50), cache.get("u"))
+    }
+
+    @Test
+    fun `unmeasured url returns null`() {
+        assertNull(DefaultIntrinsicMediaSizeCache().get("never"))
+    }
+
+    @Test
+    fun `failure is fresh within the TTL and stale after it`() {
+        val cache = DefaultIntrinsicMediaSizeCache(failureTtlMillis = 1_000L)
+        cache.putFailure("dead", nowMillis = 10_000L)
+        assertTrue(cache.isFailureFresh("dead", nowMillis = 10_500L)) // 500ms < 1000ms TTL
+        assertFalse(cache.isFailureFresh("dead", nowMillis = 11_500L)) // 1500ms > TTL → retry allowed
+    }
+
+    @Test
+    fun `a recorded failure does not masquerade as a success`() {
+        val cache = DefaultIntrinsicMediaSizeCache()
+        cache.putFailure("dead", nowMillis = 0L)
+        assertNull(cache.get("dead"))
+    }
+
+    @Test
+    fun `a later success overrides an earlier failure (transient outage recovered)`() {
+        val cache = DefaultIntrinsicMediaSizeCache()
+        cache.putFailure("u", nowMillis = 0L)
+        cache.putSuccess("u", IntSize(16, 16))
+        assertEquals(IntSize(16, 16), cache.get("u"))
+        assertFalse(cache.isFailureFresh("u", nowMillis = 0L))
+    }
+
+    @Test
+    fun `FIFO eviction drops the oldest entry past the bound`() {
+        val cache = DefaultIntrinsicMediaSizeCache(maxEntries = 2)
+        cache.putSuccess("a", IntSize(1, 1))
+        cache.putSuccess("b", IntSize(2, 2))
+        cache.putSuccess("c", IntSize(3, 3)) // evicts "a" (oldest)
+        assertNull(cache.get("a"))
+        assertEquals(IntSize(2, 2), cache.get("b"))
+        assertEquals(IntSize(3, 3), cache.get("c"))
+    }
+
+    @Test
+    fun `re-putting an existing key does not grow the insertion order (no premature eviction)`() {
+        val cache = DefaultIntrinsicMediaSizeCache(maxEntries = 2)
+        cache.putSuccess("a", IntSize(1, 1))
+        cache.putSuccess("b", IntSize(2, 2))
+        cache.putSuccess("a", IntSize(9, 9)) // update, not a new slot
+        assertEquals(IntSize(9, 9), cache.get("a"))
+        assertEquals(IntSize(2, 2), cache.get("b"))
+    }
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeMeasurerSpikeTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeMeasurerSpikeTest.kt
@@ -1,0 +1,44 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import android.content.Context
+import androidx.compose.ui.unit.IntSize
+import androidx.test.core.app.ApplicationProvider
+import coil3.ColorImage
+import coil3.ImageLoader
+import coil3.test.FakeImageLoaderEngine
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * #175 SPIKE — compiler + runtime gate for the Coil intrinsic-measurement path.
+ *
+ * Confirms (the design study flagged these as NOT provable by docs, only by the compiler):
+ *  - `coil3.Image.width/height` is the dimension API after `execute(... Size.ORIGINAL ...)` ;
+ *  - `coil3.test.ColorImage(width, height)` exists and propagates its dimensions to `image.width/height`
+ *    (so Robolectric tests can pin sizes deterministically, no network/decode) ;
+ *  - `FakeImageLoaderEngine` + `runTest` drive the suspend measurement.
+ *
+ * If this compiles and passes, the Coil API assumptions of the #175 plan hold.
+ */
+@RunWith(RobolectricTestRunner::class)
+class IntrinsicMediaSizeMeasurerSpikeTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `measures native dimensions of fake smileys via Coil`() = runTest {
+        val engine = FakeImageLoaderEngine.Builder()
+            .intercept("https://hfr/perso70x50.gif", ColorImage(width = 70, height = 50))
+            .intercept("https://hfr/micro15x15.gif", ColorImage(width = 15, height = 15))
+            .intercept("https://hfr/builtin16.gif", ColorImage(width = 16, height = 16))
+            .build()
+        val loader = ImageLoader.Builder(context).components { add(engine) }.build()
+
+        assertEquals(IntSize(70, 50), measureIntrinsicMediaSize("https://hfr/perso70x50.gif", context, loader))
+        assertEquals(IntSize(15, 15), measureIntrinsicMediaSize("https://hfr/micro15x15.gif", context, loader))
+        assertEquals(IntSize(16, 16), measureIntrinsicMediaSize("https://hfr/builtin16.gif", context, loader))
+    }
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicSmileyDisplaySizeTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicSmileyDisplaySizeTest.kt
@@ -50,4 +50,20 @@ class IntrinsicSmileyDisplaySizeTest {
     fun `non-positive native size is rejected`() {
         intrinsicSmileyDisplaySize(PixelSize(0, 50))
     }
+
+    @Test
+    fun `capToWidth is a no-op when the smiley already fits`() {
+        assertEquals(PixelSize(70, 50), capToWidth(PixelSize(70, 50), maxWidthSp = 200))
+    }
+
+    @Test
+    fun `capToWidth shrinks an over-wide smiley to the cap, preserving aspect ratio`() {
+        // 240×70 in a narrow quote whose 90% width is 120sp → 120×35 (height halved with width).
+        assertEquals(PixelSize(120, 35), capToWidth(PixelSize(240, 70), maxWidthSp = 120))
+    }
+
+    @Test
+    fun `capToWidth is defensive against a zero or negative container width`() {
+        assertEquals(PixelSize(70, 50), capToWidth(PixelSize(70, 50), maxWidthSp = 0))
+    }
 }

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicSmileyDisplaySizeTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicSmileyDisplaySizeTest.kt
@@ -1,0 +1,53 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #175 — pure JVM coverage of [intrinsicSmileyDisplaySize] (no-upscale + cap), the policy that
+ * replaces the fixed buckets. The headline behaviour change vs the old `Fit` bucket is **no
+ * upscale**: small sprites keep their native size instead of being blown up to 50×50.
+ */
+class IntrinsicSmileyDisplaySizeTest {
+
+    @Test
+    fun `dominant 70x50 perso passes through untouched (under caps)`() {
+        assertEquals(PixelSize(70, 50), intrinsicSmileyDisplaySize(PixelSize(70, 50)))
+    }
+
+    @Test
+    fun `micro 15x15 stays 15x15 — NO upscale (inverse of the old Fit bucket which blew it to 50x50)`() {
+        assertEquals(PixelSize(15, 15), intrinsicSmileyDisplaySize(PixelSize(15, 15)))
+        assertEquals(PixelSize(19, 19), intrinsicSmileyDisplaySize(PixelSize(19, 19)))
+    }
+
+    @Test
+    fun `builtin ~16x16 stays small`() {
+        assertEquals(PixelSize(16, 16), intrinsicSmileyDisplaySize(PixelSize(16, 16)))
+    }
+
+    @Test
+    fun `oversized sprite is capped down by height, aspect ratio preserved`() {
+        // 480×360, height cap 70 → scale 70/360 ≈ 0.194 → 93×70 (width 93 < 240 guard).
+        assertEquals(PixelSize(93, 70), intrinsicSmileyDisplaySize(PixelSize(480, 360)))
+    }
+
+    @Test
+    fun `abusively wide sprite is capped by the width guard`() {
+        // 1000×100, scale = min(240/1000=0.24, 70/100=0.7, 1) = 0.24 → 240×24.
+        assertEquals(PixelSize(240, 24), intrinsicSmileyDisplaySize(PixelSize(1000, 100)))
+    }
+
+    @Test
+    fun `extreme aspect ratio is clamped to at least 1 per axis`() {
+        // 1×100 → scale min(240/1, 70/100=0.7, 1) = 0.7 → width 0.7 rounds to 1 (not 0).
+        val r = intrinsicSmileyDisplaySize(PixelSize(1, 100))
+        assertEquals(1, r.width)
+        assertEquals(70, r.height)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `non-positive native size is rejected`() {
+        intrinsicSmileyDisplaySize(PixelSize(0, 50))
+    }
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineLayoutTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineLayoutTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.sp
 import fr.forumhfr.redface2.core.model.PostInline
 import fr.forumhfr.redface2.core.model.SmileyKind
 import org.junit.Assert.assertEquals
@@ -119,63 +120,70 @@ class PostRendererInlineLayoutTest {
     }
 
     @Test
-    fun `perso smiley placeholder bottom sits on the text baseline for web parity`() {
-        // #203 — HFR serves smileys as bare <img> with no vertical-align, so the browser uses the
-        // CSS default `baseline` (the bottom of the sprite rests on the text baseline). RF2 must
-        // match that: `PlaceholderVerticalAlign.AboveBaseline` aligns the placeholder bottom with
-        // the baseline. The previous `Center` straddled the 50sp perso bucket across the line centre
-        // (≈15sp above AND below a 20sp body line), the "smiley au milieu de la ligne, par-dessus le
-        // texte" reported in #203. We mount the smiley between real text so the first baseline is
-        // anchored by the font metrics, then assert the placeholder bottom lands on it. A regression
-        // back to `Center` pushes the bottom well below the baseline and fails this assertion.
+    fun `perso smiley stays contained within its line under Center (no overflow)`() {
+        // #175 — Center grows the line to contain the placeholder (vs AboveBaseline, which extended a
+        // tall sprite upward out of the line — the franzhermann overlap). Mount a perso between text
+        // and assert it stays inside line 0's bounds: the zero-overlap contract that replaces the
+        // earlier #203 baseline assertion (cf. smileyInlineContent).
         val capture = LayoutCapture()
         mountInlineContent(
             capture,
-            listOf(
-                PostInline.Text("ab "),
-                persoSmileyInlines().first(),
-                PostInline.Text(" cd"),
-            ),
+            listOf(PostInline.Text("ab "), persoSmileyInlines().first(), PostInline.Text(" cd")),
         )
         capture.fontScale.value = 1f
         composeTestRule.waitForIdle()
-        val rect = requireSingleRect(capture, "perso smiley")
-        val baseline = requireNotNull(capture.layout.value?.firstBaseline) {
-            "perso smiley : no TextLayoutResult / firstBaseline captured"
-        }
-        assertCloseEnough(
-            label = "perso smiley placeholder bottom vs first baseline",
-            expected = baseline,
-            actual = rect.bottom,
-            tolerance = BASELINE_TOLERANCE_PX,
-        )
+        assertContainedInLine(capture, "perso smiley")
     }
 
     @Test
-    fun `builtin smiley placeholder bottom sits on the text baseline for web parity`() {
-        // #203 — same baseline rule as the perso case, on the 18sp builtin bucket (served from
-        // `/icones/…`). Builtin smileys are the most common path on HFR, so pin the geometry here
-        // too: a regression back to `Center` would push the bottom below the baseline and fail.
+    fun `builtin smiley stays contained within its line under Center (no overflow)`() {
         val capture = LayoutCapture()
         mountInlineContent(
             capture,
-            listOf(
-                PostInline.Text("ab "),
-                builtinSmileyInlines().first(),
-                PostInline.Text(" cd"),
-            ),
+            listOf(PostInline.Text("ab "), builtinSmileyInlines().first(), PostInline.Text(" cd")),
         )
         capture.fontScale.value = 1f
         composeTestRule.waitForIdle()
-        val rect = requireSingleRect(capture, "builtin smiley")
-        val baseline = requireNotNull(capture.layout.value?.firstBaseline) {
-            "builtin smiley : no TextLayoutResult / firstBaseline captured"
+        assertContainedInLine(capture, "builtin smiley")
+    }
+
+    @Test
+    fun `a tall inline smiley grows its own line and never overflows onto the line above`() {
+        // #175 — a tall perso (here 70sp) on the SECOND line must grow that line, not overflow upward
+        // onto line 0 (the overlap the maintainer reported: "grow the line if needed, ZERO overlap").
+        // We force a 70sp box via a stub resolver and assert the placeholder top sits at/below the
+        // bottom of line 0 (i.e. fully inside its own, grown, line).
+        val capture = LayoutCapture()
+        val inlines = listOf(
+            PostInline.Text("ligne du dessus\n"),
+            PostInline.Text("a "),
+            PostInline.Smiley(kind = SmileyKind.Perso("tall"), imageUrl = "https://hfr/tall.gif"),
+            PostInline.Text(" b"),
+        )
+        val annotated = buildInlineText(inlines, emptyLinkStyles, imageAlt = "img")
+        val media = collectInlineMedia(inlines) { InlineMediaBox(70.sp, 70.sp) }
+        composeTestRule.setContent {
+            MaterialTheme {
+                CompositionLocalProvider(LocalDensity provides Density(density = 1f, fontScale = 1f)) {
+                    Text(
+                        text = annotated,
+                        inlineContent = media,
+                        style = MaterialTheme.typography.bodyMedium.copy(
+                            lineHeight = androidx.compose.ui.unit.TextUnit.Unspecified,
+                        ),
+                        onTextLayout = { result -> capture.layout.value = result },
+                    )
+                }
+            }
         }
-        assertCloseEnough(
-            label = "builtin smiley placeholder bottom vs first baseline",
-            expected = baseline,
-            actual = rect.bottom,
-            tolerance = BASELINE_TOLERANCE_PX,
+        composeTestRule.waitForIdle()
+        val layout = requireNotNull(capture.layout.value) { "no TextLayoutResult captured" }
+        val rect = requireNotNull(layout.placeholderRects.firstOrNull()) { "no placeholder rect" }
+        val line0Bottom = layout.getLineBottom(0)
+        assertTrue(
+            "tall smiley overflows above its line onto line 0 — overlap! rect.top=${rect.top} " +
+                "line0.bottom=$line0Bottom rect.bottom=${rect.bottom} totalLines=${layout.lineCount}",
+            rect.top >= line0Bottom - 1f,
         )
     }
 
@@ -362,7 +370,9 @@ class PostRendererInlineLayoutTest {
                     Text(
                         text = annotated,
                         inlineContent = media,
-                        style = MaterialTheme.typography.bodyMedium,
+                        style = MaterialTheme.typography.bodyMedium.copy(
+                            lineHeight = androidx.compose.ui.unit.TextUnit.Unspecified,
+                        ),
                         onTextLayout = { result -> capture.layout.value = result },
                     )
                 }
@@ -389,6 +399,26 @@ class PostRendererInlineLayoutTest {
         assertTrue(
             "$label : expected=$expected actual=$actual delta=$delta tolerance=$tolerance",
             delta <= tolerance,
+        )
+    }
+
+    /**
+     * #175 — asserts the single placeholder is fully contained within its own (first) line: no
+     * overflow above or below. This is the zero-overlap contract `Center` gives (the line grows to
+     * fit the placeholder), as opposed to `AboveBaseline` which overflowed upward.
+     */
+    private fun assertContainedInLine(capture: LayoutCapture, label: String) {
+        val rect = requireSingleRect(capture, label)
+        val layout = requireNotNull(capture.layout.value) { "$label : no TextLayoutResult captured" }
+        val lineTop = layout.getLineTop(0)
+        val lineBottom = layout.getLineBottom(0)
+        assertTrue(
+            "$label overflows ABOVE its line — top=${rect.top} lineTop=$lineTop",
+            rect.top >= lineTop - BASELINE_TOLERANCE_PX,
+        )
+        assertTrue(
+            "$label overflows BELOW its line — bottom=${rect.bottom} lineBottom=$lineBottom",
+            rect.bottom <= lineBottom + BASELINE_TOLERANCE_PX,
         )
     }
 

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineLayoutTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineLayoutTest.kt
@@ -120,11 +120,11 @@ class PostRendererInlineLayoutTest {
     }
 
     @Test
-    fun `perso smiley stays contained within its line under Center (no overflow)`() {
-        // #175 — Center grows the line to contain the placeholder (vs AboveBaseline, which extended a
-        // tall sprite upward out of the line — the franzhermann overlap). Mount a perso between text
-        // and assert it stays inside line 0's bounds: the zero-overlap contract that replaces the
-        // earlier #203 baseline assertion (cf. smileyInlineContent).
+    fun `perso smiley stays contained within its grown line (no overflow)`() {
+        // #175 — the line grows (unspecified lineHeight on media paragraphs) to contain the
+        // baseline-aligned (AboveBaseline) placeholder, so a perso never overflows onto adjacent
+        // lines. Mount a perso between text and assert it stays inside line 0's bounds — the
+        // zero-overlap contract (cf. smileyInlineContent + ParagraphBlock).
         val capture = LayoutCapture()
         mountInlineContent(
             capture,
@@ -136,7 +136,7 @@ class PostRendererInlineLayoutTest {
     }
 
     @Test
-    fun `builtin smiley stays contained within its line under Center (no overflow)`() {
+    fun `builtin smiley stays contained within its grown line (no overflow)`() {
         val capture = LayoutCapture()
         mountInlineContent(
             capture,
@@ -404,8 +404,8 @@ class PostRendererInlineLayoutTest {
 
     /**
      * #175 — asserts the single placeholder is fully contained within its own (first) line: no
-     * overflow above or below. This is the zero-overlap contract `Center` gives (the line grows to
-     * fit the placeholder), as opposed to `AboveBaseline` which overflowed upward.
+     * overflow above or below. The line grows (unspecified lineHeight on media paragraphs) to fit the
+     * baseline-aligned placeholder — the zero-overlap contract #175 requires.
      */
     private fun assertContainedInLine(capture: LayoutCapture, label: String) {
         val rect = requireSingleRect(capture, label)

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineTest.kt
@@ -2,6 +2,7 @@ package fr.forumhfr.redface2.core.ui.post
 
 import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.unit.sp
 import fr.forumhfr.redface2.core.model.PostInline
 import fr.forumhfr.redface2.core.model.SmileyKind
 import org.junit.Assert.assertEquals
@@ -103,6 +104,25 @@ class PostRendererInlineTest {
                 annotated.inlineContentIds(),
             )
         }
+    }
+
+    @Test
+    fun `collectInlineMedia applies the provided smiley box resolver to the placeholder (175 seam)`() {
+        // #175 — the production caller passes a cache-backed resolver returning the measured size;
+        // here we pin that whatever box the resolver yields lands on the InlineTextContent placeholder
+        // (the seam through which intrinsic sizing flows). Default-resolver/bucket behaviour stays
+        // covered by the bucket tests below.
+        val inlines = listOf(
+            PostInline.Smiley(
+                kind = SmileyKind.Perso("measured"),
+                imageUrl = "https://forum-images.hardware.fr/images/perso/measured.gif",
+            ),
+        )
+        val media = collectInlineMedia(inlines) { InlineMediaBox(33.sp, 21.sp) }
+        val placeholder = media["post-smiley-0"]?.placeholder
+        assertNotNull("resolved smiley should yield an InlineTextContent", placeholder)
+        assertEquals(33.sp, placeholder!!.width)
+        assertEquals(21.sp, placeholder.height)
     }
 
     @Test

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineTest.kt
@@ -126,6 +126,29 @@ class PostRendererInlineTest {
     }
 
     @Test
+    fun `collectMeasurableSmileyUrls skips builtins and keeps perso urls only`() {
+        // #175 — builtin HFR smileys have a known small size and must not trigger intrinsic measurement
+        // on the hot path. Perso smileys stay measurable because their corpus sizes are heterogeneous.
+        val builtinUrl = "https://forum-images.hardware.fr/icones/smilies/jap.gif"
+        val nestedBuiltinUrl = "https://forum-images.hardware.fr/icones/smilies/o.gif"
+        val persoUrl = "https://forum-images.hardware.fr/images/perso/cosmoschtroumpf.gif"
+        val nestedPersoUrl = "https://forum-images.hardware.fr/images/perso/t/tall.gif"
+        val inlines = listOf(
+            PostInline.Smiley(kind = SmileyKind.Builtin(":jap:"), imageUrl = builtinUrl),
+            PostInline.Smiley(kind = SmileyKind.Perso("cosmoschtroumpf"), imageUrl = persoUrl),
+            PostInline.Strong(
+                children = listOf(
+                    PostInline.Smiley(kind = SmileyKind.Builtin(":o"), imageUrl = nestedBuiltinUrl),
+                    PostInline.Smiley(kind = SmileyKind.Perso("tall"), imageUrl = nestedPersoUrl),
+                ),
+            ),
+            PostInline.InlineImage(url = "https://forum.hardware.fr/images/foo.png", description = "foo"),
+        )
+
+        assertEquals(setOf(persoUrl, nestedPersoUrl), collectMeasurableSmileyUrls(inlines))
+    }
+
+    @Test
     fun `inline image emits a post-image placeholder and a matching map entry`() {
         val inlines = listOf(
             PostInline.InlineImage(

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineTest.kt
@@ -157,7 +157,7 @@ class PostRendererInlineTest {
     }
 
     @Test
-    fun `builtin smiley with imageUrl uses the small bucket placeholder centred`() {
+    fun `builtin smiley with imageUrl uses the small bucket placeholder baseline-aligned`() {
         // Builtin smileys are typically 16x16 to 18x18 in HFR's icon set. The small bucket fits
         // them inline with body-medium text without a noticeable height bump on the line.
         val inlines = listOf(
@@ -182,12 +182,11 @@ class PostRendererInlineTest {
             placeholder.height,
         )
         assertEquals(
-            // #175 — Center, not AboveBaseline: Center grows the line to contain the placeholder so a
-            // tall perso never overflows onto the line above (AboveBaseline did — the franzhermann
-            // overlap). With intrinsic sizing small smileys are ~line height, so Center no longer
-            // straddles them (the #203 straddle came from the oversized 50sp bucket #175 removed).
-            "smileys must be Center-aligned so the line grows to contain them (zero overlap)",
-            PlaceholderVerticalAlign.Center,
+            // #175 — AboveBaseline: the sprite bottom sits on the text baseline (web/RF1 parity, #203).
+            // Zero overlap for a tall perso comes from the unspecified lineHeight on media paragraphs
+            // (the line grows upward to contain it), NOT from the alignment — see smileyInlineContent.
+            "smileys must be baseline-aligned (AboveBaseline) for web parity",
+            PlaceholderVerticalAlign.AboveBaseline,
             placeholder.placeholderVerticalAlign,
         )
     }
@@ -225,9 +224,9 @@ class PostRendererInlineTest {
             placeholder.width,
         )
         assertEquals(
-            // #175 — same rule as builtin: Center so the line grows to contain a tall perso (zero overlap).
-            "perso smileys must be Center-aligned so the line grows to contain them (zero overlap)",
-            PlaceholderVerticalAlign.Center,
+            // #175 — same rule as builtin: AboveBaseline (web parity); zero overlap via line growth.
+            "perso smileys must be baseline-aligned (AboveBaseline) for web parity",
+            PlaceholderVerticalAlign.AboveBaseline,
             placeholder.placeholderVerticalAlign,
         )
     }

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineTest.kt
@@ -157,7 +157,7 @@ class PostRendererInlineTest {
     }
 
     @Test
-    fun `builtin smiley with imageUrl uses the small bucket placeholder baseline-aligned`() {
+    fun `builtin smiley with imageUrl uses the small bucket placeholder centred`() {
         // Builtin smileys are typically 16x16 to 18x18 in HFR's icon set. The small bucket fits
         // them inline with body-medium text without a noticeable height bump on the line.
         val inlines = listOf(
@@ -182,11 +182,12 @@ class PostRendererInlineTest {
             placeholder.height,
         )
         assertEquals(
-            // #203 — HFR serves smileys as bare <img> (CSS default vertical-align: baseline), so RF2
-            // aligns the placeholder bottom with the text baseline for web parity instead of
-            // centring it across the line (which straddled tall perso buckets over the body line).
-            "smileys must align above the baseline to match HFR's web rendering",
-            PlaceholderVerticalAlign.AboveBaseline,
+            // #175 — Center, not AboveBaseline: Center grows the line to contain the placeholder so a
+            // tall perso never overflows onto the line above (AboveBaseline did — the franzhermann
+            // overlap). With intrinsic sizing small smileys are ~line height, so Center no longer
+            // straddles them (the #203 straddle came from the oversized 50sp bucket #175 removed).
+            "smileys must be Center-aligned so the line grows to contain them (zero overlap)",
+            PlaceholderVerticalAlign.Center,
             placeholder.placeholderVerticalAlign,
         )
     }
@@ -224,9 +225,9 @@ class PostRendererInlineTest {
             placeholder.width,
         )
         assertEquals(
-            // #203 — same web-parity rule as builtin: baseline-aligned, not centred on the line.
-            "perso smileys must align above the baseline to match HFR's web rendering",
-            PlaceholderVerticalAlign.AboveBaseline,
+            // #175 — same rule as builtin: Center so the line grows to contain a tall perso (zero overlap).
+            "perso smileys must be Center-aligned so the line grows to contain them (zero overlap)",
+            PlaceholderVerticalAlign.Center,
             placeholder.placeholderVerticalAlign,
         )
     }

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererSmileyRoborazziTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererSmileyRoborazziTest.kt
@@ -1,0 +1,209 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import coil3.ColorImage
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.test.FakeImageLoaderEngine
+import com.github.takahirom.roborazzi.captureRoboImage
+import fr.forumhfr.redface2.core.model.PostBlock
+import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.model.PostInline
+import fr.forumhfr.redface2.core.model.SmileyKind
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * #175 — diagnostic-only Roborazzi captures of the **adaptive inline-smiley rendering**.
+ *
+ * Visual proof of the two properties dogfood kept hammering on:
+ *  - **adaptive sizing**: each smiley renders at its measured native size (no-upscale + cap), so a
+ *    16×16 builtin stays tiny next to a 70×50 perso, a 15×15 micro-perso is NOT blown up to the old
+ *    50×50 bucket, and a 200×140 giant is capped down to 70sp-high preserving ratio ;
+ *  - **zero overlap**: a tall smiley grows its own line instead of colliding with the line above
+ *    (media paragraphs drop bodyMedium's fixed lineHeight; the sprite rides the baseline via
+ *    AboveBaseline and the ascent expands to contain it).
+ *
+ * Smileys are fed by a [FakeImageLoaderEngine] returning a distinct-coloured [ColorImage] at each
+ * URL's native px, so the rendered box IS the intrinsic size — and the cache is pre-seeded so the
+ * first composition is already at the final size (no async-measure timing dependency). Light theme
+ * so the coloured boxes read clearly.
+ *
+ * Not a CI golden gate (the Roborazzi Gradle plugin is not applied — AGP 9, cf. takahirom/roborazzi#781).
+ * Run on demand; PNGs land under `core/ui/build/outputs/roborazzi/` (gitignored) :
+ *
+ *     ./scripts/docker-dev.sh ./gradlew :core:ui:testDebugUnitTest \
+ *         --tests '*PostRendererSmileyRoborazziTest*' --console=plain --no-daemon
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@OptIn(ExperimentalTestApi::class)
+class PostRendererSmileyRoborazziTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val builtinUrl = "https://forum.hardware.fr/icones/jap.gif"
+    private val microUrl = "https://forum.hardware.fr/images/perso/m/micro15.gif"
+    private val persoUrl = "https://forum.hardware.fr/images/perso/f/franzhermann.gif"
+    private val giantUrl = "https://forum.hardware.fr/images/perso/g/giant200x140.gif"
+    private val bannerUrl = "https://forum.hardware.fr/images/perso/b/banner500x120.gif"
+
+    @OptIn(coil3.annotation.DelicateCoilApi::class)
+    @Before
+    fun installFakeImageLoader() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val engine = FakeImageLoaderEngine.Builder()
+            .intercept(builtinUrl, ColorImage(Color(0xFF1565C0).toArgb(), width = 16, height = 16))
+            .intercept(microUrl, ColorImage(Color(0xFF8E24AA).toArgb(), width = 15, height = 15))
+            .intercept(persoUrl, ColorImage(Color(0xFF2E7D32).toArgb(), width = 70, height = 50))
+            .intercept(giantUrl, ColorImage(Color(0xFFC62828).toArgb(), width = 200, height = 140))
+            .intercept(bannerUrl, ColorImage(Color(0xFFC62828).toArgb(), width = 500, height = 120))
+            .build()
+        SingletonImageLoader.setUnsafe(ImageLoader.Builder(context).components { add(engine) }.build())
+    }
+
+    /** Pre-seed the cache with the same native sizes the fake engine serves → synchronous render. */
+    private fun seededCache(): IntrinsicMediaSizeCache = DefaultIntrinsicMediaSizeCache().apply {
+        putSuccess(builtinUrl, IntSize(16, 16))
+        putSuccess(microUrl, IntSize(15, 15))
+        putSuccess(persoUrl, IntSize(70, 50))
+        putSuccess(giantUrl, IntSize(200, 140))
+        putSuccess(bannerUrl, IntSize(500, 120))
+    }
+
+    @Test
+    fun adaptiveSmileySizesInline() {
+        capture("smiley_175_adaptive_sizes", widthDp = 360) {
+            PostRenderer(content = adaptiveSizesContent())
+        }
+    }
+
+    @Test
+    fun tallSmileyGrowsLineNoOverlap() {
+        capture("smiley_175_tall_no_overlap", widthDp = 360) {
+            PostRenderer(content = tallInTextContent())
+        }
+    }
+
+    @Test
+    fun largePersoRelativeCapInNarrowQuote() {
+        // Narrow capture (280dp) so 90% of the quote's content width is below the 240sp absolute width
+        // cap — the relative cap then visibly bites and the wide banner stops ~10% short of the edge.
+        capture("smiley_175_relative_cap_in_quote", widthDp = 280) {
+            PostRenderer(content = bannerInQuoteContent())
+        }
+    }
+
+    private fun adaptiveSizesContent() = PostContent(
+        blocks = listOf(
+            PostBlock.Paragraph(
+                inlines = listOf(
+                    PostInline.Text("Builtin "),
+                    builtin("jap"),
+                    PostInline.Text(" (16px) · micro perso "),
+                    perso("micro15", microUrl),
+                    PostInline.Text(" (15px, jamais upscalé) · perso "),
+                    perso("franzhermann", persoUrl),
+                    PostInline.Text(" (70×50) · géant "),
+                    perso("giant", giantUrl),
+                    PostInline.Text(" (200×140 capé à 70sp). Les tailles viennent de l'image, pas d'un bucket fixe."),
+                ),
+            ),
+        ),
+    )
+
+    private fun tallInTextContent() = PostContent(
+        blocks = listOf(
+            PostBlock.Paragraph(
+                inlines = listOf(
+                    PostInline.Text(
+                        "Texte avant pour avoir une ligne au-dessus qui pourrait être percutée. " +
+                            "On insère un grand smiley ",
+                    ),
+                    perso("giant", giantUrl),
+                    PostInline.Text(
+                        " au milieu du paragraphe : la ligne grandit pour le contenir et il ne " +
+                            "chevauche ni la ligne du dessus ni celle du dessous. Suite du texte ensuite.",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    private fun bannerInQuoteContent() = PostContent(
+        blocks = listOf(
+            PostBlock.Paragraph(inlines = listOf(PostInline.Text("Dans une citation, le conteneur est plus étroit :"))),
+            PostBlock.Quote(
+                author = "franzhermann",
+                numreponse = null,
+                page = null,
+                content = PostContent(
+                    blocks = listOf(
+                        PostBlock.Paragraph(
+                            inlines = listOf(
+                                PostInline.Text("Une bannière large "),
+                                perso("banner", bannerUrl),
+                                PostInline.Text(
+                                    " est ramenée à ~90% de la largeur dispo (cap relatif RF1 " +
+                                        "max-width:90%) : elle s'arrête avant le bord et ne déborde pas.",
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    private fun builtin(code: String) =
+        PostInline.Smiley(kind = SmileyKind.Builtin(code), imageUrl = builtinUrl)
+
+    private fun perso(name: String, url: String) =
+        PostInline.Smiley(kind = SmileyKind.Perso(name), imageUrl = url)
+
+    private fun capture(name: String, widthDp: Int, content: @Composable () -> Unit) {
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalIntrinsicMediaSizeCache provides seededCache()) {
+                RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                    Surface(color = MaterialTheme.colorScheme.surface) {
+                        Box(
+                            modifier = Modifier
+                                .width(widthDp.dp)
+                                .background(MaterialTheme.colorScheme.surface)
+                                .padding(16.dp),
+                        ) {
+                            content()
+                        }
+                    }
+                }
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage(
+            filePath = "build/outputs/roborazzi/$name.png",
+        )
+    }
+}

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -222,9 +222,14 @@ fun TopicScreen(
  * target drift once the first image finally grows.
  * Bounded by [REANCHOR_MAX_FRAMES] so a never-resolving image cannot hold the list hostage, and we
  * bail the instant the user grabs the list (`isScrollInProgress`) so the settle window never fights
- * manual scrolling — extending the single-shot, no-focus-stealing contract on [TopicEffect]. Inline
- * smileys/images are *not* a factor: their `InlineTextContent` placeholders are fixed-size, so only
- * block images move the geometry.
+ * manual scrolling — extending the single-shot, no-focus-stealing contract on [TopicEffect].
+ *
+ * #175 note — this no longer covers every source of post-load geometry shift: inline smileys now use
+ * intrinsic (measured) placeholder sizes (`:core:ui` `IntrinsicMediaSizeCache`), so a perso whose size
+ * lands *after* this settle window — or after a manual scroll, which this loop deliberately does not
+ * fight — can still nudge the geometry. The provisional fallbacks (pre-seeded builtin / dominant 70×50
+ * perso) keep that nudge small in the common case; a dedicated warmup-before-reanchor is the follow-up
+ * if a deep-link to a perso-heavy post drifts in practice (to validate on a cold-cache device).
  *
  * The per-frame decision is delegated to the pure [reanchorStep] so the state machine is unit-tested
  * without a frame clock or a live `LazyListState`.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -115,3 +115,4 @@ coil-core = { module = "io.coil-kt.coil3:coil", version.ref = "coil" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-gif = { module = "io.coil-kt.coil3:coil-gif", version.ref = "coil" }
 coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }
+coil-test = { module = "io.coil-kt.coil3:coil-test", version.ref = "coil" }


### PR DESCRIPTION
## Contexte

#175 remplace le dimensionnement des smileys inline par buckets fixes (`InlineMediaBox` : builtin 18×18 sp, perso 70×50 sp) par un **dimensionnement intrinsèque** : chaque smiley est rendu à sa taille native mesurée, comme sur le web/RF1.

**Pourquoi** (dogfood v32–v34) : les buckets fixes maltraitaient le corpus réel. Un petit perso historique (15×15) était gonflé à 50×50 par le `ContentScale.Fit`, et un gros perso débordait/chevauchait le texte de la ligne. Aucune valeur de bucket unique ne satisfaisait à la fois les micro-sprites et les 70×50 dominants.

## Décisions de conception

- **px natifs = px logiques/CSS → `.sp` directement** : la taille native renvoyée par Coil (`Size.ORIGINAL` → `coil3.Image.width/height`, px bruts) est injectée telle quelle dans le placeholder (`70px → 70.sp`), **sans diviser par la densité** écran. Diviser par la densité rendrait les smileys ~`1/density` trop petits (le bug pointé par le design doc).
- **No-upscale + cap absolu** (`intrinsicSmileyDisplaySize`) : jamais plus grand que le natif (un 15×15 reste 15×15), puis clamp à `SMILEY_MAX_WIDTH_SP=240` × `SMILEY_MAX_HEIGHT_SP=70` sp en préservant le ratio. Le 70×50 dominant passe intact (~3,5× une ligne de corps).
- **Cap de largeur relatif ~90 %** (`capToWidth`, `SMILEY_RELATIVE_MAX_WIDTH_FRACTION=0.9`) : portage du `img { max-width: 90% }` de RF1, appliqué côté renderer via `BoxWithConstraints` (seul endroit où la largeur du conteneur est connue, et qui rétrécit avec la profondeur de citation) — un gros perso rétrécit au lieu de déborder une citation étroite.
- **`AboveBaseline` + `lineHeight` non spécifié** sur les paragraphes média : le bas du sprite repose sur la baseline (parité web, cohérent avec #203), et on retire le `lineHeight` fixe de `bodyMedium` (`TextUnit.Unspecified`) pour que **la ligne grandisse** et contienne un smiley haut → chevauchement zéro. Avec un `lineHeight` fixe, `AboveBaseline` poussait le sprite haut *au-dessus* de sa ligne sur la ligne précédente (top mesuré à y=-22 sur une 1re ligne de 28 sp).
- **Fast-path texte brut** : un paragraphe sans média (`!hasInlineMedia`) rend directement avec le rythme `bodyMedium`, sans cache, sans `LaunchedEffect` de mesure, sans `BoxWithConstraints`. L'`AnnotatedString` reste **invariant** (uniquement les marqueurs U+FFFC + IDs), jamais reconstruit quand une mesure arrive ; seul le `Map` d'`InlineTextContent` est rebâti.
- **Cache par URL** (`IntrinsicMediaSizeCache`, `SnapshotStateMap` process-wide) : la taille native est immuable, mesurée une fois et réutilisée partout (les N copies d'un même `:jap:` ne re-mesurent pas). Mémoïse aussi les **échecs avec TTL** (60 s) pour qu'un host mort/404 ne soit pas re-fetch à chaque recomposition, et bornage **FIFO** (1024 entrées). Une écriture (mesure arrivée) recompose les paragraphes lecteurs.
- **Fallback provisoire cold-cache** : tant que la mesure est en vol, builtin pré-seedé à ~16×16, perso au 70×50 dominant, pour minimiser le reflow quand la vraie taille atterrit. Pas de double fetch réseau : la mesure passe par le `SingletonImageLoader` partagé que touche aussi l'`AsyncImage` de rendu.

## Parcours des commits

- `662b3de` — phase 1 : brique de mesure intrinsèque (`measureIntrinsicMediaSize`) + cache (`IntrinsicMediaSizeCache`, succès/échec TTL/FIFO), spike sans câblage renderer.
- `52df861` — phase 2 : câblage du dimensionnement intrinsèque dans le renderer (`collectInlineMedia` paramétré par un résolveur de box cache-backed, `LaunchedEffect` de mesure).
- `3c84258` — phase 3 : cap de largeur relatif (RF1 `max-width:90%`) via `BoxWithConstraints` pour que les gros perso ne débordent pas les citations.
- `acea0ce` — fix overlap : la ligne grandit (`lineHeight` non spécifié) pour qu'un smiley haut ne chevauche jamais le texte.
- `7e78a9e` — choix de baseline : retour à `AboveBaseline` (et non `Center`) maintenant que la ligne grandit, pour la parité web.
- `81c5f6d` — corrections de la review 4-saveurs : fast-path texte brut + KDoc.
- `a48f24a` — diagnostic Roborazzi du rendu adaptatif.
- `af060d4` — sync KDoc (`PostMediaDisplayPolicy`) : `smileyContentScale`/`builtinSmiley`/`persoSmiley`/`fitScaledMediaSize` décrivaient encore le modèle pré-#175 (fit-to-bucket + upscale) ; reformulés pour refléter le dimensionnement intrinsèque (buckets = fallback cold-cache / défaut de test).

## Tests

Tests Robolectric/JVM purs :
- **Layout/containment** (`PostRendererInlineLayoutTest`) : perso et builtin restent contenus dans leur ligne grandie (pas de débordement), un smiley haut grandit sa ligne et ne déborde jamais sur la ligne au-dessus, tailles monotones sous `fontScale`.
- **Cap/no-upscale** (`IntrinsicSmileyDisplaySizeTest`) : 70×50 dominant intact, micro 15×15 reste 15×15 (inverse de l'ancien bucket Fit), builtin ~16×16 reste petit, sprite surdimensionné capé par la hauteur ratio préservé, garde de largeur abusive, clamp ≥1 par axe, `capToWidth` (no-op si déjà contenu / shrink proportionnel / défensif contre largeur ≤0).
- **Cache** (`IntrinsicMediaSizeCacheTest`) : succès stocké/relu par URL, URL non mesurée → null, fraîcheur du TTL d'échec, un échec ne masque pas un succès, succès postérieur écrase un échec (outage transitoire), éviction FIFO au-delà de la borne.
- **Spike mesure** (`IntrinsicMediaSizeMeasurerSpikeTest`) : `FakeImageLoaderEngine` + `ColorImage(w,h)` + `runTest` pour une mesure déterministe sans réseau.
- **Roborazzi DIAGNOSTIC** (`PostRendererSmileyRoborazziTest`) : preuve visuelle (sizing adaptatif + overlap zéro + cap relatif en citation). Les PNG atterrissent sous `core/ui/build/outputs/roborazzi/` (gitignoré). **Pas un golden gate CI** : le plugin Gradle Roborazzi n'est pas appliqué (AGP 9, cf. takahirom/roborazzi#781). À exécuter à la demande.

## Note d'invariant

Ce changement **casse l'invariant de placeholder taille-fixe** sur lequel s'appuyait #197 : le re-anchoring post-load de `TopicScreen` partait du principe que les placeholders d'`InlineTextContent` étaient fixes. Avec le dimensionnement intrinsèque, un perso dont la taille atterrit après la fenêtre de settle (ou après un scroll manuel que la boucle ne combat volontairement pas) peut encore décaler légèrement la géométrie. Les fallbacks provisoires gardent ce nudge petit dans le cas courant ; un warmup-before-reanchor dédié est le follow-up si un deep-link vers un post riche en perso dérive en pratique. Documenté dans le KDoc de `TopicScreen`.

## Validation

- Validation CI complète **verte** au commit `a48f24a` (le code substantiel) : `detektAll`, `lintDebug`, `testDebugUnitTest`, `:app:assembleDebug` → BUILD SUCCESSFUL (5m21s).
- Le dernier commit est **du KDoc commentaire pur** ; sa re-validation locale a été bloquée par un verrou sur le Gradle user home partagé (process concurrent, vraisemblablement une synchro Android Studio). Aucune ligne > 120 (seule règle detekt applicable à ces éditions). La CI de cette PR fait foi.

## Suivi (non bloquant — issu d'une relecture adversariale 3 lentilles, 0 must-fix confirmé)

- **Specs canoniques à acter** une fois le gate dogfood #131/#175 formellement tranché : `docs/specs/protocol-hfr.md` (§ rendu smileys décrit encore les buckets fixes), `docs/specs/roadmap.md` (item #175/#131 encore `[ ]` ; ligne #109 « pas de mesure intrinsèque »), et un ADR « rendu smileys intrinsèque RF1-like ». Volontairement non tranché ici (décision de gate, pas de décision implicite).
- **Cap relatif sous `fontScale ≠ 1`** : `maxWidth.value` (dp) est comparé à une taille consommée en sp ; exact à `fontScale=1`, légèrement permissif au-delà. Garde-fou grossier (les caps absolus 240×70 restent la contrainte primaire) ; à calibrer en dogfood, conversion via `LocalDensity` si besoin.
- **Compléments de tests** : fallback cold-cache (`smileyDisplayBox`), branches `null` du mesureur + chaîne échec→TTL bout-en-bout, câblage relatif-cap monté en conteneur étroit, et une assertion sur le décodeur GIF animé. Le cœur (no-upscale/cap, cache TTL/FIFO, overlap/croissance de ligne) est déjà couvert.

> Action par Claude Opus 4.8 (demandée par @XaaT)

Refs #175, #131
