### PR TITLE
ci(release): guard versionName bumpé pour un ship beta (anti-doublon F-Droid)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,12 @@ name: Release
 # beta-vs-dev inversion). The run creates a prerelease `app-v<N>` carrying the signed artefacts, so
 # the F-Droid publisher (which downloads from a Release) has a source. `concurrency` serialises runs
 # so two dispatches never allocate the same code. Prod/stable is deferred (#302/#304) — set aside.
+#
+# versionName (MARKETING, manual): decoupled from versionCode. MUST be bumped in app/build.gradle.kts
+# before EVERY public (beta) ship — F-Droid keys its version display on versionName, so two builds at
+# the same versionName show as duplicate "X.Y.Z" entries (happened with app-v84/v85, both 0.5.0). A
+# guard step (below) fails a beta ship whose versionName matches the previous beta release. dev is
+# exempt (it adds a versionNameSuffix).
 on:
   workflow_dispatch:
     inputs:
@@ -196,6 +202,43 @@ jobs:
             echo "release_tag=$release_tag"
           } >> "$GITHUB_OUTPUT"
           echo "::notice title=Build::channel=${CHANNEL} versionCode=${version_code} (ledger=${ledger_code} floor=${base_code}) versionName=${version_name} tag=${release_tag} sha=${short_sha} label='${APP_LABEL:-<default>}'"
+
+      - name: Guard — versionName must be bumped for a beta (public) ship
+        if: ${{ env.CHANNEL == 'beta' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CURRENT_VN: ${{ steps.meta.outputs.version_name }}
+        run: |
+          set -euo pipefail
+          # The beta track is PUBLIC (Play open testing + F-Droid). F-Droid keys its version display on
+          # versionName (not versionCode), so two beta builds at the same versionName show up as
+          # DUPLICATE "X.Y.Z" entries in the version history. versionCode is auto-allocated from the tag
+          # ledger; versionName is the ONLY manual knob — it MUST be bumped in app/build.gradle.kts before
+          # each beta ship. This guard refuses a beta whose versionName was already shipped to beta.
+          # Runs right after metadata resolution, BEFORE the build / ledger tag / Play upload, so a
+          # failure aborts with no side effect. (dev is exempt: it carries a versionNameSuffix.)
+          # Previous beta releases are the GitHub Releases whose name carries the "β" marker.
+          prev=$(gh release list --repo ForumHFR/redface2 --limit 100 --json tagName,name \
+                   --jq '[.[] | select(.name | contains("β")) | .tagName | capture("^app-v(?<n>[0-9]+)$") | .n | tonumber] | max // 0')
+          if [[ "$prev" == "0" ]]; then
+            echo "::notice::No previous beta release found — versionName bump guard is a no-op (first beta)."
+            exit 0
+          fi
+          prev_tag="app-v${prev}"
+          git fetch --depth=1 origin "refs/tags/${prev_tag}:refs/tags/${prev_tag}" >/dev/null 2>&1 || true
+          prev_vn=$(git show "${prev_tag}:app/build.gradle.kts" 2>/dev/null \
+                     | grep -E '^[[:space:]]+versionName[[:space:]]*=' | head -1 | sed -E 's/.*"(.*)".*/\1/' || true)
+          if [[ -z "$prev_vn" ]]; then
+            echo "::warning::Could not read versionName from ${prev_tag} (shallow history?); skipping the bump guard rather than blocking a legit ship."
+            exit 0
+          fi
+          echo "current versionName='${CURRENT_VN}' | previous beta ${prev_tag} versionName='${prev_vn}'"
+          if [[ "$CURRENT_VN" == "$prev_vn" ]]; then
+            echo "::error::versionName '${CURRENT_VN}' was already shipped to the public beta track (${prev_tag}). Bump versionName in app/build.gradle.kts before a beta ship — two builds at the same versionName produce duplicate entries on F-Droid."
+            exit 1
+          fi
+          echo "::notice::versionName bump OK for beta (${prev_vn} → ${CURRENT_VN})."
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,8 +219,10 @@ jobs:
           # Runs right after metadata resolution, BEFORE the build / ledger tag / Play upload, so a
           # failure aborts with no side effect. (dev is exempt: it carries a versionNameSuffix.)
           # Previous beta releases are the GitHub Releases whose name carries the "β" marker.
+          # test()+ltrimstr (not capture): capture() THROWS on a non-matching string, which would abort
+          # the whole jq under `set -e` and spuriously fail a legit beta ship. test() filters first.
           prev=$(gh release list --repo ForumHFR/redface2 --limit 100 --json tagName,name \
-                   --jq '[.[] | select(.name | contains("β")) | .tagName | capture("^app-v(?<n>[0-9]+)$") | .n | tonumber] | max // 0')
+                   --jq '[.[] | select(.name | contains("β")) | select(.tagName | test("^app-v[0-9]+$")) | (.tagName | ltrimstr("app-v") | tonumber)] | max // 0')
           if [[ "$prev" == "0" ]]; then
             echo "::notice::No previous beta release found — versionName bump guard is a no-op (first beta)."
             exit 0

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,20 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## v86 — `0.5.1` — 2026-06-07
+
+**Statut** : `open` (track open testing) + F-Droid `.beta`
+**Commit** : tag `app-v86` (versionCode alloué par le registre de tags, plancher 72)
+**Fichier** : AAB `bundleProdRelease` (`fr.forumhfr.redface2`) → **track open testing** + tag pour F-Droid beta
+
+**Bump `versionName` 0.5.0 → 0.5.1.** Aucun changement fonctionnel vs v85 : même code (MP lecture, swipe, drapeaux par catégorie/type/non-lus, fix vie privée). Le bump corrige l'historique de version : v84 et v85 avaient été shippés tous deux sous `0.5.0`, créant un doublon « 0.5.0 » sur F-Droid (qui affiche par `versionName`). L'APK v84 a été retiré du dépôt F-Droid (workflow `prune.yml` de redface2-fdroid) et la v86 repart proprement en `0.5.1`.
+
+### Changed
+- **`versionName` 0.5.0 → 0.5.1** (re-label, pas de changement de code).
+- **Guard CI anti-doublon** : `release.yml` refuse désormais un ship `channel=beta` dont le `versionName` n'a pas été bumpé vs la release beta précédente. Doc (guide release, instruction CHANGELOG) : bump `versionName` obligatoire avant un ship public.
+
+---
+
 ## v85 — `0.5.0` — 2026-06-07
 
 **Statut** : `open` (track open testing) + F-Droid `.beta`

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -12,7 +12,7 @@ Statuts possibles d'une release :
 - `open` — uploadé sur le canal Play Console *open testing* (canal `beta` de la CD, depuis #233)
 - `production` — disponible publiquement sur Play Store
 
-Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la main** — il est alloué au dispatch par le **registre de tags git** (`max(app-v<N>, plancher build.gradle.kts) + 1`, partagé entre les canaux beta et dev). On bumpe seulement `versionName` dans `app/build.gradle.kts` si pertinent, on ajoute une entrée ici, puis on dispatche `gh workflow run release.yml --ref main -f channel=beta|dev`. Quand l'AAB part vers un canal Play Console, mettre à jour le statut de la version concernée.
+Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la main** — il est alloué au dispatch par le **registre de tags git** (`max(app-v<N>, plancher build.gradle.kts) + 1`, partagé entre les canaux beta et dev). **On DOIT bumper `versionName`** dans `app/build.gradle.kts` avant chaque ship **beta** (ou prod) — F-Droid affiche les versions par `versionName`, donc deux builds au même `versionName` = doublon « X.Y.Z » (cf. `app-v84`/`app-v85`, tous deux `0.5.0`). Un guard CI dans `release.yml` refuse un ship beta dont le `versionName` n'a pas été bumpé. On ajoute une entrée ici, puis on dispatche `gh workflow run release.yml --ref main -f channel=beta|dev`. Quand l'AAB part vers un canal Play Console, mettre à jour le statut de la version concernée.
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.5.0"
+        versionName = "0.5.1"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,8 +1,9 @@
-Redface 2 v0.5.0 — beta.
+Redface 2 v0.5.1 — beta.
 
 New:
-- Private messages (read-only): your inbox and conversations right in the Messages tab.
-- Swipe left/right to change page within a topic (the page follows your finger, instant transition).
+- Private messages (read-only): your inbox and conversations in the Messages tab.
+- Swipe left/right to change page within a topic (the page follows your finger).
+- Flags: group by category, per-type display settings, "unread only" filter.
 
 Fixed: a private-message error message could reveal a private conversation's address.
 

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,8 +1,9 @@
-Redface 2 v0.5.0 — bêta.
+Redface 2 v0.5.1 — bêta.
 
 Nouveautés :
-- Messages privés en lecture : ta boîte de réception et tes conversations, directement dans l'onglet Messages.
-- Changement de page dans un sujet par swipe gauche/droite (la page suit le doigt, transition instantanée).
+- Messages privés en lecture : ta boîte de réception et tes conversations dans l'onglet Messages.
+- Swipe gauche/droite pour changer de page dans un sujet (la page suit le doigt).
+- Drapeaux : regroupement par catégorie, réglages d'affichage par type, filtre « non-lus uniquement ».
 
 Corrigé : un message d'erreur des MP pouvait laisser apparaître l'adresse d'une conversation privée.
 

--- a/docs/guides/release.md
+++ b/docs/guides/release.md
@@ -99,7 +99,9 @@ Le workflow refuse de tourner si `UPLOAD_KEYSTORE_BASE64` est manquant (un build
 - crée la Release pre-release `app-v<N>` avec AAB+APK Play **et** l'APK F-Droid `.beta` ;
 - notifie F-Droid (package `.beta`).
 
-Plus besoin de bumper `versionCode` à la main ni de publier une Release : le dispatch fait tout. (Mettre à jour `app/CHANGELOG.md` + `versionName` reste utile pour une vraie montée de version marketing.)
+Plus besoin de bumper `versionCode` à la main ni de publier une Release : le dispatch fait tout.
+
+> ⚠️ **Toujours bumper `versionName` avant un ship beta (ou prod).** F-Droid affiche les versions par `versionName` (pas `versionCode`) : deux builds beta au même `versionName` apparaissent comme deux entrées « X.Y.Z » identiques (c'est arrivé avec `app-v84`/`app-v85`, tous deux `0.5.0`). Bumper `versionName` dans `app/build.gradle.kts` (patch au minimum) + ajouter l'entrée `app/CHANGELOG.md`, via PR, **avant** de dispatcher `channel=beta`. Un guard CI (`release.yml`, step « Guard — versionName must be bumped ») **refuse** un ship beta dont le `versionName` est identique à celui de la release beta précédente. Le canal `dev` est exempté (il ajoute un `versionNameSuffix`).
 
 ## Flux dev — Play internal + F-Droid `.dev` (rapide)
 


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

**Problème** : `app-v84` et `app-v85` ont été shippés tous deux sous `versionName 0.5.0` → F-Droid (qui affiche par `versionName`, pas `versionCode`) montrait deux entrées « 0.5.0 ». Le doublon a été nettoyé côté F-Droid (prune v84 dans redface2-fdroid). Cette PR empêche que ça se reproduise.

**Guard** : nouveau step dans `release.yml`, après la résolution des métadonnées et **avant** le build / tag-ledger / upload Play (échec = zéro effet de bord). Pour `channel=beta`, lit le `versionName` de la release beta précédente (nom de Release marqueur « β » → tag → `app/build.gradle.kts` à ce tag) et échoue si le `versionName` courant est identique. `dev` exempté (`versionNameSuffix`). Warn+skip si le `versionName` précédent est illisible (ne pas bloquer un ship légitime sur un aléa).

**Doc** : en-tête `release.yml`, `docs/guides/release.md`, instruction CHANGELOG → bump `versionName` obligatoire pour beta/prod.

Validé : YAML parse OK. Le guard aurait refusé le ship v85 (0.5.0 == v84 0.5.0) — comportement voulu.

Closes-#aucune (pas d'issue dédiée ; suite directe du feedback « toujours bump de version »).