### PR TITLE
feat(ci): versionCode canonique (registre de tags) + dispatch par canal (#304)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,32 +1,43 @@
 name: Release
 
-# Channel-routed CD (#233). Design: drafts/claude-cd-channels-labels-fdroid-design.md (rev. 2, Codex).
+# Channel-routed CD (#233, #304). Dispatch-only model:
+# - The publish channel is chosen via the `channel` input (beta | dev). There is NO release-event
+#   trigger any more — beta no longer needs a hand-published GitHub Release; both channels ship from
+#   a single "Run workflow" dispatch.
 # - Play: ONE app fr.forumhfr.redface2, ONE listing; the launcher label is set per build (-PappLabel)
 #   and the channel routes only the Play TRACK.
 # - F-Droid: distinct applicationId per channel (.beta/.dev) = distinct, COEXISTING F-Droid apps.
-#   The two stores are independent artifacts, so one channel is base-appId on Play AND suffixed on F-Droid.
 #
-#   GitHub Release prerelease, tag app-v<N>  → BETA : Play open testing (base appId, label "Redface 2 β")
-#                                                     + F-Droid package fr.forumhfr.redface2.beta
-#   GitHub Release stable,    tag app-v<N>   → PROD (deferred, gated): Play production + F-Droid base
-#   workflow_dispatch                        → DEV  : Play internal (base appId, label "Redface 2 dev")
-#                                                     + F-Droid package fr.forumhfr.redface2.dev. The run
-#                                                     AUTO-CREATES a prerelease Release app-dev-v<run> that
-#                                                     carries the .dev APK, so the F-Droid publisher (which
-#                                                     downloads from a Release) has a source. → package …​.dev
+#   channel=beta → Play open testing (base appId, label "Redface 2 β")  + F-Droid fr.forumhfr.redface2.beta
+#   channel=dev  → Play internal     (base appId, label "Redface 2 dev") + F-Droid fr.forumhfr.redface2.dev
+#
+# versionCode (CANONICAL LEDGER): a single monotonic counter SHARED by beta and dev — the set of
+# `app-v<N>` git tags IS the ledger. Each ship computes `versionCode = max(app-v* tags, build.gradle
+# floor) + 1`, so beta and dev interleave on one strictly-increasing sequence (no manual bump, no
+# beta-vs-dev inversion). The run creates a prerelease `app-v<N>` carrying the signed artefacts, so
+# the F-Droid publisher (which downloads from a Release) has a source. `concurrency` serialises runs
+# so two dispatches never allocate the same code. Prod/stable is deferred (#302/#304) — set aside.
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
+      channel:
+        description: 'Canal de publication'
+        required: true
+        default: dev
+        type: choice
+        options:
+          - dev
+          - beta
       ref:
-        description: 'Branch/tag to build for the dev channel (default: current ref)'
+        description: 'Branch/tag à builder (défaut: ref courant)'
         required: false
         default: ''
         type: string
 
+# Single global group: serialise ALL ship runs so the tag-ledger versionCode allocation is atomic
+# (two parallel dispatches must not both read the same max and allocate the same code).
 concurrency:
-  group: release-${{ github.event.release.tag_name || github.ref }}
+  group: release
   cancel-in-progress: false
 
 permissions:
@@ -35,14 +46,11 @@ permissions:
 
 jobs:
   # ──────────────────────────────────────────────────────────────────────
-  # Single source of truth for routing. The release-event gate requires tag `app-v*`, which EXCLUDES
-  # both the specs `v0.x` Releases and the auto-created `app-dev-v*` dev Releases (those start with
-  # "app-dev", not "app-v"): dev is handled wholly by the dispatch run that creates them, so their
-  # published event is a deliberate no-op. A dispatch always proceeds.
+  # Routing: map the `channel` input → Play track + F-Droid package + label. No versionCode here
+  # (it needs the checkout/tags, resolved in the build job's meta step).
   # ──────────────────────────────────────────────────────────────────────
   resolve-target:
     name: Resolve channel target
-    if: ${{ github.event_name != 'release' || startsWith(github.event.release.tag_name, 'app-v') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
@@ -56,65 +64,43 @@ jobs:
       fdroid_dir: ${{ steps.r.outputs.fdroid_dir }}
       fdroid_package: ${{ steps.r.outputs.fdroid_package }}
       fdroid_channel: ${{ steps.r.outputs.fdroid_channel }}
-      version_code_override: ${{ steps.r.outputs.version_code_override }}
-      creates_dev_release: ${{ steps.r.outputs.creates_dev_release }}
-      release_tag: ${{ steps.r.outputs.release_tag }}
       build_ref: ${{ steps.r.outputs.build_ref }}
-      is_release_event: ${{ steps.r.outputs.is_release_event }}
     steps:
       - id: r
         shell: bash
         # GitHub-expressions through env, NEVER interpolated into the script body (the dispatch ref is
         # user-controlled; `${{ }}` substitution happens before bash runs).
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          PRERELEASE: ${{ github.event.release.prerelease }}
-          TAG_NAME: ${{ github.event.release.tag_name }}
+          CHANNEL_INPUT: ${{ inputs.channel }}
           DISPATCH_REF: ${{ inputs.ref }}
-          RUN_NUMBER: ${{ github.run_number }}
         run: |
           set -euo pipefail
-          # Validate user-controlled values BEFORE they reach $GITHUB_OUTPUT (a newline could inject
+          # Validate the user-controlled ref BEFORE it reaches $GITHUB_OUTPUT (a newline could inject
           # extra output lines and reroute the deploy).
           if [[ -n "${DISPATCH_REF:-}" && ! "$DISPATCH_REF" =~ ^[A-Za-z0-9._/-]+$ ]]; then
             echo "::error::Invalid dispatch ref '${DISPATCH_REF}' — only [A-Za-z0-9._/-] allowed."
             exit 1
           fi
-          if [[ "$EVENT_NAME" == "release" && ! "$TAG_NAME" =~ ^app-v[A-Za-z0-9._-]+$ ]]; then
-            echo "::error::Unexpected release tag '${TAG_NAME}' — expected app-v[A-Za-z0-9._-]+."
-            exit 1
-          fi
           # The PLAY artifact is ALWAYS the base applicationId (prod flavor); only label + track vary.
           play_package=fr.forumhfr.redface2
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            channel=dev
-            app_label="Redface 2 dev"
-            play_upload=true; play_track=internal; play_status=completed
-            fdroid_flavor=Dev; fdroid_dir=dev; fdroid_package=fr.forumhfr.redface2.dev; fdroid_channel=dev
-            # Resolved after checkout from the tracked base versionCode + run_number. Play uses the base
-            # appId for dev too, so the code must be above the current beta/prod code, not just run_number.
-            version_code_override=""
-            creates_dev_release=true
-            release_tag="app-dev-v${RUN_NUMBER}"
-            build_ref="$DISPATCH_REF"
-            is_release_event=false
-          elif [[ "$PRERELEASE" == "true" ]]; then
-            channel=beta
-            app_label="Redface 2 β"
-            play_upload=true; play_track=beta; play_status=completed
-            fdroid_flavor=Beta; fdroid_dir=beta; fdroid_package=fr.forumhfr.redface2.beta; fdroid_channel=beta
-            version_code_override=""
-            creates_dev_release=false
-            release_tag="$TAG_NAME"; build_ref="refs/tags/$TAG_NAME"; is_release_event=true
-          else
-            channel=prod
-            app_label=""                          # default → @string/app_name ("Redface 2")
-            play_upload=true; play_track=production; play_status=draft
-            fdroid_flavor=Prod; fdroid_dir=prod; fdroid_package=fr.forumhfr.redface2; fdroid_channel=release
-            version_code_override=""
-            creates_dev_release=false
-            release_tag="$TAG_NAME"; build_ref="refs/tags/$TAG_NAME"; is_release_event=true
-          fi
+          case "$CHANNEL_INPUT" in
+            beta)
+              channel=beta
+              app_label="Redface 2 β"
+              play_upload=true; play_track=beta; play_status=completed
+              fdroid_flavor=Beta; fdroid_dir=beta; fdroid_package=fr.forumhfr.redface2.beta; fdroid_channel=beta
+              ;;
+            dev)
+              channel=dev
+              app_label="Redface 2 dev"
+              play_upload=true; play_track=internal; play_status=completed
+              fdroid_flavor=Dev; fdroid_dir=dev; fdroid_package=fr.forumhfr.redface2.dev; fdroid_channel=dev
+              ;;
+            *)
+              echo "::error::Unsupported channel '${CHANNEL_INPUT}' — expected 'beta' or 'dev'."
+              exit 1
+              ;;
+          esac
           {
             echo "channel=$channel"
             echo "app_label=$app_label"
@@ -126,32 +112,13 @@ jobs:
             echo "fdroid_dir=$fdroid_dir"
             echo "fdroid_package=$fdroid_package"
             echo "fdroid_channel=$fdroid_channel"
-            echo "version_code_override=$version_code_override"
-            echo "creates_dev_release=$creates_dev_release"
-            echo "release_tag=$release_tag"
-            echo "build_ref=$build_ref"
-            echo "is_release_event=$is_release_event"
+            echo "build_ref=$DISPATCH_REF"
           } >> "$GITHUB_OUTPUT"
-          echo "::notice title=Release target::channel=$channel label='${app_label:-<default>}' play=$play_upload track=${play_track:-none} fdroid=$fdroid_channel/$fdroid_package tag=$release_tag ref=${build_ref:-<current>}"
-
-  # prod-only manual approval gate (dedicated job so a non-prod channel doesn't hit an empty
-  # `environment:` reference). Skipped for beta/dev.
-  await-prod-approval:
-    name: Await production approval
-    needs: resolve-target
-    if: ${{ needs.resolve-target.outputs.channel == 'prod' }}
-    runs-on: ubuntu-24.04
-    environment: production
-    timeout-minutes: 4320
-    steps:
-      - env:
-          RELEASE_TAG: ${{ needs.resolve-target.outputs.release_tag }}
-        run: echo "Production deploy approved for ${RELEASE_TAG}."
+          echo "::notice title=Release target::channel=$channel label='${app_label}' play=$play_upload track=$play_track fdroid=$fdroid_channel/$fdroid_package ref=${DISPATCH_REF:-<current>}"
 
   build:
     name: Build, sign and publish (${{ needs.resolve-target.outputs.channel }})
-    needs: [resolve-target, await-prod-approval]
-    if: ${{ always() && needs.resolve-target.result == 'success' && (needs.resolve-target.outputs.channel != 'prod' || needs.await-prod-approval.result == 'success') }}
+    needs: [resolve-target]
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/cirruslabs/android-sdk:36@sha256:f9b3ea9ed2b5fc9522adae82c7b4622ab7aa54207ef532c8e615a347dca08f31
@@ -161,6 +128,7 @@ jobs:
       version_name: ${{ steps.meta.outputs.version_name }}
       short_sha: ${{ steps.meta.outputs.short_sha }}
       full_sha: ${{ steps.meta.outputs.full_sha }}
+      release_tag: ${{ steps.meta.outputs.release_tag }}
       fdroid_apk: ${{ steps.artefacts.outputs.fdroid_apk_filename }}
     env:
       APP_LABEL: ${{ needs.resolve-target.outputs.app_label }}
@@ -172,50 +140,47 @@ jobs:
       FDROID_DIR: ${{ needs.resolve-target.outputs.fdroid_dir }}
       FDROID_PACKAGE: ${{ needs.resolve-target.outputs.fdroid_package }}
       CHANNEL: ${{ needs.resolve-target.outputs.channel }}
-      VERSION_CODE_OVERRIDE: ${{ needs.resolve-target.outputs.version_code_override }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.resolve-target.outputs.build_ref || github.ref }}
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Trust workspace for git
         shell: bash
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Resolve version metadata
+      - name: Resolve version metadata (canonical tag ledger)
         id: meta
         shell: bash
-        env:
-          RUN_NUMBER: ${{ github.run_number }}
         run: |
           set -euo pipefail
-          base_version_code=$(grep -E '^[[:space:]]+versionCode[[:space:]]*=' app/build.gradle.kts | head -1 | grep -oE '[0-9]+' | tail -1)
-          [[ -n "$base_version_code" ]] || { echo "::error::base versionCode unresolved"; exit 1; }
-          if [[ -n "${VERSION_CODE_OVERRIDE:-}" ]]; then
-            version_code="$VERSION_CODE_OVERRIDE"
-          elif [[ "${CHANNEL}" == "dev" ]]; then
-            # Dev uploads to the Play `internal` track under the base applicationId, so it burns
-            # Play versionCodes from the same namespace as beta/prod. `run_number` alone was below
-            # the already-published beta code; base+run is monotonic for dev runs while keeping the
-            # value obvious. Next beta tag must be bumped above the latest dev code.
-            version_code=$((base_version_code + RUN_NUMBER))
-          else
-            version_code="$base_version_code"
-          fi
+          # CANONICAL versionCode = max(app-v* tag ledger, build.gradle.kts floor) + 1.
+          # The git `app-v<N>` tags are the running ledger (shared by beta+dev). The build.gradle.kts
+          # versionCode is a SAFETY FLOOR: if the tag fetch ever returns nothing, we still never emit a
+          # code below the last shipped one (which would make Play reject and F-Droid stop updating).
+          git fetch --tags --force >/dev/null 2>&1 || true
+          base_code=$(grep -E '^[[:space:]]+versionCode[[:space:]]*=' app/build.gradle.kts | head -1 | grep -oE '[0-9]+' | tail -1)
+          [[ -n "$base_code" ]] || { echo "::error::base versionCode unresolved from build.gradle.kts"; exit 1; }
+          ledger_code=$(git tag -l 'app-v*' | sed -nE 's/^app-v([0-9]+)$/\1/p' | sort -n | tail -1)
+          ledger_code=${ledger_code:-0}
+          floor=$(( ledger_code > base_code ? ledger_code : base_code ))
+          version_code=$(( floor + 1 ))
           version_name=$(grep -E '^[[:space:]]+versionName[[:space:]]*=' app/build.gradle.kts | head -1 | sed -E 's/.*"(.*)".*/\1/')
           short_sha=$(git rev-parse --short HEAD)
           full_sha=$(git rev-parse HEAD)
-          [[ -n "$version_code" ]] || { echo "::error::versionCode unresolved"; exit 1; }
+          release_tag="app-v${version_code}"
           [[ -n "$version_name" ]] || { echo "::error::versionName unresolved"; exit 1; }
           {
             echo "version_code=$version_code"
             echo "version_name=$version_name"
             echo "short_sha=$short_sha"
             echo "full_sha=$full_sha"
+            echo "release_tag=$release_tag"
           } >> "$GITHUB_OUTPUT"
-          echo "::notice title=Build::channel=${CHANNEL} versionCode=${version_code} versionName=${version_name} sha=${short_sha} label='${APP_LABEL:-<default>}'"
+          echo "::notice title=Build::channel=${CHANNEL} versionCode=${version_code} (ledger=${ledger_code} floor=${base_code}) versionName=${version_name} tag=${release_tag} sha=${short_sha} label='${APP_LABEL:-<default>}'"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
@@ -269,21 +234,18 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          GRADLE_ARGS=(--no-daemon --stacktrace)
+          # Both channels now carry a ledger-allocated versionCode → always inject the override (into
+          # the F-Droid flavor AND the Play prod-flavor build, which share GRADLE_ARGS).
+          GRADLE_ARGS=(--no-daemon --stacktrace "-PversionCodeOverride=${EFFECTIVE_VERSION_CODE}")
           [[ -n "${APP_LABEL:-}" ]] && GRADLE_ARGS+=("-PappLabel=${APP_LABEL}")
-          if [[ "${CHANNEL}" == "dev" ]]; then
-            GRADLE_ARGS+=("-PversionCodeOverride=${EFFECTIVE_VERSION_CODE}")
-          fi
-          # F-Droid artefact: the channel flavor (suffixed appId, except prod=base). dev gets a
-          # computed override so each dispatch is a new F-Droid version and the Play internal
-          # artefact uses the same visible build number.
+          # F-Droid artefact: the channel flavor (suffixed appId .beta/.dev).
           ./gradlew ":app:assemble${FDROID_FLAVOR}Release" "${GRADLE_ARGS[@]}"
-          # Play artefact: base applicationId (prod flavor), only for channels that upload to Play.
+          # Play artefact: base applicationId (prod flavor), uploaded to the channel's track.
           if [[ "${PLAY_UPLOAD}" == "true" ]]; then
             ./gradlew ":app:bundleProdRelease" ":app:assembleProdRelease" "${GRADLE_ARGS[@]}"
           fi
 
-      - name: Verify signatures + package/label (CI check)
+      - name: Verify signatures + package/label/versionCode (CI check)
         shell: bash
         run: |
           set -euo pipefail
@@ -301,9 +263,9 @@ jobs:
             badging="$("$AAPT2" dump badging "$apk")"
             grep -q "package: name='${want_pkg}'" <<<"$badging" || {
               echo "::error::${apk}: package mismatch (want ${want_pkg})"; grep '^package:' <<<"$badging"; exit 1; }
-            # Assert the BUILT versionCode matches what we advertise (Codex P2): a dispatch on a ref
-            # without -PversionCodeOverride support would silently keep the checked-out code while we
-            # report run_number for naming + the F-Droid dispatch → duplicate/non-monotonic dev versions.
+            # Assert the BUILT versionCode matches the ledger code we advertise: a ref that lacks
+            # -PversionCodeOverride support would silently keep the checked-out code, diverging from the
+            # code we tag, upload to Play and tell F-Droid.
             vc="$(sed -nE "s/.*versionCode='([0-9]+)'.*/\1/p" <<<"$badging" | head -1)"
             [[ "$vc" == "$EXPECTED_VC" ]] || {
               echo "::error::${apk}: versionCode mismatch (apk=${vc}, expected=${EXPECTED_VC}) — ref may lack -PversionCodeOverride support"; exit 1; }
@@ -330,7 +292,7 @@ jobs:
           set -euo pipefail
           mkdir -p release-artefacts
           V="v${{ steps.meta.outputs.version_code }}-${{ steps.meta.outputs.short_sha }}"
-          # F-Droid APK (suffixed appId, except prod=base) — what redface2-fdroid downloads from the Release.
+          # F-Droid APK (suffixed appId) — what redface2-fdroid downloads from the Release.
           fdroid_apk="$(ls app/build/outputs/apk/${FDROID_DIR}/release/*.apk | head -1)"
           fdroid_dest="release-artefacts/redface2-fdroid-${CHANNEL}-${V}.apk"
           cp "$fdroid_apk" "$fdroid_dest"
@@ -353,7 +315,7 @@ jobs:
           if-no-files-found: error
 
       - name: Publish to Play Console
-        # Only channels with play_upload (beta/dev/prod). Skips cleanly when the SA secret is absent.
+        # beta → track `beta`, dev → track `internal`. Skips cleanly when the SA secret is absent.
         if: ${{ env.PLAY_UPLOAD == 'true' && steps.service_account.outputs.path != '' }}
         uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5  # v1.1.5
         with:
@@ -369,44 +331,32 @@ jobs:
         shell: bash
         run: rm -f "${RUNNER_TEMP}/upload.jks" "${RUNNER_TEMP}/play-service-account.json" || true
 
-      - name: Create dev pre-release (dev channel)
-        # dev has no Release of its own; create one (tag app-dev-v<run>) so the F-Droid publisher has a
-        # source. always() + staged guard so a Play hiccup never hides the signed artefacts. Its published event
-        # is a no-op (resolve-target requires app-v*, which app-dev-v* does not match).
-        if: ${{ always() && needs.resolve-target.outputs.creates_dev_release == 'true' && steps.artefacts.outcome == 'success' }}
+      - name: Create GitHub Release (artifact source for F-Droid)
+        # The workflow OWNS the release now (no maintainer-published trigger). Always create the
+        # prerelease app-v<code> with the signed artefacts — always() + staged guard so a Play hiccup
+        # never hides them (the documented recovery path). No `on: release` trigger exists, so the
+        # published event is a deliberate no-op (it cannot re-enter this workflow).
+        if: ${{ always() && steps.artefacts.outcome == 'success' }}
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.resolve-target.outputs.release_tag }}
+          tag_name: ${{ steps.meta.outputs.release_tag }}
           # The COMMIT ACTUALLY BUILT (the checked-out HEAD), not github.sha — a dispatch with `ref`
           # set to another branch/tag builds that ref, so tagging github.sha would break provenance.
           target_commitish: ${{ steps.meta.outputs.full_sha }}
-          name: Redface 2 dev (build ${{ steps.meta.outputs.version_code }})
-          body: "Build dev automatique (canal interne Play + F-Droid `.dev`). Non destiné au grand public."
+          name: ${{ needs.resolve-target.outputs.app_label }} (build ${{ steps.meta.outputs.version_code }})
+          body: |
+            Build automatique — canal **${{ needs.resolve-target.outputs.channel }}**.
+            Play track `${{ needs.resolve-target.outputs.play_track }}` + F-Droid `${{ needs.resolve-target.outputs.fdroid_package }}`.
+            versionCode ${{ steps.meta.outputs.version_code }} · versionName ${{ steps.meta.outputs.version_name }} · ${{ steps.meta.outputs.short_sha }}.
+            Non destiné au grand public.
           prerelease: true
           files: release-artefacts/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Attach artefacts to the GitHub Release (beta/prod)
-        # The Release already exists (the maintainer published it = the trigger); UPDATE it with the
-        # signed AAB+APK (Play base) and the F-Droid suffixed APK. always() + staged guard so the assets
-        # are attached even if the Play upload step failed (the documented recovery path).
-        if: ${{ always() && needs.resolve-target.outputs.is_release_event == 'true' && steps.artefacts.outcome == 'success' }}
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ needs.resolve-target.outputs.release_tag }}
-          files: |
-            release-artefacts/*.aab
-            release-artefacts/*.apk
-          # Preserve the pre-release flag on update (softprops defaults it to false otherwise).
-          prerelease: ${{ needs.resolve-target.outputs.channel == 'beta' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   # ──────────────────────────────────────────────────────────────────────
-  # Notify redface2-fdroid (beta/dev/release — never 'none'). Plain ubuntu runner (native gh, #219).
-  # always() + explicit result checks: the skipped prod-gate job otherwise poisons the implicit
-  # success() through `build` and silently skips this job (the bug that left F-Droid stuck at v68).
+  # Notify redface2-fdroid (beta/dev). Plain ubuntu runner (native gh, #219).
+  # always() + explicit result checks so a transient skip upstream never silently drops the notify.
   # ──────────────────────────────────────────────────────────────────────
   notify-fdroid:
     name: Notify F-Droid publisher
@@ -426,7 +376,7 @@ jobs:
       - name: Trigger F-Droid publish
         env:
           GH_TOKEN: ${{ steps.fdroid_app_token.outputs.token }}
-          TAG: ${{ needs.resolve-target.outputs.release_tag }}
+          TAG: ${{ needs.build.outputs.release_tag }}
           CHANNEL: ${{ needs.resolve-target.outputs.fdroid_channel }}
           PACKAGE_NAME: ${{ needs.resolve-target.outputs.fdroid_package }}
           APK_FILENAME: ${{ needs.build.outputs.fdroid_apk }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,9 +159,14 @@ jobs:
           set -euo pipefail
           # CANONICAL versionCode = max(app-v* tag ledger, build.gradle.kts floor) + 1.
           # The git `app-v<N>` tags are the running ledger (shared by beta+dev). The build.gradle.kts
-          # versionCode is a SAFETY FLOOR: if the tag fetch ever returns nothing, we still never emit a
-          # code below the last shipped one (which would make Play reject and F-Droid stop updating).
-          git fetch --tags --force >/dev/null 2>&1 || true
+          # versionCode is a SAFETY FLOOR for the all-tags-missing case only.
+          # FAIL CLOSED on a fetch error: once the ledger has advanced past the floor, allocating from a
+          # stale/partial tag set would reuse or lower a code (Play rejects, F-Droid stops updating). The
+          # tags are the source of truth, so a refresh failure must abort, not silently fall back (Codex P2).
+          git fetch --tags --force --prune origin >/dev/null 2>&1 || {
+            echo "::error::tag ledger fetch failed — refusing to allocate a versionCode from possibly stale tags"
+            exit 1
+          }
           base_code=$(grep -E '^[[:space:]]+versionCode[[:space:]]*=' app/build.gradle.kts | head -1 | grep -oE '[0-9]+' | tail -1)
           [[ -n "$base_code" ]] || { echo "::error::base versionCode unresolved from build.gradle.kts"; exit 1; }
           ledger_code=$(git tag -l 'app-v*' | sed -nE 's/^app-v([0-9]+)$/\1/p' | sort -n | tail -1)
@@ -314,28 +319,15 @@ jobs:
           retention-days: 30
           if-no-files-found: error
 
-      - name: Publish to Play Console
-        # beta → track `beta`, dev → track `internal`. Skips cleanly when the SA secret is absent.
-        if: ${{ env.PLAY_UPLOAD == 'true' && steps.service_account.outputs.path != '' }}
-        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5  # v1.1.5
-        with:
-          serviceAccountJson: ${{ steps.service_account.outputs.path }}
-          packageName: ${{ env.PLAY_PACKAGE }}
-          releaseFiles: ${{ steps.artefacts.outputs.play_aab }}
-          tracks: ${{ env.PLAY_TRACK }}
-          status: ${{ env.PLAY_STATUS }}
-          whatsNewDirectory: app/src/main/play/whatsnew
-
-      - name: Cleanup keystore + service account
-        if: always()
-        shell: bash
-        run: rm -f "${RUNNER_TEMP}/upload.jks" "${RUNNER_TEMP}/play-service-account.json" || true
-
-      - name: Create GitHub Release (artifact source for F-Droid)
-        # The workflow OWNS the release now (no maintainer-published trigger). Always create the
-        # prerelease app-v<code> with the signed artefacts — always() + staged guard so a Play hiccup
-        # never hides them (the documented recovery path). No `on: release` trigger exists, so the
-        # published event is a deliberate no-op (it cannot re-enter this workflow).
+      - name: Create GitHub Release (ledger tag + artifact source for F-Droid)
+        # LEDGER-FIRST (Codex P2): the app-v<N> tag IS the versionCode ledger, so it must be persisted
+        # BEFORE any Play side effect. If we tagged AFTER Play, a successful Play upload followed by a
+        # runner cancellation / GitHub API failure would consume the code on Play without recording it →
+        # the next dispatch recomputes the same code and Play rejects it. Creating the tag first makes
+        # failure safe: either the tag exists (code consumed, move on) or it doesn't (code free, clean
+        # retry), and Play runs only once the allocation is durably recorded. always() + staged guard so
+        # the signed artefacts are always attached. No `on: release` trigger exists → the published event
+        # cannot re-enter this workflow.
         if: ${{ always() && steps.artefacts.outcome == 'success' }}
         uses: softprops/action-gh-release@v2
         with:
@@ -353,6 +345,24 @@ jobs:
           files: release-artefacts/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to Play Console
+        # beta → track `beta`, dev → track `internal`. Runs AFTER the ledger tag is recorded (above), so
+        # a Play upload never consumes a code that isn't in the ledger. Skips cleanly when SA is absent.
+        if: ${{ env.PLAY_UPLOAD == 'true' && steps.service_account.outputs.path != '' }}
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5  # v1.1.5
+        with:
+          serviceAccountJson: ${{ steps.service_account.outputs.path }}
+          packageName: ${{ env.PLAY_PACKAGE }}
+          releaseFiles: ${{ steps.artefacts.outputs.play_aab }}
+          tracks: ${{ env.PLAY_TRACK }}
+          status: ${{ env.PLAY_STATUS }}
+          whatsNewDirectory: app/src/main/play/whatsnew
+
+      - name: Cleanup keystore + service account
+        if: always()
+        shell: bash
+        run: rm -f "${RUNNER_TEMP}/upload.jks" "${RUNNER_TEMP}/play-service-account.json" || true
 
   # ──────────────────────────────────────────────────────────────────────
   # Notify redface2-fdroid (beta/dev). Plain ubuntu runner (native gh, #219).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,9 +25,11 @@ val hasCiSigningConfig =
 // the per-flavor defaults below apply.
 //   -PappLabel="Redface 2 β"  → forces the launcher label for the build (lets the prod flavor /
 //                                base applicationId carry the β/dev label on the Play track build).
-//   -PversionCodeOverride=N   → overrides versionCode for the dev channel only. Dev now uploads to
-//                                Play internal under the base applicationId AND to F-Droid `.dev`, so
-//                                the workflow computes an explicit code above the current base code.
+//   -PversionCodeOverride=N   → overrides versionCode for BOTH ship channels (beta+dev). The CD
+//                                (release.yml) computes N from the canonical git tag ledger
+//                                (max(app-v* tags, the floor below) + 1) and injects it into the Play
+//                                base-appId build AND the F-Droid suffixed build, so beta and dev
+//                                share one strictly-increasing versionCode sequence.
 val cliAppLabel = providers.gradleProperty("appLabel").orNull?.takeIf { it.isNotBlank() }
 val cliVersionCode = providers.gradleProperty("versionCodeOverride").orNull?.toIntOrNull()
 
@@ -36,10 +38,12 @@ android {
 
     defaultConfig {
         applicationId = "fr.forumhfr.redface2"
-        // Bump versionCode + versionName at every release. Play Console rejects any AAB
-        // whose versionCode is already uploaded, so this is the canonical source of truth
-        // (the local signing init-script no longer overrides these — it only injects the
-        // upload signing config).
+        // versionCode: the CANONICAL source at ship time is the git `app-v<N>` tag ledger — the CD
+        // injects `-PversionCodeOverride=max(app-v* tags, this floor)+1` (release.yml). The literal
+        // below is therefore (a) the value used by LOCAL builds without the prop, and (b) a SAFETY
+        // FLOOR for the CD: it must stay ≥ nothing-special but bumping it can never lower a shipped
+        // code. versionName is the human marketing version, decoupled from versionCode.
+        // (The local signing init-script does not override these — it only injects the upload config.)
         //
         // Naming convention (effective v39 / 0.2.0): pure semver `MAJOR.MINOR.PATCH`,
         // detached from the spec/site version (`docs/_config.yml`). The previous

--- a/docs/guides/release.md
+++ b/docs/guides/release.md
@@ -7,30 +7,41 @@ nav_order: 5
 
 # Release et publication Play Console
 
-Comment construire les artefacts signés et les publier sur le bon canal depuis GitHub Actions. **Depuis #233, le canal est déterminé par le déclencheur.** Deux modèles distincts car **Play et F-Droid sont des stores indépendants** (artefacts séparés) :
+Comment construire les artefacts signés et les publier sur le bon canal depuis GitHub Actions. **Depuis #304, un seul déclencheur : `workflow_dispatch` avec un input `channel` (`beta` | `dev`).** Plus de GitHub Release à publier à la main. Deux modèles de distribution distincts car **Play et F-Droid sont des stores indépendants** (artefacts séparés) :
 
 - **Play** : **une seule app** (`fr.forumhfr.redface2`, un seul applicationId), distribuée via **tracks**. Le **label du lanceur** change par build (`-PappLabel`), pas l'applicationId.
-- **F-Droid** : **un applicationId par canal** (`.beta`/`.dev`/base) → des **apps distinctes coexistantes** (F-Droid indexe par package, pas de tracks).
+- **F-Droid** : **un applicationId par canal** (`.beta`/`.dev`) → des **apps distinctes coexistantes** (F-Droid indexe par package, pas de tracks).
 
-| Déclencheur | Canal | Play | F-Droid |
-|---|---|---|---|
-| GitHub Release **pre-release** `app-v<N>` | **beta** | `fr.forumhfr.redface2`, label « Redface 2 β », track **open testing** | package `fr.forumhfr.redface2.beta` (« Redface 2 β ») |
-| **`workflow_dispatch`** | **dev** | `fr.forumhfr.redface2`, label « Redface 2 dev », track **internal testing** | package `fr.forumhfr.redface2.dev` (« Redface 2 dev ») |
-| GitHub Release **stable** `app-v<N>` *(différé)* | **prod** | track **production** (`draft`, après gate `production`) | package base `fr.forumhfr.redface2` |
+| Input `channel` | Play | F-Droid |
+|---|---|---|
+| **`beta`** | `fr.forumhfr.redface2`, label « Redface 2 β », track **open testing** | package `fr.forumhfr.redface2.beta` (« Redface 2 β ») |
+| **`dev`** | `fr.forumhfr.redface2`, label « Redface 2 dev », track **internal testing** | package `fr.forumhfr.redface2.dev` (« Redface 2 dev ») |
 
-En pratique pré-1.0, les canaux actifs sont **beta** et **dev**. Le canal **prod/release** reste codé et documenté, mais il est différé : ne pas publier de Release GitHub stable tant que la beta n'est pas jugée prête.
+Le canal **prod/stable** est **mis de côté pour l'instant** (#302/#304) : il n'est plus câblé dans le workflow. Sa conception (gate d'approbation `production` + track production) reste récupérable dans l'historique git.
 
-Le canal **dev** n'a pas de Release maintainer propre : le run dispatch **auto-crée une Release pre-release `app-dev-v<run_number>`** (avec les artefacts signés, dont l'APK F-Droid `.dev`) pour que le publisher F-Droid ait une source. Côté Play, dev utilise le **même applicationId** que beta/prod (`fr.forumhfr.redface2`) sur le track `internal`, donc il consomme aussi le namespace Play des `versionCode`.
+**Chaque dispatch crée lui-même une Release pre-release `app-v<N>`** portant les artefacts signés (AAB Play + APK F-Droid du canal), pour que le publisher F-Droid ait une source. Comme le workflow n'a plus de trigger `on: release`, cette Release auto-créée ne re-déclenche rien.
 
-⚠️ **Le tag `app-v<N>` seul ne déclenche plus la CD** : il faut **publier une GitHub Release** (pre-release pour beta, stable pour prod). Une Release dont le tag ne commence pas par `app-v` (les `v0.x` specs **et** les `app-dev-v*` auto-créées) est **ignorée** (gate `resolve-target`).
+### versionCode — registre canonique partagé (le cœur du modèle)
+
+Le `versionCode` est un **compteur unique, monotone, partagé par beta ET dev** : l'ensemble des tags git **`app-v<N>`** EST le registre. À chaque ship, la CD calcule :
+
+```
+versionCode = max( plus grand tag app-v<N> , plancher versionCode de build.gradle.kts ) + 1
+```
+
+Conséquences :
+- **Aucun bump manuel** : un dispatch beta ou dev alloue automatiquement le code suivant et tague `app-v<N>`.
+- **Pas d'inversion beta↔dev** : les deux canaux tirent du **même** registre, donc la suite est globalement croissante quel que soit l'ordre des ships. (Play partage le namespace `versionCode` entre tracks d'une même app → c'est exactement ce qu'il faut.)
+- **Plancher de sécurité** : le `versionCode` de `app/build.gradle.kts` sert de borne basse — si le fetch des tags échouait, on n'émet jamais un code inférieur au dernier shippé (qui ferait rejeter Play / bloquer F-Droid).
+- Le `versionName` (`app/build.gradle.kts`) reste la version « marketing » humaine, **découplée** du `versionCode`.
 
 Workflow source : [`.github/workflows/release.yml`](https://github.com/ForumHFR/redface2/blob/main/.github/workflows/release.yml).
 
 ## Conventions
 
-- **Tag namespace** : les releases app utilisent `app-v<versionCode>` (ex: `app-v32`, `app-v33`). Cela évite de collisionner avec les tags `v0.x.0` du site / des specs.
-- **Tag dev** : le canal dev utilise `app-dev-v<run_number>` (auto-créé par le run dispatch), distinct de `app-v<N>` pour ne pas re-déclencher la CD.
-- **Routing (figé dans `resolve-target`)** : prerelease → beta (Play track `beta` + F-Droid `.beta`) ; dispatch → dev (Play track `internal` + F-Droid `.dev`) ; stable → prod différé (Play track `production`, gate + F-Droid base). Le **label** (`-PappLabel`) et le **versionCode** (`-PversionCodeOverride`, dev seulement) sont injectés au build ; un **check CI** (`aapt2 dump badging`) vérifie package + label de chaque APK avant publication.
+- **Tag = registre** : chaque ship (beta ou dev) crée un tag `app-v<versionCode>` (ex: `app-v73`). Cet ensemble de tags est la source canonique du compteur. (Les `v0.x.0` du site/specs et les anciens `app-dev-v*` ne matchent pas `^app-v[0-9]+$` et sont ignorés du calcul.)
+- **Routing (`resolve-target`)** : `channel=beta` → Play track `beta` + F-Droid `.beta` ; `channel=dev` → Play track `internal` + F-Droid `.dev`. Le **label** (`-PappLabel`) et le **versionCode** (`-PversionCodeOverride`, calculé depuis le registre) sont injectés au build des deux artefacts ; un **check CI** (`aapt2 dump badging`) vérifie package + label + **versionCode** de chaque APK avant publication.
+- **Sérialisation** : le `concurrency: group: release` (sans `cancel-in-progress`) sérialise les runs pour que deux dispatches n'allouent jamais le même code.
 
 ## Pré-requis (à faire une fois)
 
@@ -80,55 +91,45 @@ Le workflow refuse de tourner si `UPLOAD_KEYSTORE_BASE64` est manquant (un build
 
 ## Flux beta — open testing (public)
 
-1. Bumper `versionCode` + `versionName` dans `app/build.gradle.kts` (sur `main`), mettre à jour `app/CHANGELOG.md`, merger la PR de release.
-2. Sur `main`, **publier une GitHub Release pre-release** sur un tag `app-v<N>` :
+**GitHub → Actions → Release → Run workflow → `channel = beta`** (ou `gh workflow run release.yml -f channel=beta`). La CD :
 
-```bash
-git switch main && git pull --ff-only
-gh release create app-v72 --prerelease --title 'Redface 2 v72 (0.4.0-beta)' --notes '…'
-```
+- alloue le `versionCode` depuis le registre de tags (`max(app-v*, plancher)+1`) ;
+- build `:app:bundleProdRelease -PappLabel="Redface 2 β" -PversionCodeOverride=<N>` (Play, base appId, label β) + `:app:assembleBetaRelease -PversionCodeOverride=<N>` (F-Droid, `fr.forumhfr.redface2.beta`) ;
+- upload Play sur le **track `beta` (open testing)** en `completed` ;
+- crée la Release pre-release `app-v<N>` avec AAB+APK Play **et** l'APK F-Droid `.beta` ;
+- notifie F-Droid (package `.beta`).
 
-La CD résout **beta** : build `:app:bundleProdRelease -PappLabel="Redface 2 β"` (Play, base appId, label β) + `:app:assembleBetaRelease` (F-Droid, `fr.forumhfr.redface2.beta`). Upload Play sur le **track `beta` (open testing)** `completed`, attache AAB+APK Play **et** l'APK F-Droid `.beta` à la Release, notifie F-Droid (package `.beta`).
-
-## Flux prod — production
-
-Idem mais **Release stable** (case « pre-release » décochée) :
-
-```bash
-gh release create app-v73 --title 'Redface 2 v73 (1.0.0)' --notes '…'
-```
-
-La CD résout **prod** et **attend l'approbation** dans l'Environment GitHub `production` (required reviewer) avant tout build/upload. Build `:app:bundleProdRelease` (label par défaut « Redface 2 »), upload sur le **track `production`** en **statut `draft`** (double garde-fou : approbation GitHub + activation manuelle Play). F-Droid : package base `fr.forumhfr.redface2`. **Différé** : aucune Release stable n'est publiée tant que la beta n'est pas validée.
+Plus besoin de bumper `versionCode` à la main ni de publier une Release : le dispatch fait tout. (Mettre à jour `app/CHANGELOG.md` + `versionName` reste utile pour une vraie montée de version marketing.)
 
 ## Flux dev — Play internal + F-Droid `.dev` (rapide)
 
-**GitHub → Actions → Release → Run workflow** (ou `gh workflow run release.yml -f ref=<branche>`). La CD résout **dev** :
+**GitHub → Actions → Release → Run workflow → `channel = dev`** (défaut ; ou `gh workflow run release.yml -f channel=dev -f ref=<branche>`). Identique au flux beta mais :
 
-- Play : build `:app:bundleProdRelease -PappLabel="Redface 2 dev" -PversionCodeOverride=<code_dev>` (`fr.forumhfr.redface2`), upload sur track **`internal`** en `completed`.
-- F-Droid : build `:app:assembleDevRelease -PappLabel="Redface 2 dev" -PversionCodeOverride=<code_dev>` (`fr.forumhfr.redface2.dev`), auto-crée une Release pre-release `app-dev-v<run_number>` avec les artefacts signés, puis notifie F-Droid (package `.dev`).
+- Play : track **`internal`** au lieu de `beta`, label « Redface 2 dev ».
+- F-Droid : `:app:assembleDevRelease` → package `fr.forumhfr.redface2.dev`.
 
-Seul input : `ref` (défaut = ref courant). Les artefacts sont aussi téléchargeables depuis le run Actions (30 j) pour le sideload.
+Inputs : `channel` (`dev` par défaut) et `ref` (défaut = ref courant, pour builder une branche). Les artefacts sont aussi téléchargeables depuis le run Actions (30 j) pour le sideload.
 
-ℹ️ **versionCode dev** : le track Play `internal` partage le namespace de `versionCode` avec `beta` et `production`, car c'est la même app `fr.forumhfr.redface2`. La CD calcule donc le code dev après checkout : `versionCode` suivi dans `app/build.gradle.kts` + `github.run_number`. Cela évite le cas réel où `run_number` seul était inférieur au dernier build Play. Conséquence assumée : un build dev **brûle** un `versionCode` Play ; le prochain tag beta `app-v<N>` doit avoir `N` strictement supérieur au dernier code dev publié.
+## Flux prod — production (différé)
+
+**Mis de côté pour l'instant** (#302/#304). Le workflow ne propose plus que `beta`/`dev`. Quand on voudra (re)brancher la production (gate d'approbation `production` + track `production` en `draft`), repartir de la conception conservée dans l'historique git du workflow et dans le draft `drafts/claude-cd-channels-labels-fdroid-design.md`.
 
 ## Bump de version : convention
 
-Le `versionCode` est strictement croissant. Play Console rejette tout AAB dont le `versionCode` a déjà été uploadé (sur n'importe quel track), même si la release a été archivée. Un slot consommé est consommé.
+Le `versionCode` est strictement croissant et **géré automatiquement** par le registre de tags `app-v<N>` (cf. § versionCode ci-dessus). Play Console rejette tout AAB dont le `versionCode` a déjà été uploadé (sur n'importe quel track) — le registre garantit qu'on n'en réutilise jamais un.
 
 | Cas | Action |
 |---|---|
-| Release officielle Phase N+1 | bump majeur du `versionName` (ex: `0.1.0-phase1.4` → `0.2.0-phase2.0`) |
-| Release intermédiaire dans la même phase | bump du suffixe (ex: `0.1.0-phase1.1` → `0.1.0-phase1.2`) |
-| Build dev Play internal | pas besoin de PR de bump avant le dispatch ; la CD injecte un code dev. En revanche, le prochain `app-v<N>` beta doit être supérieur au dernier code dev consommé. |
-| Build dogfood non distribué hors Play | bumper malgré tout si distribué publiquement, marquer comme `burnt` dans `app/CHANGELOG.md` si un slot Play a été consommé |
+| Ship beta ou dev | **rien à faire** côté `versionCode` : la CD alloue le suivant depuis le registre et tague `app-v<N>`. |
+| Montée de version marketing (Phase N+1, milestone) | bumper le `versionName` dans `app/build.gradle.kts` + `app/CHANGELOG.md` via PR. Le `versionCode` reste piloté par le registre. |
+| Plancher `versionCode` de `build.gradle.kts` | ne le baisser jamais ; il sert de borne basse de sécurité. Le bumper est inutile en régime normal (le registre est au-dessus). |
 
 ## Promotion entre tracks
 
-Comme tout est l'app unique `fr.forumhfr.redface2`, **la promotion native Play fonctionne** entre ses tracks (internal → open testing → production). Mais attention à la **cohérence multi-canaux** (F-Droid + Release GitHub) :
+Comme tout est l'app unique `fr.forumhfr.redface2`, **la promotion native Play fonctionne** entre ses tracks (internal → open testing → production). Le canal prod étant différé, en pré-1.0 on reste sur `internal` (dev) et `open testing` (beta), tous deux via dispatch.
 
-- **Voie recommandée beta → prod = publier une Release GitHub *stable*** (case pre-release décochée) sur un nouveau tag `app-v<N>`. Elle déclenche **toute** l'automatisation : gate d'approbation `production`, upload Play **production**, **notification F-Droid (release)**, et la Release GitHub passe en stable. C'est le seul chemin qui garde Play, F-Droid et les artefacts GitHub **alignés**. (Le binaire peut être identique à la bêta — bumper le versionCode et republier ; le rendu utilisateur ne change pas.)
-- **Promote release dans Play Console** (open testing → production) reste possible et pratique *côté Play uniquement*, mais ⚠️ **bypasse l'automatisation** : pas de passage par la gate GitHub, **F-Droid n'est pas notifié**, et la Release GitHub bêta reste *pre-release*. À réserver à un hotfix Play urgent ; sinon F-Droid et les métadonnées publiques restent en retard sur Play prod.
-- Le `workflow_dispatch` ne sert qu'au canal **dev** (Play internal + F-Droid `.dev`) — pas un outil de promotion beta/prod.
+- **Promote dans Play Console** (internal → open testing, ou open testing → production) reste possible *côté Play uniquement*, mais ⚠️ **bypasse l'automatisation** : **F-Droid n'est pas notifié** et la Release GitHub n'est pas mise à jour. À réserver à un cas Play urgent ; sinon re-dispatcher sur le bon canal garde Play + F-Droid + GitHub **alignés** (le binaire peut être identique — le registre alloue juste un nouveau `versionCode`).
+- Le `workflow_dispatch` est désormais l'**unique** porte d'entrée de la CD (canal choisi par l'input `channel`).
 
 ## Pourquoi `r0adkll/upload-google-play` plutôt que `gradle-play-publisher`
 
@@ -146,8 +147,8 @@ Procédure : voir [docs Play Console — Reset upload key](https://support.googl
 
 Si l'étape `Publish to Play Console` du workflow échoue (auth Play, quota, track invalide…) **après** que la signature ait réussi, l'AAB et l'APK signés sont déjà stagés. Deux façons de les récupérer sans relancer le build :
 
-1. **Workflow artefacts** : aller sur la page Actions → run en échec → en bas du job `build`, télécharger l'archive `redface2-<canal>-v<N>-<sha>` (rétention 30 jours). Chemin standard pour tous les canaux (beta/prod/dev).
-2. **GitHub Release** : pour beta/prod, le step `Attach artefacts to the GitHub Release` met à jour la Release `app-v<N>` existante. Pour dev, le workflow crée `app-dev-v<run_number>`. Dans les deux cas, si le build + la signature ont passé, les artefacts signés sont disponibles même si Play a refusé. Après avoir corrigé la cause (permissions Play, premier upload manuel du listing, etc.), l'upload manuel via la Play Console UI depuis l'AAB téléchargé évite de re-bumper le `versionCode`.
+1. **Workflow artefacts** : aller sur la page Actions → run en échec → en bas du job `build`, télécharger l'archive `redface2-<canal>-v<N>-<sha>` (rétention 30 jours). Chemin standard pour les deux canaux (beta/dev).
+2. **GitHub Release** : le step `Create GitHub Release` crée la Release pre-release `app-v<N>` (`always()` + garde sur la signature) **même si l'upload Play a échoué** ensuite — les artefacts signés y sont attachés. Après avoir corrigé la cause (permissions Play, premier upload manuel du listing, etc.), l'upload manuel via la Play Console UI depuis l'AAB téléchargé évite de consommer un nouveau `versionCode`.
 
 Si la signature elle-même échoue (`keytool -list` ou `jarsigner -verify`), aucun artefact n'est produit — refixer le secret keystore avant de retenter.
 
@@ -155,7 +156,7 @@ Si la signature elle-même échoue (`keytool -list` ou `jarsigner -verify`), auc
 
 | Symptôme | Cause probable | Fix |
 |---|---|---|
-| `versionCode XX has already been used` | Slot consommé sur un build local précédent | Bumper `versionCode` dans `app/build.gradle.kts` |
+| `versionCode XX has already been used` | Un build local/manuel a consommé un code hors registre, ou un tag `app-v<N>` a été supprimé | Vérifier le plus grand tag `app-v<N>` ; au besoin bumper le plancher `versionCode` de `app/build.gradle.kts` au-dessus du code consommé |
 | `403 Service account does not have permission` | Permissions Play Console pas accordées | Refaire l'étape 1.5 du pré-requis |
 | `INVALID_ARGUMENT: package fr.forumhfr.redface2 not found` | Premier upload manuel pas fait | Faire l'étape 2 du pré-requis |
 | AAB non signé en sortie de CD | Secret `UPLOAD_KEYSTORE_BASE64` manquant ou corrompu | Re-provisionner avec `base64 -w0` (pas de retours à la ligne) |

--- a/drafts/claude-cd-channels-labels-fdroid-design.md
+++ b/drafts/claude-cd-channels-labels-fdroid-design.md
@@ -184,3 +184,26 @@ Contraintes assumées :
 - F-Droid garde des packages distincts `.beta` / `.dev` pour permettre l'installation côte à côte.
 - Dev Play internal partage le namespace de `versionCode` avec beta/prod. La CD calcule donc un `versionCode` dev après checkout (`base versionCode` + `github.run_number`) et l'injecte dans le build Play **et** F-Droid dev via `-PversionCodeOverride`.
 - Après un dispatch dev, le prochain tag beta `app-v<N>` doit utiliser un `N` strictement supérieur au dernier `versionCode` dev consommé sur Play.
+
+## 14. Révision 4 — déclencheur unique + registre de tags `app-v` comme compteur (#304)
+
+Décision @XaaT (2026-06-06, même journée que rev. 3) : la rev. 3 marchait mais laissait **deux pièges** — (a) le `versionCode` dev `base + run_number` est asymétrique vs beta (`base` nu), donc après un ship dev toute beta est rejetée par Play tant qu'on ne leapfrogue pas le `versionCode` à la main (cliquet) ; (b) beta exigeait encore de publier une GitHub Release à la main avec bump manuel. On veut : **un compteur unique qui augmente à chaque ship, beta comme dev, sans geste manuel**, et l'intention de canal exprimée explicitement.
+
+Modèle rev. 4 (implémenté dans `release.yml`, documenté dans `docs/guides/release.md`) :
+
+| Canal | Déclencheur | Play | F-Droid |
+|---|---|---|---|
+| **beta** | `workflow_dispatch` `channel=beta` | `fr.forumhfr.redface2`, label « Redface 2 β », track **beta** | package `fr.forumhfr.redface2.beta` |
+| **dev** | `workflow_dispatch` `channel=dev` | `fr.forumhfr.redface2`, label « Redface 2 dev », track **internal** | package `fr.forumhfr.redface2.dev` |
+| **prod** *(différé)* | — (retiré du workflow) | — | — |
+
+Décisions actées :
+
+- **Déclencheur unique** : `workflow_dispatch` avec input `channel` (`beta`|`dev`). Le trigger `on: release` est **retiré** → plus de Release à publier à la main, plus de re-déclenchement par les Releases auto-créées. (« Oublions les releases. »)
+- **versionCode = registre de tags canonique** : `versionCode = max(tags app-v<N>, plancher versionCode build.gradle.kts) + 1`. Les tags `app-v<N>` sont le registre partagé ; chaque ship (beta ou dev) crée `app-v<N>`. **Plus de cliquet** : beta et dev tirent du même compteur monotone, aucune inversion possible.
+- **Plancher de sécurité** : le `versionCode` de `build.gradle.kts` est une borne basse (jamais émettre un code inférieur si le fetch de tags échoue). Ce n'est plus la source canonique, juste un défaut local + filet CI.
+- **Sérialisation** : `concurrency: group: release` (sans `cancel-in-progress`) → allocation de code atomique entre dispatches.
+- **Override sur les deux artefacts** : `-PversionCodeOverride` injecté dans le build Play (base appId) ET F-Droid (suffixé), pour beta comme dev.
+- **prod retiré** (différé) : la conception gated-production (job `await-prod-approval`, track `production`) reste dans l'historique git pour resurrection. Les §8/§13 ci-dessus la décrivent.
+
+Pièges rev. 3 supersédés par rev. 4 : (a) cliquet `base+run_number` → registre `max+1` symétrique ; (b) Release manuelle beta → dispatch `channel=beta`.


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Closes #304. Supersède l'approche de #303.

## Objectif

Un **`versionCode` unique, canonique, auto-incrémenté à chaque ship** (beta comme dev, sans geste manuel), l'intention de canal exprimée explicitement, beta + dev sur F-Droid. Le canal prod/release est mis de côté.

## Ce qui change

- **Déclencheur unique** : `workflow_dispatch` avec input `channel` (`beta` | `dev`). **Retrait de `on: release`** → plus de GitHub Release à publier à la main (« oublions les releases »). Les Releases auto-créées ne re-déclenchent donc rien.
- **versionCode = registre de tags canonique** : `max(tags app-v<N>, plancher versionCode build.gradle.kts) + 1`. Les tags `app-v<N>` sont le registre **partagé** beta+dev → suite globalement croissante, **plus de cliquet ni d'inversion** (le défaut de #303 : dev=`base+run`, beta=`base` → beta rejetée après tout dev).
- **Plancher de sécurité** : le `versionCode` de `build.gradle.kts` est une borne basse — un fetch de tags raté ne peut jamais produire un code inférieur au dernier shippé (qui ferait rejeter Play / bloquer F-Droid).
- **Override sur les 2 artefacts** : `-PversionCodeOverride` injecté dans le build Play (base appId) ET F-Droid (suffixé), pour les deux canaux.
- **Sérialisation** : `concurrency: group: release` (sans `cancel-in-progress`) → allocation de code atomique entre dispatches.
- **prod retiré** (différé) : job `await-prod-approval` + branche prod supprimés du workflow ; conception récupérable dans l'historique git (rev. 2/3 du draft).
- Docs `release.md` + draft CD (rev. 4) + commentaires `build.gradle.kts` alignés.

## Routing

| `channel` | Play | F-Droid |
|---|---|---|
| `beta` | base appId, label « Redface 2 β », track **open testing** | `fr.forumhfr.redface2.beta` |
| `dev` | base appId, label « Redface 2 dev », track **internal** | `fr.forumhfr.redface2.dev` |

## Validation

- ✅ YAML valide (`ruby -ryaml`).
- ✅ Dry-run de la logique de registre contre les tags réels : floor=72, max(app-v*)=72 (les `app-dev-v*` bien exclus) → prochain code **73** / tag `app-v73`.
- ✅ Self-review : aucune référence orpheline aux anciens outputs/jobs supprimés.
- ⚠️ **Non encore prouvé end-to-end** : l'upload Play réel (internal/beta) avec un code issu du registre ne se vérifie qu'au premier dispatch. Prévu juste après merge — un dispatch `dev` puis `beta` (ce que #303 n'avait pas exercé).

## Limitation connue (hors scope, à tracer si gênant)

Si l'étape « Publish to Play Console » échoue, le job échoue → `notify-fdroid` est skippé (F-Droid non notifié), mais la Release `app-v<N>` + artefacts signés sont créés (re-dispatch facile, le registre alloue un nouveau code). Découpler Play/F-Droid demanderait un `continue-on-error` qui masquerait les vraies erreurs Play — laissé tel quel.
