### PR TITLE
feat(ui): accent neutre pour le [quote] nu manuel vs citation sourcée (#252)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -276,7 +276,8 @@ private fun QuoteFrame(
             containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
         ),
     ) {
-        // Quote accent bar (4dp, primary/tertiary alternated by depth).
+        // Quote accent bar (4dp): outline for a bare [quote] (#252), else primary/tertiary
+        // alternated by depth (#202). Colour resolved above via quoteAccentRole.
         //
         // History: the original `Row(height = IntrinsicSize.Min) + Box.fillMaxHeight()` crashes
         // on quotes containing `[img]` because `SubcomposeAsyncImage` (used by

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -94,6 +94,28 @@ internal const val MAX_VISIBLE_QUOTE_DEPTH = 3
  */
 internal fun isCollapsedQuoteDepth(depth: Int): Boolean = depth >= MAX_VISIBLE_QUOTE_DEPTH
 
+/**
+ * Which themed accent the [QuoteFrame] left bar uses. Issue #252 — a **bare** `[quote]` (typed by
+ * hand, no author) is the user formatting their own text, not citing a sourced post, so it must read
+ * differently from a real HFR citation (`[quotemsg=]`, author set) and from a nested citation:
+ *
+ *  - [BARE] → neutral `outline` accent, regardless of depth: "quoted text, no source".
+ *  - [SOURCED_EVEN] / [SOURCED_ODD] → the existing `primary` / `tertiary` alternation that keeps a
+ *    subtle hierarchy for nested real citations (cf. [QuoteFrame] KDoc).
+ *
+ * The author palette stays colored (red/gold) so a citation always looks "sourced"; the bare quote
+ * gets the muted neutral so the two are unambiguous in light, dark and AMOLED (where `secondary`
+ * would collide with `primary`). Pure decision so it is pinned in [PostRendererQuoteDepthTest]
+ * without entering Compose.
+ */
+internal enum class QuoteAccentRole { BARE, SOURCED_EVEN, SOURCED_ODD }
+
+internal fun quoteAccentRole(quoteDepth: Int, isBareQuote: Boolean): QuoteAccentRole = when {
+    isBareQuote -> QuoteAccentRole.BARE
+    quoteDepth % 2 == 0 -> QuoteAccentRole.SOURCED_EVEN
+    else -> QuoteAccentRole.SOURCED_ODD
+}
+
 @Composable
 fun PostRenderer(
     content: PostContent,
@@ -206,7 +228,7 @@ private fun QuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
         CollapsedQuoteBlock(block, quoteDepth)
         return
     }
-    QuoteFrame(quoteDepth = quoteDepth) {
+    QuoteFrame(quoteDepth = quoteDepth, isBareQuote = block.author == null) {
         block.author?.let { author ->
             Text(
                 text = stringResource(R.string.post_quote_author, author),
@@ -228,17 +250,22 @@ private fun QuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
  * theme `primary` / `tertiary` accent (alternating by depth) so nested quotes keep a
  * subtle hierarchy without redefining `quoteDepth` semantics — the existing N=3 collapse
  * rule still applies above this layer (cf. `isCollapsedQuoteDepth`).
+ *
+ * Issue #252 — a **bare** `[quote]` (`isBareQuote`, no author) instead gets a neutral `outline`
+ * accent so the user's own quoted text reads differently from a sourced HFR citation and from a
+ * nested citation. See [quoteAccentRole] for the (pure, tested) role decision.
  */
 @Composable
 private fun QuoteFrame(
     quoteDepth: Int,
+    isBareQuote: Boolean,
     modifier: Modifier = Modifier,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    val accent = if (quoteDepth % 2 == 0) {
-        MaterialTheme.colorScheme.primary
-    } else {
-        MaterialTheme.colorScheme.tertiary
+    val accent = when (quoteAccentRole(quoteDepth, isBareQuote)) {
+        QuoteAccentRole.BARE -> MaterialTheme.colorScheme.outline
+        QuoteAccentRole.SOURCED_EVEN -> MaterialTheme.colorScheme.primary
+        QuoteAccentRole.SOURCED_ODD -> MaterialTheme.colorScheme.tertiary
     }
     Card(
         modifier = modifier,
@@ -294,6 +321,7 @@ private fun CollapsedQuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
     var revealed by rememberSaveable(block) { mutableStateOf(false) }
     QuoteFrame(
         quoteDepth = quoteDepth,
+        isBareQuote = block.author == null,
         modifier = Modifier.clickable { revealed = !revealed },
     ) {
         Row(

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -116,6 +116,16 @@ internal fun quoteAccentRole(quoteDepth: Int, isBareQuote: Boolean): QuoteAccent
     else -> QuoteAccentRole.SOURCED_ODD
 }
 
+/**
+ * #252/#254 — a quote is "bare" (a hand-typed `[quote]`, no source) only when it carries **no source
+ * metadata at all**. Author alone is not enough: a sourced `[quotemsg=id,page,user]` parsed in the
+ * editor preview (`BbcodeContentParser`) yields `author == null` but a non-null `numreponse`, so an
+ * author-only test would wrongly paint a sourced citation with the bare neutral accent + "Citation"
+ * header. Reading-path citations always carry an author, so this only changes the editor-preview case.
+ */
+internal fun isBareQuote(quote: PostBlock.Quote): Boolean =
+    quote.author == null && quote.numreponse == null && quote.page == null
+
 @Composable
 fun PostRenderer(
     content: PostContent,
@@ -228,7 +238,7 @@ private fun QuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
         CollapsedQuoteBlock(block, quoteDepth)
         return
     }
-    QuoteFrame(quoteDepth = quoteDepth, isBareQuote = block.author == null) {
+    QuoteFrame(quoteDepth = quoteDepth, isBareQuote = isBareQuote(block)) {
         Text(
             // #252 — a bare quote still gets a "Citation" header (no author), mirroring the
             // "Citation de X" header of a sourced citation, so the framed block always reads
@@ -325,7 +335,7 @@ private fun CollapsedQuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
     var revealed by rememberSaveable(block) { mutableStateOf(false) }
     QuoteFrame(
         quoteDepth = quoteDepth,
-        isBareQuote = block.author == null,
+        isBareQuote = isBareQuote(block),
         modifier = Modifier.clickable { revealed = !revealed },
     ) {
         Row(

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -229,13 +229,16 @@ private fun QuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
         return
     }
     QuoteFrame(quoteDepth = quoteDepth, isBareQuote = block.author == null) {
-        block.author?.let { author ->
-            Text(
-                text = stringResource(R.string.post_quote_author, author),
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
+        Text(
+            // #252 — a bare quote still gets a "Citation" header (no author), mirroring the
+            // "Citation de X" header of a sourced citation, so the framed block always reads
+            // as a quotation and not as a stray indented paragraph.
+            text = block.author
+                ?.let { stringResource(R.string.post_quote_author, it) }
+                ?: stringResource(R.string.post_quote_bare),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
         PostBlocksRenderer(
             blocks = block.content.blocks,
             quoteDepth = quoteDepth + 1,
@@ -348,13 +351,14 @@ private fun CollapsedQuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
             )
         }
         if (revealed) {
-            block.author?.let { author ->
-                Text(
-                    text = stringResource(R.string.post_quote_author, author),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
+            Text(
+                // #252 — same "Citation"/"Citation de X" header rule as the expanded QuoteBlock.
+                text = block.author
+                    ?.let { stringResource(R.string.post_quote_author, it) }
+                    ?: stringResource(R.string.post_quote_bare),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
             PostBlocksRenderer(
                 blocks = block.content.blocks,
                 quoteDepth = 0,

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="post_quote_author">Citation de %1$s</string>
+    <string name="post_quote_bare">Citation</string>
     <string name="post_quote_collapsed">Citation imbriquée repliée</string>
     <string name="post_quote_collapsed_revealed">Citations imbriquées</string>
     <string name="post_quote_show">Afficher</string>

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteDepthTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteDepthTest.kt
@@ -1,5 +1,7 @@
 package fr.forumhfr.redface2.core.ui.post
 
+import fr.forumhfr.redface2.core.model.PostBlock
+import fr.forumhfr.redface2.core.model.PostContent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -64,6 +66,24 @@ class PostRendererQuoteDepthTest {
         assertEquals(QuoteAccentRole.BARE, quoteAccentRole(quoteDepth = 0, isBareQuote = true))
         assertEquals(QuoteAccentRole.BARE, quoteAccentRole(quoteDepth = 1, isBareQuote = true))
         assertEquals(QuoteAccentRole.BARE, quoteAccentRole(quoteDepth = 2, isBareQuote = true))
+    }
+
+    @Test
+    fun `isBareQuote is true only when a quote carries no source metadata`() {
+        fun quote(author: String?, numreponse: Int?, page: Int?) = PostBlock.Quote(
+            author = author,
+            numreponse = numreponse,
+            page = page,
+            content = PostContent(blocks = emptyList()),
+        )
+        // Hand-typed [quote]: no author, no numreponse, no page → bare.
+        assertTrue(isBareQuote(quote(author = null, numreponse = null, page = null)))
+        // #254 regression guard: a sourced [quotemsg=id,page,user] parsed in the editor preview has
+        // author == null but a non-null numreponse — it must NOT be treated as bare.
+        assertFalse(isBareQuote(quote(author = null, numreponse = 2523833, page = null)))
+        assertFalse(isBareQuote(quote(author = null, numreponse = 2523833, page = 1)))
+        // Reading-path sourced citation: author present → not bare.
+        assertFalse(isBareQuote(quote(author = "Lt Ripley", numreponse = 74749781, page = 8270)))
     }
 
     @Test

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteDepthTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteDepthTest.kt
@@ -55,4 +55,25 @@ class PostRendererQuoteDepthTest {
         assertTrue("depth 4 must collapse", isCollapsedQuoteDepth(4))
         assertTrue("very deep quotes must keep collapsing", isCollapsedQuoteDepth(99))
     }
+
+    @Test
+    fun `a bare quote always uses the neutral accent regardless of depth`() {
+        // Issue #252 — a hand-typed `[quote]` (author == null) is the user formatting their own
+        // text, never a sourced citation, so it must read with the neutral `outline` accent at
+        // every nesting level (it never alternates into the primary/tertiary citation palette).
+        assertEquals(QuoteAccentRole.BARE, quoteAccentRole(quoteDepth = 0, isBareQuote = true))
+        assertEquals(QuoteAccentRole.BARE, quoteAccentRole(quoteDepth = 1, isBareQuote = true))
+        assertEquals(QuoteAccentRole.BARE, quoteAccentRole(quoteDepth = 2, isBareQuote = true))
+    }
+
+    @Test
+    fun `a sourced citation keeps the primary-tertiary alternation by depth`() {
+        // A real HFR citation (`[quotemsg=]`, author set) keeps the issue #202 hierarchy: even
+        // depths get `primary`, odd depths `tertiary`, so nested citations stay visually layered
+        // and remain clearly distinct from the bare-quote neutral accent above.
+        assertEquals(QuoteAccentRole.SOURCED_EVEN, quoteAccentRole(quoteDepth = 0, isBareQuote = false))
+        assertEquals(QuoteAccentRole.SOURCED_ODD, quoteAccentRole(quoteDepth = 1, isBareQuote = false))
+        assertEquals(QuoteAccentRole.SOURCED_EVEN, quoteAccentRole(quoteDepth = 2, isBareQuote = false))
+        assertEquals(QuoteAccentRole.SOURCED_ODD, quoteAccentRole(quoteDepth = 3, isBareQuote = false))
+    }
 }

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteRoborazziTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteRoborazziTest.kt
@@ -104,6 +104,44 @@ class PostRendererQuoteRoborazziTest {
         )
     }
 
+    /**
+     * Issue #252 — a sourced citation (author set) immediately above a bare hand-typed `[quote]`
+     * (author == null). Confirms at a glance that the bare quote's neutral `outline` accent is
+     * distinct from the citation's colored `primary` accent. Captured in light + AMOLED.
+     */
+    @Test
+    fun postRendererQuoteBareVsSourcedLight() {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                Surface(color = MaterialTheme.colorScheme.surface) {
+                    Box(
+                        modifier = Modifier
+                            .width(360.dp)
+                            .background(MaterialTheme.colorScheme.surface)
+                            .padding(16.dp),
+                    ) {
+                        PostRenderer(content = bareVsSourcedContent())
+                    }
+                }
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage(
+            filePath = "build/outputs/roborazzi/post_renderer_quote_bare_vs_sourced_light.png",
+        )
+    }
+
+    @Test
+    fun postRendererQuoteBareVsSourcedAmoled() {
+        composeTestRule.setContent {
+            AmoledHost {
+                PostRenderer(content = bareVsSourcedContent())
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage(
+            filePath = "build/outputs/roborazzi/post_renderer_quote_bare_vs_sourced_amoled.png",
+        )
+    }
+
     @androidx.compose.runtime.Composable
     private fun AmoledHost(content: @androidx.compose.runtime.Composable () -> Unit) {
         RedfaceTheme(
@@ -166,6 +204,29 @@ class PostRendererQuoteRoborazziTest {
                 ),
             ),
             paragraph("OK on part là-dessus."),
+        ),
+    )
+
+    private fun bareVsSourcedContent(): PostContent = PostContent(
+        blocks = listOf(
+            paragraph("Citation sourcée (author renseigné) :"),
+            PostBlock.Quote(
+                author = "Lt Ripley",
+                numreponse = null,
+                page = null,
+                content = PostContent(
+                    blocks = listOf(paragraph("Le rendu intrinsèque des smileys est mergé.")),
+                ),
+            ),
+            paragraph("Quote nu tapé à la main (author == null) :"),
+            PostBlock.Quote(
+                author = null,
+                numreponse = null,
+                page = null,
+                content = PostContent(
+                    blocks = listOf(paragraph("Granfondo : épreuve cyclosportive de longue distance.")),
+                ),
+            ),
         ),
     )
 


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

**Closes #252.**

## Problème

Un `[quote]` nu (tapé à la main, `author == null`) partageait l'accent coloré `primary`/`tertiary` d'une vraie citation HFR (`[quotemsg=]`) et d'une citation imbriquée. Les deux se lisaient pareil, alors que l'un est l'utilisateur qui met en forme **son propre** texte (pas de source) et l'autre une **citation sourcée**.

## Fix

`QuoteFrame` choisit désormais l'accent via un helper pur `quoteAccentRole(quoteDepth, isBareQuote)` :

- **bare quote** (`author == null`) → accent **`outline`** neutre, à **toutes** les profondeurs (« texte cité, sans source ») ;
- **citation sourcée** → l'alternance `primary`/`tertiary` par profondeur existante (#202) inchangée.

`outline` (et **pas** `secondary`) volontairement : la palette est monochrome rouge, et `secondary` colle à `primary` en dark/AMOLED. Le gris neutre reste distinct du rouge (`primary`) **et** de l'or (`tertiary`) en light, dark et AMOLED.

| | accent |
|---|---|
| Citation HFR `[quotemsg=]` (depth pair) | `primary` (rouge) |
| Citation HFR imbriquée (depth impair) | `tertiary` (or) |
| `[quote]` nu manuel (author null) | `outline` (gris neutre) — **nouveau** |

## Validation

- `quoteAccentRole` épinglé dans `PostRendererQuoteDepthTest` (pur JVM).
- Captures Roborazzi diagnostiques (bare vs sourced, light + AMOLED) — accent neutre bien distinct.
- `detektAll` + `:core:ui:lintDebug` + `:core:ui:testDebugUnitTest` + `:app:assembleDebug` → BUILD SUCCESSFUL.

## Note

Le rendu d'un bare quote en `author == null` est garanti côté parser : anonyme (`table.quote`) sur `main`, et **connecté** (`table.oldquote`) via #248 — cette PR se teste pleinement en mode connecté **avec** #248 mergé.

Closes #252
