### PR TITLE
fix(editor): capitalisation auto des phrases (#237) + picker smileys plus compacts (#236)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextField.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextField.kt
@@ -1,10 +1,12 @@
 package fr.forumhfr.redface2.core.ui.editor
 
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.TextFieldValue
 
 /**
@@ -29,5 +31,8 @@ fun BbcodeTextField(
         label = { Text(label) },
         placeholder = placeholder?.let { hint -> { Text(hint) } },
         minLines = 5,
+        // #237 — Compose ne capitalise rien par défaut (≠ EditText/RF1 en `textCapSentences`).
+        // `Sentences` rend la majuscule en début de message ET après `. ! ?`, parité RF1.
+        keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
     )
 }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/SmileyPickerSheet.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/SmileyPickerSheet.kt
@@ -27,6 +27,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -169,7 +171,8 @@ private fun WikiTabContent(
 @Composable
 private fun SmileyGrid(items: List<EditorSmiley>, onSmileyClicked: (String) -> Unit) {
     LazyVerticalGrid(
-        columns = GridCells.Adaptive(minSize = 64.dp),
+        // #236 — denser grid: smaller min cell (was 64.dp) packs more smileys per row.
+        columns = GridCells.Adaptive(minSize = 48.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
         modifier = Modifier
@@ -190,7 +193,8 @@ private fun SmileyCell(smiley: EditorSmiley, onClick: () -> Unit) {
     val description = stringResource(R.string.editor_smiley_insert_description, smiley.token)
     Box(
         modifier = Modifier
-            .size(56.dp)
+            // #236 — 48.dp keeps the Material minimum touch target while the grid gets denser.
+            .size(48.dp)
             .clickable(onClick = onClick)
             .semantics { contentDescription = description },
         contentAlignment = Alignment.Center,
@@ -200,7 +204,12 @@ private fun SmileyCell(smiley: EditorSmiley, onClick: () -> Unit) {
             // contentDescription is on the parent Box so the click target carries it ;
             // null here keeps TalkBack from announcing the image twice.
             contentDescription = null,
-            modifier = Modifier.size(48.dp),
+            // #236 — render at 30.dp (was 48.dp): HFR builtins are ~16 px sprites, so a smaller
+            // box stops the ×3 upscale that looked huge and blurry. ContentScale.Fit preserves
+            // the aspect ratio of taller perso smileys; FilterQuality.None keeps pixel-art crisp.
+            modifier = Modifier.size(30.dp),
+            contentScale = ContentScale.Fit,
+            filterQuality = FilterQuality.None,
         )
     }
 }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -38,6 +39,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -154,6 +156,8 @@ internal fun TopicFormContent(
                 modifier = Modifier.fillMaxWidth(),
                 enabled = !state.isSubmitting,
                 label = { Text(stringResource(R.string.editor_topic_subject_label)) },
+                // #237 — sentence capitalization (parité RF1) like the body field.
+                keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
             )
             // #213 — a category WITHOUT a sub-category (e.g. IA, cat=32) renders no
             // `<select name=subcat>` on HFR's form (`hasSubcategorySelect = false`), so


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Deux retouches UX de l'éditeur, issues du dogfood @XaaT, chacune dans son commit.

## #237 — capitalisation auto en début de phrase
Sur Gboard, taper un post ne mettait jamais la première lettre en majuscule (ni début de message, ni après `. ! ?`), contrairement à RF1.

**Cause** : Compose ne capitalise rien par défaut (≠ `EditText`/RF1 en `textCapSentences`). Le champ partagé `BbcodeTextField` (`:core:ui`, réponse + création) ne passait aucun `keyboardOptions`.

**Fix** : `KeyboardOptions(capitalization = KeyboardCapitalization.Sentences)` sur `BbcodeTextField` **et** sur le champ titre de création (`TopicFormScreen`). Parité RF1.

## #236 — smiley picker : smileys trop gros
Le picker rendait chaque smiley en `48.dp` dans une cellule de grille `minSize = 64.dp` → les builtin HFR (~16 px) étaient upscalés ×3 (énormes, flous, peu visibles par écran).

**Fix** (option B, pragmatique) :
- grille plus dense : `GridCells.Adaptive(minSize = 64.dp → 48.dp)` → plus de colonnes ;
- cellule touch **48.dp** conservée (minimum Material, accessibilité) ;
- image `48.dp → 30.dp`, `ContentScale.Fit` (ratio des perso préservé) + `FilterQuality.None` (pixel-art net, pas de flou bilinéaire à l'upscale).

L'option A (mesure intrinsèque façon #175, promotion des helpers `:core:ui` en `public`) reste un raffinement possible ultérieur.

## Tests / validation
- Pas de test unitaire : ce sont des consignes IME / paramètres de rendu Compose, non testables sans infra Compose UI (absente du repo, cf. conventions). **DoD = dogfood** (Gboard pour #237 ; les 2 onglets Standard/Wiki pour #236).
- Local vert (gradle home isolé) : `detektAll` + `:core:ui:lintDebug` + `:feature:editor:lintDebug` + `:app:assembleDebug` → `BUILD SUCCESSFUL`.

## Issues
Closes #237
Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)
