### PR TITLE
feat(ci): 3 product flavors channel (prod/beta/dev), CD pinné prod (#233)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,9 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
 
       - name: Verify
-        run: ./gradlew detektAll lintDebug test testDebugUnitTest :app:assembleDebug
+        # `:app` now has product flavors (#233 channels) so its variant tasks are flavored:
+        # the unqualified `lintDebug` / `:app:assembleDebug` no longer resolve for `:app`. Use the
+        # default `prod` flavor for the `:app` lint + APK; `lintDebug`/`test`/`testDebugUnitTest`
+        # still cover the (flavour-less) core/feature/jvm modules, and the unqualified `test`
+        # covers `:app`'s unit tests across variants (incl. the Konsist architecture test).
+        run: ./gradlew detektAll lintDebug test testDebugUnitTest :app:lintProdDebug :app:assembleProdDebug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,15 +203,18 @@ jobs:
           UPLOAD_KEYSTORE_PASSWORD: ${{ secrets.UPLOAD_KEYSTORE_PASSWORD }}
           UPLOAD_KEY_ALIAS: ${{ secrets.UPLOAD_KEY_ALIAS }}
           UPLOAD_KEY_PASSWORD: ${{ secrets.UPLOAD_KEY_PASSWORD }}
-        run: ./gradlew :app:bundleRelease :app:assembleRelease --no-daemon --stacktrace
+        # Pinned to the `prod` flavor (#233 channels): prodRelease keeps the canonical
+        # applicationId `fr.forumhfr.redface2` + label "Redface 2", identical to the pre-flavor
+        # build. beta/dev routing arrives with the release-event trigger rework (PR-B).
+        run: ./gradlew :app:bundleProdRelease :app:assembleProdRelease --no-daemon --stacktrace
 
       - name: Verify AAB signature
         shell: bash
         run: |
           set -euo pipefail
-          aab=$(ls app/build/outputs/bundle/release/*.aab | head -1)
+          aab=$(ls app/build/outputs/bundle/prodRelease/*.aab | head -1)
           if [[ -z "${aab}" ]]; then
-            echo "::error::No AAB produced under app/build/outputs/bundle/release/"
+            echo "::error::No AAB produced under app/build/outputs/bundle/prodRelease/"
             exit 1
           fi
           echo "Built AAB: ${aab}"
@@ -227,8 +230,8 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release-artefacts
-          aab=$(ls app/build/outputs/bundle/release/*.aab | head -1)
-          apk=$(ls app/build/outputs/apk/release/*.apk | head -1)
+          aab=$(ls app/build/outputs/bundle/prodRelease/*.aab | head -1)
+          apk=$(ls app/build/outputs/apk/prodRelease/*.apk | head -1)
           aab_dest="release-artefacts/redface2-v${{ steps.meta.outputs.version_code }}-${{ steps.meta.outputs.short_sha }}.aab"
           apk_dest="release-artefacts/redface2-v${{ steps.meta.outputs.version_code }}-${{ steps.meta.outputs.short_sha }}.apk"
           cp "${aab}" "${aab_dest}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,7 +231,7 @@ jobs:
           set -euo pipefail
           mkdir -p release-artefacts
           aab=$(ls app/build/outputs/bundle/prodRelease/*.aab | head -1)
-          apk=$(ls app/build/outputs/apk/prodRelease/*.apk | head -1)
+          apk=$(ls app/build/outputs/apk/prod/release/*.apk | head -1)
           aab_dest="release-artefacts/redface2-v${{ steps.meta.outputs.version_code }}-${{ steps.meta.outputs.short_sha }}.aab"
           apk_dest="release-artefacts/redface2-v${{ steps.meta.outputs.version_code }}-${{ steps.meta.outputs.short_sha }}.apk"
           cp "${aab}" "${aab_dest}"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -106,6 +106,33 @@ android {
         }
     }
 
+    // #233 — coexisting channels (prod / beta / dev) as a `channel` product-flavor dimension.
+    // A distinct applicationId per channel is what lets a user keep prod + beta + dev installed
+    // side by side (Play *tracks* of ONE app share an applicationId → a single install that swaps on
+    // track change). Code is 100% shared; only the applicationId suffix + launcher label differ.
+    // Release signing + Play-track / F-Droid routing live in the CD (release.yml). `prod` is the
+    // canonical app: base applicationId, default flavor, label @string/app_name ("Redface 2").
+    // NB: the `debug` buildType still forces label "Redface 2 ADB" + `.debug` suffix (it overrides
+    // the flavor placeholder), so the local adb dogfood build remains `prodDebug` == today's debug
+    // build (fr.forumhfr.redface2.debug). Only *release* builds surface the per-channel label.
+    flavorDimensions += "channel"
+    productFlavors {
+        create("prod") {
+            dimension = "channel"
+            isDefault = true
+        }
+        create("beta") {
+            dimension = "channel"
+            applicationIdSuffix = ".beta"
+            manifestPlaceholders["appLabel"] = "Redface 2 β"
+        }
+        create("dev") {
+            dimension = "channel"
+            applicationIdSuffix = ".dev"
+            manifestPlaceholders["appLabel"] = "Redface 2 dev"
+        }
+    }
+
     buildFeatures {
         // Expose BuildConfig.VERSION_NAME / VERSION_CODE to Kotlin code so the
         // placeholder screens can show them while :feature:settings (the future

--- a/scripts/docker-dev.sh
+++ b/scripts/docker-dev.sh
@@ -42,7 +42,9 @@ inject_project_cache_dir() {
 }
 
 if [ "$#" -eq 0 ]; then
-  set -- ./gradlew :app:assembleDebug
+  # `:app` has product flavors (#233 channels); assembleDebug would build all three. Default to the
+  # canonical `prod` channel debug (== the historical local dogfood build, applicationId .debug).
+  set -- ./gradlew :app:assembleProdDebug
 fi
 
 case "$1" in


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

**PR-A de la refonte CD post-alpha (umbrella #233).** Socle = les 3 channels en product flavors.

## Flavors (dimension `channel`)
| Flavor | applicationId | label launcher |
|---|---|---|
| `prod` (défaut) | `fr.forumhfr.redface2` | Redface 2 |
| `beta` | `fr.forumhfr.redface2.beta` | Redface 2 β |
| `dev` | `fr.forumhfr.redface2.dev` | Redface 2 dev |

applicationId distinct ⟹ coexistence sur l'appareil. Code 100% partagé (seuls suffixe + label diffèrent). Le buildType `debug` force toujours `.debug` + « Redface 2 ADB » → **`prodDebug` == le build dogfood actuel** (`fr.forumhfr.redface2.debug`, vérifié).

## Ripple (les flavors ne touchent que `:app` ; core/feature sont sans flavor)
- `release.yml` **pinné sur `prodRelease`** → même applicationId/label qu'avant les flavors, **zéro changement de comportement** (le routing beta/dev arrive avec le rework du trigger, PR-B).
- `ci.yml` : `:app` utilise les tâches flavor-prod (`:app:lintProdDebug` / `:app:assembleProdDebug`).
- `docker-dev.sh` : défaut → `:app:assembleProdDebug`.

## Validation
`detektAll` + `:app:lintProdDebug` + `:app:testProdDebugUnitTest` (Konsist) + `:app:assembleProdDebug` → BUILD SUCCESSFUL ; les 3 APK debug (prod/beta/dev) buildent, applicationId vérifiés.

## Suite
- **PR-B** : trigger **Option B** (avis Codex gpt-5.5 xhigh) — `on: release: [published]` + `prerelease→beta` / stable→prod / dispatch→dev, job `resolve-target`, `tracks`, idempotence, **Environment `production` (gate d'approbation manuelle)**. Nécessite les **listings Play `.beta` + `.dev`** (à créer côté @XaaT).
- **PR-C** : F-Droid beta.
- Plus tard : bump 0.4.0.
