### PR TITLE
chore(release): prepare app v68

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -21,6 +21,24 @@ Aucun changement applicatif non distribué.
 
 ---
 
+## v68 — `0.3.28` — 2026-05-31
+
+**Statut** : `closed`
+**Commit** : tag `app-v68` après merge de la PR #230
+**Fichier** : AAB uploadé sur le canal Play closed alpha + tag pour F-Droid
+
+Phase 2 finish — corrections de fin de dogfood sur les actions d'écriture et l'écran Drapeaux.
+
+### Fixed
+- **#220 — Actions d'écriture masquées hors connexion.** Répondre, Citer, Modifier et Modifier-FP sont maintenant gated sur `canReply && isAuthenticated`, afin d'éviter d'ouvrir un éditeur qui ne peut échouer qu'au submit après logout ou cache topic périmé.
+- **#225 — Drapeaux : suppression du double loader au swipe-to-refresh.** La liste reste affichée sous l'indicateur Material 3 au lieu de disparaître derrière un spinner central.
+- **#229 — Drapeaux : swipe-to-refresh sur état vide ou erreur.** Les états vides/erreur remplissent maintenant l'écran et restent scrollables pour que le geste de refresh soit capté.
+
+### Changed
+- **Build / release** : `app/build.gradle.kts` passe à `versionCode = 68`, `versionName = "0.3.28"`.
+
+---
+
 ## v67 — `0.3.27` — 2026-05-31
 
 **Statut** : `closed`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         // track (alpha) and in the GitHub Release flag, not in versionName itself.
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
-        versionCode = 67
-        versionName = "0.3.27"
+        versionCode = 68
+        versionName = "0.3.28"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,9 +1,9 @@
-Redface 2 alpha v67 — more robust replies and quotes.
+Redface 2 alpha v68 — write actions and flags polish.
 
 Changes:
-- Reply now works on categories without subcategories.
-- Quote stays available even when HFR hides the quote link.
-- Old topic caches are invalidated to avoid missing buttons after update.
-- Docs and tests now match real HFR fixtures.
+- Reply, quote and edit actions are no longer shown while logged out.
+- Flags: no more double loader during pull-to-refresh.
+- Flags: pull-to-refresh now works on empty and error states.
+- Targeted tests cover write gates and refresh behavior.
 
 Report bugs via alpha or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,9 +1,9 @@
-Alpha Redface 2 v67 — réponses et citations plus robustes.
+Alpha Redface 2 v68 — finitions écriture et drapeaux.
 
 Changements :
-- Répondre fonctionne sur les catégories sans sous-catégorie.
-- Citer reste disponible même quand HFR masque le lien de citation.
-- Les anciens caches topic sont invalidés pour éviter des boutons absents après mise à jour.
-- Documentation et tests alignés sur les fixtures HFR réelles.
+- Répondre, citer et modifier ne s'affichent plus hors connexion.
+- Drapeaux : plus de double loader pendant le swipe-to-refresh.
+- Drapeaux : le swipe-to-refresh fonctionne aussi sur liste vide ou erreur.
+- Tests ciblés ajoutés sur les gates d'écriture et le refresh.
 
 Bugs : alpha ou GitHub.


### PR DESCRIPTION
> Action par GPT-5 Codex (demandée par @XaaT)

Prépare la release Play alpha après merge de #230.

Changements :
- `versionCode = 68`, `versionName = 0.3.28`
- entrée `app/CHANGELOG.md` v68
- release notes Play `fr-FR` / `en-US`

Validation locale :
- `git diff --check`
- `./scripts/docker-dev.sh ./gradlew :app:assembleDebug --no-watch-fs --console=plain --no-daemon`

Merge prévu : squash admin mono-maintainer après CI verte, puis tag `app-v68` pour déclencher la release Play alpha + F-Droid.