### PR TITLE
fix(ui): images-liens en blocs cliquables + décode inline stable + mesure bornée (#257)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeMeasurer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeMeasurer.kt
@@ -5,6 +5,7 @@ import coil3.ImageLoader
 import coil3.PlatformContext
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
+import coil3.size.Precision
 import coil3.size.Scale
 
 /**
@@ -36,6 +37,11 @@ internal suspend fun measureIntrinsicMediaSize(
             .data(url)
             .size(INTRINSIC_PROBE_SIZE_PX)
             .scale(Scale.FIT)
+            // INEXACT is REQUIRED here (Codex review): Coil's default EXACT precision would UPSCALE a
+            // source smaller than the probe (a 16×16 emoji, a 70×50 smiley) up to 1024 before reporting
+            // image.width/height — measuring small media as huge and breaking imageDisplayBox sizing +
+            // the promotion threshold. INEXACT lets Coil report the native size for sources ≤ probe.
+            .precision(Precision.INEXACT)
             .build(),
     )
     val image = (result as? SuccessResult)?.image ?: return null

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeMeasurer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeMeasurer.kt
@@ -5,26 +5,27 @@ import coil3.ImageLoader
 import coil3.PlatformContext
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
-import coil3.size.Size
+import coil3.size.Scale
 
 /**
- * #175 — measure a media's **intrinsic** (native) pixel dimensions via Coil.
+ * #175/#257 — probe a media's dimensions via a **bounded** Coil decode (aspect ratio + size class).
  *
- * Requests `Size.ORIGINAL` so Coil decodes to the SOURCE dimensions (not the display target), then
- * reads `coil3.Image.width/height` (raw bitmap px, never screen-density scaled). `execute()` is a
- * main-safe suspend call (Coil dispatches its own I/O), so the caller invokes it directly from a
- * `LaunchedEffect` and caches the result by URL. Returns `null` on error / non-positive dimensions so
- * the caller can fall back to a provisional size.
- *
- * Caveat: `Size.ORIGINAL` sets the request *target*, not Coil's `maxBitmapSize` (default 4096) — so
- * the reported size equals the source only while the source is ≤ 4096 on each axis; a larger source
- * is reported at the clamped decode size. Irrelevant for smileys (all well under 4096); it would only
- * matter if this were reused to size arbitrary large inline images.
+ * Requests a [INTRINSIC_PROBE_SIZE_PX]-bounded `FIT` decode (NOT `Size.ORIGINAL`), then reads
+ * `coil3.Image.width/height`. `Size.ORIGINAL` fully decoded a large photo at source resolution **just
+ * to read its dimensions** — slow and memory-heavy on every measurable image, on top of the render
+ * decode (#257). A 1024-bounded decode is far cheaper and still answers everything the callers need:
+ *  - **aspect ratio** — preserved by Coil's uniform downsample, used by `imageDisplayBox`;
+ *  - **size class** ("larger than the inline caps?") — all inline caps (≤ 240×200 sp) are well below
+ *    1024, so a source exceeding them still reports a width/height past the cap after probing.
+ * A source ≤ 1024 px (every smiley, most inline images) decodes at native size, unchanged from before.
+ * `execute()` is main-safe (Coil dispatches its own I/O); the caller invokes it from a `LaunchedEffect`
+ * and caches the result by URL. Returns `null` on error / non-positive dimensions.
  *
  * NB (#175 conversion): the returned px are CSS/logical-pixel equivalents — fed to the placeholder as
- * `.sp` directly (`70px → 70.sp`), NOT divided by screen density (which would render smileys
- * ~`1/density` too small — the bug the design doc calls out).
+ * `.sp` directly (`70px → 70.sp`), NOT divided by screen density.
  */
+internal const val INTRINSIC_PROBE_SIZE_PX = 1024
+
 internal suspend fun measureIntrinsicMediaSize(
     url: String,
     context: PlatformContext,
@@ -33,7 +34,8 @@ internal suspend fun measureIntrinsicMediaSize(
     val result = imageLoader.execute(
         ImageRequest.Builder(context)
             .data(url)
-            .size(Size.ORIGINAL)
+            .size(INTRINSIC_PROBE_SIZE_PX)
+            .scale(Scale.FIT)
             .build(),
     )
     val image = (result as? SuccessResult)?.image ?: return null

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
@@ -210,6 +210,14 @@ internal const val INLINE_IMAGE_MAX_HEIGHT_SP = 200
 internal const val INLINE_IMAGE_MAX_WIDTH_SP = 240
 
 /**
+ * #257 — upper bound (px) for the **decode** size of an inline `[img]`. The inline AsyncImage requests
+ * the inline cap converted to px (density × fontScale) clamped to this, so Coil decodes ONE stable
+ * bitmap that survives the cold→measured box growth without a re-decode + pixelated upscale. 1024 covers
+ * the 240×200 sp cap on any realistic density/fontScale while staying cheap to decode and cache.
+ */
+internal const val INLINE_IMAGE_DECODE_CAP_PX = 1024
+
+/**
  * #224/#253 — minimum display **height** (sp) for an inline `[img]`, so a sub-16 low-res source can't
  * render below ~one text line. The community "cc-image" emoji (served as 16×16 PNGs) sits exactly at
  * this floor → rendered at its native 16 (dogfood: the right size next to text, per @XaaT); anything

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
@@ -214,6 +214,10 @@ internal const val INLINE_IMAGE_MAX_WIDTH_SP = 240
  * the inline cap converted to px (density × fontScale) clamped to this, so Coil decodes ONE stable
  * bitmap that survives the cold→measured box growth without a re-decode + pixelated upscale. 1024 covers
  * the 240×200 sp cap on any realistic density/fontScale while staying cheap to decode and cache.
+ *
+ * Distinct from `INTRINSIC_PROBE_SIZE_PX` (also 1024): that one bounds the **measure** probe in
+ * `IntrinsicMediaSizeMeasurer`, this one bounds the **render** decode here. Same value, different role —
+ * don't merge them.
  */
 internal const val INLINE_IMAGE_DECODE_CAP_PX = 1024
 

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -40,7 +40,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.Placeholder
@@ -69,6 +71,9 @@ import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
 import coil3.compose.SubcomposeAsyncImage
 import coil3.compose.SubcomposeAsyncImageContent
+import coil3.request.ImageRequest
+import coil3.size.Precision
+import coil3.size.Scale
 import fr.forumhfr.redface2.core.ui.R
 import fr.forumhfr.redface2.core.model.PostBlock
 import fr.forumhfr.redface2.core.model.PostContent
@@ -227,7 +232,13 @@ private fun ParagraphBlock(inlines: List<PostInline>) {
             modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            galleryImages.forEach { image -> BlockImage(url = image.url, description = image.description) }
+            galleryImages.forEach { promoted ->
+                BlockImage(
+                    url = promoted.image.url,
+                    description = promoted.image.description,
+                    linkUrl = promoted.linkUrl,
+                )
+            }
         }
         return
     }
@@ -461,19 +472,34 @@ private fun ImageBlock(block: PostBlock.Image) = BlockImage(url = block.url, des
  * Full-width, centred, bounded image. The home of a standalone `PostBlock.Image`, and (since #224
  * option B) of a large image promoted out of an image-only paragraph.
  *
+ * When [linkUrl] is non-null the image was posted as `[url=…][img]` (the "click to enlarge" pattern):
+ * the whole block is tappable and opens that URL (#257), so a linked image gets the full-width
+ * treatment AND keeps its tap-through instead of being kept as a small inline thumbnail.
+ *
  * Bounded so a 4000×3000 RAW screenshot can't blow up the post and destroy the scroll position.
  * SubcomposeAsyncImage exposes loading/error slots so the user gets visual feedback when an HFR image
  * host (rehost.diberie.com, super-h.fr, …) is offline rather than a silent empty Box. Phase 1 keeps the
  * loading + error layout minimal — no material-icons-extended dependency just for a placeholder glyph.
  */
 @Composable
-private fun BlockImage(url: String, description: String?) {
+private fun BlockImage(url: String, description: String?, linkUrl: String? = null) {
+    val uriHandler = LocalUriHandler.current
+    val openLabel = stringResource(R.string.post_image_open_link)
     val containerModifier = Modifier
         .fillMaxWidth()
         .defaultMinSize(minHeight = PostMediaDisplayPolicy.blockImageMinHeight)
         .heightIn(max = PostMediaDisplayPolicy.blockImageMaxHeight)
         .clip(RoundedCornerShape(8.dp))
         .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+        .then(
+            if (linkUrl != null) {
+                Modifier.clickable(role = Role.Button, onClickLabel = openLabel) {
+                    runCatching { uriHandler.openUri(linkUrl) }
+                }
+            } else {
+                Modifier
+            },
+        )
     SubcomposeAsyncImage(
         model = url,
         contentDescription = description,
@@ -918,42 +944,43 @@ internal fun imageDisplayBox(
     return InlineMediaBox(capped.width.sp, capped.height.sp)
 }
 
+/** #224/#257 — an image eligible for block promotion, paired with its enclosing `[url=…]` link (if any). */
+internal data class PromotedImage(val image: PostInline.InlineImage, val linkUrl: String?)
+
 /**
- * #224 (option B) — if a paragraph's only meaningful content is bare image(s) (a single posted image
- * the parser kept inline because of a stray sibling, or a gallery of several), return them in order so
- * they can be promoted to full-width centred blocks. Blank text and line breaks are ignored.
+ * #224 (option B) / #257 — if a paragraph's only meaningful content is image(s) (a single posted image
+ * the parser kept inline because of a stray sibling, or a gallery of several), return them in order,
+ * each paired with the URL of its enclosing `[url=…]` link if there is one, so they can be promoted to
+ * full-width centred blocks. Blank text and line breaks are ignored.
  *
- * Returns null when the paragraph has any other meaningful inline (non-blank text, a smiley) — genuine
- * prose keeps its inline image treatment — OR when an image is wrapped in a link (`[url=…][img]`): the
- * block renderer has no click handling, so promoting a linked image would drop its tap-through. Those
- * stay inline where the link annotation keeps them clickable (RF2 has no image click-to-open yet, #182).
+ * Returns null when the paragraph has any other meaningful inline (non-blank text, a smiley): genuine
+ * prose keeps its inline image treatment. A link wrapping ONLY an image is fine — #257 promotes it to a
+ * block that opens the link on tap, so the "click to enlarge" tap-through is preserved AND the image
+ * fills the width (before #257 a linked image was kept inline → small + the inline pixelation path).
+ * A link wrapping image **+** text still counts as other content → null (stays inline prose).
  */
 @Suppress("CyclomaticComplexMethod") // exhaustive when over the PostInline sealed type, like appendInline
-internal fun imageOnlyParagraphImages(inlines: List<PostInline>): List<PostInline.InlineImage>? {
-    val images = mutableListOf<PostInline.InlineImage>()
+internal fun imageOnlyParagraphImages(inlines: List<PostInline>): List<PromotedImage>? {
+    val images = mutableListOf<PromotedImage>()
     var hasOtherContent = false
-    var hasLinkedImage = false
-    fun walk(list: List<PostInline>, insideLink: Boolean) {
+    fun walk(list: List<PostInline>, linkUrl: String?) {
         list.forEach { inline ->
             when (inline) {
-                is PostInline.InlineImage -> {
-                    images += inline
-                    if (insideLink) hasLinkedImage = true
-                }
+                is PostInline.InlineImage -> images += PromotedImage(inline, linkUrl)
                 is PostInline.Text -> if (inline.value.isNotBlank()) hasOtherContent = true
                 PostInline.LineBreak -> Unit
                 is PostInline.Smiley -> hasOtherContent = true
-                is PostInline.Strong -> walk(inline.children, insideLink)
-                is PostInline.Emphasis -> walk(inline.children, insideLink)
-                is PostInline.Underline -> walk(inline.children, insideLink)
-                is PostInline.Strike -> walk(inline.children, insideLink)
-                is PostInline.Color -> walk(inline.children, insideLink)
-                is PostInline.Link -> walk(inline.children, insideLink = true)
+                is PostInline.Strong -> walk(inline.children, linkUrl)
+                is PostInline.Emphasis -> walk(inline.children, linkUrl)
+                is PostInline.Underline -> walk(inline.children, linkUrl)
+                is PostInline.Strike -> walk(inline.children, linkUrl)
+                is PostInline.Color -> walk(inline.children, linkUrl)
+                is PostInline.Link -> walk(inline.children, inline.url)
             }
         }
     }
-    walk(inlines, insideLink = false)
-    return images.takeIf { it.isNotEmpty() && !hasOtherContent && !hasLinkedImage }
+    walk(inlines, linkUrl = null)
+    return images.takeIf { it.isNotEmpty() && !hasOtherContent }
 }
 
 /**
@@ -964,10 +991,10 @@ internal fun imageOnlyParagraphImages(inlines: List<PostInline>): List<PostInlin
  * Returns false while every size is unknown (cold) so promotion only kicks in after measurement.
  */
 internal fun shouldPromoteImagesToBlocks(
-    images: List<PostInline.InlineImage>,
+    images: List<PromotedImage>,
     measured: Map<String, IntSize?>,
-): Boolean = images.any { img ->
-    val size = measured[img.url] ?: return@any false
+): Boolean = images.any { promoted ->
+    val size = measured[promoted.image.url] ?: return@any false
     size.width > INLINE_IMAGE_MAX_WIDTH_SP || size.height > INLINE_IMAGE_MAX_HEIGHT_SP
 }
 
@@ -1001,8 +1028,31 @@ internal fun imageInlineContent(image: PostInline.InlineImage, box: InlineMediaB
         // The image fills the placeholder via fillMaxSize() (ContentScale.Fit) so the rendered size
         // tracks the sp-based placeholder under any fontScale; the no-upscale rule lives in the BOX
         // sizing (imageDisplayBox), not the content scale.
+        //
+        // #257 — decode at a STABLE size (the inline display cap in px, bounded) instead of letting
+        // Coil resolve the size from the placeholder constraints. The box grows from the cold-fallback
+        // square to the measured size when the measurement lands; with constraint-driven sizing Coil
+        // re-decodes at the new size and, meanwhile, paints the previous tiny bitmap upscaled →
+        // pixelated. A fixed decode size keeps ONE sharp bitmap that Fit scales into whatever box (Coil
+        // never upscales the decode past the source, so a small image still decodes at native). The
+        // request is remembered so a measurement landing doesn't rebuild it. Smileys keep their own
+        // (much smaller) path — this cap is photo-sized.
+        val density = LocalDensity.current
+        val context = LocalPlatformContext.current
+        val widthPx = with(density) { INLINE_IMAGE_MAX_WIDTH_SP.sp.roundToPx() }
+            .coerceAtMost(INLINE_IMAGE_DECODE_CAP_PX)
+        val heightPx = with(density) { INLINE_IMAGE_MAX_HEIGHT_SP.sp.roundToPx() }
+            .coerceAtMost(INLINE_IMAGE_DECODE_CAP_PX)
+        val request = remember(image.url, widthPx, heightPx, context) {
+            ImageRequest.Builder(context)
+                .data(image.url)
+                .size(widthPx, heightPx)
+                .scale(Scale.FIT)
+                .precision(Precision.INEXACT)
+                .build()
+        }
         AsyncImage(
-            model = image.url,
+            model = request,
             contentDescription = image.description,
             contentScale = PostMediaDisplayPolicy.inlineImageContentScale,
             modifier = Modifier.fillMaxSize(),

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -493,7 +493,9 @@ private fun BlockImage(url: String, description: String?, linkUrl: String? = nul
         .background(MaterialTheme.colorScheme.surfaceContainerHighest)
         .then(
             if (linkUrl != null) {
-                Modifier.clickable(role = Role.Button, onClickLabel = openLabel) {
+                // Role.Image (not Button): the element IS an image that opens its full version on tap;
+                // the localized onClickLabel carries the action for TalkBack ("Image, double-tap to …").
+                Modifier.clickable(role = Role.Image, onClickLabel = openLabel) {
                     runCatching { uriHandler.openUri(linkUrl) }
                 }
             } else {

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="post_image_loading">Chargement…</string>
     <string name="post_image_error">Image indisponible</string>
     <string name="post_image_error_with_alt">Image indisponible — %1$s</string>
+    <string name="post_image_open_link">Ouvrir l\'image</string>
     <string name="bbcode_action_bold">Gras</string>
     <string name="bbcode_action_italic">Italique</string>
     <string name="bbcode_action_underline">Souligné</string>

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/InlineImagePromotionTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/InlineImagePromotionTest.kt
@@ -10,18 +10,22 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * #224 (option B) — pure coverage for the image-only-paragraph promotion decision: which paragraphs are
- * "just image(s)" ([imageOnlyParagraphImages]) and when they grow past the inline caps enough to deserve
- * the full-width centred block treatment ([shouldPromoteImagesToBlocks]). Keeping it pure means the
- * heuristic is pinned without driving Compose.
+ * #224 (option B) / #257 — pure coverage for the image-only-paragraph promotion decision: which
+ * paragraphs are "just image(s)" ([imageOnlyParagraphImages], with the enclosing `[url=…]` link per
+ * image) and when they grow past the inline caps enough to deserve the full-width centred block
+ * treatment ([shouldPromoteImagesToBlocks]). Keeping it pure means the heuristic is pinned without
+ * driving Compose.
  */
 class InlineImagePromotionTest {
 
     private fun img(url: String) = PostInline.InlineImage(url = url, description = null)
+    private fun promoted(url: String, linkUrl: String? = null) = PromotedImage(img(url), linkUrl)
 
     @Test
-    fun `a lone image paragraph is image-only`() {
-        assertEquals(listOf("a"), imageOnlyParagraphImages(listOf(img("a")))?.map { it.url })
+    fun `a lone image paragraph is image-only, with no link`() {
+        val result = imageOnlyParagraphImages(listOf(img("a")))
+        assertEquals(listOf("a"), result?.map { it.image.url })
+        assertNull(result?.single()?.linkUrl)
     }
 
     @Test
@@ -29,29 +33,27 @@ class InlineImagePromotionTest {
         val result = imageOnlyParagraphImages(
             listOf(img("a"), PostInline.Text("   "), PostInline.LineBreak, img("b"), img("c")),
         )
-        assertEquals(listOf("a", "b", "c"), result?.map { it.url })
+        assertEquals(listOf("a", "b", "c"), result?.map { it.image.url })
     }
 
     @Test
-    fun `a link-wrapped image is NOT promoted (keeps its inline tap-through)`() {
-        // [url=…][img] — the block renderer has no click handling, so promoting it would drop the
-        // link. Stay inline (returns null) where the link annotation keeps the image clickable.
-        assertNull(
-            imageOnlyParagraphImages(
-                listOf(PostInline.Link(url = "u", children = listOf(img("a")))),
-            ),
+    fun `a link-wrapped image is promoted, carrying its link url (#257)`() {
+        // [url=…][img] (the "click to enlarge" pattern). Since #257 it IS promoted to a full-width
+        // block that opens the link on tap — the linkUrl is captured so the block can wire the click.
+        val result = imageOnlyParagraphImages(
+            listOf(PostInline.Link(url = "https://full/size", children = listOf(img("thumb")))),
         )
+        assertEquals(listOf("thumb"), result?.map { it.image.url })
+        assertEquals("https://full/size", result?.single()?.linkUrl)
     }
 
     @Test
-    fun `a bare image alongside a link-wrapped image is still not promoted`() {
-        // Mixed gallery where one image carries a link: don't promote the whole paragraph, or the
-        // linked one loses its tap-through. Conservative — keep the lot inline.
-        assertNull(
-            imageOnlyParagraphImages(
-                listOf(img("bare"), PostInline.Link(url = "u", children = listOf(img("linked")))),
-            ),
+    fun `a bare image alongside a link-wrapped image are both promoted, each keeping its own link`() {
+        val result = imageOnlyParagraphImages(
+            listOf(img("bare"), PostInline.Link(url = "u", children = listOf(img("linked")))),
         )
+        assertEquals(listOf("bare", "linked"), result?.map { it.image.url })
+        assertEquals(listOf(null, "u"), result?.map { it.linkUrl })
     }
 
     @Test
@@ -85,7 +87,7 @@ class InlineImagePromotionTest {
 
     @Test
     fun `promotion needs a measured image larger than the inline caps`() {
-        val images = listOf(img("a"), img("b"))
+        val images = listOf(promoted("a"), promoted("b"))
         // cold (unknown size) → stay inline until measured
         assertFalse(shouldPromoteImagesToBlocks(images, emptyMap()))
         // emoji + small reaction → stay inline
@@ -106,6 +108,6 @@ class InlineImagePromotionTest {
 
     @Test
     fun `promotion also triggers on the height cap`() {
-        assertTrue(shouldPromoteImagesToBlocks(listOf(img("tall")), mapOf("tall" to IntSize(100, 600))))
+        assertTrue(shouldPromoteImagesToBlocks(listOf(promoted("tall")), mapOf("tall" to IntSize(100, 600))))
     }
 }

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeMeasurerSpikeTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeMeasurerSpikeTest.kt
@@ -16,7 +16,9 @@ import org.robolectric.RobolectricTestRunner
  * #175 SPIKE — compiler + runtime gate for the Coil intrinsic-measurement path.
  *
  * Confirms (the design study flagged these as NOT provable by docs, only by the compiler):
- *  - `coil3.Image.width/height` is the dimension API after `execute(... Size.ORIGINAL ...)` ;
+ *  - `coil3.Image.width/height` is the dimension API after `execute(...)` (#257: the request is now a
+ *    bounded `size(1024)` FIT probe, not `Size.ORIGINAL`; the `ColorImage` fixtures are ≤ 70px so the
+ *    bound is a no-op and these assertions are unchanged) ;
  *  - `coil3.test.ColorImage(width, height)` exists and propagates its dimensions to `image.width/height`
  *    (so Robolectric tests can pin sizes deterministically, no network/decode) ;
  *  - `FakeImageLoaderEngine` + `runTest` drive the suspend measurement.


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Corrige #257 (régression #224 sur le rendu des images). Investigation + avis Codex gpt-5.5 xhigh (option 3 validée), 3 causes :

## 1. Images-liens rendues petites (incohérence)
`#224` B laissait une image dans `[url=][img]` **inline** (capée ≤240sp) pour préserver le clic, alors qu'une image nue passait en bloc pleine largeur → incohérence sans-lien (bien) / avec-lien (bof). Désormais `imageOnlyParagraphImages` renvoie `PromotedImage(image, linkUrl)` et une image **seule** dans un lien **est promue** ; `BlockImage` prend un `linkUrl` optionnel → cliquable (`Role.Button` + `onClickLabel`, `runCatching { uriHandler.openUri }`). Pleine largeur **ET** « clic pour agrandir » préservé. (Un lien image **+** texte reste de la prose → inline.)

## 2. Pixelisation des images inline
`imageInlineContent` rendait `AsyncImage` **sans `.size()`** → Coil re-décodait quand la box passait du cold-fallback à la taille mesurée, en peignant entre-temps le bitmap 16px upscalé (pixelisé). Désormais décode à **taille stable** (cap inline en px, plafonné à `INLINE_IMAGE_DECODE_CAP_PX=1024`) avec `scale(FIT)`+`precision(INEXACT)`, `remember(url, w, h)`. Un seul bitmap net, pas de re-décode. Chemin smiley inchangé.

## 3. Lenteur (décode pleine résolution juste pour mesurer)
`measureIntrinsicMediaSize` décodait `Size.ORIGINAL` (full-res) uniquement pour lire les dimensions, par image, en plus du décode de rendu. Désormais probe **borné 1024** (FIT) : ratio + « dépasse les caps 240/200 » préservés, source ≤1024 décodée native. Plus de décode full-res pour mesurer.

## Validation
`detektAll` + `:core:ui:lintDebug` + `:core:ui:testDebugUnitTest` + `:app:assembleDebug` → BUILD SUCCESSFUL. `InlineImagePromotionTest` mis à jour (`PromotedImage` + capture `linkUrl`).

## Suivi (avis Codex, non bloquant)
Nice-to-have : crossfade, refactor global vers un display-model `ImagePlacement.Inline/Block/Gallery`.

Closes #257
