### PR TITLE
fix(ci): CD = 1 app Play + tracks (pas 1 app/canal) + libellés neutres (#233)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,16 @@
 name: Release
 
-# Channel-routed CD (#233). The TRIGGER decides the channel (Codex gpt-5.5 xhigh recommended this
-# release-event model over channel-encoding tags — one source of truth, the GitHub Release flag):
+# Track-routed CD (#233). ONE Play app (fr.forumhfr.redface2) distributed via TRACKS — the standard
+# Play model (one app, one applicationId, several tracks), not one Play app per channel. The TRIGGER
+# decides the Play TRACK (Codex gpt-5.5 xhigh recommended this release-event model over channel tags
+# — one source of truth, the GitHub Release flag):
 #
-#   GitHub Release published, prerelease = true   → beta  → fr.forumhfr.redface2.beta  → Play open testing + F-Droid beta
-#   GitHub Release published, prerelease = false  → prod  → fr.forumhfr.redface2       → Play production   + F-Droid release  (gated by the `production` Environment)
-#   workflow_dispatch                             → dev   → fr.forumhfr.redface2.dev   → Play internal     (no F-Droid)
+#   GitHub Release published, prerelease = true   → Play track "beta" (open testing) + F-Droid beta
+#   GitHub Release published, prerelease = false  → Play track "production"           + F-Droid release  (gated by the `production` Environment)
+#   workflow_dispatch                             → Play track "internal"             (no F-Droid)
+#
+# All three build + upload the SAME applicationId (fr.forumhfr.redface2). The .beta/.dev flavor
+# suffixes in app/build.gradle.kts are LOCAL-only (side-by-side dogfood sideload) and never reach Play.
 #
 # A `release: published` fires for BOTH stable and pre-release publications (NOT for drafts), so the
 # deploy only starts when you actually publish. To ship a beta, publish a GitHub Release with the
@@ -84,13 +89,16 @@ jobs:
             echo "::error::Unexpected release tag '${TAG_NAME}' — expected app-v[A-Za-z0-9._-]+."
             exit 1
           fi
+          # Single Play app (fr.forumhfr.redface2) distributed via TRACKS, not one app per channel.
+          # The trigger picks the Play TRACK (+ status / F-Droid channel / approval gate); the build
+          # is ALWAYS the prod applicationId. Distinct applicationId suffixes (.beta/.dev) only exist
+          # for LOCAL side-by-side dogfood installs (cf. app/build.gradle.kts) and never go to Play —
+          # Play tracks of one app share an applicationId, and only one install exists per device.
           if [[ "$EVENT_NAME" == "release" ]]; then
             if [[ "$PRERELEASE" == "true" ]]; then
-              channel=beta; flavor=Beta; dir=beta
-              pkg=fr.forumhfr.redface2.beta; track=beta;       status=completed; fdroid=beta
+              channel=beta; track=beta;       status=completed; fdroid=beta
             else
-              channel=prod; flavor=Prod; dir=prod
-              pkg=fr.forumhfr.redface2;      track=production; status=draft;     fdroid=release
+              channel=prod; track=production; status=draft;     fdroid=release
             fi
             # Fully-qualified tag ref (Codex P2): actions/checkout resolves a bare `app-v72` as a
             # BRANCH first, so a branch sharing the tag name would be built instead of the Release tag.
@@ -98,12 +106,15 @@ jobs:
             release_tag="$TAG_NAME"
             is_release_event=true
           else
-            channel=dev; flavor=Dev; dir=dev
-            pkg=fr.forumhfr.redface2.dev; track=internal; status=completed; fdroid=none
+            channel=dev; track=internal; status=completed; fdroid=none
             build_ref="$DISPATCH_REF"
             release_tag=""
             is_release_event=false
           fi
+          # Constant across every channel: build + upload the prod applicationId. The `beta` Play
+          # track = open testing, `production` = prod, `internal` = internal testing — all of app
+          # fr.forumhfr.redface2.
+          flavor=Prod; dir=prod; pkg=fr.forumhfr.redface2
           {
             echo "channel=$channel"
             echo "gradle_flavor=$flavor"
@@ -233,7 +244,7 @@ jobs:
           UPLOAD_KEYSTORE_PASSWORD: ${{ secrets.UPLOAD_KEYSTORE_PASSWORD }}
           UPLOAD_KEY_ALIAS: ${{ secrets.UPLOAD_KEY_ALIAS }}
           UPLOAD_KEY_PASSWORD: ${{ secrets.UPLOAD_KEY_PASSWORD }}
-        # Build the resolved channel's flavor only (e.g. :app:bundleBetaRelease).
+        # GRADLE_FLAVOR is always Prod (single Play app, track-routed): builds :app:bundleProdRelease.
         run: ./gradlew ":app:bundle${GRADLE_FLAVOR}Release" ":app:assemble${GRADLE_FLAVOR}Release" --no-daemon --stacktrace
 
       - name: Verify AAB signature

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -25,15 +25,16 @@ Aucun changement applicatif non distribué.
 ## v72 — `0.4.0` — 2026-06-02
 
 **Statut** : `open`
-**Commit** : tag `app-v72` (Release GitHub cochée *pre-release* → canal beta de la CD)
-**Fichier** : AAB `bundleBetaRelease` (`fr.forumhfr.redface2.beta`) uploadé sur le canal Play **open testing** par la CD + tag pour F-Droid beta
+**Commit** : tag `app-v72` (Release GitHub cochée *pre-release* → track open testing)
+**Fichier** : AAB `bundleProdRelease` (`fr.forumhfr.redface2`) uploadé sur le **track open testing** de l'app unique par la CD + tag pour F-Droid beta
 
-**Passage en bêta.** Première release distribuée par la nouvelle CD routée par release-event (#233) : une Release GitHub *pre-release* déclenche le build du flavor `beta`, l'upload Play *open testing* et la notification F-Droid. Le bump mineur `0.3.x → 0.4.0` matérialise la sortie d'alpha. Pas de nouvelle fonctionnalité utilisateur depuis v71 (le rendu `[quote]`/`[img]` de v70/v71 est inclus) — la valeur de cette version est l'ouverture du canal bêta public et l'industrialisation de la livraison.
+**Passage en bêta.** Première release distribuée par la nouvelle CD routée par release-event (#233) : une Release GitHub *pre-release* déclenche le build prod + l'upload sur le **track open testing** de l'app `fr.forumhfr.redface2` + la notification F-Droid. Le bump mineur `0.3.x → 0.4.0` matérialise la sortie d'alpha. Pas de nouvelle fonctionnalité utilisateur depuis v71 (le rendu `[quote]`/`[img]` de v70/v71 est inclus) — la valeur de cette version est l'ouverture du canal bêta public et l'industrialisation de la livraison.
 
 ### Changed
-- **Canal de distribution** : alpha (closed testing de l'app unique) → **bêta (open testing)**, package dédié `fr.forumhfr.redface2.beta` coexistant avec une future prod et un canal dev (`.dev`). Les libellés visibles « alpha » de l'app passent à « bêta ».
-- **CD** : `release.yml` réécrit en routing par déclencheur — prerelease→beta (open testing), stable→prod (production, draft, après approbation manuelle via l'Environment GitHub `production`), `workflow_dispatch`→dev (internal). Durci par 5 passes de review Codex gpt-5.5 xhigh.
-- **Build** : `app/build.gradle.kts` passe à `versionCode = 72`, `versionName = "0.4.0"` ; 3 product flavors `channel` (prod/beta/dev) avec applicationId distincts.
+- **Canal de distribution** : alpha (closed testing) → **bêta (open testing)**, **tracks de la même app `fr.forumhfr.redface2`** (modèle Play standard, pas une app par canal — un seul applicationId, plusieurs tracks).
+- **Libellés in-app neutres** : « Paramètres bêta / Diagnostics bêta / Maintenance bêta » → « Paramètres / Diagnostics / Maintenance ». Le binaire est identique sur tous les tracks (promouvable open testing → production sans re-build), donc aucun marqueur de canal n'y est gravé ; l'indication « test » vient de la bannière testeur Play. (Le marqueur de phase éventuel reviendra/partira avec la 1.0.)
+- **CD** : `release.yml` route par déclencheur vers le **track Play** — prerelease→open testing (beta), stable→production (draft, après approbation via l'Environment GitHub `production`), `workflow_dispatch`→internal (dev). Tous buildent et uploadent le **package prod** ; seul le track diffère. Durci par 5 passes de review Codex gpt-5.5 xhigh.
+- **Build** : `app/build.gradle.kts` passe à `versionCode = 72`, `versionName = "0.4.0"`. Les 3 product flavors `channel` (prod/beta/dev, applicationId distincts) servent au **sideload dogfood local uniquement** — la CD n'uploade que `prod` sur Play.
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -106,12 +106,14 @@ android {
         }
     }
 
-    // #233 — coexisting channels (prod / beta / dev) as a `channel` product-flavor dimension.
-    // A distinct applicationId per channel is what lets a user keep prod + beta + dev installed
-    // side by side (Play *tracks* of ONE app share an applicationId → a single install that swaps on
-    // track change). Code is 100% shared; only the applicationId suffix + launcher label differ.
-    // Release signing + Play-track / F-Droid routing live in the CD (release.yml). `prod` is the
-    // canonical app: base applicationId, default flavor, label @string/app_name ("Redface 2").
+    // #233 — `channel` product-flavor dimension (prod / beta / dev) for LOCAL side-by-side installs.
+    // Each suffixed applicationId lets a maintainer sideload a release-signed beta/dev build next to
+    // the Play prod build for dogfooding. IMPORTANT: Play distribution does NOT use these — the CD
+    // (release.yml) uploads ONLY the `prod` applicationId (fr.forumhfr.redface2) and routes by Play
+    // *track* (open testing / production / internal), because Play tracks of one app share an
+    // applicationId and only one install exists per device. So beta/dev flavors are a local tool,
+    // never a Play package. Code is 100% shared; only the applicationId suffix + launcher label differ.
+    // `prod` is the canonical app: base applicationId, default flavor, label @string/app_name.
     // NB: the `debug` buildType still forces label "Redface 2 ADB" + `.debug` suffix (it overrides
     // the flavor placeholder), so the local adb dogfood build remains `prodDebug` == today's debug
     // build (fr.forumhfr.redface2.debug). Only *release* builds surface the per-channel label.

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -39,8 +39,8 @@
     <string name="account_menu_status_authenticated">Connecté en tant que %1$s</string>
     <string name="account_menu_login">Se connecter</string>
     <string name="account_menu_logout">Se déconnecter</string>
-    <string name="account_menu_settings">Paramètres bêta</string>
-    <string name="account_menu_diagnostics">Diagnostics bêta</string>
+    <string name="account_menu_settings">Paramètres</string>
+    <string name="account_menu_diagnostics">Diagnostics</string>
     <string name="account_menu_report_content">Signaler un contenu</string>
     <string name="account_menu_version_footer">Redface 2 — v%1$s (build %2$d)</string>
     <string name="account_menu_no_email_client">Aucune application e-mail trouvée pour envoyer le signalement.</string>

--- a/docs/guides/release.md
+++ b/docs/guides/release.md
@@ -7,11 +7,13 @@ nav_order: 5
 
 # Release et publication Play Console
 
-Comment construire un AAB signé et le publier sur le bon canal Play Console depuis GitHub Actions. **Depuis #233, le canal est déterminé par le déclencheur** (3 product flavors coexistants, applicationId distincts ; une seule source de vérité = la Release GitHub) :
+Comment construire un AAB signé et le publier sur le bon **track** Play Console depuis GitHub Actions. **Depuis #233, le track est déterminé par le déclencheur.** Modèle Play standard : **une seule app** (`fr.forumhfr.redface2`, un seul applicationId) distribuée via plusieurs **tracks** — pas une app Play par canal. Une seule source de vérité = la Release GitHub :
 
-1. **GitHub Release publiée + cochée « pre-release »** → canal **beta** (`fr.forumhfr.redface2.beta`) → Play **open testing** + F-Droid beta.
-2. **GitHub Release publiée, normale (stable)** → canal **prod** (`fr.forumhfr.redface2`) → Play **production** (statut `draft`) **après approbation manuelle** via l'Environment GitHub `production` + F-Droid release.
-3. **`workflow_dispatch` manuel** → canal **dev** (`fr.forumhfr.redface2.dev`) → Play **internal testing** (rapide, pas de F-Droid).
+1. **GitHub Release publiée + cochée « pre-release »** → track **open testing** (beta) + F-Droid beta.
+2. **GitHub Release publiée, normale (stable)** → track **production** (statut `draft`) **après approbation manuelle** via l'Environment GitHub `production` + F-Droid release.
+3. **`workflow_dispatch` manuel** → track **internal testing** (dev, rapide, pas de F-Droid).
+
+Les trois buildent et uploadent le **même package `fr.forumhfr.redface2`** ; seul le track diffère. Les suffixes `.beta`/`.dev` des product flavors (`app/build.gradle.kts`) servent **uniquement au sideload dogfood local** (installs côte-à-côte) et ne vont jamais sur Play.
 
 ⚠️ **Le tag `app-v<N>` seul ne déclenche plus la CD** : il faut **publier une GitHub Release** (sur ce tag) — pre-release pour beta, stable pour prod. Une Release dont le tag ne commence pas par `app-v` (ex. les `v0.x` specs/site) est **ignorée** (gate dans `resolve-target`).
 
@@ -20,7 +22,7 @@ Workflow source : [`.github/workflows/release.yml`](https://github.com/ForumHFR/
 ## Conventions
 
 - **Tag namespace** : les releases app utilisent `app-v<versionCode>` (ex: `app-v32`, `app-v33`). Cela évite de collisionner avec les tags `v0.x.0` du site / des specs.
-- **Canaux / tracks Play Console** : depuis #233, **le canal est dérivé du déclencheur** (cf. en-tête), pas d'input `play_track` libre. Mapping figé dans `resolve-target` : beta → `fr.forumhfr.redface2.beta` track **open testing** ; prod → `fr.forumhfr.redface2` track **production** ; dev → `fr.forumhfr.redface2.dev` track **internal**. Chaque `applicationId` est un listing Play distinct (coexistence sur l'appareil). L'alpha (closed testing de l'app unique) est **retiré** au profit de ces 3 canaux.
+- **Tracks Play Console** : depuis #233, **le track est dérivé du déclencheur** (cf. en-tête), pas d'input `play_track` libre. Mapping figé dans `resolve-target`, **tous sur l'app `fr.forumhfr.redface2`** : prerelease → track **`beta`** (open testing) ; stable → track **`production`** ; dispatch → track **`internal`**. L'ancien closed testing (alpha) est remplacé par l'open testing (bêta).
 
 ## Pré-requis (à faire une fois)
 
@@ -32,25 +34,25 @@ Le seul flux supporté en 2026 par Google pour les uploads CI est via **GCP IAM*
 2. **GCP Console → IAM → Service accounts** → créer `redface2-play-publisher`. Aucun rôle GCP n'est nécessaire — la création du compte de service suffit. Les droits applicatifs (publication AAB, gestion tracks) sont accordés exclusivement côté Play Console à l'étape 1.5. Le rôle GCP `Service Account User` n'est utile **que si** d'autres principals doivent impersonner ce SA via la CLI `gcloud` ; pour un upload CI direct depuis GitHub Actions avec la clé JSON, on peut le laisser vide.
 3. Onglet **Keys → Add Key → JSON** → télécharger le fichier `redface2-play-publisher.json`. **Ne le commit nulle part.**
 4. **Play Console → Settings → Developer API → API access** → **Link existing project** (le projet GCP de l'étape 1) → **Grant access** au service account.
-5. Permissions Play Console — à accorder sur **chacune** des 3 apps (`fr.forumhfr.redface2`, `fr.forumhfr.redface2.beta`, `fr.forumhfr.redface2.dev`), ou en accès **account-wide** (sinon les uploads beta/dev échouent en 403 / `package not found`) :
+5. Permissions Play Console — à accorder sur l'app **`fr.forumhfr.redface2`** (un seul applicationId, tous les tracks sont dessus) :
    - `View app information`
    - `Manage testing track and edit drafts`
    - `Manage testing track releases` (couvre `internal` + `beta` = open testing)
-   - `Release apps to production` (pour le canal prod)
+   - `Release apps to production` (pour le track production)
 
 Référence Google : [Use the Play Developer API with a service account](https://developers.google.com/android-publisher/getting_started).
 
-### 2. Premier upload manuel — **par package** (obligatoire)
+### 2. Premier upload manuel (obligatoire, une fois)
 
-Play Console exige **un premier AAB uploadé manuellement** par **`applicationId`** avant que l'API service account puisse pousser. Les 3 canaux étant 3 packages distincts, il faut le faire **pour chacun** (`…redface2`, `…redface2.beta`, `…redface2.dev`). Les AAB signés se génèrent localement (keystore sous `.gradle-user/signing/`, gitignored — à posséder/obtenir hors-repo) :
+Play Console exige **un premier AAB uploadé manuellement** sur l'app avant que l'API service account puisse pousser (sinon l'API répond `Package not found` — l'applicationId n'est fixé qu'au premier upload). Comme on n'a **qu'une seule app**, c'est à faire **une seule fois** (déjà fait historiquement : l'app `fr.forumhfr.redface2` a reçu les builds alpha v14…v71). Pour mémoire, l'AAB prod se génère localement (keystore sous `.gradle-user/signing/`, gitignored) :
 
 ```bash
-./scripts/docker-dev.sh ./gradlew :app:bundleProdRelease :app:bundleBetaRelease :app:bundleDevRelease \
+./scripts/docker-dev.sh ./gradlew :app:bundleProdRelease \
   --init-script .gradle-user/signing/signing.init.gradle
-# AAB : app/build/outputs/bundle/{prod,beta,dev}Release/app-{flavor}-release.aab
+# AAB : app/build/outputs/bundle/prodRelease/*.aab
 ```
 
-Puis dans **chaque** listing Play Console : **App → Test → \<track\> → Create new release** → upload manuel. Une fois ce premier upload fait par package, la CD prend le relais sur ce package.
+Puis Play Console : **App → Test → \<track\> → Create new release** → upload manuel. Ensuite la CD prend le relais sur tous les tracks.
 
 ### 3. Secrets GitHub Actions
 
@@ -78,7 +80,7 @@ git switch main && git pull --ff-only
 gh release create app-v72 --prerelease --title 'Redface 2 v72 (0.4.0-beta)' --notes '…'
 ```
 
-La CD résout **beta** : build `:app:bundleBetaRelease` (`fr.forumhfr.redface2.beta`), upload Play **open testing** (statut `completed`), attache l'AAB+APK à la Release, notifie F-Droid (beta).
+La CD résout **beta** : build `:app:bundleProdRelease` (`fr.forumhfr.redface2`), upload sur le **track `beta` (open testing)** en statut `completed`, attache l'AAB+APK à la Release, notifie F-Droid (beta).
 
 ## Flux prod — production
 
@@ -88,11 +90,13 @@ Idem mais **Release stable** (case « pre-release » décochée) :
 gh release create app-v73 --title 'Redface 2 v73 (1.0.0)' --notes '…'
 ```
 
-La CD résout **prod** et **attend l'approbation** dans l'Environment GitHub `production` (required reviewer) avant tout build/upload. Upload Play **production** en **statut `draft`** (double garde-fou : approbation GitHub + activation manuelle Play). Notifie F-Droid (release).
+La CD résout **prod** et **attend l'approbation** dans l'Environment GitHub `production` (required reviewer) avant tout build/upload. Build `:app:bundleProdRelease`, upload sur le **track `production`** en **statut `draft`** (double garde-fou : approbation GitHub + activation manuelle Play). Notifie F-Droid (release).
 
 ## Flux dev — internal testing (rapide)
 
-**GitHub → Actions → Release → Run workflow** (ou `gh workflow run release.yml -f ref=<branche>`). Pas de GitHub Release, pas de F-Droid. La CD résout **dev** : build `:app:bundleDevRelease` (`fr.forumhfr.redface2.dev`), upload Play **internal** (`completed`). Seul input : `ref` (défaut = ref courant). Artefacts du run téléchargeables 30 j.
+**GitHub → Actions → Release → Run workflow** (ou `gh workflow run release.yml -f ref=<branche>`). Pas de GitHub Release, pas de F-Droid. La CD résout **dev** : build `:app:bundleProdRelease` (`fr.forumhfr.redface2`), upload sur le **track `internal`** en statut `completed`. Seul input : `ref` (défaut = ref courant). Artefacts du run téléchargeables 30 j.
+
+⚠️ **Caveat versionCode (app unique)** : le track internal partage le namespace de versionCode de l'app `fr.forumhfr.redface2`. Un dispatch dev **consomme** le versionCode présent dans `app/build.gradle.kts` au ref buildé. Si tu dispatches dev avec un versionCode que tu publieras ensuite en Release (beta/prod), l'upload de la Release sera **rejeté** (`versionCode already used`). Discipline : soit tu dispatches dev sur un versionCode déjà bumpé que tu **promouvras** ensuite via Play Console (internal → open → production) au lieu de re-publier une Release, soit tu re-bumpes avant la Release. (Une numérotation dev dédiée — ex. offset run_number — est **incompatible** avec une app unique car Play exige des versionCode croissants : un code dev élevé bloquerait les Releases suivantes.) Le dogfood quotidien passe de toute façon par le sideload `.debug` (adb), pas par ce track.
 
 ## Bump de version : convention
 
@@ -104,13 +108,13 @@ Le `versionCode` est strictement croissant. Play Console rejette tout AAB dont l
 | Release intermédiaire dans la même phase | bump du suffixe (ex: `0.1.0-phase1.1` → `0.1.0-phase1.2`) |
 | Build dogfood non distribué | bumper malgré tout, marquer comme `burnt` dans `app/CHANGELOG.md` si jamais distribué |
 
-## Promotion entre canaux
+## Promotion entre tracks
 
-⚠️ **beta → prod n'est PAS une promotion Play.** beta est le package `…redface2.beta` et prod `…redface2` : Play Console ne promeut **qu'entre les tracks d'un MÊME package**, pas entre packages distincts. Donc :
+Comme tout est l'app unique `fr.forumhfr.redface2`, **la promotion native Play fonctionne** entre ses tracks (internal → open testing → production) — c'est l'intérêt principal du modèle 1-app. Deux façons d'amener un binaire en prod :
 
-- **beta → prod** = publier une **Release stable** (case pre-release décochée) sur un **nouveau tag `app-v<N>`** avec un `versionCode` neuf → la CD build/upload le package prod. C'est le seul chemin beta→prod.
-- **Promote release (même package)** reste valable *à l'intérieur* d'un package : ex. au sein de prod, promouvoir d'un track de test interne vers `production`, ou faire un rollout progressif. Via Play Console : Test → `<track>` → release → **Promote release** (ne traverse jamais une frontière de package).
-- Le `workflow_dispatch` ne sert qu'au canal **dev** (son seul input est `ref`) — pas un outil de promotion.
+- **Promotion Play (recommandé pour beta → prod)** : Play Console → Test → `<track source>` (ex. open testing) → la release concernée → **Promote release** → choisir `production`. Promeut **le même binaire** (même versionCode) sans re-build ni nouvelle Release GitHub. Idéal après validation en bêta.
+- **Nouvelle Release stable** : publier une Release GitHub **stable** (case pre-release décochée) sur un nouveau tag `app-v<N>` avec un versionCode neuf → la CD build/upload sur `production` (après la gate d'approbation). À utiliser quand le binaire prod doit différer du binaire bêta.
+- Le `workflow_dispatch` ne sert qu'au track **internal** (dev) — pas un outil de promotion.
 
 ## Pourquoi `r0adkll/upload-google-play` plutôt que `gradle-play-publisher`
 

--- a/docs/guides/release.md
+++ b/docs/guides/release.md
@@ -110,10 +110,10 @@ Le `versionCode` est strictement croissant. Play Console rejette tout AAB dont l
 
 ## Promotion entre tracks
 
-Comme tout est l'app unique `fr.forumhfr.redface2`, **la promotion native Play fonctionne** entre ses tracks (internal → open testing → production) — c'est l'intérêt principal du modèle 1-app. Deux façons d'amener un binaire en prod :
+Comme tout est l'app unique `fr.forumhfr.redface2`, **la promotion native Play fonctionne** entre ses tracks (internal → open testing → production). Mais attention à la **cohérence multi-canaux** (F-Droid + Release GitHub) :
 
-- **Promotion Play (recommandé pour beta → prod)** : Play Console → Test → `<track source>` (ex. open testing) → la release concernée → **Promote release** → choisir `production`. Promeut **le même binaire** (même versionCode) sans re-build ni nouvelle Release GitHub. Idéal après validation en bêta.
-- **Nouvelle Release stable** : publier une Release GitHub **stable** (case pre-release décochée) sur un nouveau tag `app-v<N>` avec un versionCode neuf → la CD build/upload sur `production` (après la gate d'approbation). À utiliser quand le binaire prod doit différer du binaire bêta.
+- **Voie recommandée beta → prod = publier une Release GitHub *stable*** (case pre-release décochée) sur un nouveau tag `app-v<N>`. Elle déclenche **toute** l'automatisation : gate d'approbation `production`, upload Play **production**, **notification F-Droid (release)**, et la Release GitHub passe en stable. C'est le seul chemin qui garde Play, F-Droid et les artefacts GitHub **alignés**. (Le binaire peut être identique à la bêta — bumper le versionCode et republier ; le rendu utilisateur ne change pas.)
+- **Promote release dans Play Console** (open testing → production) reste possible et pratique *côté Play uniquement*, mais ⚠️ **bypasse l'automatisation** : pas de passage par la gate GitHub, **F-Droid n'est pas notifié**, et la Release GitHub bêta reste *pre-release*. À réserver à un hotfix Play urgent ; sinon F-Droid et les métadonnées publiques restent en retard sur Play prod.
 - Le `workflow_dispatch` ne sert qu'au track **internal** (dev) — pas un outil de promotion.
 
 ## Pourquoi `r0adkll/upload-google-play` plutôt que `gradle-play-publisher`

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -17,7 +17,7 @@
          parser / AST evolution makes the locally persisted PostContent stale ; forces a
          re-fetch + re-parse on the next topic open. Does NOT log the user out, drop the
          flag cache, or touch the proxy preferences. -->
-    <string name="settings_maintenance_title">Maintenance bêta</string>
+    <string name="settings_maintenance_title">Maintenance</string>
     <string name="settings_clear_topic_cache_intro">Supprime les pages de topics stockées localement. Les prochains topics ouverts seront retéléchargés depuis HFR. Les drapeaux, l\'authentification et les préférences proxy ne sont pas affectés.</string>
     <string name="settings_clear_topic_cache_button">Vider le cache des topics</string>
     <string name="settings_clear_topic_cache_confirm_title">Vider le cache des topics ?</string>
@@ -33,6 +33,6 @@
          change is observed on the next topic open without manually clearing the cache. Strictly
          an alpha dogfood tool — flags, auth, proxy preferences are untouched. -->
     <string name="settings_ignore_topic_cache_title">Ignorer le cache topic</string>
-    <string name="settings_ignore_topic_cache_description">Bêta : force le retéléchargement et le reparse des pages de topic. Utile après un changement de parser/rendu. Désactive le prefetch topic pour éviter de remplir Room inutilement.</string>
+    <string name="settings_ignore_topic_cache_description">Force le retéléchargement et le reparse des pages de topic. Utile après un changement de parser/rendu. Désactive le prefetch topic pour éviter de remplir Room inutilement.</string>
     <string name="settings_ignore_topic_cache_persist_failed">Impossible de mémoriser le réglage « Ignorer le cache topic ». Réessayez.</string>
 </resources>


### PR DESCRIPTION
## Correction de conception

Le design flavor-par-canal uploadait des applicationId distincts (`.beta`/`.dev`) comme **apps Play séparées**. Mais Play (et notre setup) = **une seule app** distribuée via **tracks**. L'upload beta réel a échoué `Package not found: fr.forumhfr.redface2.beta` — cette app n'existe pas ; beta est le **track open testing** de `fr.forumhfr.redface2`.

### Changements
- **release.yml** : `resolve-target` build/upload **toujours le package prod** (`:app:bundleProdRelease`, `fr.forumhfr.redface2`) ; le déclencheur ne choisit plus que le **track Play** (prerelease→beta/open-testing, stable→production, dispatch→internal). Gate prod, validation du ref, attach-recovery et préservation du flag prerelease : tous conservés (durcissement des 5 passes Codex intact).
- **Libellés in-app neutres** (`Paramètres`/`Diagnostics`/`Maintenance`, sans « bêta ») : le binaire est identique sur tous les tracks (promouvable open testing → production sans re-build), donc aucun marqueur de canal n'y est gravé ; l'indication « test » vient de la bannière testeur Play.
- **build.gradle.kts** : flavors `.beta`/`.dev` documentés comme **sideload local uniquement** (jamais un package Play) ; flavors conservés pour la coexistence dogfood locale.
- **release.md** : réécrit pour le modèle 1-app/tracks (grant SA unique, 1er upload manuel unique, promotion native beta→prod, caveat versionCode du dispatch dev).
- **app/CHANGELOG.md** : entrée v72 corrigée (package prod sur track open testing, libellés neutres).

### Validation
Après merge : je supprime + recrée la Release `app-v72` (prerelease) sur le nouveau main → la CD pousse le package prod sur l'open testing → 0.4.0 bêta. (v72 est libre sur `fr.forumhfr.redface2`, l'alpha s'arrête à v71.)

> Action par Claude Opus 4.8 (demandée par @XaaT)