### PR TITLE
feat(topic): swipe gauche/droite pour changer de page + ressenti drag-follow (#282)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -756,14 +756,15 @@ private fun RedfaceNavHost(
                         )
                     },
                     onOpenPage = { targetPage ->
-                        backStack.removeAt(backStack.lastIndex)
-                        backStack.add(
-                            TopicRoute(
-                                cat = route.cat,
-                                post = route.post,
-                                page = targetPage,
-                                scrollTo = null,
-                            ),
+                        // #282 — replace the top entry IN PLACE rather than removeAt + add. The two-step
+                        // version briefly leaves the parent on top (size-1), an observable intermediate
+                        // state NavDisplay can start transitioning toward; an indexed set is a single
+                        // mutation straight from TopicRoute(page=N) to TopicRoute(page=target).
+                        backStack[backStack.lastIndex] = TopicRoute(
+                            cat = route.cat,
+                            post = route.post,
+                            page = targetPage,
+                            scrollTo = null,
                         )
                     },
                 )

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -503,13 +503,15 @@ private fun RedfaceNavHost(
                 backStack.removeAt(backStack.lastIndex)
             }
         },
-        // #282 — a topic page change (swipe) replaces the top TopicRoute with the same route at a
-        // new page; our gesture already slides the outgoing page off-screen, so the default 700 ms
-        // NavDisplay cross-fade is redundant AND keeps the incoming entry below RESUMED for its whole
-        // duration — exactly the window the swipe is gated off. Skipping it for TopicRoute→TopicRoute
-        // collapses that dead-zone to ~one frame. Every other transition keeps nav3's default.
+        // #282 — a topic page change (swipe) replaces the top TopicRoute with the same route at a new
+        // page; our gesture already slides the outgoing page off-screen, so the default 700 ms NavDisplay
+        // cross-fade is redundant AND keeps the incoming entry below RESUMED for its whole duration —
+        // exactly the window the swipe is gated off. Making the FORWARD topic→topic transition instant
+        // collapses that dead-zone to ~one frame. The pop direction ALWAYS cross-fades: a page change is
+        // always a forward in-place replace (never a pop), so a genuine back-pop never goes instant even
+        // if two TopicRoute entries ever coexist. Every other transition keeps nav3's default cross-fade.
         transitionSpec = { navContentTransform(initialState, targetState) },
-        popTransitionSpec = { navContentTransform(initialState, targetState) },
+        popTransitionSpec = { navCrossfade() },
         entryDecorators = listOf(
             rememberSaveableStateHolderNavEntryDecorator(),
             rememberViewModelStoreNavEntryDecorator(),
@@ -981,26 +983,40 @@ private fun resetStack(
 /** Default NavDisplay cross-fade duration, mirroring nav3 1.1.1 `defaultTransitionSpec` (700 ms). */
 private const val NAV_CROSSFADE_MILLIS = 700
 
+/** nav3 1.1.1 default transition: a 700 ms cross-fade (mirrors androidx `defaultTransitionSpec`). */
+private fun navCrossfade(): ContentTransform =
+    fadeIn(tween(NAV_CROSSFADE_MILLIS)) togetherWith fadeOut(tween(NAV_CROSSFADE_MILLIS))
+
 /**
- * Marks a [TopicRoute] NavEntry so [navContentTransform] can recognise a topic page change without
- * relying on the route type: nav3 1.1.1 exposes `Scene.key` as `route.toString()` (a String), not
- * the route object, so an `is TopicRoute` test on the scene key would never match. The entry's
- * public metadata is the stable signal instead.
+ * Marks a [TopicRoute] NavEntry so [isTopicScene] can recognise a topic scene without relying on the
+ * route type: nav3 1.1.1 exposes `Scene.key` as `route.toString()` (a String), not the route object,
+ * so an `is TopicRoute` test on the scene key would never match. The entry's public metadata is the
+ * stable signal instead.
  */
-private const val TOPIC_SCENE_METADATA_KEY = "fr.forumhfr.redface2.topicScene"
+internal const val TOPIC_SCENE_METADATA_KEY = "fr.forumhfr.redface2.topicScene"
+
+/**
+ * True iff [metadata] carries the topic-scene marker. Null/empty/other-keys/false → false. Extracted
+ * as a pure function so the marker contract (incl. the empty-`entries` → null case) is unit-testable
+ * without a Compose/nav3 runtime.
+ */
+internal fun isTopicSceneMetadata(metadata: Map<String, Any>?): Boolean =
+    metadata?.get(TOPIC_SCENE_METADATA_KEY) == true
 
 /** True when this scene's top entry is a [TopicRoute] (tagged via [TOPIC_SCENE_METADATA_KEY]). */
 private fun Scene<NavKey>.isTopicScene(): Boolean =
-    entries.lastOrNull()?.metadata?.get(TOPIC_SCENE_METADATA_KEY) == true
+    isTopicSceneMetadata(entries.lastOrNull()?.metadata)
 
 /**
- * ContentTransform for a NavDisplay transition: instant for a topic page change (see #282), and
- * nav3's default 700 ms cross-fade for every other navigation (preserved verbatim). A page change
- * is detected by both the outgoing and incoming scene being a topic scene.
+ * Forward ContentTransform for a NavDisplay transition: instant for a topic→topic FORWARD transition
+ * (the swipe page change is an in-place backStack replace — always forward, never a pop — collapsing
+ * the dead-zone, see #282), nav3's default 700 ms cross-fade otherwise. Only used for the forward
+ * direction; the pop direction always uses [navCrossfade]. A deep-link reset that swaps one topic for
+ * another while already in a topic would also be instant here, which is benign.
  */
 private fun navContentTransform(from: Scene<NavKey>, to: Scene<NavKey>): ContentTransform =
     if (from.isTopicScene() && to.isTopicScene()) {
         EnterTransition.None togetherWith ExitTransition.None
     } else {
-        fadeIn(tween(NAV_CROSSFADE_MILLIS)) togetherWith fadeOut(tween(NAV_CROSSFADE_MILLIS))
+        navCrossfade()
     }

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -5,6 +5,13 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.widget.Toast
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -30,6 +37,7 @@ import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.scene.Scene
 import androidx.navigation3.ui.NavDisplay
 import fr.forumhfr.redface2.BuildConfig
 import fr.forumhfr.redface2.R
@@ -495,6 +503,13 @@ private fun RedfaceNavHost(
                 backStack.removeAt(backStack.lastIndex)
             }
         },
+        // #282 — a topic page change (swipe) replaces the top TopicRoute with the same route at a
+        // new page; our gesture already slides the outgoing page off-screen, so the default 700 ms
+        // NavDisplay cross-fade is redundant AND keeps the incoming entry below RESUMED for its whole
+        // duration — exactly the window the swipe is gated off. Skipping it for TopicRoute→TopicRoute
+        // collapses that dead-zone to ~one frame. Every other transition keeps nav3's default.
+        transitionSpec = { navContentTransform(initialState, targetState) },
+        popTransitionSpec = { navContentTransform(initialState, targetState) },
         entryDecorators = listOf(
             rememberSaveableStateHolderNavEntryDecorator(),
             rememberViewModelStoreNavEntryDecorator(),
@@ -682,7 +697,7 @@ private fun RedfaceNavHost(
                     },
                 )
             }
-            entry<TopicRoute> { route ->
+            entry<TopicRoute>(metadata = mapOf(TOPIC_SCENE_METADATA_KEY to true)) { route ->
                 TopicScreen(
                     request = TopicRequest(
                         cat = route.cat,
@@ -962,3 +977,30 @@ private fun resetStack(
         backStack.add(route)
     }
 }
+
+/** Default NavDisplay cross-fade duration, mirroring nav3 1.1.1 `defaultTransitionSpec` (700 ms). */
+private const val NAV_CROSSFADE_MILLIS = 700
+
+/**
+ * Marks a [TopicRoute] NavEntry so [navContentTransform] can recognise a topic page change without
+ * relying on the route type: nav3 1.1.1 exposes `Scene.key` as `route.toString()` (a String), not
+ * the route object, so an `is TopicRoute` test on the scene key would never match. The entry's
+ * public metadata is the stable signal instead.
+ */
+private const val TOPIC_SCENE_METADATA_KEY = "fr.forumhfr.redface2.topicScene"
+
+/** True when this scene's top entry is a [TopicRoute] (tagged via [TOPIC_SCENE_METADATA_KEY]). */
+private fun Scene<NavKey>.isTopicScene(): Boolean =
+    entries.lastOrNull()?.metadata?.get(TOPIC_SCENE_METADATA_KEY) == true
+
+/**
+ * ContentTransform for a NavDisplay transition: instant for a topic page change (see #282), and
+ * nav3's default 700 ms cross-fade for every other navigation (preserved verbatim). A page change
+ * is detected by both the outgoing and incoming scene being a topic scene.
+ */
+private fun navContentTransform(from: Scene<NavKey>, to: Scene<NavKey>): ContentTransform =
+    if (from.isTopicScene() && to.isTopicScene()) {
+        EnterTransition.None togetherWith ExitTransition.None
+    } else {
+        fadeIn(tween(NAV_CROSSFADE_MILLIS)) togetherWith fadeOut(tween(NAV_CROSSFADE_MILLIS))
+    }

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/NavTransitionTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/NavTransitionTest.kt
@@ -1,0 +1,41 @@
+package fr.forumhfr.redface2.navigation
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the topic-scene marker contract used by the instant `TopicRoute → TopicRoute` NavDisplay
+ * transition (#282). The transition reads this marker off a scene's top NavEntry metadata; if the
+ * lookup silently returned the wrong answer the page-change would degrade to the 700 ms cross-fade
+ * (re-introducing the swipe dead-zone) without any crash. These cover the lookup + the edge cases
+ * (empty `entries` surfaces as a null metadata map).
+ */
+class NavTransitionTest {
+
+    @Test
+    fun `marker present and true is a topic scene`() {
+        assertTrue(isTopicSceneMetadata(mapOf(TOPIC_SCENE_METADATA_KEY to true)))
+    }
+
+    @Test
+    fun `null metadata is not a topic scene`() {
+        // entries.lastOrNull() on an empty scene yields null -> must be treated as non-topic.
+        assertFalse(isTopicSceneMetadata(null))
+    }
+
+    @Test
+    fun `empty metadata is not a topic scene`() {
+        assertFalse(isTopicSceneMetadata(emptyMap()))
+    }
+
+    @Test
+    fun `marker explicitly false is not a topic scene`() {
+        assertFalse(isTopicSceneMetadata(mapOf(TOPIC_SCENE_METADATA_KEY to false)))
+    }
+
+    @Test
+    fun `unrelated metadata keys are not a topic scene`() {
+        assertFalse(isTopicSceneMetadata(mapOf("some.other.key" to true)))
+    }
+}

--- a/drafts/claude-swipe-page-282-impl-prompt.md
+++ b/drafts/claude-swipe-page-282-impl-prompt.md
@@ -1,0 +1,75 @@
+# Prompt d'implémentation — #282 swipe gauche/droite pour changer de page de topic (Option A)
+
+> Non normatif (draft). Issu de l'analyse #282 + avis Codex gpt-5.5 xhigh (2026-06-06).
+
+## Objectif
+
+Permettre de changer de page d'un topic par **geste horizontal** (gauche = page suivante, droite = page précédente), **sans remonter en haut pour atteindre les boutons**. MVP **Option A** : le geste appelle le chemin de navigation EXISTANT `onOpenPage(page±1)` — aucun nouveau modèle de page, aucune modif repo/VM/nav.
+
+## Contraintes (à NE PAS violer)
+
+- **Pas de fetch authentifié de page voisine** (règle prefetch non-auth) → donc PAS de `HorizontalPager` avec VM voisin. Le geste ne fait que déclencher `onOpenPage`.
+- **Ne pas voler le scroll vertical** du `LazyColumn` ni le `horizontalScroll` de la grille de pages (`TopicPageNavigation`, item header du LazyColumn).
+- detekt : `LongParameterList` ≤ 5 params ; `ForbiddenImport` interdit `androidx.compose.material.*` et `androidx.lifecycle.LiveData`/`GlobalScope` (utiliser `androidx.compose.foundation.*` / `material3`).
+- Pas de claim « testé » sans exécution réelle.
+
+## Implémentation
+
+### 1. Helper pur et testable — `feature/topic/.../TopicSwipe.kt` (nouveau)
+
+```kotlin
+internal enum class HorizontalSwipe { LEFT, RIGHT }
+
+/**
+ * Page cible d'un swipe horizontal en lecture topic, ou null si le geste est bloqué (bord).
+ * LEFT = page suivante, RIGHT = page précédente. Pure → testée unitairement.
+ */
+internal fun swipeTargetPage(
+    currentPage: Int,
+    totalPages: Int,
+    swipe: HorizontalSwipe,
+): Int? = when (swipe) {
+    HorizontalSwipe.LEFT -> (currentPage + 1).takeIf { it <= totalPages }
+    HorizontalSwipe.RIGHT -> (currentPage - 1).takeIf { it >= 1 }
+}
+```
+
+### 2. Détecteur de geste — `feature/topic/.../TopicScreen.kt`
+
+> ⚠️ La grille de pages (`TopicPageNavigation`, avec `Modifier.horizontalScroll`) est l'**item header DANS** le `LazyColumn`. On ne peut donc pas « ne pas couvrir » la grille en posant le détecteur sur un conteneur dédié. Le détecteur est posé sur le `Box`/`LazyColumn` de `TopicLoadedContent` MAIS, étant **bas niveau et respectueux de la consommation**, il laisse la grille (enfant) consommer ses gestes horizontaux en premier (passe Main enfant→parent) et le `LazyColumn` gérer le scroll vertical.
+
+- API (validée Codex, **à confirmer Context7 « stable release » au moment de coder**) : `Modifier.pointerInput(currentPage, totalPages) { awaitEachGesture { ... } }` avec
+  `awaitFirstDown(requireUnconsumed = false)` → `awaitHorizontalTouchSlopOrCancellation(down.id) { change, _ -> /* ne consume QUE si on prend le geste */ }` → boucle `awaitHorizontalDragOrCancellation(pointerId)` en accumulant `totalDx` et en alimentant un `VelocityTracker` (`androidx.compose.ui.input.pointer.util.VelocityTracker`).
+  - `awaitHorizontalTouchSlopOrCancellation` ne se déclenche que sur **slop HORIZONTAL** → un drag vertical-dominant (scroll) ne l'active jamais (désambiguïsation d'axe gratuite). S'il renvoie null (geste annulé / consommé par un enfant comme la grille) → on abandonne sans naviguer.
+- **Décision en fin de geste** : commit si `abs(totalDx) >= max(72.dp.toPx(), size.width * 0.20f)` **ou** `abs(velocity.x) >= 900.dp.toPx()` (px/s ; `size` et `Density` dispo dans `PointerInputScope`). Sinon no-op.
+  - `totalDx < 0` (drag vers la gauche) → `HorizontalSwipe.LEFT` → `swipeTargetPage(...)` → si non-null `onOpenPage(target)`.
+  - `totalDx > 0` → `HorizontalSwipe.RIGHT` → idem.
+- **Un seul** `onOpenPage` par geste. Aux bords (`swipeTargetPage == null`) : pas de navigation, pas de flash.
+
+### 3. Câblage
+
+- `onOpenPage: (Int) -> Unit` est déjà disponible dans `TopicScreen`/`TopicLoadedContent` (remonte à `RedfaceNavigation.kt:758`, pop+push `TopicRoute(scrollTo=null)`). Réutiliser tel quel.
+- **Source unique** : `currentPage = mode.topic.page` (ou `state.request.page`) et `totalPages = mode.topic.totalPages` — la MÊME source que `canGoPrevious`/`canGoNext` (`TopicUiState`), pour zéro divergence. `swipeTargetPage` borne donc exactement comme les boutons.
+- Le geste n'est actif **qu'en mode `Content`** (sinon rien à paginer) → le `Modifier` n'est appliqué que dans `TopicLoadedContent`.
+
+### 4. Hors scope (à NE PAS faire)
+
+- Pas de drag continu / peek / `HorizontalPager`.
+- Pas d'animation de transition (slide) : elle nécessiterait une transition au niveau `NavDisplay` (`:app`) car le changement de page recrée l'écran ; follow-up séparé si désiré.
+- Pas de prefetch du sens précédent ni de préservation d'offset vertical entre pages (reset en haut = comportement attendu).
+
+## Tests
+
+- `feature/topic/src/test/.../TopicSwipeTest.kt` : `swipeTargetPage` — LEFT depuis page<totalPages → +1 ; LEFT depuis dernière page → null ; RIGHT depuis page>1 → -1 ; RIGHT depuis page 1 → null ; cas totalPages=1 → null des deux côtés.
+- Vérif émulateur : swipe horizontal change de page ; scroll vertical intact ; la grille de pages garde son scroll horizontal ; pas de double-navigation ; bords no-op.
+
+## Validation locale (obligatoire avant push)
+
+```
+cd /work/xaat/redface2 && ./scripts/docker-dev.sh ./gradlew \
+  detektAll lintDebug test testDebugUnitTest :app:lintProdDebug :app:assembleProdDebug
+```
+
+## Livrable
+
+Branche `feat/282-swipe-page`, commit(s) Conventional + `Co-Authored-By: Claude Opus 4.8`. PR `Closes #282`.

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -414,7 +414,15 @@ private fun TopicLoadedContent(
         modifier = Modifier
             .fillMaxSize()
             .statusBarsPadding()
-            .navigationBarsPadding(),
+            .navigationBarsPadding()
+            // #282 — horizontal swipe changes page via the existing route-driven onOpenPage.
+            // Engages on horizontal slop only, so vertical scroll and the page-grid's own
+            // horizontalScroll keep their gestures; edges are a no-op.
+            .topicPageSwipe(
+                currentPage = topic.page,
+                totalPages = topic.totalPages,
+                onOpenPage = onOpenPage,
+            ),
         state = listState,
         contentPadding = PaddingValues(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
@@ -419,10 +420,17 @@ private fun TopicLoadedContent(
     val dragOffset = remember { mutableFloatStateOf(0f) }
     // #282 — hoisted so the gesture can tick on arming and confirm on commit.
     val haptics = LocalHapticFeedback.current
-    // #282 (P2-b) — if the pagination target re-keys while we stay Loaded (a force-refresh that lands
-    // the same screen on a new page/total, or the cache swapping the loaded page under the user mid
-    // or post-drag), drop any residual translation so the page is never left frozen off-centre.
-    LaunchedEffect(topic.page, topic.totalPages) {
+    // #282 — live page count for the swipe gesture, read through a lambda so the gesture sees the
+    // latest value WITHOUT re-keying its `pointerInput` (which would cancel an in-flight commit
+    // slide-out and drop the navigation — see `topicPageSwipe`). `rememberUpdatedState` keeps the
+    // State identity stable while its value tracks `topic.totalPages` across recompositions.
+    val currentTotalPages by rememberUpdatedState(topic.totalPages)
+    // #282 (P2-b) — if the loaded page re-keys while we stay Loaded (a force-refresh or page jump that
+    // lands the same screen on a new page), drop any residual translation so the page is never left
+    // frozen off-centre. Keyed on `topic.page` ONLY — never `topic.totalPages`: a page-count change
+    // landing during a commit's slide-out must not reset the offset mid-animation (it would yank the
+    // sliding page back); the gesture reads the live count via `currentTotalPages` instead.
+    LaunchedEffect(topic.page) {
         dragOffset.floatValue = 0f
     }
     LazyColumn(
@@ -438,13 +446,13 @@ private fun TopicLoadedContent(
             // horizontalScroll keep their gestures; edges are a damped no-op.
             .topicPageSwipeEdge(
                 currentPage = topic.page,
-                totalPages = topic.totalPages,
+                totalPages = { currentTotalPages },
                 dragOffset = dragOffset,
                 accent = MaterialTheme.colorScheme.primary,
             )
             .topicPageSwipe(
                 currentPage = topic.page,
-                totalPages = topic.totalPages,
+                totalPages = { currentTotalPages },
                 dragOffset = dragOffset,
                 haptics = haptics,
                 onOpenPage = onOpenPage,

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -50,6 +50,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.model.Poll
 import fr.forumhfr.redface2.core.model.Post
@@ -426,6 +428,13 @@ private fun TopicLoadedContent(
     // slide-out and drop the navigation — see `topicPageSwipe`). `rememberUpdatedState` keeps the
     // State identity stable while its value tracks `topic.totalPages` across recompositions.
     val currentTotalPages by rememberUpdatedState(topic.totalPages)
+    // #282 — the swipe must be INERT while this nav entry is not yet settled (mid NavDisplay
+    // transition, lifecycle < RESUMED). During the transition the incoming (cached) page is a fresh
+    // composition that would otherwise accept a swipe and commit a second onOpenPage mid-flight,
+    // interrupting the transition → frozen screen. The lambda reads `lifecycle.currentState` live, so
+    // the gesture (whose pointerInput does not re-key on this) always sees the current state.
+    val entryLifecycle = LocalLifecycleOwner.current.lifecycle
+    val swipeEnabled: () -> Boolean = { entryLifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED) }
     // #282 (P2-b) — if the loaded page re-keys while we stay Loaded (a force-refresh or page jump that
     // lands the same screen on a new page), drop any residual translation so the page is never left
     // frozen off-centre. Keyed on `topic.page` ONLY — never `topic.totalPages`: a page-count change
@@ -456,13 +465,17 @@ private fun TopicLoadedContent(
                     MaterialTheme.colorScheme.primary,
                     0.3f,
                 ),
+                enabled = swipeEnabled,
             )
             .topicPageSwipe(
                 currentPage = topic.page,
                 totalPages = { currentTotalPages },
                 dragOffset = dragOffset,
-                haptics = haptics,
-                onOpenPage = onOpenPage,
+                handlers = TopicSwipeHandlers(
+                    haptics = haptics,
+                    onOpenPage = onOpenPage,
+                    enabled = swipeEnabled,
+                ),
             ),
         state = listState,
         contentPadding = PaddingValues(16.dp),

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.feature.topic
 
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -410,17 +411,25 @@ private fun TopicLoadedContent(
     listState: LazyListState,
 ) {
     val highlight = state.request.scrollTo
+    // #282 — shared offset between the gesture (drives translationX) and the edge glow. Lives in the
+    // Loaded composition only, so a committed swipe (which recreates the screen) starts back at rest.
+    val dragOffset = remember { Animatable(0f) }
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
             .statusBarsPadding()
             .navigationBarsPadding()
-            // #282 — horizontal swipe changes page via the existing route-driven onOpenPage.
+            // #282 — horizontal swipe changes page via the existing route-driven onOpenPage, with
+            // drag-follow feedback: the page tracks the finger (graphicsLayer inside topicPageSwipe)
+            // and topicPageSwipeEdge paints an edge glow as the swipe arms. topicPageSwipeEdge must
+            // precede topicPageSwipe so the glow draws in untranslated (screen) space.
             // Engages on horizontal slop only, so vertical scroll and the page-grid's own
-            // horizontalScroll keep their gestures; edges are a no-op.
+            // horizontalScroll keep their gestures; edges are a damped no-op.
+            .topicPageSwipeEdge(dragOffset, MaterialTheme.colorScheme.primary)
             .topicPageSwipe(
                 currentPage = topic.page,
                 totalPages = topic.totalPages,
+                dragOffset = dragOffset,
                 onOpenPage = onOpenPage,
             ),
         state = listState,

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -436,7 +436,12 @@ private fun TopicLoadedContent(
             // precede topicPageSwipe so the glow draws in untranslated (screen) space.
             // Engages on horizontal slop only, so vertical scroll and the page-grid's own
             // horizontalScroll keep their gestures; edges are a damped no-op.
-            .topicPageSwipeEdge(dragOffset, MaterialTheme.colorScheme.primary)
+            .topicPageSwipeEdge(
+                currentPage = topic.page,
+                totalPages = topic.totalPages,
+                dragOffset = dragOffset,
+                accent = MaterialTheme.colorScheme.primary,
+            )
             .topicPageSwipe(
                 currentPage = topic.page,
                 totalPages = topic.totalPages,

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -448,7 +449,13 @@ private fun TopicLoadedContent(
                 currentPage = topic.page,
                 totalPages = { currentTotalPages },
                 dragOffset = dragOffset,
-                accent = MaterialTheme.colorScheme.primary,
+                // #282 — desaturated edge-glow tint: mostly neutral (onSurfaceVariant) with a touch of
+                // primary, instead of full primary which read as an imposing pink/mauve panel.
+                accent = lerp(
+                    MaterialTheme.colorScheme.onSurfaceVariant,
+                    MaterialTheme.colorScheme.primary,
+                    0.3f,
+                ),
             )
             .topicPageSwipe(
                 currentPage = topic.page,

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1,6 +1,5 @@
 package fr.forumhfr.redface2.feature.topic
 
-import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -33,6 +32,7 @@ import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -40,6 +40,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
@@ -411,9 +412,19 @@ private fun TopicLoadedContent(
     listState: LazyListState,
 ) {
     val highlight = state.request.scrollTo
-    // #282 — shared offset between the gesture (drives translationX) and the edge glow. Lives in the
+    // #282 — shared offset between the gesture (drives translationX) and the edge glow. A plain
+    // MutableFloatState: the gesture writes it synchronously per frame (no coroutine/alloc), the draw
+    // phase reads it; an Animatable inside the gesture handles only release transitions. Lives in the
     // Loaded composition only, so a committed swipe (which recreates the screen) starts back at rest.
-    val dragOffset = remember { Animatable(0f) }
+    val dragOffset = remember { mutableFloatStateOf(0f) }
+    // #282 — hoisted so the gesture can tick on arming and confirm on commit.
+    val haptics = LocalHapticFeedback.current
+    // #282 (P2-b) — if the pagination target re-keys while we stay Loaded (a force-refresh that lands
+    // the same screen on a new page/total, or the cache swapping the loaded page under the user mid
+    // or post-drag), drop any residual translation so the page is never left frozen off-centre.
+    LaunchedEffect(topic.page, topic.totalPages) {
+        dragOffset.floatValue = 0f
+    }
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
@@ -430,6 +441,7 @@ private fun TopicLoadedContent(
                 currentPage = topic.page,
                 totalPages = topic.totalPages,
                 dragOffset = dragOffset,
+                haptics = haptics,
                 onOpenPage = onOpenPage,
             ),
         state = listState,

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.gestures.awaitHorizontalTouchSlopOrCancellati
 import androidx.compose.foundation.gestures.horizontalDrag
 import androidx.compose.runtime.MutableFloatState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
@@ -123,7 +123,8 @@ internal fun swipeArmed(offsetPx: Float, commitDistancePx: Float): Boolean =
 
 /**
  * Edge-glow opacity for a swipe [progress] = `|offset| / commitDistance` (`0f` at rest, `1f` at the
- * commit/armed point, up to ~`1.5f` in the bounded overpull region). Pure → unit-tested.
+ * commit/armed point, up to `1f + OVERPULL_MAX_FRACTION` — currently `1.5f` — in the bounded overpull
+ * region). Pure → unit-tested.
  *
  * Two segments, continuous at `progress = 1f` so the brighten is finger-driven (no separate
  * animation primitive needed in the draw phase, which reads state synchronously without
@@ -185,16 +186,20 @@ private val SPRING_BACK = spring<Float>(
  * launched per drag event.
  *
  * On commit the page first animates off-screen (translationX → ±width, a short [tween]) and only then
- * navigates, killing the figé "flash" of the old instant cut. Otherwise (no-commit, edge, or a child
- * taking the drag) it springs back to rest. Haptics: a tick when the swipe arms (crosses the commit
- * distance, once per rising edge) and a confirm on commit.
+ * navigates, softening the **departure** of the old instant cut (the incoming page still hard-appears
+ * via the route change until the NavDisplay slide-in follow-up (a) lands — out of scope here, it would
+ * touch `:app`/navigation). Otherwise (no-commit, edge, or a child taking the drag) it springs back to
+ * rest. Haptics: a tick when the swipe arms (crosses the commit distance, once per rising edge) and a
+ * confirm on commit.
  *
  * Coexistence (unchanged from the discrete version, validated with Codex gpt-5.5):
  * - it engages only on **horizontal** touch slop, so the vertical `LazyColumn` scroll is never stolen;
  * - a child that consumes the horizontal drag first (the page-grid's `horizontalScroll`) cancels our
  *   slop detection / `horizontalDrag`, so it keeps its own gesture and the page springs back;
  * - at the edges (target is `null`) the gesture is a damped no-op (no navigation, no flash);
- * - exactly one [onOpenPage] per gesture.
+ * - exactly one [onOpenPage] per committing gesture: once a commit starts its slide-out, a
+ *   re-entrance latch ignores any further gesture until the route change tears this modifier down,
+ *   so a second swipe landing inside the slide-out window can never fire a duplicate navigation.
  *
  * Direction is **geometric**, not layout-direction aware: a physical leftward drag always opens the
  * next page (rightward = previous), regardless of `LayoutDirection`. The forum content is LTR
@@ -227,8 +232,18 @@ internal fun Modifier.topicPageSwipe(
         val release = Animatable(0f)
         coroutineScope {
             val animationScope = this
+            // Re-entrance latch: a committed swipe defers `onOpenPage` by COMMIT_SLIDE_OUT_MILLIS (the
+            // slide-out), during which `awaitEachGesture` has already rebooted and is armed for a new
+            // `down` while the outgoing composition is NOT yet replaced. Without this guard, a second
+            // commit landing in that window could fire a second `onOpenPage` on the stale composition
+            // (currentPage unchanged) → a duplicate pop+push / phantom back-stack entry, or silently
+            // drop the first navigation. Once any commit starts the slide-out we ignore further
+            // gestures until this pointerInput is torn down by the route change — so `onOpenPage` fires
+            // exactly once.
+            var committed = false
             awaitEachGesture {
                 val down = awaitFirstDown(requireUnconsumed = false)
+                if (committed) return@awaitEachGesture
                 val velocityTracker = VelocityTracker()
                 velocityTracker.addPosition(down.uptimeMillis, down.position)
                 var overSlop = 0f
@@ -239,7 +254,9 @@ internal fun Modifier.topicPageSwipe(
                     overSlop = slop
                 } ?: return@awaitEachGesture
                 // A new drag cancels any release animation still running from the previous swipe.
-                animationScope.launch { release.stop() }
+                // Gated: `stop()` on an idle `Animatable` is a no-op, so skip the coroutine unless a
+                // release transition is actually in flight (the common case is none).
+                if (release.isRunning) animationScope.launch { release.stop() }
                 var totalDx = overSlop
                 var armed = false
                 velocityTracker.addPosition(drag.uptimeMillis, drag.position)
@@ -265,6 +282,9 @@ internal fun Modifier.topicPageSwipe(
                 val forward = swipeCommitDirection(totalDx, velocityX, commitDistancePx, flingThresholdPx)
                 val target = forward?.let { swipeTargetPage(currentPage, totalPages, it) }
                 if (forward != null && target != null) {
+                    // Latch BEFORE the deferred slide-out so any gesture starting in the slide-out
+                    // window is ignored (see `committed` declaration) — no second `onOpenPage`.
+                    committed = true
                     haptics.performHapticFeedback(HapticFeedbackType.Confirm)
                     // Slide in the commit direction (forward = next = leftward = negative), not the
                     // residual offset sign: a fast fling can commit with a near-zero/opposite offset.
@@ -276,13 +296,17 @@ internal fun Modifier.topicPageSwipe(
             }
         }
     }
-    // Draw-only translation of the page content + a slight elevation lift so a committed page reads as
-    // leaving. After `pointerInput` (see above) so the gesture is read in untranslated space; reading
-    // `dragOffset.floatValue` here keeps the follow on the draw phase (no recomposition per frame).
+    // Draw-only translation of the page content + a slight elevation lift so a committing page reads
+    // as leaving. After `pointerInput` (see above) so the gesture is read in untranslated space;
+    // reading `dragOffset.floatValue` here keeps the follow on the draw phase (no recomposition per
+    // frame). The lift is gated on the ARMED state (offset past the commit distance), not on any
+    // offset: an exploratory nudge or the damped wall at a blocked edge must NOT float, so the shadow
+    // sells the commit ("this page will leave") rather than mere exploration.
     .graphicsLayer {
         val offset = dragOffset.floatValue
         translationX = offset
-        shadowElevation = if (offset == 0f) 0f else COMMIT_SHADOW_ELEVATION_DP.dp.toPx()
+        val commitDistancePx = swipeCommitDistancePx(size.width, MIN_COMMIT_DISTANCE.toPx())
+        shadowElevation = if (swipeArmed(offset, commitDistancePx)) COMMIT_SHADOW_ELEVATION_DP.dp.toPx() else 0f
     }
 
 /** Spring the page back to rest (cancel / no-commit), streaming the animation into [dragOffset]. */
@@ -333,41 +357,57 @@ private fun followOffsetFor(totalDx: Float, commitDistancePx: Float, currentPage
  * ([swipeEdgeHintAlpha]) once the swipe is armed, so the user sees that releasing will validate. It
  * reads [dragOffset] at draw time only, so following the finger never recomposes.
  *
- * Only the edge band (a [EDGE_HINT_WIDTH_FRACTION] sub-rect of the page) is painted — not a
- * full-screen `Brush` per frame.
+ * The glow is the "release brings the neighbour page" affordance, so it is **suppressed at a blocked
+ * edge**: when the dragged direction has no target page ([currentPage]/[totalPages] = first/last), the
+ * damped wall already communicates the boundary and lighting a glow there would contradict it. Only a
+ * direction that can actually commit gets the hint.
  *
- * Must sit **before** [topicPageSwipe] in the modifier chain: it draws via `drawWithContent` in the
- * element's own (untranslated) space, so the glow stays pinned to the screen edge while the page
- * itself is translated by the `graphicsLayer` that [topicPageSwipe] adds further down the chain.
- * [accent] is read from the theme by the (composable) caller and passed in, since a draw scope cannot.
+ * Per-frame work is **allocation-free**: the two edge brushes (left / right, baked at full opacity,
+ * Transparent → [accent]) and the band geometry are cached in [drawWithCache], keyed on size; the
+ * per-frame draw block only reads the offset, computes the opacity and calls `drawRect(brush, …,
+ * alpha = …)` on the matching sub-rect. Only the edge band (a [EDGE_HINT_WIDTH_FRACTION] sub-rect of
+ * the page) is painted — never a full-screen brush, never a brush re-allocated per frame.
+ *
+ * Must sit **before** [topicPageSwipe] in the modifier chain: it draws in the element's own
+ * (untranslated) space, so the glow stays pinned to the screen edge while the page itself is
+ * translated by the `graphicsLayer` that [topicPageSwipe] adds further down the chain. [accent] is
+ * read from the theme by the (composable) caller and passed in, since a draw scope cannot.
  */
 internal fun Modifier.topicPageSwipeEdge(
+    currentPage: Int,
+    totalPages: Int,
     dragOffset: MutableFloatState,
     accent: Color,
-): Modifier = drawWithContent {
-    drawContent()
-    val offset = dragOffset.floatValue
-    if (offset == 0f) return@drawWithContent
+): Modifier = drawWithCache {
+    // Cache (per size) what does not vary per frame: the band geometry and the two full-opacity edge
+    // brushes. The per-frame opacity is applied via `drawRect`'s `alpha`, so neither brush nor the
+    // colors `List` is re-allocated while the finger moves.
     val commitDistancePx = swipeCommitDistancePx(size.width, MIN_COMMIT_DISTANCE.toPx())
-    if (commitDistancePx <= 0f) return@drawWithContent
-    val progress = abs(offset) / commitDistancePx
-    val alpha = swipeEdgeHintAlpha(progress)
     val band = size.width * EDGE_HINT_WIDTH_FRACTION
-    val leftward = offset < 0f
-    val brush = if (leftward) {
-        Brush.horizontalGradient(
-            colors = listOf(Color.Transparent, accent.copy(alpha = alpha)),
-            startX = size.width - band,
-            endX = size.width,
-        )
-    } else {
-        Brush.horizontalGradient(
-            colors = listOf(accent.copy(alpha = alpha), Color.Transparent),
-            startX = 0f,
-            endX = band,
-        )
+    val rightTopLeft = Offset(size.width - band, 0f)
+    val bandSize = Size(band, size.height)
+    val rightBrush = Brush.horizontalGradient(
+        colors = listOf(Color.Transparent, accent),
+        startX = size.width - band,
+        endX = size.width,
+    )
+    val leftBrush = Brush.horizontalGradient(
+        colors = listOf(accent, Color.Transparent),
+        startX = 0f,
+        endX = band,
+    )
+    onDrawWithContent {
+        drawContent()
+        val offset = dragOffset.floatValue
+        if (offset == 0f || commitDistancePx <= 0f) return@onDrawWithContent
+        val leftward = offset < 0f
+        // Suppress the glow when this direction is a blocked edge (no neighbour page to bring in).
+        if (swipeTargetPage(currentPage, totalPages, forward = leftward) == null) return@onDrawWithContent
+        val alpha = swipeEdgeHintAlpha(abs(offset) / commitDistancePx)
+        if (leftward) {
+            drawRect(brush = rightBrush, topLeft = rightTopLeft, size = bandSize, alpha = alpha)
+        } else {
+            drawRect(brush = leftBrush, topLeft = Offset.Zero, size = bandSize, alpha = alpha)
+        }
     }
-    // Paint only the edge band, not the whole page, so the per-frame fill stays small.
-    val topLeft = if (leftward) Offset(size.width - band, 0f) else Offset.Zero
-    drawRect(brush = brush, topLeft = topLeft, size = Size(band, size.height))
 }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
@@ -1,15 +1,25 @@
 package fr.forumhfr.redface2.feature.topic
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.awaitHorizontalTouchSlopOrCancellation
 import androidx.compose.foundation.gestures.horizontalDrag
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.compose.ui.unit.dp
 import kotlin.math.abs
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 
 /**
  * Target page of a horizontal swipe while reading a topic (#282), or `null` when the gesture is
@@ -53,22 +63,75 @@ internal fun swipeCommitDirection(
     return if (orientation == 0f) null else orientation < 0f
 }
 
-// Commit thresholds: a swipe changes page only past a clear intent, never on the bare touch slop.
-private const val COMMIT_FRACTION = 0.20f
-private val MIN_COMMIT_DISTANCE = 72.dp
-private val FLING_VELOCITY_THRESHOLD = 900.dp
+/**
+ * Distance (px) past which a slow drag commits to a page change. The same value drives the visual
+ * drag-follow cap and the edge hint (so the page stops growing exactly when the hint is fully lit),
+ * so it is computed once per layout and shared by [topicPageSwipe] and [topicPageSwipeEdge].
+ * Pure (takes already-resolved pixels) → unit-tested without a `Density`.
+ */
+internal fun swipeCommitDistancePx(widthPx: Float, minCommitPx: Float): Float =
+    maxOf(minCommitPx, widthPx * COMMIT_FRACTION)
 
 /**
- * Horizontal swipe → change topic page (#282, Option A). A committed left/right swipe calls
- * [onOpenPage] (the existing route-driven navigation: pop+push of `TopicRoute`), reusing the whole
- * pagination/prefetch machinery — no neighbour page is composed, so the « prefetch non authentifié »
- * invariant is never touched.
+ * Visual translation (px) of the current page for a raw horizontal displacement [rawDx], giving the
+ * drag immediate feedback (#282 follow). The sign matches [rawDx] (leftward drag → negative offset).
+ * Pure → unit-tested.
  *
- * Coexistence (validated with Codex gpt-5.5):
+ * - [hasTarget] = true (a page exists that way): track the finger 1:1 up to [commitDistancePx], then
+ *   apply [OVERPULL_RESISTANCE] so the page keeps giving a little without sliding the whole way —
+ *   reaching `commitDistancePx` is the visual "armed" point the edge hint mirrors.
+ * - [hasTarget] = false (first/last page): a damped "wall", capped at [EDGE_MAX_FRACTION] of the
+ *   commit distance, so a swipe into the void barely moves and reads as a boundary.
+ */
+internal fun swipeFollowOffset(rawDx: Float, commitDistancePx: Float, hasTarget: Boolean): Float {
+    if (commitDistancePx <= 0f) return 0f
+    val magnitude = abs(rawDx)
+    val sign = if (rawDx < 0f) -1f else 1f
+    val travel = if (hasTarget) {
+        if (magnitude <= commitDistancePx) {
+            magnitude
+        } else {
+            commitDistancePx + (magnitude - commitDistancePx) * OVERPULL_RESISTANCE
+        }
+    } else {
+        minOf(magnitude * EDGE_RESISTANCE, commitDistancePx * EDGE_MAX_FRACTION)
+    }
+    return sign * travel
+}
+
+// Commit thresholds: a swipe changes page only past a clear intent, never on the bare touch slop.
+private const val COMMIT_FRACTION = 0.20f
+internal val MIN_COMMIT_DISTANCE = 72.dp
+private val FLING_VELOCITY_THRESHOLD = 900.dp
+
+// Drag-follow feel (#282 (b)+(c)). All purely visual — they never affect the commit decision.
+private const val OVERPULL_RESISTANCE = 0.35f // diminishing follow past the commit point
+private const val EDGE_RESISTANCE = 0.30f // damping into a blocked edge (first/last page)
+private const val EDGE_MAX_FRACTION = 0.4f // a blocked edge can travel at most this × commit distance
+private const val EDGE_HINT_WIDTH_FRACTION = 0.18f // edge-glow band width, as a fraction of the page
+private const val EDGE_HINT_MAX_ALPHA = 0.5f // edge-glow opacity once the swipe is fully armed
+
+private val SPRING_BACK = spring<Float>(
+    dampingRatio = Spring.DampingRatioLowBouncy,
+    stiffness = Spring.StiffnessMediumLow,
+)
+
+/**
+ * Horizontal swipe → change topic page (#282, Option A) with drag-follow feedback (b). A committed
+ * left/right swipe calls [onOpenPage] (the existing route-driven navigation: pop+push of
+ * `TopicRoute`), reusing the whole pagination/prefetch machinery — no neighbour page is composed, so
+ * the « prefetch non authentifié » invariant is never touched.
+ *
+ * While dragging, the current page follows the finger ([dragOffset] drives a `translationX`, shaped
+ * by [swipeFollowOffset]); on commit it navigates, otherwise (no-commit, edge, or a child taking the
+ * drag) it springs back to rest. The cross-page cut after a commit is unchanged (no shared-element
+ * transition) — that is the optional follow-up (a) at the `NavDisplay` level.
+ *
+ * Coexistence (unchanged from the discrete version, validated with Codex gpt-5.5):
  * - it engages only on **horizontal** touch slop, so the vertical `LazyColumn` scroll is never stolen;
  * - a child that consumes the horizontal drag first (the page-grid's `horizontalScroll`) cancels our
- *   slop detection, so it keeps its own gesture;
- * - at the edges (target is `null`) the gesture is a no-op (no navigation, no flash);
+ *   slop detection / `horizontalDrag`, so it keeps its own gesture and the page springs back;
+ * - at the edges (target is `null`) the gesture is a damped no-op (no navigation, no flash);
  * - exactly one [onOpenPage] per gesture.
  *
  * Direction is **geometric**, not layout-direction aware: a physical leftward drag always opens the
@@ -78,40 +141,115 @@ private val FLING_VELOCITY_THRESHOLD = 900.dp
  *
  * Primitive choice: low-level `awaitEachGesture` + `awaitHorizontalTouchSlopOrCancellation` rather
  * than `detectHorizontalDragGestures` (too blunt — auto-consumes and locks the axis) or
- * `anchoredDraggable` (offset/snap animation, overkill for a discrete route-driven page change).
+ * `anchoredDraggable` (anchored snap states, the wrong model for a threshold/velocity commit that has
+ * to coexist with the list scroll, the page grid and `[fixed]` blocks).
  */
 internal fun Modifier.topicPageSwipe(
     currentPage: Int,
     totalPages: Int,
+    dragOffset: Animatable<Float, AnimationVector1D>,
     onOpenPage: (Int) -> Unit,
-): Modifier = pointerInput(currentPage, totalPages) {
-    val commitDistancePx = maxOf(MIN_COMMIT_DISTANCE.toPx(), size.width * COMMIT_FRACTION)
-    val flingThresholdPx = FLING_VELOCITY_THRESHOLD.toPx()
-    awaitEachGesture {
-        val down = awaitFirstDown(requireUnconsumed = false)
-        val velocityTracker = VelocityTracker()
-        velocityTracker.addPosition(down.uptimeMillis, down.position)
-        var overSlop = 0f
-        // Horizontal slop only: a vertical-dominant drag (list scroll) never reaches this branch;
-        // a child that already consumed the horizontal move makes this return null (we bail).
-        val drag = awaitHorizontalTouchSlopOrCancellation(down.id) { change, slop ->
-            change.consume()
-            overSlop = slop
-        } ?: return@awaitEachGesture
-        var totalDx = overSlop
-        velocityTracker.addPosition(drag.uptimeMillis, drag.position)
-        // `horizontalDrag` returns false when the drag is CANCELLED — e.g. a descendant horizontal
-        // scroller (a wide `[fixed]` code block, the page grid) takes the pointer over after we crossed
-        // slop. Honour it: a taken-over gesture must NOT navigate the page (Codex gpt-5.5 P2).
-        val completed = horizontalDrag(drag.id) { change ->
-            totalDx += change.positionChange().x
-            velocityTracker.addPosition(change.uptimeMillis, change.position)
-            change.consume()
-        }
-        if (!completed) return@awaitEachGesture
-        val velocityX = velocityTracker.calculateVelocity().x
-        swipeCommitDirection(totalDx, velocityX, commitDistancePx, flingThresholdPx)?.let { forward ->
-            swipeTargetPage(currentPage, totalPages, forward)?.let(onOpenPage)
+): Modifier = this
+    // `pointerInput` sits BEFORE `graphicsLayer` on purpose: the gesture must read finger deltas in
+    // the untranslated coordinate space. If it were inside the translated layer, each frame's
+    // `positionChange()` would be `Δfinger − Δtranslation`, halving the tracking and doubling the
+    // effective commit distance. `graphicsLayer` (draw-only) leaves the hit-test bounds put, so the
+    // finger stays over the page while the page visibly follows.
+    .pointerInput(currentPage, totalPages) {
+        val commitDistancePx = swipeCommitDistancePx(size.width.toFloat(), MIN_COMMIT_DISTANCE.toPx())
+        val flingThresholdPx = FLING_VELOCITY_THRESHOLD.toPx()
+        coroutineScope {
+            val animationScope = this
+            awaitEachGesture {
+                val down = awaitFirstDown(requireUnconsumed = false)
+                val velocityTracker = VelocityTracker()
+                velocityTracker.addPosition(down.uptimeMillis, down.position)
+                var overSlop = 0f
+                // Horizontal slop only: a vertical-dominant drag (list scroll) never reaches this
+                // branch; a child that already consumed the horizontal move makes this return null.
+                val drag = awaitHorizontalTouchSlopOrCancellation(down.id) { change, slop ->
+                    change.consume()
+                    overSlop = slop
+                } ?: return@awaitEachGesture
+                var totalDx = overSlop
+                velocityTracker.addPosition(drag.uptimeMillis, drag.position)
+                // The first snapTo also cancels any spring-back still running from a previous swipe.
+                animationScope.launch {
+                    dragOffset.snapTo(followOffsetFor(totalDx, commitDistancePx, currentPage, totalPages))
+                }
+                // `horizontalDrag` returns false when the drag is CANCELLED — e.g. a descendant
+                // horizontal scroller (a wide `[fixed]` code block, the page grid) takes the pointer
+                // over after we crossed slop. Honour it: a taken-over gesture must NOT navigate.
+                val completed = horizontalDrag(drag.id) { change ->
+                    totalDx += change.positionChange().x
+                    velocityTracker.addPosition(change.uptimeMillis, change.position)
+                    animationScope.launch {
+                        dragOffset.snapTo(followOffsetFor(totalDx, commitDistancePx, currentPage, totalPages))
+                    }
+                    change.consume()
+                }
+                if (!completed) {
+                    animationScope.launch { dragOffset.animateTo(0f, SPRING_BACK) }
+                    return@awaitEachGesture
+                }
+                val velocityX = velocityTracker.calculateVelocity().x
+                val target = swipeCommitDirection(totalDx, velocityX, commitDistancePx, flingThresholdPx)
+                    ?.let { forward -> swipeTargetPage(currentPage, totalPages, forward) }
+                if (target != null) {
+                    // Navigation replaces the screen; the offset state is discarded with it.
+                    onOpenPage(target)
+                } else {
+                    animationScope.launch { dragOffset.animateTo(0f, SPRING_BACK) }
+                }
+            }
         }
     }
+    // Draw-only translation of the page content. After `pointerInput` (see above) so the gesture is
+    // read in untranslated space; reading `dragOffset.value` here keeps the follow on the draw phase
+    // (no recomposition per frame).
+    .graphicsLayer { translationX = dragOffset.value }
+
+private fun followOffsetFor(totalDx: Float, commitDistancePx: Float, currentPage: Int, totalPages: Int): Float {
+    val hasTarget = swipeTargetPage(currentPage, totalPages, forward = totalDx < 0f) != null
+    return swipeFollowOffset(totalDx, commitDistancePx, hasTarget)
+}
+
+/**
+ * Edge hint for the topic page swipe (#282 (c)). Draws a glow on the edge the neighbour page is being
+ * pulled in from — right edge for a leftward drag (next page), left edge for a rightward drag — whose
+ * opacity ramps with the swipe's progress toward the commit distance and reaches [EDGE_HINT_MAX_ALPHA]
+ * once the swipe is armed. It reads [dragOffset] at draw time only, so following the finger never
+ * recomposes.
+ *
+ * Must sit **before** [topicPageSwipe] in the modifier chain: it draws via `drawWithContent` in the
+ * element's own (untranslated) space, so the glow stays pinned to the screen edge while the page
+ * itself is translated by the `graphicsLayer` that [topicPageSwipe] adds further down the chain.
+ * [accent] is read from the theme by the (composable) caller and passed in, since a draw scope cannot.
+ */
+internal fun Modifier.topicPageSwipeEdge(
+    dragOffset: Animatable<Float, AnimationVector1D>,
+    accent: Color,
+): Modifier = drawWithContent {
+    drawContent()
+    val offset = dragOffset.value
+    if (offset == 0f) return@drawWithContent
+    val commitDistancePx = swipeCommitDistancePx(size.width, MIN_COMMIT_DISTANCE.toPx())
+    if (commitDistancePx <= 0f) return@drawWithContent
+    val progress = (abs(offset) / commitDistancePx).coerceIn(0f, 1f)
+    val alpha = progress * EDGE_HINT_MAX_ALPHA
+    val band = size.width * EDGE_HINT_WIDTH_FRACTION
+    val brush = if (offset < 0f) {
+        Brush.horizontalGradient(
+            colors = listOf(Color.Transparent, accent.copy(alpha = alpha)),
+            startX = size.width - band,
+            endX = size.width,
+        )
+    } else {
+        Brush.horizontalGradient(
+            colors = listOf(accent.copy(alpha = alpha), Color.Transparent),
+            startX = 0f,
+            endX = band,
+        )
+    }
+    drawRect(brush = brush)
 }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
@@ -1,0 +1,83 @@
+package fr.forumhfr.redface2.feature.topic
+
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitHorizontalTouchSlopOrCancellation
+import androidx.compose.foundation.gestures.horizontalDrag
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.input.pointer.util.VelocityTracker
+import androidx.compose.ui.unit.dp
+import kotlin.math.abs
+
+/**
+ * Target page of a horizontal swipe while reading a topic (#282), or `null` when the gesture is
+ * blocked by an edge. [forward] = true → next page (drag left), false → previous page (drag right).
+ * Pure → unit-tested without Compose.
+ *
+ * Mirrors the exact bounds of `TopicUiState.canGoNext` / `canGoPrevious` (page in `1..totalPages`)
+ * so the swipe and the Previous/Next buttons agree.
+ */
+internal fun swipeTargetPage(currentPage: Int, totalPages: Int, forward: Boolean): Int? =
+    if (forward) {
+        (currentPage + 1).takeIf { it <= totalPages }
+    } else {
+        (currentPage - 1).takeIf { it >= 1 }
+    }
+
+// Commit thresholds: a swipe changes page only past a clear intent, never on the bare touch slop.
+private const val COMMIT_FRACTION = 0.20f
+private val MIN_COMMIT_DISTANCE = 72.dp
+private val FLING_VELOCITY_THRESHOLD = 900.dp
+
+/**
+ * Horizontal swipe → change topic page (#282, Option A). A committed left/right swipe calls
+ * [onOpenPage] (the existing route-driven navigation: pop+push of `TopicRoute`), reusing the whole
+ * pagination/prefetch machinery — no neighbour page is composed, so the « prefetch non authentifié »
+ * invariant is never touched.
+ *
+ * Coexistence (validated with Codex gpt-5.5):
+ * - it engages only on **horizontal** touch slop, so the vertical `LazyColumn` scroll is never stolen;
+ * - a child that consumes the horizontal drag first (the page-grid's `horizontalScroll`) cancels our
+ *   slop detection, so it keeps its own gesture;
+ * - at the edges ([swipeTargetPage] returns `null`) the gesture is a no-op (no navigation, no flash);
+ * - exactly one [onOpenPage] per gesture.
+ *
+ * Primitive choice: low-level `awaitEachGesture` + `awaitHorizontalTouchSlopOrCancellation` rather
+ * than `detectHorizontalDragGestures` (too blunt — auto-consumes and locks the axis) or
+ * `anchoredDraggable` (offset/snap animation, overkill for a discrete route-driven page change).
+ */
+internal fun Modifier.topicPageSwipe(
+    currentPage: Int,
+    totalPages: Int,
+    onOpenPage: (Int) -> Unit,
+): Modifier = pointerInput(currentPage, totalPages) {
+    val commitDistancePx = maxOf(MIN_COMMIT_DISTANCE.toPx(), size.width * COMMIT_FRACTION)
+    val flingThresholdPx = FLING_VELOCITY_THRESHOLD.toPx()
+    awaitEachGesture {
+        val down = awaitFirstDown(requireUnconsumed = false)
+        val velocityTracker = VelocityTracker()
+        velocityTracker.addPosition(down.uptimeMillis, down.position)
+        var overSlop = 0f
+        // Horizontal slop only: a vertical-dominant drag (list scroll) never reaches this branch;
+        // a child that already consumed the horizontal move makes this return null (we bail).
+        val drag = awaitHorizontalTouchSlopOrCancellation(down.id) { change, slop ->
+            change.consume()
+            overSlop = slop
+        } ?: return@awaitEachGesture
+        var totalDx = overSlop
+        velocityTracker.addPosition(drag.uptimeMillis, drag.position)
+        horizontalDrag(drag.id) { change ->
+            totalDx += change.positionChange().x
+            velocityTracker.addPosition(change.uptimeMillis, change.position)
+            change.consume()
+        }
+        val velocityX = velocityTracker.calculateVelocity().x
+        val committed = abs(totalDx) >= commitDistancePx || abs(velocityX) >= flingThresholdPx
+        if (committed) {
+            // Drag left (negative dx) reveals the next page; drag right the previous one.
+            swipeTargetPage(currentPage, totalPages, forward = totalDx < 0f)?.let(onOpenPage)
+        }
+    }
+}

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
@@ -232,8 +232,7 @@ internal fun Modifier.topicPageSwipe(
     currentPage: Int,
     totalPages: () -> Int,
     dragOffset: MutableFloatState,
-    haptics: HapticFeedback,
-    onOpenPage: (Int) -> Unit,
+    handlers: TopicSwipeHandlers,
 ): Modifier = this
     // `pointerInput` sits BEFORE `graphicsLayer` on purpose: the gesture must read finger deltas in
     // the untranslated coordinate space. If it were inside the translated layer, each frame's
@@ -277,6 +276,15 @@ internal fun Modifier.topicPageSwipe(
             awaitEachGesture {
                 val down = awaitFirstDown(requireUnconsumed = false)
                 if (committed) return@awaitEachGesture
+                // Ignore the gesture while this nav entry is NOT settled (lifecycle < RESUMED), i.e.
+                // mid NavDisplay transition. A freshly-Loaded incoming page (served from cache) would
+                // otherwise accept a swipe DURING the transition and commit a SECOND `onOpenPage`
+                // mid-flight, interrupting the transition and freezing the screen — the per-composition
+                // `committed` latch cannot span the inter-page transition (the incoming page is a fresh
+                // composition with its own latch). Gating at `down`, before the gesture arms/follows, is
+                // required: merely dropping `onOpenPage` after the slide-out would still park the page
+                // off-screen (the very freeze). See #282.
+                if (!handlers.enabled()) return@awaitEachGesture
                 val velocityTracker = VelocityTracker()
                 velocityTracker.addPosition(down.uptimeMillis, down.position)
                 var overSlop = 0f
@@ -309,7 +317,7 @@ internal fun Modifier.topicPageSwipe(
                     val offset = followOffsetFor(totalDx, commitDistancePx, currentPage, totalPages())
                     dragOffset.floatValue = offset // synchronous, no coroutine, no allocation
                     val nowArmed = swipeArmed(offset, commitDistancePx)
-                    if (nowArmed && !armed) haptics.performHapticFeedback(ARMED_HAPTIC)
+                    if (nowArmed && !armed) handlers.haptics.performHapticFeedback(ARMED_HAPTIC)
                     armed = nowArmed
                     change.consume()
                 }
@@ -324,11 +332,13 @@ internal fun Modifier.topicPageSwipe(
                     // Latch BEFORE the deferred slide-out so any gesture starting in the slide-out
                     // window is ignored (see `committed` declaration) — no second `onOpenPage`.
                     committed = true
-                    haptics.performHapticFeedback(HapticFeedbackType.Confirm)
+                    handlers.haptics.performHapticFeedback(HapticFeedbackType.Confirm)
                     // Slide in the commit direction (forward = next = leftward = negative), not the
                     // residual offset sign: a fast fling can commit with a near-zero/opposite offset.
                     val targetX = if (forward) -widthPx else widthPx
-                    releaseJob = commitSlideOut(animationScope, release, dragOffset, targetX) { onOpenPage(target) }
+                    releaseJob = commitSlideOut(animationScope, release, dragOffset, targetX) {
+                        handlers.onOpenPage(target)
+                    }
                 } else {
                     releaseJob = springBackTo(animationScope, release, dragOffset)
                 }
@@ -347,6 +357,18 @@ internal fun Modifier.topicPageSwipe(
         val commitDistancePx = swipeCommitDistancePx(size.width, MIN_COMMIT_DISTANCE.toPx())
         shadowElevation = if (swipeArmed(offset, commitDistancePx)) COMMIT_SHADOW_ELEVATION_DP.dp.toPx() else 0f
     }
+
+/**
+ * The non-per-frame inputs of [topicPageSwipe], bundled so the gesture's parameter list stays within
+ * the project's limit. [enabled] is read once per gesture (at `down`) and gates the whole gesture off
+ * while this nav entry is mid-transition (lifecycle < RESUMED, see #282); [haptics] fires on arm and
+ * commit; [onOpenPage] performs the route-driven page change exactly once per committed swipe.
+ */
+internal class TopicSwipeHandlers(
+    val haptics: HapticFeedback,
+    val onOpenPage: (Int) -> Unit,
+    val enabled: () -> Boolean,
+)
 
 /** Spring the page back to rest (cancel / no-commit), streaming the animation into [dragOffset]. */
 private fun springBackTo(
@@ -413,6 +435,7 @@ internal fun Modifier.topicPageSwipeEdge(
     totalPages: () -> Int,
     dragOffset: MutableFloatState,
     accent: Color,
+    enabled: () -> Boolean,
 ): Modifier = drawWithCache {
     // Cache (per size) what does not vary per frame: the band geometry and the two full-opacity edge
     // brushes. The per-frame opacity is applied via `drawRect`'s `alpha`, so neither brush nor the
@@ -433,6 +456,9 @@ internal fun Modifier.topicPageSwipeEdge(
     )
     onDrawWithContent {
         drawContent()
+        // No glow while this nav entry is mid-transition (lifecycle < RESUMED): the gesture is gated
+        // off then (see topicPageSwipe), and an exiting page parked off-screen must not keep its glow.
+        if (!enabled()) return@onDrawWithContent
         val offset = dragOffset.floatValue
         if (offset == 0f || commitDistancePx <= 0f) return@onDrawWithContent
         val leftward = offset < 0f

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
@@ -213,7 +213,7 @@ private val SPRING_BACK = spring<Float>(
  */
 internal fun Modifier.topicPageSwipe(
     currentPage: Int,
-    totalPages: Int,
+    totalPages: () -> Int,
     dragOffset: MutableFloatState,
     haptics: HapticFeedback,
     onOpenPage: (Int) -> Unit,
@@ -223,7 +223,15 @@ internal fun Modifier.topicPageSwipe(
     // `positionChange()` would be `Δfinger − Δtranslation`, halving the tracking and doubling the
     // effective commit distance. `graphicsLayer` (draw-only) leaves the hit-test bounds put, so the
     // finger stays over the page while the page visibly follows.
-    .pointerInput(currentPage, totalPages) {
+    //
+    // Keyed on `currentPage` ONLY — never `totalPages`. A commit defers `onOpenPage` by
+    // COMMIT_SLIDE_OUT_MILLIS inside this block's `coroutineScope`; if `totalPages` were part of the
+    // key, a background refresh changing the page count (cache→network, or a new post) during that
+    // slide-out window would restart `pointerInput`, cancel the scope and drop `onOpenPage` — a silent
+    // nav failure with a snap-back. `totalPages` is instead read fresh through the `totalPages()`
+    // lambda (backed by `rememberUpdatedState` at the call site), so the gesture always sees the live
+    // count without ever re-keying.
+    .pointerInput(currentPage) {
         val commitDistancePx = swipeCommitDistancePx(size.width.toFloat(), MIN_COMMIT_DISTANCE.toPx())
         val flingThresholdPx = FLING_VELOCITY_THRESHOLD.toPx()
         val widthPx = size.width.toFloat()
@@ -254,20 +262,22 @@ internal fun Modifier.topicPageSwipe(
                     overSlop = slop
                 } ?: return@awaitEachGesture
                 // A new drag cancels any release animation still running from the previous swipe.
-                // Gated: `stop()` on an idle `Animatable` is a no-op, so skip the coroutine unless a
-                // release transition is actually in flight (the common case is none).
-                if (release.isRunning) animationScope.launch { release.stop() }
+                // `stop()` is idempotent (a no-op on an idle `Animatable`), so call it unconditionally
+                // rather than gate on a `release.isRunning` read that could flip between the check and
+                // the launched `stop()` actually running; the drag writes `dragOffset` synchronously
+                // each frame and supersedes any last tick of the cancelled release.
+                animationScope.launch { release.stop() }
                 var totalDx = overSlop
                 var armed = false
                 velocityTracker.addPosition(drag.uptimeMillis, drag.position)
-                dragOffset.floatValue = followOffsetFor(totalDx, commitDistancePx, currentPage, totalPages)
+                dragOffset.floatValue = followOffsetFor(totalDx, commitDistancePx, currentPage, totalPages())
                 // `horizontalDrag` returns false when the drag is CANCELLED — e.g. a descendant
                 // horizontal scroller (a wide `[fixed]` code block, the page grid) takes the pointer
                 // over after we crossed slop. Honour it: a taken-over gesture must NOT navigate.
                 val completed = horizontalDrag(drag.id) { change ->
                     totalDx += change.positionChange().x
                     velocityTracker.addPosition(change.uptimeMillis, change.position)
-                    val offset = followOffsetFor(totalDx, commitDistancePx, currentPage, totalPages)
+                    val offset = followOffsetFor(totalDx, commitDistancePx, currentPage, totalPages())
                     dragOffset.floatValue = offset // synchronous, no coroutine, no allocation
                     val nowArmed = swipeArmed(offset, commitDistancePx)
                     if (nowArmed && !armed) haptics.performHapticFeedback(ARMED_HAPTIC)
@@ -280,7 +290,7 @@ internal fun Modifier.topicPageSwipe(
                 }
                 val velocityX = velocityTracker.calculateVelocity().x
                 val forward = swipeCommitDirection(totalDx, velocityX, commitDistancePx, flingThresholdPx)
-                val target = forward?.let { swipeTargetPage(currentPage, totalPages, it) }
+                val target = forward?.let { swipeTargetPage(currentPage, totalPages(), it) }
                 if (forward != null && target != null) {
                     // Latch BEFORE the deferred slide-out so any gesture starting in the slide-out
                     // window is ignored (see `committed` declaration) — no second `onOpenPage`.
@@ -375,7 +385,7 @@ private fun followOffsetFor(totalDx: Float, commitDistancePx: Float, currentPage
  */
 internal fun Modifier.topicPageSwipeEdge(
     currentPage: Int,
-    totalPages: Int,
+    totalPages: () -> Int,
     dragOffset: MutableFloatState,
     accent: Color,
 ): Modifier = drawWithCache {
@@ -402,7 +412,7 @@ internal fun Modifier.topicPageSwipeEdge(
         if (offset == 0f || commitDistancePx <= 0f) return@onDrawWithContent
         val leftward = offset < 0f
         // Suppress the glow when this direction is a blocked edge (no neighbour page to bring in).
-        if (swipeTargetPage(currentPage, totalPages, forward = leftward) == null) return@onDrawWithContent
+        if (swipeTargetPage(currentPage, totalPages(), forward = leftward) == null) return@onDrawWithContent
         val alpha = swipeEdgeHintAlpha(abs(offset) / commitDistancePx)
         if (leftward) {
             drawRect(brush = rightBrush, topLeft = rightTopLeft, size = bandSize, alpha = alpha)

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
@@ -1,23 +1,30 @@
 package fr.forumhfr.redface2.feature.topic
 
 import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.awaitHorizontalTouchSlopOrCancellation
 import androidx.compose.foundation.gestures.horizontalDrag
+import androidx.compose.runtime.MutableFloatState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.compose.ui.unit.dp
 import kotlin.math.abs
+import kotlin.math.tanh
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 
@@ -77,9 +84,12 @@ internal fun swipeCommitDistancePx(widthPx: Float, minCommitPx: Float): Float =
  * drag immediate feedback (#282 follow). The sign matches [rawDx] (leftward drag → negative offset).
  * Pure → unit-tested.
  *
- * - [hasTarget] = true (a page exists that way): track the finger 1:1 up to [commitDistancePx], then
- *   apply [OVERPULL_RESISTANCE] so the page keeps giving a little without sliding the whole way —
- *   reaching `commitDistancePx` is the visual "armed" point the edge hint mirrors.
+ * - [hasTarget] = true (a page exists that way): track the finger 1:1 up to [commitDistancePx]
+ *   (`commitDistancePx` is the visual "armed" point the edge hint mirrors), then a **bounded
+ *   overpull** — a `tanh` asymptote that lets the page keep giving a little while it can never drift
+ *   past `commitDistancePx + OVERPULL_MAX_FRACTION × commitDistancePx`. The old linear-with-resistance
+ *   ramp grew without bound on a long drag, pulling the page arbitrarily far off-screen; the asymptote
+ *   keeps the gesture readable as "armed, will commit" instead of "I am tearing the page off".
  * - [hasTarget] = false (first/last page): a damped "wall", capped at [EDGE_MAX_FRACTION] of the
  *   commit distance, so a swipe into the void barely moves and reads as a boundary.
  */
@@ -91,7 +101,9 @@ internal fun swipeFollowOffset(rawDx: Float, commitDistancePx: Float, hasTarget:
         if (magnitude <= commitDistancePx) {
             magnitude
         } else {
-            commitDistancePx + (magnitude - commitDistancePx) * OVERPULL_RESISTANCE
+            val overpull = commitDistancePx * OVERPULL_MAX_FRACTION
+            val excess = magnitude - commitDistancePx
+            commitDistancePx + overpull * tanh(excess / overpull)
         }
     } else {
         minOf(magnitude * EDGE_RESISTANCE, commitDistancePx * EDGE_MAX_FRACTION)
@@ -99,33 +111,83 @@ internal fun swipeFollowOffset(rawDx: Float, commitDistancePx: Float, hasTarget:
     return sign * travel
 }
 
+/**
+ * Whether the swipe has crossed the commit distance, i.e. releasing now would change page. Pure →
+ * unit-tested. Drives the haptic "armed" tick (fired once on the rising edge, see [topicPageSwipe]);
+ * the edge-hint mirrors the same threshold continuously via [swipeEdgeHintAlpha]. Mirrors the
+ * distance arm of [swipeCommitDirection]; the fling arm can still commit a shorter drag (no static
+ * "armed" state for a fling, which is decided only at release).
+ */
+internal fun swipeArmed(offsetPx: Float, commitDistancePx: Float): Boolean =
+    commitDistancePx > 0f && abs(offsetPx) >= commitDistancePx
+
+/**
+ * Edge-glow opacity for a swipe [progress] = `|offset| / commitDistance` (`0f` at rest, `1f` at the
+ * commit/armed point, up to ~`1.5f` in the bounded overpull region). Pure → unit-tested.
+ *
+ * Two segments, continuous at `progress = 1f` so the brighten is finger-driven (no separate
+ * animation primitive needed in the draw phase, which reads state synchronously without
+ * recomposition):
+ * - `0f..1f`: ramp to [EDGE_HINT_MAX_ALPHA] as the swipe approaches arming.
+ * - past `1f`: a quick further brighten to [EDGE_HINT_ARMED_ALPHA] over the
+ *   [EDGE_HINT_ARMED_RAMP] window, so crossing the threshold visibly intensifies the glow — the
+ *   user sees that releasing will validate, in lock-step with the arming haptic tick.
+ */
+internal fun swipeEdgeHintAlpha(progress: Float): Float =
+    if (progress <= 1f) {
+        progress.coerceAtLeast(0f) * EDGE_HINT_MAX_ALPHA
+    } else {
+        val armedProgress = ((progress - 1f) / EDGE_HINT_ARMED_RAMP).coerceAtMost(1f)
+        EDGE_HINT_MAX_ALPHA + (EDGE_HINT_ARMED_ALPHA - EDGE_HINT_MAX_ALPHA) * armedProgress
+    }
+
 // Commit thresholds: a swipe changes page only past a clear intent, never on the bare touch slop.
 private const val COMMIT_FRACTION = 0.20f
 internal val MIN_COMMIT_DISTANCE = 72.dp
 private val FLING_VELOCITY_THRESHOLD = 900.dp
 
 // Drag-follow feel (#282 (b)+(c)). All purely visual — they never affect the commit decision.
-private const val OVERPULL_RESISTANCE = 0.35f // diminishing follow past the commit point
+// Past the commit point the follow saturates: `tanh` asymptote bounded to this × commit distance so
+// the page can never drift arbitrarily far on a long drag.
+private const val OVERPULL_MAX_FRACTION = 0.5f
 private const val EDGE_RESISTANCE = 0.30f // damping into a blocked edge (first/last page)
 private const val EDGE_MAX_FRACTION = 0.4f // a blocked edge can travel at most this × commit distance
 private const val EDGE_HINT_WIDTH_FRACTION = 0.18f // edge-glow band width, as a fraction of the page
-private const val EDGE_HINT_MAX_ALPHA = 0.5f // edge-glow opacity once the swipe is fully armed
+private const val EDGE_HINT_MAX_ALPHA = 0.5f // edge-glow opacity right at the arming point
+private const val EDGE_HINT_ARMED_ALPHA = 0.7f // brighter edge-glow once the swipe is fully armed
+private const val EDGE_HINT_ARMED_RAMP = 0.15f // overpull-progress window over which the armed glow fills
+private const val COMMIT_SLIDE_OUT_MILLIS = 120 // page slide-out before navigation on commit
+
+// A committed page slides fully off-screen before navigating; the elevation lift sells "the page
+// leaves". Both are read at draw time from the same offset state the drag writes.
+private const val COMMIT_SHADOW_ELEVATION_DP = 8f
 
 private val SPRING_BACK = spring<Float>(
-    dampingRatio = Spring.DampingRatioLowBouncy,
-    stiffness = Spring.StiffnessMediumLow,
+    // Crisp, non-bouncy return when a drag does NOT commit (cancel / fling-less release): the page
+    // snaps back to rest without the soft overshoot used for a blocked edge, so a cancel reads as a
+    // deliberate "no" rather than a wobble.
+    dampingRatio = Spring.DampingRatioNoBouncy,
+    stiffness = Spring.StiffnessMedium,
 )
 
 /**
  * Horizontal swipe → change topic page (#282, Option A) with drag-follow feedback (b). A committed
- * left/right swipe calls [onOpenPage] (the existing route-driven navigation: pop+push of
- * `TopicRoute`), reusing the whole pagination/prefetch machinery — no neighbour page is composed, so
- * the « prefetch non authentifié » invariant is never touched.
+ * left/right swipe slides the current page off-screen then calls [onOpenPage] (the existing
+ * route-driven navigation: pop+push of `TopicRoute`), reusing the whole pagination/prefetch
+ * machinery — no neighbour page is composed, so the « prefetch non authentifié » invariant is never
+ * touched.
  *
- * While dragging, the current page follows the finger ([dragOffset] drives a `translationX`, shaped
- * by [swipeFollowOffset]); on commit it navigates, otherwise (no-commit, edge, or a child taking the
- * drag) it springs back to rest. The cross-page cut after a commit is unchanged (no shared-element
- * transition) — that is the optional follow-up (a) at the `NavDisplay` level.
+ * Per-frame follow is **synchronous and allocation-free**: the gesture writes the shaped offset into
+ * [dragOffset] (a [MutableFloatState]) directly in the `horizontalDrag` callback, and the draw phase
+ * reads it via `graphicsLayer { translationX = … }`. An [Animatable] is used ONLY for the two release
+ * transitions (spring-back on cancel/no-commit, slide-out on commit); it streams its value back into
+ * the same [dragOffset] so the draw phase never has to know which drives it. No `snapTo`/coroutine is
+ * launched per drag event.
+ *
+ * On commit the page first animates off-screen (translationX → ±width, a short [tween]) and only then
+ * navigates, killing the figé "flash" of the old instant cut. Otherwise (no-commit, edge, or a child
+ * taking the drag) it springs back to rest. Haptics: a tick when the swipe arms (crosses the commit
+ * distance, once per rising edge) and a confirm on commit.
  *
  * Coexistence (unchanged from the discrete version, validated with Codex gpt-5.5):
  * - it engages only on **horizontal** touch slop, so the vertical `LazyColumn` scroll is never stolen;
@@ -147,7 +209,8 @@ private val SPRING_BACK = spring<Float>(
 internal fun Modifier.topicPageSwipe(
     currentPage: Int,
     totalPages: Int,
-    dragOffset: Animatable<Float, AnimationVector1D>,
+    dragOffset: MutableFloatState,
+    haptics: HapticFeedback,
     onOpenPage: (Int) -> Unit,
 ): Modifier = this
     // `pointerInput` sits BEFORE `graphicsLayer` on purpose: the gesture must read finger deltas in
@@ -158,6 +221,10 @@ internal fun Modifier.topicPageSwipe(
     .pointerInput(currentPage, totalPages) {
         val commitDistancePx = swipeCommitDistancePx(size.width.toFloat(), MIN_COMMIT_DISTANCE.toPx())
         val flingThresholdPx = FLING_VELOCITY_THRESHOLD.toPx()
+        val widthPx = size.width.toFloat()
+        // Reserved for release transitions ONLY (spring-back / slide-out). The drag itself writes
+        // `dragOffset` synchronously; this `Animatable` streams its value back into the same state.
+        val release = Animatable(0f)
         coroutineScope {
             val animationScope = this
             awaitEachGesture {
@@ -171,43 +238,88 @@ internal fun Modifier.topicPageSwipe(
                     change.consume()
                     overSlop = slop
                 } ?: return@awaitEachGesture
+                // A new drag cancels any release animation still running from the previous swipe.
+                animationScope.launch { release.stop() }
                 var totalDx = overSlop
+                var armed = false
                 velocityTracker.addPosition(drag.uptimeMillis, drag.position)
-                // The first snapTo also cancels any spring-back still running from a previous swipe.
-                animationScope.launch {
-                    dragOffset.snapTo(followOffsetFor(totalDx, commitDistancePx, currentPage, totalPages))
-                }
+                dragOffset.floatValue = followOffsetFor(totalDx, commitDistancePx, currentPage, totalPages)
                 // `horizontalDrag` returns false when the drag is CANCELLED — e.g. a descendant
                 // horizontal scroller (a wide `[fixed]` code block, the page grid) takes the pointer
                 // over after we crossed slop. Honour it: a taken-over gesture must NOT navigate.
                 val completed = horizontalDrag(drag.id) { change ->
                     totalDx += change.positionChange().x
                     velocityTracker.addPosition(change.uptimeMillis, change.position)
-                    animationScope.launch {
-                        dragOffset.snapTo(followOffsetFor(totalDx, commitDistancePx, currentPage, totalPages))
-                    }
+                    val offset = followOffsetFor(totalDx, commitDistancePx, currentPage, totalPages)
+                    dragOffset.floatValue = offset // synchronous, no coroutine, no allocation
+                    val nowArmed = swipeArmed(offset, commitDistancePx)
+                    if (nowArmed && !armed) haptics.performHapticFeedback(ARMED_HAPTIC)
+                    armed = nowArmed
                     change.consume()
                 }
                 if (!completed) {
-                    animationScope.launch { dragOffset.animateTo(0f, SPRING_BACK) }
+                    springBackTo(animationScope, release, dragOffset)
                     return@awaitEachGesture
                 }
                 val velocityX = velocityTracker.calculateVelocity().x
-                val target = swipeCommitDirection(totalDx, velocityX, commitDistancePx, flingThresholdPx)
-                    ?.let { forward -> swipeTargetPage(currentPage, totalPages, forward) }
-                if (target != null) {
-                    // Navigation replaces the screen; the offset state is discarded with it.
-                    onOpenPage(target)
+                val forward = swipeCommitDirection(totalDx, velocityX, commitDistancePx, flingThresholdPx)
+                val target = forward?.let { swipeTargetPage(currentPage, totalPages, it) }
+                if (forward != null && target != null) {
+                    haptics.performHapticFeedback(HapticFeedbackType.Confirm)
+                    // Slide in the commit direction (forward = next = leftward = negative), not the
+                    // residual offset sign: a fast fling can commit with a near-zero/opposite offset.
+                    val targetX = if (forward) -widthPx else widthPx
+                    commitSlideOut(animationScope, release, dragOffset, targetX) { onOpenPage(target) }
                 } else {
-                    animationScope.launch { dragOffset.animateTo(0f, SPRING_BACK) }
+                    springBackTo(animationScope, release, dragOffset)
                 }
             }
         }
     }
-    // Draw-only translation of the page content. After `pointerInput` (see above) so the gesture is
-    // read in untranslated space; reading `dragOffset.value` here keeps the follow on the draw phase
-    // (no recomposition per frame).
-    .graphicsLayer { translationX = dragOffset.value }
+    // Draw-only translation of the page content + a slight elevation lift so a committed page reads as
+    // leaving. After `pointerInput` (see above) so the gesture is read in untranslated space; reading
+    // `dragOffset.floatValue` here keeps the follow on the draw phase (no recomposition per frame).
+    .graphicsLayer {
+        val offset = dragOffset.floatValue
+        translationX = offset
+        shadowElevation = if (offset == 0f) 0f else COMMIT_SHADOW_ELEVATION_DP.dp.toPx()
+    }
+
+/** Spring the page back to rest (cancel / no-commit), streaming the animation into [dragOffset]. */
+private fun springBackTo(
+    scope: CoroutineScope,
+    release: Animatable<Float, *>,
+    dragOffset: MutableFloatState,
+) {
+    scope.launch {
+        release.snapTo(dragOffset.floatValue)
+        release.animateTo(0f, SPRING_BACK) { dragOffset.floatValue = value }
+    }
+}
+
+/**
+ * Slide the committed page fully off-screen to [targetX] (±width, chosen by the commit direction) over
+ * [COMMIT_SLIDE_OUT_MILLIS], then navigate exactly once via [onCommitted]. The navigation replaces the
+ * screen (the offset state is discarded with it), so there is nothing to reset afterwards. Streaming
+ * into [dragOffset] keeps the draw phase agnostic of what drives the offset.
+ */
+private fun commitSlideOut(
+    scope: CoroutineScope,
+    release: Animatable<Float, *>,
+    dragOffset: MutableFloatState,
+    targetX: Float,
+    onCommitted: () -> Unit,
+) {
+    scope.launch {
+        release.snapTo(dragOffset.floatValue)
+        release.animateTo(targetX, tween(durationMillis = COMMIT_SLIDE_OUT_MILLIS)) {
+            dragOffset.floatValue = value
+        }
+        onCommitted()
+    }
+}
+
+private val ARMED_HAPTIC = HapticFeedbackType.GestureThresholdActivate
 
 private fun followOffsetFor(totalDx: Float, commitDistancePx: Float, currentPage: Int, totalPages: Int): Float {
     val hasTarget = swipeTargetPage(currentPage, totalPages, forward = totalDx < 0f) != null
@@ -217,9 +329,12 @@ private fun followOffsetFor(totalDx: Float, commitDistancePx: Float, currentPage
 /**
  * Edge hint for the topic page swipe (#282 (c)). Draws a glow on the edge the neighbour page is being
  * pulled in from — right edge for a leftward drag (next page), left edge for a rightward drag — whose
- * opacity ramps with the swipe's progress toward the commit distance and reaches [EDGE_HINT_MAX_ALPHA]
- * once the swipe is armed. It reads [dragOffset] at draw time only, so following the finger never
- * recomposes.
+ * opacity ramps with the swipe's progress toward the commit distance and brightens to an armed accent
+ * ([swipeEdgeHintAlpha]) once the swipe is armed, so the user sees that releasing will validate. It
+ * reads [dragOffset] at draw time only, so following the finger never recomposes.
+ *
+ * Only the edge band (a [EDGE_HINT_WIDTH_FRACTION] sub-rect of the page) is painted — not a
+ * full-screen `Brush` per frame.
  *
  * Must sit **before** [topicPageSwipe] in the modifier chain: it draws via `drawWithContent` in the
  * element's own (untranslated) space, so the glow stays pinned to the screen edge while the page
@@ -227,18 +342,19 @@ private fun followOffsetFor(totalDx: Float, commitDistancePx: Float, currentPage
  * [accent] is read from the theme by the (composable) caller and passed in, since a draw scope cannot.
  */
 internal fun Modifier.topicPageSwipeEdge(
-    dragOffset: Animatable<Float, AnimationVector1D>,
+    dragOffset: MutableFloatState,
     accent: Color,
 ): Modifier = drawWithContent {
     drawContent()
-    val offset = dragOffset.value
+    val offset = dragOffset.floatValue
     if (offset == 0f) return@drawWithContent
     val commitDistancePx = swipeCommitDistancePx(size.width, MIN_COMMIT_DISTANCE.toPx())
     if (commitDistancePx <= 0f) return@drawWithContent
-    val progress = (abs(offset) / commitDistancePx).coerceIn(0f, 1f)
-    val alpha = progress * EDGE_HINT_MAX_ALPHA
+    val progress = abs(offset) / commitDistancePx
+    val alpha = swipeEdgeHintAlpha(progress)
     val band = size.width * EDGE_HINT_WIDTH_FRACTION
-    val brush = if (offset < 0f) {
+    val leftward = offset < 0f
+    val brush = if (leftward) {
         Brush.horizontalGradient(
             colors = listOf(Color.Transparent, accent.copy(alpha = alpha)),
             startX = size.width - band,
@@ -251,5 +367,7 @@ internal fun Modifier.topicPageSwipeEdge(
             endX = band,
         )
     }
-    drawRect(brush = brush)
+    // Paint only the edge band, not the whole page, so the per-frame fill stays small.
+    val topLeft = if (leftward) Offset(size.width - band, 0f) else Offset.Zero
+    drawRect(brush = brush, topLeft = topLeft, size = Size(band, size.height))
 }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.feature.topic
 
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
@@ -25,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import kotlin.math.abs
 import kotlin.math.tanh
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 
@@ -131,20 +133,28 @@ internal fun swipeArmed(offsetPx: Float, commitDistancePx: Float): Boolean =
  * commit/armed point, up to `1f + OVERPULL_MAX_FRACTION` — currently `1.5f` — in the bounded overpull
  * region). Pure → unit-tested.
  *
- * Two segments, continuous at `progress = 1f` so the brighten is finger-driven (no separate
- * animation primitive needed in the draw phase, which reads state synchronously without
- * recomposition):
- * - `0f..1f`: ramp to [EDGE_HINT_MAX_ALPHA] as the swipe approaches arming.
- * - past `1f`: a quick further brighten to [EDGE_HINT_ARMED_ALPHA] over the
- *   [EDGE_HINT_ARMED_RAMP] window, so crossing the threshold visibly intensifies the glow — the
- *   user sees that releasing will validate, in lock-step with the arming haptic tick.
+ * **Late-start** so the glow is a "you're about to commit" confirmation, not a decoration that
+ * occupies the screen from the first pixel: it stays fully invisible below [EDGE_HINT_START_PROGRESS]
+ * (the page already follows the finger, which conveys direction early). Three segments, continuous at
+ * `progress = 1f` so the brighten is finger-driven (no separate animation primitive in the draw phase,
+ * which reads state synchronously without recomposition):
+ * - `0f..EDGE_HINT_START_PROGRESS`: nothing (`0f`).
+ * - `EDGE_HINT_START_PROGRESS..1f`: ramp to [EDGE_HINT_MAX_ALPHA] as the swipe nears arming.
+ * - past `1f`: a quick further brighten to [EDGE_HINT_ARMED_ALPHA] over the [EDGE_HINT_ARMED_RAMP]
+ *   window, so crossing the threshold visibly intensifies the glow — the user sees that releasing will
+ *   validate, in lock-step with the arming haptic tick.
  */
 internal fun swipeEdgeHintAlpha(progress: Float): Float =
-    if (progress <= 1f) {
-        progress.coerceAtLeast(0f) * EDGE_HINT_MAX_ALPHA
-    } else {
-        val armedProgress = ((progress - 1f) / EDGE_HINT_ARMED_RAMP).coerceAtMost(1f)
-        EDGE_HINT_MAX_ALPHA + (EDGE_HINT_ARMED_ALPHA - EDGE_HINT_MAX_ALPHA) * armedProgress
+    when {
+        progress <= EDGE_HINT_START_PROGRESS -> 0f
+        progress <= 1f -> {
+            val ramp = (progress - EDGE_HINT_START_PROGRESS) / (1f - EDGE_HINT_START_PROGRESS)
+            ramp * EDGE_HINT_MAX_ALPHA
+        }
+        else -> {
+            val armedProgress = ((progress - 1f) / EDGE_HINT_ARMED_RAMP).coerceAtMost(1f)
+            EDGE_HINT_MAX_ALPHA + (EDGE_HINT_ARMED_ALPHA - EDGE_HINT_MAX_ALPHA) * armedProgress
+        }
     }
 
 // Commit thresholds: a swipe changes page only past a clear intent, never on the bare touch slop.
@@ -158,11 +168,13 @@ private val FLING_VELOCITY_THRESHOLD = 900.dp
 private const val OVERPULL_MAX_FRACTION = 0.5f
 private const val EDGE_RESISTANCE = 0.30f // damping into a blocked edge (first/last page)
 private const val EDGE_MAX_FRACTION = 0.4f // a blocked edge can travel at most this × commit distance
-private const val EDGE_HINT_WIDTH_FRACTION = 0.18f // edge-glow band width, as a fraction of the page
-private const val EDGE_HINT_MAX_ALPHA = 0.5f // edge-glow opacity right at the arming point
-private const val EDGE_HINT_ARMED_ALPHA = 0.7f // brighter edge-glow once the swipe is fully armed
+private const val EDGE_HINT_WIDTH_FRACTION = 0.10f // edge-glow band width, as a fraction of the page…
+private val EDGE_HINT_MAX_WIDTH = 40.dp // …but never wider than this, so it reads as an edge accent
+private const val EDGE_HINT_START_PROGRESS = 0.65f // glow stays invisible below this fraction of commit
+private const val EDGE_HINT_MAX_ALPHA = 0.2f // edge-glow opacity right at the arming point
+private const val EDGE_HINT_ARMED_ALPHA = 0.3f // brighter edge-glow once the swipe is fully armed
 private const val EDGE_HINT_ARMED_RAMP = 0.15f // overpull-progress window over which the armed glow fills
-private const val COMMIT_SLIDE_OUT_MILLIS = 120 // page slide-out before navigation on commit
+private const val COMMIT_SLIDE_OUT_MILLIS = 200 // page slide-out before navigation on commit (decelerated)
 
 // A committed page slides fully off-screen before navigating; the elevation lift sells "the page
 // leaves". Both are read at draw time from the same offset state the drag writes.
@@ -254,6 +266,14 @@ internal fun Modifier.topicPageSwipe(
             // gestures until this pointerInput is torn down by the route change — so `onOpenPage` fires
             // exactly once.
             var committed = false
+            // Tracks the in-flight release transition (spring-back / slide-out) so a new drag can
+            // cancel it DETERMINISTICALLY and SYNCHRONOUSLY (see the slop branch below). Replaces the
+            // former fire-and-forget `launch { release.stop() }`, whose dispatch order was not
+            // guaranteed: a late `stop()` could cancel the WRONG (newer) animation — including a commit
+            // slide-out before its `onOpenPage` fired, leaving `committed` latched true forever and the
+            // page frozen off-screen. Cancelling this exact job — and only behind the `committed` guard
+            // — means a committing slide-out is never interrupted, so navigation always completes.
+            var releaseJob: Job? = null
             awaitEachGesture {
                 val down = awaitFirstDown(requireUnconsumed = false)
                 if (committed) return@awaitEachGesture
@@ -266,16 +286,16 @@ internal fun Modifier.topicPageSwipe(
                     change.consume()
                     overSlop = slop
                 } ?: return@awaitEachGesture
-                // A new drag cancels any release animation still running from the previous swipe.
-                // It MUST be `launch`-ed: `awaitEachGesture` runs in a `@RestrictsSuspension`
-                // `AwaitPointerEventScope`, which can only await suspend members of that scope — never
-                // `Animatable.stop()` — so the stop is handed to the (unrestricted) `animationScope`.
-                // Unconditional, no `release.isRunning` gate: `stop()` is a no-op on an idle
-                // `Animatable`, so dropping the check removes a TOCTOU read; the drag then writes
-                // `dragOffset` synchronously each frame and supersedes any final tick of the cancelled
-                // spring-back (bounded to at most one frame, since synchronous await is impossible
-                // here). A committed slide-out never reaches here (the `committed` latch returned above).
-                animationScope.launch { release.stop() }
+                // Cancel the previous release transition deterministically — AT slop crossing, not at
+                // `down` (a tap / vertical scroll that never crosses horizontal slop returned above and
+                // must NOT interrupt a running spring-back). `Job.cancel()` is not `suspend`, so it runs
+                // in-order right here, before this drag writes `dragOffset` below — there is no late,
+                // out-of-order `stop()` that could kill a newer animation. The drag then owns
+                // `dragOffset` synchronously each frame; the next release transition (set at gesture
+                // end) streams into it again. A committed slide-out never reaches this line (the
+                // `committed` latch returned at the top of the gesture), so a commit's `onOpenPage`
+                // always fires.
+                releaseJob?.cancel()
                 var totalDx = overSlop
                 var armed = false
                 velocityTracker.addPosition(drag.uptimeMillis, drag.position)
@@ -294,7 +314,7 @@ internal fun Modifier.topicPageSwipe(
                     change.consume()
                 }
                 if (!completed) {
-                    springBackTo(animationScope, release, dragOffset)
+                    releaseJob = springBackTo(animationScope, release, dragOffset)
                     return@awaitEachGesture
                 }
                 val velocityX = velocityTracker.calculateVelocity().x
@@ -308,9 +328,9 @@ internal fun Modifier.topicPageSwipe(
                     // Slide in the commit direction (forward = next = leftward = negative), not the
                     // residual offset sign: a fast fling can commit with a near-zero/opposite offset.
                     val targetX = if (forward) -widthPx else widthPx
-                    commitSlideOut(animationScope, release, dragOffset, targetX) { onOpenPage(target) }
+                    releaseJob = commitSlideOut(animationScope, release, dragOffset, targetX) { onOpenPage(target) }
                 } else {
-                    springBackTo(animationScope, release, dragOffset)
+                    releaseJob = springBackTo(animationScope, release, dragOffset)
                 }
             }
         }
@@ -333,11 +353,9 @@ private fun springBackTo(
     scope: CoroutineScope,
     release: Animatable<Float, *>,
     dragOffset: MutableFloatState,
-) {
-    scope.launch {
-        release.snapTo(dragOffset.floatValue)
-        release.animateTo(0f, SPRING_BACK) { dragOffset.floatValue = value }
-    }
+): Job = scope.launch {
+    release.snapTo(dragOffset.floatValue)
+    release.animateTo(0f, SPRING_BACK) { dragOffset.floatValue = value }
 }
 
 /**
@@ -352,14 +370,12 @@ private fun commitSlideOut(
     dragOffset: MutableFloatState,
     targetX: Float,
     onCommitted: () -> Unit,
-) {
-    scope.launch {
-        release.snapTo(dragOffset.floatValue)
-        release.animateTo(targetX, tween(durationMillis = COMMIT_SLIDE_OUT_MILLIS)) {
-            dragOffset.floatValue = value
-        }
-        onCommitted()
+): Job = scope.launch {
+    release.snapTo(dragOffset.floatValue)
+    release.animateTo(targetX, tween(durationMillis = COMMIT_SLIDE_OUT_MILLIS, easing = LinearOutSlowInEasing)) {
+        dragOffset.floatValue = value
     }
+    onCommitted()
 }
 
 private val ARMED_HAPTIC = HapticFeedbackType.GestureThresholdActivate
@@ -402,7 +418,7 @@ internal fun Modifier.topicPageSwipeEdge(
     // brushes. The per-frame opacity is applied via `drawRect`'s `alpha`, so neither brush nor the
     // colors `List` is re-allocated while the finger moves.
     val commitDistancePx = swipeCommitDistancePx(size.width, MIN_COMMIT_DISTANCE.toPx())
-    val band = size.width * EDGE_HINT_WIDTH_FRACTION
+    val band = minOf(size.width * EDGE_HINT_WIDTH_FRACTION, EDGE_HINT_MAX_WIDTH.toPx())
     val rightTopLeft = Offset(size.width - band, 0f)
     val bandSize = Size(band, size.height)
     val rightBrush = Brush.horizontalGradient(

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
@@ -203,11 +203,11 @@ private val SPRING_BACK = spring<Float>(
  * launched per drag event.
  *
  * On commit the page first animates off-screen (translationX → ±width, a short [tween]) and only then
- * navigates, softening the **departure** of the old instant cut (the incoming page still hard-appears
- * via the route change until the NavDisplay slide-in follow-up (a) lands — out of scope here, it would
- * touch `:app`/navigation). Otherwise (no-commit, edge, or a child taking the drag) it springs back to
- * rest. Haptics: a tick when the swipe arms (crosses the commit distance, once per rising edge) and a
- * confirm on commit.
+ * navigates, softening the **departure**. The incoming page then appears via an instant
+ * `TopicRoute → TopicRoute` NavDisplay transition wired in `:app` navigation (see #282), which also
+ * collapses the swipe dead-zone — not a generic slide-in. Otherwise (no-commit, edge, or a child taking
+ * the drag) it springs back to rest. Haptics: a tick when the swipe arms (crosses the commit distance,
+ * once per rising edge) and a confirm on commit.
  *
  * Coexistence (unchanged from the discrete version, validated with Codex gpt-5.5):
  * - it engages only on **horizontal** touch slop, so the vertical `LazyColumn` scroll is never stolen;

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
@@ -100,11 +100,15 @@ internal fun Modifier.topicPageSwipe(
         } ?: return@awaitEachGesture
         var totalDx = overSlop
         velocityTracker.addPosition(drag.uptimeMillis, drag.position)
-        horizontalDrag(drag.id) { change ->
+        // `horizontalDrag` returns false when the drag is CANCELLED — e.g. a descendant horizontal
+        // scroller (a wide `[fixed]` code block, the page grid) takes the pointer over after we crossed
+        // slop. Honour it: a taken-over gesture must NOT navigate the page (Codex gpt-5.5 P2).
+        val completed = horizontalDrag(drag.id) { change ->
             totalDx += change.positionChange().x
             velocityTracker.addPosition(change.uptimeMillis, change.position)
             change.consume()
         }
+        if (!completed) return@awaitEachGesture
         val velocityX = velocityTracker.calculateVelocity().x
         swipeCommitDirection(totalDx, velocityX, commitDistancePx, flingThresholdPx)?.let { forward ->
             swipeTargetPage(currentPage, totalPages, forward)?.let(onOpenPage)

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
@@ -13,11 +13,12 @@ import kotlin.math.abs
 
 /**
  * Target page of a horizontal swipe while reading a topic (#282), or `null` when the gesture is
- * blocked by an edge. [forward] = true → next page (drag left), false → previous page (drag right).
- * Pure → unit-tested without Compose.
+ * blocked by an edge. [forward] = true → next page, false → previous page. Pure → unit-tested
+ * without Compose.
  *
- * Mirrors the exact bounds of `TopicUiState.canGoNext` / `canGoPrevious` (page in `1..totalPages`)
- * so the swipe and the Previous/Next buttons agree.
+ * Bounds the result to `1..totalPages` — the same range as `TopicUiState.canGoNext` /
+ * `canGoPrevious`. The page source is the rendered `Topic.page` (what the user is looking at), which
+ * matches the value the Previous/Next buttons pass to `onOpenPage`.
  */
 internal fun swipeTargetPage(currentPage: Int, totalPages: Int, forward: Boolean): Int? =
     if (forward) {
@@ -25,6 +26,32 @@ internal fun swipeTargetPage(currentPage: Int, totalPages: Int, forward: Boolean
     } else {
         (currentPage - 1).takeIf { it >= 1 }
     }
+
+/**
+ * Direction a finished horizontal drag committed to, or `null` for a no-op (drag too small AND too
+ * slow). `true` = next page (leftward drag), `false` = previous page (rightward). Pure → unit-tested
+ * without a gesture clock. Edge clamping is the caller's job (via [swipeTargetPage]).
+ *
+ * Commit when the drag crossed EITHER the distance ([commitDistancePx]) or the fling velocity
+ * ([flingThresholdPx]) threshold. Direction follows the **velocity** when a fling carried the commit,
+ * otherwise the **distance** — so a fast flick that happens to lift on the wrong side of its start
+ * (finger reversed) still goes the way it was thrown, and a near-zero displacement never picks an
+ * unstable sign. Negative = leftward drag = next page (geometric, see [topicPageSwipe]).
+ */
+internal fun swipeCommitDirection(
+    totalDx: Float,
+    velocityX: Float,
+    commitDistancePx: Float,
+    flingThresholdPx: Float,
+): Boolean? {
+    val committedByFling = abs(velocityX) >= flingThresholdPx
+    val orientation = when {
+        committedByFling -> velocityX
+        abs(totalDx) >= commitDistancePx -> totalDx
+        else -> return null
+    }
+    return if (orientation == 0f) null else orientation < 0f
+}
 
 // Commit thresholds: a swipe changes page only past a clear intent, never on the bare touch slop.
 private const val COMMIT_FRACTION = 0.20f
@@ -41,8 +68,13 @@ private val FLING_VELOCITY_THRESHOLD = 900.dp
  * - it engages only on **horizontal** touch slop, so the vertical `LazyColumn` scroll is never stolen;
  * - a child that consumes the horizontal drag first (the page-grid's `horizontalScroll`) cancels our
  *   slop detection, so it keeps its own gesture;
- * - at the edges ([swipeTargetPage] returns `null`) the gesture is a no-op (no navigation, no flash);
+ * - at the edges (target is `null`) the gesture is a no-op (no navigation, no flash);
  * - exactly one [onOpenPage] per gesture.
+ *
+ * Direction is **geometric**, not layout-direction aware: a physical leftward drag always opens the
+ * next page (rightward = previous), regardless of `LayoutDirection`. The forum content is LTR
+ * (French) so an RTL-mirrored mapping would only matter for a locale this app does not target;
+ * mirroring on `LayoutDirection` is a deliberate non-goal here (revisit if RTL becomes a use case).
  *
  * Primitive choice: low-level `awaitEachGesture` + `awaitHorizontalTouchSlopOrCancellation` rather
  * than `detectHorizontalDragGestures` (too blunt — auto-consumes and locks the axis) or
@@ -74,10 +106,8 @@ internal fun Modifier.topicPageSwipe(
             change.consume()
         }
         val velocityX = velocityTracker.calculateVelocity().x
-        val committed = abs(totalDx) >= commitDistancePx || abs(velocityX) >= flingThresholdPx
-        if (committed) {
-            // Drag left (negative dx) reveals the next page; drag right the previous one.
-            swipeTargetPage(currentPage, totalPages, forward = totalDx < 0f)?.let(onOpenPage)
+        swipeCommitDirection(totalDx, velocityX, commitDistancePx, flingThresholdPx)?.let { forward ->
+            swipeTargetPage(currentPage, totalPages, forward)?.let(onOpenPage)
         }
     }
 }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
@@ -283,7 +283,8 @@ internal fun Modifier.topicPageSwipe(
                 // `committed` latch cannot span the inter-page transition (the incoming page is a fresh
                 // composition with its own latch). Gating at `down`, before the gesture arms/follows, is
                 // required: merely dropping `onOpenPage` after the slide-out would still park the page
-                // off-screen (the very freeze). See #282.
+                // off-screen (the very freeze). See #282. (A `down` that lands while still RESUMED but
+                // whose slop is crossed mid-transition is safe: the `committed` latch blocks a 2nd fire.)
                 if (!handlers.enabled()) return@awaitEachGesture
                 val velocityTracker = VelocityTracker()
                 velocityTracker.addPosition(down.uptimeMillis, down.position)

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
@@ -50,10 +50,14 @@ internal fun swipeTargetPage(currentPage: Int, totalPages: Int, forward: Boolean
  * without a gesture clock. Edge clamping is the caller's job (via [swipeTargetPage]).
  *
  * Commit when the drag crossed EITHER the distance ([commitDistancePx]) or the fling velocity
- * ([flingThresholdPx]) threshold. Direction follows the **velocity** when a fling carried the commit,
- * otherwise the **distance** — so a fast flick that happens to lift on the wrong side of its start
- * (finger reversed) still goes the way it was thrown, and a near-zero displacement never picks an
- * unstable sign. Negative = leftward drag = next page (geometric, see [topicPageSwipe]).
+ * ([flingThresholdPx]) threshold. Direction priority is **distance first, then velocity**: once the
+ * drag has travelled past [commitDistancePx] it is "armed" and the page-follow, edge glow and arming
+ * haptic have already committed the user to the direction of [totalDx] — so the commit MUST follow
+ * that direction even if the finger flicked back the other way at lift-off (a fast reverse on release
+ * would otherwise open the opposite page and contradict every bit of feedback the user just saw).
+ * Velocity decides ONLY for a short gesture that never crossed the distance threshold (a quick flick
+ * that lifts on the wrong side of its start still goes the way it was thrown). A near-zero orientation
+ * never picks an unstable sign. Negative = leftward drag = next page (geometric, see [topicPageSwipe]).
  */
 internal fun swipeCommitDirection(
     totalDx: Float,
@@ -61,10 +65,11 @@ internal fun swipeCommitDirection(
     commitDistancePx: Float,
     flingThresholdPx: Float,
 ): Boolean? {
+    val committedByDistance = abs(totalDx) >= commitDistancePx
     val committedByFling = abs(velocityX) >= flingThresholdPx
     val orientation = when {
+        committedByDistance -> totalDx
         committedByFling -> velocityX
-        abs(totalDx) >= commitDistancePx -> totalDx
         else -> return null
     }
     return if (orientation == 0f) null else orientation < 0f
@@ -262,10 +267,14 @@ internal fun Modifier.topicPageSwipe(
                     overSlop = slop
                 } ?: return@awaitEachGesture
                 // A new drag cancels any release animation still running from the previous swipe.
-                // `stop()` is idempotent (a no-op on an idle `Animatable`), so call it unconditionally
-                // rather than gate on a `release.isRunning` read that could flip between the check and
-                // the launched `stop()` actually running; the drag writes `dragOffset` synchronously
-                // each frame and supersedes any last tick of the cancelled release.
+                // It MUST be `launch`-ed: `awaitEachGesture` runs in a `@RestrictsSuspension`
+                // `AwaitPointerEventScope`, which can only await suspend members of that scope — never
+                // `Animatable.stop()` — so the stop is handed to the (unrestricted) `animationScope`.
+                // Unconditional, no `release.isRunning` gate: `stop()` is a no-op on an idle
+                // `Animatable`, so dropping the check removes a TOCTOU read; the drag then writes
+                // `dragOffset` synchronously each frame and supersedes any final tick of the cancelled
+                // spring-back (bounded to at most one frame, since synchronous await is impossible
+                // here). A committed slide-out never reaches here (the `committed` latch returned above).
                 animationScope.launch { release.stop() }
                 var totalDx = overSlop
                 var armed = false

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipeTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipeTest.kt
@@ -201,6 +201,27 @@ class TopicSwipeTest {
         assertEquals(0.7f, swipeEdgeHintAlpha(progress = 5f), TOLERANCE)
     }
 
+    // --- blocked-edge glow suppression contract (feel-lens fix) ---
+    // topicPageSwipeEdge gates the glow on `swipeTargetPage(...) == null` for the dragged direction:
+    // at a wall the damped follow still moves the page (so the wall is felt) but no glow lights up,
+    // since no neighbour page is being brought in. These two pure functions are the gate's inputs.
+
+    @Test
+    fun `at a blocked edge the page still moves but the direction has no target`() {
+        // Last page dragged leftward (forward = next): damped wall produces a non-zero offset...
+        val offset = swipeFollowOffset(rawDx = -1000f, commitDistancePx = commit, hasTarget = false)
+        assertTrue("the wall should still give a little", abs(offset) > 0f)
+        // ...yet there is no target page that way, so the call-site suppresses the glow.
+        assertNull(swipeTargetPage(currentPage = 5, totalPages = 5, forward = true))
+    }
+
+    @Test
+    fun `away from a blocked edge the same drag direction has a target`() {
+        // From a middle page the forward direction has a target, so the glow is allowed.
+        assertEquals(3, swipeTargetPage(currentPage = 2, totalPages = 5, forward = true))
+        assertEquals(1, swipeTargetPage(currentPage = 2, totalPages = 5, forward = false))
+    }
+
     private companion object {
         const val TOLERANCE = 0.001f
     }

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipeTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipeTest.kt
@@ -6,6 +6,8 @@ import org.junit.Test
 
 class TopicSwipeTest {
 
+    // --- swipeTargetPage : bornes ---
+
     @Test
     fun `forward swipe from a middle page targets the next page`() {
         assertEquals(3, swipeTargetPage(currentPage = 2, totalPages = 5, forward = true))
@@ -30,5 +32,42 @@ class TopicSwipeTest {
     fun `single-page topic blocks both directions`() {
         assertNull(swipeTargetPage(currentPage = 1, totalPages = 1, forward = true))
         assertNull(swipeTargetPage(currentPage = 1, totalPages = 1, forward = false))
+    }
+
+    // --- swipeCommitDirection : seuils de commit + direction ---
+
+    private val commitDistance = 200f
+    private val flingThreshold = 900f
+
+    @Test
+    fun `no commit when both distance and velocity stay under their thresholds`() {
+        assertNull(swipeCommitDirection(totalDx = 50f, velocityX = 100f, commitDistance, flingThreshold))
+    }
+
+    @Test
+    fun `distance commit leftward is forward`() {
+        assertEquals(true, swipeCommitDirection(totalDx = -250f, velocityX = 0f, commitDistance, flingThreshold))
+    }
+
+    @Test
+    fun `distance commit rightward is backward`() {
+        assertEquals(false, swipeCommitDirection(totalDx = 250f, velocityX = 0f, commitDistance, flingThreshold))
+    }
+
+    @Test
+    fun `a fling decides direction over a small reversed displacement`() {
+        // Thrown left (forward) but the finger lifted slightly to the right of its start (totalDx > 0,
+        // under the distance threshold). The fling velocity carried the commit, so direction follows it.
+        assertEquals(true, swipeCommitDirection(totalDx = 30f, velocityX = -1500f, commitDistance, flingThreshold))
+    }
+
+    @Test
+    fun `a rightward fling is backward`() {
+        assertEquals(false, swipeCommitDirection(totalDx = -30f, velocityX = 1500f, commitDistance, flingThreshold))
+    }
+
+    @Test
+    fun `a degenerate zero orientation is a no-op`() {
+        assertNull(swipeCommitDirection(totalDx = 0f, velocityX = 0f, commitDistancePx = 0f, flingThresholdPx = 0f))
     }
 }

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipeTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipeTest.kt
@@ -70,6 +70,21 @@ class TopicSwipeTest {
     }
 
     @Test
+    fun `an armed leftward distance wins over a contradictory rightward fling`() {
+        // Dragged firmly left past the commit distance (armed: page-follow, glow and haptic all say
+        // "next page"), then the finger flicked back rightward at lift-off (positive velocity over the
+        // fling threshold). The armed distance must win → next page, matching the feedback the user
+        // already saw; the reverse fling must NOT open the previous page.
+        assertEquals(true, swipeCommitDirection(totalDx = -250f, velocityX = 1500f, commitDistance, flingThreshold))
+    }
+
+    @Test
+    fun `an armed rightward distance wins over a contradictory leftward fling`() {
+        // Symmetric: dragged firmly right past the commit distance, finger flicked back leftward.
+        assertEquals(false, swipeCommitDirection(totalDx = 250f, velocityX = -1500f, commitDistance, flingThreshold))
+    }
+
+    @Test
     fun `a degenerate zero orientation is a no-op`() {
         assertNull(swipeCommitDirection(totalDx = 0f, velocityX = 0f, commitDistancePx = 0f, flingThresholdPx = 0f))
     }

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipeTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipeTest.kt
@@ -189,10 +189,19 @@ class TopicSwipeTest {
     }
 
     @Test
-    fun `the edge hint ramps to the pre-armed ceiling at the commit point`() {
-        // progress 0.5 → 0.5 * 0.5 = 0.25 ; progress 1.0 → 0.5 (EDGE_HINT_MAX_ALPHA).
-        assertEquals(0.25f, swipeEdgeHintAlpha(progress = 0.5f), TOLERANCE)
-        assertEquals(0.5f, swipeEdgeHintAlpha(progress = 1f), TOLERANCE)
+    fun `the edge hint stays invisible below the late-start threshold`() {
+        // Late-start (#282 glow pass): nothing shows until progress crosses EDGE_HINT_START_PROGRESS
+        // (0.65), so small exploratory drags never light the edge.
+        assertEquals(0f, swipeEdgeHintAlpha(progress = 0.5f), TOLERANCE)
+        assertEquals(0f, swipeEdgeHintAlpha(progress = 0.64f), TOLERANCE)
+        assertEquals(0f, swipeEdgeHintAlpha(progress = 0.65f), TOLERANCE)
+    }
+
+    @Test
+    fun `the edge hint ramps from the late start to the pre-armed ceiling`() {
+        // Ramp over 0.65..1.0 → EDGE_HINT_MAX_ALPHA (0.20). Midpoint 0.825 → 0.5 * 0.20 = 0.10.
+        assertEquals(0.10f, swipeEdgeHintAlpha(progress = 0.825f), TOLERANCE)
+        assertEquals(0.2f, swipeEdgeHintAlpha(progress = 1f), TOLERANCE)
     }
 
     @Test
@@ -205,15 +214,15 @@ class TopicSwipeTest {
 
     @Test
     fun `the edge hint brightens to the armed accent past the threshold`() {
-        // ramp window 0.15 ; progress 1.075 is halfway → 0.5 + (0.7 - 0.5) * 0.5 = 0.6.
-        assertEquals(0.6f, swipeEdgeHintAlpha(progress = 1.075f), TOLERANCE)
+        // ramp window 0.15 ; progress 1.075 is halfway → 0.20 + (0.30 - 0.20) * 0.5 = 0.25.
+        assertEquals(0.25f, swipeEdgeHintAlpha(progress = 1.075f), TOLERANCE)
     }
 
     @Test
     fun `the edge hint saturates at the armed accent and never exceeds it`() {
-        // Full ramp at progress 1.15 → 0.7 ; deep overpull stays clamped at 0.7.
-        assertEquals(0.7f, swipeEdgeHintAlpha(progress = 1.15f), TOLERANCE)
-        assertEquals(0.7f, swipeEdgeHintAlpha(progress = 5f), TOLERANCE)
+        // Full ramp at progress 1.15 → 0.30 ; deep overpull stays clamped at 0.30.
+        assertEquals(0.3f, swipeEdgeHintAlpha(progress = 1.15f), TOLERANCE)
+        assertEquals(0.3f, swipeEdgeHintAlpha(progress = 5f), TOLERANCE)
     }
 
     // --- blocked-edge glow suppression contract (feel-lens fix) ---

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipeTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipeTest.kt
@@ -1,7 +1,10 @@
 package fr.forumhfr.redface2.feature.topic
 
+import kotlin.math.abs
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class TopicSwipeTest {
@@ -99,15 +102,28 @@ class TopicSwipeTest {
     }
 
     @Test
-    fun `past the commit point the follow is damped (overpull resistance)`() {
-        // 200 + (400 - 200) * 0.35 = 270.
-        assertEquals(-270f, swipeFollowOffset(rawDx = -400f, commitDistancePx = commit, hasTarget = true), TOLERANCE)
+    fun `past the commit point the follow is a bounded tanh overpull`() {
+        // overpull = 200 * 0.5 = 100 ; excess = 400 - 200 = 200.
+        // 200 + 100 * tanh(200 / 100) = 200 + 100 * tanh(2) ≈ 296.4027.
+        val offset = swipeFollowOffset(rawDx = -400f, commitDistancePx = commit, hasTarget = true)
+        assertEquals(-296.4027f, offset, TOLERANCE)
     }
 
     @Test
-    fun `the follow is sign-symmetric for a rightward drag`() {
-        // 200 + (300 - 200) * 0.35 = 235.
-        assertEquals(235f, swipeFollowOffset(rawDx = 300f, commitDistancePx = commit, hasTarget = true), TOLERANCE)
+    fun `the overpull is sign-symmetric for a rightward drag`() {
+        // overpull = 100 ; excess = 300 - 200 = 100. 200 + 100 * tanh(1) ≈ 276.1594.
+        val offset = swipeFollowOffset(rawDx = 300f, commitDistancePx = commit, hasTarget = true)
+        assertEquals(276.1594f, offset, TOLERANCE)
+    }
+
+    @Test
+    fun `the overpull saturates to a bounded cap on a very long drag`() {
+        // As the drag grows the tanh saturates: travel → commit + overpull = 200 + 100 = 300,
+        // never beyond. A huge drag must not slide the page arbitrarily far off-screen.
+        val far = swipeFollowOffset(rawDx = -100_000f, commitDistancePx = commit, hasTarget = true)
+        assertEquals(-300f, far, 0.5f)
+        // At/under the asymptote (commit + overpull), never beyond a half-page extra past the commit.
+        assertTrue("overpull $far exceeded the bound", abs(far) <= commit + commit * 0.5f)
     }
 
     @Test
@@ -125,6 +141,64 @@ class TopicSwipeTest {
     @Test
     fun `a zero commit distance yields no offset`() {
         assertEquals(0f, swipeFollowOffset(rawDx = -100f, commitDistancePx = 0f, hasTarget = true), TOLERANCE)
+    }
+
+    // --- swipeArmed : franchissement du seuil (tick haptique + indice) ---
+
+    @Test
+    fun `the swipe is not armed below the commit distance`() {
+        assertFalse(swipeArmed(offsetPx = -150f, commitDistancePx = commit))
+    }
+
+    @Test
+    fun `the swipe arms exactly at the commit distance`() {
+        assertTrue(swipeArmed(offsetPx = -200f, commitDistancePx = commit))
+    }
+
+    @Test
+    fun `the swipe stays armed past the commit distance, both signs`() {
+        assertTrue(swipeArmed(offsetPx = -260f, commitDistancePx = commit))
+        assertTrue(swipeArmed(offsetPx = 260f, commitDistancePx = commit))
+    }
+
+    @Test
+    fun `a zero commit distance is never armed`() {
+        assertFalse(swipeArmed(offsetPx = 100f, commitDistancePx = 0f))
+    }
+
+    // --- swipeEdgeHintAlpha : opacite de l'indice de bord (rampe + bump d'armement) ---
+
+    @Test
+    fun `the edge hint is invisible at rest`() {
+        assertEquals(0f, swipeEdgeHintAlpha(progress = 0f), TOLERANCE)
+    }
+
+    @Test
+    fun `the edge hint ramps to the pre-armed ceiling at the commit point`() {
+        // progress 0.5 → 0.5 * 0.5 = 0.25 ; progress 1.0 → 0.5 (EDGE_HINT_MAX_ALPHA).
+        assertEquals(0.25f, swipeEdgeHintAlpha(progress = 0.5f), TOLERANCE)
+        assertEquals(0.5f, swipeEdgeHintAlpha(progress = 1f), TOLERANCE)
+    }
+
+    @Test
+    fun `the edge hint is continuous across the arming point`() {
+        // Just above 1.0 must equal just below 1.0 (no flicker jump).
+        val justBelow = swipeEdgeHintAlpha(progress = 0.999f)
+        val justAbove = swipeEdgeHintAlpha(progress = 1.001f)
+        assertEquals(justBelow, justAbove, 0.01f)
+    }
+
+    @Test
+    fun `the edge hint brightens to the armed accent past the threshold`() {
+        // ramp window 0.15 ; progress 1.075 is halfway → 0.5 + (0.7 - 0.5) * 0.5 = 0.6.
+        assertEquals(0.6f, swipeEdgeHintAlpha(progress = 1.075f), TOLERANCE)
+    }
+
+    @Test
+    fun `the edge hint saturates at the armed accent and never exceeds it`() {
+        // Full ramp at progress 1.15 → 0.7 ; deep overpull stays clamped at 0.7.
+        assertEquals(0.7f, swipeEdgeHintAlpha(progress = 1.15f), TOLERANCE)
+        assertEquals(0.7f, swipeEdgeHintAlpha(progress = 5f), TOLERANCE)
     }
 
     private companion object {

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipeTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipeTest.kt
@@ -1,0 +1,34 @@
+package fr.forumhfr.redface2.feature.topic
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TopicSwipeTest {
+
+    @Test
+    fun `forward swipe from a middle page targets the next page`() {
+        assertEquals(3, swipeTargetPage(currentPage = 2, totalPages = 5, forward = true))
+    }
+
+    @Test
+    fun `forward swipe from the last page is blocked`() {
+        assertNull(swipeTargetPage(currentPage = 5, totalPages = 5, forward = true))
+    }
+
+    @Test
+    fun `backward swipe from a middle page targets the previous page`() {
+        assertEquals(1, swipeTargetPage(currentPage = 2, totalPages = 5, forward = false))
+    }
+
+    @Test
+    fun `backward swipe from the first page is blocked`() {
+        assertNull(swipeTargetPage(currentPage = 1, totalPages = 5, forward = false))
+    }
+
+    @Test
+    fun `single-page topic blocks both directions`() {
+        assertNull(swipeTargetPage(currentPage = 1, totalPages = 1, forward = true))
+        assertNull(swipeTargetPage(currentPage = 1, totalPages = 1, forward = false))
+    }
+}

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipeTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipeTest.kt
@@ -70,4 +70,64 @@ class TopicSwipeTest {
     fun `a degenerate zero orientation is a no-op`() {
         assertNull(swipeCommitDirection(totalDx = 0f, velocityX = 0f, commitDistancePx = 0f, flingThresholdPx = 0f))
     }
+
+    // --- swipeCommitDistancePx : seuil partagé geste/indice ---
+
+    @Test
+    fun `commit distance falls back to the minimum on a narrow page`() {
+        assertEquals(72f, swipeCommitDistancePx(widthPx = 100f, minCommitPx = 72f), TOLERANCE)
+    }
+
+    @Test
+    fun `commit distance follows the width fraction on a wide page`() {
+        // 1000 * 0.20 = 200 > 72 → the fraction wins.
+        assertEquals(200f, swipeCommitDistancePx(widthPx = 1000f, minCommitPx = 72f), TOLERANCE)
+    }
+
+    // --- swipeFollowOffset : translation visuelle (drag-follow + bord) ---
+
+    private val commit = 200f
+
+    @Test
+    fun `below the commit point the page tracks the finger one to one`() {
+        assertEquals(-100f, swipeFollowOffset(rawDx = -100f, commitDistancePx = commit, hasTarget = true), TOLERANCE)
+    }
+
+    @Test
+    fun `at the commit point the offset equals the commit distance`() {
+        assertEquals(-200f, swipeFollowOffset(rawDx = -200f, commitDistancePx = commit, hasTarget = true), TOLERANCE)
+    }
+
+    @Test
+    fun `past the commit point the follow is damped (overpull resistance)`() {
+        // 200 + (400 - 200) * 0.35 = 270.
+        assertEquals(-270f, swipeFollowOffset(rawDx = -400f, commitDistancePx = commit, hasTarget = true), TOLERANCE)
+    }
+
+    @Test
+    fun `the follow is sign-symmetric for a rightward drag`() {
+        // 200 + (300 - 200) * 0.35 = 235.
+        assertEquals(235f, swipeFollowOffset(rawDx = 300f, commitDistancePx = commit, hasTarget = true), TOLERANCE)
+    }
+
+    @Test
+    fun `a blocked edge is damped and capped to a fraction of the commit distance`() {
+        // No target that way: min(1000 * 0.30, 200 * 0.40) = min(300, 80) = 80.
+        assertEquals(-80f, swipeFollowOffset(rawDx = -1000f, commitDistancePx = commit, hasTarget = false), TOLERANCE)
+    }
+
+    @Test
+    fun `a small drag into a blocked edge stays in the damped regime`() {
+        // min(100 * 0.30, 80) = 30.
+        assertEquals(-30f, swipeFollowOffset(rawDx = -100f, commitDistancePx = commit, hasTarget = false), TOLERANCE)
+    }
+
+    @Test
+    fun `a zero commit distance yields no offset`() {
+        assertEquals(0f, swipeFollowOffset(rawDx = -100f, commitDistancePx = 0f, hasTarget = true), TOLERANCE)
+    }
+
+    private companion object {
+        const val TOLERANCE = 0.001f
+    }
 }


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

## Objectif

Changer de page d'un topic par **geste horizontal** (gauche = page suivante, droite = précédente), sans remonter aux boutons Précédent/Suivant. Closes #282.

## Ce que ça fait

- **Geste** (Option A) : `awaitEachGesture` bas niveau + `awaitHorizontalTouchSlopOrCancellation` + `horizontalDrag` (return `completed` honoré) + `VelocityTracker`. N'engage que sur slop **horizontal** → le scroll vertical du `LazyColumn` et le `horizontalScroll` de la grille de pages gardent leurs gestes. Commit si `|dx| ≥ max(72.dp, 20% largeur)` **ou** `|vélocité| ≥ 900.dp/s`. Le geste ne fait que déclencher la nav route-driven existante (`onOpenPage`) — **aucune page voisine composée/fetchée** : l'invariant prefetch-non-auth est intact.
- **Ressenti drag-follow** : la page courante suit le doigt (`graphicsLayer.translationX` piloté par un `MutableFloatState` écrit en phase draw, zéro coroutine par frame), overpull borné (`tanh`, plafond `commit×1.5`), « mur » amorti aux bords. Edge-glow (`drawWithCache`) qui s'intensifie à l'armement. Haptique à l'armement + au commit. Slide-out de la page sortante au commit (latch anti double-navigation). Ressort de retour si non-commité/annulé/bord.
- Décision clé : `pointerInput` **avant** `graphicsLayer` dans la chaîne (sinon les deltas du doigt seraient lus en espace translaté → suivi /2 + seuil doublé).

## Hors scope (follow-ups)

- Transition slide au niveau `NavDisplay` (animation de l'**arrivée** de la nouvelle page) — option (a), séparée car elle touche `:app`.
- RTL : direction géométrique (non-goal documenté, contenu LTR).

## Tests & validation

- `TopicSwipeTest` : **32 tests** sur les fonctions pures (`swipeTargetPage`, `swipeCommitDirection`, `swipeCommitDistancePx`, `swipeFollowOffset` overpull tanh, `swipeArmed`, `swipeEdgeHintAlpha`), 0 échec.
- Validation locale verte : `detektAll` + `lintDebug` + `:app:lintProdDebug` + tests + `:app:assembleProdDebug`.
- Pipeline de revue : 4-flavor Opus (1 P2 latch corrigé) + Codex gpt-5.5 xhigh (review propre).

## Distribution

Déjà livré sur le canal **dev** : `app-v76` (Play internal + F-Droid `.dev`) pour test device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)