### PR TITLE
feat(flags): affichage des drapeaux par type + menu d'affichage (#309)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -7,8 +7,10 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
+import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
+import fr.forumhfr.redface2.core.model.FlagType
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
@@ -90,6 +92,60 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeFlagsPerTabOverride(): Flow<Boolean> =
+        dataStore.data
+            // Default `false`: every tab shares the global toggles unless the user opts in (#309).
+            .map { prefs -> prefs[KEY_FLAGS_PER_TAB_OVERRIDE] ?: false }
+            .catch { emit(false) }
+
+    override suspend fun setFlagsPerTabOverride(enabled: Boolean) {
+        withContext(ioDispatcher) {
+            dataStore.edit { prefs ->
+                prefs[KEY_FLAGS_PER_TAB_OVERRIDE] = enabled
+            }
+        }
+    }
+
+    override fun observeFlagsViewSettings(type: FlagType): Flow<FlagsViewSettings> =
+        dataStore.data
+            .map { prefs -> resolveFlagsViewSettings(prefs, type) }
+            // Fall back to the #179 global defaults (grouped on, hide-read off) on a read error.
+            .catch { emit(FlagsViewSettings()) }
+
+    override suspend fun setFlagsGroupByCategoryForType(type: FlagType, enabled: Boolean) {
+        withContext(ioDispatcher) {
+            dataStore.edit { prefs ->
+                prefs[flagsGroupByCategoryKey(type)] = enabled
+            }
+        }
+    }
+
+    override suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean) {
+        withContext(ioDispatcher) {
+            dataStore.edit { prefs ->
+                prefs[flagsHideReadCategoriesKey(type)] = enabled
+            }
+        }
+    }
+
+    /**
+     * Resolves the per-tab view settings (#309). With the override off, the global pair is
+     * returned verbatim; with it on, each toggle reads the per-type key and falls back to the
+     * matching global value when that tab key is unset. The global defaults (grouped on,
+     * hide-read off) are applied here so an empty DataStore yields the #179 behaviour.
+     */
+    private fun resolveFlagsViewSettings(prefs: Preferences, type: FlagType): FlagsViewSettings {
+        val globalGroup = prefs[KEY_FLAGS_GROUP_BY_CATEGORY] ?: true
+        val globalHide = prefs[KEY_FLAGS_HIDE_READ_CATEGORIES] ?: false
+        if (prefs[KEY_FLAGS_PER_TAB_OVERRIDE] != true) {
+            return FlagsViewSettings(groupByCategory = globalGroup, hideReadCategories = globalHide)
+        }
+        return FlagsViewSettings(
+            groupByCategory = prefs[flagsGroupByCategoryKey(type)] ?: globalGroup,
+            hideReadCategories = prefs[flagsHideReadCategoriesKey(type)] ?: globalHide,
+        )
+    }
+
     private fun toProxyConfig(prefs: Preferences): ProxyConfig =
         ProxyConfig(
             enabled = prefs[KEY_PROXY_ENABLED] ?: false,
@@ -108,5 +164,15 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         val KEY_IGNORE_TOPIC_CACHE = booleanPreferencesKey("ignore_topic_cache")
         val KEY_FLAGS_GROUP_BY_CATEGORY = booleanPreferencesKey("flags_group_by_category")
         val KEY_FLAGS_HIDE_READ_CATEGORIES = booleanPreferencesKey("flags_hide_read_categories")
+        // #309 — per-tab display override. The master switch plus one nullable key per FlagType for
+        // each toggle; absence of a per-type key means « fall back to the global value ». Keys are
+        // derived from the stable enum name (cyan/red/favorite), e.g. `flags_group_by_category_cyan`.
+        val KEY_FLAGS_PER_TAB_OVERRIDE = booleanPreferencesKey("flags_per_tab_override")
+
+        fun flagsGroupByCategoryKey(type: FlagType) =
+            booleanPreferencesKey("flags_group_by_category_${type.name.lowercase()}")
+
+        fun flagsHideReadCategoriesKey(type: FlagType) =
+            booleanPreferencesKey("flags_hide_read_categories_${type.name.lowercase()}")
     }
 }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -16,6 +16,7 @@ import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
@@ -109,6 +110,10 @@ class DataStoreUserPreferencesRepository @Inject constructor(
     override fun observeFlagsViewSettings(type: FlagType): Flow<FlagsViewSettings> =
         dataStore.data
             .map { prefs -> resolveFlagsViewSettings(prefs, type) }
+            // `dataStore.data` re-emits the whole snapshot on ANY write (proxy, another tab's
+            // per-type key, …); distinctUntilChanged keeps this flow quiet unless THIS type's
+            // resolved settings actually change, so the Flags combine doesn't churn on unrelated edits.
+            .distinctUntilChanged()
             // Fall back to the #179 global defaults (grouped on, hide-read off) on a read error.
             .catch { emit(FlagsViewSettings()) }
 
@@ -133,6 +138,11 @@ class DataStoreUserPreferencesRepository @Inject constructor(
      * returned verbatim; with it on, each toggle reads the per-type key and falls back to the
      * matching global value when that tab key is unset. The global defaults (grouped on,
      * hide-read off) are applied here so an empty DataStore yields the #179 behaviour.
+     *
+     * Per-type keys are intentionally **sticky**: turning the override off does not clear them, so
+     * re-enabling it later restores each tab's previously customised values (rather than silently
+     * re-inheriting the global pair). This is the "remember my per-tab tuning" contract; the keys
+     * simply sit dormant while the override is off.
      */
     private fun resolveFlagsViewSettings(prefs: Preferences, type: FlagType): FlagsViewSettings {
         val globalGroup = prefs[KEY_FLAGS_GROUP_BY_CATEGORY] ?: true

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
+import fr.forumhfr.redface2.core.model.FlagType
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -181,6 +182,77 @@ class DataStoreUserPreferencesRepositoryTest {
         repository.setFlagsHideReadCategories(false)
         repository.observeFlagsHideReadCategories().test {
             assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `observeFlagsPerTabOverride defaults to false on an empty store`() = runTest(dispatcher) {
+        repository.observeFlagsPerTabOverride().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `observeFlagsViewSettings returns the global pair when the per-tab override is off`() = runTest(dispatcher) {
+        // Global = flat + hide-read on; per-type values are set but must be IGNORED while the
+        // override is off, so every tab resolves to the global pair.
+        repository.setFlagsGroupByCategory(false)
+        repository.setFlagsHideReadCategories(true)
+        repository.setFlagsGroupByCategoryForType(FlagType.RED, true)
+        repository.setFlagsHideReadCategoriesForType(FlagType.RED, false)
+
+        repository.observeFlagsViewSettings(FlagType.RED).test {
+            val settings = awaitItem()
+            assertFalse("grouped must reflect the global value, not the RED override", settings.groupByCategory)
+            assertTrue("hide-read must reflect the global value, not the RED override", settings.hideReadCategories)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `observeFlagsViewSettings reads per-type values, falling back to global per toggle`() = runTest(dispatcher) {
+        repository.setFlagsPerTabOverride(true)
+        // Global defaults: grouped on, hide-read off.
+        // CYAN customises ONLY grouped (off); its hide-read must fall back to the global false.
+        repository.setFlagsGroupByCategoryForType(FlagType.CYAN, false)
+        // RED customises ONLY hide-read (on); its grouped must fall back to the global true.
+        repository.setFlagsHideReadCategoriesForType(FlagType.RED, true)
+
+        repository.observeFlagsViewSettings(FlagType.CYAN).test {
+            val cyan = awaitItem()
+            assertFalse("CYAN grouped is its own override", cyan.groupByCategory)
+            assertFalse("CYAN hide-read falls back to the global false", cyan.hideReadCategories)
+            cancelAndIgnoreRemainingEvents()
+        }
+        repository.observeFlagsViewSettings(FlagType.RED).test {
+            val red = awaitItem()
+            assertTrue("RED grouped falls back to the global true", red.groupByCategory)
+            assertTrue("RED hide-read is its own override", red.hideReadCategories)
+            cancelAndIgnoreRemainingEvents()
+        }
+        // FAVORITE never customised anything → full global fallback.
+        repository.observeFlagsViewSettings(FlagType.FAVORITE).test {
+            val fav = awaitItem()
+            assertTrue("FAVORITE grouped is the global default", fav.groupByCategory)
+            assertFalse("FAVORITE hide-read is the global default", fav.hideReadCategories)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setFlagsGroupByCategoryForType is isolated per type`() = runTest(dispatcher) {
+        repository.setFlagsPerTabOverride(true)
+        repository.setFlagsGroupByCategoryForType(FlagType.CYAN, false)
+
+        // CYAN is flat; RED keeps the global grouped default (its per-type key is unset).
+        repository.observeFlagsViewSettings(FlagType.CYAN).test {
+            assertFalse(awaitItem().groupByCategory)
+            cancelAndIgnoreRemainingEvents()
+        }
+        repository.observeFlagsViewSettings(FlagType.RED).test {
+            assertTrue(awaitItem().groupByCategory)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -6,8 +6,10 @@ import app.cash.turbine.test
 import fr.forumhfr.redface2.core.database.RedfaceDatabase
 import fr.forumhfr.redface2.core.database.dao.TopicDao
 import fr.forumhfr.redface2.core.database.entities.FetchMode
+import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
+import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.network.HfrClient
 import fr.forumhfr.redface2.core.parser.HfrParser
 import java.time.Clock
@@ -479,5 +481,16 @@ class TopicRepositoryImplTest {
         override fun observeFlagsHideReadCategories(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setFlagsHideReadCategories(enabled: Boolean) = Unit
+
+        override fun observeFlagsPerTabOverride(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setFlagsPerTabOverride(enabled: Boolean) = Unit
+
+        override fun observeFlagsViewSettings(type: FlagType): Flow<FlagsViewSettings> =
+            MutableStateFlow(FlagsViewSettings())
+
+        override suspend fun setFlagsGroupByCategoryForType(type: FlagType, enabled: Boolean) = Unit
+
+        override suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean) = Unit
     }
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FlagsViewSettings.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FlagsViewSettings.kt
@@ -1,0 +1,23 @@
+package fr.forumhfr.redface2.core.domain.preferences
+
+/**
+ * Resolved Drapeaux view layout for one tab (#309). Bundles the two persisted toggles the Flags
+ * screen consumes:
+ *
+ * - [groupByCategory] — group flags by forum category (sticky bands) vs. the legacy flat list.
+ * - [hideReadCategories] — trim categories without an unread flag in the grouped view (no effect
+ *   in the flat view).
+ *
+ * "Resolved" is load-bearing. The app exposes a single GLOBAL pair of toggles plus an optional
+ * PER-TAB override ([UserPreferencesRepository.observeFlagsPerTabOverride]). When the override is
+ * off, every tab sees the global values; when it is on, each tab sees its own stored value and
+ * falls back to the global value for any toggle that tab has never customised.
+ * [UserPreferencesRepository.observeFlagsViewSettings] performs that resolution so the ViewModel
+ * never has to.
+ *
+ * Defaults match the global DataStore defaults (#179): grouped on, hide-read off.
+ */
+data class FlagsViewSettings(
+    val groupByCategory: Boolean = true,
+    val hideReadCategories: Boolean = false,
+)

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.core.domain.preferences
 
+import fr.forumhfr.redface2.core.model.FlagType
 import kotlinx.coroutines.flow.Flow
 
 interface UserPreferencesRepository {
@@ -55,4 +56,41 @@ interface UserPreferencesRepository {
 
     /** Persists [observeFlagsHideReadCategories]. Default `false` until the first call. */
     suspend fun setFlagsHideReadCategories(enabled: Boolean)
+
+    /**
+     * Per-tab display override master switch (#309): when `true`, each Drapeaux tab
+     * ([FlagType.CYAN]/[FlagType.RED]/[FlagType.FAVORITE]) resolves its own stored view settings
+     * (falling back to the global toggles for anything that tab never customised); when `false`
+     * (default), every tab shares the single global pair. Observed so flipping it from the bottom
+     * sheet or Settings re-renders the list without a refetch.
+     */
+    fun observeFlagsPerTabOverride(): Flow<Boolean>
+
+    /** Persists [observeFlagsPerTabOverride]. Default `false` until the first call. */
+    suspend fun setFlagsPerTabOverride(enabled: Boolean)
+
+    /**
+     * Resolved Drapeaux view settings for [type] (#309), honouring [observeFlagsPerTabOverride]:
+     * - override off → the global [observeFlagsGroupByCategory] / [observeFlagsHideReadCategories].
+     * - override on → this [type]'s stored values, each falling back to the matching global value
+     *   when that tab has never been customised.
+     *
+     * This is the single source the Flags screen list rendering reads; the global observers stay
+     * the editable defaults (and the per-tab fallback) the Settings mirror writes.
+     */
+    fun observeFlagsViewSettings(type: FlagType): Flow<FlagsViewSettings>
+
+    /**
+     * Persists the per-tab « grouper par catégorie » value for [type] (#309). Only consulted by
+     * [observeFlagsViewSettings] when [observeFlagsPerTabOverride] is `true`; until set, that tab
+     * falls back to the global [setFlagsGroupByCategory] value.
+     */
+    suspend fun setFlagsGroupByCategoryForType(type: FlagType, enabled: Boolean)
+
+    /**
+     * Persists the per-tab « masquer les catégories sans non-lu » value for [type] (#309). Only
+     * consulted by [observeFlagsViewSettings] when [observeFlagsPerTabOverride] is `true`; until
+     * set, that tab falls back to the global [setFlagsHideReadCategories] value.
+     */
+    suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean)
 }

--- a/docs/specs/navigation.md
+++ b/docs/specs/navigation.md
@@ -101,9 +101,17 @@ L'écran le plus important de l'app. Affiche les topics suivis par l'utilisateur
 - Chaque catégorie est une bande séparatrice (`stickyHeader`). Par défaut, les **catégories vides sont conservées** (parité web) avec un placeholder par onglet (« Aucun nouveau message » pour cyan, « Aucun sujet dans cette catégorie » sinon).
 - Le regroupement est **purement client-side** : group-by sur `Flag.cat` de la liste plate déjà chargée, aucun fetch authentifié supplémentaire (invariant prefetch-non-auth). Une catégorie absente du catalogue n'est jamais filtrée : elle tombe en section « inconnue » en fin de liste (anti-régression #251).
 
-**Préférences d'affichage (#179, persistées via `UserPreferencesRepository` / DataStore, réglées dans Réglages > Drapeaux)** :
+**Préférences d'affichage (#179, persistées via `UserPreferencesRepository` / DataStore)** :
 - **Grouper par catégorie** (défaut : activé) : désactivé, l'écran rend la **liste à plat** héritée (tous les drapeaux d'un coup, ordre dernière réponse, sans bandes de catégorie). Permet de conserver la lecture à plat des drapeaux.
 - **Masquer les catégories sans message non lu** (défaut : désactivé = parité web) : en vue groupée, cache les catégories qui n'ont aucun drapeau non lu. Le toggle cyan « +lus » **prime** sur ce filtre : afficher les sujets participés déjà lus garde leurs catégories visibles (sinon les deux réglages se contrediraient). Sans effet en vue à plat. Si le filtre vide toutes les sections, un placeholder « Aucune catégorie avec un message non lu » est affiché (corps jamais blanc, ancre pull-to-refresh préservée #229).
+
+**Réglages par type de drapeau (#309)** : un master **« Réglages différents par onglet »** (défaut : désactivé) contrôle la portée des deux préférences ci-dessus :
+- **désactivé** : un réglage **global** unique partagé par tous les onglets ;
+- **activé** : chaque type de drapeau (cyan / rouge / favoris) garde ses propres valeurs, avec **repli sur la valeur globale toggle par toggle** (`UserPreferencesRepository.observeFlagsViewSettings(type)` résout global vs per-type). Les clés per-type sont **sticky** : désactiver le master ne les efface pas, le réactiver restaure le réglage par onglet précédent.
+
+**Deux surfaces de réglage** (miroir) :
+- un **bottom sheet M3** (`ModalBottomSheet`, « Affichage ») ouvert depuis l'en-tête de l'écran Drapeaux — masqué sur l'onglet Super (placeholder) et en anonyme ; il édite la portée courante (globale, ou l'onglet sélectionné quand le master est activé) et affiche un libellé de portée explicite ;
+- le miroir dans **Réglages > Drapeaux** (master « Réglages différents par onglet » + les deux toggles globaux qui servent de valeurs par défaut/repli).
 
 **Actions sur un topic :**
 - Tap → ouvrir le topic à la dernière position non lue

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -115,6 +115,13 @@ fun FlagsRoute(
     var showViewSettingsSheet by remember { mutableStateOf(false) }
     val canConfigureView = authState is AuthState.Authenticated && selectedTab.flagType != null
 
+    // If the screen stops being configurable while the sheet is open (session expired, or the user
+    // lands on the Super tab), clear the flag so the sheet can't silently reappear on the next
+    // configurable tab/re-auth.
+    LaunchedEffect(canConfigureView) {
+        if (!canConfigureView) showViewSettingsSheet = false
+    }
+
     // One-shot snackbar for the delflag outcome (#99). Keyed on the event instance so a
     // config change does not replay it ; consumed once shown so it never re-fires.
     val successMessage = stringResource(R.string.flags_remove_success)

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -29,16 +30,20 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -50,6 +55,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
@@ -98,8 +104,16 @@ fun FlagsRoute(
     val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
     val removeFlagState by viewModel.removeFlagState.collectAsStateWithLifecycle()
     val removeFlagEvent by viewModel.removeFlagEvent.collectAsStateWithLifecycle()
+    val flagsViewSettings by viewModel.flagsViewSettings.collectAsStateWithLifecycle()
+    val flagsPerTabOverride by viewModel.flagsPerTabOverride.collectAsStateWithLifecycle()
 
     val snackbarHostState = remember { SnackbarHostState() }
+
+    // #309 — display-settings bottom sheet. Opened from the header « Affichage » action; the trigger
+    // is only offered when there is a real list to configure (authenticated AND a real FlagType tab,
+    // i.e. not the Super placeholder).
+    var showViewSettingsSheet by remember { mutableStateOf(false) }
+    val canConfigureView = authState is AuthState.Authenticated && selectedTab.flagType != null
 
     // One-shot snackbar for the delflag outcome (#99). Keyed on the event instance so a
     // config change does not replay it ; consumed once shown so it never re-fires.
@@ -137,7 +151,14 @@ fun FlagsRoute(
                     .statusBarsPadding()
                     .navigationBarsPadding(),
             ) {
-                FlagsHeader(topBarActions = topBarActions)
+                FlagsHeader(
+                    topBarActions = topBarActions,
+                    onOpenViewSettings = if (canConfigureView) {
+                        { showViewSettingsSheet = true }
+                    } else {
+                        null
+                    },
+                )
 
                 // Render nothing while authState is null (cookie jar warming up). Same
                 // anti-flicker convention as PR #91; defaulting to "Anonymous" here would
@@ -165,6 +186,23 @@ fun FlagsRoute(
                 }
             }
         }
+    }
+
+    // #309 — display-settings bottom sheet. Reflects + edits the current tab's resolved view
+    // settings (or the global pair when « par onglet » is off). Writes route through the ViewModel
+    // so they land on the right scope; the sheet stays open so the user sees the list re-render live.
+    if (showViewSettingsSheet && canConfigureView) {
+        FlagsViewSettingsSheet(
+            selectedTab = selectedTab,
+            settings = flagsViewSettings,
+            perTabOverride = flagsPerTabOverride,
+            actions = FlagsViewSettingsActions(
+                onPerTabOverrideChange = viewModel::setFlagsPerTabOverride,
+                onGroupByCategoryChange = viewModel::setFlagsGroupByCategory,
+                onHideReadCategoriesChange = viewModel::setFlagsHideReadCategories,
+                onDismiss = { showViewSettingsSheet = false },
+            ),
+        )
     }
 
     // Confirmation gate before any network call (#99). The dialog renders only while the
@@ -222,6 +260,7 @@ private fun flagTypeLabel(type: FlagType): Int = when (type) {
 @Composable
 private fun FlagsHeader(
     topBarActions: @Composable (() -> Unit)?,
+    onOpenViewSettings: (() -> Unit)?,
 ) {
     Row(
         modifier = Modifier
@@ -235,10 +274,156 @@ private fun FlagsHeader(
             style = MaterialTheme.typography.headlineMedium,
             color = MaterialTheme.colorScheme.onSurface,
         )
-        // Refresh moved to a PullToRefreshBox (swipe down) on the list — the header now only
-        // carries the global account menu slot.
-        topBarActions?.invoke()
+        // Refresh moved to a PullToRefreshBox (swipe down) on the list — the header now carries the
+        // display-settings trigger (#309, text-only: the icons-extended dependency is not on this
+        // module's classpath) and the global account menu slot.
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            onOpenViewSettings?.let { open ->
+                TextButton(onClick = open) {
+                    Text(stringResource(R.string.flags_view_settings_action))
+                }
+            }
+            topBarActions?.invoke()
+        }
     }
+}
+
+/**
+ * Display-settings bottom sheet (#309). Three switches edit the active scope: the per-tab override
+ * master switch, then « grouper par catégorie » and « masquer les catégories sans non-lu » (the
+ * latter disabled in the flat view, mirroring Settings). A caption spells out the current scope so
+ * the user knows whether a flip touches every tab or only [selectedTab]. Writes route through the
+ * ViewModel ([onPerTabOverrideChange]/[onGroupByCategoryChange]/[onHideReadCategoriesChange]) so
+ * they land on the right key; the sheet stays open so the list re-renders live underneath.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun FlagsViewSettingsSheet(
+    selectedTab: FlagTab,
+    settings: FlagsViewSettings,
+    perTabOverride: Boolean,
+    actions: FlagsViewSettingsActions,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = actions.onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(
+                    text = stringResource(R.string.flags_view_settings_title),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                val scope = if (perTabOverride) {
+                    stringResource(
+                        R.string.flags_view_settings_scope_per_tab,
+                        stringResource(flagTabLabel(selectedTab)),
+                    )
+                } else {
+                    stringResource(R.string.flags_view_settings_scope_global)
+                }
+                Text(
+                    text = scope,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            ViewSettingsSwitchRow(
+                title = stringResource(R.string.flags_view_settings_per_tab_title),
+                description = stringResource(R.string.flags_view_settings_per_tab_description),
+                checked = perTabOverride,
+                enabled = true,
+                onCheckedChange = actions.onPerTabOverrideChange,
+            )
+            ViewSettingsSwitchRow(
+                title = stringResource(R.string.flags_view_settings_group_title),
+                description = stringResource(R.string.flags_view_settings_group_description),
+                checked = settings.groupByCategory,
+                enabled = true,
+                onCheckedChange = actions.onGroupByCategoryChange,
+            )
+            ViewSettingsSwitchRow(
+                title = stringResource(R.string.flags_view_settings_hide_read_title),
+                description = stringResource(R.string.flags_view_settings_hide_read_description),
+                checked = settings.hideReadCategories,
+                // Hiding read categories is only meaningful in the grouped view (mirrors Settings).
+                enabled = settings.groupByCategory,
+                onCheckedChange = actions.onHideReadCategoriesChange,
+            )
+
+            TextButton(
+                onClick = actions.onDismiss,
+                modifier = Modifier.align(Alignment.End),
+            ) {
+                Text(stringResource(R.string.flags_view_settings_done))
+            }
+        }
+    }
+}
+
+/** One label + description + Material 3 [Switch] row for the display-settings sheet (#309). */
+@Composable
+private fun ViewSettingsSwitchRow(
+    title: String,
+    description: String,
+    checked: Boolean,
+    enabled: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(end = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Switch(
+            checked = checked,
+            enabled = enabled,
+            onCheckedChange = onCheckedChange,
+        )
+    }
+}
+
+/**
+ * Human label for a real [FlagTab], used in the display-settings sheet scope caption (#309). RED
+ * uses the full « Lus uniquement » (not the cramped « Lu » tab label) since the caption has room.
+ * [FlagTab.Super] has no list to configure (the trigger is hidden there), so its label is only a
+ * defensive fallback.
+ */
+private fun flagTabLabel(tab: FlagTab): Int = when (tab) {
+    FlagTab.Cyan -> R.string.flags_tab_my_topics
+    FlagTab.Red -> R.string.flags_type_read_only
+    FlagTab.Favorite -> R.string.flags_tab_favorite
+    FlagTab.Super -> R.string.flags_tab_super
 }
 
 @Composable
@@ -701,6 +886,18 @@ private data class AuthenticatedActions(
     val onRefresh: () -> Unit,
     val onLoginRequested: () -> Unit,
     val onRequestRemoveFlag: (Flag) -> Unit,
+)
+
+/**
+ * Callback bundle for [FlagsViewSettingsSheet] (#309), grouped so the sheet stays under the detekt
+ * parameter-count threshold. The three `*Change` writes route through the ViewModel (which decides
+ * global vs per-type scope); [onDismiss] closes the sheet.
+ */
+private data class FlagsViewSettingsActions(
+    val onPerTabOverrideChange: (Boolean) -> Unit,
+    val onGroupByCategoryChange: (Boolean) -> Unit,
+    val onHideReadCategoriesChange: (Boolean) -> Unit,
+    val onDismiss: () -> Unit,
 )
 
 @Composable

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -308,6 +308,7 @@ private fun FlagsViewSettingsSheet(
     actions: FlagsViewSettingsActions,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val scope = rememberCoroutineScope()
     ModalBottomSheet(
         onDismissRequest = actions.onDismiss,
         sheetState = sheetState,
@@ -365,7 +366,14 @@ private fun FlagsViewSettingsSheet(
             )
 
             TextButton(
-                onClick = actions.onDismiss,
+                // Animate the sheet out (M3 stable pattern) before removing it from composition,
+                // instead of an abrupt `if`-driven teardown. Swipe/scrim dismissals already animate
+                // via onDismissRequest.
+                onClick = {
+                    scope.launch { sheetState.hide() }.invokeOnCompletion {
+                        if (!sheetState.isVisible) actions.onDismiss()
+                    }
+                },
                 modifier = Modifier.align(Alignment.End),
             ) {
                 Text(stringResource(R.string.flags_view_settings_done))

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -8,6 +8,7 @@ import fr.forumhfr.redface2.core.domain.flags.FlagRepository
 import fr.forumhfr.redface2.core.domain.flags.FlagsResult
 import fr.forumhfr.redface2.core.domain.forum.ForumRepository
 import fr.forumhfr.redface2.core.domain.forum.ForumResult
+import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.Category
@@ -21,6 +22,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.onEach
@@ -125,6 +127,40 @@ class FlagsViewModel @Inject constructor(
         )
 
     /**
+     * Display-settings bottom sheet state (#309). Tracks the RESOLVED view settings for the
+     * currently selected tab so the sheet's two switches reflect what the list is actually using
+     * (global, or this tab's override). The [FlagTab.Super] placeholder has no real [FlagType], so
+     * it falls back to the global pair — the trigger is hidden there anyway (no list to configure).
+     */
+    val flagsViewSettings: StateFlow<FlagsViewSettings> = selectedTab
+        .flatMapLatest { tab ->
+            when (val type = tab.flagType) {
+                null -> combine(
+                    userPreferencesRepository.observeFlagsGroupByCategory(),
+                    userPreferencesRepository.observeFlagsHideReadCategories(),
+                ) { group, hide -> FlagsViewSettings(group, hide) }
+                else -> userPreferencesRepository.observeFlagsViewSettings(type)
+            }
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = FlagsViewSettings(),
+        )
+
+    /**
+     * Per-tab override master switch (#309), surfaced so the bottom sheet can show + flip it and so
+     * the write routing in [setFlagsGroupByCategory] / [setFlagsHideReadCategories] can read the
+     * authoritative current value before deciding global vs per-type.
+     */
+    val flagsPerTabOverride: StateFlow<Boolean> = userPreferencesRepository.observeFlagsPerTabOverride()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = false,
+        )
+
+    /**
      * Builds the UI state for an authenticated tab with a real [type]. Kept as a dedicated method
      * so the `flatMapLatest` chain stays readable. Both `observe(type)` and `observeCategories()`
      * are subscribed here — and only here.
@@ -167,14 +203,16 @@ class FlagsViewModel @Inject constructor(
         return combine(
             filteredFlags,
             categories,
-            userPreferencesRepository.observeFlagsGroupByCategory(),
-            userPreferencesRepository.observeFlagsHideReadCategories(),
-        ) { filtered, catsResult, groupByCategory, hideReadCategories ->
+            // #309 — resolved per-tab view settings (global, or this tab's override when the
+            // per-tab master switch is on). Replaces the two separate global pref flows; the
+            // resolution lives in the repository so this combine stays a 3-source map.
+            userPreferencesRepository.observeFlagsViewSettings(type),
+        ) { filtered, catsResult, viewSettings ->
             toFlagsListUiState(
                 flagsResult = filtered.result,
                 categoriesResult = catsResult,
-                groupByCategory = groupByCategory,
-                hideReadCategories = hideReadCategories,
+                groupByCategory = viewSettings.groupByCategory,
+                hideReadCategories = viewSettings.hideReadCategories,
                 keepFullyReadSections = filtered.keepFullyReadSections,
             )
         }
@@ -284,6 +322,43 @@ class FlagsViewModel @Inject constructor(
 
     fun setShowReadParticipatedTopics(value: Boolean) {
         _showReadParticipatedTopics.value = value
+    }
+
+    /**
+     * Bottom-sheet write for « grouper par catégorie » (#309). Routes to the per-type key when the
+     * per-tab master switch is on AND the active tab has a real [FlagType] (not Super); otherwise
+     * writes the global value. The override is re-read with `.first()` at write time so the routing
+     * always reflects the persisted truth even if the user just flipped it.
+     */
+    fun setFlagsGroupByCategory(enabled: Boolean) {
+        val type = _selectedTab.value.flagType
+        viewModelScope.launch {
+            if (type != null && userPreferencesRepository.observeFlagsPerTabOverride().first()) {
+                userPreferencesRepository.setFlagsGroupByCategoryForType(type, enabled)
+            } else {
+                userPreferencesRepository.setFlagsGroupByCategory(enabled)
+            }
+        }
+    }
+
+    /** Bottom-sheet write for « masquer les catégories sans non-lu » (#309). Same routing as
+     * [setFlagsGroupByCategory]: per-type when the override is on and the tab is real, else global. */
+    fun setFlagsHideReadCategories(enabled: Boolean) {
+        val type = _selectedTab.value.flagType
+        viewModelScope.launch {
+            if (type != null && userPreferencesRepository.observeFlagsPerTabOverride().first()) {
+                userPreferencesRepository.setFlagsHideReadCategoriesForType(type, enabled)
+            } else {
+                userPreferencesRepository.setFlagsHideReadCategories(enabled)
+            }
+        }
+    }
+
+    /** Flips the per-tab override master switch (#309) from the bottom sheet. */
+    fun setFlagsPerTabOverride(enabled: Boolean) {
+        viewModelScope.launch {
+            userPreferencesRepository.setFlagsPerTabOverride(enabled)
+        }
     }
 
     fun refresh() {

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.onEach
@@ -150,8 +149,9 @@ class FlagsViewModel @Inject constructor(
 
     /**
      * Per-tab override master switch (#309), surfaced so the bottom sheet can show + flip it and so
-     * the write routing in [setFlagsGroupByCategory] / [setFlagsHideReadCategories] can read the
-     * authoritative current value before deciding global vs per-type.
+     * the write routing in [setFlagsGroupByCategory] / [setFlagsHideReadCategories] reads its
+     * `.value` (the value the master switch is rendered from) to decide global vs per-type — keeping
+     * the write scope consistent with what the user currently sees.
      */
     val flagsPerTabOverride: StateFlow<Boolean> = userPreferencesRepository.observeFlagsPerTabOverride()
         .stateIn(
@@ -327,13 +327,15 @@ class FlagsViewModel @Inject constructor(
     /**
      * Bottom-sheet write for « grouper par catégorie » (#309). Routes to the per-type key when the
      * per-tab master switch is on AND the active tab has a real [FlagType] (not Super); otherwise
-     * writes the global value. The override is re-read with `.first()` at write time so the routing
-     * always reflects the persisted truth even if the user just flipped it.
+     * writes the global value. The scope is decided from [flagsPerTabOverride]`.value` — the very
+     * StateFlow the sheet's master switch renders from — so the routing always matches what the
+     * user currently sees (reading a fresh `observeFlagsPerTabOverride().first()` instead would open
+     * an independent cold flow that can race the still-in-flight master write).
      */
     fun setFlagsGroupByCategory(enabled: Boolean) {
         val type = _selectedTab.value.flagType
         viewModelScope.launch {
-            if (type != null && userPreferencesRepository.observeFlagsPerTabOverride().first()) {
+            if (type != null && flagsPerTabOverride.value) {
                 userPreferencesRepository.setFlagsGroupByCategoryForType(type, enabled)
             } else {
                 userPreferencesRepository.setFlagsGroupByCategory(enabled)
@@ -342,11 +344,12 @@ class FlagsViewModel @Inject constructor(
     }
 
     /** Bottom-sheet write for « masquer les catégories sans non-lu » (#309). Same routing as
-     * [setFlagsGroupByCategory]: per-type when the override is on and the tab is real, else global. */
+     * [setFlagsGroupByCategory]: per-type when [flagsPerTabOverride] is on and the tab is real, else
+     * global. */
     fun setFlagsHideReadCategories(enabled: Boolean) {
         val type = _selectedTab.value.flagType
         viewModelScope.launch {
-            if (type != null && userPreferencesRepository.observeFlagsPerTabOverride().first()) {
+            if (type != null && flagsPerTabOverride.value) {
                 userPreferencesRepository.setFlagsHideReadCategoriesForType(type, enabled)
             } else {
                 userPreferencesRepository.setFlagsHideReadCategories(enabled)

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -148,12 +148,25 @@ class FlagsViewModel @Inject constructor(
         )
 
     /**
+     * Optimistic shim for the per-tab master switch (#309 Codex review). `setFlagsPerTabOverride`
+     * seeds this synchronously so [flagsPerTabOverride] (hence both the rendered switch and the
+     * write routing) reflects a flip immediately, instead of waiting for the DataStore round-trip —
+     * otherwise a quick « master ON » then content-toggle could route to the wrong scope because the
+     * persisted value (and the switch) had not caught up. Cleared once the write persists.
+     */
+    private val pendingPerTabOverride = MutableStateFlow<Boolean?>(null)
+
+    /**
      * Per-tab override master switch (#309), surfaced so the bottom sheet can show + flip it and so
      * the write routing in [setFlagsGroupByCategory] / [setFlagsHideReadCategories] reads its
-     * `.value` (the value the master switch is rendered from) to decide global vs per-type — keeping
-     * the write scope consistent with what the user currently sees.
+     * `.value` to decide global vs per-type. The optimistic [pendingPerTabOverride] wins until the
+     * persisted value catches up, so the rendered switch and the routing scope agree with the user's
+     * latest tap even before DataStore commits.
      */
-    val flagsPerTabOverride: StateFlow<Boolean> = userPreferencesRepository.observeFlagsPerTabOverride()
+    val flagsPerTabOverride: StateFlow<Boolean> = combine(
+        userPreferencesRepository.observeFlagsPerTabOverride(),
+        pendingPerTabOverride,
+    ) { persisted, pending -> pending ?: persisted }
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.Eagerly,
@@ -357,10 +370,17 @@ class FlagsViewModel @Inject constructor(
         }
     }
 
-    /** Flips the per-tab override master switch (#309) from the bottom sheet. */
+    /**
+     * Flips the per-tab override master switch (#309) from the bottom sheet. Sets the optimistic
+     * [pendingPerTabOverride] synchronously (instant switch + routing scope), then persists. The
+     * shim is dropped only if no newer flip superseded this one (compareAndSet), so the persisted
+     * value — and any external change, e.g. the Settings mirror — takes over afterwards.
+     */
     fun setFlagsPerTabOverride(enabled: Boolean) {
+        pendingPerTabOverride.value = enabled
         viewModelScope.launch {
             userPreferencesRepository.setFlagsPerTabOverride(enabled)
+            pendingPerTabOverride.compareAndSet(expect = enabled, update = null)
         }
     }
 

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -47,6 +47,21 @@
     <string name="flags_item_metadata_with_author">%1$s · %2$d rép. · p.%3$d/%4$d</string>
     <string name="flags_item_metadata_no_author">%1$d rép. · p.%2$d/%3$d</string>
 
+    <!-- #309 — Menu d'affichage des drapeaux (bottom sheet M3 ouvert depuis l'en-tête). Reflète et
+         modifie les réglages d'affichage de l'onglet courant (ou globaux selon « par onglet »). -->
+    <string name="flags_view_settings_action">Affichage</string>
+    <string name="flags_view_settings_title">Affichage des drapeaux</string>
+    <!-- Portée affichée sous le titre : globale, ou onglet courant. %1$s = libellé de l'onglet. -->
+    <string name="flags_view_settings_scope_global">S\'applique à tous les onglets</string>
+    <string name="flags_view_settings_scope_per_tab">S\'applique à l\'onglet « %1$s »</string>
+    <string name="flags_view_settings_per_tab_title">Réglages différents par onglet</string>
+    <string name="flags_view_settings_per_tab_description">Chaque onglet garde son propre affichage. Sinon, un réglage unique partagé par tous les onglets.</string>
+    <string name="flags_view_settings_group_title">Grouper par catégorie</string>
+    <string name="flags_view_settings_group_description">Regroupe les drapeaux par catégorie de forum. Désactivé : liste à plat triée par dernière réponse.</string>
+    <string name="flags_view_settings_hide_read_title">Masquer les catégories sans non-lu</string>
+    <string name="flags_view_settings_hide_read_description">Cache les catégories sans message non lu. Sans effet en vue à plat.</string>
+    <string name="flags_view_settings_done">Fermer</string>
+
     <!-- #99 — Retirer un drapeau (delflag). Action sur chaque ligne + dialog de confirmation
          obligatoire avant l'appel réseau, puis snackbar de résultat. -->
     <string name="flags_remove_action">Retirer</string>

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -944,6 +944,28 @@ class FlagsViewModelTest {
     }
 
     @Test
+    fun `toggle routing uses the optimistic master value before the override write persists`() = runTest {
+        // #309 Codex review: routing must honour the just-flipped master even while its DataStore
+        // write is still in flight. Gate the persisted master write so `perTab` never updates, then
+        // assert the group write went to the PER-TYPE key (driven by the optimistic value), not the
+        // global one. (Resolution/display catches up once the master persists; routing must not.)
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1))
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val prefs = FakeUserPreferencesRepository() // persisted override OFF
+        prefs.blockPerTabOverrideSetUntil = kotlinx.coroutines.CompletableDeferred()
+        val vm = FlagsViewModel(auth, flags, forum, prefs)
+
+        vm.setFlagsPerTabOverride(true) // optimistic ON; persisted write GATED (never commits here)
+        vm.setFlagsGroupByCategory(false)
+
+        assertTrue(
+            "the group write must hit the per-type key via the optimistic master",
+            prefs.lastGroupByWriteWasPerType == true,
+        )
+    }
+
+    @Test
     fun `flipping the override then a toggle in sequence routes per-type`() = runTest {
         // Regression guard for the write-routing fix: the toggle write must honour the master value
         // the user just flipped (read from flagsPerTabOverride.value, consistent with the rendered
@@ -1176,6 +1198,15 @@ class FlagsViewModelTest {
         private val perTypeHide: Map<FlagType, MutableStateFlow<Boolean?>> =
             FlagType.entries.associateWith { MutableStateFlow<Boolean?>(null) }
 
+        /** When set, holds the persisted master write so a test can prove routing uses the
+         * OPTIMISTIC value (the persisted `perTab` never updates while gated). */
+        var blockPerTabOverrideSetUntil: kotlinx.coroutines.CompletableDeferred<Unit>? = null
+
+        /** Records whether the most recent group-by write hit the per-type key (`true`) or the
+         * global key (`false`) — lets a test assert the routing decision directly. */
+        var lastGroupByWriteWasPerType: Boolean? = null
+            private set
+
         override fun observeProxyConfig(): Flow<ProxyConfig> = MutableStateFlow(ProxyConfig())
         override suspend fun saveProxyConfig(config: ProxyConfig) = Unit
         override fun readProxyConfigForNetworkBootstrap(): ProxyConfig = ProxyConfig()
@@ -1185,6 +1216,7 @@ class FlagsViewModelTest {
         override fun observeFlagsGroupByCategory(): Flow<Boolean> = groupBy
         override suspend fun setFlagsGroupByCategory(enabled: Boolean) {
             groupBy.value = enabled
+            lastGroupByWriteWasPerType = false
         }
 
         override fun observeFlagsHideReadCategories(): Flow<Boolean> = hideRead
@@ -1194,6 +1226,7 @@ class FlagsViewModelTest {
 
         override fun observeFlagsPerTabOverride(): Flow<Boolean> = perTab
         override suspend fun setFlagsPerTabOverride(enabled: Boolean) {
+            blockPerTabOverrideSetUntil?.await()
             perTab.value = enabled
         }
 
@@ -1214,6 +1247,7 @@ class FlagsViewModelTest {
 
         override suspend fun setFlagsGroupByCategoryForType(type: FlagType, enabled: Boolean) {
             perTypeGroup.getValue(type).value = enabled
+            lastGroupByWriteWasPerType = true
         }
 
         override suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean) {

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -906,6 +906,76 @@ class FlagsViewModelTest {
         }
     }
 
+    @Test
+    fun `setFlagsHideReadCategories writes the global scope when the override is off`() = runTest {
+        // hide-read routing mirror of the group-by tests; asserted via flagsViewSettings.value since
+        // the cross-tab value is identical (global), which a StateFlow would dedup out of a turbine.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1))
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val prefs = FakeUserPreferencesRepository()
+        val vm = FlagsViewModel(auth, flags, forum, prefs)
+
+        assertFalse(vm.flagsViewSettings.value.hideReadCategories)
+        vm.setFlagsHideReadCategories(true)
+        assertTrue("CYAN reflects the write", vm.flagsViewSettings.value.hideReadCategories)
+        vm.selectTab(FlagTab.Red)
+        assertTrue(
+            "RED is on too → the write landed on the global key",
+            vm.flagsViewSettings.value.hideReadCategories,
+        )
+    }
+
+    @Test
+    fun `setFlagsHideReadCategories writes the per-type scope when the override is on`() = runTest {
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1))
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val prefs = FakeUserPreferencesRepository(perTabOverride = true)
+        val vm = FlagsViewModel(auth, flags, forum, prefs)
+
+        vm.setFlagsHideReadCategories(true) // CYAN selected
+        assertTrue("CYAN per-type hide-read on", vm.flagsViewSettings.value.hideReadCategories)
+        vm.selectTab(FlagTab.Red)
+        assertFalse(
+            "RED untouched → global false; the write did not leak across tabs",
+            vm.flagsViewSettings.value.hideReadCategories,
+        )
+    }
+
+    @Test
+    fun `flipping the override then a toggle in sequence routes per-type`() = runTest {
+        // Regression guard for the write-routing fix: the toggle write must honour the master value
+        // the user just flipped (read from flagsPerTabOverride.value, consistent with the rendered
+        // switch), so it routes per-type and leaves the global default (other tabs) untouched.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1))
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val prefs = FakeUserPreferencesRepository(groupByCategory = true) // override OFF initially
+        val vm = FlagsViewModel(auth, flags, forum, prefs)
+
+        vm.flagsState.test {
+            awaitItem() // initial null
+            flags.emit(FlagType.CYAN, FlagsResult.Success(listOf(stubFlag(1, FlagType.CYAN, cat = 1))))
+            assertTrue((awaitItem() as FlagsListUiState.Success).content is FlagsContent.Grouped)
+
+            vm.setFlagsPerTabOverride(true) // flip master…
+            vm.setFlagsGroupByCategory(false) // …then immediately flip group on CYAN
+            assertTrue(
+                "CYAN flips to flat via its per-type key",
+                (awaitItem() as FlagsListUiState.Success).content is FlagsContent.Flat,
+            )
+
+            vm.selectTab(FlagTab.Red)
+            flags.emit(FlagType.RED, FlagsResult.Success(listOf(stubFlag(2, FlagType.RED, cat = 1))))
+            assertTrue(
+                "RED stays grouped → the toggle honoured the just-flipped master and wrote per-type",
+                (awaitItem() as FlagsListUiState.Success).content is FlagsContent.Grouped,
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
     /**
      * Builds the ViewModel with a default (grouped-on, hide-read-off) [FakeUserPreferencesRepository]
      * so the existing tests keep asserting on the grouped sections. Tests that exercise the flat

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -8,6 +8,7 @@ import fr.forumhfr.redface2.core.domain.flags.FlagRepository
 import fr.forumhfr.redface2.core.domain.flags.FlagsResult
 import fr.forumhfr.redface2.core.domain.forum.ForumRepository
 import fr.forumhfr.redface2.core.domain.forum.ForumResult
+import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.model.AuthState
@@ -23,6 +24,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -30,6 +32,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -791,6 +794,118 @@ class FlagsViewModelTest {
         }
     }
 
+    @Test
+    fun `per-tab override resolves a per-type flat view while another tab stays grouped`() = runTest {
+        // #309: with the override on, each tab reads its own settings. Here CYAN is customised flat
+        // while RED keeps the global grouped default — the resolution must be tab-scoped.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1))
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val prefs = FakeUserPreferencesRepository(groupByCategory = true, perTabOverride = true)
+        val vm = FlagsViewModel(auth, flags, forum, prefs)
+        prefs.setFlagsGroupByCategoryForType(FlagType.CYAN, false)
+
+        vm.flagsState.test {
+            awaitItem() // initial null
+            flags.emit(FlagType.CYAN, FlagsResult.Success(listOf(stubFlag(1, FlagType.CYAN, cat = 1))))
+            assertTrue(
+                "CYAN's per-type override is flat",
+                (awaitItem() as FlagsListUiState.Success).content is FlagsContent.Flat,
+            )
+
+            vm.selectTab(FlagTab.Red)
+            flags.emit(FlagType.RED, FlagsResult.Success(listOf(stubFlag(2, FlagType.RED, cat = 1))))
+            assertTrue(
+                "RED has no override → falls back to the global grouped default",
+                (awaitItem() as FlagsListUiState.Success).content is FlagsContent.Grouped,
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setFlagsGroupByCategory writes the global scope when the override is off`() = runTest {
+        // Override off: the bottom-sheet write must hit the GLOBAL key, so every tab flips, not
+        // just the one currently selected.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1))
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val prefs = FakeUserPreferencesRepository(groupByCategory = true)
+        val vm = FlagsViewModel(auth, flags, forum, prefs)
+
+        vm.flagsState.test {
+            awaitItem() // initial null
+            flags.emit(FlagType.CYAN, FlagsResult.Success(listOf(stubFlag(1, FlagType.CYAN, cat = 1))))
+            assertTrue((awaitItem() as FlagsListUiState.Success).content is FlagsContent.Grouped)
+
+            vm.setFlagsGroupByCategory(false)
+            assertTrue(
+                "CYAN flips to flat after the global write",
+                (awaitItem() as FlagsListUiState.Success).content is FlagsContent.Flat,
+            )
+
+            vm.selectTab(FlagTab.Red)
+            flags.emit(FlagType.RED, FlagsResult.Success(listOf(stubFlag(2, FlagType.RED, cat = 1))))
+            assertTrue(
+                "RED is flat too → the write landed on the global key, not a per-type one",
+                (awaitItem() as FlagsListUiState.Success).content is FlagsContent.Flat,
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setFlagsGroupByCategory writes the per-type scope when the override is on`() = runTest {
+        // Override on: the write must hit only the SELECTED tab's per-type key, leaving the others
+        // (and the global default) untouched.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1))
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val prefs = FakeUserPreferencesRepository(groupByCategory = true, perTabOverride = true)
+        val vm = FlagsViewModel(auth, flags, forum, prefs)
+
+        vm.flagsState.test {
+            awaitItem() // initial null
+            flags.emit(FlagType.CYAN, FlagsResult.Success(listOf(stubFlag(1, FlagType.CYAN, cat = 1))))
+            assertTrue((awaitItem() as FlagsListUiState.Success).content is FlagsContent.Grouped)
+
+            vm.setFlagsGroupByCategory(false) // CYAN selected → CYAN per-type only.
+            assertTrue(
+                "CYAN flips to flat via its per-type key",
+                (awaitItem() as FlagsListUiState.Success).content is FlagsContent.Flat,
+            )
+
+            vm.selectTab(FlagTab.Red)
+            flags.emit(FlagType.RED, FlagsResult.Success(listOf(stubFlag(2, FlagType.RED, cat = 1))))
+            assertTrue(
+                "RED stays grouped → the write did NOT touch the global default",
+                (awaitItem() as FlagsListUiState.Success).content is FlagsContent.Grouped,
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `flagsViewSettings tracks the resolved settings of the selected tab`() = runTest {
+        // The bottom sheet reads flagsViewSettings to render its switches; under the override it
+        // must follow the selected tab's resolution.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1))
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val prefs = FakeUserPreferencesRepository(groupByCategory = true, perTabOverride = true)
+        val vm = FlagsViewModel(auth, flags, forum, prefs)
+        prefs.setFlagsGroupByCategoryForType(FlagType.RED, false)
+
+        vm.flagsViewSettings.test {
+            assertTrue("CYAN resolves to the global grouped default", awaitItem().groupByCategory)
+            vm.selectTab(FlagTab.Red)
+            assertFalse("RED resolves to its per-type flat override", awaitItem().groupByCategory)
+            vm.selectTab(FlagTab.Cyan)
+            assertTrue("back on CYAN, grouped again", awaitItem().groupByCategory)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
     /**
      * Builds the ViewModel with a default (grouped-on, hide-read-off) [FakeUserPreferencesRepository]
      * so the existing tests keep asserting on the grouped sections. Tests that exercise the flat
@@ -972,16 +1087,24 @@ class FlagsViewModelTest {
     }
 
     /**
-     * Fake [UserPreferencesRepository] exposing only the two Drapeaux view preferences the
-     * ViewModel reads (group-by-category, hide-read-categories) as writable hot flows; the proxy
-     * and topic-cache members are stubbed at their defaults (the ViewModel never touches them).
+     * Fake [UserPreferencesRepository] modelling the Drapeaux view preferences the ViewModel reads:
+     * the global group-by-category / hide-read pair, the #309 per-tab override master switch, and
+     * the per-type overrides — as writable hot flows. [observeFlagsViewSettings] resolves them the
+     * same way the real DataStore impl does (override off → global; on → per-type value, else global
+     * fallback). The proxy and topic-cache members are stubbed at their defaults (untouched here).
      */
     private class FakeUserPreferencesRepository(
         groupByCategory: Boolean = true,
         hideReadCategories: Boolean = false,
+        perTabOverride: Boolean = false,
     ) : UserPreferencesRepository {
         private val groupBy = MutableStateFlow(groupByCategory)
         private val hideRead = MutableStateFlow(hideReadCategories)
+        private val perTab = MutableStateFlow(perTabOverride)
+        private val perTypeGroup: Map<FlagType, MutableStateFlow<Boolean?>> =
+            FlagType.entries.associateWith { MutableStateFlow<Boolean?>(null) }
+        private val perTypeHide: Map<FlagType, MutableStateFlow<Boolean?>> =
+            FlagType.entries.associateWith { MutableStateFlow<Boolean?>(null) }
 
         override fun observeProxyConfig(): Flow<ProxyConfig> = MutableStateFlow(ProxyConfig())
         override suspend fun saveProxyConfig(config: ProxyConfig) = Unit
@@ -999,12 +1122,44 @@ class FlagsViewModelTest {
             hideRead.value = enabled
         }
 
+        override fun observeFlagsPerTabOverride(): Flow<Boolean> = perTab
+        override suspend fun setFlagsPerTabOverride(enabled: Boolean) {
+            perTab.value = enabled
+        }
+
+        override fun observeFlagsViewSettings(type: FlagType): Flow<FlagsViewSettings> =
+            combine(
+                groupBy,
+                hideRead,
+                perTab,
+                perTypeGroup.getValue(type),
+                perTypeHide.getValue(type),
+            ) { global, globalHide, override, typeGroup, typeHide ->
+                if (override) {
+                    FlagsViewSettings(typeGroup ?: global, typeHide ?: globalHide)
+                } else {
+                    FlagsViewSettings(global, globalHide)
+                }
+            }
+
+        override suspend fun setFlagsGroupByCategoryForType(type: FlagType, enabled: Boolean) {
+            perTypeGroup.getValue(type).value = enabled
+        }
+
+        override suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean) {
+            perTypeHide.getValue(type).value = enabled
+        }
+
         fun setGroupBy(value: Boolean) {
             groupBy.value = value
         }
 
         fun setHideRead(value: Boolean) {
             hideRead.value = value
+        }
+
+        fun setPerTabOverride(value: Boolean) {
+            perTab.value = value
         }
     }
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -231,6 +231,16 @@ private fun FlagsPreferencesCard(
             if (state.flagsHideReadCategoriesError) {
                 PreferencePersistError(R.string.settings_flags_hide_read_categories_persist_failed)
             }
+            PreferenceSwitchRow(
+                title = stringResource(R.string.settings_flags_per_tab_override_title),
+                description = stringResource(R.string.settings_flags_per_tab_override_description),
+                checked = state.flagsPerTabOverride,
+                enabled = state.canToggleFlagsPerTabOverride,
+                onCheckedChange = { onIntent(SettingsIntent.FlagsPerTabOverrideChanged(it)) },
+            )
+            if (state.flagsPerTabOverrideError) {
+                PreferencePersistError(R.string.settings_flags_per_tab_override_persist_failed)
+            }
         }
     }
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -61,8 +61,11 @@ data class SettingsState(
     val canToggleFlagsGroupByCategory: Boolean
         get() = !isUpdatingFlagsGroupByCategory
 
+    // The global hide-read toggle is meaningful when the global grouped view is on, OR when the
+    // per-tab override is on (it still serves as the fallback for a tab that is grouped per-type but
+    // has no per-type hide-read value). #309 Codex review.
     val canToggleFlagsHideReadCategories: Boolean
-        get() = flagsGroupByCategory && !isUpdatingFlagsHideReadCategories
+        get() = (flagsGroupByCategory || flagsPerTabOverride) && !isUpdatingFlagsHideReadCategories
 
     val canToggleFlagsPerTabOverride: Boolean
         get() = !isUpdatingFlagsPerTabOverride

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -41,6 +41,13 @@ data class SettingsState(
     val isUpdatingFlagsHideReadCategories: Boolean = false,
     val flagsHideReadCategoriesError: Boolean = false,
     val flagsHideReadCategoriesTouchedLocally: Boolean = false,
+    // #309 — per-tab display override master switch. Same optimistic-flip machinery; when on, each
+    // Drapeaux tab keeps its own view settings (tuned from the Drapeaux bottom sheet), the two
+    // toggles above acting as the shared fallback. Default false (global view for every tab).
+    val flagsPerTabOverride: Boolean = false,
+    val isUpdatingFlagsPerTabOverride: Boolean = false,
+    val flagsPerTabOverrideError: Boolean = false,
+    val flagsPerTabOverrideTouchedLocally: Boolean = false,
 ) {
     val canSave: Boolean
         get() = !isSaving
@@ -56,6 +63,9 @@ data class SettingsState(
 
     val canToggleFlagsHideReadCategories: Boolean
         get() = flagsGroupByCategory && !isUpdatingFlagsHideReadCategories
+
+    val canToggleFlagsPerTabOverride: Boolean
+        get() = !isUpdatingFlagsPerTabOverride
 }
 
 sealed interface SettingsError {
@@ -98,4 +108,7 @@ sealed interface SettingsIntent {
     // IgnoreTopicCacheChanged: the boolean is the desired post-flip state.
     data class FlagsGroupByCategoryChanged(val enabled: Boolean) : SettingsIntent
     data class FlagsHideReadCategoriesChanged(val enabled: Boolean) : SettingsIntent
+
+    // #309 — per-tab display override master switch.
+    data class FlagsPerTabOverrideChanged(val enabled: Boolean) : SettingsIntent
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -67,6 +67,16 @@ class SettingsViewModel @Inject constructor(
                 }
             }
         }
+        viewModelScope.launch {
+            val perTab = userPreferencesRepository.observeFlagsPerTabOverride().first()
+            _state.update { current ->
+                if (current.flagsPerTabOverrideTouchedLocally || current.isUpdatingFlagsPerTabOverride) {
+                    current
+                } else {
+                    current.copy(flagsPerTabOverride = perTab)
+                }
+            }
+        }
     }
 
     fun submit(intent: SettingsIntent) {
@@ -95,6 +105,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.IgnoreTopicCacheChanged -> updateIgnoreTopicCache(intent.enabled)
             is SettingsIntent.FlagsGroupByCategoryChanged -> updateFlagsGroupByCategory(intent.enabled)
             is SettingsIntent.FlagsHideReadCategoriesChanged -> updateFlagsHideReadCategories(intent.enabled)
+            is SettingsIntent.FlagsPerTabOverrideChanged -> updateFlagsPerTabOverride(intent.enabled)
         }
     }
 
@@ -255,8 +266,35 @@ class SettingsViewModel @Inject constructor(
         )
     }
 
+    private fun updateFlagsPerTabOverride(desired: Boolean) {
+        val previous = _state.value.flagsPerTabOverride
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    flagsPerTabOverride = desired,
+                    isUpdatingFlagsPerTabOverride = true,
+                    flagsPerTabOverrideError = false,
+                    flagsPerTabOverrideTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(flagsPerTabOverride = desired, isUpdatingFlagsPerTabOverride = false)
+                } else {
+                    state.copy(
+                        flagsPerTabOverride = previous,
+                        isUpdatingFlagsPerTabOverride = false,
+                        flagsPerTabOverrideError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setFlagsPerTabOverride,
+        )
+    }
+
     /**
-     * Shared optimistic-flip machinery for a persisted boolean preference (the two Drapeaux view
+     * Shared optimistic-flip machinery for a persisted boolean preference (the Drapeaux view
      * toggles). Flips the field immediately via [optimistic] (which also sets the `*TouchedLocally`
      * guard so a late `init` hydration can't clobber it), persists [desired] on a background
      * coroutine, then reconciles the final state from the persist [Result] via [onSettled] (success

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -45,4 +45,11 @@
     <string name="settings_flags_hide_read_categories_title">Masquer les catégories sans non-lu</string>
     <string name="settings_flags_hide_read_categories_description">Cache les catégories qui n\'ont aucun message non lu. Les cyans déjà lus restent accessibles en activant « +lus » sur l\'onglet Mes sujets. Sans effet en vue à plat.</string>
     <string name="settings_flags_hide_read_categories_persist_failed">Impossible de mémoriser le filtre des catégories. Réessayez.</string>
+
+    <!-- #309 — Réglages d'affichage différents par type de drapeau (onglet). Quand activé, les deux
+         réglages ci-dessus servent de valeurs par défaut et chaque onglet (Mes sujets / Lu / Favoris)
+         garde son propre affichage, ajustable depuis le menu d'affichage de l'écran Drapeaux. -->
+    <string name="settings_flags_per_tab_override_title">Réglages différents par onglet</string>
+    <string name="settings_flags_per_tab_override_description">Chaque onglet (Mes sujets, Lu, Favoris) garde son propre affichage. Les réglages ci-dessus deviennent les valeurs par défaut ; ajustez chaque onglet depuis le menu d\'affichage de l\'écran Drapeaux.</string>
+    <string name="settings_flags_per_tab_override_persist_failed">Impossible de mémoriser le réglage par onglet. Réessayez.</string>
 </resources>

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -434,6 +434,23 @@ class SettingsViewModelTest {
     }
 
     @Test
+    fun `hide-read switch stays enabled under per-tab override even when global grouped is off`() = runTest {
+        // #309 Codex review: with the per-tab override on, the global hide-read still serves as the
+        // fallback for a tab grouped per-type, so the Settings switch must NOT be disabled just
+        // because the GLOBAL grouped toggle is off.
+        repository.emitFlagsPerTabOverride(true)
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.FlagsGroupByCategoryChanged(false))
+
+        assertFalse(viewModel.state.value.flagsGroupByCategory)
+        assertTrue(
+            "per-tab override keeps the global hide-read editable as a fallback",
+            viewModel.state.value.canToggleFlagsHideReadCategories,
+        )
+    }
+
+    @Test
     fun `FlagsGroupByCategoryChanged reverts and raises the error flag on persist failure`() = runTest {
         repository.failOnFlagsGroupByCategorySet = true
         val viewModel = newViewModel()

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -1,8 +1,10 @@
 package fr.forumhfr.redface2.feature.settings
 
 import fr.forumhfr.redface2.core.domain.cache.TopicCacheMaintenance
+import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
+import fr.forumhfr.redface2.core.model.FlagType
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -467,6 +469,40 @@ class SettingsViewModelTest {
         assertTrue(viewModel.state.value.flagsHideReadCategoriesError)
     }
 
+    @Test
+    fun `FlagsPerTabOverrideChanged persists the flip and clears the updating flag`() = runTest {
+        val viewModel = newViewModel()
+        assertFalse("per-tab override is off by default", viewModel.state.value.flagsPerTabOverride)
+
+        viewModel.submit(SettingsIntent.FlagsPerTabOverrideChanged(true))
+
+        assertTrue(viewModel.state.value.flagsPerTabOverride)
+        assertFalse(viewModel.state.value.isUpdatingFlagsPerTabOverride)
+        assertFalse(viewModel.state.value.flagsPerTabOverrideError)
+        assertEquals(1, repository.flagsPerTabOverrideSetCalls)
+    }
+
+    @Test
+    fun `FlagsPerTabOverrideChanged reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnFlagsPerTabOverrideSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.FlagsPerTabOverrideChanged(true))
+
+        assertFalse("must revert to the previous value on failure", viewModel.state.value.flagsPerTabOverride)
+        assertFalse(viewModel.state.value.isUpdatingFlagsPerTabOverride)
+        assertTrue(viewModel.state.value.flagsPerTabOverrideError)
+    }
+
+    @Test
+    fun `per-tab override hydrates from the persisted value on init`() = runTest {
+        repository.emitFlagsPerTabOverride(true)
+
+        val viewModel = newViewModel()
+
+        assertTrue("init must hydrate the per-tab override from DataStore", viewModel.state.value.flagsPerTabOverride)
+    }
+
     private fun newViewModel(): SettingsViewModel =
         SettingsViewModel(repository, topicCacheMaintenance)
 
@@ -546,6 +582,29 @@ class SettingsViewModelTest {
             flagsHideReadCategories.value = enabled
         }
 
+        // #309 — per-tab override master switch. Same optimistic-flip seam as the toggles above so
+        // the Settings mirror tests can gate the write and assert the intermediate / revert states.
+        private val flagsPerTabOverride = MutableStateFlow(false)
+        var flagsPerTabOverrideSetCalls: Int = 0
+            private set
+        var failOnFlagsPerTabOverrideSet: Boolean = false
+
+        override fun observeFlagsPerTabOverride(): Flow<Boolean> = flagsPerTabOverride
+
+        override suspend fun setFlagsPerTabOverride(enabled: Boolean) {
+            flagsPerTabOverrideSetCalls += 1
+            check(!failOnFlagsPerTabOverrideSet) { "boom" }
+            flagsPerTabOverride.value = enabled
+        }
+
+        // Per-type resolution / writes are exercised by the Flags ViewModel, not Settings; stubbed.
+        override fun observeFlagsViewSettings(type: FlagType): Flow<FlagsViewSettings> =
+            MutableStateFlow(FlagsViewSettings())
+
+        override suspend fun setFlagsGroupByCategoryForType(type: FlagType, enabled: Boolean) = Unit
+
+        override suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean) = Unit
+
         fun emit(value: ProxyConfig) {
             config.value = value
         }
@@ -560,6 +619,10 @@ class SettingsViewModelTest {
 
         fun emitFlagsHideReadCategories(value: Boolean) {
             flagsHideReadCategories.value = value
+        }
+
+        fun emitFlagsPerTabOverride(value: Boolean) {
+            flagsPerTabOverride.value = value
         }
     }
 


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Empilée sur #308 (base = `feat/179-flags-by-category`). Se retargettera sur `main` quand #308 sera mergée. Closes #309.

## Quoi

Les deux réglages d'affichage Drapeaux livrés par #179 (grouper par catégorie / masquer les catégories sans non-lu) deviennent **résolus par type de drapeau**. Un master **« réglages différents par onglet »** : OFF (défaut) = un réglage global partagé par tous les onglets ; ON = chaque type (cyan / rouge / favoris) garde son propre affichage, avec repli sur la valeur globale **toggle par toggle**.

Surface : **bottom sheet M3** (`ModalBottomSheet`) ouvert depuis un bouton « Affichage » dans l'en-tête Drapeaux (masqué sur l'onglet Super et en anonyme) + **miroir dans Réglages** (master « réglages différents par onglet »).

## Couches

- **domain** : `FlagsViewSettings(groupByCategory, hideReadCategories)` + `observeFlagsViewSettings(type)` (résolution) + master `observeFlagsPerTabOverride`/`setFlagsPerTabOverride` + `setFlagsGroupByCategoryForType`/`setFlagsHideReadCategoriesForType`. Les observers globaux #179 restent (valeurs par défaut + repli).
- **data** : clé master `flags_per_tab_override` (défaut false) + clés per-type **nullables** (`flags_group_by_category_<type>`, `flags_hide_read_categories_<type>`) dérivées du nom d'enum stable ; résolution `resolveFlagsViewSettings` (override off → global ; on → per-type avec repli global par toggle).
- **flags** : `FlagsViewModel` câblé sur `observeFlagsViewSettings(type)` (combine 4→3 sources), `flagsViewSettings`/`flagsPerTabOverride` exposés pour le sheet, setters routés (global vs per-type, override relu via `.first()` à l'écriture). Bottom sheet + trigger.
- **settings** : miroir master (même optimistic-flip + hydration + guard startup-race que les toggles #179).

## Invariants préservés

- Prefetch non authentifié intact (lecture seule, aucun fetch déclenché par un toggle d'affichage).
- Le toggle « +lus » cyan garde sa priorité sur « masquer les catégories sans non-lu » (`keepFullyReadSections`).
- Aucun refetch réseau sur un changement d'affichage (prouvé par test).

## Tests

- `DataStoreUserPreferencesRepositoryTest` : défaut master, repli global quand override off, lecture per-type avec repli par toggle, isolation per-type.
- `FlagsViewModelTest` : résolution per-type, routing global vs per-type des setters, `flagsViewSettings` suit l'onglet sélectionné.
- `SettingsViewModelTest` : toggle master (flip optimiste + revert sur échec) + hydration init.
- Validation locale Docker : `detektAll lintDebug test :app:lintProdDebug :app:assembleProdDebug` ✅ (BUILD SUCCESSFUL).

## Vérification API

`ModalBottomSheet` / `rememberModalBottomSheetState(skipPartiallyExpanded)` confirmés stables (non dépréciés) sur le BOM verrouillé via Context7.