### PR TITLE
fix(flags,topic): finitions Phase 2 — gate auth écriture (#220) + loaders/swipe drapeaux (#225, #229)

### DIFF
--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -14,7 +14,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -326,8 +328,12 @@ private fun ColumnScope.AuthenticatedBody(
             }
 
             is FlagsResult.Failure -> Column(
+                // #229 — scrollable so the PullToRefreshBox still captures a swipe-to-refresh
+                // on this short, listless state (an un-scrollable body gives the pull gesture
+                // nothing to anchor on).
                 modifier = Modifier
                     .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
                     .padding(24.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
@@ -352,12 +358,23 @@ private fun ColumnScope.AuthenticatedBody(
 
             is FlagsResult.Success -> {
                 if (current.flags.isEmpty()) {
-                    Text(
-                        text = stringResource(R.string.flags_empty),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(24.dp),
-                    )
+                    // #229 — the empty state must fill the box AND be scrollable, otherwise the
+                    // PullToRefreshBox has no scrollable child to anchor the pull gesture on and
+                    // the user can no longer swipe-to-refresh an empty list (e.g. Cyan with no
+                    // actionable topic). A `verticalScroll` Column provides the nested-scroll
+                    // connection the pull needs even though the content is short.
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .verticalScroll(rememberScrollState())
+                            .padding(24.dp),
+                    ) {
+                        Text(
+                            text = stringResource(R.string.flags_empty),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                 } else {
                     LazyColumn(
                         modifier = Modifier

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -92,6 +92,15 @@ class FlagsViewModel @Inject constructor(
                         ) { result, showRead ->
                             filterReadParticipatedIfNeeded(result, type, showRead)
                         }
+                            // #225 — keep the existing list anchored during a user refresh
+                            // instead of blanking it to a cold centered spinner under the
+                            // PullToRefreshBox indicator (double loader). Same pattern as
+                            // :feature:forum. Applied per-tab (inside flatMapLatest) so a
+                            // genuine tab switch still shows its own cold spinner.
+                            .keepContentDuringRefresh(
+                                isLoading = { it is FlagsResult.Loading },
+                                isContent = { it is FlagsResult.Success },
+                            )
                     }
                 }
             }

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/RefreshUiHelpers.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/RefreshUiHelpers.kt
@@ -1,0 +1,43 @@
+package fr.forumhfr.redface2.feature.flags
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+/**
+ * Suppresses a transient `Loading` re-emitted by a repository `refresh*()` broadcast when a
+ * prior `Content` is already showing, so the `PullToRefreshBox` body stays visible under the
+ * refresh indicator instead of blanking back to a cold spinner.
+ *
+ * Fixes the #225 double loader: a swipe-to-refresh toggled `isRefreshing` (→ pull indicator)
+ * AND let the repo re-emit `FlagsResult.Loading` (→ a second, centered spinner that also
+ * blanked the list). Keeping the previous content during the refresh round-trip removes the
+ * second spinner and the list flicker.
+ *
+ * Behaviour (mirrors the `:feature:forum` helper, pinned by `FlagsViewModelTest`):
+ * - the first `Loading` (cold start, no prior content) passes through → initial spinner;
+ * - any later `Loading` while a prior content exists is suppressed → list stays anchored;
+ * - everything else (content, failure, `null`) passes through (a failed refresh must surface
+ *   its error/retry, never silently keep stale data).
+ *
+ * NOTE: deliberate copy of `:feature:forum`'s identical `keepContentDuringRefresh`. Kept local
+ * to avoid editing `:feature:forum` during concurrent work; extract to a shared module (e.g.
+ * `:core:ui`) when deduplicating.
+ */
+internal fun <T : Any> Flow<T>.keepContentDuringRefresh(
+    isLoading: (T) -> Boolean,
+    isContent: (T) -> Boolean,
+): Flow<T> = flow {
+    var lastContent: T? = null
+    collect { value ->
+        when {
+            isContent(value) -> {
+                lastContent = value
+                emit(value)
+            }
+            isLoading(value) && lastContent != null -> {
+                // Suppress: keep showing the previous content under the refresh indicator.
+            }
+            else -> emit(value)
+        }
+    }
+}

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -72,6 +72,31 @@ class FlagsViewModelTest {
     }
 
     @Test
+    fun `flagsState keeps the list during a refresh instead of blanking to Loading (#225)`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val vm = FlagsViewModel(auth, flags)
+
+        vm.flagsState.test {
+            awaitItem() // initial null before stateIn fires
+            // Cold load: the first Loading passes through so the screen shows its initial spinner.
+            flags.emit(FlagType.CYAN, FlagsResult.Loading)
+            assertEquals(FlagsResult.Loading, awaitItem())
+            flags.emit(FlagType.CYAN, FlagsResult.Success(listOf(stubFlag(1, FlagType.CYAN))))
+            assertEquals(1, (awaitItem() as FlagsResult.Success).flags.single().topicId)
+
+            // A swipe refresh re-broadcasts Loading: it must be SUPPRESSED so the list stays
+            // anchored under the PullToRefreshBox indicator (no second centered spinner, #225).
+            flags.emit(FlagType.CYAN, FlagsResult.Loading)
+            // The next *visible* state is the refreshed Success — the intermediate Loading
+            // never surfaces (otherwise awaitItem() here would return Loading and fail the cast).
+            flags.emit(FlagType.CYAN, FlagsResult.Success(listOf(stubFlag(2, FlagType.CYAN))))
+            assertEquals(2, (awaitItem() as FlagsResult.Success).flags.single().topicId)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `selectTab switches the flagsState source`() = runTest {
         val flags = FakeFlagRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -434,21 +434,13 @@ private fun TopicLoadedContent(
             // editor that fails with MissingSubcat. Kept strict to avoid a
             // button-shows-but-submit-fails regression (FP-in-0-subcat = #213 follow-up).
             // `numreponse` of the FP comes from the first post, not `topic.post`.
-            @Suppress("ComplexCondition") // FP visibility = 6-way conjunction by design : auth (#220),
-            // ownership, postable topic, real subcat, page 1, non-empty posts. Extracting is unhelpful —
-            // each clause guards a different invariant (login, HFR permission, write contract, page scope).
-            val editFirstPostAction: (() -> Unit)? = if (
-                state.isAuthenticated &&
-                topic.isFirstPostOwner &&
-                topic.canReply &&
-                topic.subcat > 0 &&
-                topic.page == 1 &&
-                topic.posts.isNotEmpty()
-            ) {
-                { onEditFirstPost(topic.subcat, topic.page, topic.posts.first().numreponse) }
-            } else {
-                null
-            }
+            // #220 — the gate (incl. the auth clause) is the testable `shouldShowEditFirstPost`.
+            val editFirstPostAction: (() -> Unit)? =
+                if (shouldShowEditFirstPost(topic, state.isAuthenticated)) {
+                    { onEditFirstPost(topic.subcat, topic.page, topic.posts.first().numreponse) }
+                } else {
+                    null
+                }
             TopicHeaderCard(
                 topic = topic,
                 state = state,
@@ -905,6 +897,18 @@ internal fun shouldShowQuoteAction(topic: Topic, isAuthenticated: Boolean): Bool
 
 internal fun shouldShowEditAction(topic: Topic, post: Post, isAuthenticated: Boolean): Boolean =
     post.isEditable && topic.canReply && isAuthenticated
+
+// Phase 2D #148 / #220 — « Modifier le premier message ». 6-way conjunction by design: auth,
+// FP ownership, postable topic, a real sub-category (FP recategorise is NOT relaxed for subcat=0,
+// cf. #213), page 1 (the FP lives there), non-empty posts. Each clause guards a distinct invariant.
+@Suppress("ComplexCondition")
+internal fun shouldShowEditFirstPost(topic: Topic, isAuthenticated: Boolean): Boolean =
+    isAuthenticated &&
+        topic.isFirstPostOwner &&
+        topic.canReply &&
+        topic.subcat > 0 &&
+        topic.page == 1 &&
+        topic.posts.isNotEmpty()
 
 private const val PAGE_GRID_LIMIT = 40
 private const val JUMP_MAX_DIGITS = 4

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -434,10 +434,11 @@ private fun TopicLoadedContent(
             // editor that fails with MissingSubcat. Kept strict to avoid a
             // button-shows-but-submit-fails regression (FP-in-0-subcat = #213 follow-up).
             // `numreponse` of the FP comes from the first post, not `topic.post`.
-            @Suppress("ComplexCondition") // FP visibility = 5-way conjunction by design : ownership,
-            // postable topic, real subcat, page 1, non-empty posts. Extracting is unhelpful — each
-            // clause guards a different invariant (HFR permission, write contract, page scope, fixture safety).
+            @Suppress("ComplexCondition") // FP visibility = 6-way conjunction by design : auth (#220),
+            // ownership, postable topic, real subcat, page 1, non-empty posts. Extracting is unhelpful —
+            // each clause guards a different invariant (login, HFR permission, write contract, page scope).
             val editFirstPostAction: (() -> Unit)? = if (
+                state.isAuthenticated &&
                 topic.isFirstPostOwner &&
                 topic.canReply &&
                 topic.subcat > 0 &&
@@ -468,7 +469,7 @@ private fun TopicLoadedContent(
             // pinned topics ship them as `md_noclass_cryptlink`, cf. #227) no longer
             // hides Citer. `quoteRef` is forwarded when known (positional, cosmetic)
             // and may be null — the whole quote chain tolerates it.
-            val quoteAction: (() -> Unit)? = if (shouldShowQuoteAction(topic)) {
+            val quoteAction: (() -> Unit)? = if (shouldShowQuoteAction(topic, state.isAuthenticated)) {
                 { onQuote(topic.subcat, topic.page, post.numreponse, post.quoteRef) }
             } else {
                 null
@@ -476,7 +477,7 @@ private fun TopicLoadedContent(
             // Phase 2D (#147) — « Modifier » is exposed by HFR only on the
             // user's own posts of an unlocked topic. Same canReply gate as
             // Citer (#213) to refuse a read-only topic (no reply form).
-            val editAction: (() -> Unit)? = if (shouldShowEditAction(topic, post)) {
+            val editAction: (() -> Unit)? = if (shouldShowEditAction(topic, post, state.isAuthenticated)) {
                 { onEdit(topic.subcat, topic.page, post.numreponse) }
             } else {
                 null
@@ -547,13 +548,12 @@ private fun TopicHeaderCard(
             }
             Button(
                 onClick = { onReply(topic.subcat, topic.page) },
-                // #213 — the button is enabled only when HFR rendered the `bddpost`
-                // reply form (authenticated, non-locked topic). Read-only topics
-                // (logged-out / prefetch anon rows, locked topics, pre-#213 cache)
-                // carry `canReply = false` ; the button comes back after a live
-                // authenticated refresh surfaces the form. `subcat = 0` (cat without
-                // sub-category, e.g. IA) is a valid postable value and is forwarded.
-                enabled = topic.canReply,
+                // #213 — enabled only when HFR rendered the `bddpost` reply form
+                // (authenticated, non-locked topic → `canReply`). #220 — also gated on the
+                // live auth state so a stale cached `canReply = true` row (the topic cache is
+                // not purged on logout) never offers Reply to a logged-out user. `subcat = 0`
+                // (cat without sub-category, e.g. IA) is a valid postable value and is forwarded.
+                enabled = shouldEnableReply(topic, state.isAuthenticated),
             ) {
                 Text(text = stringResource(R.string.topic_reply))
             }
@@ -892,9 +892,19 @@ private val topicDateFormatter = DateTimeFormatter
 
 private fun java.time.Instant.asTopicDate(): String = topicDateFormatter.format(this)
 
-internal fun shouldShowQuoteAction(topic: Topic): Boolean = topic.canReply
+// #220 — write affordances additionally require an authenticated session. A logged-out user
+// can still hold a stale cached `canReply = true` row (the topic page cache is intentionally
+// not purged on logout, cf. CacheInvalidator), so these gates consult auth explicitly instead
+// of trusting `canReply` alone — symmetric with the « Créer topic » FAB
+// (CategoryViewModel.canCreateTopic).
+internal fun shouldEnableReply(topic: Topic, isAuthenticated: Boolean): Boolean =
+    topic.canReply && isAuthenticated
 
-internal fun shouldShowEditAction(topic: Topic, post: Post): Boolean = post.isEditable && topic.canReply
+internal fun shouldShowQuoteAction(topic: Topic, isAuthenticated: Boolean): Boolean =
+    topic.canReply && isAuthenticated
+
+internal fun shouldShowEditAction(topic: Topic, post: Post, isAuthenticated: Boolean): Boolean =
+    post.isEditable && topic.canReply && isAuthenticated
 
 private const val PAGE_GRID_LIMIT = 40
 private const val JUMP_MAX_DIGITS = 4

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -8,10 +8,13 @@ data class TopicUiState(
     val availablePages: List<Int>,
     /**
      * #220 — whether the current HFR session is authenticated. Drives the write
-     * affordances (Répondre / Citer / Modifier) so they are not offered to a
-     * logged-out user, symmetric with the « Créer topic » FAB
-     * (`CategoryViewModel.canCreateTopic`). Defaults `false` until the first auth
-     * emission lands so a cold start never flashes a write button.
+     * affordances (Répondre / Citer / Modifier / Modifier-FP) so they are not offered
+     * to a logged-out user, symmetric with the « Créer topic » FAB
+     * (`CategoryViewModel.canCreateTopic`). Defaults `false` and flips on the first
+     * auth emission. The conservative default means an already-authenticated user may
+     * see a brief disabled→enabled transient on a cold open (we never momentarily
+     * *offer* a write action to a not-yet-known session) — same trade-off as the FAB;
+     * in practice the cookie jar is primed at nav-host start so the window rarely shows.
      */
     val isAuthenticated: Boolean = false,
 ) {

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -6,6 +6,14 @@ data class TopicUiState(
     val request: TopicRequest,
     val mode: Mode,
     val availablePages: List<Int>,
+    /**
+     * #220 — whether the current HFR session is authenticated. Drives the write
+     * affordances (Répondre / Citer / Modifier) so they are not offered to a
+     * logged-out user, symmetric with the « Créer topic » FAB
+     * (`CategoryViewModel.canCreateTopic`). Defaults `false` until the first auth
+     * emission lands so a cold start never flashes a write button.
+     */
+    val isAuthenticated: Boolean = false,
 ) {
     /**
      * Helper used by the screen / ViewModel : `true` when the user has navigated to a

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -7,7 +7,9 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.topic.TopicRepository
+import fr.forumhfr.redface2.core.model.AuthState
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -16,6 +18,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -35,6 +39,7 @@ import kotlinx.coroutines.launch
 class TopicViewModel @AssistedInject constructor(
     @Assisted private val request: TopicRequest,
     private val topicRepository: TopicRepository,
+    private val authRepository: AuthRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(TopicUiState.initial(request))
@@ -78,6 +83,16 @@ class TopicViewModel @AssistedInject constructor(
         } else {
             loadCurrentPage()
         }
+        // #220 — gate the write affordances on the live auth state, not just `canReply`.
+        // A logged-out user may still hold a stale cached `canReply = true` row (the topic
+        // cache is intentionally not purged on logout, cf. CacheInvalidator), so the gate
+        // must consult auth explicitly to avoid opening a reply editor that can only fail
+        // at submit. Symmetric with the « Créer topic » FAB (CategoryViewModel.canCreateTopic).
+        authRepository.observeAuthState()
+            .onEach { authState ->
+                _state.update { it.copy(isAuthenticated = authState is AuthState.Authenticated) }
+            }
+            .launchIn(viewModelScope)
     }
 
     fun send(intent: TopicIntent) {

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicActionGatesTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicActionGatesTest.kt
@@ -11,26 +11,45 @@ import org.junit.Test
 class TopicActionGatesTest {
 
     @Test
-    fun `quote action follows topic canReply and ignores missing quoteRef`() {
+    fun `quote action requires a postable topic AND an authenticated session`() {
         val postWithNoParsedQuoteLink = post(quoteRef = null)
+        val postable = topic(canReply = true, posts = listOf(postWithNoParsedQuoteLink))
+        val readOnly = topic(canReply = false, posts = listOf(postWithNoParsedQuoteLink))
 
         assertTrue(
-            "postable topics can quote by numreponse even when the toolbar quoteRef was obfuscated",
-            shouldShowQuoteAction(topic(canReply = true, posts = listOf(postWithNoParsedQuoteLink))),
+            "postable + authenticated can quote by numreponse even when the quoteRef was obfuscated",
+            shouldShowQuoteAction(postable, isAuthenticated = true),
         )
         assertFalse(
             "read-only topics must not expose quote, regardless of per-post data",
-            shouldShowQuoteAction(topic(canReply = false, posts = listOf(postWithNoParsedQuoteLink))),
+            shouldShowQuoteAction(readOnly, isAuthenticated = true),
+        )
+        assertFalse(
+            "#220 — logged-out must never see quote, even on a stale canReply=true row",
+            shouldShowQuoteAction(postable, isAuthenticated = false),
         )
     }
 
     @Test
-    fun `edit action still requires both edit link and postable topic`() {
+    fun `edit action requires edit link, a postable topic AND authentication`() {
         val editablePost = post(isEditable = true)
+        val postable = topic(canReply = true, posts = listOf(editablePost))
+        val readOnly = topic(canReply = false, posts = listOf(editablePost))
 
-        assertTrue(shouldShowEditAction(topic(canReply = true, posts = listOf(editablePost)), editablePost))
-        assertFalse(shouldShowEditAction(topic(canReply = false, posts = listOf(editablePost)), editablePost))
-        assertFalse(shouldShowEditAction(topic(canReply = true), post(isEditable = false)))
+        assertTrue(shouldShowEditAction(postable, editablePost, isAuthenticated = true))
+        assertFalse(shouldShowEditAction(readOnly, editablePost, isAuthenticated = true))
+        assertFalse(shouldShowEditAction(topic(canReply = true), post(isEditable = false), isAuthenticated = true))
+        assertFalse(
+            "#220 — logged-out must never see edit, even on a stale canReply=true row",
+            shouldShowEditAction(postable, editablePost, isAuthenticated = false),
+        )
+    }
+
+    @Test
+    fun `reply is enabled only when the topic is postable AND the session is authenticated (#220)`() {
+        assertTrue(shouldEnableReply(topic(canReply = true), isAuthenticated = true))
+        assertFalse("read-only topic", shouldEnableReply(topic(canReply = false), isAuthenticated = true))
+        assertFalse("logged-out (e.g. stale cache)", shouldEnableReply(topic(canReply = true), isAuthenticated = false))
     }
 
     private fun topic(

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicActionGatesTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicActionGatesTest.kt
@@ -52,18 +52,49 @@ class TopicActionGatesTest {
         assertFalse("logged-out (e.g. stale cache)", shouldEnableReply(topic(canReply = true), isAuthenticated = false))
     }
 
+    @Test
+    fun `edit-first-post needs auth, FP ownership, postable real-subcat topic on page 1 (#148, #220)`() {
+        val fp = post(isEditable = true)
+        val ready = topic(canReply = true, posts = listOf(fp), isFirstPostOwner = true, subcat = 550, page = 1)
+
+        assertTrue(shouldShowEditFirstPost(ready, isAuthenticated = true))
+        assertFalse(
+            "#220 — logged-out never sees Modifier-FP, even on a stale postable row",
+            shouldShowEditFirstPost(ready, isAuthenticated = false),
+        )
+        assertFalse(
+            "not the FP owner",
+            shouldShowEditFirstPost(ready.copy(isFirstPostOwner = false), isAuthenticated = true),
+        )
+        assertFalse(
+            "#213 — FP recategorise is not relaxed for subcat=0 (IA-style cat)",
+            shouldShowEditFirstPost(ready.copy(subcat = 0), isAuthenticated = true),
+        )
+        assertFalse(
+            "FP lives on page 1 only",
+            shouldShowEditFirstPost(ready.copy(page = 2, totalPages = 2), isAuthenticated = true),
+        )
+        assertFalse(
+            "read-only topic",
+            shouldShowEditFirstPost(ready.copy(canReply = false), isAuthenticated = true),
+        )
+    }
+
     private fun topic(
         canReply: Boolean,
         posts: List<Post> = listOf(post()),
+        isFirstPostOwner: Boolean = false,
+        subcat: Int = if (canReply) 0 else Topic.SUBCAT_UNKNOWN,
+        page: Int = 1,
     ): Topic = Topic(
         cat = 32,
         post = 7,
-        subcat = if (canReply) 0 else Topic.SUBCAT_UNKNOWN,
+        subcat = subcat,
         title = "Topic IA",
         posts = posts,
-        page = 1,
-        totalPages = 1,
-        isFirstPostOwner = false,
+        page = page,
+        totalPages = page.coerceAtLeast(1),
+        isFirstPostOwner = isFirstPostOwner,
         poll = null,
         canReply = canReply,
     )

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -341,6 +341,23 @@ class TopicViewModelTest {
         assertEquals(false, anon.state.value.isAuthenticated)
     }
 
+    @Test
+    fun `isAuthenticated flips when the session changes while the topic is open (#220)`() = runTest {
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"))
+        val vm = TopicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) })),
+            authRepository = auth,
+        )
+        assertEquals(true, vm.state.value.isAuthenticated)
+
+        auth.emit(AuthState.Anonymous) // logout while the topic is on screen → gates must close
+        assertEquals(false, vm.state.value.isAuthenticated)
+
+        auth.emit(AuthState.Authenticated("xaat")) // log back in → gates reopen
+        assertEquals(true, vm.state.value.isAuthenticated)
+    }
+
     private fun topicRequest(
         page: Int,
         scrollTo: Int? = null,
@@ -572,6 +589,12 @@ class TopicViewModelTest {
 
 private class FakeAuthRepository(initial: AuthState) : AuthRepository {
     private val state = MutableStateFlow(initial)
+
+    /** Simulate a live auth change (login / logout) after the ViewModel has subscribed. */
+    fun emit(value: AuthState) {
+        state.value = value
+    }
+
     override fun observeAuthState() = state.asStateFlow()
     override suspend fun login(pseudo: String, password: String) =
         error("login is not exercised by TopicViewModelTest")

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -1,7 +1,9 @@
 package fr.forumhfr.redface2.feature.topic
 
 import app.cash.turbine.test
+import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.topic.TopicRepository
+import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.Post
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.Topic
@@ -10,6 +12,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -42,6 +46,7 @@ class TopicViewModelTest {
         val viewModel = TopicViewModel(
             request = topicRequest(page = 2),
             topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
         )
 
         viewModel.state.test {
@@ -83,6 +88,7 @@ class TopicViewModelTest {
         val vm = TopicViewModel(
             request = topicRequest(page = 2),
             topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
         )
 
         vm.state.test {
@@ -118,6 +124,7 @@ class TopicViewModelTest {
         TopicViewModel(
             request = topicRequest(page = 5),
             topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
         ).state.test {
             awaitItem()
             cancelAndIgnoreRemainingEvents()
@@ -140,6 +147,7 @@ class TopicViewModelTest {
         val viewModel = TopicViewModel(
             request = topicRequest(page = 1),
             topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
         )
 
         viewModel.state.test {
@@ -166,6 +174,7 @@ class TopicViewModelTest {
         val viewModel = TopicViewModel(
             request = topicRequest(page = 1),
             topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
         )
 
         val mode = assertMode<TopicUiState.Mode.Error>(viewModel.state.value)
@@ -187,6 +196,7 @@ class TopicViewModelTest {
         val viewModel = TopicViewModel(
             request = topicRequest(page = 1),
             topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
         )
 
         val mode = assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value)
@@ -206,6 +216,7 @@ class TopicViewModelTest {
         val viewModel = TopicViewModel(
             request = topicRequest(page = 3, scrollTo = target),
             topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
         )
 
         viewModel.effects.test {
@@ -223,6 +234,7 @@ class TopicViewModelTest {
         val viewModel = TopicViewModel(
             request = topicRequest(page = 1, scrollTo = 999),
             topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
         )
 
         viewModel.effects.test {
@@ -247,6 +259,7 @@ class TopicViewModelTest {
         val viewModel = TopicViewModel(
             request = topicRequest(page = 2, scrollTo = target),
             topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
         )
 
         viewModel.effects.test {
@@ -264,6 +277,7 @@ class TopicViewModelTest {
         val viewModel = TopicViewModel(
             request = topicRequest(page = 1),
             topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
         )
         assertEquals(false, viewModel.state.value.canGoPrevious)
         assertEquals(true, viewModel.state.value.canGoNext)
@@ -276,6 +290,7 @@ class TopicViewModelTest {
         val viewModel = TopicViewModel(
             request = topicRequest(page = 5),
             topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
         )
         assertEquals(true, viewModel.state.value.canGoPrevious)
         assertEquals(false, viewModel.state.value.canGoNext)
@@ -294,6 +309,7 @@ class TopicViewModelTest {
         val viewModel = TopicViewModel(
             request = topicRequest(page = 2),
             topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
         )
 
         assertMode<TopicUiState.Mode.Error>(viewModel.state.value)
@@ -306,6 +322,23 @@ class TopicViewModelTest {
             listOf(Triple(SAMPLE_CAT, SAMPLE_POST, 2), Triple(SAMPLE_CAT, SAMPLE_POST, 2)),
             repository.calls,
         )
+    }
+
+    @Test
+    fun `state isAuthenticated reflects the auth repository (#220)`() = runTest {
+        val authed = TopicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+        assertEquals(true, authed.state.value.isAuthenticated)
+
+        val anon = TopicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) })),
+            authRepository = FakeAuthRepository(AuthState.Anonymous),
+        )
+        assertEquals(false, anon.state.value.isAuthenticated)
     }
 
     private fun topicRequest(
@@ -339,6 +372,7 @@ class TopicViewModelTest {
         val viewModel = TopicViewModel(
             request = topicRequest(page = 2, submitSignal = 1_700_000_000_000L),
             topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
         )
 
         viewModel.state.test {
@@ -377,6 +411,7 @@ class TopicViewModelTest {
         val viewModel = TopicViewModel(
             request = topicRequest(page = 1, scrollTo = targetNumreponse, submitSignal = 42L),
             topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
         )
 
         viewModel.effects.test {
@@ -403,6 +438,7 @@ class TopicViewModelTest {
         val viewModel = TopicViewModel(
             request = topicRequest(page = 20, scrollTo = null, submitSignal = 99L),
             topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
         )
 
         viewModel.effects.test {
@@ -422,6 +458,7 @@ class TopicViewModelTest {
         val viewModel = TopicViewModel(
             request = topicRequest(page = 1, scrollTo = null, submitSignal = null),
             topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
         )
 
         viewModel.state.test {
@@ -458,6 +495,7 @@ class TopicViewModelTest {
         val viewModel = TopicViewModel(
             request = topicRequest(page = 2, submitSignal = 7L),
             topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
         )
 
         // The first effect emitted on the failure path must be PostSubmitRefreshFailed so the
@@ -530,6 +568,15 @@ class TopicViewModelTest {
         private const val SAMPLE_SUBCAT = 432
         private const val CANCEL_TIMEOUT_MS = 2_000L
     }
+}
+
+private class FakeAuthRepository(initial: AuthState) : AuthRepository {
+    private val state = MutableStateFlow(initial)
+    override fun observeAuthState() = state.asStateFlow()
+    override suspend fun login(pseudo: String, password: String) =
+        error("login is not exercised by TopicViewModelTest")
+
+    override suspend fun logout() = error("logout is not exercised by TopicViewModelTest")
 }
 
 private class FakeTopicRepository(


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

## Résumé

Trois bugs de finition Phase 2, même thématique UI écriture / drapeaux :

- **#220** — l'éditeur de réponse était ouvrable hors connexion (échec seulement au submit). Répondre / Citer / Modifier / Modifier-FP sont désormais gated sur `canReply && isAuthenticated`.
- **#225** — double loader sur les Drapeaux au swipe-to-refresh (indicateur pull + spinner central qui blanchissait la liste). La liste reste ancrée.
- **#229** — swipe-to-refresh impossible sur une liste vide (ex. Cyan) ou en erreur. Les états vides/erreur sont rendus scrollables.

## Détail

### #220 — gate auth écriture (`:feature:topic`)
Les affordances d'écriture étaient gated sur `Topic.canReply` seul. Une lecture anonyme n'a pas de form `bddpost` (`canReply=false` → masqué), **mais** un utilisateur déconnecté peut conserver une ligne cache `canReply=true` périmée (le cache topic n'est volontairement pas purgé au logout, cf. `CacheInvalidator`). Fix : `AuthRepository` injecté dans `TopicViewModel`, `isAuthenticated` exposé sur `TopicUiState` (depuis `observeAuthState`), 4 gates sur `canReply && isAuthenticated` via helpers testables (`shouldEnableReply` / `shouldShowQuoteAction` / `shouldShowEditAction` / `shouldShowEditFirstPost`). Symétrique avec le FAB « Créer topic » (`CategoryViewModel.canCreateTopic`).

**Décision de design (cf. #220 « pas de décision implicite »)** : on retient le **gate symétrique « disable/hide silencieux »** (comme le FAB « Créer topic » qui se masque hors connexion), **pas** de CTA login par bouton (« Connecte-toi pour répondre »). Rationale : cohérence avec l'existant + périmètre ; un CTA login reste un follow-up possible. Acté ici faute d'ADR dédié.

### #225 — double loader Drapeaux (`:feature:flags`)
Depuis la refonte swipe (#210), un pull togglait `isRefreshing` (indicateur M3) **et** laissait le repo ré-émettre `FlagsResult.Loading` (2ᵉ spinner central qui blanchissait la liste). Fix : copie locale de `keepContentDuringRefresh` de `:feature:forum` (supprime un Loading transitoire quand un Success est déjà affiché), appliquée par onglet. Copie délibérée (documentée) pour ne pas toucher `:feature:forum` pendant un travail concurrent ; à dédupliquer plus tard.

### #229 — swipe liste vide/erreur (`:feature:flags`)
L'état vide rendait un `Text` non scrollable et `Failure` une `Column` non scrollable → le `PullToRefreshBox` n'avait aucun enfant scrollable pour ancrer le pull. Fix : `fillMaxSize().verticalScroll(...)` sur les deux états.

## Tests / validation
- Local (gradle home isolé) : `detektAll`, `:feature:flags:test` + `:feature:topic:test` (incl. nouveaux cas auth/transition), `lintDebug`, `:app:assembleDebug` → **verts**.
- **Vérif live émulateur** : #229 swipe sur liste Cyan vide → l'indicateur pull s'affiche ✅ ; #220 happy path loggé → « Répondre » actif + « Citer » présents (pas de régression) ✅.
- **Auto-revue 4-flavors Opus** (chaque finding revérifié adversarialement) : findings doc/test corrigés (gate edit-FP extrait + testé, test de transition logout ajouté) ; cold-start flash `isAuthenticated` jugé **cosmétique** (sens sûr false→true, jar primé au nav-host, pattern identique à `CategoryViewModel`) ; absence de CTA login = **choix de design documenté ci-dessus**.

## Issues
Closes #220
Closes #225
Closes #229

## Note merge
Mono-maintainer : merge `--admin --squash` acceptable (revue Codex côté @XaaT) ; justification à porter dans le message de merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
