### PR TITLE
fix(parser): rendre le [quote] nu en mode connecté (table.oldquote) (#247)

### DIFF
--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
@@ -109,11 +109,13 @@ class PostContentParser {
 
     private fun classifyDiv(element: Element): NodeKind = when {
         element.selectFirst("table.spoiler") != null -> NodeKind.SPOILER
-        // HFR renders [quotemsg=...] as <table class="citation"> (with author anchor) and
-        // [quote] (anonymous) as <table class="quote"> — both map to the same Quote block.
-        // Logged-in users whose profile uses the classic citation style get <table
-        // class="oldcitation"> instead of "citation" — same structure, different class.
-        element.selectFirst("table.citation, table.oldcitation, table.quote") != null -> NodeKind.QUOTE
+        // HFR renders [quotemsg=...] as <table class="citation"> (with author anchor) and a bare
+        // [quote] as <table class="quote"> — both map to the same Quote block. Logged-in users whose
+        // profile uses the classic citation style get the "old"-prefixed classes instead:
+        // <table class="oldcitation"> for [quotemsg] and <table class="oldquote"> for a bare [quote]
+        // — same structure, different class. All four must be recognised or the quote is swallowed
+        // and rendered as plain text (real bug on the logged-in vélo topic, page 8270, post 74749781).
+        element.selectFirst("table.citation, table.oldcitation, table.quote, table.oldquote") != null -> NodeKind.QUOTE
         // Defensive wrapper support: every fixture captured so far emits [fixed] / [code] as a
         // <table> child direct of <div id="paraN"> (handled by classifyTable above), but quotes
         // use <div class="container"> wrappers. Synthetic tests pin this fallback so a future HFR
@@ -126,7 +128,8 @@ class PostContentParser {
 
     private fun classifyTable(element: Element): NodeKind = when {
         element.hasClass("spoiler") -> NodeKind.SPOILER
-        element.hasClass("citation") || element.hasClass("oldcitation") || element.hasClass("quote") -> NodeKind.QUOTE
+        element.hasClass("citation") || element.hasClass("oldcitation") ||
+            element.hasClass("quote") || element.hasClass("oldquote") -> NodeKind.QUOTE
         element.hasClass("fixed") -> NodeKind.FIXED_BLOCK
         element.hasClass("code") -> NodeKind.CODE_BLOCK
         else -> NodeKind.INLINE
@@ -145,13 +148,13 @@ class PostContentParser {
     }
 
     private fun parseQuote(element: Element): PostBlock.Quote? {
-        val table = resolveTable(element, "table.citation, table.oldcitation, table.quote")
+        val table = resolveTable(element, "table.citation, table.oldcitation, table.quote, table.oldquote")
         val cell = table?.selectFirst("td")?.clone()
         if (table == null || cell == null) return null
 
         val authorAnchor = table.selectFirst(HfrSelectors.POST_CITATION_AUTHOR)
-        // <table class="quote"> (anonymous [quote]) has no a.Topic, so author/page/numreponse
-        // stay null. The "Citation :" <b class="s1"> label is removed below for both shapes.
+        // <table class="quote"> / <table class="oldquote"> (a bare [quote]) has no a.Topic, so
+        // author/page/numreponse stay null. The "Citation :" <b class="s1"> label is removed below.
         val author = authorAnchor
             ?.text()
             ?.substringBefore(" a écrit")

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
@@ -135,6 +135,53 @@ class PostContentParserTest {
     }
 
     @Test
+    fun `logged-in oldquote table (bare quote) surfaces as a Quote block`() {
+        // Real fragment captured from the cyclisme topic page 8270 while LOGGED IN (post
+        // #74749781, Konovalov). A bare [quote] (no author) is served as <table class="quote">
+        // anonymously but as <table class="oldquote"> for accounts using the classic citation
+        // style — the "old"-prefixed sibling of oldcitation. Before adding "oldquote" to the
+        // selectors the parser only knew "quote" → the whole bare quote was swallowed and rendered
+        // as plain text (bug reported logged-in only, vélo topic).
+        val loggedInBareQuoteHtml = """
+            <div id="para74749781"><p></p><div class="container"><table class="oldquote">
+            <tr class="none"><td><b class="s1">Citation :</b><hr size="1" /><p>Saranno considerate Granfondo tutte le manifestazioni superiori a 120 Km. Totali.<br /></p>
+            <hr size="1" /></td></tr></table></div><p><br />Source : federciclismo.it</p></div>
+        """.trimIndent()
+        val contentElement = Jsoup.parse(loggedInBareQuoteHtml).selectFirst("div[id^=para]")
+
+        val ast = PostContentParser().parse(contentElement).ast
+
+        val quotes = ast.allBlocks().filterIsInstance<PostBlock.Quote>()
+        assertTrue(
+            "logged-in <table class=\"oldquote\"> must be parsed as a Quote, not swallowed",
+            quotes.isNotEmpty(),
+        )
+        // A bare [quote] has no a.Topic author anchor → author/page/numreponse stay null.
+        assertEquals("bare quote has no author", null, quotes.first().author)
+        // The quoted body is preserved inside the Quote block.
+        val quotedText = quotes.first().content.allInlines()
+            .filterIsInstance<PostInline.Text>()
+            .joinToString(" ") { it.value }
+        assertTrue(
+            "quoted body must be kept inside the Quote, got=$quotedText",
+            quotedText.contains("Saranno considerate Granfondo"),
+        )
+        // The reply text after the quote survives outside, and neither the quoted body nor the
+        // "Citation :" label leaks into the post's own rendered paragraph text.
+        val renderedText = ast.allInlines()
+            .filterIsInstance<PostInline.Text>()
+            .joinToString(" ") { it.value }
+        assertTrue(
+            "reply body after the quote must remain, got=$renderedText",
+            renderedText.contains("Source : federciclismo"),
+        )
+        assertFalse(
+            "bare-quote `Citation :` label must not leak into rendered text, got=$renderedText",
+            renderedText.contains("Citation :"),
+        )
+    }
+
+    @Test
     fun `spoiler block is recognised and not flattened into paragraph`() {
         val topic = pageParser.parse(fixture("topic_khakha_page_146.html"))
 


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

**Closes #247.**

## Bug (dogfood, mode connecté)

Un `[quote]` nu (sans auteur) n'était pas rendu comme citation en mode connecté : contenu en texte brut + label littéral « Citation : ». Repro : topic Vélo p.8270, post n°74749781.

## Cause

HFR sert le `[quote]` nu en `<table class="quote">` (anonyme) mais `<table class="oldquote">` (connecté, style classique) — même mécanique que `citation→oldcitation`. Le parser gérait `citation/oldcitation/quote` mais **pas `oldquote`**. Angle mort symétrique du fix oldcitation.

## Fix

`table.oldquote` ajouté aux 3 sélecteurs (`classifyDiv`, `classifyTable`, `parseQuote`). Bare quote → `PostBlock.Quote(author=null)`, label retiré.

## Validation

- `detektAll` + `:core:parser:test` + `:app:assembleDebug` → BUILD SUCCESSFUL
- Test de régression `logged-in oldquote table (bare quote) surfaces as a Quote block` (fragment HTML réel capturé page 8270).
- Confirmé sur l'émulateur (loggé) : le `[quote]` Granfondo est maintenant encadré, label « Citation : » retiré.

Closes #247
