### PR TITLE
feat(ui): blocs [code] — wrap (#244) + gouttière de numéros de ligne

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -21,6 +21,25 @@ Aucun changement applicatif non distribué.
 
 ---
 
+## v69 — `0.3.29` — 2026-06-01
+
+**Statut** : `closed`
+**Commit** : tag `app-v69` après merge de la PR #245
+**Fichier** : AAB uploadé sur le canal Play closed alpha + tag pour F-Droid
+
+Lecture topic — rendu des blocs `[code]` (suite du dogfood #244).
+
+### Fixed
+- **#244 — Blocs `[code]` illisibles sur mobile.** `[code]` wrappe désormais dans la largeur de la carte au lieu de scroller horizontalement (une ligne longue ne montrait que son début). `[fixed]` conserve le no-wrap + scroll horizontal pour l'ASCII art / tableaux alignés en colonnes.
+
+### Added
+- **Gouttière de numéros de ligne sur `[code]`** (parité avec le rendu web HFR). Un numéro par ligne logique, peint en `drawBehind` via `TextLayoutResult` ; une continuation de soft-wrap n'est pas numérotée, ce qui lève l'ambiguïté wrap ↔ nouvelle ligne. Bloc forcé en LTR (review Codex). Couvert par `PostRendererCodeBlockRoborazziTest` (ligne qui wrappe + cas >9 lignes).
+
+### Changed
+- **Build / release** : `app/build.gradle.kts` passe à `versionCode = 69`, `versionName = "0.3.29"`.
+
+---
+
 ## v68 — `0.3.28` — 2026-05-31
 
 **Statut** : `closed`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         // track (alpha) and in the GitHub Release flag, not in versionName itself.
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
-        versionCode = 68
-        versionName = "0.3.28"
+        versionCode = 69
+        versionName = "0.3.29"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,9 +1,9 @@
-Redface 2 alpha v68 — write actions and flags polish.
+Redface 2 alpha v69 — code block reading.
 
 Changes:
-- Reply, quote and edit actions are no longer shown while logged out.
-- Flags: no more double loader during pull-to-refresh.
-- Flags: pull-to-refresh now works on empty and error states.
-- Targeted tests cover write gates and refresh behavior.
+- [code] blocks now wrap instead of overflowing off-screen.
+- Line-number gutter on [code] blocks, like the HFR web render.
+- A long line that wraps onto several rows shows a single number.
+- [fixed] unchanged (alignment preserved for ASCII art / tables).
 
 Report bugs via alpha or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,9 +1,9 @@
-Alpha Redface 2 v68 — finitions écriture et drapeaux.
+Alpha Redface 2 v69 — lecture des blocs de code.
 
 Changements :
-- Répondre, citer et modifier ne s'affichent plus hors connexion.
-- Drapeaux : plus de double loader pendant le swipe-to-refresh.
-- Drapeaux : le swipe-to-refresh fonctionne aussi sur liste vide ou erreur.
-- Tests ciblés ajoutés sur les gates d'écriture et le refresh.
+- Les blocs [code] reviennent à la ligne au lieu de déborder hors écran.
+- Numéros de ligne à gauche des blocs [code], comme sur le web HFR.
+- Une ligne longue qui passe sur plusieurs lignes ne reçoit qu'un seul numéro.
+- [fixed] inchangé (alignement préservé pour l'ASCII art / tableaux).
 
 Bugs : alpha ou GitHub.

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -38,6 +39,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
@@ -58,6 +60,7 @@ import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -509,40 +512,45 @@ private fun CodeWithLineNumbers(
 
     var layout by remember { mutableStateOf<TextLayoutResult?>(null) }
 
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .drawBehind {
-                val result = layout ?: return@drawBehind
-                val dividerX = gutterTextWidthPx + gapPx / 2f
-                drawLine(
-                    color = dividerColor,
-                    start = Offset(dividerX, 0f),
-                    end = Offset(dividerX, size.height),
-                )
-                lineStartOffsets.forEachIndexed { index, offset ->
-                    val visualLine = result.getLineForOffset(offset).coerceIn(0, result.lineCount - 1)
-                    val label = (index + 1).toString()
-                    val x = (gutterTextWidthPx - label.length * digitAdvancePx).toFloat()
-                    drawText(
-                        textMeasurer = measurer,
-                        text = label,
-                        topLeft = Offset(x, result.getLineTop(visualLine)),
-                        style = gutterStyle,
-                    )
-                }
-            },
-    ) {
-        Text(
-            text = code,
-            style = codeStyle,
-            color = codeColor,
-            softWrap = true,
-            onTextLayout = { layout = it },
+    // Code is LTR by nature; force it so the painted gutter (absolute-left coords) and the Text's
+    // `start` padding agree under RTL locales (Codex review on the #244 PR) — otherwise `start` flips
+    // to the right while the gutter stays on the left and overlaps the code.
+    CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+        Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = gutterWidthDp),
-        )
+                .drawBehind {
+                    val result = layout ?: return@drawBehind
+                    val dividerX = gutterTextWidthPx + gapPx / 2f
+                    drawLine(
+                        color = dividerColor,
+                        start = Offset(dividerX, 0f),
+                        end = Offset(dividerX, size.height),
+                    )
+                    lineStartOffsets.forEachIndexed { index, offset ->
+                        val visualLine = result.getLineForOffset(offset).coerceIn(0, result.lineCount - 1)
+                        val label = (index + 1).toString()
+                        val x = (gutterTextWidthPx - label.length * digitAdvancePx).toFloat()
+                        drawText(
+                            textMeasurer = measurer,
+                            text = label,
+                            topLeft = Offset(x, result.getLineTop(visualLine)),
+                            style = gutterStyle,
+                        )
+                    }
+                },
+        ) {
+            Text(
+                text = code,
+                style = codeStyle,
+                color = codeColor,
+                softWrap = true,
+                onTextLayout = { layout = it },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = gutterWidthDp),
+            )
+        }
     }
 }
 

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -37,17 +37,22 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
@@ -436,7 +441,8 @@ private fun FixedBlock(block: PostBlock.Fixed) {
 @Composable
 private fun CodeBlockBlock(block: PostBlock.CodeBlock) {
     // [code] = often prose / long pasted lines → WRAP within the card width so it stays readable on
-    // mobile (#244, dogfood). No horizontal scroll; the soft-wrapping Text flows in the full width.
+    // mobile (#244, dogfood). No horizontal scroll. A left line-number gutter (like HFR's web render)
+    // makes the wrap unambiguous: one number per LOGICAL line, wrapped continuations stay unnumbered.
     MonospaceContainer(scrollHorizontally = false) {
         Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
             block.language?.let { lang ->
@@ -446,13 +452,97 @@ private fun CodeBlockBlock(block: PostBlock.CodeBlock) {
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-            Text(
-                text = block.text,
-                style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
-                color = MaterialTheme.colorScheme.onSurface,
-                softWrap = true,
+            CodeWithLineNumbers(
+                code = block.text,
+                codeStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+                codeColor = MaterialTheme.colorScheme.onSurface,
+                gutterColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                dividerColor = MaterialTheme.colorScheme.outlineVariant,
             )
         }
+    }
+}
+
+/** Gap between the right edge of the line-number gutter and the start of the code text. */
+private val CodeGutterGap = 8.dp
+
+/**
+ * Renders `[code]` with a left line-number gutter that stays aligned when long lines soft-wrap.
+ *
+ * The whole block is a SINGLE soft-wrapping [Text] (so selection/copy stay contiguous and the
+ * composable count is O(1) regardless of line count). Numbers are PAINTED in [Modifier.drawBehind] —
+ * never part of the text content — by mapping each LOGICAL line's start offset to its first visual
+ * line via [TextLayoutResult.getLineForOffset] then [TextLayoutResult.getLineTop]. A wrapped
+ * continuation visual line is never visited, so it gets no number: that is what lets the reader tell
+ * a soft-wrap apart from a real newline.
+ *
+ * The gutter width comes from the digit count of the line total (monospace ⇒ fixed advance), so
+ * numbers are right-aligned and the code column never shifts. [layout] is read only in the draw phase
+ * to avoid a recomposition loop.
+ */
+@Composable
+private fun CodeWithLineNumbers(
+    code: String,
+    codeStyle: TextStyle,
+    codeColor: Color,
+    gutterColor: Color,
+    dividerColor: Color,
+) {
+    val density = LocalDensity.current
+    val measurer = rememberTextMeasurer()
+    val gutterStyle = remember(codeStyle, gutterColor) { codeStyle.copy(color = gutterColor) }
+
+    // Start offset of each LOGICAL line, computed from the raw source before layout.
+    val lineStartOffsets = remember(code) {
+        buildList {
+            add(0)
+            code.forEachIndexed { index, char -> if (char == '\n') add(index + 1) }
+            if (code.endsWith("\n")) removeAt(lastIndex)
+        }
+    }
+
+    val digitCount = lineStartOffsets.size.toString().length
+    val digitAdvancePx = remember(gutterStyle, density) { measurer.measure("0", gutterStyle).size.width }
+    val gutterTextWidthPx = digitCount * digitAdvancePx
+    val gapPx = with(density) { CodeGutterGap.toPx() }
+    val gutterWidthDp = with(density) { (gutterTextWidthPx + gapPx).toDp() }
+
+    var layout by remember { mutableStateOf<TextLayoutResult?>(null) }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .drawBehind {
+                val result = layout ?: return@drawBehind
+                val dividerX = gutterTextWidthPx + gapPx / 2f
+                drawLine(
+                    color = dividerColor,
+                    start = Offset(dividerX, 0f),
+                    end = Offset(dividerX, size.height),
+                )
+                lineStartOffsets.forEachIndexed { index, offset ->
+                    val visualLine = result.getLineForOffset(offset).coerceIn(0, result.lineCount - 1)
+                    val label = (index + 1).toString()
+                    val x = (gutterTextWidthPx - label.length * digitAdvancePx).toFloat()
+                    drawText(
+                        textMeasurer = measurer,
+                        text = label,
+                        topLeft = Offset(x, result.getLineTop(visualLine)),
+                        style = gutterStyle,
+                    )
+                }
+            },
+    ) {
+        Text(
+            text = code,
+            style = codeStyle,
+            color = codeColor,
+            softWrap = true,
+            onTextLayout = { layout = it },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = gutterWidthDp),
+        )
     }
 }
 

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -422,7 +422,8 @@ private fun ImageBlockError(description: String?) {
 
 @Composable
 private fun FixedBlock(block: PostBlock.Fixed) {
-    MonospaceContainer {
+    // [fixed] = column-aligned ASCII art/tables → keep no-wrap + horizontal scroll (#244).
+    MonospaceContainer(scrollHorizontally = true) {
         Text(
             text = block.text,
             style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
@@ -434,7 +435,9 @@ private fun FixedBlock(block: PostBlock.Fixed) {
 
 @Composable
 private fun CodeBlockBlock(block: PostBlock.CodeBlock) {
-    MonospaceContainer {
+    // [code] = often prose / long pasted lines → WRAP within the card width so it stays readable on
+    // mobile (#244, dogfood). No horizontal scroll; the soft-wrapping Text flows in the full width.
+    MonospaceContainer(scrollHorizontally = false) {
         Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
             block.language?.let { lang ->
                 Text(
@@ -447,36 +450,45 @@ private fun CodeBlockBlock(block: PostBlock.CodeBlock) {
                 text = block.text,
                 style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
                 color = MaterialTheme.colorScheme.onSurface,
-                softWrap = false,
+                softWrap = true,
             )
         }
     }
 }
 
 /**
- * Wraps a `[fixed]` / `[code]` body in a tinted card with horizontal scroll. Long lines (raw URL,
- * indented snippets, syntax-highlighted source) must overflow horizontally instead of wrapping —
- * wrap would mangle indentation and break the visual contract of a monospace block.
+ * Wraps a `[fixed]` / `[code]` body in a tinted monospace card. [scrollHorizontally] picks the
+ * overflow behaviour per block kind (#244) :
  *
- * Modifier order matters here: the **outer** [Card] carries [Modifier.fillMaxWidth] so the card
- * itself spans the parent. The **inner** [Column] must NOT carry [Modifier.fillMaxWidth] before
- * [Modifier.horizontalScroll] — that would clamp the children's measured width to the card's
- * width and turn the scroll into a no-op. [Modifier.padding] sits before the scroll modifier so
- * the inset is fixed and the children scroll inside it (otherwise the left padding would slide
- * out of view on overflow). The monospace [Text] children opt out of soft wrap explicitly.
+ * - **`true` (`[fixed]`)** : long lines OVERFLOW horizontally (children opt out of soft wrap, the
+ *   inner [Column] scrolls). `[fixed]` is column-aligned ASCII art / tables, so wrapping would
+ *   mangle the alignment — horizontal scroll preserves it.
+ * - **`false` (`[code]`)** : the body WRAPS within the card width. HFR `[code]` is most often prose
+ *   or long pasted lines (e.g. articles), where a single horizontally-scrolling line is unreadable
+ *   on mobile (the original dogfood bug — RF1's WebView wraps it). The inner [Column] fills the
+ *   width so the soft-wrapping monospace [Text] flows.
+ *
+ * Modifier order (scroll mode): the **outer** [Card] carries [Modifier.fillMaxWidth] so the card
+ * spans the parent; the **inner** [Column] must NOT carry [Modifier.fillMaxWidth] before
+ * [Modifier.horizontalScroll] (that would clamp the children's measured width to the card's width
+ * and turn the scroll into a no-op). [Modifier.padding] sits before the scroll so the inset stays
+ * fixed and the children scroll inside it.
  */
 @Composable
-private fun MonospaceContainer(content: @Composable () -> Unit) {
+private fun MonospaceContainer(scrollHorizontally: Boolean, content: @Composable () -> Unit) {
     Card(
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
         ),
         modifier = Modifier.fillMaxWidth(),
     ) {
+        val scrollState = rememberScrollState()
         Column(
             modifier = Modifier
                 .padding(12.dp)
-                .horizontalScroll(rememberScrollState()),
+                .let { base ->
+                    if (scrollHorizontally) base.horizontalScroll(scrollState) else base.fillMaxWidth()
+                },
         ) {
             content()
         }

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererCodeBlockRoborazziTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererCodeBlockRoborazziTest.kt
@@ -1,0 +1,121 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.unit.dp
+import com.github.takahirom.roborazzi.captureRoboImage
+import fr.forumhfr.redface2.core.model.PostBlock
+import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Visual captures for the `[code]` line-number gutter (#244 follow-up).
+ *
+ * HFR renders `[code]` with a left line-number gutter; [CodeWithLineNumbers] replicates it so the
+ * soft-wrap introduced in #244 stays unambiguous — exactly one number per LOGICAL line, and a
+ * wrapped continuation visual line gets NO number. These captures prove:
+ *
+ * - [codeBlockWrappingLine] : a deliberately over-long line 2 soft-wraps onto a second visual line
+ *   that carries no number (1, 2, 3, 4 stay aligned to the logical lines).
+ * - [codeBlockManyLines]    : >9 lines, so the gutter widens to two digits and numbers stay
+ *   right-aligned without shifting the code column.
+ *
+ * Run on demand (writes PNGs under `core/ui/build/outputs/roborazzi/`, gitignored — see the header
+ * of [PostRendererQuoteRoborazziTest] for why the Roborazzi Gradle plugin is not applied) :
+ *
+ *     ./scripts/docker-dev.sh ./gradlew :core:ui:testDebugUnitTest \
+ *         --tests '*PostRendererCodeBlockRoborazziTest*' --console=plain --no-daemon
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@OptIn(ExperimentalTestApi::class)
+class PostRendererCodeBlockRoborazziTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun codeBlockWrappingLine() {
+        composeTestRule.setContent {
+            LightHost {
+                PostRenderer(content = wrappingCodeContent())
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage(
+            filePath = "build/outputs/roborazzi/post_renderer_code_wrapping.png",
+        )
+    }
+
+    @Test
+    fun codeBlockManyLines() {
+        composeTestRule.setContent {
+            LightHost {
+                PostRenderer(content = manyLineCodeContent())
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage(
+            filePath = "build/outputs/roborazzi/post_renderer_code_many_lines.png",
+        )
+    }
+
+    @Composable
+    private fun LightHost(content: @Composable () -> Unit) {
+        RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+            Surface(color = MaterialTheme.colorScheme.surface) {
+                Box(
+                    modifier = Modifier
+                        .width(360.dp)
+                        .background(MaterialTheme.colorScheme.surface)
+                        .padding(16.dp),
+                ) {
+                    content()
+                }
+            }
+        }
+    }
+
+    private fun wrappingCodeContent(): PostContent = PostContent(
+        blocks = listOf(
+            PostBlock.CodeBlock(
+                text = buildString {
+                    appendLine("fun greet(name: String) {")
+                    appendLine(
+                        "    val message = \"This is a deliberately very long line that has to " +
+                            "exceed the card width on a 360dp screen so it soft-wraps onto a " +
+                            "second visual line with no line number\"",
+                    )
+                    appendLine("    println(message)")
+                    append("}")
+                },
+                language = "kotlin",
+            ),
+        ),
+    )
+
+    private fun manyLineCodeContent(): PostContent = PostContent(
+        blocks = listOf(
+            PostBlock.CodeBlock(
+                text = (1..12).joinToString(separator = "\n") { index ->
+                    "line $index of the snippet"
+                },
+                language = null,
+            ),
+        ),
+    )
+}


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Deux changements sur le rendu des blocs `[code]` (lecture topic), trouvés en dogfood.

## 1. `[code]` wrappe au lieu de scroller (#244)

`[code]` et `[fixed]` partageaient le même rendu monospace (`softWrap = false` + scroll horizontal). Or `[code]` contient souvent de la prose / lignes longues (extraits d'articles) → une ligne longue n'affichait que son début et débordait hors écran, illisible sur mobile (post #74746885 signalé par un testeur ; RF1 wrappe).

`MonospaceContainer` prend un flag `scrollHorizontally` :
- `[code]` → **wrappe** dans la largeur de la carte
- `[fixed]` → garde **no-wrap + scroll horizontal** (ASCII art / tableaux alignés)

## 2. Gouttière de numéros de ligne sur `[code]`

HFR (web) affiche une gouttière de numéros de ligne sur `[code]`. Avec le wrap, une ligne longue s'étale sur plusieurs lignes visuelles → un numéro par ligne **logique** lève l'ambiguïté wrap ↔ vraie nouvelle ligne.

`CodeWithLineNumbers` rend tout le bloc en **un seul `Text`** wrappé et **peint** les numéros en `drawBehind` (jamais du texte) : chaque offset de début de ligne logique → première ligne visuelle via `TextLayoutResult.getLineForOffset` puis `getLineTop`. Une continuation de wrap n'est jamais visitée → pas de numéro.

- Sélection contiguë préservée, nombre de composables O(1) quel que soit le nombre de lignes.
- Largeur de gouttière dérivée du nombre de chiffres du total (monospace, alignée à droite) → la colonne de code ne bouge pas.
- **Render-time only** : `PostBlock.CodeBlock` (contrat on-disk gelé) inchangé, pas de migration Room.

## Validation

- `detektAll` + `:core:ui:lintDebug` + `:core:ui:testDebugUnitTest` → BUILD SUCCESSFUL
- `PostRendererCodeBlockRoborazziTest` (nouveau) : capture la ligne qui wrappe + le cas >9 lignes (gouttière 2 chiffres). Les 2 rendus vérifiés visuellement.

Closes #244
