### PR TITLE
chore(release): app v70 (0.3.30) — Phase 2 finish [quote]/[img]

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -21,6 +21,26 @@ Aucun changement applicatif non distribué.
 
 ---
 
+## v70 — `0.3.30` — 2026-06-02
+
+**Statut** : `closed`
+**Commit** : tag `app-v70` après merge des PR #248 / #254 / #246
+**Fichier** : AAB uploadé sur le canal Play closed alpha + tag pour F-Droid
+
+Phase 2 finish — rendu des `[quote]` / `[img]` (dogfood S25 + double review Claude/Codex).
+
+### Fixed
+- **#247 — `[quote]` nu non rendu en mode connecté.** Le parser reconnaît `table.oldquote` (variante servie au profil « classique » connecté, symétrique d'`oldcitation`) aux 3 sélecteurs de citation → le bloc est encadré au lieu de tomber en texte brut.
+
+### Added
+- **#252 — distinction visuelle du `[quote]` nu manuel.** Accent gris neutre `outline` + header « Citation » pour un `[quote]` tapé à la main (sans source), distinct de la citation sourcée (`[quotemsg=]`, accent rouge/or alterné par profondeur). `isBareQuote` dérive de l'absence de **toute** métadonnée source (author / numreponse / page) pour ne pas misclassifier un `[quotemsg]` de l'aperçu éditeur.
+- **#224 — dimensionnement intrinsèque des `[img]` inline + promotion en bloc.** Mesure native (no-upscale + caps absolus, cap relatif converti en sp donc fontScale-safe) au lieu de la box fixe 240×180 ; un paragraphe « galerie » (images seules) dont une image dépasse les caps inline est promu en blocs full-width centrés (les images dans un `[url=]` restent inline pour garder le tap-through). Cold-fallback réduit à un carré d'une ligne (#253, plus de flash d'emoji géant avant mesure). Alignement vertical `TextBottom` pour les `[img]` et les smileys.
+
+### Changed
+- **Build / release** : `app/build.gradle.kts` passe à `versionCode = 70`, `versionName = "0.3.30"`.
+
+---
+
 ## v69 — `0.3.29` — 2026-06-01
 
 **Statut** : `closed`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         // track (alpha) and in the GitHub Release flag, not in versionName itself.
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
-        versionCode = 69
-        versionName = "0.3.29"
+        versionCode = 70
+        versionName = "0.3.30"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

## Release alpha v70 / 0.3.30 — Phase 2 finish (rendu `[quote]` / `[img]`)

Bump `versionCode 69 → 70`, `versionName 0.3.29 → 0.3.30` + entrée `app/CHANGELOG.md`.

Agrège les 3 PR Phase 2 finish déjà mergées sur main (CI verte + double review IA Claude 5 agents opus + Codex gpt-5.5 xhigh) :
- **#247** (`#248`) — `[quote]` nu rendu en mode connecté (`table.oldquote`).
- **#252** (`#254`) — accent neutre + header « Citation » distincts pour le `[quote]` nu manuel.
- **#224** (`#246`) — dimensionnement intrinsèque des `[img]` inline + promotion galerie en bloc + cold-fallback #253.

Une fois mergée, le tag `app-v70` déclenche la CD (`release.yml`) : build AAB signé → upload Play **closed alpha** (DRAFT) + GitHub Release.
