### PR TITLE
fix(topic): force-refresh à l'ouverture depuis un drapeau (#231) + champ « aller à la page » sans plafond 9999 (#235)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -104,6 +104,13 @@ data class TopicRoute(
      * link) so the cache-first behaviour is preserved everywhere else.
      */
     val submitSignal: Long? = null,
+    /**
+     * #231 — `true` when this route is pushed from a drapeau/flag tap. The topic screen
+     * still shows the cached page instantly but always refreshes afterwards (bypassing the
+     * 60s snappy-cache TTL), so opening a followed topic to catch up never shows it stale.
+     * `false` on ordinary navigation (forum / deep link / back-nav) to keep the cache snappy.
+     */
+    val forceRefresh: Boolean = false,
 ) : RedfaceNavKey
 
 @Serializable
@@ -448,6 +455,10 @@ private fun RedfaceNavHost(
                                 scrollTo = flag.lastPostReadId
                                     ?.takeIf { it in 1L..Int.MAX_VALUE.toLong() }
                                     ?.toInt(),
+                                // #231 — a flag open means « catch up on new posts » → refresh
+                                // past the 60s snappy-cache TTL (the cached page is still shown
+                                // instantly first). Avoids landing on a stale followed topic.
+                                forceRefresh = true,
                             ),
                         )
                     },
@@ -584,6 +595,7 @@ private fun RedfaceNavHost(
                         page = route.page,
                         scrollTo = route.scrollTo,
                         submitSignal = route.submitSignal,
+                        forceRefresh = route.forceRefresh,
                     ),
                     onOpenProfile = onOpenProfile,
                     onReply = { subcat, page ->

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImpl.kt
@@ -55,7 +55,7 @@ class TopicRepositoryImpl @Inject constructor(
      * - Cache miss → fetch directly. A failure here propagates so the UI can
      *   show its error state.
      */
-    override fun observeTopicPage(cat: Int, post: Int, page: Int): Flow<Topic> = flow {
+    override fun observeTopicPage(cat: Int, post: Int, page: Int, forceRefresh: Boolean): Flow<Topic> = flow {
         // Alpha "Ignorer le cache topic" toggle (Phase 2 finish): when enabled, skip the
         // Room read entirely and emit a fresh network fetch. The result is still persisted
         // so toggling back OFF later finds a cache coherent with the current parser. We
@@ -71,7 +71,13 @@ class TopicRepositoryImpl @Inject constructor(
         val cached = withContext(ioDispatcher) { loadFromCache(cat, post, page) }
         if (cached != null) {
             emit(cached.topic)
-            val canSkipRefresh = cached.authMode == FetchMode.AUTHENTICATED &&
+            // #231 — `forceRefresh` (set when opening a topic from a flag, where the user
+            // wants the latest posts) bypasses the snappy-cache TTL: the cached page was
+            // emitted instantly above, but we still always re-fetch below so a followed
+            // topic that grew is never shown stale within the 60s window. The TTL skip
+            // remains for ordinary back-nav (forceRefresh = false).
+            val canSkipRefresh = !forceRefresh &&
+                cached.authMode == FetchMode.AUTHENTICATED &&
                 CachePolicy.isFresh(cached.fetchedAt, CachePolicy.topicPage, clock)
             if (canSkipRefresh) {
                 return@flow

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -110,6 +110,29 @@ class TopicRepositoryImplTest {
     }
 
     @Test
+    fun `observeTopicPage with forceRefresh re-fetches despite a fresh cache (#231)`() = runTest {
+        // Two responses: the warmup + the forced refresh that must fire even though the
+        // cache is fresh by TTL — the #231 « open from a flag = catch up on new posts » path.
+        server.enqueue(MockResponse().setBody(fixtureHtml("topic_page_single.html")))
+        server.enqueue(MockResponse().setBody(fixtureHtml("topic_page_single.html")))
+        val repo = repository(now = Instant.parse("2026-04-26T18:00:00Z"))
+        repo.refreshTopicPage(1, 999_395, 1)
+        assertEquals("warmup should issue exactly one network request", 1, server.requestCount)
+
+        // Same fixed clock → cache fresh by TTL → without forceRefresh it would skip.
+        repo.observeTopicPage(1, 999_395, 1, forceRefresh = true).test {
+            awaitItem() // cached emission (instant)
+            awaitItem() // forced refresh emission
+            awaitComplete()
+        }
+        assertEquals(
+            "forceRefresh must re-fetch despite a fresh AUTHENTICATED cache",
+            2,
+            server.requestCount,
+        )
+    }
+
+    @Test
     fun `observeTopicPage on a stale cache emits cache then refreshes`() = runTest {
         // Warm cache as of T0.
         server.enqueue(MockResponse().setBody(fixtureHtml("topic_page_single.html")))

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/topic/TopicRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/topic/TopicRepository.kt
@@ -9,11 +9,17 @@ interface TopicRepository {
      * only when the cached row is stale relative to the implementation's TTL
      * (cf. `CachePolicy.topicPage`) — a hot revisit returns the cache and stops.
      *
+     * [forceRefresh] (#231) bypasses that TTL skip: the cached page is still emitted
+     * instantly for a snappy first paint, but a network refresh **always** follows.
+     * Set it when the user's intent is to catch up on new posts (e.g. opening a topic
+     * from a drapeau/flag), so a followed topic that grew is never shown stale within
+     * the snappy-cache window.
+     *
      * Network errors after a cache emission are swallowed so the user keeps
      * seeing the last-known-good page; on a cold cache, errors are surfaced as
      * exceptions on the flow.
      */
-    fun observeTopicPage(cat: Int, post: Int, page: Int): Flow<Topic>
+    fun observeTopicPage(cat: Int, post: Int, page: Int, forceRefresh: Boolean = false): Flow<Topic>
 
     /**
      * Forces a network fetch, bypasses TTL, and writes the result to the cache.

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicRequest.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicRequest.kt
@@ -13,4 +13,12 @@ data class TopicRequest(
      * host — only its presence/absence matters, not its magnitude.
      */
     val submitSignal: Long? = null,
+    /**
+     * #231 — `true` when the topic is opened from a drapeau/flag (the user's intent is
+     * to catch up on new posts). The cache-aside path still shows the cached page
+     * instantly but **always** refreshes afterwards, bypassing the 60s snappy-cache TTL
+     * that would otherwise serve a followed topic stale. Ordinary in-app navigation
+     * leaves it `false` to keep back-nav snappy.
+     */
+    val forceRefresh: Boolean = false,
 )

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -642,7 +642,7 @@ private fun TopicPageJumpField(
     ) {
         OutlinedTextField(
             value = input,
-            onValueChange = { raw -> input = raw.filter(Char::isDigit).take(JUMP_MAX_DIGITS) },
+            onValueChange = { raw -> input = coercePageJumpInput(raw, totalPages) },
             singleLine = true,
             label = { Text(stringResource(R.string.topic_page_jump_label)) },
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
@@ -910,5 +910,12 @@ internal fun shouldShowEditFirstPost(topic: Topic, isAuthenticated: Boolean): Bo
         topic.page == 1 &&
         topic.posts.isNotEmpty()
 
+// #235 — the page-jump field must accept any valid page. Binding the input width to the digit
+// count of [totalPages] (instead of a fixed 4-digit ceiling that made pages >= 10000 untypable)
+// lets very long topics — e.g. the ~16k-page Ukraine topic — reach their last pages, while a
+// small topic stays tight. The jump action already validates `target in 1..totalPages`, so the
+// cap only needs to mirror that bound. `maxOf(1, …)` guards a degenerate totalPages <= 0.
+internal fun coercePageJumpInput(raw: String, totalPages: Int): String =
+    raw.filter(Char::isDigit).take(maxOf(1, totalPages).toString().length)
+
 private const val PAGE_GRID_LIMIT = 40
-private const val JUMP_MAX_DIGITS = 4

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -134,7 +134,7 @@ class TopicViewModel @AssistedInject constructor(
         _state.update { it.copy(mode = TopicUiState.Mode.Loading) }
         loadJob = viewModelScope.launch {
             topicRepository
-                .observeTopicPage(request.cat, request.post, request.page)
+                .observeTopicPage(request.cat, request.post, request.page, forceRefresh = request.forceRefresh)
                 .catch { error ->
                     if (error is CancellationException) throw error
                     // Cache-first UX: if we already showed a cached page, keep it on screen

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/PageJumpInputTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/PageJumpInputTest.kt
@@ -1,0 +1,30 @@
+package fr.forumhfr.redface2.feature.topic
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PageJumpInputTest {
+
+    @Test
+    fun `strips non-digit characters from the raw input`() {
+        // totalPages = 9999 → 4-digit room, so "123" is not clipped; only the non-digits go.
+        assertEquals("123", coercePageJumpInput("1a2-3 ", totalPages = 9999))
+    }
+
+    @Test
+    fun `caps the input to the digit count of a small topic`() {
+        // 30 pages → 2 digits: a third digit is dropped (page 300 never exists anyway).
+        assertEquals("30", coercePageJumpInput("300", totalPages = 30))
+    }
+
+    @Test
+    fun `#235 — a very long topic accepts a 5-digit page (Ukraine, 15992 pages)`() {
+        // The old fixed 4-digit cap truncated this to "1599", making page 15992 untypable.
+        assertEquals("15992", coercePageJumpInput("15992", totalPages = 15992))
+    }
+
+    @Test
+    fun `degenerate non-positive totalPages still allows at least one digit`() {
+        assertEquals("7", coercePageJumpInput("77", totalPages = 0))
+    }
+}

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -358,6 +358,21 @@ class TopicViewModelTest {
         assertEquals(true, vm.state.value.isAuthenticated)
     }
 
+    @Test
+    fun `forceRefresh from the request is forwarded to observeTopicPage (#231)`() = runTest {
+        val repository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) }))
+        TopicViewModel(
+            request = topicRequest(page = 1).copy(forceRefresh = true),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+        assertEquals(
+            "a flag-open request must force the topic cache to refresh",
+            true,
+            repository.lastForceRefresh,
+        )
+    }
+
     private fun topicRequest(
         page: Int,
         scrollTo: Int? = null,
@@ -621,8 +636,12 @@ private class FakeTopicRepository(
      */
     var prefetchHook: (suspend (cat: Int, post: Int, page: Int) -> Unit)? = null
 
-    override fun observeTopicPage(cat: Int, post: Int, page: Int): Flow<Topic> {
+    var lastForceRefresh: Boolean? = null
+        private set
+
+    override fun observeTopicPage(cat: Int, post: Int, page: Int, forceRefresh: Boolean): Flow<Topic> {
         calls += Triple(cat, post, page)
+        lastForceRefresh = forceRefresh
         return queue.removeFirstOrNull() ?: error("No more flows queued")
     }
 
@@ -642,7 +661,7 @@ private class FakeTopicRepository(
 private class FakeStreamingTopicRepository(
     private val source: Flow<Topic>,
 ) : TopicRepository {
-    override fun observeTopicPage(cat: Int, post: Int, page: Int): Flow<Topic> = source
+    override fun observeTopicPage(cat: Int, post: Int, page: Int, forceRefresh: Boolean): Flow<Topic> = source
 
     override suspend fun refreshTopicPage(cat: Int, post: Int, page: Int): Topic {
         error("refreshTopicPage not used by ViewModel under test")


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Cette PR regroupe deux bugs du lecteur de sujet (cf. #231 et #235), chacun dans son commit dédié.

---

## Bug #231 — page périmée à l'ouverture depuis un drapeau Cyan
Ouvrir un sujet **depuis un drapeau Cyan** pour lire les **derniers posts** affiche une page **cachée périmée qui ne se rafraîchit pas**. Vider le cache topic « marche » ; rafraîchir les drapeaux ne change rien.

### Cause racine
Le seul chemin sans-refresh de `observeTopicPage` est `canSkipRefresh` : une ligne **AUTHENTICATED** encore **fraîche** au sens du TTL **snappy-cache de 60 s** (`CachePolicy.topicPage`) court-circuite le réseau (optimisation back-nav). Un sujet suivi qui a grossi est donc servi périmé dans cette fenêtre.
- « Vider le cache marche » car le chemin **cache-miss** appelle le **même `fetchAndPersist`** → le skip TTL était le **seul** bloquant.
- « Rafraîchir les drapeaux ne marche pas » car le pull-to-refresh drapeaux ne touche **que** le listing REST, **pas** `topic_pages`.

### Fix
Un flag **`forceRefresh`** plumbé `TopicRoute → TopicRequest → TopicRepository.observeTopicPage` : une ouverture **depuis un drapeau** émet la page cachée **instantanément** (first paint snappy) **puis rafraîchit TOUJOURS** (bypass le skip TTL). La navigation ordinaire / back-nav garde `forceRefresh = false` → cache snappy préservé. Ne touche pas le listing.

À chaque émission, `availablePages` est recalculé depuis `topic.totalPages` : si le sujet a débordé sur de nouvelles pages, l'indicateur passe « X/Y », la liste des pages montre les nouvelles, et l'utilisateur y va s'il veut (comportement **resume**, pas de jump forcé — décision UX assumée).

---

## Bug #235 — champ « aller à la page » plafonné à 9999
Le champ **« aller à la page »** était plafonné à **4 chiffres** (`JUMP_MAX_DIGITS = 4`) → page **9999 max**. Les très longs sujets (ex. **Ukraine, 15992 pages**) avaient leurs dernières pages **injoignables par saisie directe**.

### Fix
La validation borne déjà à `target in 1..totalPages` ; le plafond de saisie n'a qu'à **refléter** ce bornage. Remplacement de la constante figée par un helper pur `coercePageJumpInput(raw, totalPages)` qui garde le **nombre de chiffres de `totalPages`** (`maxOf(1, …)` pour un total dégénéré). Un sujet de 30 pages reste à 2 chiffres ; Ukraine accepte 5 ; ne pourra jamais re-péter.

---

## Tests
- `TopicRepositoryImplTest` (#231) : `forceRefresh` re-fetch **malgré** un cache frais (≠ le test « fresh cache skips refresh »).
- `TopicViewModelTest` (#231) : le `forceRefresh` de la requête est bien transmis à `observeTopicPage`.
- `PageJumpInputTest` (#235) : strip non-digits, cap sur petit topic, **régression Ukraine 15992** (5 chiffres acceptés, plus tronqués à `1599`), cas dégénéré. 4 tests, 0 échec.
- Local vert (gradle home isolé) : `detektAll` + `:feature:topic:testDebugUnitTest` + `:feature:topic:lintDebug` `--rerun-tasks` → `BUILD SUCCESSFUL`. (#234 d'origine : + `:core:data:test` + `:app:assembleDebug`.)

## Hors lot
- Le **refresh-on-resume du listing drapeaux** (cohérence de la *liste* Cyan au retour — autre écran) reste non traité, non nécessaire pour ces bugs. À ouvrir en issue séparée si besoin.

## Issues
Closes #231
Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)
