### PR TITLE
fix(ci): publier le canal dev sur Play internal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,8 @@ name: Release
 #   GitHub Release prerelease, tag app-v<N>  → BETA : Play open testing (base appId, label "Redface 2 β")
 #                                                     + F-Droid package fr.forumhfr.redface2.beta
 #   GitHub Release stable,    tag app-v<N>   → PROD (deferred, gated): Play production + F-Droid base
-#   workflow_dispatch                        → DEV  : NO Play (shared versionCode namespace risk). The run
+#   workflow_dispatch                        → DEV  : Play internal (base appId, label "Redface 2 dev")
+#                                                     + F-Droid package fr.forumhfr.redface2.dev. The run
 #                                                     AUTO-CREATES a prerelease Release app-dev-v<run> that
 #                                                     carries the .dev APK, so the F-Droid publisher (which
 #                                                     downloads from a Release) has a source. → package …​.dev
@@ -88,9 +89,11 @@ jobs:
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             channel=dev
             app_label="Redface 2 dev"
-            play_upload=false; play_track=""; play_status=""
+            play_upload=true; play_track=internal; play_status=completed
             fdroid_flavor=Dev; fdroid_dir=dev; fdroid_package=fr.forumhfr.redface2.dev; fdroid_channel=dev
-            version_code_override="$RUN_NUMBER"   # .dev is its own versionCode namespace (monotonic per run)
+            # Resolved after checkout from the tracked base versionCode + run_number. Play uses the base
+            # appId for dev too, so the code must be above the current beta/prod code, not just run_number.
+            version_code_override=""
             creates_dev_release=true
             release_tag="app-dev-v${RUN_NUMBER}"
             build_ref="$DISPATCH_REF"
@@ -184,12 +187,22 @@ jobs:
       - name: Resolve version metadata
         id: meta
         shell: bash
+        env:
+          RUN_NUMBER: ${{ github.run_number }}
         run: |
           set -euo pipefail
+          base_version_code=$(grep -E '^[[:space:]]+versionCode[[:space:]]*=' app/build.gradle.kts | head -1 | grep -oE '[0-9]+' | tail -1)
+          [[ -n "$base_version_code" ]] || { echo "::error::base versionCode unresolved"; exit 1; }
           if [[ -n "${VERSION_CODE_OVERRIDE:-}" ]]; then
             version_code="$VERSION_CODE_OVERRIDE"
+          elif [[ "${CHANNEL}" == "dev" ]]; then
+            # Dev uploads to the Play `internal` track under the base applicationId, so it burns
+            # Play versionCodes from the same namespace as beta/prod. `run_number` alone was below
+            # the already-published beta code; base+run is monotonic for dev runs while keeping the
+            # value obvious. Next beta tag must be bumped above the latest dev code.
+            version_code=$((base_version_code + RUN_NUMBER))
           else
-            version_code=$(grep -E '^[[:space:]]+versionCode[[:space:]]*=' app/build.gradle.kts | head -1 | grep -oE '[0-9]+' | tail -1)
+            version_code="$base_version_code"
           fi
           version_name=$(grep -E '^[[:space:]]+versionName[[:space:]]*=' app/build.gradle.kts | head -1 | sed -E 's/.*"(.*)".*/\1/')
           short_sha=$(git rev-parse --short HEAD)
@@ -252,16 +265,19 @@ jobs:
           UPLOAD_KEYSTORE_PASSWORD: ${{ secrets.UPLOAD_KEYSTORE_PASSWORD }}
           UPLOAD_KEY_ALIAS: ${{ secrets.UPLOAD_KEY_ALIAS }}
           UPLOAD_KEY_PASSWORD: ${{ secrets.UPLOAD_KEY_PASSWORD }}
+          EFFECTIVE_VERSION_CODE: ${{ steps.meta.outputs.version_code }}
         shell: bash
         run: |
           set -euo pipefail
           GRADLE_ARGS=(--no-daemon --stacktrace)
           [[ -n "${APP_LABEL:-}" ]] && GRADLE_ARGS+=("-PappLabel=${APP_LABEL}")
+          if [[ "${CHANNEL}" == "dev" ]]; then
+            GRADLE_ARGS+=("-PversionCodeOverride=${EFFECTIVE_VERSION_CODE}")
+          fi
           # F-Droid artefact: the channel flavor (suffixed appId, except prod=base). dev gets a
-          # run_number versionCode (its own namespace) so each dispatch is a new F-Droid version.
-          FDROID_ARGS=("${GRADLE_ARGS[@]}")
-          [[ -n "${VERSION_CODE_OVERRIDE:-}" ]] && FDROID_ARGS+=("-PversionCodeOverride=${VERSION_CODE_OVERRIDE}")
-          ./gradlew ":app:assemble${FDROID_FLAVOR}Release" "${FDROID_ARGS[@]}"
+          # computed override so each dispatch is a new F-Droid version and the Play internal
+          # artefact uses the same visible build number.
+          ./gradlew ":app:assemble${FDROID_FLAVOR}Release" "${GRADLE_ARGS[@]}"
           # Play artefact: base applicationId (prod flavor), only for channels that upload to Play.
           if [[ "${PLAY_UPLOAD}" == "true" ]]; then
             ./gradlew ":app:bundleProdRelease" ":app:assembleProdRelease" "${GRADLE_ARGS[@]}"
@@ -337,7 +353,7 @@ jobs:
           if-no-files-found: error
 
       - name: Publish to Play Console
-        # Only channels with play_upload (beta/prod). Skips cleanly when the SA secret is absent.
+        # Only channels with play_upload (beta/dev/prod). Skips cleanly when the SA secret is absent.
         if: ${{ env.PLAY_UPLOAD == 'true' && steps.service_account.outputs.path != '' }}
         uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5  # v1.1.5
         with:
@@ -355,7 +371,7 @@ jobs:
 
       - name: Create dev pre-release (dev channel)
         # dev has no Release of its own; create one (tag app-dev-v<run>) so the F-Droid publisher has a
-        # source. always() + staged guard so a Play hiccup elsewhere never skips it. Its published event
+        # source. always() + staged guard so a Play hiccup never hides the signed artefacts. Its published event
         # is a no-op (resolve-target requires app-v*, which app-dev-v* does not match).
         if: ${{ always() && needs.resolve-target.outputs.creates_dev_release == 'true' && steps.artefacts.outcome == 'success' }}
         uses: softprops/action-gh-release@v2
@@ -365,9 +381,9 @@ jobs:
           # set to another branch/tag builds that ref, so tagging github.sha would break provenance.
           target_commitish: ${{ steps.meta.outputs.full_sha }}
           name: Redface 2 dev (build ${{ steps.meta.outputs.version_code }})
-          body: "Build dev automatique (canal interne). APK F-Droid `.dev` attaché. Non destiné au grand public."
+          body: "Build dev automatique (canal interne Play + F-Droid `.dev`). Non destiné au grand public."
           prerelease: true
-          files: release-artefacts/*.apk
+          files: release-artefacts/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,9 +25,9 @@ val hasCiSigningConfig =
 // the per-flavor defaults below apply.
 //   -PappLabel="Redface 2 β"  → forces the launcher label for the build (lets the prod flavor /
 //                                base applicationId carry the β/dev label on the Play track build).
-//   -PversionCodeOverride=N   → overrides versionCode for the dev channel only (F-Droid `.dev` is
-//                                its own applicationId namespace, so a run_number-based code there
-//                                never collides with — nor blocks — the base/Play versionCode).
+//   -PversionCodeOverride=N   → overrides versionCode for the dev channel only. Dev now uploads to
+//                                Play internal under the base applicationId AND to F-Droid `.dev`, so
+//                                the workflow computes an explicit code above the current base code.
 val cliAppLabel = providers.gradleProperty("appLabel").orNull?.takeIf { it.isNotBlank() }
 val cliVersionCode = providers.gradleProperty("versionCodeOverride").orNull?.toIntOrNull()
 
@@ -119,7 +119,8 @@ android {
     // #233 — `channel` product-flavor dimension (prod / beta / dev). The applicationId suffix decides
     // WHERE the artifact goes; the launcher label is set per build (cliAppLabel ?: per-flavor default):
     //   prod (base applicationId fr.forumhfr.redface2) → the PLAY artifact (one Play listing, label
-    //         set by -PappLabel per track: "Redface 2 β" on the beta track, "Redface 2" on production).
+    //         set by -PappLabel per track: "Redface 2 β" on beta, "Redface 2 dev" on internal,
+    //         "Redface 2" on production).
     //   beta (.beta) / dev (.dev) → the F-DROID artifacts (distinct applicationId = distinct, coexisting
     //         F-Droid apps "Redface 2 β" / "Redface 2 dev"; F-Droid indexes by package, has no tracks).
     // Play = ONE applicationId (1 listing, label varies by track); F-Droid = packages per channel.

--- a/docs/guides/release.md
+++ b/docs/guides/release.md
@@ -15,10 +15,12 @@ Comment construire les artefacts signés et les publier sur le bon canal depuis 
 | Déclencheur | Canal | Play | F-Droid |
 |---|---|---|---|
 | GitHub Release **pre-release** `app-v<N>` | **beta** | `fr.forumhfr.redface2`, label « Redface 2 β », track **open testing** | package `fr.forumhfr.redface2.beta` (« Redface 2 β ») |
+| **`workflow_dispatch`** | **dev** | `fr.forumhfr.redface2`, label « Redface 2 dev », track **internal testing** | package `fr.forumhfr.redface2.dev` (« Redface 2 dev ») |
 | GitHub Release **stable** `app-v<N>` *(différé)* | **prod** | track **production** (`draft`, après gate `production`) | package base `fr.forumhfr.redface2` |
-| **`workflow_dispatch`** | **dev** | — (pas de Play : versionCode partagé) | package `fr.forumhfr.redface2.dev` (« Redface 2 dev ») |
 
-Le canal **dev** n'a pas de Release propre : le run dispatch **auto-crée une Release pre-release `app-dev-v<run_number>`** (avec l'APK `.dev`) pour que le publisher F-Droid ait une source. La `.dev` a son propre espace de versionCode (= `run_number`), donc aucune collision avec la base/Play.
+En pratique pré-1.0, les canaux actifs sont **beta** et **dev**. Le canal **prod/release** reste codé et documenté, mais il est différé : ne pas publier de Release GitHub stable tant que la beta n'est pas jugée prête.
+
+Le canal **dev** n'a pas de Release maintainer propre : le run dispatch **auto-crée une Release pre-release `app-dev-v<run_number>`** (avec les artefacts signés, dont l'APK F-Droid `.dev`) pour que le publisher F-Droid ait une source. Côté Play, dev utilise le **même applicationId** que beta/prod (`fr.forumhfr.redface2`) sur le track `internal`, donc il consomme aussi le namespace Play des `versionCode`.
 
 ⚠️ **Le tag `app-v<N>` seul ne déclenche plus la CD** : il faut **publier une GitHub Release** (pre-release pour beta, stable pour prod). Une Release dont le tag ne commence pas par `app-v` (les `v0.x` specs **et** les `app-dev-v*` auto-créées) est **ignorée** (gate `resolve-target`).
 
@@ -28,7 +30,7 @@ Workflow source : [`.github/workflows/release.yml`](https://github.com/ForumHFR/
 
 - **Tag namespace** : les releases app utilisent `app-v<versionCode>` (ex: `app-v32`, `app-v33`). Cela évite de collisionner avec les tags `v0.x.0` du site / des specs.
 - **Tag dev** : le canal dev utilise `app-dev-v<run_number>` (auto-créé par le run dispatch), distinct de `app-v<N>` pour ne pas re-déclencher la CD.
-- **Routing (figé dans `resolve-target`)** : prerelease → beta (Play track `beta` + F-Droid `.beta`) ; stable → prod (Play track `production`, gate + F-Droid base) ; dispatch → dev (pas de Play, F-Droid `.dev`). Le **label** (`-PappLabel`) et le **versionCode** (`-PversionCodeOverride`, dev seulement) sont injectés au build ; un **check CI** (`aapt2 dump badging`) vérifie package + label de chaque APK avant publication.
+- **Routing (figé dans `resolve-target`)** : prerelease → beta (Play track `beta` + F-Droid `.beta`) ; dispatch → dev (Play track `internal` + F-Droid `.dev`) ; stable → prod différé (Play track `production`, gate + F-Droid base). Le **label** (`-PappLabel`) et le **versionCode** (`-PversionCodeOverride`, dev seulement) sont injectés au build ; un **check CI** (`aapt2 dump badging`) vérifie package + label de chaque APK avant publication.
 
 ## Pré-requis (à faire une fois)
 
@@ -98,11 +100,16 @@ gh release create app-v73 --title 'Redface 2 v73 (1.0.0)' --notes '…'
 
 La CD résout **prod** et **attend l'approbation** dans l'Environment GitHub `production` (required reviewer) avant tout build/upload. Build `:app:bundleProdRelease` (label par défaut « Redface 2 »), upload sur le **track `production`** en **statut `draft`** (double garde-fou : approbation GitHub + activation manuelle Play). F-Droid : package base `fr.forumhfr.redface2`. **Différé** : aucune Release stable n'est publiée tant que la beta n'est pas validée.
 
-## Flux dev — F-Droid `.dev` (rapide)
+## Flux dev — Play internal + F-Droid `.dev` (rapide)
 
-**GitHub → Actions → Release → Run workflow** (ou `gh workflow run release.yml -f ref=<branche>`). La CD résout **dev** : build `:app:assembleDevRelease -PappLabel="Redface 2 dev" -PversionCodeOverride=<run_number>` (`fr.forumhfr.redface2.dev`), **auto-crée une Release pre-release `app-dev-v<run_number>`** avec l'APK `.dev`, puis notifie F-Droid (package `.dev`). **Pas d'upload Play** (le canal dev partagerait l'espace versionCode de la base appId). Seul input : `ref` (défaut = ref courant). L'APK est aussi téléchargeable depuis les artefacts du run (30 j) pour le sideload.
+**GitHub → Actions → Release → Run workflow** (ou `gh workflow run release.yml -f ref=<branche>`). La CD résout **dev** :
 
-ℹ️ **versionCode dev** : la `.dev` est un applicationId **distinct** → son propre espace de versionCode, **indépendant** de la base/Play. La CD lui injecte `versionCode = run_number` (monotone par run), donc chaque dispatch est une nouvelle version F-Droid sans jamais bloquer ni collisionner la base. Garde-fou : le check CI lit le versionCode **réel** de l'APK produit et échoue si le ref buildé ne supporte pas `-PversionCodeOverride` (sinon Gradle ignorerait la prop et l'APK garderait le code checkout, divergeant de ce qu'on annonce à F-Droid).
+- Play : build `:app:bundleProdRelease -PappLabel="Redface 2 dev" -PversionCodeOverride=<code_dev>` (`fr.forumhfr.redface2`), upload sur track **`internal`** en `completed`.
+- F-Droid : build `:app:assembleDevRelease -PappLabel="Redface 2 dev" -PversionCodeOverride=<code_dev>` (`fr.forumhfr.redface2.dev`), auto-crée une Release pre-release `app-dev-v<run_number>` avec les artefacts signés, puis notifie F-Droid (package `.dev`).
+
+Seul input : `ref` (défaut = ref courant). Les artefacts sont aussi téléchargeables depuis le run Actions (30 j) pour le sideload.
+
+ℹ️ **versionCode dev** : le track Play `internal` partage le namespace de `versionCode` avec `beta` et `production`, car c'est la même app `fr.forumhfr.redface2`. La CD calcule donc le code dev après checkout : `versionCode` suivi dans `app/build.gradle.kts` + `github.run_number`. Cela évite le cas réel où `run_number` seul était inférieur au dernier build Play. Conséquence assumée : un build dev **brûle** un `versionCode` Play ; le prochain tag beta `app-v<N>` doit avoir `N` strictement supérieur au dernier code dev publié.
 
 ## Bump de version : convention
 
@@ -112,7 +119,8 @@ Le `versionCode` est strictement croissant. Play Console rejette tout AAB dont l
 |---|---|
 | Release officielle Phase N+1 | bump majeur du `versionName` (ex: `0.1.0-phase1.4` → `0.2.0-phase2.0`) |
 | Release intermédiaire dans la même phase | bump du suffixe (ex: `0.1.0-phase1.1` → `0.1.0-phase1.2`) |
-| Build dogfood non distribué | bumper malgré tout, marquer comme `burnt` dans `app/CHANGELOG.md` si jamais distribué |
+| Build dev Play internal | pas besoin de PR de bump avant le dispatch ; la CD injecte un code dev. En revanche, le prochain `app-v<N>` beta doit être supérieur au dernier code dev consommé. |
+| Build dogfood non distribué hors Play | bumper malgré tout si distribué publiquement, marquer comme `burnt` dans `app/CHANGELOG.md` si un slot Play a été consommé |
 
 ## Promotion entre tracks
 
@@ -120,7 +128,7 @@ Comme tout est l'app unique `fr.forumhfr.redface2`, **la promotion native Play f
 
 - **Voie recommandée beta → prod = publier une Release GitHub *stable*** (case pre-release décochée) sur un nouveau tag `app-v<N>`. Elle déclenche **toute** l'automatisation : gate d'approbation `production`, upload Play **production**, **notification F-Droid (release)**, et la Release GitHub passe en stable. C'est le seul chemin qui garde Play, F-Droid et les artefacts GitHub **alignés**. (Le binaire peut être identique à la bêta — bumper le versionCode et republier ; le rendu utilisateur ne change pas.)
 - **Promote release dans Play Console** (open testing → production) reste possible et pratique *côté Play uniquement*, mais ⚠️ **bypasse l'automatisation** : pas de passage par la gate GitHub, **F-Droid n'est pas notifié**, et la Release GitHub bêta reste *pre-release*. À réserver à un hotfix Play urgent ; sinon F-Droid et les métadonnées publiques restent en retard sur Play prod.
-- Le `workflow_dispatch` ne sert qu'au canal **dev** (F-Droid `.dev`) — pas un outil de promotion.
+- Le `workflow_dispatch` ne sert qu'au canal **dev** (Play internal + F-Droid `.dev`) — pas un outil de promotion beta/prod.
 
 ## Pourquoi `r0adkll/upload-google-play` plutôt que `gradle-play-publisher`
 
@@ -139,7 +147,7 @@ Procédure : voir [docs Play Console — Reset upload key](https://support.googl
 Si l'étape `Publish to Play Console` du workflow échoue (auth Play, quota, track invalide…) **après** que la signature ait réussi, l'AAB et l'APK signés sont déjà stagés. Deux façons de les récupérer sans relancer le build :
 
 1. **Workflow artefacts** : aller sur la page Actions → run en échec → en bas du job `build`, télécharger l'archive `redface2-<canal>-v<N>-<sha>` (rétention 30 jours). Chemin standard pour tous les canaux (beta/prod/dev).
-2. **GitHub Release** (canaux beta/prod uniquement) : le step `Attach artefacts to the GitHub Release` tourne **après** l'upload Play mais indépendamment de son succès — si le build + la signature ont passé, l'AAB+APK sont attachés à la Release `app-v<N>` (que tu as publiée) même si Play a refusé. Après avoir corrigé la cause (permissions Play, premier upload manuel du listing, etc.), l'upload manuel via la Play Console UI depuis l'AAB téléchargé évite de re-bumper le `versionCode`. (Le canal **dev** n'a pas de Release → utiliser les workflow artefacts.)
+2. **GitHub Release** : pour beta/prod, le step `Attach artefacts to the GitHub Release` met à jour la Release `app-v<N>` existante. Pour dev, le workflow crée `app-dev-v<run_number>`. Dans les deux cas, si le build + la signature ont passé, les artefacts signés sont disponibles même si Play a refusé. Après avoir corrigé la cause (permissions Play, premier upload manuel du listing, etc.), l'upload manuel via la Play Console UI depuis l'AAB téléchargé évite de re-bumper le `versionCode`.
 
 Si la signature elle-même échoue (`keytool -list` ou `jarsigner -verify`), aucun artefact n'est produit — refixer le secret keystore avant de retenter.
 

--- a/drafts/claude-cd-channels-labels-fdroid-design.md
+++ b/drafts/claude-cd-channels-labels-fdroid-design.md
@@ -1,6 +1,7 @@
 # Design CD — canaux beta/dev, label par canal, Play 1-fiche + F-Droid 2-apps
 
-> Statut : **draft non normatif** (drafts/ ne gouverne rien tant que non promu). À faire relire par Codex gpt-5.5 xhigh avant implémentation.
+> Statut : **draft non normatif** (drafts/ ne gouverne rien tant que non promu). Historique de design ; la décision effective est documentée dans `docs/guides/release.md`.
+> Révision active : **rev. 3** (§13) — dev est distribué sur Play internal **et** F-Droid `.dev`.
 > Auteur : Claude Opus 4.8 (demandé par @XaaT). Contexte : #233 (umbrella release/distrib).
 
 ## 1. Objectif
@@ -93,7 +94,7 @@ Payload `repository_dispatch` (déjà supporté côté redface2-fdroid) : `chann
 
 - **F-Droid** : chaque `applicationId` (`.beta`, `.dev`, base) a son **propre** espace de versionCode → pas de collision inter-canaux. Builds successifs d'un même canal = versionCode croissant (le bump release suffit).
 - **Play** (base appId, beta + dev = tracks de la même fiche) : **espace de versionCode partagé**. Un build dev (internal) et un build beta (open testing) ne peuvent pas avoir le **même** versionCode. La beta prend le versionCode de release ; un build dev doit en prendre un **distinct et croissant**.
-  - ⚠️ **Question ouverte (cf. §10)** : un offset run_number pour dev est **incompatible** avec un appId unique (Play exige des codes croissants ; un code dev élevé bloquerait les beta/prod suivantes). Option pragmatique : dev sur Play reste **manuel/occasionnel** avec un versionCode bumpé exprès, ou on **retire dev de Play** (dev = F-Droid `.dev` + sideload uniquement), F-Droid n'ayant pas ce souci.
+  - ⚠️ **Question historique (résolue en rev. 3, cf. §13)** : dev sur Play partage le namespace de `versionCode` avec beta/prod. Décision finale : on assume ce coût et le workflow calcule un code dev explicite.
 
 ## 8. Prod différé
 
@@ -108,7 +109,7 @@ Payload `repository_dispatch` (déjà supporté côté redface2-fdroid) : `chann
 
 ## 10. Questions ouvertes pour Codex
 
-1. **dev sur Play** : vaut-il le coût du versionCode partagé (base appId), ou vaut-il mieux **dev = F-Droid `.dev` + sideload uniquement** (et Play = beta only en pré-1.0) ? Recommandation provisoire : retirer dev de Play, le garder F-Droid+sideload.
+1. **dev sur Play** : résolu en rev. 3 (§13) — dev est publié sur Play internal et F-Droid `.dev`, en assumant les `versionCode` consommés.
 2. **Double build par canal** (Play base + F-Droid suffixé) : acceptable en temps CI, ou faut-il une matrice/parallélisation ? Risque de divergence entre les 2 artefacts (même code, appId/label seuls diffèrent — a priori OK).
 3. **Label via propriété vs flavor** : la propriété `-PappLabel` est-elle la bonne source unique, ou garder un défaut par flavor (robustesse si build manuel sans la propriété) ? Proposition : propriété prioritaire, fallback `@string/app_name`.
 4. **Reproducibilité F-Droid** : notre dépôt publie des **APK prébuildés signés** (pas de build-from-source côté F-Droid). OK pour un dépôt privé ; à acter si on vise un jour le dépôt F-Droid officiel.
@@ -141,10 +142,10 @@ Le §4 disait « retirer les labels par flavor, source unique = propriété ». 
   ```
 - **Check CI obligatoire** : après build, vérifier le `package` + le `application-label` de l'APK produit (via `aapt dump badging`) contre l'attendu du canal. Garde-fou contre un mauvais appId/label poussé sur le mauvais store.
 
-### Fix 2 — source d'artefact pour le canal **dev** (le vrai trou)
-Le publisher F-Droid (`redface2-fdroid/publish.yml`) télécharge l'APK **depuis une GitHub Release** (tag + apk_filename). Or **dev est déclenché par `workflow_dispatch` → pas de Release/tag** → F-Droid ne peut pas servir dev avec le mécanisme actuel. Et dev sur **Play** partage l'espace versionCode de la base appId (risqué). **Décision (reco Codex + à valider @XaaT) :**
+### Fix 2 — source d'artefact pour le canal **dev** (historique, supersédé en rev. 3)
+Le publisher F-Droid (`redface2-fdroid/publish.yml`) télécharge l'APK **depuis une GitHub Release** (tag + apk_filename). Or **dev est déclenché par `workflow_dispatch` → pas de Release/tag** → F-Droid ne peut pas servir dev avec le mécanisme actuel. Et dev sur **Play** partage l'espace versionCode de la base appId (risqué). La recommandation ci-dessous était celle de la rev. 2 ; elle est remplacée par la rev. 3 (§13).
 
-> **dev = artefact Actions (sideload) uniquement** pour l'instant. **Pas de dev sur Play, pas de dev sur F-Droid.** Le canal public = **beta** (Play open testing + F-Droid `.beta`). Le dogfood dev reste le build `.debug` adb + l'APK `.dev` téléchargeable depuis les artefacts du run dispatch.
+> **Ancienne recommandation rev. 2, supersédée** : limiter dev à un artefact Actions sideload-only. Décision finale rev. 3 : dev part sur Play internal et F-Droid `.dev`.
 
 Si on veut **plus tard** dev sur F-Droid : introduire un **schéma de Release/tag dédié `app-dev-v<N>`** (prerelease) pour que le publisher ait une source — pas un dispatch.
 
@@ -162,4 +163,24 @@ Si on veut **plus tard** dev sur F-Droid : introduire un **schéma de Release/ta
 | **prod** *(différé)* | Release stable | production (gate) | package base |
 
 ### Reste à trancher avec @XaaT
-**dev = sideload-only (reco)** OU **dev sur F-Droid via un schéma de Release/tag `app-dev-v<N>`** (plus de cérémonie, mais dev devient installable F-Droid en « Redface 2 dev »).
+Résolu en rev. 3 (§13) : **dev sur Play internal + F-Droid `.dev` via Release auto `app-dev-v<N>`**.
+
+## 13. Révision 3 — décision maintainer : dev sur Play internal + F-Droid `.dev`
+
+Décision @XaaT (2026-06-06) : on assume de brûler des `versionCode` Play pour avoir un vrai canal **dev** sur les **deux** plateformes.
+
+La révision 2 est donc supersédée :
+
+| Canal | Déclencheur | Play | F-Droid |
+|---|---|---|---|
+| **beta** | Release *pre-release* `app-v<N>` | `fr.forumhfr.redface2`, label « Redface 2 β », track **beta/open testing** | package `fr.forumhfr.redface2.beta` « Redface 2 β » |
+| **dev** | `workflow_dispatch` | `fr.forumhfr.redface2`, label « Redface 2 dev », track **internal** | package `fr.forumhfr.redface2.dev` « Redface 2 dev » via Release auto `app-dev-v<run_number>` |
+| **prod** *(différé)* | Release stable | production (gate) | package base |
+
+Contraintes assumées :
+
+- Play reste **une seule fiche** et **un seul applicationId** ; beta/dev/prod sont des tracks du même package `fr.forumhfr.redface2`.
+- Le label change au build via `-PappLabel`.
+- F-Droid garde des packages distincts `.beta` / `.dev` pour permettre l'installation côte à côte.
+- Dev Play internal partage le namespace de `versionCode` avec beta/prod. La CD calcule donc un `versionCode` dev après checkout (`base versionCode` + `github.run_number`) et l'injecte dans le build Play **et** F-Droid dev via `-PversionCodeOverride`.
+- Après un dispatch dev, le prochain tag beta `app-v<N>` doit utiliser un `N` strictement supérieur au dernier `versionCode` dev consommé sur Play.


### PR DESCRIPTION
> Action par GPT-5 Codex (demandée par @XaaT)

## Résumé

- Route `workflow_dispatch` vers le canal dev complet : Play internal (`fr.forumhfr.redface2`, label `Redface 2 dev`) + F-Droid `.dev`.
- Calcule un `versionCode` dev explicite après checkout (`versionCode` suivi + `github.run_number`) et l'injecte dans les artefacts Play et F-Droid.
- Documente le nouveau contrat beta/dev/prod différé et garde la décision historique dans le draft CD.

Closes #302

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml_ok"'`\n- `./scripts/docker-dev.sh ./gradlew :app:assembleDevRelease :app:assembleProdRelease -PappLabel="Redface 2 dev" -PversionCodeOverride=120`\n- `./scripts/docker-dev.sh ./gradlew :app:assembleBetaRelease :app:assembleProdRelease -PappLabel="Redface 2 β"`\n- `aapt2 dump badging` sur APK dev/beta/prod pour vérifier package, label et versionCode\n\n## Note\n\nLe canal dev Play internal partage le namespace `versionCode` avec beta/prod. Après un dispatch dev, le prochain tag beta `app-v<N>` doit utiliser un `N` strictement supérieur au dernier code dev publié.