### PR TITLE
chore(ui): libellés visibles « alpha » → « bêta » (open testing)

### DIFF
--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -39,8 +39,8 @@
     <string name="account_menu_status_authenticated">Connecté en tant que %1$s</string>
     <string name="account_menu_login">Se connecter</string>
     <string name="account_menu_logout">Se déconnecter</string>
-    <string name="account_menu_settings">Paramètres alpha</string>
-    <string name="account_menu_diagnostics">Diagnostics alpha</string>
+    <string name="account_menu_settings">Paramètres bêta</string>
+    <string name="account_menu_diagnostics">Diagnostics bêta</string>
     <string name="account_menu_report_content">Signaler un contenu</string>
     <string name="account_menu_version_footer">Redface 2 — v%1$s (build %2$d)</string>
     <string name="account_menu_no_email_client">Aucune application e-mail trouvée pour envoyer le signalement.</string>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -17,7 +17,7 @@
          parser / AST evolution makes the locally persisted PostContent stale ; forces a
          re-fetch + re-parse on the next topic open. Does NOT log the user out, drop the
          flag cache, or touch the proxy preferences. -->
-    <string name="settings_maintenance_title">Maintenance alpha</string>
+    <string name="settings_maintenance_title">Maintenance bêta</string>
     <string name="settings_clear_topic_cache_intro">Supprime les pages de topics stockées localement. Les prochains topics ouverts seront retéléchargés depuis HFR. Les drapeaux, l\'authentification et les préférences proxy ne sont pas affectés.</string>
     <string name="settings_clear_topic_cache_button">Vider le cache des topics</string>
     <string name="settings_clear_topic_cache_confirm_title">Vider le cache des topics ?</string>
@@ -33,6 +33,6 @@
          change is observed on the next topic open without manually clearing the cache. Strictly
          an alpha dogfood tool — flags, auth, proxy preferences are untouched. -->
     <string name="settings_ignore_topic_cache_title">Ignorer le cache topic</string>
-    <string name="settings_ignore_topic_cache_description">Alpha : force le retéléchargement et le reparse des pages de topic. Utile après un changement de parser/rendu. Désactive le prefetch topic pour éviter de remplir Room inutilement.</string>
+    <string name="settings_ignore_topic_cache_description">Bêta : force le retéléchargement et le reparse des pages de topic. Utile après un changement de parser/rendu. Désactive le prefetch topic pour éviter de remplir Room inutilement.</string>
     <string name="settings_ignore_topic_cache_persist_failed">Impossible de mémoriser le réglage « Ignorer le cache topic ». Réessayez.</string>
 </resources>


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

L'app est passée sur le canal **open testing (beta)** → les libellés visibles « alpha » sont obsolètes. Rename des 4 strings user-visibles (menu compte « Paramètres/Diagnostics bêta », « Maintenance bêta », description « Bêta : … »). **Strings UI uniquement**, pas de bump versionName (le 0.4.0 viendra avec la refonte CD). Les commentaires de code internes (« alpha phase ») sont laissés tels quels.

detektAll + lintDebug (core:ui, settings) + assembleDebug → BUILD SUCCESSFUL.