### PR TITLE
feat(flags): vue drapeaux regroupée par catégorie (#179)

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -7,6 +7,11 @@ complexity:
     active: false
   TooManyFunctions:
     active: false
+  # LargeClass stays enforced on production code, but an exhaustive test class (one method per
+  # behaviour + in-file fakes) legitimately grows past the threshold — that's coverage, not debt.
+  # Consistent with LongMethod/TooManyFunctions already disabled project-wide.
+  LargeClass:
+    excludes: ['**/src/test/**', '**/src/androidTest/**']
 
 naming:
   FunctionNaming:

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/forum/DefaultForumRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/forum/DefaultForumRepository.kt
@@ -20,6 +20,8 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 
@@ -54,6 +56,15 @@ class DefaultForumRepository @Inject constructor(
     private val cachedSubcategories: MutableMap<Int, CachedEntry<List<SubCategory>>> = HashMap()
     private val subcategoriesLock = Any()
 
+    // Single-flight guard for the cold categories fetch. `observeCategories()` is a cold
+    // `flow {}` builder with no in-flight coalescing, so two concurrent first-collectors
+    // (e.g. `FlagsViewModel` grouping #179 + `DefaultFlagRepository.loadCategories()`, both
+    // observing on an authenticated cold start before the Forum tab has populated the cache)
+    // would each see `cachedCategories == null` and each fire `getCategories()` — two
+    // redundant public REST calls. The mutex serialises the fetch path and the second
+    // collector double-checks the now-warm cache instead of re-fetching.
+    private val categoriesFetchMutex = Mutex()
+
     private val categoriesRefresh: MutableSharedFlow<ForumResult<List<Category>>> =
         MutableSharedFlow(replay = 0, extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
     private val subcategoriesRefresh: MutableMap<Int, MutableSharedFlow<ForumResult<List<SubCategory>>>> = HashMap()
@@ -68,7 +79,7 @@ class DefaultForumRepository @Inject constructor(
         } else {
             if (cached != null) emit(ForumResult.Success(cached.value))
             emit(ForumResult.Loading)
-            emit(fetchCategories())
+            emit(fetchCategoriesSingleFlight(now))
         }
         emitAll(categoriesRefresh.asSharedFlow())
     }
@@ -141,6 +152,26 @@ class DefaultForumRepository @Inject constructor(
             }
         }
     }
+
+    /**
+     * Coalesces concurrent cold category fetches behind [categoriesFetchMutex]. Whoever wins
+     * the lock first performs the single [fetchCategories] round-trip and warms
+     * [cachedCategories]; any collector that was waiting on the lock then double-checks the
+     * (now fresh) cache and returns it without a second network call. A still-cold cache after
+     * the lock (the previous fetch failed and left no entry) falls through to its own fetch.
+     *
+     * Note: only the **cold** fetch path is serialised. [refreshCategories] deliberately
+     * bypasses this guard — it is an explicit user/forced refresh and must always re-hit HFR.
+     */
+    private suspend fun fetchCategoriesSingleFlight(now: Instant): ForumResult<List<Category>> =
+        categoriesFetchMutex.withLock {
+            val cached = cachedCategories
+            if (cached != null && CachePolicy.isFresh(cached.fetchedAt, CachePolicy.categories, now)) {
+                ForumResult.Success(cached.value)
+            } else {
+                fetchCategories()
+            }
+        }
 
     private suspend fun fetchCategories(): ForumResult<List<Category>> = withContext(ioDispatcher) {
         runCatching {

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -62,6 +62,34 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeFlagsGroupByCategory(): Flow<Boolean> =
+        dataStore.data
+            // Default `true`: grouped view is the #179 default (cf. UserPreferencesRepository KDoc).
+            .map { prefs -> prefs[KEY_FLAGS_GROUP_BY_CATEGORY] ?: true }
+            .catch { emit(true) }
+
+    override suspend fun setFlagsGroupByCategory(enabled: Boolean) {
+        withContext(ioDispatcher) {
+            dataStore.edit { prefs ->
+                prefs[KEY_FLAGS_GROUP_BY_CATEGORY] = enabled
+            }
+        }
+    }
+
+    override fun observeFlagsHideReadCategories(): Flow<Boolean> =
+        dataStore.data
+            // Default `false`: HFR web parity (every category band shown).
+            .map { prefs -> prefs[KEY_FLAGS_HIDE_READ_CATEGORIES] ?: false }
+            .catch { emit(false) }
+
+    override suspend fun setFlagsHideReadCategories(enabled: Boolean) {
+        withContext(ioDispatcher) {
+            dataStore.edit { prefs ->
+                prefs[KEY_FLAGS_HIDE_READ_CATEGORIES] = enabled
+            }
+        }
+    }
+
     private fun toProxyConfig(prefs: Preferences): ProxyConfig =
         ProxyConfig(
             enabled = prefs[KEY_PROXY_ENABLED] ?: false,
@@ -78,5 +106,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         val KEY_PROXY_USERNAME = stringPreferencesKey("proxy_username")
         val KEY_PROXY_PASSWORD = stringPreferencesKey("proxy_password")
         val KEY_IGNORE_TOPIC_CACHE = booleanPreferencesKey("ignore_topic_cache")
+        val KEY_FLAGS_GROUP_BY_CATEGORY = booleanPreferencesKey("flags_group_by_category")
+        val KEY_FLAGS_HIDE_READ_CATEGORIES = booleanPreferencesKey("flags_hide_read_categories")
     }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/forum/DefaultForumRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/forum/DefaultForumRepositoryTest.kt
@@ -9,8 +9,12 @@ import io.mockk.mockk
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
@@ -58,6 +62,34 @@ class DefaultForumRepositoryTest {
             assertEquals(19, cached.value.size)
             cancelAndIgnoreRemainingEvents()
         }
+        coVerify(exactly = 1) { apiClient.getCategories(any()) }
+    }
+
+    @Test
+    fun `concurrent cold observers coalesce into a single categories fetch`() = runTest {
+        // Two collectors subscribe before either fetch completes (the gate keeps the first
+        // getCategories suspended). Without the single-flight mutex both would see a cold
+        // cache and each fire getCategories — the classic #179 cold-start double-fetch
+        // (FlagsViewModel grouping + DefaultFlagRepository.loadCategories racing).
+        val gate = CompletableDeferred<Unit>()
+        val apiClient = mockk<HfrApiClient> {
+            coEvery { getCategories(any()) } coAnswers {
+                gate.await()
+                fixture("rest_categories.json")
+            }
+        }
+        val repo = repository(apiClient)
+
+        val first = async { repo.observeCategories().first { it is ForumResult.Success } }
+        val second = async { repo.observeCategories().first { it is ForumResult.Success } }
+        runCurrent() // let both collectors reach the (cold) fetch branch and the mutex
+
+        gate.complete(Unit)
+        val firstResult = first.await() as ForumResult.Success
+        val secondResult = second.await() as ForumResult.Success
+
+        assertEquals(19, firstResult.value.size)
+        assertEquals(19, secondResult.value.size)
         coVerify(exactly = 1) { apiClient.getCategories(any()) }
     }
 

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -132,6 +132,60 @@ class DataStoreUserPreferencesRepositoryTest {
     }
 
     @Test
+    fun `observeFlagsGroupByCategory defaults to true on an empty store`() = runTest(dispatcher) {
+        // Grouped is the #179 default — an empty store must report `true`, not the boolean zero.
+        repository.observeFlagsGroupByCategory().test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setFlagsGroupByCategory persists false and true`() = runTest(dispatcher) {
+        repository.setFlagsGroupByCategory(false)
+        repository.observeFlagsGroupByCategory().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setFlagsGroupByCategory(true)
+        repository.observeFlagsGroupByCategory().test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `observeFlagsHideReadCategories defaults to false on an empty store`() = runTest(dispatcher) {
+        repository.observeFlagsHideReadCategories().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setFlagsHideReadCategories persists true and false independently of the grouped pref`() = runTest(dispatcher) {
+        repository.setFlagsGroupByCategory(false)
+
+        repository.setFlagsHideReadCategories(true)
+        repository.observeFlagsHideReadCategories().test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        // Flipping one Drapeaux pref must not disturb the other (distinct keys).
+        repository.observeFlagsGroupByCategory().test {
+            assertFalse("grouped pref must stay false", awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setFlagsHideReadCategories(false)
+        repository.observeFlagsHideReadCategories().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `saving disabled proxy removes optional fields from effective config`() = runTest(dispatcher) {
         repository.saveProxyConfig(
             ProxyConfig(

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -470,5 +470,14 @@ class TopicRepositoryImplTest {
         override suspend fun setIgnoreTopicCache(enabled: Boolean) {
             ignoreTopicCache.value = enabled
         }
+
+        // Flags view preferences are irrelevant to TopicRepositoryImpl — stubbed at their defaults.
+        override fun observeFlagsGroupByCategory(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setFlagsGroupByCategory(enabled: Boolean) = Unit
+
+        override fun observeFlagsHideReadCategories(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setFlagsHideReadCategories(enabled: Boolean) = Unit
     }
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -32,4 +32,27 @@ interface UserPreferencesRepository {
      * implementation; callers should not wrap this in another `withContext(ioDispatcher)`.
      */
     suspend fun setIgnoreTopicCache(enabled: Boolean)
+
+    /**
+     * Drapeaux screen layout (#179 follow-up): `true` (default) groups the flags by forum
+     * category with a sticky band per category; `false` renders the legacy flat list ordered
+     * by last reply (the pre-#179 behaviour the user must always be able to fall back to).
+     * Observed by the Flags screen so flipping it from Settings re-renders without a refetch.
+     */
+    fun observeFlagsGroupByCategory(): Flow<Boolean>
+
+    /** Persists [observeFlagsGroupByCategory]. Default `true` until the first call. */
+    suspend fun setFlagsGroupByCategory(enabled: Boolean)
+
+    /**
+     * Drapeaux category filter (#179 follow-up): when `true`, categories that have no UNREAD
+     * flag are hidden from the grouped view (along with empty ones). Default `false` = HFR web
+     * parity (every category band shown). Only meaningful in the grouped view. The cyan « +lus »
+     * toggle takes precedence: when the user opts to show already-read participated topics, their
+     * categories stay visible so this filter never makes them unreachable.
+     */
+    fun observeFlagsHideReadCategories(): Flow<Boolean>
+
+    /** Persists [observeFlagsHideReadCategories]. Default `false` until the first call. */
+    suspend fun setFlagsHideReadCategories(enabled: Boolean)
 }

--- a/docs/specs/navigation.md
+++ b/docs/specs/navigation.md
@@ -98,9 +98,12 @@ L'écran le plus important de l'app. Affiche les topics suivis par l'utilisateur
 
 **Regroupement par catégorie (#179, vue par défaut)** :
 - À l'intérieur de chaque onglet réel, les topics sont **groupés par catégorie**, dans l'ordre canonique du forum (cf. `ForumRepository.observeCategories()` ; ordre de secours en dur si le catalogue n'est pas encore chargé). C'est la parité avec la vue web « Vos sujets ».
-- Chaque catégorie est une bande séparatrice (`stickyHeader`). Les **catégories vides sont conservées** (parité web) avec un placeholder par onglet (« Aucun nouveau message » pour cyan, « Aucun sujet dans cette catégorie » sinon).
+- Chaque catégorie est une bande séparatrice (`stickyHeader`). Par défaut, les **catégories vides sont conservées** (parité web) avec un placeholder par onglet (« Aucun nouveau message » pour cyan, « Aucun sujet dans cette catégorie » sinon).
 - Le regroupement est **purement client-side** : group-by sur `Flag.cat` de la liste plate déjà chargée, aucun fetch authentifié supplémentaire (invariant prefetch-non-auth). Une catégorie absente du catalogue n'est jamais filtrée : elle tombe en section « inconnue » en fin de liste (anti-régression #251).
-- Différé hors MVP #179 : toggle vue plate/groupée + préférence persistée, repli des catégories vides.
+
+**Préférences d'affichage (#179, persistées via `UserPreferencesRepository` / DataStore, réglées dans Réglages > Drapeaux)** :
+- **Grouper par catégorie** (défaut : activé) : désactivé, l'écran rend la **liste à plat** héritée (tous les drapeaux d'un coup, ordre dernière réponse, sans bandes de catégorie). Permet de conserver la lecture à plat des drapeaux.
+- **Masquer les catégories sans message non lu** (défaut : désactivé = parité web) : en vue groupée, cache les catégories qui n'ont aucun drapeau non lu. Le toggle cyan « +lus » **prime** sur ce filtre : afficher les sujets participés déjà lus garde leurs catégories visibles (sinon les deux réglages se contrediraient). Sans effet en vue à plat. Si le filtre vide toutes les sections, un placeholder « Aucune catégorie avec un message non lu » est affiché (corps jamais blanc, ancre pull-to-refresh préservée #229).
 
 **Actions sur un topic :**
 - Tap → ouvrir le topic à la dernière position non lue

--- a/docs/specs/navigation.md
+++ b/docs/specs/navigation.md
@@ -42,8 +42,8 @@ graph TB
         MSGS[Messages]
     end
 
-    FLAGS -->|"tri: date / catégorie"| FLAGS
-    FLAGS -->|"filtre: tous / cyan / favori / rouge"| FLAGS
+    FLAGS -->|"onglets: cyan / lu / favoris / super"| FLAGS
+    FLAGS -->|"groupé par catégorie (#179)"| FLAGS
     FLAGS --> TOPIC
 
     FORUM --> CATS[Catégories]
@@ -90,20 +90,21 @@ graph TB
 
 L'écran le plus important de l'app. Affiche les topics suivis par l'utilisateur.
 
-**Tri :**
-- **Par date** (défaut) : tous les topics mélangés, triés par dernier message
-- **Par catégorie** : groupes par cat/subcat, chaque groupe trie par date
+**Onglets** (`FlagTab`, un `FlagType` chacun sauf `Super`) :
+- **Mes sujets** (cyan) : topics où l'utilisateur a participé. Re-tap de l'onglet déjà sélectionné → toggle « +lus » (afficher/masquer les cyans déjà lus, #154).
+- **Lu** (rouge) : topics lus uniquement (drapeau de lecture sans participation).
+- **Favoris** : topics marqués d'une étoile jaune.
+- **Super** : placeholder « super favoris » (pas de backend, pas de fetch).
 
-**Filtres :**
-- **Tous** : tous les drapeaux confondus
-- **Cyan** : topics où l'utilisateur a participé
-- **Favori** : topics marqués d'une étoile jaune
-- **Rouge** : topics lus uniquement (drapeau de lecture sans participation)
+**Regroupement par catégorie (#179, vue par défaut)** :
+- À l'intérieur de chaque onglet réel, les topics sont **groupés par catégorie**, dans l'ordre canonique du forum (cf. `ForumRepository.observeCategories()` ; ordre de secours en dur si le catalogue n'est pas encore chargé). C'est la parité avec la vue web « Vos sujets ».
+- Chaque catégorie est une bande séparatrice (`stickyHeader`). Les **catégories vides sont conservées** (parité web) avec un placeholder par onglet (« Aucun nouveau message » pour cyan, « Aucun sujet dans cette catégorie » sinon).
+- Le regroupement est **purement client-side** : group-by sur `Flag.cat` de la liste plate déjà chargée, aucun fetch authentifié supplémentaire (invariant prefetch-non-auth). Une catégorie absente du catalogue n'est jamais filtrée : elle tombe en section « inconnue » en fin de liste (anti-régression #251).
+- Différé hors MVP #179 : toggle vue plate/groupée + préférence persistée, repli des catégories vides.
 
 **Actions sur un topic :**
 - Tap → ouvrir le topic à la dernière position non lue
-- Long press → menu contextuel (retirer drapeau, copier URL, partager)
-- Swipe → retirer le drapeau (avec undo)
+- Swipe (end-to-start) → ouvre le dialog de confirmation de retrait du drapeau (#99). Le retrait n'est **pas** annulable dans l'app (pas d'undo) ; la ligne revient en place tant que l'utilisateur n'a pas confirmé.
 
 ### Profil utilisateur (Phase 2 finish #208)
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagCategorySection.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagCategorySection.kt
@@ -1,0 +1,108 @@
+package fr.forumhfr.redface2.feature.flags
+
+import fr.forumhfr.redface2.core.model.Flag
+
+/**
+ * One section of the category-grouped Drapeaux screen (#179). On HFR web, the « Vos sujets »
+ * view is grouped by forum category in canonical order, with one separator band per category —
+ * empty categories included. Redface 2 reproduces that grouping inside each existing tab.
+ *
+ * [topics] empty ⇒ the section renders an empty placeholder (the wording is chosen per tab in
+ * Compose, cf. `flags_category_empty*` strings ; no fake domain item is emitted for emptiness).
+ * [catName] is the canonical label of a known category ; **`null` ⇒ unknown category** (absent
+ * from the REST catalogue AND the hard-coded fallback order), whose label is resolved CÔTÉ
+ * COMPOSE via `stringResource(R.string.flags_category_fallback, catId)`. The pure grouping
+ * function never fabricates an Android string.
+ */
+data class FlagCategorySection(
+    val catId: Int,
+    val catName: String?,
+    val topics: List<Flag>,
+)
+
+/**
+ * Canonical-order entry for a forum category (id + name). Local model to `:feature:flags`,
+ * deliberately narrower than [fr.forumhfr.redface2.core.model.Category]: grouping/sorting/
+ * labelling only needs the id and the name, not `forceSubcat`/`subcategoryCount`. Keeping it
+ * narrow also lets the hard-coded fallback order ([FALLBACK_CATEGORY_ORDER]) avoid fabricating
+ * those extra fields.
+ */
+data class FlagCategoryOrderEntry(val id: Int, val name: String)
+
+/**
+ * Hard-coded canonical category order used ONLY for display/sort when
+ * [fr.forumhfr.redface2.core.domain.forum.ForumRepository.observeCategories] has not yet emitted
+ * a `Success` (cold start, `Loading`/`Failure`). Never used to filter flags or decide a fetch.
+ *
+ * 19 public categories captured from `core/data/src/test/resources/fixtures/rest_categories.json`
+ * (REST `forums/hardwarefr/categories/`), `&amp;` entities decoded to `&`. Order matches the HFR
+ * web layout: id sequence 1, 16, 15, 2, 30, 23, 25, 3, 14, 5, 4, 22, 21, 11, 10, 12, 6, 8, 13.
+ */
+internal val FALLBACK_CATEGORY_ORDER: List<FlagCategoryOrderEntry> = listOf(
+    FlagCategoryOrderEntry(1, "Hardware"),
+    FlagCategoryOrderEntry(16, "Hardware - Périphériques"),
+    FlagCategoryOrderEntry(15, "Ordinateurs portables"),
+    FlagCategoryOrderEntry(2, "Overclocking, Cooling & Modding"),
+    FlagCategoryOrderEntry(30, "Electronique, domotique, DIY"),
+    FlagCategoryOrderEntry(23, "Technologies Mobiles"),
+    FlagCategoryOrderEntry(25, "Apple"),
+    FlagCategoryOrderEntry(3, "Video & Son"),
+    FlagCategoryOrderEntry(14, "Photo numérique"),
+    FlagCategoryOrderEntry(5, "Jeux Video"),
+    FlagCategoryOrderEntry(4, "Windows & Software"),
+    FlagCategoryOrderEntry(22, "Réseaux grand public / SoHo"),
+    FlagCategoryOrderEntry(21, "Systèmes & Réseaux Pro"),
+    FlagCategoryOrderEntry(11, "Linux et OS Alternatifs"),
+    FlagCategoryOrderEntry(10, "Programmation"),
+    FlagCategoryOrderEntry(12, "Graphisme"),
+    FlagCategoryOrderEntry(6, "Achats & Ventes"),
+    FlagCategoryOrderEntry(8, "Emploi & Etudes"),
+    FlagCategoryOrderEntry(13, "Discussions"),
+)
+
+/**
+ * Groups [flags] (already cyan-filtered, cf. #154) by category and orders the sections by the
+ * canonical [orderedCategories]. Returns FIRST every known category (empty sections included,
+ * for web parity), THEN at the end the categories present in the flags but absent from the
+ * catalogue, as « unknown » sections (`catName == null`) sorted by `catId` ascending.
+ *
+ * Pure, testable without Android, NO Android dependency (no label lambda — the fallback label
+ * is resolved in Compose via `stringResource`).
+ *
+ * Per-section internal order: PRESERVES the input order of the flags (the repository already
+ * sorts globally by `lastReplyAt` descending). Grouping is STABLE (tie-break on the original
+ * index). Pinned by test.
+ *
+ * Invariant #251 (passive): no flag is ever dropped. A category outside the catalogue is
+ * rendered as an « unknown » section (`catName == null`) at the end, never filtered out.
+ */
+fun groupFlagsByCategory(
+    flags: List<Flag>,
+    orderedCategories: List<FlagCategoryOrderEntry>,
+): List<FlagCategorySection> {
+    // Stable group-by: LinkedHashMap preserves first-seen order, and a list per bucket
+    // preserves the input order of flags within a category (tie-break = original index).
+    val byCat: Map<Int, List<Flag>> = flags.groupByTo(LinkedHashMap()) { it.cat }
+
+    val knownSections = orderedCategories.map { entry ->
+        FlagCategorySection(
+            catId = entry.id,
+            catName = entry.name,
+            topics = byCat[entry.id].orEmpty(),
+        )
+    }
+
+    val knownIds = orderedCategories.mapTo(HashSet()) { it.id }
+    val unknownSections = byCat.keys
+        .filterNot { it in knownIds }
+        .sorted()
+        .map { catId ->
+            FlagCategorySection(
+                catId = catId,
+                catName = null,
+                topics = byCat.getValue(catId),
+            )
+        }
+
+    return knownSections + unknownSections
+}

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagCategorySection.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagCategorySection.kt
@@ -84,7 +84,11 @@ fun groupFlagsByCategory(
     // preserves the input order of flags within a category (tie-break = original index).
     val byCat: Map<Int, List<Flag>> = flags.groupByTo(LinkedHashMap()) { it.cat }
 
-    val knownSections = orderedCategories.map { entry ->
+    // Defensive dedup: a corrupt catalogue with two entries sharing the same id would otherwise
+    // emit two sections with the same catId → duplicate LazyColumn keys (`cat-$catId-header`),
+    // which throws at runtime. The REST contract returns 19 distinct ids, so this is a guard,
+    // not an expected path; keep the FIRST occurrence (canonical order/label).
+    val knownSections = orderedCategories.distinctBy { it.id }.map { entry ->
         FlagCategorySection(
             catId = entry.id,
             catName = entry.name,
@@ -105,4 +109,28 @@ fun groupFlagsByCategory(
         }
 
     return knownSections + unknownSections
+}
+
+/**
+ * Filters [sections] for the « masquer les catégories sans message non lu » preference (#179
+ * follow-up). A section is KEPT when it has at least one unread flag; empty sections are always
+ * dropped.
+ *
+ * [keepFullyRead] is the cyan « +lus » override: when the user explicitly opted to show
+ * already-read participated topics, a section that holds only read flags is still kept (only
+ * truly empty sections are dropped) — otherwise the read topics the user just asked to see would
+ * be hidden by this very filter. For the RED/FAVORITE tabs (no « +lus » affordance) the caller
+ * passes `false`, so fully-read categories are dropped as the preference intends.
+ *
+ * Pure, testable without Android.
+ */
+fun filterCategoriesWithUnread(
+    sections: List<FlagCategorySection>,
+    keepFullyRead: Boolean,
+): List<FlagCategorySection> = sections.filter { section ->
+    when {
+        section.topics.isEmpty() -> false
+        keepFullyRead -> true
+        else -> section.topics.any { it.hasUnread }
+    }
 }

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -354,12 +354,21 @@ private fun ColumnScope.AuthenticatedBody(
                 }
             }
 
-            is FlagsListUiState.Success -> CategorySectionedFlagList(
-                sections = current.sections,
-                selectedTab = selectedTab,
-                removalInFlight = state.removeFlagState is RemoveFlagState.Removing,
-                actions = actions,
-            )
+            is FlagsListUiState.Success -> when (val content = current.content) {
+                is FlagsContent.Grouped -> CategorySectionedFlagList(
+                    sections = content.sections,
+                    selectedTab = selectedTab,
+                    removalInFlight = state.removeFlagState is RemoveFlagState.Removing,
+                    actions = actions,
+                )
+
+                is FlagsContent.Flat -> FlatFlagList(
+                    flags = content.flags,
+                    selectedTab = selectedTab,
+                    removalInFlight = state.removeFlagState is RemoveFlagState.Removing,
+                    actions = actions,
+                )
+            }
         }
     }
 }
@@ -471,6 +480,65 @@ private fun CategoryHeaderBand(label: String) {
 private fun emptySectionLabel(tab: FlagTab): Int = when (tab) {
     FlagTab.Cyan -> R.string.flags_category_empty_cyan
     else -> R.string.flags_category_empty
+}
+
+/**
+ * Flat flag list — the legacy pre-#179 view, kept reachable via the « grouper par catégorie »
+ * preference (Settings). Renders every [flags] entry in repository order (last reply descending)
+ * with no category bands. Like [CategorySectionedFlagList] it is a single [LazyColumn] so the
+ * surrounding `PullToRefreshBox` keeps a scrollable child to anchor the pull gesture on (#229);
+ * an empty list still emits one placeholder item so the « rien à afficher » wording is shown and
+ * the pull gesture has a target. Rows reuse [SwipeableFlagItem] so the #99 swipe-to-remove and
+ * accessibility action behave identically to the grouped view.
+ */
+@Composable
+private fun FlatFlagList(
+    flags: List<Flag>,
+    selectedTab: FlagTab,
+    removalInFlight: Boolean,
+    actions: AuthenticatedActions,
+) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface),
+    ) {
+        if (flags.isEmpty()) {
+            item(key = "flat-empty", contentType = CONTENT_TYPE_EMPTY) {
+                Text(
+                    text = stringResource(flatEmptyLabel(selectedTab)),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
+                )
+            }
+        } else {
+            items(
+                items = flags,
+                key = { "${it.cat}-${it.topicId}" },
+                contentType = { CONTENT_TYPE_ROW },
+            ) { flag ->
+                SwipeableFlagItem(
+                    flag = flag,
+                    metadata = flagMetadata(flag),
+                    removalInFlight = removalInFlight,
+                    onClick = { actions.onOpenFlag(flag) },
+                    onRequestRemove = { actions.onRequestRemoveFlag(flag) },
+                )
+                FlagItemDivider()
+            }
+        }
+    }
+}
+
+/**
+ * Empty-list wording per tab for the FLAT view (#179 follow-up). Mirrors [emptySectionLabel] but
+ * without the « catégorie » noun, which would be misleading in a flat list. Cyan keeps the « aucun
+ * nouveau message » parity wording.
+ */
+private fun flatEmptyLabel(tab: FlagTab): Int = when (tab) {
+    FlagTab.Cyan -> R.string.flags_list_empty_cyan
+    else -> R.string.flags_list_empty
 }
 
 /**

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -410,6 +410,21 @@ private fun CategorySectionedFlagList(
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.surface),
     ) {
+        // « Masquer les catégories sans non-lu » can filter every section out (no unread anywhere,
+        // or all-read CYAN with « +lus » off). Without this guard the LazyColumn would render an
+        // empty body — a blank screen with no scrollable target for the PullToRefreshBox (#229).
+        // A single placeholder item keeps the body informative and the pull gesture anchored.
+        if (sections.isEmpty()) {
+            item(key = "grouped-empty", contentType = CONTENT_TYPE_EMPTY) {
+                Text(
+                    text = stringResource(R.string.flags_no_unread_category),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
+                )
+            }
+        }
+
         sections.forEach { section ->
             // contentType groups the three structurally distinct slot kinds (band / placeholder /
             // row) into separate reuse pools so scrolling across a header→rows→header boundary

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.feature.flags
 
 import android.annotation.SuppressLint
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -12,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
@@ -364,6 +364,13 @@ private fun ColumnScope.AuthenticatedBody(
     }
 }
 
+// LazyColumn contentType tags (#179 compose-perf): one reuse pool per structurally distinct slot
+// kind so Compose recycles like-for-like across the header→row→header alternation of the grouped
+// list. Plain strings (the contentType is only ever compared for equality).
+private const val CONTENT_TYPE_HEADER = "category_header"
+private const val CONTENT_TYPE_EMPTY = "empty_section"
+private const val CONTENT_TYPE_ROW = "flag_row"
+
 /**
  * Category-grouped flag list (#179). Renders one sticky band per [FlagCategorySection] in the
  * canonical category order the ViewModel produced, with the rows under each band. Empty sections
@@ -377,7 +384,9 @@ private fun ColumnScope.AuthenticatedBody(
  * `@ExperimentalFoundationApi` in the locked stable Compose (verified via Context7), hence the
  * `@OptIn`. Keys are prefixed so headers, empty placeholders and rows never collide
  * (`key` throws on duplicates): `topicId` is unique per category only (cf. AGENTS.md), so rows
- * use `"${flag.cat}-${flag.topicId}"`.
+ * use `"${flag.cat}-${flag.topicId}"`. Each slot kind also carries a distinct `contentType`
+ * ([CONTENT_TYPE_HEADER]/[CONTENT_TYPE_EMPTY]/[CONTENT_TYPE_ROW]) so Compose keeps a separate
+ * reuse pool per kind across the header→row→header alternation.
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -393,7 +402,10 @@ private fun CategorySectionedFlagList(
             .background(MaterialTheme.colorScheme.surface),
     ) {
         sections.forEach { section ->
-            stickyHeader(key = "cat-${section.catId}-header") {
+            // contentType groups the three structurally distinct slot kinds (band / placeholder /
+            // row) into separate reuse pools so scrolling across a header→rows→header boundary
+            // recycles a row slot for a row instead of recreating the node from a header slot.
+            stickyHeader(key = "cat-${section.catId}-header", contentType = CONTENT_TYPE_HEADER) {
                 CategoryHeaderBand(
                     label = section.catName
                         ?: stringResource(R.string.flags_category_fallback, section.catId),
@@ -401,7 +413,7 @@ private fun CategorySectionedFlagList(
             }
 
             if (section.topics.isEmpty()) {
-                item(key = "cat-${section.catId}-empty") {
+                item(key = "cat-${section.catId}-empty", contentType = CONTENT_TYPE_EMPTY) {
                     Text(
                         text = stringResource(emptySectionLabel(selectedTab)),
                         style = MaterialTheme.typography.labelMedium,
@@ -410,7 +422,11 @@ private fun CategorySectionedFlagList(
                     )
                 }
             } else {
-                items(items = section.topics, key = { "${it.cat}-${it.topicId}" }) { flag ->
+                items(
+                    items = section.topics,
+                    key = { "${it.cat}-${it.topicId}" },
+                    contentType = { CONTENT_TYPE_ROW },
+                ) { flag ->
                     // Anti double-tap (#99): while a removal is in flight, swipe is disabled
                     // across the list. `removeFlagState` is Removing only between confirm and the
                     // repository result (a brief window); the modal dialog already blocks the

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -12,10 +12,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -41,7 +41,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.customActions
@@ -51,7 +50,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
-import fr.forumhfr.redface2.core.domain.flags.FlagsResult
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
@@ -318,7 +316,7 @@ private fun ColumnScope.AuthenticatedBody(
             .weight(1f),
     ) {
         when (val current = state.flagsState) {
-            null, FlagsResult.Loading -> Box(
+            null, FlagsListUiState.Loading -> Box(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(vertical = 32.dp),
@@ -327,7 +325,7 @@ private fun ColumnScope.AuthenticatedBody(
                 CircularProgressIndicator()
             }
 
-            is FlagsResult.Failure -> Column(
+            is FlagsListUiState.Failure -> Column(
                 // #229 — scrollable so the PullToRefreshBox still captures a swipe-to-refresh
                 // on this short, listless state (an un-scrollable body gives the pull gesture
                 // nothing to anchor on).
@@ -356,56 +354,107 @@ private fun ColumnScope.AuthenticatedBody(
                 }
             }
 
-            is FlagsResult.Success -> {
-                if (current.flags.isEmpty()) {
-                    // #229 — the empty state must fill the box AND be scrollable, otherwise the
-                    // PullToRefreshBox has no scrollable child to anchor the pull gesture on and
-                    // the user can no longer swipe-to-refresh an empty list (e.g. Cyan with no
-                    // actionable topic). A `verticalScroll` Column provides the nested-scroll
-                    // connection the pull needs even though the content is short.
-                    Column(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .verticalScroll(rememberScrollState())
-                            .padding(24.dp),
-                    ) {
-                        Text(
-                            text = stringResource(R.string.flags_empty),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                } else {
-                    LazyColumn(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .clip(RoundedCornerShape(0.dp))
-                            .background(MaterialTheme.colorScheme.surface),
-                    ) {
-                        // Compose `key` rejects duplicates with IllegalArgumentException, but
-                        // HFR's `post=` topic id is only guaranteed unique within a category
-                        // (cf. AGENTS.md), not globally. Using "cat-topicId" eliminates the
-                        // latent crash if the listing ever returns the same topicId in two cats.
-                        items(items = current.flags, key = { "${it.cat}-${it.topicId}" }) { flag ->
-                            // Anti double-tap (#99): while a removal is in flight, swipe is
-                            // disabled across the list. `removeFlagState` is Removing only between
-                            // confirm and the repository result (a brief window); the modal dialog
-                            // already blocks the Confirming phase and the ViewModel rejects re-entry.
-                            val removalInFlight = state.removeFlagState is RemoveFlagState.Removing
-                            SwipeableFlagItem(
-                                flag = flag,
-                                metadata = flagMetadata(flag),
-                                removalInFlight = removalInFlight,
-                                onClick = { actions.onOpenFlag(flag) },
-                                onRequestRemove = { actions.onRequestRemoveFlag(flag) },
-                            )
-                            FlagItemDivider()
-                        }
-                    }
+            is FlagsListUiState.Success -> CategorySectionedFlagList(
+                sections = current.sections,
+                selectedTab = selectedTab,
+                removalInFlight = state.removeFlagState is RemoveFlagState.Removing,
+                actions = actions,
+            )
+        }
+    }
+}
+
+/**
+ * Category-grouped flag list (#179). Renders one sticky band per [FlagCategorySection] in the
+ * canonical category order the ViewModel produced, with the rows under each band. Empty sections
+ * are kept (HFR web parity) and show a per-tab placeholder instead of a row list.
+ *
+ * The whole list is a single [LazyColumn] so the surrounding `PullToRefreshBox` keeps a real
+ * scrollable child to anchor the pull gesture on (#229) — the former `verticalScroll(Column)`
+ * empty-state trick is no longer needed now that the body is always a lazy list.
+ *
+ * `stickyHeader` is the idiomatic foundation API for grouped lists; it is still annotated
+ * `@ExperimentalFoundationApi` in the locked stable Compose (verified via Context7), hence the
+ * `@OptIn`. Keys are prefixed so headers, empty placeholders and rows never collide
+ * (`key` throws on duplicates): `topicId` is unique per category only (cf. AGENTS.md), so rows
+ * use `"${flag.cat}-${flag.topicId}"`.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun CategorySectionedFlagList(
+    sections: List<FlagCategorySection>,
+    selectedTab: FlagTab,
+    removalInFlight: Boolean,
+    actions: AuthenticatedActions,
+) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface),
+    ) {
+        sections.forEach { section ->
+            stickyHeader(key = "cat-${section.catId}-header") {
+                CategoryHeaderBand(
+                    label = section.catName
+                        ?: stringResource(R.string.flags_category_fallback, section.catId),
+                )
+            }
+
+            if (section.topics.isEmpty()) {
+                item(key = "cat-${section.catId}-empty") {
+                    Text(
+                        text = stringResource(emptySectionLabel(selectedTab)),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
+                    )
+                }
+            } else {
+                items(items = section.topics, key = { "${it.cat}-${it.topicId}" }) { flag ->
+                    // Anti double-tap (#99): while a removal is in flight, swipe is disabled
+                    // across the list. `removeFlagState` is Removing only between confirm and the
+                    // repository result (a brief window); the modal dialog already blocks the
+                    // Confirming phase and the ViewModel rejects re-entry.
+                    SwipeableFlagItem(
+                        flag = flag,
+                        metadata = flagMetadata(flag),
+                        removalInFlight = removalInFlight,
+                        onClick = { actions.onOpenFlag(flag) },
+                        onRequestRemove = { actions.onRequestRemoveFlag(flag) },
+                    )
+                    FlagItemDivider()
                 }
             }
         }
     }
+}
+
+/**
+ * Opaque category separator band for the grouped list (#179). Uses `surfaceVariant` /
+ * `onSurfaceVariant` from the theme (no hardcoded color) so it reads as a sticky header over
+ * the scrolling rows without bleed-through.
+ */
+@Composable
+private fun CategoryHeaderBand(label: String) {
+    Text(
+        text = label,
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(horizontal = 24.dp, vertical = 8.dp),
+    )
+}
+
+/**
+ * Empty-section wording per tab (#179). Cyan (« Mes sujets ») is the only bucket where « Aucun
+ * nouveau message » is literally true (web parity); RED/FAVORITE list read topics too, so a
+ * neutral « Aucun sujet dans cette catégorie » is used to avoid a misleading label.
+ */
+private fun emptySectionLabel(tab: FlagTab): Int = when (tab) {
+    FlagTab.Cyan -> R.string.flags_category_empty_cyan
+    else -> R.string.flags_category_empty
 }
 
 /**
@@ -541,7 +590,7 @@ private fun ColumnScope.SuperPlaceholderBody() {
  */
 private data class FlagsBodyState(
     val selectedTab: FlagTab,
-    val flagsState: FlagsResult?,
+    val flagsState: FlagsListUiState?,
     val showReadParticipated: Boolean,
     val isRefreshing: Boolean,
     val removeFlagState: RemoveFlagState,

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -91,9 +91,10 @@ class FlagsViewModel @Inject constructor(
      * combine with categories → map to sections. Reversing the first two would regress #225
      * (the list blanks to a cold spinner during a pull-to-refresh).
      *
-     * A [ForumResult.Failure]/[ForumResult.Loading] on the categories side NEVER turns a
-     * `FlagsResult.Success` into a [FlagsListUiState.Failure]: the hard-coded
-     * [FALLBACK_CATEGORY_ORDER] is used so the sections still render and no flag is lost.
+     * A [ForumResult.Failure]/[ForumResult.Loading] — or an EMPTY [ForumResult.Success] — on the
+     * categories side NEVER turns a `FlagsResult.Success` into a [FlagsListUiState.Failure]: the
+     * hard-coded [FALLBACK_CATEGORY_ORDER] is used so the sections still render and no flag is lost
+     * (an empty Success is treated as « no catalogue yet », guarding the double-empty blank body).
      *
      * Empty sections are kept for **all** tabs (web parity, MVP); the per-tab empty wording is
      * chosen in Compose. `refreshCategories()` is **never** called from here (the 24h memory
@@ -281,10 +282,17 @@ class FlagsViewModel @Inject constructor(
         FlagsResult.Loading -> FlagsListUiState.Loading
         is FlagsResult.Failure -> FlagsListUiState.Failure(flagsResult.cause)
         is FlagsResult.Success -> {
+            // A `Success` carrying an EMPTY catalogue is treated like « no catalogue yet »
+            // (falls back to FALLBACK_CATEGORY_ORDER), not like an empty order. Otherwise the
+            // double-empty case (zero flags AND zero categories) would render zero sections —
+            // a fully blank body with not even an « aucun drapeau » band. In prod the REST
+            // endpoint always returns the 19 categories, so this only guards the degenerate
+            // Success-but-empty edge; flags in unknown cats are still never lost either way.
             val order = when (categoriesResult) {
-                is ForumResult.Success -> categoriesResult.value.map {
-                    FlagCategoryOrderEntry(it.id, it.name)
-                }
+                is ForumResult.Success -> categoriesResult.value
+                    .takeIf { it.isNotEmpty() }
+                    ?.map { FlagCategoryOrderEntry(it.id, it.name) }
+                    ?: FALLBACK_CATEGORY_ORDER
                 else -> FALLBACK_CATEGORY_ORDER
             }
             FlagsListUiState.Success(groupFlagsByCategory(flagsResult.flags, order))

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -8,6 +8,7 @@ import fr.forumhfr.redface2.core.domain.flags.FlagRepository
 import fr.forumhfr.redface2.core.domain.flags.FlagsResult
 import fr.forumhfr.redface2.core.domain.forum.ForumRepository
 import fr.forumhfr.redface2.core.domain.forum.ForumResult
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.Category
 import fr.forumhfr.redface2.core.model.Flag
@@ -42,6 +43,7 @@ class FlagsViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val flagRepository: FlagRepository,
     private val forumRepository: ForumRepository,
+    private val userPreferencesRepository: UserPreferencesRepository,
 ) : ViewModel() {
 
     private var observedPseudo: String? = null
@@ -74,10 +76,12 @@ class FlagsViewModel @Inject constructor(
         )
 
     /**
-     * Category-grouped UI state for the currently selected tab (#179). Replaces the former flat
-     * `FlagsResult?` exposure: the screen renders one section per forum category in canonical
-     * order (empty sections included for HFR web parity), grouping the already-loaded flat list
-     * client-side — no extra authenticated fetch (prefetch-non-auth invariant).
+     * UI state for the currently selected tab (#179). Replaces the former flat `FlagsResult?`
+     * exposure: the screen renders either one section per forum category in canonical order
+     * (empty sections included for HFR web parity) or — when the persisted « grouper par
+     * catégorie » preference is off — the legacy flat list, grouping the already-loaded flat list
+     * client-side either way (no extra authenticated fetch, prefetch-non-auth invariant). The
+     * « masquer les catégories sans non-lu » preference further trims the grouped sections.
      *
      * - Anonymous → `null` (the home tab shows the login intro instead of a list).
      * - [FlagTab.Super] → `null` (placeholder body, no backend, **no** repository observation —
@@ -121,23 +125,35 @@ class FlagsViewModel @Inject constructor(
         )
 
     /**
-     * Builds the grouped UI state for an authenticated tab with a real [type]. Kept as a
-     * dedicated method so the `flatMapLatest` chain stays readable. Both `observe(type)` and
-     * `observeCategories()` are subscribed here — and only here.
+     * Builds the UI state for an authenticated tab with a real [type]. Kept as a dedicated method
+     * so the `flatMapLatest` chain stays readable. Both `observe(type)` and `observeCategories()`
+     * are subscribed here — and only here.
+     *
+     * The cyan « +lus » decision ([showReadParticipatedTopics]) travels INSIDE [FilteredFlags]
+     * rather than as a separate `combine` source. This is load-bearing: folding it into the same
+     * source the flags arrive on means toggling « +lus » re-emits exactly once (no transient
+     * intermediate state where the new toggle value meets the stale flag list), and lets the
+     * downstream section filter know whether read participated topics were opted in.
      */
     private fun authenticatedFlagsListState(type: FlagType): Flow<FlagsListUiState?> {
         val filteredFlags = combine(
             flagRepository.observe(type),
             _showReadParticipatedTopics,
         ) { result, showRead ->
-            filterReadParticipatedIfNeeded(result, type, showRead)
+            FilteredFlags(
+                result = filterReadParticipatedIfNeeded(result, type, showRead),
+                // The cyan « +lus » override for the hide-read-categories filter: only CYAN has a
+                // « show already-read participated topics » affordance, so it's the only tab where
+                // a fully-read category must survive the filter when the user opted in.
+                keepFullyReadSections = type == FlagType.CYAN && showRead,
+            )
         }
             // #225 — keep the existing list anchored during a user refresh instead of blanking
             // it to a cold centered spinner under the PullToRefreshBox indicator (double loader).
             // MUST stay before the section mapping (cf. KDoc on flagsState).
             .keepContentDuringRefresh(
-                isLoading = { it is FlagsResult.Loading },
-                isContent = { it is FlagsResult.Success },
+                isLoading = { it.result is FlagsResult.Loading },
+                isContent = { it.result is FlagsResult.Success },
             )
 
         // Prepend a synthetic Loading on the categories side so `combine` does not BLOCK the
@@ -148,10 +164,31 @@ class FlagsViewModel @Inject constructor(
         val categories = forumRepository.observeCategories()
             .onStart { emit(ForumResult.Loading) }
 
-        return combine(filteredFlags, categories) { flagsResult, catsResult ->
-            toFlagsListUiState(flagsResult, catsResult)
+        return combine(
+            filteredFlags,
+            categories,
+            userPreferencesRepository.observeFlagsGroupByCategory(),
+            userPreferencesRepository.observeFlagsHideReadCategories(),
+        ) { filtered, catsResult, groupByCategory, hideReadCategories ->
+            toFlagsListUiState(
+                flagsResult = filtered.result,
+                categoriesResult = catsResult,
+                groupByCategory = groupByCategory,
+                hideReadCategories = hideReadCategories,
+                keepFullyReadSections = filtered.keepFullyReadSections,
+            )
         }
     }
+
+    /**
+     * Carries the cyan « +lus » override alongside the filtered [result] so it travels as one
+     * unit through [keepContentDuringRefresh] and the outer `combine` (cf.
+     * [authenticatedFlagsListState]).
+     */
+    private data class FilteredFlags(
+        val result: FlagsResult,
+        val keepFullyReadSections: Boolean,
+    )
 
     /**
      * Drives the « Retirer le drapeau » interaction (#99). MVI-style explicit state so the
@@ -269,34 +306,76 @@ class FlagsViewModel @Inject constructor(
     // moved to `AppAccountViewModelTest`.
 
     /**
-     * Maps a (filtered) [FlagsResult] + a categories [ForumResult] into the single grouped UI
-     * state (#179). A `Loading`/`Failure` on the categories side is **non-fatal**: it only
-     * affects which canonical order is used, never whether the flags render. The hard-coded
+     * Maps a (filtered) [FlagsResult] + a categories [ForumResult] into the single UI state
+     * (#179). A `Loading`/`Failure` on the categories side is **non-fatal**: it only affects which
+     * canonical order is used, never whether the flags render. The hard-coded
      * [FALLBACK_CATEGORY_ORDER] kicks in until the real catalogue arrives, so flags appear
      * immediately on a cold start and no flag is ever lost (anti-regression #251).
+     *
+     * [groupByCategory] / [hideReadCategories] are the two persisted Drapeaux view preferences
+     * (#179 follow-up): flat vs grouped layout, and whether to hide categories without an unread
+     * flag. [keepFullyReadSections] is the cyan « +lus » override forwarded from [FilteredFlags].
      */
     private fun toFlagsListUiState(
         flagsResult: FlagsResult,
         categoriesResult: ForumResult<List<Category>>,
+        groupByCategory: Boolean,
+        hideReadCategories: Boolean,
+        keepFullyReadSections: Boolean,
     ): FlagsListUiState = when (flagsResult) {
         FlagsResult.Loading -> FlagsListUiState.Loading
         is FlagsResult.Failure -> FlagsListUiState.Failure(flagsResult.cause)
-        is FlagsResult.Success -> {
-            // A `Success` carrying an EMPTY catalogue is treated like « no catalogue yet »
-            // (falls back to FALLBACK_CATEGORY_ORDER), not like an empty order. Otherwise the
-            // double-empty case (zero flags AND zero categories) would render zero sections —
-            // a fully blank body with not even an « aucun drapeau » band. In prod the REST
-            // endpoint always returns the 19 categories, so this only guards the degenerate
-            // Success-but-empty edge; flags in unknown cats are still never lost either way.
-            val order = when (categoriesResult) {
-                is ForumResult.Success -> categoriesResult.value
-                    .takeIf { it.isNotEmpty() }
-                    ?.map { FlagCategoryOrderEntry(it.id, it.name) }
-                    ?: FALLBACK_CATEGORY_ORDER
-                else -> FALLBACK_CATEGORY_ORDER
-            }
-            FlagsListUiState.Success(groupFlagsByCategory(flagsResult.flags, order))
+        is FlagsResult.Success -> FlagsListUiState.Success(
+            flagsContent(
+                flags = flagsResult.flags,
+                categoriesResult = categoriesResult,
+                groupByCategory = groupByCategory,
+                hideReadCategories = hideReadCategories,
+                keepFullyReadSections = keepFullyReadSections,
+            ),
+        )
+    }
+
+    /**
+     * Shapes the [FlagsContent] for a `Success`: a flat list (legacy view) when [groupByCategory]
+     * is off, otherwise the category-grouped sections — with the « masquer les catégories sans
+     * non-lu » filter applied when [hideReadCategories] is on. The flat list keeps the repository
+     * order (last reply descending); grouping reorders by canonical category.
+     */
+    private fun flagsContent(
+        flags: List<Flag>,
+        categoriesResult: ForumResult<List<Category>>,
+        groupByCategory: Boolean,
+        hideReadCategories: Boolean,
+        keepFullyReadSections: Boolean,
+    ): FlagsContent {
+        if (!groupByCategory) return FlagsContent.Flat(flags)
+        val grouped = groupFlagsByCategory(flags, resolveCategoryOrder(categoriesResult))
+        val sections = if (hideReadCategories) {
+            filterCategoriesWithUnread(grouped, keepFullyRead = keepFullyReadSections)
+        } else {
+            grouped
         }
+        return FlagsContent.Grouped(sections)
+    }
+
+    /**
+     * Resolves the canonical category order from the catalogue result. A `Success` carrying an
+     * EMPTY catalogue is treated like « no catalogue yet » (falls back to
+     * [FALLBACK_CATEGORY_ORDER]), not like an empty order. Otherwise the double-empty case (zero
+     * flags AND zero categories) would render zero sections — a fully blank body with not even an
+     * « aucun drapeau » band. In prod the REST endpoint always returns the 19 categories, so this
+     * only guards the degenerate Success-but-empty edge; flags in unknown cats are still never
+     * lost either way.
+     */
+    private fun resolveCategoryOrder(
+        categoriesResult: ForumResult<List<Category>>,
+    ): List<FlagCategoryOrderEntry> = when (categoriesResult) {
+        is ForumResult.Success -> categoriesResult.value
+            .takeIf { it.isNotEmpty() }
+            ?.map { FlagCategoryOrderEntry(it.id, it.name) }
+            ?: FALLBACK_CATEGORY_ORDER
+        else -> FALLBACK_CATEGORY_ORDER
     }
 
     private fun filterReadParticipatedIfNeeded(
@@ -380,14 +459,34 @@ sealed interface FlagsListUiState {
     data object Loading : FlagsListUiState
 
     /**
-     * Grouped sections in canonical category order, empty sections included (web parity).
-     * [sections] is non-empty in practice — the fallback order guarantees at least the known
-     * categories even before the catalogue loads.
+     * Loaded flags, rendered either grouped by category or as a flat list depending on the
+     * persisted view preference (cf. [FlagsContent]).
      */
-    data class Success(val sections: List<FlagCategorySection>) : FlagsListUiState
+    data class Success(val content: FlagsContent) : FlagsListUiState
 
     /** A flags fetch failed; [cause] drives the reconnect/retry CTA (e.g. SessionExpiredException). */
     data class Failure(val cause: Throwable) : FlagsListUiState
+}
+
+/**
+ * The two render shapes of a loaded Drapeaux list (#179 follow-up). The user picks the layout in
+ * Settings ([UserPreferencesRepository.observeFlagsGroupByCategory]); the ViewModel emits the
+ * matching shape so the screen stays a pure `when`.
+ */
+sealed interface FlagsContent {
+    /**
+     * Grouped sections in canonical category order. With the « masquer les catégories sans
+     * non-lu » preference off, empty sections are included (HFR web parity) and [sections] is
+     * non-empty in practice (the fallback order guarantees the known categories). With it on,
+     * only categories carrying an unread flag survive (cf. [filterCategoriesWithUnread]).
+     */
+    data class Grouped(val sections: List<FlagCategorySection>) : FlagsContent
+
+    /**
+     * Flat list in repository order (last reply descending) — the legacy pre-#179 view, kept as
+     * an explicit fallback so the user can always read every flag at once without category bands.
+     */
+    data class Flat(val flags: List<Flag>) : FlagsContent
 }
 
 /**

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -6,11 +6,15 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.flags.FlagRepository
 import fr.forumhfr.redface2.core.domain.flags.FlagsResult
+import fr.forumhfr.redface2.core.domain.forum.ForumRepository
+import fr.forumhfr.redface2.core.domain.forum.ForumResult
 import fr.forumhfr.redface2.core.model.AuthState
+import fr.forumhfr.redface2.core.model.Category
 import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
 import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -19,6 +23,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -36,6 +41,7 @@ import kotlinx.coroutines.launch
 class FlagsViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val flagRepository: FlagRepository,
+    private val forumRepository: ForumRepository,
 ) : ViewModel() {
 
     private var observedPseudo: String? = null
@@ -68,39 +74,41 @@ class FlagsViewModel @Inject constructor(
         )
 
     /**
-     * Flag list for the currently selected tab. Anonymous → emits null (the home tab
-     * shows the login intro instead of an empty list); Authenticated → emits the result
-     * from FlagRepository for the current tab. Switching tabs (or auth state) cancels
-     * any in-flight observation via [flatMapLatest].
+     * Category-grouped UI state for the currently selected tab (#179). Replaces the former flat
+     * `FlagsResult?` exposure: the screen renders one section per forum category in canonical
+     * order (empty sections included for HFR web parity), grouping the already-loaded flat list
+     * client-side — no extra authenticated fetch (prefetch-non-auth invariant).
      *
-     * The [FlagTab.Super] tab is a placeholder (future « super favoris », no backend yet):
-     * selecting it maps to no [FlagType] and emits `null`, so the screen renders its
-     * placeholder body instead of a list and **no** repository observation is started.
+     * - Anonymous → `null` (the home tab shows the login intro instead of a list).
+     * - [FlagTab.Super] → `null` (placeholder body, no backend, **no** repository observation —
+     *   neither flags NOR categories are observed, cf. §5 « no double-fetch »).
+     * - Authenticated + a real [FlagType] → the per-tab flag flow (filtered cyan #154, then
+     *   [keepContentDuringRefresh] #225) is combined with [ForumRepository.observeCategories]
+     *   to build [FlagsListUiState]. Categories are observed **only** in this branch so we never
+     *   trigger a spurious public categories fetch for Anonymous/Super.
+     *
+     * Ordering of the mapping is load-bearing: cyan filter → `keepContentDuringRefresh` →
+     * combine with categories → map to sections. Reversing the first two would regress #225
+     * (the list blanks to a cold spinner during a pull-to-refresh).
+     *
+     * A [ForumResult.Failure]/[ForumResult.Loading] on the categories side NEVER turns a
+     * `FlagsResult.Success` into a [FlagsListUiState.Failure]: the hard-coded
+     * [FALLBACK_CATEGORY_ORDER] is used so the sections still render and no flag is lost.
+     *
+     * Empty sections are kept for **all** tabs (web parity, MVP); the per-tab empty wording is
+     * chosen in Compose. `refreshCategories()` is **never** called from here (the 24h memory
+     * cache of [ForumRepository] is enough; pull-to-refresh refreshes flags only).
      */
-    val flagsState: StateFlow<FlagsResult?> = authState
+    val flagsState: StateFlow<FlagsListUiState?> = authState
         .onEach(::clearFlagsCacheIfSessionChanged)
         .flatMapLatest { state ->
             when (state) {
-                null -> flowOf<FlagsResult?>(null)
-                AuthState.Anonymous -> flowOf<FlagsResult?>(null)
+                null -> flowOf<FlagsListUiState?>(null)
+                AuthState.Anonymous -> flowOf<FlagsListUiState?>(null)
                 is AuthState.Authenticated -> selectedTab.flatMapLatest { tab ->
                     when (val type = tab.flagType) {
-                        null -> flowOf<FlagsResult?>(null) // Super placeholder: no fetch.
-                        else -> combine(
-                            flagRepository.observe(type),
-                            _showReadParticipatedTopics,
-                        ) { result, showRead ->
-                            filterReadParticipatedIfNeeded(result, type, showRead)
-                        }
-                            // #225 — keep the existing list anchored during a user refresh
-                            // instead of blanking it to a cold centered spinner under the
-                            // PullToRefreshBox indicator (double loader). Same pattern as
-                            // :feature:forum. Applied per-tab (inside flatMapLatest) so a
-                            // genuine tab switch still shows its own cold spinner.
-                            .keepContentDuringRefresh(
-                                isLoading = { it is FlagsResult.Loading },
-                                isContent = { it is FlagsResult.Success },
-                            )
+                        null -> flowOf<FlagsListUiState?>(null) // Super placeholder: no fetch.
+                        else -> authenticatedFlagsListState(type)
                     }
                 }
             }
@@ -110,6 +118,39 @@ class FlagsViewModel @Inject constructor(
             started = SharingStarted.Eagerly,
             initialValue = null,
         )
+
+    /**
+     * Builds the grouped UI state for an authenticated tab with a real [type]. Kept as a
+     * dedicated method so the `flatMapLatest` chain stays readable. Both `observe(type)` and
+     * `observeCategories()` are subscribed here — and only here.
+     */
+    private fun authenticatedFlagsListState(type: FlagType): Flow<FlagsListUiState?> {
+        val filteredFlags = combine(
+            flagRepository.observe(type),
+            _showReadParticipatedTopics,
+        ) { result, showRead ->
+            filterReadParticipatedIfNeeded(result, type, showRead)
+        }
+            // #225 — keep the existing list anchored during a user refresh instead of blanking
+            // it to a cold centered spinner under the PullToRefreshBox indicator (double loader).
+            // MUST stay before the section mapping (cf. KDoc on flagsState).
+            .keepContentDuringRefresh(
+                isLoading = { it is FlagsResult.Loading },
+                isContent = { it is FlagsResult.Success },
+            )
+
+        // Prepend a synthetic Loading on the categories side so `combine` does not BLOCK the
+        // flags render until the categories flow has emitted (cf. test 10bis): on a cold start
+        // where Success(flags) lands before observeCategories emits, the screen must render
+        // immediately using FALLBACK_CATEGORY_ORDER, then re-derive when the real catalogue
+        // arrives. Without this onStart, `combine` waits for both sources and the list stalls.
+        val categories = forumRepository.observeCategories()
+            .onStart { emit(ForumResult.Loading) }
+
+        return combine(filteredFlags, categories) { flagsResult, catsResult ->
+            toFlagsListUiState(flagsResult, catsResult)
+        }
+    }
 
     /**
      * Drives the « Retirer le drapeau » interaction (#99). MVI-style explicit state so the
@@ -226,6 +267,30 @@ class FlagsViewModel @Inject constructor(
     // here was dead code that drifted at the first refactor; the matching invariant test was
     // moved to `AppAccountViewModelTest`.
 
+    /**
+     * Maps a (filtered) [FlagsResult] + a categories [ForumResult] into the single grouped UI
+     * state (#179). A `Loading`/`Failure` on the categories side is **non-fatal**: it only
+     * affects which canonical order is used, never whether the flags render. The hard-coded
+     * [FALLBACK_CATEGORY_ORDER] kicks in until the real catalogue arrives, so flags appear
+     * immediately on a cold start and no flag is ever lost (anti-regression #251).
+     */
+    private fun toFlagsListUiState(
+        flagsResult: FlagsResult,
+        categoriesResult: ForumResult<List<Category>>,
+    ): FlagsListUiState = when (flagsResult) {
+        FlagsResult.Loading -> FlagsListUiState.Loading
+        is FlagsResult.Failure -> FlagsListUiState.Failure(flagsResult.cause)
+        is FlagsResult.Success -> {
+            val order = when (categoriesResult) {
+                is ForumResult.Success -> categoriesResult.value.map {
+                    FlagCategoryOrderEntry(it.id, it.name)
+                }
+                else -> FALLBACK_CATEGORY_ORDER
+            }
+            FlagsListUiState.Success(groupFlagsByCategory(flagsResult.flags, order))
+        }
+    }
+
     private fun filterReadParticipatedIfNeeded(
         result: FlagsResult,
         type: FlagType,
@@ -292,6 +357,29 @@ sealed interface FlagTab {
     data object Super : FlagTab {
         override val flagType: FlagType? = null
     }
+}
+
+/**
+ * Single route-facing UI state for the category-grouped Drapeaux list (#179). Replaces a
+ * direct `FlagsResult` exposure so a `Loading`/`Failure` can never diverge from a stale set
+ * of sections (cf. impl prompt §4.1 correction #2).
+ *
+ * A `null` value (not a member of this interface) keeps its prior meaning « not applicable »:
+ * the Anonymous login intro or the [FlagTab.Super] placeholder.
+ */
+sealed interface FlagsListUiState {
+    /** Cold fetch in flight, no prior content to keep. */
+    data object Loading : FlagsListUiState
+
+    /**
+     * Grouped sections in canonical category order, empty sections included (web parity).
+     * [sections] is non-empty in practice — the fallback order guarantees at least the known
+     * categories even before the catalogue loads.
+     */
+    data class Success(val sections: List<FlagCategorySection>) : FlagsListUiState
+
+    /** A flags fetch failed; [cause] drives the reconnect/retry CTA (e.g. SessionExpiredException). */
+    data class Failure(val cause: Throwable) : FlagsListUiState
 }
 
 /**

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -22,6 +22,16 @@
     <string name="flags_super_placeholder_body">Les « super favoris » permettront d\'épingler les sujets les plus importants. Cette vue arrivera dans une prochaine version.</string>
 
     <string name="flags_empty">Aucun drapeau dans cette vue.</string>
+
+    <!-- #179 — Vue drapeaux groupée par catégorie (parité vue web par défaut). -->
+    <!-- Cyan (« Mes sujets ») : section de catégorie sans nouveau message non lu. Wording parité web. -->
+    <string name="flags_category_empty_cyan">Aucun nouveau message</string>
+    <!-- RED / FAVORITE : section de catégorie sans sujet suivi. « Aucun nouveau message » serait
+         trompeur ici (ces vues listent aussi les sujets lus). -->
+    <string name="flags_category_empty">Aucun sujet dans cette catégorie</string>
+    <!-- Fallback de libellé pour une catégorie absente du catalogue REST (anti-régression #251).
+         %1$d = identifiant de la catégorie. -->
+    <string name="flags_category_fallback">Catégorie %1$d</string>
     <string name="flags_error">Impossible de récupérer les drapeaux. Vérifie ta connexion ou réessaie.</string>
     <string name="flags_session_expired">Session HFR expirée. Reconnecte-toi pour recharger tes drapeaux.</string>
     <string name="flags_retry">Réessayer</string>

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -34,6 +34,10 @@
          « catégorie » (il n'y a pas de regroupement dans cette vue). -->
     <string name="flags_list_empty_cyan">Aucun nouveau message</string>
     <string name="flags_list_empty">Aucun drapeau à afficher</string>
+    <!-- #179 follow-up — Vue groupée AVEC « masquer les catégories sans non-lu » : quand aucune
+         catégorie n'a de message non lu, toutes les sections sont masquées. Message + item unique
+         pour ne pas laisser un corps blanc et garder une cible scrollable au pull-to-refresh (#229). -->
+    <string name="flags_no_unread_category">Aucune catégorie avec un message non lu</string>
     <string name="flags_error">Impossible de récupérer les drapeaux. Vérifie ta connexion ou réessaie.</string>
     <string name="flags_session_expired">Session HFR expirée. Reconnecte-toi pour recharger tes drapeaux.</string>
     <string name="flags_retry">Réessayer</string>

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -30,6 +30,10 @@
     <!-- Fallback de libellé pour une catégorie absente du catalogue REST (anti-régression #251).
          %1$d = identifiant de la catégorie. -->
     <string name="flags_category_fallback">Catégorie %1$d</string>
+    <!-- #179 follow-up — Vue à plat (legacy) : message quand la liste est vide. Sans le mot
+         « catégorie » (il n'y a pas de regroupement dans cette vue). -->
+    <string name="flags_list_empty_cyan">Aucun nouveau message</string>
+    <string name="flags_list_empty">Aucun drapeau à afficher</string>
     <string name="flags_error">Impossible de récupérer les drapeaux. Vérifie ta connexion ou réessaie.</string>
     <string name="flags_session_expired">Session HFR expirée. Reconnecte-toi pour recharger tes drapeaux.</string>
     <string name="flags_retry">Réessayer</string>

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -21,8 +21,6 @@
     <string name="flags_super_placeholder_title">Super favoris — à venir</string>
     <string name="flags_super_placeholder_body">Les « super favoris » permettront d\'épingler les sujets les plus importants. Cette vue arrivera dans une prochaine version.</string>
 
-    <string name="flags_empty">Aucun drapeau dans cette vue.</string>
-
     <!-- #179 — Vue drapeaux groupée par catégorie (parité vue web par défaut). -->
     <!-- Cyan (« Mes sujets ») : section de catégorie sans nouveau message non lu. Wording parité web. -->
     <string name="flags_category_empty_cyan">Aucun nouveau message</string>

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagCategorySectionTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagCategorySectionTest.kt
@@ -1,0 +1,162 @@
+package fr.forumhfr.redface2.feature.flags
+
+import fr.forumhfr.redface2.core.model.Flag
+import fr.forumhfr.redface2.core.model.FlagType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * 100% coverage of the pure [groupFlagsByCategory] grouping/sort (#179). No Android dependency:
+ * the function takes raw [Flag] + [FlagCategoryOrderEntry] and returns [FlagCategorySection].
+ */
+class FlagCategorySectionTest {
+
+    private val order = listOf(
+        FlagCategoryOrderEntry(1, "Hardware"),
+        FlagCategoryOrderEntry(10, "Programmation"),
+        FlagCategoryOrderEntry(13, "Discussions"),
+    )
+
+    @Test
+    fun `sections follow the canonical order, not the flags arrival order`() {
+        // Flags arrive in 13, 1, 10 order; sections must come out 1, 10, 13.
+        val flags = listOf(
+            flag(topicId = 100, cat = 13),
+            flag(topicId = 200, cat = 1),
+            flag(topicId = 300, cat = 10),
+        )
+
+        val sections = groupFlagsByCategory(flags, order)
+
+        assertEquals(listOf(1, 10, 13), sections.map { it.catId })
+        assertEquals(listOf("Hardware", "Programmation", "Discussions"), sections.map { it.catName })
+    }
+
+    @Test
+    fun `a category with no flags is kept as an empty section (web parity)`() {
+        val flags = listOf(flag(topicId = 1, cat = 1))
+
+        val sections = groupFlagsByCategory(flags, order)
+
+        assertEquals(listOf(1, 10, 13), sections.map { it.catId })
+        assertEquals(listOf(1), sections.first { it.catId == 1 }.topics.map { it.topicId })
+        assertTrue(sections.first { it.catId == 10 }.topics.isEmpty())
+        assertTrue(sections.first { it.catId == 13 }.topics.isEmpty())
+    }
+
+    @Test
+    fun `a flag in an unknown category is never dropped (anti-regression #251)`() {
+        val flags = listOf(
+            flag(topicId = 1, cat = 1),
+            flag(topicId = 2, cat = 999), // not in the order catalogue
+        )
+
+        val sections = groupFlagsByCategory(flags, order)
+
+        // Unknown section is appended at the end, after all known categories.
+        assertEquals(listOf(1, 10, 13, 999), sections.map { it.catId })
+        val unknown = sections.last()
+        assertEquals(999, unknown.catId)
+        assertNull("unknown category carries a null name for Compose fallback", unknown.catName)
+        assertEquals(listOf(2), unknown.topics.map { it.topicId })
+    }
+
+    @Test
+    fun `multiple unknown categories are sorted by catId after the known ones`() {
+        val flags = listOf(
+            flag(topicId = 1, cat = 50),
+            flag(topicId = 2, cat = 10),
+            flag(topicId = 3, cat = 40),
+        )
+
+        val sections = groupFlagsByCategory(flags, order)
+
+        // Known order first (1, 10, 13), then unknowns ascending (40, 50).
+        assertEquals(listOf(1, 10, 13, 40, 50), sections.map { it.catId })
+        val unknowns = sections.filter { it.catName == null }
+        assertEquals(listOf(40, 50), unknowns.map { it.catId })
+        assertTrue("every unknown section has a null name", unknowns.all { it.catName == null })
+    }
+
+    @Test
+    fun `internal order preserves the input order of flags within a category`() {
+        // The repository already sorts globally by lastReplyAt desc; grouping must be stable.
+        val flags = listOf(
+            flag(topicId = 30, cat = 1),
+            flag(topicId = 10, cat = 1),
+            flag(topicId = 20, cat = 1),
+        )
+
+        val sections = groupFlagsByCategory(flags, order)
+
+        assertEquals(
+            "grouping must preserve input order (stable), not re-sort by topicId",
+            listOf(30, 10, 20),
+            sections.first { it.catId == 1 }.topics.map { it.topicId },
+        )
+    }
+
+    @Test
+    fun `empty flags with a non-empty catalogue yields all known sections empty`() {
+        val sections = groupFlagsByCategory(emptyList(), order)
+
+        assertEquals(listOf(1, 10, 13), sections.map { it.catId })
+        assertTrue("every section is empty when there are no flags", sections.all { it.topics.isEmpty() })
+    }
+
+    @Test
+    fun `empty flags and empty catalogue yields an empty section list`() {
+        val sections = groupFlagsByCategory(emptyList(), emptyList())
+
+        assertTrue(sections.isEmpty())
+    }
+
+    @Test
+    fun `one flag per category yields one section per category with no duplicates`() {
+        val flags = listOf(
+            flag(topicId = 1, cat = 1),
+            flag(topicId = 2, cat = 10),
+            flag(topicId = 3, cat = 13),
+        )
+
+        val sections = groupFlagsByCategory(flags, order)
+
+        assertEquals(3, sections.size)
+        assertEquals(listOf(1, 10, 13), sections.map { it.catId })
+        assertTrue("no duplicated catId", sections.map { it.catId }.distinct().size == sections.size)
+        sections.forEach { assertEquals(1, it.topics.size) }
+    }
+
+    @Test
+    fun `the hard-coded fallback order has the 19 public categories in canonical sequence`() {
+        // Pins FALLBACK_CATEGORY_ORDER against the documented HFR web layout (impl prompt §5).
+        assertEquals(19, FALLBACK_CATEGORY_ORDER.size)
+        assertEquals(
+            listOf(1, 16, 15, 2, 30, 23, 25, 3, 14, 5, 4, 22, 21, 11, 10, 12, 6, 8, 13),
+            FALLBACK_CATEGORY_ORDER.map { it.id },
+        )
+        assertEquals("Hardware", FALLBACK_CATEGORY_ORDER.first().name)
+        assertEquals("Discussions", FALLBACK_CATEGORY_ORDER.last().name)
+    }
+
+    private fun flag(
+        topicId: Int,
+        cat: Int,
+    ): Flag = Flag(
+        cat = cat,
+        subcat = null,
+        topicId = topicId,
+        title = "Topic $topicId",
+        totalPages = 1,
+        replyCount = 0,
+        type = FlagType.CYAN,
+        hasUnread = true,
+        lastReadPage = 1,
+        lastPostReadId = null,
+        firstPostAuthor = "",
+        lastReplyAuthor = "",
+        lastReplyAt = "",
+    )
+}

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagCategorySectionTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagCategorySectionTest.kt
@@ -130,6 +130,49 @@ class FlagCategorySectionTest {
     }
 
     @Test
+    fun `groupFlagsByCategory dedups duplicate category ids in the catalogue order`() {
+        // A corrupt catalogue with two entries sharing the same id must not yield two sections
+        // with the same catId (duplicate LazyColumn keys → runtime crash). First occurrence wins.
+        val duplicatedOrder = listOf(
+            FlagCategoryOrderEntry(1, "Hardware"),
+            FlagCategoryOrderEntry(1, "Hardware (doublon)"),
+            FlagCategoryOrderEntry(10, "Programmation"),
+        )
+
+        val sections = groupFlagsByCategory(listOf(flag(topicId = 1, cat = 1)), duplicatedOrder)
+
+        assertEquals(listOf(1, 10), sections.map { it.catId })
+        assertEquals("first occurrence wins for the label", "Hardware", sections.first().catName)
+    }
+
+    @Test
+    fun `filterCategoriesWithUnread keeps unread sections and drops empty plus fully-read ones`() {
+        val sections = listOf(
+            FlagCategorySection(1, "A", listOf(flag(topicId = 1, cat = 1, hasUnread = true))),
+            FlagCategorySection(10, "B", listOf(flag(topicId = 2, cat = 10, hasUnread = false))),
+            FlagCategorySection(13, "C", emptyList()),
+        )
+
+        val filtered = filterCategoriesWithUnread(sections, keepFullyRead = false)
+
+        assertEquals("only the category with an unread survives", listOf(1), filtered.map { it.catId })
+    }
+
+    @Test
+    fun `filterCategoriesWithUnread with keepFullyRead keeps read sections but still drops empty ones`() {
+        // The cyan « +lus » override: a fully-read section is kept, but a truly empty section is
+        // always dropped (nothing to show).
+        val sections = listOf(
+            FlagCategorySection(1, "A", listOf(flag(topicId = 1, cat = 1, hasUnread = false))),
+            FlagCategorySection(10, "B", emptyList()),
+        )
+
+        val filtered = filterCategoriesWithUnread(sections, keepFullyRead = true)
+
+        assertEquals(listOf(1), filtered.map { it.catId })
+    }
+
+    @Test
     fun `the hard-coded fallback order has the 19 public categories in canonical sequence`() {
         // Pins FALLBACK_CATEGORY_ORDER against the documented HFR web layout (impl prompt §5).
         assertEquals(19, FALLBACK_CATEGORY_ORDER.size)
@@ -144,6 +187,7 @@ class FlagCategorySectionTest {
     private fun flag(
         topicId: Int,
         cat: Int,
+        hasUnread: Boolean = true,
     ): Flag = Flag(
         cat = cat,
         subcat = null,
@@ -152,7 +196,7 @@ class FlagCategorySectionTest {
         totalPages = 1,
         replyCount = 0,
         type = FlagType.CYAN,
-        hasUnread = true,
+        hasUnread = hasUnread,
         lastReadPage = 1,
         lastPostReadId = null,
         firstPostAuthor = "",

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -758,6 +758,39 @@ class FlagsViewModelTest {
         }
     }
 
+    @Test
+    fun `hide-read with no unread flag collapses the grouped sections to empty`() = runTest {
+        // Codex review: when hide-read is on and NO category has an unread flag (all read, or CYAN
+        // all-read with +lus off), the grouped content must be Grouped(emptyList()). The screen
+        // renders a placeholder for this state so the body never blanks (anti #229 regression);
+        // this test pins the state contract the screen relies on.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1, 10))
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val prefs = FakeUserPreferencesRepository(hideReadCategories = true)
+        val vm = FlagsViewModel(auth, flags, forum, prefs)
+
+        vm.flagsState.test {
+            awaitItem() // initial null
+            vm.selectTab(FlagTab.Red) // RED isn't read-filtered: the all-read flags reach grouping.
+            flags.emit(
+                FlagType.RED,
+                FlagsResult.Success(
+                    listOf(
+                        stubFlag(1, FlagType.RED, hasUnread = false, cat = 1),
+                        stubFlag(2, FlagType.RED, hasUnread = false, cat = 10),
+                    ),
+                ),
+            )
+            val grouped = (awaitItem() as FlagsListUiState.Success).content as FlagsContent.Grouped
+            assertTrue(
+                "every category is fully read → hide-read collapses to zero sections",
+                grouped.sections.isEmpty(),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
     /**
      * Builds the ViewModel with a default (grouped-on, hide-read-off) [FakeUserPreferencesRepository]
      * so the existing tests keep asserting on the grouped sections. Tests that exercise the flat

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -8,6 +8,8 @@ import fr.forumhfr.redface2.core.domain.flags.FlagRepository
 import fr.forumhfr.redface2.core.domain.flags.FlagsResult
 import fr.forumhfr.redface2.core.domain.forum.ForumRepository
 import fr.forumhfr.redface2.core.domain.forum.ForumResult
+import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.Category
 import fr.forumhfr.redface2.core.model.Flag
@@ -51,7 +53,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Anonymous, flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
 
         vm.flagsState.test {
             assertNull(awaitItem())
@@ -67,7 +69,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
 
         vm.flagsState.test {
             // Initial value (null) before stateIn fires.
@@ -87,7 +89,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
 
         vm.flagsState.test {
             awaitItem() // initial null before stateIn fires
@@ -113,7 +115,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -136,7 +138,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
 
         vm.selectTab(FlagTab.Favorite)
         vm.refresh()
@@ -151,7 +153,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
 
         assertEquals(false, vm.isRefreshing.value)
         vm.refresh()
@@ -168,7 +170,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -197,7 +199,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
 
         // Cyan is selected by default; re-tapping it flips the toggle on, then off.
         assertEquals(false, vm.showReadParticipatedTopics.value)
@@ -215,7 +217,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
 
         vm.selectTab(FlagTab.Red)
         assertEquals(false, vm.showReadParticipatedTopics.value)
@@ -243,7 +245,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
         val expired = SessionExpiredException("https://forum.hardware.fr/login.php")
 
         vm.flagsState.test {
@@ -268,7 +270,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository(catIds = listOf(1, 10))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -299,7 +301,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -331,7 +333,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -380,7 +382,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository(catIds = listOf(1, 10, 13))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -394,10 +396,10 @@ class FlagsViewModelTest {
                 ),
             )
             val success = awaitItem() as FlagsListUiState.Success
-            assertEquals(listOf(1, 10, 13), success.sections.map { it.catId })
-            assertEquals(listOf(200), success.sections.first { it.catId == 1 }.topics.map { it.topicId })
-            assertTrue(success.sections.first { it.catId == 10 }.topics.isEmpty())
-            assertEquals(listOf(100), success.sections.first { it.catId == 13 }.topics.map { it.topicId })
+            assertEquals(listOf(1, 10, 13), sections(success).map { it.catId })
+            assertEquals(listOf(200), sections(success).first { it.catId == 1 }.topics.map { it.topicId })
+            assertTrue(sections(success).first { it.catId == 10 }.topics.isEmpty())
+            assertEquals(listOf(100), sections(success).first { it.catId == 13 }.topics.map { it.topicId })
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -409,20 +411,20 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository(autoEmit = false) // hold categories back
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
 
         vm.flagsState.test {
             awaitItem() // initial null
             // observeCategories has emitted nothing yet → fallback order is used.
             flags.emit(FlagType.CYAN, FlagsResult.Success(listOf(stubFlag(1, FlagType.CYAN, cat = 1))))
             val onFallback = awaitItem() as FlagsListUiState.Success
-            assertEquals("fallback exposes the 19 hard-coded categories", 19, onFallback.sections.size)
+            assertEquals("fallback exposes the 19 hard-coded categories", 19, sections(onFallback).size)
             assertEquals(listOf(1), flatTopics(onFallback).map { it.topicId })
 
             // Real catalogue arrives with a narrower set → sections re-derive, flag kept.
             forum.emitCategories(ForumResult.Success(categories(listOf(1, 10))))
             val onReal = awaitItem() as FlagsListUiState.Success
-            assertEquals(listOf(1, 10), onReal.sections.map { it.catId })
+            assertEquals(listOf(1, 10), sections(onReal).map { it.catId })
             assertEquals(listOf(1), flatTopics(onReal).map { it.topicId })
             cancelAndIgnoreRemainingEvents()
         }
@@ -435,14 +437,14 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository(autoEmit = false)
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
 
         vm.flagsState.test {
             awaitItem() // initial null
             forum.emitCategories(ForumResult.Loading)
             flags.emit(FlagType.CYAN, FlagsResult.Success(listOf(stubFlag(7, FlagType.CYAN, cat = 1))))
             val onLoading = awaitItem() as FlagsListUiState.Success
-            assertEquals(19, onLoading.sections.size)
+            assertEquals(19, sections(onLoading).size)
             assertEquals(listOf(7), flatTopics(onLoading).map { it.topicId })
 
             // A Failure on the categories side must NOT turn the screen into a Failure. Because
@@ -452,7 +454,7 @@ class FlagsViewModelTest {
             forum.emitCategories(ForumResult.Failure(IllegalStateException("categories down")))
             flags.emit(FlagType.CYAN, FlagsResult.Success(listOf(stubFlag(8, FlagType.CYAN, cat = 1))))
             val onFailure = awaitItem() as FlagsListUiState.Success
-            assertEquals(19, onFailure.sections.size)
+            assertEquals(19, sections(onFailure).size)
             assertEquals(listOf(8), flatTopics(onFailure).map { it.topicId })
             cancelAndIgnoreRemainingEvents()
         }
@@ -466,7 +468,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository(autoEmit = false)
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -477,11 +479,11 @@ class FlagsViewModelTest {
             assertEquals(
                 "empty Success catalogue must use the 19-category fallback, not zero sections",
                 19,
-                onEmptyCatalogue.sections.size,
+                sections(onEmptyCatalogue).size,
             )
             assertTrue(
                 "every fallback section is empty when there are no flags",
-                onEmptyCatalogue.sections.all { it.topics.isEmpty() },
+                sections(onEmptyCatalogue).all { it.topics.isEmpty() },
             )
             cancelAndIgnoreRemainingEvents()
         }
@@ -494,7 +496,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -513,7 +515,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -532,7 +534,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
         val flag = stubFlag(1, FlagType.CYAN)
 
         vm.removeFlagState.test {
@@ -560,7 +562,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
 
         vm.requestRemoveFlag(stubFlag(1, FlagType.CYAN))
         vm.cancelRemoveFlag()
@@ -577,7 +579,7 @@ class FlagsViewModelTest {
         )
         val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
         val flag = stubFlag(2, FlagType.FAVORITE)
 
         vm.requestRemoveFlag(flag)
@@ -593,7 +595,7 @@ class FlagsViewModelTest {
         flags.removeFlagResult = kotlinx.coroutines.CompletableDeferred()
         val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
         val firstFlag = stubFlag(1, FlagType.CYAN)
 
         vm.requestRemoveFlag(firstFlag)
@@ -611,7 +613,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags, forum)
+        val vm = viewModel(auth, flags, forum)
         val flag = stubFlag(3, FlagType.RED)
 
         vm.requestRemoveFlag(flag)
@@ -622,9 +624,162 @@ class FlagsViewModelTest {
         assertNull(vm.removeFlagEvent.value)
     }
 
-    /** Flattens the grouped sections back to the topics order for assertions on flag content. */
+    @Test
+    fun `flat view preference yields a flat content preserving repository order`() = runTest {
+        // #179 follow-up: the legacy flat view must keep the repository order (last reply desc),
+        // NOT the category-grouped order — proven here with flags arriving cat 13 then cat 1.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1, 13))
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val prefs = FakeUserPreferencesRepository(groupByCategory = false)
+        val vm = FlagsViewModel(auth, flags, forum, prefs)
+
+        vm.flagsState.test {
+            awaitItem() // initial null
+            flags.emit(
+                FlagType.CYAN,
+                FlagsResult.Success(
+                    listOf(
+                        stubFlag(100, FlagType.CYAN, cat = 13),
+                        stubFlag(200, FlagType.CYAN, cat = 1),
+                    ),
+                ),
+            )
+            val flat = (awaitItem() as FlagsListUiState.Success).content as FlagsContent.Flat
+            assertEquals(listOf(100, 200), flat.flags.map { it.topicId })
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `toggling group-by-category pref switches content shape without a refetch`() = runTest {
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1))
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val prefs = FakeUserPreferencesRepository(groupByCategory = true)
+        val vm = FlagsViewModel(auth, flags, forum, prefs)
+
+        vm.flagsState.test {
+            awaitItem() // initial null
+            flags.emit(FlagType.CYAN, FlagsResult.Success(listOf(stubFlag(1, FlagType.CYAN, cat = 1))))
+            assertTrue((awaitItem() as FlagsListUiState.Success).content is FlagsContent.Grouped)
+
+            prefs.setGroupBy(false)
+            assertTrue((awaitItem() as FlagsListUiState.Success).content is FlagsContent.Flat)
+            assertTrue("a view-mode toggle must never trigger a network refresh", flags.refreshCalls.isEmpty())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `hide-read pref drops categories without an unread flag on RED`() = runTest {
+        // RED is not read-filtered, so both read and unread reach the grouping: hide-read must
+        // drop the all-read category (10) and the empty ones, keeping only the one with an unread.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1, 10))
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val prefs = FakeUserPreferencesRepository(hideReadCategories = true)
+        val vm = FlagsViewModel(auth, flags, forum, prefs)
+
+        vm.flagsState.test {
+            awaitItem() // initial null
+            vm.selectTab(FlagTab.Red)
+            flags.emit(
+                FlagType.RED,
+                FlagsResult.Success(
+                    listOf(
+                        stubFlag(1, FlagType.RED, hasUnread = true, cat = 1),
+                        stubFlag(2, FlagType.RED, hasUnread = false, cat = 10),
+                    ),
+                ),
+            )
+            val success = awaitItem() as FlagsListUiState.Success
+            assertEquals(listOf(1), sections(success).map { it.catId })
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `cyan +lus override keeps a fully-read category visible under hide-read`() = runTest {
+        // The tension the user flagged: « +lus » (show read participated topics) must win over
+        // « masquer les catégories sans non-lu » so the read cyans stay reachable.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1, 10))
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val prefs = FakeUserPreferencesRepository(hideReadCategories = true)
+        val vm = FlagsViewModel(auth, flags, forum, prefs)
+
+        vm.flagsState.test {
+            awaitItem() // initial null
+            vm.setShowReadParticipatedTopics(true)
+            flags.emit(
+                FlagType.CYAN,
+                FlagsResult.Success(
+                    listOf(
+                        stubFlag(1, FlagType.CYAN, hasUnread = true, cat = 1),
+                        stubFlag(2, FlagType.CYAN, hasUnread = false, cat = 10),
+                    ),
+                ),
+            )
+            val success = awaitItem() as FlagsListUiState.Success
+            assertEquals(
+                "with +lus on, a category holding only a read cyan must survive hide-read",
+                listOf(1, 10),
+                sections(success).map { it.catId },
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `cyan without +lus under hide-read shows only categories with an unread cyan`() = runTest {
+        // Without « +lus », the #154 filter removes the read cyan first, so its category becomes
+        // empty and hide-read drops it — leaving only the category with an actionable unread.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1, 10))
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val prefs = FakeUserPreferencesRepository(hideReadCategories = true)
+        val vm = FlagsViewModel(auth, flags, forum, prefs)
+
+        vm.flagsState.test {
+            awaitItem() // initial null
+            flags.emit(
+                FlagType.CYAN,
+                FlagsResult.Success(
+                    listOf(
+                        stubFlag(1, FlagType.CYAN, hasUnread = true, cat = 1),
+                        stubFlag(2, FlagType.CYAN, hasUnread = false, cat = 10),
+                    ),
+                ),
+            )
+            val success = awaitItem() as FlagsListUiState.Success
+            assertEquals(listOf(1), sections(success).map { it.catId })
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    /**
+     * Builds the ViewModel with a default (grouped-on, hide-read-off) [FakeUserPreferencesRepository]
+     * so the existing tests keep asserting on the grouped sections. Tests that exercise the flat
+     * view or the hide-read filter pass an explicit [prefs].
+     */
+    private fun viewModel(
+        auth: FakeAuthRepository,
+        flags: FakeFlagRepository,
+        forum: FakeForumRepository,
+        prefs: FakeUserPreferencesRepository = FakeUserPreferencesRepository(),
+    ): FlagsViewModel = FlagsViewModel(auth, flags, forum, prefs)
+
+    /** Flattens whatever content shape into the topics order for assertions on flag content. */
     private fun flatTopics(state: FlagsListUiState.Success): List<Flag> =
-        state.sections.flatMap { it.topics }
+        when (val content = state.content) {
+            is FlagsContent.Grouped -> content.sections.flatMap { it.topics }
+            is FlagsContent.Flat -> content.flags
+        }
+
+    /** Extracts the grouped sections, failing the cast if the content was flat (test misuse). */
+    private fun sections(state: FlagsListUiState.Success): List<FlagCategorySection> =
+        (state.content as FlagsContent.Grouped).sections
 
     private fun categories(ids: List<Int>): List<Category> =
         ids.map { Category(id = it, name = "Cat $it", forceSubcat = false, subcategoryCount = 0) }
@@ -781,5 +936,42 @@ class FlagsViewModelTest {
         override suspend fun refreshTopicList(cat: Int, subcat: Int?, page: Int) = Unit
 
         override suspend fun prefetchTopicList(cat: Int, subcat: Int?, page: Int) = Unit
+    }
+
+    /**
+     * Fake [UserPreferencesRepository] exposing only the two Drapeaux view preferences the
+     * ViewModel reads (group-by-category, hide-read-categories) as writable hot flows; the proxy
+     * and topic-cache members are stubbed at their defaults (the ViewModel never touches them).
+     */
+    private class FakeUserPreferencesRepository(
+        groupByCategory: Boolean = true,
+        hideReadCategories: Boolean = false,
+    ) : UserPreferencesRepository {
+        private val groupBy = MutableStateFlow(groupByCategory)
+        private val hideRead = MutableStateFlow(hideReadCategories)
+
+        override fun observeProxyConfig(): Flow<ProxyConfig> = MutableStateFlow(ProxyConfig())
+        override suspend fun saveProxyConfig(config: ProxyConfig) = Unit
+        override fun readProxyConfigForNetworkBootstrap(): ProxyConfig = ProxyConfig()
+        override fun observeIgnoreTopicCache(): Flow<Boolean> = MutableStateFlow(false)
+        override suspend fun setIgnoreTopicCache(enabled: Boolean) = Unit
+
+        override fun observeFlagsGroupByCategory(): Flow<Boolean> = groupBy
+        override suspend fun setFlagsGroupByCategory(enabled: Boolean) {
+            groupBy.value = enabled
+        }
+
+        override fun observeFlagsHideReadCategories(): Flow<Boolean> = hideRead
+        override suspend fun setFlagsHideReadCategories(enabled: Boolean) {
+            hideRead.value = enabled
+        }
+
+        fun setGroupBy(value: Boolean) {
+            groupBy.value = value
+        }
+
+        fun setHideRead(value: Boolean) {
+            hideRead.value = value
+        }
     }
 }

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -459,6 +459,35 @@ class FlagsViewModelTest {
     }
 
     @Test
+    fun `an empty categories Success falls back to the hard-coded order, never a blank body`() = runTest {
+        // Guards the double-empty edge: zero flags AND a Success carrying an empty catalogue must
+        // NOT collapse to zero sections (a fully blank body). An empty Success is treated as
+        // « no catalogue yet » → FALLBACK_CATEGORY_ORDER drives the 19 known sections.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(autoEmit = false)
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val vm = FlagsViewModel(auth, flags, forum)
+
+        vm.flagsState.test {
+            awaitItem() // initial null
+            forum.emitCategories(ForumResult.Success(emptyList()))
+            // Double-empty: no flags + empty catalogue Success.
+            flags.emit(FlagType.CYAN, FlagsResult.Success(emptyList()))
+            val onEmptyCatalogue = awaitItem() as FlagsListUiState.Success
+            assertEquals(
+                "empty Success catalogue must use the 19-category fallback, not zero sections",
+                19,
+                onEmptyCatalogue.sections.size,
+            )
+            assertTrue(
+                "every fallback section is empty when there are no flags",
+                onEmptyCatalogue.sections.all { it.topics.isEmpty() },
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `categories are observed once for the authenticated tab and never refreshed`() = runTest {
         // 11bis: exactly one categories subscription for the active authenticated tab, and the
         // flags screen never calls refreshCategories (the read path / 24h cache owns that).

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -6,9 +6,14 @@ import fr.forumhfr.redface2.core.domain.auth.LoginError
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.domain.flags.FlagRepository
 import fr.forumhfr.redface2.core.domain.flags.FlagsResult
+import fr.forumhfr.redface2.core.domain.forum.ForumRepository
+import fr.forumhfr.redface2.core.domain.forum.ForumResult
 import fr.forumhfr.redface2.core.model.AuthState
+import fr.forumhfr.redface2.core.model.Category
 import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
+import fr.forumhfr.redface2.core.model.SubCategory
+import fr.forumhfr.redface2.core.model.TopicListPage
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -16,6 +21,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -43,30 +49,35 @@ class FlagsViewModelTest {
     @Test
     fun `flagsState stays null while user is anonymous`() = runTest {
         val flags = FakeFlagRepository()
+        val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Anonymous, flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags)
+        val vm = FlagsViewModel(auth, flags, forum)
 
         vm.flagsState.test {
             assertNull(awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
+
+        // Anonymous must NOT subscribe to categories (no spurious public fetch, cf. §5).
+        assertEquals(0, forum.observeCategoriesSubscriptions)
     }
 
     @Test
     fun `flagsState mirrors the current tab when authenticated`() = runTest {
         val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags)
+        val vm = FlagsViewModel(auth, flags, forum)
 
         vm.flagsState.test {
             // Initial value (null) before stateIn fires.
             awaitItem()
             // FakeFlagRepository emits Loading then Success(emptyList) on subscribe.
             flags.emit(FlagType.CYAN, FlagsResult.Loading)
-            assertEquals(FlagsResult.Loading, awaitItem())
+            assertEquals(FlagsListUiState.Loading, awaitItem())
             flags.emit(FlagType.CYAN, FlagsResult.Success(listOf(stubFlag(1, FlagType.CYAN))))
-            val success = awaitItem() as FlagsResult.Success
-            assertEquals(1, success.flags.single().topicId)
+            val success = awaitItem() as FlagsListUiState.Success
+            assertEquals(1, flatTopics(success).single().topicId)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -74,16 +85,17 @@ class FlagsViewModelTest {
     @Test
     fun `flagsState keeps the list during a refresh instead of blanking to Loading (#225)`() = runTest {
         val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags)
+        val vm = FlagsViewModel(auth, flags, forum)
 
         vm.flagsState.test {
             awaitItem() // initial null before stateIn fires
             // Cold load: the first Loading passes through so the screen shows its initial spinner.
             flags.emit(FlagType.CYAN, FlagsResult.Loading)
-            assertEquals(FlagsResult.Loading, awaitItem())
+            assertEquals(FlagsListUiState.Loading, awaitItem())
             flags.emit(FlagType.CYAN, FlagsResult.Success(listOf(stubFlag(1, FlagType.CYAN))))
-            assertEquals(1, (awaitItem() as FlagsResult.Success).flags.single().topicId)
+            assertEquals(1, flatTopics(awaitItem() as FlagsListUiState.Success).single().topicId)
 
             // A swipe refresh re-broadcasts Loading: it must be SUPPRESSED so the list stays
             // anchored under the PullToRefreshBox indicator (no second centered spinner, #225).
@@ -91,7 +103,7 @@ class FlagsViewModelTest {
             // The next *visible* state is the refreshed Success — the intermediate Loading
             // never surfaces (otherwise awaitItem() here would return Loading and fail the cast).
             flags.emit(FlagType.CYAN, FlagsResult.Success(listOf(stubFlag(2, FlagType.CYAN))))
-            assertEquals(2, (awaitItem() as FlagsResult.Success).flags.single().topicId)
+            assertEquals(2, flatTopics(awaitItem() as FlagsListUiState.Success).single().topicId)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -99,20 +111,21 @@ class FlagsViewModelTest {
     @Test
     fun `selectTab switches the flagsState source`() = runTest {
         val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags)
+        val vm = FlagsViewModel(auth, flags, forum)
 
         vm.flagsState.test {
             awaitItem() // initial null
 
             flags.emit(FlagType.CYAN, FlagsResult.Success(listOf(stubFlag(1, FlagType.CYAN))))
-            val cyan = awaitItem() as FlagsResult.Success
-            assertEquals(FlagType.CYAN, cyan.flags.single().type)
+            val cyan = awaitItem() as FlagsListUiState.Success
+            assertEquals(FlagType.CYAN, flatTopics(cyan).single().type)
 
             vm.selectTab(FlagTab.Red)
             flags.emit(FlagType.RED, FlagsResult.Success(listOf(stubFlag(2, FlagType.RED))))
-            val red = awaitItem() as FlagsResult.Success
-            assertEquals(FlagType.RED, red.flags.single().type)
+            val red = awaitItem() as FlagsListUiState.Success
+            assertEquals(FlagType.RED, flatTopics(red).single().type)
 
             cancelAndIgnoreRemainingEvents()
         }
@@ -121,20 +134,24 @@ class FlagsViewModelTest {
     @Test
     fun `refresh forwards to the repository for the current tab`() = runTest {
         val flags = FakeFlagRepository()
+        val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags)
+        val vm = FlagsViewModel(auth, flags, forum)
 
         vm.selectTab(FlagTab.Favorite)
         vm.refresh()
 
         assertEquals(listOf(FlagType.FAVORITE), flags.refreshCalls)
+        // The catalogue is refreshed by the read path, never by the flags screen (cf. §5).
+        assertEquals(0, forum.refreshCategoriesCalls)
     }
 
     @Test
     fun `refresh toggles isRefreshing around the round-trip`() = runTest {
         val flags = FakeFlagRepository()
+        val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags)
+        val vm = FlagsViewModel(auth, flags, forum)
 
         assertEquals(false, vm.isRefreshing.value)
         vm.refresh()
@@ -143,23 +160,29 @@ class FlagsViewModelTest {
         // it eagerly). The contract pinned here: it must end at false, never stuck true.
         assertEquals(false, vm.isRefreshing.value)
         assertEquals(listOf(FlagType.CYAN), flags.refreshCalls)
+        assertEquals("pull-to-refresh must never refresh the categories catalogue", 0, forum.refreshCategoriesCalls)
     }
 
     @Test
     fun `selecting the Super tab is a placeholder with no fetch and null state`() = runTest {
         val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags)
+        val vm = FlagsViewModel(auth, flags, forum)
 
         vm.flagsState.test {
             awaitItem() // initial null
 
             flags.emit(FlagType.CYAN, FlagsResult.Success(listOf(stubFlag(1, FlagType.CYAN))))
             awaitItem() // CYAN content
+            val subscriptionsWhileOnCyan = forum.observeCategoriesSubscriptions
 
             vm.selectTab(FlagTab.Super)
             // Super maps to no FlagType: the state collapses back to null (placeholder body).
             assertNull(awaitItem())
+
+            // Super must not start a new categories observation either.
+            assertEquals(subscriptionsWhileOnCyan, forum.observeCategoriesSubscriptions)
             cancelAndIgnoreRemainingEvents()
         }
 
@@ -172,8 +195,9 @@ class FlagsViewModelTest {
     @Test
     fun `re-tapping the already selected Cyan tab toggles the read participated filter`() = runTest {
         val flags = FakeFlagRepository()
+        val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags)
+        val vm = FlagsViewModel(auth, flags, forum)
 
         // Cyan is selected by default; re-tapping it flips the toggle on, then off.
         assertEquals(false, vm.showReadParticipatedTopics.value)
@@ -189,8 +213,9 @@ class FlagsViewModelTest {
     @Test
     fun `selecting Cyan from another tab does not toggle the filter`() = runTest {
         val flags = FakeFlagRepository()
+        val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags)
+        val vm = FlagsViewModel(auth, flags, forum)
 
         vm.selectTab(FlagTab.Red)
         assertEquals(false, vm.showReadParticipatedTopics.value)
@@ -211,19 +236,20 @@ class FlagsViewModelTest {
     @Test
     fun `flagsState propagates SessionExpiredException cause to drive the reconnect CTA`() = runTest {
         // FlagsRoute renders the reconnect CTA branch when `current.cause is SessionExpiredException`.
-        // A future refactor that drops the `cause` field on FlagsResult.Failure (e.g. flattening
+        // A future refactor that drops the `cause` field on FlagsListUiState.Failure (e.g. flattening
         // it to a `String message`) would silently break that detection. This test pins the
         // contract: the SessionExpiredException must traverse the repository → ViewModel →
         // exposed state without being unwrapped.
         val flags = FakeFlagRepository()
+        val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags)
+        val vm = FlagsViewModel(auth, flags, forum)
         val expired = SessionExpiredException("https://forum.hardware.fr/login.php")
 
         vm.flagsState.test {
             awaitItem() // initial null
             flags.emit(FlagType.CYAN, FlagsResult.Failure(expired))
-            val failure = awaitItem() as FlagsResult.Failure
+            val failure = awaitItem() as FlagsListUiState.Failure
             assertTrue(
                 "expected SessionExpiredException to traverse the stack — got ${failure.cause::class.simpleName}",
                 failure.cause is SessionExpiredException,
@@ -233,14 +259,16 @@ class FlagsViewModelTest {
     }
 
     @Test
-    fun `CYAN tab hides read participated topics by default`() = runTest {
+    fun `CYAN tab hides read participated topics by default before grouping`() = runTest {
         // #154: « Mes sujets » should not pollute the actionable view with topics the user
         // already finished reading. The filter is applied at the ViewModel layer (not in
         // the repository) so toggling the preference reactively re-emits the filtered list
-        // without re-fetching.
+        // without re-fetching. #179: the filter happens BEFORE the category grouping, so a
+        // category whose every cyan is read becomes an empty section.
         val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1, 10))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags)
+        val vm = FlagsViewModel(auth, flags, forum)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -249,18 +277,18 @@ class FlagsViewModelTest {
                 FlagType.CYAN,
                 FlagsResult.Success(
                     listOf(
-                        stubFlag(1, FlagType.CYAN, hasUnread = true),
-                        stubFlag(2, FlagType.CYAN, hasUnread = false),
-                        stubFlag(3, FlagType.CYAN, hasUnread = true),
+                        stubFlag(1, FlagType.CYAN, hasUnread = true, cat = 1),
+                        stubFlag(2, FlagType.CYAN, hasUnread = false, cat = 1),
+                        stubFlag(3, FlagType.CYAN, hasUnread = true, cat = 10),
                     ),
                 ),
             )
 
-            val filtered = awaitItem() as FlagsResult.Success
+            val filtered = awaitItem() as FlagsListUiState.Success
             assertEquals(
                 "expected only hasUnread=true topics under default CYAN filter",
                 listOf(1, 3),
-                filtered.flags.map { it.topicId },
+                flatTopics(filtered).map { it.topicId },
             )
             cancelAndIgnoreRemainingEvents()
         }
@@ -269,8 +297,9 @@ class FlagsViewModelTest {
     @Test
     fun `setShowReadParticipatedTopics true reveals read CYAN topics without refetch`() = runTest {
         val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags)
+        val vm = FlagsViewModel(auth, flags, forum)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -284,13 +313,13 @@ class FlagsViewModelTest {
                     ),
                 ),
             )
-            assertEquals(listOf(1), (awaitItem() as FlagsResult.Success).flags.map { it.topicId })
+            assertEquals(listOf(1), flatTopics(awaitItem() as FlagsListUiState.Success).map { it.topicId })
 
             vm.setShowReadParticipatedTopics(true)
             // No new refresh() call — the toggle alone must re-emit the unfiltered list
             // because flagsState combines the source flow with showReadParticipatedTopics.
-            val full = awaitItem() as FlagsResult.Success
-            assertEquals(listOf(1, 2), full.flags.map { it.topicId })
+            val full = awaitItem() as FlagsListUiState.Success
+            assertEquals(listOf(1, 2), flatTopics(full).map { it.topicId })
             assertTrue("toggle must not trigger a network refresh", flags.refreshCalls.isEmpty())
 
             cancelAndIgnoreRemainingEvents()
@@ -300,8 +329,9 @@ class FlagsViewModelTest {
     @Test
     fun `RED and FAVORITE tabs are never filtered by the read participated toggle`() = runTest {
         val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags)
+        val vm = FlagsViewModel(auth, flags, forum)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -316,11 +346,11 @@ class FlagsViewModelTest {
                     ),
                 ),
             )
-            val red = awaitItem() as FlagsResult.Success
+            val red = awaitItem() as FlagsListUiState.Success
             assertEquals(
                 "RED must include both read and unread regardless of the toggle",
                 listOf(10, 11),
-                red.flags.map { it.topicId },
+                flatTopics(red).map { it.topicId },
             )
 
             vm.selectTab(FlagTab.Favorite)
@@ -333,11 +363,11 @@ class FlagsViewModelTest {
                     ),
                 ),
             )
-            val favorite = awaitItem() as FlagsResult.Success
+            val favorite = awaitItem() as FlagsListUiState.Success
             assertEquals(
                 "FAVORITE must include both read and unread regardless of the toggle",
                 listOf(20, 21),
-                favorite.flags.map { it.topicId },
+                flatTopics(favorite).map { it.topicId },
             )
 
             cancelAndIgnoreRemainingEvents()
@@ -345,10 +375,116 @@ class FlagsViewModelTest {
     }
 
     @Test
+    fun `sections reflect the canonical order emitted by the forum repository`() = runTest {
+        // #179: the grouped sections follow the categories order, not the flags arrival order.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1, 10, 13))
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val vm = FlagsViewModel(auth, flags, forum)
+
+        vm.flagsState.test {
+            awaitItem() // initial null
+            flags.emit(
+                FlagType.CYAN,
+                FlagsResult.Success(
+                    listOf(
+                        stubFlag(100, FlagType.CYAN, cat = 13),
+                        stubFlag(200, FlagType.CYAN, cat = 1),
+                    ),
+                ),
+            )
+            val success = awaitItem() as FlagsListUiState.Success
+            assertEquals(listOf(1, 10, 13), success.sections.map { it.catId })
+            assertEquals(listOf(200), success.sections.first { it.catId == 1 }.topics.map { it.topicId })
+            assertTrue(success.sections.first { it.catId == 10 }.topics.isEmpty())
+            assertEquals(listOf(100), success.sections.first { it.catId == 13 }.topics.map { it.topicId })
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `flags arriving before categories render immediately with the hard-coded fallback order`() = runTest {
+        // 10bis: cold start where Success(flags) lands before observeCategories emits — the
+        // fallback order must drive the sections so no flag is lost, then the real order applies.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(autoEmit = false) // hold categories back
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val vm = FlagsViewModel(auth, flags, forum)
+
+        vm.flagsState.test {
+            awaitItem() // initial null
+            // observeCategories has emitted nothing yet → fallback order is used.
+            flags.emit(FlagType.CYAN, FlagsResult.Success(listOf(stubFlag(1, FlagType.CYAN, cat = 1))))
+            val onFallback = awaitItem() as FlagsListUiState.Success
+            assertEquals("fallback exposes the 19 hard-coded categories", 19, onFallback.sections.size)
+            assertEquals(listOf(1), flatTopics(onFallback).map { it.topicId })
+
+            // Real catalogue arrives with a narrower set → sections re-derive, flag kept.
+            forum.emitCategories(ForumResult.Success(categories(listOf(1, 10))))
+            val onReal = awaitItem() as FlagsListUiState.Success
+            assertEquals(listOf(1, 10), onReal.sections.map { it.catId })
+            assertEquals(listOf(1), flatTopics(onReal).map { it.topicId })
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `categories Loading and Failure fall back to the hard-coded order without losing flags`() = runTest {
+        // 11 + 11ter: a Loading/Failure on the categories side must NOT turn a flags Success
+        // into a Failure screen — the fallback order is used and the flags still render.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(autoEmit = false)
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val vm = FlagsViewModel(auth, flags, forum)
+
+        vm.flagsState.test {
+            awaitItem() // initial null
+            forum.emitCategories(ForumResult.Loading)
+            flags.emit(FlagType.CYAN, FlagsResult.Success(listOf(stubFlag(7, FlagType.CYAN, cat = 1))))
+            val onLoading = awaitItem() as FlagsListUiState.Success
+            assertEquals(19, onLoading.sections.size)
+            assertEquals(listOf(7), flatTopics(onLoading).map { it.topicId })
+
+            // A Failure on the categories side must NOT turn the screen into a Failure. Because
+            // both Loading and Failure map to the SAME fallback Success state, stateIn dedupes
+            // the identical value — so we change the FLAGS too, proving the new distinct state
+            // is still a Success (fallback order, flag kept) and never a Failure.
+            forum.emitCategories(ForumResult.Failure(IllegalStateException("categories down")))
+            flags.emit(FlagType.CYAN, FlagsResult.Success(listOf(stubFlag(8, FlagType.CYAN, cat = 1))))
+            val onFailure = awaitItem() as FlagsListUiState.Success
+            assertEquals(19, onFailure.sections.size)
+            assertEquals(listOf(8), flatTopics(onFailure).map { it.topicId })
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `categories are observed once for the authenticated tab and never refreshed`() = runTest {
+        // 11bis: exactly one categories subscription for the active authenticated tab, and the
+        // flags screen never calls refreshCategories (the read path / 24h cache owns that).
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1))
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val vm = FlagsViewModel(auth, flags, forum)
+
+        vm.flagsState.test {
+            awaitItem() // initial null
+            flags.emit(FlagType.CYAN, FlagsResult.Success(listOf(stubFlag(1, FlagType.CYAN))))
+            awaitItem()
+            assertEquals("one categories subscription for the active tab", 1, forum.observeCategoriesSubscriptions)
+
+            vm.refresh()
+            assertEquals(0, forum.refreshCategoriesCalls)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `switching authenticated pseudo clears the private flags cache`() = runTest {
         val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags)
+        val vm = FlagsViewModel(auth, flags, forum)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -365,8 +501,9 @@ class FlagsViewModelTest {
     @Test
     fun `requestRemoveFlag moves to Confirming and confirm runs through to Success`() = runTest {
         val flags = FakeFlagRepository()
+        val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags)
+        val vm = FlagsViewModel(auth, flags, forum)
         val flag = stubFlag(1, FlagType.CYAN)
 
         vm.removeFlagState.test {
@@ -392,8 +529,9 @@ class FlagsViewModelTest {
     @Test
     fun `cancelRemoveFlag returns to Idle without calling the repository`() = runTest {
         val flags = FakeFlagRepository()
+        val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags)
+        val vm = FlagsViewModel(auth, flags, forum)
 
         vm.requestRemoveFlag(stubFlag(1, FlagType.CYAN))
         vm.cancelRemoveFlag()
@@ -408,8 +546,9 @@ class FlagsViewModelTest {
         flags.removeFlagResult = kotlinx.coroutines.CompletableDeferred(
             Result.failure(IllegalStateException("delflag refused")),
         )
+        val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags)
+        val vm = FlagsViewModel(auth, flags, forum)
         val flag = stubFlag(2, FlagType.FAVORITE)
 
         vm.requestRemoveFlag(flag)
@@ -423,8 +562,9 @@ class FlagsViewModelTest {
     fun `requestRemoveFlag is ignored while a removal is in flight`() = runTest {
         val flags = FakeFlagRepository()
         flags.removeFlagResult = kotlinx.coroutines.CompletableDeferred()
+        val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags)
+        val vm = FlagsViewModel(auth, flags, forum)
         val firstFlag = stubFlag(1, FlagType.CYAN)
 
         vm.requestRemoveFlag(firstFlag)
@@ -440,8 +580,9 @@ class FlagsViewModelTest {
     @Test
     fun `consumeRemoveFlagEvent clears the one-shot event`() = runTest {
         val flags = FakeFlagRepository()
+        val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = FlagsViewModel(auth, flags)
+        val vm = FlagsViewModel(auth, flags, forum)
         val flag = stubFlag(3, FlagType.RED)
 
         vm.requestRemoveFlag(flag)
@@ -452,12 +593,20 @@ class FlagsViewModelTest {
         assertNull(vm.removeFlagEvent.value)
     }
 
+    /** Flattens the grouped sections back to the topics order for assertions on flag content. */
+    private fun flatTopics(state: FlagsListUiState.Success): List<Flag> =
+        state.sections.flatMap { it.topics }
+
+    private fun categories(ids: List<Int>): List<Category> =
+        ids.map { Category(id = it, name = "Cat $it", forceSubcat = false, subcategoryCount = 0) }
+
     private fun stubFlag(
         topicId: Int,
         type: FlagType,
         hasUnread: Boolean = true,
+        cat: Int = 1,
     ): Flag = Flag(
-        cat = 1,
+        cat = cat,
         subcat = null,
         topicId = topicId,
         title = "Topic $topicId",
@@ -543,5 +692,65 @@ class FlagsViewModelTest {
         suspend fun emit(type: FlagType, result: FlagsResult) {
             perType.getValue(type).emit(result)
         }
+    }
+
+    /**
+     * Fake [ForumRepository] for the grouped-flags tests. Exposes subscription / refresh
+     * counters so a test can assert the ViewModel does NOT trigger a spurious public
+     * categories fetch (Anonymous / Super) and NEVER calls [refreshCategories] (cf. §5).
+     *
+     * When [autoEmit] is true the categories flow replays a [ForumResult.Success] built from
+     * [catIds] on every subscription (mirrors the warm 24h memory cache). When false, the test
+     * drives emissions explicitly via [emitCategories] to exercise the cold-start ordering.
+     */
+    private class FakeForumRepository(
+        private val catIds: List<Int> = emptyList(),
+        private val autoEmit: Boolean = true,
+    ) : ForumRepository {
+        private val categoriesFlow = MutableSharedFlow<ForumResult<List<Category>>>(
+            replay = 1,
+            extraBufferCapacity = 8,
+        )
+
+        var observeCategoriesSubscriptions: Int = 0
+            private set
+        var refreshCategoriesCalls: Int = 0
+            private set
+
+        init {
+            if (autoEmit) {
+                val cats = catIds.map {
+                    Category(id = it, name = "Cat $it", forceSubcat = false, subcategoryCount = 0)
+                }
+                categoriesFlow.tryEmit(ForumResult.Success(cats))
+            }
+        }
+
+        suspend fun emitCategories(result: ForumResult<List<Category>>) {
+            categoriesFlow.emit(result)
+        }
+
+        override fun observeCategories(): Flow<ForumResult<List<Category>>> =
+            categoriesFlow.asSharedFlow().onSubscription { observeCategoriesSubscriptions += 1 }
+
+        override suspend fun refreshCategories() {
+            refreshCategoriesCalls += 1
+        }
+
+        override fun observeSubcategories(cat: Int): Flow<ForumResult<List<SubCategory>>> =
+            MutableSharedFlow<ForumResult<List<SubCategory>>>(replay = 1).asSharedFlow()
+
+        override suspend fun refreshSubcategories(cat: Int) = Unit
+
+        override fun observeTopicList(
+            cat: Int,
+            subcat: Int?,
+            page: Int,
+        ): Flow<ForumResult<TopicListPage>> =
+            MutableSharedFlow<ForumResult<TopicListPage>>(replay = 1).asSharedFlow()
+
+        override suspend fun refreshTopicList(cat: Int, subcat: Int?, page: Int) = Unit
+
+        override suspend fun prefetchTopicList(cat: Int, subcat: Int?, page: Int) = Unit
     }
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -171,6 +171,11 @@ internal fun SettingsContent(
                 }
             }
 
+            FlagsPreferencesCard(
+                state = state,
+                onIntent = onIntent,
+            )
+
             MaintenanceCard(
                 state = state,
                 onIntent = onIntent,
@@ -184,6 +189,101 @@ internal fun SettingsContent(
             onDismiss = { onIntent(SettingsIntent.ClearTopicCacheDismissed) },
         )
     }
+}
+
+/**
+ * Drapeaux display preferences (#179 follow-up): grouped-vs-flat layout and the « masquer les
+ * catégories sans non-lu » filter. Persisted via DataStore and observed live by the Flags screen,
+ * so a flip here re-renders the list without a refetch.
+ */
+@Composable
+private fun FlagsPreferencesCard(
+    state: SettingsState,
+    onIntent: (SettingsIntent) -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_flags_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            PreferenceSwitchRow(
+                title = stringResource(R.string.settings_flags_group_by_category_title),
+                description = stringResource(R.string.settings_flags_group_by_category_description),
+                checked = state.flagsGroupByCategory,
+                enabled = state.canToggleFlagsGroupByCategory,
+                onCheckedChange = { onIntent(SettingsIntent.FlagsGroupByCategoryChanged(it)) },
+            )
+            if (state.flagsGroupByCategoryError) {
+                PreferencePersistError(R.string.settings_flags_group_by_category_persist_failed)
+            }
+            PreferenceSwitchRow(
+                title = stringResource(R.string.settings_flags_hide_read_categories_title),
+                description = stringResource(R.string.settings_flags_hide_read_categories_description),
+                checked = state.flagsHideReadCategories,
+                enabled = state.canToggleFlagsHideReadCategories,
+                onCheckedChange = { onIntent(SettingsIntent.FlagsHideReadCategoriesChanged(it)) },
+            )
+            if (state.flagsHideReadCategoriesError) {
+                PreferencePersistError(R.string.settings_flags_hide_read_categories_persist_failed)
+            }
+        }
+    }
+}
+
+/**
+ * One label + description + Material 3 [Switch] row. Generic so the two Drapeaux preference rows
+ * share the layout; the persist-failure message is rendered by the caller via
+ * [PreferencePersistError] so this stays a layout-only composable.
+ */
+@Composable
+private fun PreferenceSwitchRow(
+    title: String,
+    description: String,
+    checked: Boolean,
+    enabled: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Switch(
+            checked = checked,
+            enabled = enabled,
+            onCheckedChange = onCheckedChange,
+        )
+    }
+}
+
+/** Inline persist-failure message for a [PreferenceSwitchRow], shown below the row. */
+@Composable
+private fun PreferencePersistError(messageRes: Int) {
+    Text(
+        text = stringResource(messageRes),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.error,
+    )
 }
 
 @Composable

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -28,6 +28,19 @@ data class SettingsState(
      * later and overwrite the optimistic flip with a stale snapshot. Never surfaced in the UI.
      */
     val ignoreTopicCacheTouchedLocally: Boolean = false,
+    // Drapeaux view preferences (#179 follow-up). Same optimistic-flip + startup-race-guard
+    // machinery as ignoreTopicCache: the field is the displayed value, `isUpdating*` gates the
+    // switch while DataStore writes, `*Error` surfaces a persist failure, and `*TouchedLocally`
+    // forbids a late hydration from clobbering a fast user flip. Defaults match the DataStore
+    // defaults (grouped on, hide-read off).
+    val flagsGroupByCategory: Boolean = true,
+    val isUpdatingFlagsGroupByCategory: Boolean = false,
+    val flagsGroupByCategoryError: Boolean = false,
+    val flagsGroupByCategoryTouchedLocally: Boolean = false,
+    val flagsHideReadCategories: Boolean = false,
+    val isUpdatingFlagsHideReadCategories: Boolean = false,
+    val flagsHideReadCategoriesError: Boolean = false,
+    val flagsHideReadCategoriesTouchedLocally: Boolean = false,
 ) {
     val canSave: Boolean
         get() = !isSaving
@@ -37,6 +50,12 @@ data class SettingsState(
 
     val canToggleIgnoreTopicCache: Boolean
         get() = !isUpdatingIgnoreTopicCache
+
+    val canToggleFlagsGroupByCategory: Boolean
+        get() = !isUpdatingFlagsGroupByCategory
+
+    val canToggleFlagsHideReadCategories: Boolean
+        get() = !isUpdatingFlagsHideReadCategories
 }
 
 sealed interface SettingsError {
@@ -74,4 +93,9 @@ sealed interface SettingsIntent {
     // ViewModel applies it optimistically, then reverts on DataStore failure so the UI never
     // shows a value that doesn't match what's persisted.
     data class IgnoreTopicCacheChanged(val enabled: Boolean) : SettingsIntent
+
+    // Drapeaux view preferences (#179 follow-up). Same optimistic-flip contract as
+    // IgnoreTopicCacheChanged: the boolean is the desired post-flip state.
+    data class FlagsGroupByCategoryChanged(val enabled: Boolean) : SettingsIntent
+    data class FlagsHideReadCategoriesChanged(val enabled: Boolean) : SettingsIntent
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -55,7 +55,7 @@ data class SettingsState(
         get() = !isUpdatingFlagsGroupByCategory
 
     val canToggleFlagsHideReadCategories: Boolean
-        get() = !isUpdatingFlagsHideReadCategories
+        get() = flagsGroupByCategory && !isUpdatingFlagsHideReadCategories
 }
 
 sealed interface SettingsError {

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -47,6 +47,26 @@ class SettingsViewModel @Inject constructor(
                 }
             }
         }
+        viewModelScope.launch {
+            val grouped = userPreferencesRepository.observeFlagsGroupByCategory().first()
+            _state.update { current ->
+                if (current.flagsGroupByCategoryTouchedLocally || current.isUpdatingFlagsGroupByCategory) {
+                    current
+                } else {
+                    current.copy(flagsGroupByCategory = grouped)
+                }
+            }
+        }
+        viewModelScope.launch {
+            val hideRead = userPreferencesRepository.observeFlagsHideReadCategories().first()
+            _state.update { current ->
+                if (current.flagsHideReadCategoriesTouchedLocally || current.isUpdatingFlagsHideReadCategories) {
+                    current
+                } else {
+                    current.copy(flagsHideReadCategories = hideRead)
+                }
+            }
+        }
     }
 
     fun submit(intent: SettingsIntent) {
@@ -73,6 +93,8 @@ class SettingsViewModel @Inject constructor(
                 _state.update { it.copy(showClearTopicCacheConfirm = false) }
             SettingsIntent.ClearTopicCacheConfirmed -> clearTopicCache()
             is SettingsIntent.IgnoreTopicCacheChanged -> updateIgnoreTopicCache(intent.enabled)
+            is SettingsIntent.FlagsGroupByCategoryChanged -> updateFlagsGroupByCategory(intent.enabled)
+            is SettingsIntent.FlagsHideReadCategoriesChanged -> updateFlagsHideReadCategories(intent.enabled)
         }
     }
 
@@ -176,6 +198,82 @@ class SettingsViewModel @Inject constructor(
                         )
                     }
                 }
+        }
+    }
+
+    private fun updateFlagsGroupByCategory(desired: Boolean) {
+        val previous = _state.value.flagsGroupByCategory
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    flagsGroupByCategory = desired,
+                    isUpdatingFlagsGroupByCategory = true,
+                    flagsGroupByCategoryError = false,
+                    flagsGroupByCategoryTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(flagsGroupByCategory = desired, isUpdatingFlagsGroupByCategory = false)
+                } else {
+                    state.copy(
+                        flagsGroupByCategory = previous,
+                        isUpdatingFlagsGroupByCategory = false,
+                        flagsGroupByCategoryError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setFlagsGroupByCategory,
+        )
+    }
+
+    private fun updateFlagsHideReadCategories(desired: Boolean) {
+        val previous = _state.value.flagsHideReadCategories
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    flagsHideReadCategories = desired,
+                    isUpdatingFlagsHideReadCategories = true,
+                    flagsHideReadCategoriesError = false,
+                    flagsHideReadCategoriesTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(flagsHideReadCategories = desired, isUpdatingFlagsHideReadCategories = false)
+                } else {
+                    state.copy(
+                        flagsHideReadCategories = previous,
+                        isUpdatingFlagsHideReadCategories = false,
+                        flagsHideReadCategoriesError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setFlagsHideReadCategories,
+        )
+    }
+
+    /**
+     * Shared optimistic-flip machinery for a persisted boolean preference (the two Drapeaux view
+     * toggles). Flips the field immediately via [optimistic] (which also sets the `*TouchedLocally`
+     * guard so a late `init` hydration can't clobber it), persists [desired] on a background
+     * coroutine, then reconciles the final state from the persist [Result] via [onSettled] (success
+     * re-affirms the value, failure reverts and raises the error flag — both captured in the
+     * caller's closures). Mirrors the bespoke `updateIgnoreTopicCache` contract, factored because
+     * the two new toggles are identical bar their state fields.
+     */
+    private fun updateBooleanPreference(
+        desired: Boolean,
+        optimistic: (SettingsState) -> SettingsState,
+        onSettled: (SettingsState, Result<Unit>) -> SettingsState,
+        persist: suspend (Boolean) -> Unit,
+    ) {
+        _state.update(optimistic)
+        viewModelScope.launch {
+            val result = runCatching { persist(desired) }
+            _state.update { onSettled(it, result) }
         }
     }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -35,4 +35,14 @@
     <string name="settings_ignore_topic_cache_title">Ignorer le cache topic</string>
     <string name="settings_ignore_topic_cache_description">Force le retéléchargement et le reparse des pages de topic. Utile après un changement de parser/rendu. Désactive le prefetch topic pour éviter de remplir Room inutilement.</string>
     <string name="settings_ignore_topic_cache_persist_failed">Impossible de mémoriser le réglage « Ignorer le cache topic ». Réessayez.</string>
+
+    <!-- #179 follow-up — Préférences d'affichage de l'écran Drapeaux. Persistées (DataStore) et
+         observées en direct par l'écran Drapeaux : un changement ici se reflète sans refetch. -->
+    <string name="settings_flags_title">Drapeaux</string>
+    <string name="settings_flags_group_by_category_title">Grouper par catégorie</string>
+    <string name="settings_flags_group_by_category_description">Affiche les drapeaux regroupés par catégorie de forum, avec un en-tête par catégorie. Désactivé : une liste à plat triée par dernière réponse (comme avant).</string>
+    <string name="settings_flags_group_by_category_persist_failed">Impossible de mémoriser l\'affichage des drapeaux. Réessayez.</string>
+    <string name="settings_flags_hide_read_categories_title">Masquer les catégories sans non-lu</string>
+    <string name="settings_flags_hide_read_categories_description">Cache les catégories qui n\'ont aucun message non lu. Les cyans déjà lus restent accessibles en activant « +lus » sur l\'onglet Mes sujets. Sans effet en vue à plat.</string>
+    <string name="settings_flags_hide_read_categories_persist_failed">Impossible de mémoriser le filtre des catégories. Réessayez.</string>
 </resources>

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -387,6 +387,55 @@ class SettingsViewModelTest {
         assertEquals(TopicCacheClearResult.Success, state.topicCacheClearResult)
     }
 
+    @Test
+    fun `init hydrates flags view preferences from storage`() = runTest {
+        repository.emitFlagsGroupByCategory(false)
+        repository.emitFlagsHideReadCategories(true)
+
+        val viewModel = newViewModel()
+        val state = viewModel.state.value
+
+        assertFalse(state.flagsGroupByCategory)
+        assertTrue(state.flagsHideReadCategories)
+    }
+
+    @Test
+    fun `FlagsGroupByCategoryChanged persists the flip and clears the updating flag`() = runTest {
+        val viewModel = newViewModel()
+        assertTrue("grouped is the default", viewModel.state.value.flagsGroupByCategory)
+
+        viewModel.submit(SettingsIntent.FlagsGroupByCategoryChanged(false))
+
+        assertFalse(viewModel.state.value.flagsGroupByCategory)
+        assertFalse(viewModel.state.value.isUpdatingFlagsGroupByCategory)
+        assertFalse(viewModel.state.value.flagsGroupByCategoryError)
+        assertEquals(1, repository.flagsGroupByCategorySetCalls)
+    }
+
+    @Test
+    fun `FlagsGroupByCategoryChanged reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnFlagsGroupByCategorySet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.FlagsGroupByCategoryChanged(false))
+
+        assertTrue("must revert to the previous value on failure", viewModel.state.value.flagsGroupByCategory)
+        assertFalse(viewModel.state.value.isUpdatingFlagsGroupByCategory)
+        assertTrue(viewModel.state.value.flagsGroupByCategoryError)
+    }
+
+    @Test
+    fun `FlagsHideReadCategoriesChanged persists the flip`() = runTest {
+        val viewModel = newViewModel()
+        assertFalse("hide-read is off by default (web parity)", viewModel.state.value.flagsHideReadCategories)
+
+        viewModel.submit(SettingsIntent.FlagsHideReadCategoriesChanged(true))
+
+        assertTrue(viewModel.state.value.flagsHideReadCategories)
+        assertFalse(viewModel.state.value.isUpdatingFlagsHideReadCategories)
+        assertEquals(1, repository.flagsHideReadCategoriesSetCalls)
+    }
+
     private fun newViewModel(): SettingsViewModel =
         SettingsViewModel(repository, topicCacheMaintenance)
 
@@ -438,12 +487,48 @@ class SettingsViewModelTest {
             ignoreTopicCache.value = enabled
         }
 
+        // Flags view preferences — same optimistic-flip seams as ignoreTopicCache so the Settings
+        // tests can gate the write and assert intermediate / revert states.
+        private val flagsGroupByCategory = MutableStateFlow(true)
+        var flagsGroupByCategorySetCalls: Int = 0
+            private set
+        var failOnFlagsGroupByCategorySet: Boolean = false
+
+        private val flagsHideReadCategories = MutableStateFlow(false)
+        var flagsHideReadCategoriesSetCalls: Int = 0
+            private set
+        var failOnFlagsHideReadCategoriesSet: Boolean = false
+
+        override fun observeFlagsGroupByCategory(): Flow<Boolean> = flagsGroupByCategory
+
+        override suspend fun setFlagsGroupByCategory(enabled: Boolean) {
+            flagsGroupByCategorySetCalls += 1
+            check(!failOnFlagsGroupByCategorySet) { "boom" }
+            flagsGroupByCategory.value = enabled
+        }
+
+        override fun observeFlagsHideReadCategories(): Flow<Boolean> = flagsHideReadCategories
+
+        override suspend fun setFlagsHideReadCategories(enabled: Boolean) {
+            flagsHideReadCategoriesSetCalls += 1
+            check(!failOnFlagsHideReadCategoriesSet) { "boom" }
+            flagsHideReadCategories.value = enabled
+        }
+
         fun emit(value: ProxyConfig) {
             config.value = value
         }
 
         fun emitIgnoreTopicCache(value: Boolean) {
             ignoreTopicCache.value = value
+        }
+
+        fun emitFlagsGroupByCategory(value: Boolean) {
+            flagsGroupByCategory.value = value
+        }
+
+        fun emitFlagsHideReadCategories(value: Boolean) {
+            flagsHideReadCategories.value = value
         }
     }
 

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -413,6 +413,25 @@ class SettingsViewModelTest {
     }
 
     @Test
+    fun `hide-read categories switch is disabled while the flat flags view is selected`() = runTest {
+        val viewModel = newViewModel()
+        assertTrue(viewModel.state.value.canToggleFlagsHideReadCategories)
+
+        viewModel.submit(SettingsIntent.FlagsGroupByCategoryChanged(false))
+
+        assertFalse(viewModel.state.value.flagsGroupByCategory)
+        assertFalse(
+            "hide-read categories has no effect in flat view, so the Settings switch must be disabled",
+            viewModel.state.value.canToggleFlagsHideReadCategories,
+        )
+
+        viewModel.submit(SettingsIntent.FlagsGroupByCategoryChanged(true))
+
+        assertTrue(viewModel.state.value.flagsGroupByCategory)
+        assertTrue(viewModel.state.value.canToggleFlagsHideReadCategories)
+    }
+
+    @Test
     fun `FlagsGroupByCategoryChanged reverts and raises the error flag on persist failure`() = runTest {
         repository.failOnFlagsGroupByCategorySet = true
         val viewModel = newViewModel()

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -436,6 +436,18 @@ class SettingsViewModelTest {
         assertEquals(1, repository.flagsHideReadCategoriesSetCalls)
     }
 
+    @Test
+    fun `FlagsHideReadCategoriesChanged reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnFlagsHideReadCategoriesSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.FlagsHideReadCategoriesChanged(true))
+
+        assertFalse("must revert to the previous value on failure", viewModel.state.value.flagsHideReadCategories)
+        assertFalse(viewModel.state.value.isUpdatingFlagsHideReadCategories)
+        assertTrue(viewModel.state.value.flagsHideReadCategoriesError)
+    }
+
     private fun newViewModel(): SettingsViewModel =
         SettingsViewModel(repository, topicCacheMaintenance)
 


### PR DESCRIPTION
> Action par Claude Opus 4.8 puis GPT-5 Codex (demandée par @XaaT)

Regroupe la vue Drapeaux/Favoris **par catégorie** en ordre canonique (parité web « Vos sujets »), **dans chacun des 4 onglets existants** (Cyan / Red / Favorite / Super) — option A retenue.

## Contenu
- **`groupFlagsByCategory`** (fonction pure, `FlagCategorySection.kt`) + `FALLBACK_CATEGORY_ORDER` (19 catégories publiques, ordre HFR web) utilisé uniquement au cold-start tant que `ForumRepository.observeCategories()` n'a pas émis `Success` (jamais pour filtrer/décider un fetch).
- **`FlagsViewModel`** injecte `ForumRepository` → état unique regroupé ; ordre canonique = REST `categories/` (pas Room).
- **`FlagsRoute`** : `LazyColumn` + `stickyHeader` par catégorie ; libellé d'une catégorie inconnue résolu côté Compose (`flags_category_fallback`), la fonction pure ne fabrique aucune string Android.
- **Préférences Settings/DataStore livrées** : toggle vue groupée/plate (défaut groupé) + toggle « masquer les catégories sans non-lu » (défaut off, sans effet et désactivé en vue plate).
- **`DefaultForumRepository`** : single-flight (Mutex) du fetch catégories → corrige un double-fetch cold-start.
- **Anti-régression #251** : une catégorie absente du catalogue → groupe fallback **terminal**, jamais droppée. Filtre cyan #154 appliqué **avant** le group-by.

## Tests / validation
- Unitaires ajoutés/étendus sur `FlagCategorySectionTest`, `FlagsViewModelTest`, `SettingsViewModelTest`, `DataStoreUserPreferencesRepositoryTest`, `DefaultForumRepositoryTest`.
- Local : `./scripts/docker-dev.sh ./gradlew :feature:settings:testDebugUnitTest` vert après le dernier fix Codex.
- Local rereview précédente : `:feature:flags:testDebugUnitTest`, `:feature:settings:testDebugUnitTest`, `:core:data:testDebugUnitTest` verts.
- CI GitHub `Build, lint and test` verte sur le head précédent ; nouvelle CI attendue sur le head `4f1ba7a`.

## Revue
Construit via workflow ultracode (recherche → Codex → 4-flavor → fix → Codex final → fix). Re-revue pré-push : 4-type (feature-dev / superpowers / code-review:code-review seuil >50 / review builtin) + Codex. Rebasé sur `main` (inclut #306, aucun chevauchement de fichiers). Smoke émulateur : lance + onglet Drapeaux rend sans crash (regroupement non exerçable sans login HFR).

## Hors scope
- #297 (poser des drapeaux en listant une catégorie) reste séparée.
- #251 (bug cyan) reste séparée.

Closes #179
