### PR TITLE
feat(flags): filtre « non-lus uniquement » par type de drapeau (#317)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,21 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## v85 — `0.5.0` — 2026-06-07
+
+**Statut** : `open` (track open testing) + F-Droid `.beta`
+**Commit** : tag `app-v85` (versionCode alloué par le registre de tags, plancher 72)
+**Fichier** : AAB `bundleProdRelease` (`fr.forumhfr.redface2`) → **track open testing** + tag pour F-Droid beta
+
+**Affichage des drapeaux dans la bêta 0.5.0** — les trois fonctionnalités drapeaux, déjà éprouvées sur le canal dev (v81/v82/v83), rejoignent la bêta ouverte ; la v84 livrait 0.5.0 sans elles.
+
+### Added
+- **#179 — Drapeaux/favoris regroupés par catégorie** dans les 4 onglets (Cyan/Lu/Favoris/Super), vue groupée par défaut (parité web), en-têtes de catégorie collants. Toggle vue plate/groupée + masquage des catégories sans non-lu dans les Réglages.
+- **#309 — Affichage configurable par type de drapeau** : un menu « Affichage » (bottom sheet sur l'en-tête Drapeaux + miroir Réglages) permet à chaque onglet de résoudre son propre regroupement / masquage (master switch `flagsPerTabOverride`, fallback global).
+- **#317 — Filtre « non-lus uniquement » par type de drapeau** : défaut adapté au type (Cyan = non-lus, Lu/Favoris = tout afficher), toggle persistant par onglet ; le re-tap cyan « +lus » bascule désormais un réglage persistant.
+
+---
+
 ## v84 — `0.5.0` — 2026-06-07
 
 **Statut** : `open` (track open testing) + F-Droid `.beta`

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -133,6 +133,14 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) {
+        withContext(ioDispatcher) {
+            dataStore.edit { prefs ->
+                prefs[flagsUnreadOnlyKey(type)] = enabled
+            }
+        }
+    }
+
     /**
      * Resolves the per-tab view settings (#309). With the override off, the global pair is
      * returned verbatim; with it on, each toggle reads the per-type key and falls back to the
@@ -147,14 +155,27 @@ class DataStoreUserPreferencesRepository @Inject constructor(
     private fun resolveFlagsViewSettings(prefs: Preferences, type: FlagType): FlagsViewSettings {
         val globalGroup = prefs[KEY_FLAGS_GROUP_BY_CATEGORY] ?: true
         val globalHide = prefs[KEY_FLAGS_HIDE_READ_CATEGORIES] ?: false
+        // #317 — unreadOnly is always per-type with a type-aware default (CYAN actionable by default).
+        val unreadOnly = prefs[flagsUnreadOnlyKey(type)] ?: defaultUnreadOnly(type)
         if (prefs[KEY_FLAGS_PER_TAB_OVERRIDE] != true) {
-            return FlagsViewSettings(groupByCategory = globalGroup, hideReadCategories = globalHide)
+            return FlagsViewSettings(
+                groupByCategory = globalGroup,
+                hideReadCategories = globalHide,
+                unreadOnly = unreadOnly,
+            )
         }
         return FlagsViewSettings(
             groupByCategory = prefs[flagsGroupByCategoryKey(type)] ?: globalGroup,
             hideReadCategories = prefs[flagsHideReadCategoriesKey(type)] ?: globalHide,
+            unreadOnly = unreadOnly,
         )
     }
+
+    /**
+     * Type-aware default for the #317 « non-lus uniquement » filter: CYAN (« Mes sujets ») shows the
+     * actionable unread subset by default (legacy behaviour); RED / FAVORITE show everything.
+     */
+    private fun defaultUnreadOnly(type: FlagType): Boolean = type == FlagType.CYAN
 
     private fun toProxyConfig(prefs: Preferences): ProxyConfig =
         ProxyConfig(
@@ -184,5 +205,9 @@ class DataStoreUserPreferencesRepository @Inject constructor(
 
         fun flagsHideReadCategoriesKey(type: FlagType) =
             booleanPreferencesKey("flags_hide_read_categories_${type.name.lowercase()}")
+
+        // #317 — per-type « non-lus uniquement » key (no global counterpart; type-aware default).
+        fun flagsUnreadOnlyKey(type: FlagType) =
+            booleanPreferencesKey("flags_unread_only_${type.name.lowercase()}")
     }
 }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -114,8 +114,10 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             // per-type key, …); distinctUntilChanged keeps this flow quiet unless THIS type's
             // resolved settings actually change, so the Flags combine doesn't churn on unrelated edits.
             .distinctUntilChanged()
-            // Fall back to the #179 global defaults (grouped on, hide-read off) on a read error.
-            .catch { emit(FlagsViewSettings()) }
+            // Fall back to the defaults on a read error: #179 layout (grouped on, hide-read off) and
+            // the #317 type-aware unreadOnly — so CYAN still degrades to its actionable subset, not
+            // « show all », keeping the error path faithful to resolveFlagsViewSettings.
+            .catch { emit(FlagsViewSettings(unreadOnly = defaultUnreadOnly(type))) }
 
     override suspend fun setFlagsGroupByCategoryForType(type: FlagType, enabled: Boolean) {
         withContext(ioDispatcher) {
@@ -142,10 +144,13 @@ class DataStoreUserPreferencesRepository @Inject constructor(
     }
 
     /**
-     * Resolves the per-tab view settings (#309). With the override off, the global pair is
-     * returned verbatim; with it on, each toggle reads the per-type key and falls back to the
-     * matching global value when that tab key is unset. The global defaults (grouped on,
-     * hide-read off) are applied here so an empty DataStore yields the #179 behaviour.
+     * Resolves the per-tab view settings (#309 layout) plus the per-type unreadOnly (#317). For the
+     * LAYOUT pair: with the override off, the global pair is returned verbatim; with it on, each
+     * toggle reads the per-type key and falls back to the matching global value when that tab key is
+     * unset. The global defaults (grouped on, hide-read off) are applied here so an empty DataStore
+     * yields the #179 behaviour. The #317 [FlagsViewSettings.unreadOnly] is resolved independently of
+     * the override (always per-type, type-aware default via [defaultUnreadOnly]) and added to BOTH
+     * return paths.
      *
      * Per-type keys are intentionally **sticky**: turning the override off does not clear them, so
      * re-enabling it later restores each tab's previously customised values (rather than silently

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -258,6 +258,46 @@ class DataStoreUserPreferencesRepositoryTest {
     }
 
     @Test
+    fun `unreadOnly defaults are type-aware on an empty store`() = runTest(dispatcher) {
+        // #317: unreadOnly is always per-type with a type-aware default — CYAN (« Mes sujets »)
+        // shows the actionable unread subset by default; RED / FAVORITE show everything.
+        repository.observeFlagsViewSettings(FlagType.CYAN).test {
+            assertTrue("CYAN defaults to unread-only", awaitItem().unreadOnly)
+            cancelAndIgnoreRemainingEvents()
+        }
+        repository.observeFlagsViewSettings(FlagType.RED).test {
+            assertFalse("RED defaults to show all", awaitItem().unreadOnly)
+            cancelAndIgnoreRemainingEvents()
+        }
+        repository.observeFlagsViewSettings(FlagType.FAVORITE).test {
+            assertFalse("FAVORITE defaults to show all", awaitItem().unreadOnly)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setFlagsUnreadOnlyForType persists per type and ignores the per-tab override`() = runTest(dispatcher) {
+        // unreadOnly is always per-type: it overrides the type-aware default regardless of the
+        // layout per-tab override (which stays OFF here), and never leaks across types.
+        repository.setFlagsUnreadOnlyForType(FlagType.CYAN, false)
+        repository.setFlagsUnreadOnlyForType(FlagType.RED, true)
+
+        repository.observeFlagsViewSettings(FlagType.CYAN).test {
+            assertFalse("CYAN flipped off overrides its true default", awaitItem().unreadOnly)
+            cancelAndIgnoreRemainingEvents()
+        }
+        repository.observeFlagsViewSettings(FlagType.RED).test {
+            assertTrue("RED flipped on overrides its false default", awaitItem().unreadOnly)
+            cancelAndIgnoreRemainingEvents()
+        }
+        // FAVORITE untouched → still its type-aware default (false).
+        repository.observeFlagsViewSettings(FlagType.FAVORITE).test {
+            assertFalse("FAVORITE keeps its default, no cross-type leak", awaitItem().unreadOnly)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `saving disabled proxy removes optional fields from effective config`() = runTest(dispatcher) {
         repository.saveProxyConfig(
             ProxyConfig(

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -492,5 +492,7 @@ class TopicRepositoryImplTest {
         override suspend fun setFlagsGroupByCategoryForType(type: FlagType, enabled: Boolean) = Unit
 
         override suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean) = Unit
+
+        override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) = Unit
     }
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FlagsViewSettings.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FlagsViewSettings.kt
@@ -7,17 +7,28 @@ package fr.forumhfr.redface2.core.domain.preferences
  * - [groupByCategory] — group flags by forum category (sticky bands) vs. the legacy flat list.
  * - [hideReadCategories] — trim categories without an unread flag in the grouped view (no effect
  *   in the flat view).
+ * - [unreadOnly] — show only topics with an unread post, in BOTH the flat and grouped views (#317).
  *
- * "Resolved" is load-bearing. The app exposes a single GLOBAL pair of toggles plus an optional
- * PER-TAB override ([UserPreferencesRepository.observeFlagsPerTabOverride]). When the override is
- * off, every tab sees the global values; when it is on, each tab sees its own stored value and
- * falls back to the global value for any toggle that tab has never customised.
+ * "Resolved" is load-bearing. The app exposes a single GLOBAL pair of layout toggles
+ * ([groupByCategory] / [hideReadCategories]) plus an optional PER-TAB override
+ * ([UserPreferencesRepository.observeFlagsPerTabOverride]). When the override is off, every tab
+ * sees the global layout values; when it is on, each tab sees its own stored value and falls back
+ * to the global value for any toggle that tab has never customised.
  * [UserPreferencesRepository.observeFlagsViewSettings] performs that resolution so the ViewModel
  * never has to.
  *
- * Defaults match the global DataStore defaults (#179): grouped on, hide-read off.
+ * [unreadOnly] is different: it is ALWAYS per flag type (not subject to the override), because
+ * "show only unread" has a genuinely type-specific natural default — CYAN (« Mes sujets ») defaults
+ * to unread-only (the actionable subset), while RED (« Lus ») and FAVORITE default to showing every
+ * topic. The repository applies that type-aware default; toggling it (bottom sheet, or the CYAN
+ * re-tap shortcut) writes the per-type value.
+ *
+ * Data-class defaults match the global layout defaults (#179): grouped on, hide-read off. The
+ * [unreadOnly] default here is `false` (the safe "show all") — the meaningful type-aware default is
+ * applied at resolution time in the repository, not by this constructor.
  */
 data class FlagsViewSettings(
     val groupByCategory: Boolean = true,
     val hideReadCategories: Boolean = false,
+    val unreadOnly: Boolean = false,
 )

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -70,13 +70,17 @@ interface UserPreferencesRepository {
     suspend fun setFlagsPerTabOverride(enabled: Boolean)
 
     /**
-     * Resolved Drapeaux view settings for [type] (#309), honouring [observeFlagsPerTabOverride]:
-     * - override off → the global [observeFlagsGroupByCategory] / [observeFlagsHideReadCategories].
-     * - override on → this [type]'s stored values, each falling back to the matching global value
-     *   when that tab has never been customised.
+     * Resolved Drapeaux view settings for [type], combining the #309 layout toggles and the #317
+     * unread filter:
+     * - layout ([FlagsViewSettings.groupByCategory] / [FlagsViewSettings.hideReadCategories]),
+     *   honouring [observeFlagsPerTabOverride]: override off → the global
+     *   [observeFlagsGroupByCategory] / [observeFlagsHideReadCategories]; override on → this
+     *   [type]'s stored values, each falling back to the matching global value when unset.
+     * - [FlagsViewSettings.unreadOnly] (#317): ALWAYS per-type, with a type-aware default
+     *   (CYAN → true, RED/FAVORITE → false) until [setFlagsUnreadOnlyForType] is called.
      *
-     * This is the single source the Flags screen list rendering reads; the global observers stay
-     * the editable defaults (and the per-tab fallback) the Settings mirror writes.
+     * This is the single source the Flags screen list rendering reads; the global layout observers
+     * stay the editable defaults (and the per-tab fallback) the Settings mirror writes.
      */
     fun observeFlagsViewSettings(type: FlagType): Flow<FlagsViewSettings>
 
@@ -93,4 +97,12 @@ interface UserPreferencesRepository {
      * set, that tab falls back to the global [setFlagsHideReadCategories] value.
      */
     suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean)
+
+    /**
+     * Persists the « non-lus uniquement » value for [type] (#317). Unlike the layout toggles this
+     * is ALWAYS per-type (no global key, not subject to [observeFlagsPerTabOverride]). Until set,
+     * [observeFlagsViewSettings] applies a type-aware default: `true` for [FlagType.CYAN] (the
+     * actionable « Mes sujets » subset), `false` for [FlagType.RED] / [FlagType.FAVORITE].
+     */
+    suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean)
 }

--- a/docs/specs/mvi.md
+++ b/docs/specs/mvi.md
@@ -128,6 +128,9 @@ class FlagsViewModel @Inject constructor(
         )
 
     // Re-tap Cyan déjà sélectionné → toggle du filtre via le setter (point de mutation unique).
+    // NB prod : le VM réel lit un `cyanUnreadOnly` dédié (StateFlow CYAN-scopé, shim optimiste +
+    // défaut eager `true`) plutôt que `flagsViewSettings.value`, pour éviter qu'un changement
+    // d'onglet ou un double re-tap rapide ne lise une valeur en retard sur DataStore (cf. #309/#317).
     fun selectTab(tab: FlagTab) {
         if (tab == FlagTab.Cyan && _selectedTab.value == FlagTab.Cyan) {
             setFlagsUnreadOnly(!flagsViewSettings.value.unreadOnly)

--- a/docs/specs/mvi.md
+++ b/docs/specs/mvi.md
@@ -54,7 +54,7 @@ Les exemples ViewModel ci-dessous sont **des squelettes illustratifs** — certa
 
 ## Écran Drapeaux (accueil)
 
-> **Statut Phase 2 finish livré** : le `FlagsViewModel` réel expose plusieurs `StateFlow` séparés (auth, onglet courant `FlagTab`, liste de drapeaux du tab, `isRefreshing`, `removeFlagState`/`removeFlagEvent`) plutôt qu'un seul `FlagsState` agrégé. Onglets via `FlagTab` (Cyan/Red/Favorite + **Super**, placeholder « super favoris » sans backend, `flagType == null`). Le filtre CYAN « afficher les cyans déjà lus » se pilote par **re-tap de l'onglet Cyan** (le `FilterChip` a été retiré). Le **retrait d'un drapeau** (#99, `delflag.php`, confirmation + pas d'undo optimiste) est livré. Le **pull-to-refresh** (`PullToRefreshBox` M3) a remplacé le bouton « Actualiser ». `logout()` ne vit plus ici (déplacé dans `AppAccountViewModel`, #198). Le squelette illustratif ci-dessous reflète la forme shippée.
+> **Statut Phase 2 finish livré** : le `FlagsViewModel` réel expose plusieurs `StateFlow` séparés (auth, onglet courant `FlagTab`, liste de drapeaux du tab, `isRefreshing`, `removeFlagState`/`removeFlagEvent`) plutôt qu'un seul `FlagsState` agrégé. Onglets via `FlagTab` (Cyan/Red/Favorite + **Super**, placeholder « super favoris » sans backend, `flagType == null`). Le filtre « non-lus uniquement » est désormais **par type de drapeau** (#317, persisté en préférences, défaut type-aware : CYAN activé, RED/FAVORITE non) ; il se pilote par le **bottom sheet d'affichage** et, pour CYAN, par **re-tap de l'onglet** (raccourci « +lus » ; le `FilterChip` a été retiré). Le **retrait d'un drapeau** (#99, `delflag.php`, confirmation + pas d'undo optimiste) est livré. Le **pull-to-refresh** (`PullToRefreshBox` M3) a remplacé le bouton « Actualiser ». `logout()` ne vit plus ici (déplacé dans `AppAccountViewModel`, #198). Le squelette illustratif ci-dessous reflète la forme shippée.
 
 ### ViewModel — forme livrée
 
@@ -64,6 +64,7 @@ Les exemples ViewModel ci-dessous sont **des squelettes illustratifs** — certa
 class FlagsViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val flagRepository: FlagRepository,
+    private val userPreferencesRepository: UserPreferencesRepository,
 ) : ViewModel() {
 
     private var observedPseudo: String? = null
@@ -74,10 +75,10 @@ class FlagsViewModel @Inject constructor(
     private val _selectedTab = MutableStateFlow<FlagTab>(FlagTab.Cyan)
     val selectedTab: StateFlow<FlagTab> = _selectedTab.asStateFlow()
 
-    // CYAN-only client filter (default hides `hasUnread = false`). Le toggle est déclenché par un
-    // re-tap de l'onglet Cyan déjà sélectionné (le FilterChip a été retiré).
-    private val _showReadParticipatedTopics = MutableStateFlow(false)
-    val showReadParticipatedTopics: StateFlow<Boolean> = _showReadParticipatedTopics.asStateFlow()
+    // #317 — filtre « non-lus uniquement » par type de drapeau, persisté (DataStore) et résolu avec
+    // un défaut type-aware (CYAN → true = sous-ensemble actionnable, RED/FAVORITE → false). Le toggle
+    // est déclenché soit par le bottom sheet d'affichage, soit par un re-tap de l'onglet Cyan déjà
+    // sélectionné (raccourci « +lus »). Aucun état en mémoire : la valeur vit dans les préférences.
 
     // Anchored over the existing list during the user-driven pull-to-refresh round-trip
     // (Material 3 PullToRefreshBox a remplacé le bouton « Actualiser »). Même pattern que ForumViewModel.
@@ -103,23 +104,42 @@ class FlagsViewModel @Inject constructor(
                         null -> flowOf<FlagsResult?>(null) // Super placeholder : pas de fetch
                         else -> combine(
                             flagRepository.observe(type),
-                            _showReadParticipatedTopics,
-                        ) { result, showRead -> filterReadParticipatedIfNeeded(result, type, showRead) }
+                            userPreferencesRepository.observeFlagsViewSettings(type)
+                                .map { it.unreadOnly }
+                                .distinctUntilChanged(),
+                        ) { result, unreadOnly -> filterUnreadOnly(result, unreadOnly) }
                     }
                 }
             }
         }
         .stateIn(viewModelScope, SharingStarted.Eagerly, initialValue = null)
 
+    // #317 — réglages d'affichage résolus pour l'onglet courant ; le re-tap y lit `unreadOnly`.
+    // initialValue type-aware (CYAN → true) pour éviter un flash « +lus » au démarrage à froid.
+    val flagsViewSettings: StateFlow<FlagsViewSettings> = selectedTab
+        .flatMapLatest { tab ->
+            tab.flagType?.let { userPreferencesRepository.observeFlagsViewSettings(it) }
+                ?: flowOf(FlagsViewSettings())
+        }
+        .stateIn(
+            viewModelScope,
+            SharingStarted.Eagerly,
+            FlagsViewSettings(unreadOnly = _selectedTab.value == FlagTab.Cyan),
+        )
+
     // Re-tap Cyan déjà sélectionné → toggle du filtre via le setter (point de mutation unique).
     fun selectTab(tab: FlagTab) {
         if (tab == FlagTab.Cyan && _selectedTab.value == FlagTab.Cyan) {
-            setShowReadParticipatedTopics(!_showReadParticipatedTopics.value)
+            setFlagsUnreadOnly(!flagsViewSettings.value.unreadOnly)
             return
         }
         _selectedTab.value = tab
     }
-    fun setShowReadParticipatedTopics(value: Boolean) { _showReadParticipatedTopics.value = value }
+    // Écrit la valeur per-type de l'onglet courant (toujours par type ; no-op sur Super).
+    fun setFlagsUnreadOnly(enabled: Boolean) {
+        val type = _selectedTab.value.flagType ?: return
+        viewModelScope.launch { userPreferencesRepository.setFlagsUnreadOnlyForType(type, enabled) }
+    }
 
     fun refresh() { // no-op sur Super (flagType == null)
         val type = _selectedTab.value.flagType ?: return
@@ -133,12 +153,10 @@ class FlagsViewModel @Inject constructor(
     // → one-shot event ; consumeRemoveFlagEvent() après affichage du snackbar.
     // NB : logout() ne vit plus ici — déplacé dans AppAccountViewModel (#198, menu compte global).
 
-    private fun filterReadParticipatedIfNeeded(
-        result: FlagsResult,
-        type: FlagType,
-        showReadParticipated: Boolean,
-    ): FlagsResult {
-        if (type != FlagType.CYAN || showReadParticipated) return result
+    // #317 — filtre générique : ne garde que les sujets non lus quand `unreadOnly` est actif (tout
+    // type ; CYAN l'active par défaut, RED/FAVORITE non — cf. défaut type-aware côté repository).
+    private fun filterUnreadOnly(result: FlagsResult, unreadOnly: Boolean): FlagsResult {
+        if (!unreadOnly) return result
         return when (result) {
             is FlagsResult.Success -> result.copy(flags = result.flags.filter { it.hasUnread })
             else -> result
@@ -195,7 +213,7 @@ Quand cette extension arrive, `FlagsState` agrégé peut redevenir préférable 
 
 ### Screen (Compose) — forme livrée
 
-`feature/flags/src/main/kotlin/.../FlagsRoute.kt` est l'entrée stateful (récupère `FlagsViewModel` via `hiltViewModel()`, collecte ses `StateFlow` via `collectAsStateWithLifecycle()`). Depuis le polish #154 et la refonte Phase 2 finish, `FlagsRoute` se concentre sur la liste : 4 onglets (Cyan / Lu / Favoris / **Super** placeholder), toggle « afficher les sujets participés déjà lus » (CYAN, via re-tap de l'onglet), pull-to-refresh `PullToRefreshBox` (plus de bouton Actualiser), retrait d'un drapeau par **swipe-to-remove** (`SwipeToDismissBox` M3, swipe end-to-start) qui ouvre le dialog de confirmation (#99) — le swipe ne supprime jamais la ligne seul (la ligne est ramenée à `Settled` via `reset()`, la suppression réelle n'a lieu qu'après confirmation, quand le repo évince l'item du cache), branche login si anonyme, branche reconnect si `SessionExpiredException`. Pas de footer alpha — les actions compte (pseudo / logout) et outils (Diagnostics, signalement, version) vivent depuis #198 dans le menu compte global injecté via `topBarActions: @Composable (() -> Unit)? = null`. Le découpage `<Name>Screen` / `<Name>Content` reste l'objectif quand la complexité justifie le coût (filtre, tri, undo) — cf. cible Phase 2.
+`feature/flags/src/main/kotlin/.../FlagsRoute.kt` est l'entrée stateful (récupère `FlagsViewModel` via `hiltViewModel()`, collecte ses `StateFlow` via `collectAsStateWithLifecycle()`). Depuis le polish #154 et la refonte Phase 2 finish, `FlagsRoute` se concentre sur la liste : 4 onglets (Cyan / Lu / Favoris / **Super** placeholder), filtre « non-lus uniquement » par type (#317, via le bottom sheet d'affichage ou, pour CYAN, le re-tap de l'onglet), pull-to-refresh `PullToRefreshBox` (plus de bouton Actualiser), retrait d'un drapeau par **swipe-to-remove** (`SwipeToDismissBox` M3, swipe end-to-start) qui ouvre le dialog de confirmation (#99) — le swipe ne supprime jamais la ligne seul (la ligne est ramenée à `Settled` via `reset()`, la suppression réelle n'a lieu qu'après confirmation, quand le repo évince l'item du cache), branche login si anonyme, branche reconnect si `SessionExpiredException`. Pas de footer alpha — les actions compte (pseudo / logout) et outils (Diagnostics, signalement, version) vivent depuis #198 dans le menu compte global injecté via `topBarActions: @Composable (() -> Unit)? = null`. Le découpage `<Name>Screen` / `<Name>Content` reste l'objectif quand la complexité justifie le coût (filtre, tri, undo) — cf. cible Phase 2.
 
 ---
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagCategorySection.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagCategorySection.kt
@@ -61,7 +61,8 @@ internal val FALLBACK_CATEGORY_ORDER: List<FlagCategoryOrderEntry> = listOf(
 )
 
 /**
- * Groups [flags] (already cyan-filtered, cf. #154) by category and orders the sections by the
+ * Groups [flags] (already unread-filtered per type when that tab's « non-lus uniquement » is on,
+ * cf. #154/#317) by category and orders the sections by the
  * canonical [orderedCategories]. Returns FIRST every known category (empty sections included,
  * for web parity), THEN at the end the categories present in the flags but absent from the
  * catalogue, as « unknown » sections (`catName == null`) sorted by `catId` ascending.

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -106,10 +106,11 @@ fun FlagsRoute(
     val flagsViewSettings by viewModel.flagsViewSettings.collectAsStateWithLifecycle()
     val flagsPerTabOverride by viewModel.flagsPerTabOverride.collectAsStateWithLifecycle()
 
-    // « +lus » suffix on the Cyan tab: shown when the Cyan tab is selected and its « non-lus
-    // uniquement » filter is off (read participated topics are visible). `flagsViewSettings` resolves
-    // the SELECTED tab, so this is meaningful while Cyan is the active tab (#317).
-    val cyanShowsRead = selectedTab == FlagTab.Cyan && !flagsViewSettings.unreadOnly
+    // « +lus » suffix on the Cyan tab: shown when the Cyan tab is selected and CYAN's « non-lus
+    // uniquement » filter is off (read participated topics are visible). The ViewModel derives this
+    // from [cyanUnreadOnly] (CYAN-specific, optimistic, eager `true`) so the suffix never flashes on
+    // a cold start or a tab switch before DataStore re-resolves the selected tab (#317).
+    val cyanShowsRead by viewModel.cyanShowsReadShortcut.collectAsStateWithLifecycle()
 
     val snackbarHostState = remember { SnackbarHostState() }
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -100,12 +100,16 @@ fun FlagsRoute(
     val authState by viewModel.authState.collectAsStateWithLifecycle()
     val selectedTab by viewModel.selectedTab.collectAsStateWithLifecycle()
     val flagsState by viewModel.flagsState.collectAsStateWithLifecycle()
-    val showReadParticipated by viewModel.showReadParticipatedTopics.collectAsStateWithLifecycle()
     val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
     val removeFlagState by viewModel.removeFlagState.collectAsStateWithLifecycle()
     val removeFlagEvent by viewModel.removeFlagEvent.collectAsStateWithLifecycle()
     val flagsViewSettings by viewModel.flagsViewSettings.collectAsStateWithLifecycle()
     val flagsPerTabOverride by viewModel.flagsPerTabOverride.collectAsStateWithLifecycle()
+
+    // « +lus » suffix on the Cyan tab: shown when the Cyan tab is selected and its « non-lus
+    // uniquement » filter is off (read participated topics are visible). `flagsViewSettings` resolves
+    // the SELECTED tab, so this is meaningful while Cyan is the active tab (#317).
+    val cyanShowsRead = selectedTab == FlagTab.Cyan && !flagsViewSettings.unreadOnly
 
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -177,7 +181,7 @@ fun FlagsRoute(
                             state = FlagsBodyState(
                                 selectedTab = selectedTab,
                                 flagsState = flagsState,
-                                showReadParticipated = showReadParticipated,
+                                cyanShowsRead = cyanShowsRead,
                                 isRefreshing = isRefreshing,
                                 removeFlagState = removeFlagState,
                             ),
@@ -207,6 +211,7 @@ fun FlagsRoute(
                 onPerTabOverrideChange = viewModel::setFlagsPerTabOverride,
                 onGroupByCategoryChange = viewModel::setFlagsGroupByCategory,
                 onHideReadCategoriesChange = viewModel::setFlagsHideReadCategories,
+                onUnreadOnlyChange = viewModel::setFlagsUnreadOnly,
                 onDismiss = { showViewSettingsSheet = false },
             ),
         )
@@ -299,12 +304,14 @@ private fun FlagsHeader(
 }
 
 /**
- * Display-settings bottom sheet (#309). Three switches edit the active scope: the per-tab override
- * master switch, then « grouper par catégorie » and « masquer les catégories sans non-lu » (the
- * latter disabled in the flat view, mirroring Settings). A caption spells out the current scope so
- * the user knows whether a flip touches every tab or only [selectedTab]. Writes route through the
- * ViewModel ([onPerTabOverrideChange]/[onGroupByCategoryChange]/[onHideReadCategoriesChange]) so
- * they land on the right key; the sheet stays open so the list re-renders live underneath.
+ * Display-settings bottom sheet (#309 + #317). The first three switches edit the active LAYOUT
+ * scope: the per-tab override master switch, then « grouper par catégorie » and « masquer les
+ * catégories sans non-lu » (the latter disabled in the flat view, mirroring Settings). A caption
+ * spells out the current scope so the user knows whether a layout flip touches every tab or only
+ * [selectedTab]. The last switch, « non-lus uniquement » (#317), is ALWAYS per-tab (independent of
+ * the scope caption) — its description says so. Writes route through the ViewModel
+ * ([onPerTabOverrideChange]/[onGroupByCategoryChange]/[onHideReadCategoriesChange]/[onUnreadOnlyChange])
+ * so they land on the right key; the sheet stays open so the list re-renders live underneath.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -370,6 +377,15 @@ private fun FlagsViewSettingsSheet(
                 // Hiding read categories is only meaningful in the grouped view (mirrors Settings).
                 enabled = settings.groupByCategory,
                 onCheckedChange = actions.onHideReadCategoriesChange,
+            )
+            // #317 — « non-lus uniquement ». Always per-tab (not governed by the override above), so
+            // it's always enabled and its description says it applies to this tab only.
+            ViewSettingsSwitchRow(
+                title = stringResource(R.string.flags_view_settings_unread_only_title),
+                description = stringResource(R.string.flags_view_settings_unread_only_description),
+                checked = settings.unreadOnly,
+                enabled = true,
+                onCheckedChange = actions.onUnreadOnlyChange,
             )
 
             TextButton(
@@ -470,7 +486,7 @@ private fun ColumnScope.AuthenticatedBody(
     actions: AuthenticatedActions,
 ) {
     val selectedTab = state.selectedTab
-    val showReadParticipated = state.showReadParticipated
+    val cyanShowsRead = state.cyanShowsRead
     val tabs = listOf(
         FlagTab.Cyan to stringResource(R.string.flags_tab_my_topics),
         FlagTab.Red to stringResource(R.string.flags_tab_read_only),
@@ -484,7 +500,7 @@ private fun ColumnScope.AuthenticatedBody(
 
     PrimaryTabRow(selectedTabIndex = selectedIndex) {
         tabs.forEachIndexed { index, (tab, label) ->
-            val displayLabel = if (tab == FlagTab.Cyan && showReadParticipated) {
+            val displayLabel = if (tab == FlagTab.Cyan && cyanShowsRead) {
                 label + cyanReadSuffix
             } else {
                 label
@@ -890,7 +906,8 @@ private fun ColumnScope.SuperPlaceholderBody() {
 private data class FlagsBodyState(
     val selectedTab: FlagTab,
     val flagsState: FlagsListUiState?,
-    val showReadParticipated: Boolean,
+    /** Whether the Cyan tab currently shows read topics (« +lus » suffix), #317. */
+    val cyanShowsRead: Boolean,
     val isRefreshing: Boolean,
     val removeFlagState: RemoveFlagState,
 )
@@ -904,14 +921,16 @@ private data class AuthenticatedActions(
 )
 
 /**
- * Callback bundle for [FlagsViewSettingsSheet] (#309), grouped so the sheet stays under the detekt
- * parameter-count threshold. The three `*Change` writes route through the ViewModel (which decides
- * global vs per-type scope); [onDismiss] closes the sheet.
+ * Callback bundle for [FlagsViewSettingsSheet] (#309 + #317), grouped so the sheet stays under the
+ * detekt parameter-count threshold. The layout `*Change` writes route through the ViewModel (which
+ * decides global vs per-type scope); [onUnreadOnlyChange] is always per-type (#317); [onDismiss]
+ * closes the sheet.
  */
 private data class FlagsViewSettingsActions(
     val onPerTabOverrideChange: (Boolean) -> Unit,
     val onGroupByCategoryChange: (Boolean) -> Unit,
     val onHideReadCategoriesChange: (Boolean) -> Unit,
+    val onUnreadOnlyChange: (Boolean) -> Unit,
     val onDismiss: () -> Unit,
 )
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -131,21 +131,54 @@ class FlagsViewModel @Inject constructor(
             scope = viewModelScope,
             started = SharingStarted.Eagerly,
             // Seed the type-aware #317 default for the initial tab (CYAN → unread-only) so the
-            // cold-start frame (before observeFlagsViewSettings emits) matches the resolved value:
-            // otherwise the data-class default (unreadOnly=false) would flash the « +lus » suffix on
-            // Cyan and a re-tap in that window would read a stale value. Mirrors defaultUnreadOnly.
+            // bottom sheet's « non-lus uniquement » switch shows the right state on a cold start
+            // (before observeFlagsViewSettings emits), instead of the data-class default `false`.
+            // The « +lus » suffix and the re-tap read [cyanUnreadOnly], not this StateFlow.
             initialValue = FlagsViewSettings(unreadOnly = _selectedTab.value == FlagTab.Cyan),
         )
 
     /**
-     * Optimistic shim for the per-type « non-lus uniquement » value (#317), mirroring
-     * [pendingPerTabOverride]. The CYAN re-tap shortcut computes its flip from the RESOLVED settings,
-     * an async DataStore flow; seeding this synchronously on each write keeps a rapid double re-tap
-     * flipping from the value the user last chose rather than one lagging the round-trip. It always
-     * describes the currently selected tab (reset on a real tab switch); cleared once the write
-     * persists. Read only by the re-tap path — the list/suffix read the resolved settings directly.
+     * Optimistic shim for CYAN's « non-lus uniquement » value (#317), mirroring
+     * [pendingPerTabOverride]. The « +lus » re-tap is the ONLY read-then-flip site, and it is always
+     * CYAN — so the shim is deliberately CYAN-scoped (RED/FAVORITE writes never touch it, so a
+     * concurrent RED write can't clobber a CYAN flip). [setFlagsUnreadOnly] seeds it synchronously
+     * for CYAN; cleared once that write persists.
      */
-    private val pendingUnreadOnly = MutableStateFlow<Boolean?>(null)
+    private val pendingCyanUnreadOnly = MutableStateFlow<Boolean?>(null)
+
+    /**
+     * CYAN's resolved « non-lus uniquement » value, optimistic shim ([pendingCyanUnreadOnly]) winning
+     * until the persisted value catches up. Tracks CYAN **regardless of the selected tab** (it is not
+     * keyed on [selectedTab]) and is eagerly seeded with CYAN's type-aware default (`true`), so the
+     * « +lus » re-tap and the Cyan tab suffix never read a value lagging a tab switch or the cold
+     * start (cf. [selectTab] / [cyanShowsReadShortcut]). The bottom-sheet switch keeps reading the
+     * selected-tab [flagsViewSettings] like every other toggle.
+     */
+    val cyanUnreadOnly: StateFlow<Boolean> = combine(
+        userPreferencesRepository.observeFlagsViewSettings(FlagType.CYAN).map { it.unreadOnly },
+        pendingCyanUnreadOnly,
+    ) { persisted, pending -> pending ?: persisted }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = true,
+        )
+
+    /**
+     * Whether the Cyan tab currently shows read participated topics (drives the discreet « +lus »
+     * tab-label suffix, #317): Cyan selected AND its unread filter off. Reads [cyanUnreadOnly] (not
+     * the selected-tab [flagsViewSettings]) so it never flashes the suffix on a cold start or a
+     * tab switch before DataStore re-resolves.
+     */
+    val cyanShowsReadShortcut: StateFlow<Boolean> = combine(
+        selectedTab,
+        cyanUnreadOnly,
+    ) { tab, unreadOnly -> tab == FlagTab.Cyan && !unreadOnly }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = false,
+        )
 
     /**
      * Optimistic shim for the per-tab master switch (#309 Codex review). `setFlagsPerTabOverride`
@@ -220,19 +253,24 @@ class FlagsViewModel @Inject constructor(
         val categories = forumRepository.observeCategories()
             .onStart { emit(ForumResult.Loading) }
 
+        // #309 — resolved per-tab LAYOUT pair (global, or this tab's override). Projected to
+        // layout-only + distinctUntilChanged so an `unreadOnly` flip re-fires ONLY the inner
+        // [unreadOnlyFlow] (→ filteredFlags), never this outer source — keeping the « toggling
+        // re-emits exactly once » property exact (cf. KDoc above).
+        val layoutFlow = userPreferencesRepository.observeFlagsViewSettings(type)
+            .map { it.groupByCategory to it.hideReadCategories }
+            .distinctUntilChanged()
+
         return combine(
             filteredFlags,
             categories,
-            // #309 — resolved per-tab view settings (global, or this tab's override when the
-            // per-tab master switch is on). Replaces the two separate global pref flows; the
-            // resolution lives in the repository so this combine stays a 3-source map.
-            userPreferencesRepository.observeFlagsViewSettings(type),
-        ) { filtered, catsResult, viewSettings ->
+            layoutFlow,
+        ) { filtered, catsResult, (groupByCategory, hideReadCategories) ->
             toFlagsListUiState(
                 flagsResult = filtered.result,
                 categoriesResult = catsResult,
-                groupByCategory = viewSettings.groupByCategory,
-                hideReadCategories = viewSettings.hideReadCategories,
+                groupByCategory = groupByCategory,
+                hideReadCategories = hideReadCategories,
                 keepFullyReadSections = filtered.keepFullyReadSections,
             )
         }
@@ -292,15 +330,12 @@ class FlagsViewModel @Inject constructor(
             // Re-tapping the already-selected Cyan tab toggles its « non-lus uniquement » filter
             // (the « +lus » shortcut). It flips the CYAN per-type value, persisted via
             // [setFlagsUnreadOnly] — the same write the bottom-sheet toggle uses (single mutation
-            // point). Flip from the optimistic [pendingUnreadOnly] if a write is still in flight,
-            // else from the resolved CYAN settings — so a rapid double re-tap can't read a value
-            // lagging the DataStore round-trip and lose a toggle (cf. #309 shim rationale).
-            val current = pendingUnreadOnly.value ?: flagsViewSettings.value.unreadOnly
-            setFlagsUnreadOnly(!current)
+            // point). Flip from [cyanUnreadOnly], which tracks CYAN specifically (not the selected
+            // tab) with an optimistic shim and an eager `true` default — so a tab switch, the cold
+            // start, or a rapid double re-tap can never feed it a lagging value and lose a toggle.
+            setFlagsUnreadOnly(!cyanUnreadOnly.value)
             return
         }
-        // A real tab switch drops any pending optimistic value (it described the previous tab).
-        if (_selectedTab.value != tab) pendingUnreadOnly.value = null
         _selectedTab.value = tab
     }
 
@@ -355,13 +390,16 @@ class FlagsViewModel @Inject constructor(
      */
     fun setFlagsUnreadOnly(enabled: Boolean) {
         val type = _selectedTab.value.flagType ?: return
-        // Seed the optimistic value synchronously (instant, lag-free re-tap target), then persist
-        // and drop the shim only if no newer flip superseded this one (compareAndSet) — same pattern
-        // as [setFlagsPerTabOverride]. The resolved settings take over once DataStore commits.
-        pendingUnreadOnly.value = enabled
+        // CYAN is the only read-then-flip path (the « +lus » re-tap), so only CYAN needs the
+        // optimistic shim: seed it synchronously (instant, lag-free re-tap target), then persist and
+        // drop the shim only if no newer flip superseded it (compareAndSet) — same pattern as
+        // [setFlagsPerTabOverride]. RED/FAVORITE writes (bottom sheet, explicit on/off) never touch
+        // the shim, so they can't clobber a concurrent CYAN flip. Resolved settings take over once
+        // DataStore commits.
+        if (type == FlagType.CYAN) pendingCyanUnreadOnly.value = enabled
         viewModelScope.launch {
             userPreferencesRepository.setFlagsUnreadOnlyForType(type, enabled)
-            pendingUnreadOnly.compareAndSet(expect = enabled, update = null)
+            if (type == FlagType.CYAN) pendingCyanUnreadOnly.compareAndSet(expect = enabled, update = null)
         }
     }
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -130,8 +130,22 @@ class FlagsViewModel @Inject constructor(
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.Eagerly,
-            initialValue = FlagsViewSettings(),
+            // Seed the type-aware #317 default for the initial tab (CYAN → unread-only) so the
+            // cold-start frame (before observeFlagsViewSettings emits) matches the resolved value:
+            // otherwise the data-class default (unreadOnly=false) would flash the « +lus » suffix on
+            // Cyan and a re-tap in that window would read a stale value. Mirrors defaultUnreadOnly.
+            initialValue = FlagsViewSettings(unreadOnly = _selectedTab.value == FlagTab.Cyan),
         )
+
+    /**
+     * Optimistic shim for the per-type « non-lus uniquement » value (#317), mirroring
+     * [pendingPerTabOverride]. The CYAN re-tap shortcut computes its flip from the RESOLVED settings,
+     * an async DataStore flow; seeding this synchronously on each write keeps a rapid double re-tap
+     * flipping from the value the user last chose rather than one lagging the round-trip. It always
+     * describes the currently selected tab (reset on a real tab switch); cleared once the write
+     * persists. Read only by the re-tap path — the list/suffix read the resolved settings directly.
+     */
+    private val pendingUnreadOnly = MutableStateFlow<Boolean?>(null)
 
     /**
      * Optimistic shim for the per-tab master switch (#309 Codex review). `setFlagsPerTabOverride`
@@ -278,10 +292,15 @@ class FlagsViewModel @Inject constructor(
             // Re-tapping the already-selected Cyan tab toggles its « non-lus uniquement » filter
             // (the « +lus » shortcut). It flips the CYAN per-type value, persisted via
             // [setFlagsUnreadOnly] — the same write the bottom-sheet toggle uses (single mutation
-            // point). `flagsViewSettings.value` is the CYAN resolution while Cyan is selected.
-            setFlagsUnreadOnly(!flagsViewSettings.value.unreadOnly)
+            // point). Flip from the optimistic [pendingUnreadOnly] if a write is still in flight,
+            // else from the resolved CYAN settings — so a rapid double re-tap can't read a value
+            // lagging the DataStore round-trip and lose a toggle (cf. #309 shim rationale).
+            val current = pendingUnreadOnly.value ?: flagsViewSettings.value.unreadOnly
+            setFlagsUnreadOnly(!current)
             return
         }
+        // A real tab switch drops any pending optimistic value (it described the previous tab).
+        if (_selectedTab.value != tab) pendingUnreadOnly.value = null
         _selectedTab.value = tab
     }
 
@@ -336,8 +355,13 @@ class FlagsViewModel @Inject constructor(
      */
     fun setFlagsUnreadOnly(enabled: Boolean) {
         val type = _selectedTab.value.flagType ?: return
+        // Seed the optimistic value synchronously (instant, lag-free re-tap target), then persist
+        // and drop the shim only if no newer flip superseded this one (compareAndSet) — same pattern
+        // as [setFlagsPerTabOverride]. The resolved settings take over once DataStore commits.
+        pendingUnreadOnly.value = enabled
         viewModelScope.launch {
             userPreferencesRepository.setFlagsUnreadOnlyForType(type, enabled)
+            pendingUnreadOnly.compareAndSet(expect = enabled, update = null)
         }
     }
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -22,8 +22,10 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
@@ -52,23 +54,6 @@ class FlagsViewModel @Inject constructor(
     private val _selectedTab = MutableStateFlow<FlagTab>(FlagTab.Cyan)
     val selectedTab: StateFlow<FlagTab> = _selectedTab.asStateFlow()
 
-    /**
-     * User-controlled visibility of CYAN flags whose [fr.forumhfr.redface2.core.model.Flag.hasUnread]
-     * is `false` — i.e. topics the user already finished reading but still participated in.
-     * Default `false`: a fresh launch shows only actionable « Mes sujets » entries. Toggling this
-     * reactively re-emits the filtered list without a refetch (cf. [combine] in [flagsState]).
-     *
-     * Filter applies only when [selectedTab] == [FlagType.CYAN]. RED (« Lus uniquement » — topics
-     * the user reads without participating) and FAVORITE (bookmarks) keep their full content
-     * regardless — they don't have the « stale read flag » pollution problem CYAN does, where the
-     * user explicitly wants the actionable subset by default.
-     *
-     * In-memory only for now (#154 polish scope) — persisting the preference is deferred
-     * until a real settings surface exists.
-     */
-    private val _showReadParticipatedTopics = MutableStateFlow(false)
-    val showReadParticipatedTopics: StateFlow<Boolean> = _showReadParticipatedTopics.asStateFlow()
-
     val authState: StateFlow<AuthState?> = authRepository.observeAuthState()
         .stateIn(
             scope = viewModelScope,
@@ -87,12 +72,13 @@ class FlagsViewModel @Inject constructor(
      * - Anonymous → `null` (the home tab shows the login intro instead of a list).
      * - [FlagTab.Super] → `null` (placeholder body, no backend, **no** repository observation —
      *   neither flags NOR categories are observed, cf. §5 « no double-fetch »).
-     * - Authenticated + a real [FlagType] → the per-tab flag flow (filtered cyan #154, then
-     *   [keepContentDuringRefresh] #225) is combined with [ForumRepository.observeCategories]
-     *   to build [FlagsListUiState]. Categories are observed **only** in this branch so we never
-     *   trigger a spurious public categories fetch for Anonymous/Super.
+     * - Authenticated + a real [FlagType] → the per-tab flag flow (« non-lus uniquement » filter
+     *   #154/#317, then [keepContentDuringRefresh] #225) is combined with
+     *   [ForumRepository.observeCategories] to build [FlagsListUiState]. Categories are observed
+     *   **only** in this branch so we never trigger a spurious public categories fetch for
+     *   Anonymous/Super.
      *
-     * Ordering of the mapping is load-bearing: cyan filter → `keepContentDuringRefresh` →
+     * Ordering of the mapping is load-bearing: unread filter → `keepContentDuringRefresh` →
      * combine with categories → map to sections. Reversing the first two would regress #225
      * (the list blanks to a cold spinner during a pull-to-refresh).
      *
@@ -178,23 +164,30 @@ class FlagsViewModel @Inject constructor(
      * so the `flatMapLatest` chain stays readable. Both `observe(type)` and `observeCategories()`
      * are subscribed here — and only here.
      *
-     * The cyan « +lus » decision ([showReadParticipatedTopics]) travels INSIDE [FilteredFlags]
-     * rather than as a separate `combine` source. This is load-bearing: folding it into the same
-     * source the flags arrive on means toggling « +lus » re-emits exactly once (no transient
-     * intermediate state where the new toggle value meets the stale flag list), and lets the
-     * downstream section filter know whether read participated topics were opted in.
+     * The « non-lus uniquement » decision ([FlagsViewSettings.unreadOnly], #317) travels INSIDE
+     * [FilteredFlags] rather than only as part of the outer `combine` source. This is load-bearing:
+     * folding the topic filter into the same source the flags arrive on means toggling it re-emits
+     * exactly once (no transient intermediate state where the new toggle value meets the stale flag
+     * list), and lets the downstream section filter know whether read topics are being shown
+     * ([keepFullyReadSections]). It is sourced via a `distinctUntilChanged` projection of the
+     * resolved view settings so an unrelated layout change doesn't re-run the topic filter.
      */
     private fun authenticatedFlagsListState(type: FlagType): Flow<FlagsListUiState?> {
+        val unreadOnlyFlow = userPreferencesRepository.observeFlagsViewSettings(type)
+            .map { it.unreadOnly }
+            .distinctUntilChanged()
         val filteredFlags = combine(
             flagRepository.observe(type),
-            _showReadParticipatedTopics,
-        ) { result, showRead ->
+            unreadOnlyFlow,
+        ) { result, unreadOnly ->
             FilteredFlags(
-                result = filterReadParticipatedIfNeeded(result, type, showRead),
-                // The cyan « +lus » override for the hide-read-categories filter: only CYAN has a
-                // « show already-read participated topics » affordance, so it's the only tab where
-                // a fully-read category must survive the filter when the user opted in.
-                keepFullyReadSections = type == FlagType.CYAN && showRead,
+                result = filterUnreadOnly(result, unreadOnly),
+                // The « +lus » override: keep fully-read categories under « masquer les catégories
+                // sans non-lu » ONLY on CYAN when its unread filter is off — i.e. the user explicitly
+                // opted to see read participated topics, so this filter must not hide them right back.
+                // RED/FAVORITE default to showing read topics, but there hide-read keeps its literal
+                // meaning (drop categories without an unread flag), preserving the #179/#309 behaviour.
+                keepFullyReadSections = type == FlagType.CYAN && !unreadOnly,
             )
         }
             // #225 — keep the existing list anchored during a user refresh instead of blanking
@@ -232,9 +225,10 @@ class FlagsViewModel @Inject constructor(
     }
 
     /**
-     * Carries the cyan « +lus » override alongside the filtered [result] so it travels as one
-     * unit through [keepContentDuringRefresh] and the outer `combine` (cf.
-     * [authenticatedFlagsListState]).
+     * Carries the « +lus » decision ([keepFullyReadSections]) alongside the filtered [result] so it
+     * travels as one unit through [keepContentDuringRefresh] and the outer `combine` (cf.
+     * [authenticatedFlagsListState]). It is the CYAN-specific override (`type == CYAN && !unreadOnly`,
+     * #317) — RED/FAVORITE always pass `false` so hide-read keeps its literal meaning there.
      */
     private data class FilteredFlags(
         val result: FlagsResult,
@@ -274,17 +268,18 @@ class FlagsViewModel @Inject constructor(
     val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
 
     /**
-     * Tab selection. Re-tapping [FlagTab.Cyan] while it is **already** selected toggles
-     * [showReadParticipatedTopics] (show / hide the already-read participated topics) —
-     * the inline replacement for the former « Cyans lus » FilterChip. Selecting Cyan from
+     * Tab selection. Re-tapping [FlagTab.Cyan] while it is **already** selected toggles its
+     * « non-lus uniquement » filter (show / hide the already-read participated topics) — the « +lus »
+     * shortcut, inline replacement for the former « Cyans lus » FilterChip. Selecting Cyan from
      * another tab only switches to it (no toggle). Other tabs just switch.
      */
     fun selectTab(tab: FlagTab) {
         if (tab == FlagTab.Cyan && _selectedTab.value == FlagTab.Cyan) {
-            // Re-tapping the already-selected Cyan tab toggles the read-cyan filter. Route the
-            // mutation through [setShowReadParticipatedTopics] so that setter stays the single
-            // mutation point for `_showReadParticipatedTopics` (no second code path to drift).
-            setShowReadParticipatedTopics(!_showReadParticipatedTopics.value)
+            // Re-tapping the already-selected Cyan tab toggles its « non-lus uniquement » filter
+            // (the « +lus » shortcut). It flips the CYAN per-type value, persisted via
+            // [setFlagsUnreadOnly] — the same write the bottom-sheet toggle uses (single mutation
+            // point). `flagsViewSettings.value` is the CYAN resolution while Cyan is selected.
+            setFlagsUnreadOnly(!flagsViewSettings.value.unreadOnly)
             return
         }
         _selectedTab.value = tab
@@ -333,8 +328,17 @@ class FlagsViewModel @Inject constructor(
         _removeFlagEvent.value = null
     }
 
-    fun setShowReadParticipatedTopics(value: Boolean) {
-        _showReadParticipatedTopics.value = value
+    /**
+     * Bottom-sheet write (and CYAN re-tap shortcut) for « non-lus uniquement » (#317). Always writes
+     * the CURRENT tab's per-type value — unlike the layout toggles, this filter is never global, so
+     * there is no override routing. Super has no real [FlagType], so it is a no-op there (the sheet
+     * trigger is hidden on Super anyway).
+     */
+    fun setFlagsUnreadOnly(enabled: Boolean) {
+        val type = _selectedTab.value.flagType ?: return
+        viewModelScope.launch {
+            userPreferencesRepository.setFlagsUnreadOnlyForType(type, enabled)
+        }
     }
 
     /**
@@ -410,9 +414,11 @@ class FlagsViewModel @Inject constructor(
      * [FALLBACK_CATEGORY_ORDER] kicks in until the real catalogue arrives, so flags appear
      * immediately on a cold start and no flag is ever lost (anti-regression #251).
      *
-     * [groupByCategory] / [hideReadCategories] are the two persisted Drapeaux view preferences
+     * [groupByCategory] / [hideReadCategories] are the two persisted Drapeaux layout preferences
      * (#179 follow-up): flat vs grouped layout, and whether to hide categories without an unread
-     * flag. [keepFullyReadSections] is the cyan « +lus » override forwarded from [FilteredFlags].
+     * flag. [keepFullyReadSections] (the CYAN « +lus » override, #317) is forwarded from
+     * [FilteredFlags]: when CYAN explicitly shows read topics, its fully-read categories survive the
+     * hide filter so those topics stay reachable.
      */
     private fun toFlagsListUiState(
         flagsResult: FlagsResult,
@@ -476,17 +482,14 @@ class FlagsViewModel @Inject constructor(
         else -> FALLBACK_CATEGORY_ORDER
     }
 
-    private fun filterReadParticipatedIfNeeded(
-        result: FlagsResult,
-        type: FlagType,
-        showReadParticipated: Boolean,
-    ): FlagsResult {
-        // CYAN is the only bucket where « topics already finished reading » legitimately
-        // pollutes the actionable view (the user *participated*, then moved on). RED
-        // (« Lus uniquement » — topics watched without participation) and FAVORITE
-        // (bookmarks) are not filtered: their value comes from listing both read and
-        // unread entries.
-        if (type != FlagType.CYAN || showReadParticipated) return result
+    /**
+     * Applies the « non-lus uniquement » filter (#317) when [unreadOnly] is on: keeps only topics
+     * with [fr.forumhfr.redface2.core.model.Flag.hasUnread]. Generalises the former cyan-only
+     * actionable-subset filter to every type — RED and FAVORITE now honour the same toggle (off by
+     * default for them, on by default for CYAN, cf. the type-aware default in the repository).
+     */
+    private fun filterUnreadOnly(result: FlagsResult, unreadOnly: Boolean): FlagsResult {
+        if (!unreadOnly) return result
         return when (result) {
             is FlagsResult.Success -> result.copy(flags = result.flags.filter { it.hasUnread })
             else -> result

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -60,6 +60,10 @@
     <string name="flags_view_settings_group_description">Regroupe les drapeaux par catégorie de forum. Désactivé : liste à plat triée par dernière réponse.</string>
     <string name="flags_view_settings_hide_read_title">Masquer les catégories sans non-lu</string>
     <string name="flags_view_settings_hide_read_description">Cache les catégories sans message non lu. Sans effet en vue à plat.</string>
+    <!-- #317 — Filtre « non-lus uniquement », toujours propre à l'onglet (indépendant de « par
+         onglet » ci-dessus). Activé par défaut sur « Mes sujets », désactivé sur Lu et Favoris. -->
+    <string name="flags_view_settings_unread_only_title">Non-lus uniquement</string>
+    <string name="flags_view_settings_unread_only_description">N\'affiche que les sujets avec un message non lu. Propre à cet onglet.</string>
     <string name="flags_view_settings_done">Fermer</string>
 
     <!-- #99 — Retirer un drapeau (delflag). Action sur chaque ligne + dialog de confirmation

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -233,6 +233,31 @@ class FlagsViewModelTest {
         assertEquals(true, vm.flagsViewSettings.value.unreadOnly)
     }
 
+    @Test
+    fun `rapid double re-tap on Cyan flips twice via the optimistic value`() = runTest {
+        // #317 review (cf. #309 shim): a re-tap reads the RESOLVED settings (an async DataStore
+        // flow). Without the optimistic [pendingUnreadOnly], a second rapid re-tap before the first
+        // write commits would read the SAME lagging value and lose the toggle. Gate the write so
+        // both re-taps fire before either persists, then prove the value still ends at its start
+        // (true → false → true) — i.e. the second tap flipped from the optimistic `false`.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val prefs = FakeUserPreferencesRepository() // CYAN default unreadOnly = true
+        prefs.blockUnreadOnlySetUntil = kotlinx.coroutines.CompletableDeferred()
+        val vm = FlagsViewModel(auth, flags, forum, prefs)
+
+        vm.selectTab(FlagTab.Cyan) // re-tap: true → write(false) gated, pending = false
+        vm.selectTab(FlagTab.Cyan) // re-tap: reads optimistic false → write(true) gated, pending = true
+        prefs.blockUnreadOnlySetUntil!!.complete(Unit) // release both gated writes (FIFO)
+
+        assertEquals(
+            "two rapid re-taps must net back to the start, not lose the second flip",
+            true,
+            vm.flagsViewSettings.value.unreadOnly,
+        )
+    }
+
     // Round-2 review (PR #207): the `logout clears the private flags cache before resetting
     // auth state` test moved to `AppAccountViewModelTest`. `FlagsViewModel.logout()` is gone —
     // the global account menu (#198) now drives the logout from `AppAccountViewModel` which
@@ -1314,7 +1339,12 @@ class FlagsViewModelTest {
             perTypeHide.getValue(type).value = enabled
         }
 
+        /** When set, gates the unreadOnly write so a test can prove the re-tap uses the OPTIMISTIC
+         * value while the DataStore round-trip is still in flight. */
+        var blockUnreadOnlySetUntil: kotlinx.coroutines.CompletableDeferred<Unit>? = null
+
         override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) {
+            blockUnreadOnlySetUntil?.await()
             perTypeUnread.getValue(type).value = enabled
         }
 

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -198,18 +198,18 @@ class FlagsViewModelTest {
     }
 
     @Test
-    fun `re-tapping the already selected Cyan tab toggles the read participated filter`() = runTest {
+    fun `re-tapping the already selected Cyan tab toggles its unread-only filter`() = runTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val vm = viewModel(auth, flags, forum)
 
-        // Cyan is selected by default; re-tapping it flips the toggle on, then off.
-        assertEquals(false, vm.showReadParticipatedTopics.value)
+        // CYAN defaults to unreadOnly = true (« +lus » off); re-tapping it flips it off, then on.
+        assertEquals(true, vm.flagsViewSettings.value.unreadOnly)
         vm.selectTab(FlagTab.Cyan)
-        assertEquals(true, vm.showReadParticipatedTopics.value)
+        assertEquals(false, vm.flagsViewSettings.value.unreadOnly)
         vm.selectTab(FlagTab.Cyan)
-        assertEquals(false, vm.showReadParticipatedTopics.value)
+        assertEquals(true, vm.flagsViewSettings.value.unreadOnly)
         // Re-tap must not switch the selected tab or trigger a refetch.
         assertEquals(FlagTab.Cyan, vm.selectedTab.value)
         assertTrue("re-tap must not refetch", flags.refreshCalls.isEmpty())
@@ -223,12 +223,14 @@ class FlagsViewModelTest {
         val vm = viewModel(auth, flags, forum)
 
         vm.selectTab(FlagTab.Red)
-        assertEquals(false, vm.showReadParticipatedTopics.value)
+        // RED defaults to unreadOnly = false (show all).
+        assertEquals(false, vm.flagsViewSettings.value.unreadOnly)
 
-        // First tap on Cyan from RED selects it without toggling the filter.
+        // First tap on Cyan from RED selects it WITHOUT toggling — CYAN keeps its default (true),
+        // it is not flipped off as a re-tap would do.
         vm.selectTab(FlagTab.Cyan)
         assertEquals(FlagTab.Cyan, vm.selectedTab.value)
-        assertEquals(false, vm.showReadParticipatedTopics.value)
+        assertEquals(true, vm.flagsViewSettings.value.unreadOnly)
     }
 
     // Round-2 review (PR #207): the `logout clears the private flags cache before resetting
@@ -300,7 +302,7 @@ class FlagsViewModelTest {
     }
 
     @Test
-    fun `setShowReadParticipatedTopics true reveals read CYAN topics without refetch`() = runTest {
+    fun `setFlagsUnreadOnly false reveals read CYAN topics without refetch`() = runTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
@@ -318,11 +320,12 @@ class FlagsViewModelTest {
                     ),
                 ),
             )
+            // CYAN defaults to unreadOnly = true, so the read topic (2) is filtered out at first.
             assertEquals(listOf(1), flatTopics(awaitItem() as FlagsListUiState.Success).map { it.topicId })
 
-            vm.setShowReadParticipatedTopics(true)
-            // No new refresh() call — the toggle alone must re-emit the unfiltered list
-            // because flagsState combines the source flow with showReadParticipatedTopics.
+            vm.setFlagsUnreadOnly(false)
+            // No new refresh() call — the toggle alone must re-emit the unfiltered list because
+            // flagsState combines the source flow with the resolved unreadOnly value.
             val full = awaitItem() as FlagsListUiState.Success
             assertEquals(listOf(1, 2), flatTopics(full).map { it.topicId })
             assertTrue("toggle must not trigger a network refresh", flags.refreshCalls.isEmpty())
@@ -332,7 +335,9 @@ class FlagsViewModelTest {
     }
 
     @Test
-    fun `RED and FAVORITE tabs are never filtered by the read participated toggle`() = runTest {
+    fun `RED and FAVORITE show every topic by default (unread-only off)`() = runTest {
+        // #317: unreadOnly is type-aware — RED and FAVORITE default to false (show all), unlike
+        // CYAN. With no toggle set, both list read and unread topics.
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
@@ -353,7 +358,7 @@ class FlagsViewModelTest {
             )
             val red = awaitItem() as FlagsListUiState.Success
             assertEquals(
-                "RED must include both read and unread regardless of the toggle",
+                "RED defaults to show all (unreadOnly false)",
                 listOf(10, 11),
                 flatTopics(red).map { it.topicId },
             )
@@ -370,10 +375,51 @@ class FlagsViewModelTest {
             )
             val favorite = awaitItem() as FlagsListUiState.Success
             assertEquals(
-                "FAVORITE must include both read and unread regardless of the toggle",
+                "FAVORITE defaults to show all (unreadOnly false)",
                 listOf(20, 21),
                 flatTopics(favorite).map { it.topicId },
             )
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setFlagsUnreadOnly true filters RED to unread topics only`() = runTest {
+        // #317: the filter now generalises to every type — toggling unreadOnly on RED keeps only
+        // the topics with an unread post, per the selected tab's own value.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1))
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val vm = viewModel(auth, flags, forum)
+
+        vm.flagsState.test {
+            awaitItem() // initial null
+
+            vm.selectTab(FlagTab.Red)
+            flags.emit(
+                FlagType.RED,
+                FlagsResult.Success(
+                    listOf(
+                        stubFlag(10, FlagType.RED, hasUnread = true),
+                        stubFlag(11, FlagType.RED, hasUnread = false),
+                    ),
+                ),
+            )
+            assertEquals(
+                "RED shows all before the toggle",
+                listOf(10, 11),
+                flatTopics(awaitItem() as FlagsListUiState.Success).map { it.topicId },
+            )
+
+            vm.setFlagsUnreadOnly(true) // RED is selected → flips RED's per-type value.
+            val filtered = awaitItem() as FlagsListUiState.Success
+            assertEquals(
+                "RED now keeps only the unread topic, without a refetch",
+                listOf(10),
+                flatTopics(filtered).map { it.topicId },
+            )
+            assertTrue("toggle must not trigger a network refresh", flags.refreshCalls.isEmpty())
 
             cancelAndIgnoreRemainingEvents()
         }
@@ -704,8 +750,8 @@ class FlagsViewModelTest {
 
     @Test
     fun `cyan +lus override keeps a fully-read category visible under hide-read`() = runTest {
-        // The tension the user flagged: « +lus » (show read participated topics) must win over
-        // « masquer les catégories sans non-lu » so the read cyans stay reachable.
+        // The tension the user flagged: « +lus » (unreadOnly off → show read participated topics)
+        // must win over « masquer les catégories sans non-lu » so the read cyans stay reachable.
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository(catIds = listOf(1, 10))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
@@ -714,7 +760,7 @@ class FlagsViewModelTest {
 
         vm.flagsState.test {
             awaitItem() // initial null
-            vm.setShowReadParticipatedTopics(true)
+            vm.setFlagsUnreadOnly(false)
             flags.emit(
                 FlagType.CYAN,
                 FlagsResult.Success(
@@ -1180,10 +1226,12 @@ class FlagsViewModelTest {
 
     /**
      * Fake [UserPreferencesRepository] modelling the Drapeaux view preferences the ViewModel reads:
-     * the global group-by-category / hide-read pair, the #309 per-tab override master switch, and
-     * the per-type overrides — as writable hot flows. [observeFlagsViewSettings] resolves them the
-     * same way the real DataStore impl does (override off → global; on → per-type value, else global
-     * fallback). The proxy and topic-cache members are stubbed at their defaults (untouched here).
+     * the global group-by-category / hide-read pair, the #309 per-tab override master switch, the
+     * per-type layout overrides, and the #317 per-type « non-lus uniquement » value — as writable
+     * hot flows. [observeFlagsViewSettings] resolves them the same way the real DataStore impl does
+     * (layout: override off → global; on → per-type value, else global fallback; unreadOnly: ALWAYS
+     * per-type with a type-aware default — CYAN true, RED/FAVORITE false). The proxy and topic-cache
+     * members are stubbed at their defaults (untouched here).
      */
     private class FakeUserPreferencesRepository(
         groupByCategory: Boolean = true,
@@ -1196,6 +1244,9 @@ class FlagsViewModelTest {
         private val perTypeGroup: Map<FlagType, MutableStateFlow<Boolean?>> =
             FlagType.entries.associateWith { MutableStateFlow<Boolean?>(null) }
         private val perTypeHide: Map<FlagType, MutableStateFlow<Boolean?>> =
+            FlagType.entries.associateWith { MutableStateFlow<Boolean?>(null) }
+        // #317 — per-type « non-lus uniquement », null = unset → type-aware default applied at read.
+        private val perTypeUnread: Map<FlagType, MutableStateFlow<Boolean?>> =
             FlagType.entries.associateWith { MutableStateFlow<Boolean?>(null) }
 
         /** When set, holds the persisted master write so a test can prove routing uses the
@@ -1230,8 +1281,10 @@ class FlagsViewModelTest {
             perTab.value = enabled
         }
 
-        override fun observeFlagsViewSettings(type: FlagType): Flow<FlagsViewSettings> =
-            combine(
+        override fun observeFlagsViewSettings(type: FlagType): Flow<FlagsViewSettings> {
+            // Layout resolution (#309), then fold in the always-per-type unreadOnly (#317). Nested
+            // combine because the typed `combine` overload tops out at 5 sources.
+            val layout = combine(
                 groupBy,
                 hideRead,
                 perTab,
@@ -1239,11 +1292,18 @@ class FlagsViewModelTest {
                 perTypeHide.getValue(type),
             ) { global, globalHide, override, typeGroup, typeHide ->
                 if (override) {
-                    FlagsViewSettings(typeGroup ?: global, typeHide ?: globalHide)
+                    (typeGroup ?: global) to (typeHide ?: globalHide)
                 } else {
-                    FlagsViewSettings(global, globalHide)
+                    global to globalHide
                 }
             }
+            return combine(layout, perTypeUnread.getValue(type)) { (group, hide), unread ->
+                FlagsViewSettings(group, hide, unread ?: defaultUnreadOnly(type))
+            }
+        }
+
+        // Mirrors DataStoreUserPreferencesRepository.defaultUnreadOnly (CYAN actionable by default).
+        private fun defaultUnreadOnly(type: FlagType): Boolean = type == FlagType.CYAN
 
         override suspend fun setFlagsGroupByCategoryForType(type: FlagType, enabled: Boolean) {
             perTypeGroup.getValue(type).value = enabled
@@ -1252,6 +1312,10 @@ class FlagsViewModelTest {
 
         override suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean) {
             perTypeHide.getValue(type).value = enabled
+        }
+
+        override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) {
+            perTypeUnread.getValue(type).value = enabled
         }
 
         fun setGroupBy(value: Boolean) {

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -236,7 +236,7 @@ class FlagsViewModelTest {
     @Test
     fun `rapid double re-tap on Cyan flips twice via the optimistic value`() = runTest {
         // #317 review (cf. #309 shim): a re-tap reads the RESOLVED settings (an async DataStore
-        // flow). Without the optimistic [pendingUnreadOnly], a second rapid re-tap before the first
+        // flow). Without the optimistic [pendingCyanUnreadOnly], a second rapid re-tap before the first
         // write commits would read the SAME lagging value and lose the toggle. Gate the write so
         // both re-taps fire before either persists, then prove the value still ends at its start
         // (true → false → true) — i.e. the second tap flipped from the optimistic `false`.
@@ -256,6 +256,31 @@ class FlagsViewModelTest {
             true,
             vm.flagsViewSettings.value.unreadOnly,
         )
+    }
+
+    @Test
+    fun `an in-flight RED write never clobbers the CYAN re-tap shim`() = runTest {
+        // #317 Codex review: the optimistic shim is CYAN-scoped, so a concurrent (or late-completing)
+        // RED/FAVORITE write must never touch — let alone clear — CYAN's pending flip. Gate ONLY the
+        // RED write so it stays in flight while CYAN is re-tapped, then release it and assert CYAN
+        // kept its flip.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val prefs = FakeUserPreferencesRepository() // CYAN default unreadOnly = true
+        prefs.blockUnreadOnlySetForType = FlagType.RED
+        prefs.blockUnreadOnlySetUntil = kotlinx.coroutines.CompletableDeferred()
+        val vm = FlagsViewModel(auth, flags, forum, prefs)
+
+        vm.selectTab(FlagTab.Red)
+        vm.setFlagsUnreadOnly(false) // RED write goes in flight (gated), must not touch the CYAN shim
+
+        vm.selectTab(FlagTab.Cyan) // select CYAN (first tap from RED)
+        vm.selectTab(FlagTab.Cyan) // re-tap CYAN → flips true → false via its own shim
+        assertEquals("CYAN re-tap flips regardless of the in-flight RED write", false, vm.cyanUnreadOnly.value)
+
+        prefs.blockUnreadOnlySetUntil!!.complete(Unit) // late RED completion
+        assertEquals("late RED completion must not disturb CYAN's value", false, vm.cyanUnreadOnly.value)
     }
 
     // Round-2 review (PR #207): the `logout clears the private flags cache before resetting
@@ -1340,11 +1365,15 @@ class FlagsViewModelTest {
         }
 
         /** When set, gates the unreadOnly write so a test can prove the re-tap uses the OPTIMISTIC
-         * value while the DataStore round-trip is still in flight. */
+         * value while the DataStore round-trip is still in flight. [blockUnreadOnlySetForType] scopes
+         * the gate to one type (null = gate every type). */
         var blockUnreadOnlySetUntil: kotlinx.coroutines.CompletableDeferred<Unit>? = null
+        var blockUnreadOnlySetForType: FlagType? = null
 
         override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) {
-            blockUnreadOnlySetUntil?.await()
+            if (blockUnreadOnlySetForType == null || blockUnreadOnlySetForType == type) {
+                blockUnreadOnlySetUntil?.await()
+            }
             perTypeUnread.getValue(type).value = enabled
         }
 

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -622,6 +622,8 @@ class SettingsViewModelTest {
 
         override suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean) = Unit
 
+        override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) = Unit
+
         fun emit(value: ProxyConfig) {
             config.value = value
         }


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

## Objectif (#317)

Filtre « non-lus uniquement » **par type de drapeau**, généralisant l'ancien filtre cyan en mémoire en un réglage `unreadOnly` persistant par `FlagType`.

PR **stackée sur `feat/309-flags-per-type-display`** (PR #315) : la base se retargetera sur `main` une fois #309 mergée. Le diff ici ne contient que le delta #317.

## Décision de design : `unreadOnly` est TOUJOURS par type

Contrairement aux toggles de disposition #309 (global avec override per-tab optionnel), `unreadOnly` est **toujours par type**, car « ne montrer que les non-lus » a un défaut naturellement type-spécifique :

| Type | Défaut `unreadOnly` | Sens |
|---|---|---|
| CYAN (« Mes sujets ») | `true` | sous-ensemble actionnable (comportement legacy) |
| RED (« Lus ») | `false` | tout afficher |
| FAVORITE | `false` | tout afficher |

Le défaut type-aware est appliqué **à la résolution** dans le repository (`defaultUnreadOnly`), pas dans le constructeur de `FlagsViewSettings` (qui reste `false` = safe « tout afficher »).

## Changements par couche

- **`:core:domain`** — `FlagsViewSettings.unreadOnly` + `UserPreferencesRepository.setFlagsUnreadOnlyForType`, KDoc détaillant le contrat per-type.
- **`:core:data`** — clé DataStore `flags_unread_only_<type>` (dérivée du nom d'enum), résolution avec défaut type-aware, jamais de fuite inter-type.
- **`:feature:flags` (ViewModel)** — `filterUnreadOnly` appliqué à **tous** les types ; le re-tap cyan « +lus » devient un toggle **persistant** de `unreadOnly` (même point de mutation que le bottom sheet) ; suppression de l'ancien `_showReadParticipatedTopics` en mémoire.
- **`:feature:flags` (UI)** — toggle « Non-lus uniquement » dans le bottom sheet d'affichage, toujours par onglet (description explicite « Propre à cet onglet »), au-dessus de « Fermer ».
- **`keepFullyReadSections`** reste l'override « +lus » **spécifique à CYAN** (`type == CYAN && !unreadOnly`) : hide-read garde son sens littéral sur RED/FAVORITE (comportement #179/#309 **préservé**, pas de régression hors-scope).

## Tests

- Défaut type-aware DataStore (CYAN true, RED/FAVORITE false).
- Persistance per-type sans fuite inter-type, indépendante du master per-tab.
- Filtre RED activable (généralisation), CYAN re-tap toggle, conversions des tests `showReadParticipated` → `unreadOnly`.
- Fakes mis à jour dans les 3 implémenteurs de test (`FlagsViewModelTest`, `SettingsViewModelTest`, `TopicRepositoryImplTest`).

## Validation

Docker pin (`scripts/docker-dev.sh`) : `detektAll`, `test` (51 tests flags+data verts), `lintDebug`, `:app:lintProdDebug`, `:app:assembleProdDebug` — **tous verts**.

Closes #317
