### PR TITLE
fix(ci): trigger F-Droid dans un job dédié (gh natif) — #219 (umbrella #233)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,12 @@ jobs:
     container:
       image: ghcr.io/cirruslabs/android-sdk:36@sha256:f9b3ea9ed2b5fc9522adae82c7b4622ab7aa54207ef532c8e615a347dca08f31
     timeout-minutes: 30
+    # Exposed for the `notify-fdroid` job (which runs outside this Android-SDK container).
+    outputs:
+      version_code: ${{ steps.meta.outputs.version_code }}
+      short_sha: ${{ steps.meta.outputs.short_sha }}
+      release_tag: ${{ steps.meta.outputs.release_tag }}
+      release_kind: ${{ steps.meta.outputs.release_kind }}
     env:
       # Resolved Play track for the upload action below; defaults to alpha (closed testing).
       # The historical comment here mentioned `gradle-play-publisher` which was retired in
@@ -301,21 +307,26 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # ──────────────────────────────────────────────────────────────────────
-      # Cross-repo trigger : signal the redface2-fdroid repo to fetch the
-      # newly-uploaded APK and rebuild its F-Droid index. Uses a GitHub App
-      # (redface2-fdroid-publisher) installed only on redface2-fdroid ; the App
-      # generates a 1-hour token via JWT exchange — zero PAT, zero recurring
-      # maintenance. If the dispatch fails (App revoked, F-Droid repo down,
-      # GitHub API hiccup), we DON'T fail the whole release job : the APK is
-      # already on Play + GitHub Releases, the F-Droid mirror catching up
-      # later is a downstream concern. The publisher workflow has a manual
-      # workflow_dispatch fallback to recover.
-      # ──────────────────────────────────────────────────────────────────────
+  # ──────────────────────────────────────────────────────────────────────
+  # Cross-repo trigger : signal redface2-fdroid to fetch the newly-published
+  # APK and rebuild its index. Runs on a PLAIN ubuntu runner (NOT the Android
+  # SDK container) — that container has no `gh` CLI, so the previous in-job
+  # `gh api` call failed with exit 127 on every release and was swallowed by
+  # `continue-on-error` (#219: F-Droid was never actually notified for v65 /
+  # v70 / v71). A dedicated job uses the runner's native `gh`. It does NOT undo
+  # the release (the build job already shipped Play + the GitHub Release); if the
+  # dispatch fails it now surfaces as a visible red run instead of a hidden one,
+  # and redface2-fdroid keeps its manual workflow_dispatch fallback.
+  # ──────────────────────────────────────────────────────────────────────
+  notify-fdroid:
+    name: Notify F-Droid publisher
+    needs: build
+    if: ${{ needs.build.outputs.release_kind == 'tag' || inputs.attach_release }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
       - name: Generate F-Droid publisher App token
         id: fdroid_app_token
-        if: ${{ steps.meta.outputs.release_kind == 'tag' || inputs.attach_release }}
-        continue-on-error: true
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.RF2_FDROID_APP_ID }}
@@ -324,20 +335,18 @@ jobs:
           repositories: redface2-fdroid
 
       - name: Trigger F-Droid publish
-        if: ${{ steps.fdroid_app_token.outcome == 'success' }}
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.fdroid_app_token.outputs.token }}
+          TAG: ${{ needs.build.outputs.release_tag }}
+          VERSION_CODE: ${{ needs.build.outputs.version_code }}
+          SHORT_SHA: ${{ needs.build.outputs.short_sha }}
         run: |
-          # The APK filename follows the `stamp_apk_name` convention
-          # established by `app/build.gradle.kts` (cf. ADR-0XX release
-          # filenames) : `redface2-v<vc>-<short_sha>.apk`. We rebuild it
-          # from the `meta` step outputs rather than scanning release
-          # assets, so we don't add another API roundtrip.
-          APK_FILENAME="redface2-v${{ steps.meta.outputs.version_code }}-${{ steps.meta.outputs.short_sha }}.apk"
-          echo "Triggering F-Droid publish for tag ${{ steps.meta.outputs.release_tag }} (apk=$APK_FILENAME)"
+          # APK filename follows app/build.gradle.kts' stamp convention:
+          # redface2-v<vc>-<short_sha>.apk — rebuilt from the build job outputs.
+          APK_FILENAME="redface2-v${VERSION_CODE}-${SHORT_SHA}.apk"
+          echo "Triggering F-Droid publish for tag ${TAG} (apk=${APK_FILENAME})"
           gh api repos/ForumHFR/redface2-fdroid/dispatches \
             -f event_type=rf2_release \
-            -f "client_payload[tag]=${{ steps.meta.outputs.release_tag }}" \
-            -f "client_payload[apk_filename]=$APK_FILENAME" \
-            -f "client_payload[version_code]=${{ steps.meta.outputs.version_code }}"
+            -f "client_payload[tag]=${TAG}" \
+            -f "client_payload[apk_filename]=${APK_FILENAME}" \
+            -f "client_payload[version_code]=${VERSION_CODE}"


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

## Bug confirmé (logs CD v71)

Le step `Trigger F-Droid publish` tournait **dans** le container `cirruslabs/android-sdk:36`, qui n'a **pas** de CLI `gh` → `gh: not found`, exit 127. Le `continue-on-error: true` le **masquait en « success »** : F-Droid n'a donc **jamais** été notifié pour v65 / v70 / v71 (le dispatch n'est jamais parti). C'est l'item « **#219 — BLOQUANT, à faire en 1er** » de la checklist de l'umbrella #233.

```
/__w/_temp/….sh: 8: gh: not found
Triggering F-Droid publish for tag app-v71 (apk=redface2-v71-e0cd4e4.apk)
##[error]Process completed with exit code 127.
```

## Fix

Extraction du trigger dans un **job dédié `notify-fdroid`** :
- `runs-on: ubuntu-24.04` **sans container** → `gh` préinstallé (natif runner).
- `needs: build`, même condition (`release_kind == 'tag' || attach_release`), lit `version_code`/`short_sha`/`release_tag` via de **nouveaux outputs** du job `build`.
- **Plus de `continue-on-error`** : un vrai échec de notif F-Droid devient **visible** (run rouge) au lieu d'être masqué — les artefacts (Play + GitHub Release) sont déjà publiés par le job `build`, donc un échec de notif ne défait pas la release.

YAML validé (parse + structure des jobs). `release.yml` ne tourne pas sur PR → **validation au prochain release/dispatch**.

Cible la checklist de #233 (item #219). Première brique de la refonte CD (le reste — `on: release [published]` + route `prerelease→beta` + flavor `dev` — suit séparément).
