### PR TITLE
feat: batch Phase 5 — UX lecture topic, thème, bouton Envoyer, pseudo & citations

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTop"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustNothing">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:launchMode="singleTop">
+            android:launchMode="singleTop"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
@@ -1,0 +1,35 @@
+package fr.forumhfr.redface2.navigation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * App-root theme state (#286). Exposes the persisted [ThemeMode] and AMOLED toggle so
+ * [RedfaceApp] can compute the effective dark theme passed to `RedfaceTheme` (which previously
+ * only read `isSystemInDarkTheme()`).
+ *
+ * [SharingStarted.Eagerly] so the first DataStore read starts as soon as the ViewModel is created,
+ * keeping the initial-frame window where the default ([ThemeMode.SYSTEM] / amoled off) is shown as
+ * short as possible. Only a user who picked a non-SYSTEM mode differing from the OS could see a
+ * one-frame flicker, which is acceptable for the default-SYSTEM majority.
+ */
+@HiltViewModel
+class AppThemeViewModel @Inject constructor(
+    userPreferencesRepository: UserPreferencesRepository,
+) : ViewModel() {
+
+    val themeMode: StateFlow<ThemeMode> =
+        userPreferencesRepository.observeThemeMode()
+            .stateIn(viewModelScope, SharingStarted.Eagerly, ThemeMode.SYSTEM)
+
+    val amoledEnabled: StateFlow<Boolean> =
+        userPreferencesRepository.observeAmoledEnabled()
+            .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+}

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
@@ -16,9 +16,11 @@ import kotlinx.coroutines.flow.stateIn
  * only read `isSystemInDarkTheme()`).
  *
  * [SharingStarted.Eagerly] so the first DataStore read starts as soon as the ViewModel is created,
- * keeping the initial-frame window where the default ([ThemeMode.SYSTEM] / amoled off) is shown as
- * short as possible. Only a user who picked a non-SYSTEM mode differing from the OS could see a
- * one-frame flicker, which is acceptable for the default-SYSTEM majority.
+ * keeping the initial-default window as short as possible. The default ([ThemeMode.SYSTEM] / amoled
+ * off) is shown until that first read resolves — a brief flash (not a single frame) that only a user
+ * who forced a non-SYSTEM mode differing from the OS can perceive on a cold start. Acceptable for the
+ * default-SYSTEM majority; a dedicated `Loading` gate is the follow-up if that cold-start flash ever
+ * becomes a complaint.
  */
 @HiltViewModel
 class AppThemeViewModel @Inject constructor(

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -1,7 +1,9 @@
 package fr.forumhfr.redface2.navigation
 
+import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Context
+import android.content.ContextWrapper
 import android.content.Intent
 import android.net.Uri
 import android.widget.Toast
@@ -16,6 +18,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -24,12 +27,14 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
 import androidx.core.net.toUri
+import androidx.core.view.WindowCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
@@ -291,6 +296,23 @@ fun RedfaceApp(intent: Intent?) {
         ThemeMode.LIGHT -> false
         ThemeMode.DARK -> true
         ThemeMode.SYSTEM -> isSystemInDarkTheme()
+    }
+    // #286 — keep the system bar ICON contrast in sync with the EFFECTIVE app theme, not the OS night
+    // mode. MainActivity calls enableEdgeToEdge() once, whose default SystemBarStyle derives bar icon
+    // contrast from the OS uiMode; once the user forces LIGHT/DARK against the OS, the status /
+    // navigation bar icons would otherwise keep the OS contrast (e.g. light icons on a forced-light
+    // background = invisible). SideEffect re-asserts it after each themed recomposition.
+    val view = LocalView.current
+    // Resolve the host Activity defensively (Context.findActivity) instead of casting view.context
+    // directly: RedfaceApp is mounted under MainActivity today, but a future ContextWrapper in the
+    // chain would make a hard `as Activity` cast crash. isInEditMode guards the @Preview path.
+    val window = view.context.findActivity()?.window
+    if (!view.isInEditMode && window != null) {
+        SideEffect {
+            val controller = WindowCompat.getInsetsController(window, view)
+            controller.isAppearanceLightStatusBars = !darkTheme
+            controller.isAppearanceLightNavigationBars = !darkTheme
+        }
     }
     RedfaceTheme(darkTheme = darkTheme, amoledTheme = amoledEnabled) {
         val flagsBackStack = rememberNavBackStack(FlagsListRoute)
@@ -990,6 +1012,16 @@ private fun resetStack(
     if (route != root) {
         backStack.add(route)
     }
+}
+
+/**
+ * #286 — walk the Context chain to the host [Activity] (or null), so the system-bar SideEffect never
+ * crashes on a non-Activity / ContextWrapper context. Tail-recursive over [ContextWrapper.baseContext].
+ */
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
 }
 
 /** Default NavDisplay cross-fade duration, mirroring nav3 1.1.1 `defaultTransitionSpec` (700 ms). */

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -818,6 +818,28 @@ private fun RedfaceNavHost(
                             scrollTo = null,
                         )
                     },
+                    onBack = {
+                        // #285 — explicit back affordance in the topic top bar. Pop to the screen that
+                        // opened the topic (list / flags). Guard size > 1 so we never pop a tab root
+                        // (mirrors the global back handling used across the other entries).
+                        if (backStack.size > 1) {
+                            backStack.removeAt(backStack.lastIndex)
+                        }
+                    },
+                    onNavigateToLastPage = { lastPage ->
+                        // #226 — the plain reply overflowed onto a freshly created page. Re-route IN
+                        // PLACE to that last page with a fresh submitSignal so its ViewModel force-
+                        // refreshes and anchors the new post at the bottom (ScrollToEndOfPage), instead
+                        // of leaving the user on the stale form page. Indexed set (not removeAt + add)
+                        // for the same single-mutation reason as onOpenPage (#282).
+                        backStack[backStack.lastIndex] = TopicRoute(
+                            cat = route.cat,
+                            post = route.post,
+                            page = lastPage,
+                            scrollTo = null,
+                            submitSignal = System.currentTimeMillis(),
+                        )
+                    },
                 )
             }
             entry<PostEditorRoute> { route ->

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -827,17 +827,18 @@ private fun RedfaceNavHost(
                         }
                     },
                     onNavigateToLastPage = { lastPage ->
-                        // #226 — the plain reply overflowed onto a freshly created page. Re-route IN
-                        // PLACE to that last page with a fresh submitSignal so its ViewModel force-
-                        // refreshes and anchors the new post at the bottom (ScrollToEndOfPage), instead
-                        // of leaving the user on the stale form page. Indexed set (not removeAt + add)
-                        // for the same single-mutation reason as onOpenPage (#282).
+                        // #226 — the plain reply overflowed onto a freshly created page; land the user
+                        // there (their reply lives on the last page, not the stale form page). We do
+                        // NOT carry a submitSignal here: a second force-refresh would re-run the overflow
+                        // guard and, if a concurrent post created yet another page during the refresh
+                        // window, keep chasing the moving tail (review finding). A plain cache-aside load
+                        // surfaces the reply without re-triggering the redirect. Indexed set (not
+                        // removeAt + add) for the same single-mutation reason as onOpenPage (#282).
                         backStack[backStack.lastIndex] = TopicRoute(
                             cat = route.cat,
                             post = route.post,
                             page = lastPage,
                             scrollTo = null,
-                            submitSignal = System.currentTimeMillis(),
                         )
                     },
                 )

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
 import androidx.core.net.toUri
@@ -42,6 +43,7 @@ import androidx.navigation3.ui.NavDisplay
 import fr.forumhfr.redface2.BuildConfig
 import fr.forumhfr.redface2.R
 import fr.forumhfr.redface2.core.model.AuthState
+import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.ui.RedfaceTheme
 import fr.forumhfr.redface2.core.ui.account.RedfaceAccountMenu
 import fr.forumhfr.redface2.feature.auth.LoginScreen
@@ -280,7 +282,17 @@ private data class ProfileSheetRequest(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RedfaceApp(intent: Intent?) {
-    RedfaceTheme {
+    // #286 — resolve the persisted theme selection before applying RedfaceTheme. SYSTEM (default)
+    // keeps the historical isSystemInDarkTheme() behaviour; LIGHT/DARK force the app theme.
+    val themeViewModel: AppThemeViewModel = hiltViewModel()
+    val themeMode by themeViewModel.themeMode.collectAsStateWithLifecycle()
+    val amoledEnabled by themeViewModel.amoledEnabled.collectAsStateWithLifecycle()
+    val darkTheme = when (themeMode) {
+        ThemeMode.LIGHT -> false
+        ThemeMode.DARK -> true
+        ThemeMode.SYSTEM -> isSystemInDarkTheme()
+    }
+    RedfaceTheme(darkTheme = darkTheme, amoledTheme = amoledEnabled) {
         val flagsBackStack = rememberNavBackStack(FlagsListRoute)
         val forumBackStack = rememberNavBackStack(ForumRoute)
         val searchBackStack = rememberNavBackStack(SearchRoute)

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -32,7 +32,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldDefaults
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.core.net.toUri
 import androidx.core.view.WindowCompat
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -284,7 +288,7 @@ private data class ProfileSheetRequest(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3AdaptiveApi::class)
 @Composable
 fun RedfaceApp(intent: Intent?) {
     // #286 — resolve the persisted theme selection before applying RedfaceTheme. SYSTEM (default)
@@ -382,7 +386,20 @@ fun RedfaceApp(intent: Intent?) {
             }
         }
 
+        // #624 — the post/topic editor pins an « Envoyer » bar above the keyboard. Inside the bottom-nav
+        // scaffold that bar sat ABOVE the navigation component, so the window-relative IME inset overshot
+        // it by the nav bar height (the bar floated mid-screen with a gap). Hiding the navigation for editor
+        // routes makes the editor full-screen: its submit bar then sits at the window bottom and the IME
+        // inset lands exactly on the keyboard. Bonus UX: no tab switching mid-compose (would drop the draft).
+        val topRoute = backStacks.getValue(currentDestination).lastOrNull()
+        val navLayoutType = if (topRoute is PostEditorRoute || topRoute is TopicFormRoute) {
+            NavigationSuiteType.None
+        } else {
+            NavigationSuiteScaffoldDefaults.calculateFromAdaptiveInfo(currentWindowAdaptiveInfo())
+        }
+
         NavigationSuiteScaffold(
+            layoutType = navLayoutType,
             navigationSuiteItems = {
                 TopLevelDestination.entries.forEach { destination ->
                     item(

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/auth/DefaultAuthRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/auth/DefaultAuthRepository.kt
@@ -5,6 +5,7 @@ import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.network.auth.AuthRemoteDataSource
 import fr.forumhfr.redface2.core.network.cookie.PersistentCookieJar
+import java.net.URLDecoder
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
@@ -38,7 +39,7 @@ class DefaultAuthRepository @Inject constructor(
         .filterNotNull()
         .map { cookies ->
             val mdUser = cookies.firstOrNull { it.name == COOKIE_MD_USER && it.value.isNotBlank() }
-            if (mdUser != null) AuthState.Authenticated(mdUser.value) else AuthState.Anonymous
+            if (mdUser != null) AuthState.Authenticated(decodePseudo(mdUser.value)) else AuthState.Anonymous
         }
         .distinctUntilChanged()
 
@@ -68,5 +69,17 @@ class DefaultAuthRepository @Inject constructor(
 
     private companion object {
         const val COOKIE_MD_USER = "md_user"
+
+        /**
+         * #260 — HFR stores the pseudo in the `md_user` cookie form-urlencoded, so a pseudo with a
+         * space arrives as e.g. `Dintr-un+lemn`. Decode it here, at the single capture point for the
+         * displayed session pseudo, so every consumer (account menu, …) sees the real pseudo rather
+         * than each display site having to decode. `URLDecoder` also handles `%XX`; the runCatching
+         * fallback (just `+` → space) guards a malformed `%` sequence — HFR's pseudo charset
+         * `[a-zA-Z0-9 _-]` never form-encodes anything but the space, so this is belt-and-braces.
+         */
+        fun decodePseudo(raw: String): String =
+            runCatching { URLDecoder.decode(raw, Charsets.UTF_8.name()) }
+                .getOrDefault(raw.replace('+', ' '))
     }
 }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
+import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.model.FlagType
 import javax.inject.Inject
@@ -143,6 +144,48 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeThemeMode(): Flow<ThemeMode> =
+        dataStore.data
+            // Default SYSTEM: follow the OS dark-mode setting unless the user picked otherwise (#286).
+            .map(::readThemeMode)
+            // `dataStore.data` re-emits on ANY write; keep the theme flow quiet unless the mode
+            // actually changes so RedfaceApp doesn't recompose the whole tree on unrelated edits.
+            .distinctUntilChanged()
+            .catch { emit(ThemeMode.SYSTEM) }
+
+    override suspend fun setThemeMode(mode: ThemeMode) {
+        withContext(ioDispatcher) {
+            dataStore.edit { prefs ->
+                prefs[KEY_THEME_MODE] = mode.name
+            }
+        }
+    }
+
+    override fun observeAmoledEnabled(): Flow<Boolean> =
+        dataStore.data
+            // Default `false`: AMOLED is opt-in and only meaningful in dark (#286).
+            .map { prefs -> prefs[KEY_AMOLED_ENABLED] ?: false }
+            .distinctUntilChanged()
+            .catch { emit(false) }
+
+    override suspend fun setAmoledEnabled(enabled: Boolean) {
+        withContext(ioDispatcher) {
+            dataStore.edit { prefs ->
+                prefs[KEY_AMOLED_ENABLED] = enabled
+            }
+        }
+    }
+
+    /**
+     * Reads [KEY_THEME_MODE] defensively: an unknown / corrupt stored value (older build with a
+     * renamed enum, manual edit) falls back to [ThemeMode.SYSTEM] instead of crashing on
+     * `ThemeMode.valueOf`.
+     */
+    private fun readThemeMode(prefs: Preferences): ThemeMode =
+        prefs[KEY_THEME_MODE]
+            ?.let { stored -> runCatching { ThemeMode.valueOf(stored) }.getOrNull() }
+            ?: ThemeMode.SYSTEM
+
     /**
      * Resolves the per-tab view settings (#309 layout) plus the per-type unreadOnly (#317). For the
      * LAYOUT pair: with the override off, the global pair is returned verbatim; with it on, each
@@ -214,5 +257,9 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         // #317 — per-type « non-lus uniquement » key (no global counterpart; type-aware default).
         fun flagsUnreadOnlyKey(type: FlagType) =
             booleanPreferencesKey("flags_unread_only_${type.name.lowercase()}")
+
+        // #286 — app theme selection (ThemeMode.name, defensively parsed) + AMOLED toggle.
+        val KEY_THEME_MODE = stringPreferencesKey("theme_mode")
+        val KEY_AMOLED_ENABLED = booleanPreferencesKey("amoled_enabled")
     }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/auth/DefaultAuthRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/auth/DefaultAuthRepositoryTest.kt
@@ -47,6 +47,19 @@ class DefaultAuthRepositoryTest {
     }
 
     @Test
+    fun `observeAuthState decodes a form-urlencoded pseudo with a space (#260)`() = runTest {
+        // HFR stores the pseudo in md_user form-urlencoded; a pseudo with a space arrives as
+        // `Dintr-un+lemn`. The repository must decode it at capture so the account menu shows the
+        // real pseudo, not the literal `+`.
+        val (repo, _) = buildRepository(initialCookies = listOf(cookie("md_user", "Dintr-un+lemn")))
+
+        repo.observeAuthState().test {
+            assertEquals(AuthState.Authenticated("Dintr-un lemn"), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `observeAuthState emits Anonymous when md_user value is blank`() = runTest {
         // Defensive: an md_user cookie with empty value can show up during a deletion-marker
         // Set-Cookie before the jar's merge runs. We don't want to flap to a phantom session.

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -3,8 +3,11 @@ package fr.forumhfr.redface2.core.data.preferences
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
+import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.model.FlagType
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -293,6 +296,56 @@ class DataStoreUserPreferencesRepositoryTest {
         // FAVORITE untouched → still its type-aware default (false).
         repository.observeFlagsViewSettings(FlagType.FAVORITE).test {
             assertFalse("FAVORITE keeps its default, no cross-type leak", awaitItem().unreadOnly)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `observeThemeMode defaults to SYSTEM on an empty store`() = runTest(dispatcher) {
+        // #286 — SYSTEM is the default (follow the OS), never the enum's first ordinal.
+        repository.observeThemeMode().test {
+            assertEquals(ThemeMode.SYSTEM, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setThemeMode persists and round-trips DARK then LIGHT`() = runTest(dispatcher) {
+        repository.setThemeMode(ThemeMode.DARK)
+        repository.observeThemeMode().test {
+            assertEquals(ThemeMode.DARK, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setThemeMode(ThemeMode.LIGHT)
+        repository.observeThemeMode().test {
+            assertEquals(ThemeMode.LIGHT, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `corrupt theme_mode value falls back to SYSTEM instead of crashing`() = runTest(dispatcher) {
+        // A value from an older build / manual edit that no longer maps to a ThemeMode must not
+        // crash observeThemeMode on ThemeMode.valueOf — it degrades to SYSTEM.
+        dataStore.edit { prefs -> prefs[stringPreferencesKey("theme_mode")] = "PURPLE" }
+
+        repository.observeThemeMode().test {
+            assertEquals(ThemeMode.SYSTEM, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `observeAmoledEnabled defaults to false then persists true`() = runTest(dispatcher) {
+        repository.observeAmoledEnabled().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setAmoledEnabled(true)
+        repository.observeAmoledEnabled().test {
+            assertTrue(awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -8,6 +8,7 @@ import fr.forumhfr.redface2.core.database.dao.TopicDao
 import fr.forumhfr.redface2.core.database.entities.FetchMode
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
+import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.network.HfrClient
@@ -494,5 +495,14 @@ class TopicRepositoryImplTest {
         override suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean) = Unit
 
         override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) = Unit
+
+        // #286 — theme prefs are irrelevant to TopicRepositoryImpl; stubbed at their defaults.
+        override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
+
+        override suspend fun setThemeMode(mode: ThemeMode) = Unit
+
+        override fun observeAmoledEnabled(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setAmoledEnabled(enabled: Boolean) = Unit
     }
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/ThemeMode.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/ThemeMode.kt
@@ -1,0 +1,15 @@
+package fr.forumhfr.redface2.core.domain.preferences
+
+/**
+ * App theme selection (#286).
+ *
+ * - [SYSTEM] (default) follows the OS dark-mode setting — the historical behaviour, where
+ *   `RedfaceTheme` read `isSystemInDarkTheme()` directly.
+ * - [LIGHT] / [DARK] force the app theme regardless of the OS, for users whose phone is in light
+ *   mode but who want a dark app (and vice-versa) — the explicit bêta request behind #286.
+ */
+enum class ThemeMode {
+    LIGHT,
+    DARK,
+    SYSTEM,
+}

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -105,4 +105,24 @@ interface UserPreferencesRepository {
      * actionable « Mes sujets » subset), `false` for [FlagType.RED] / [FlagType.FAVORITE].
      */
     suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean)
+
+    /**
+     * App theme selection (#286): [ThemeMode.SYSTEM] (default) follows the OS dark-mode setting;
+     * [ThemeMode.LIGHT] / [ThemeMode.DARK] force the app theme regardless of the OS. Observed at the
+     * app root ([fr.forumhfr.redface2.navigation.RedfaceApp]) to compute the effective dark theme
+     * passed to `RedfaceTheme`, and mirrored in Settings.
+     */
+    fun observeThemeMode(): Flow<ThemeMode>
+
+    /** Persists [observeThemeMode]. Default [ThemeMode.SYSTEM] until the first call. */
+    suspend fun setThemeMode(mode: ThemeMode)
+
+    /**
+     * AMOLED (true-black) theme toggle (#286): only takes effect when the effective theme is dark
+     * (forced [ThemeMode.DARK] or [ThemeMode.SYSTEM] while the OS is in dark mode). Default `false`.
+     */
+    fun observeAmoledEnabled(): Flow<Boolean>
+
+    /** Persists [observeAmoledEnabled]. Default `false` until the first call. */
+    suspend fun setAmoledEnabled(enabled: Boolean)
 }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.foundation.text.appendInlineContent
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -135,8 +136,20 @@ internal fun isBareQuote(quote: PostBlock.Quote): Boolean =
 fun PostRenderer(
     content: PostContent,
     modifier: Modifier = Modifier,
+    selectable: Boolean = true,
 ) {
-    PostBlocksRenderer(blocks = content.blocks, modifier = modifier, quoteDepth = 0)
+    if (selectable) {
+        // #281 — allow selecting / copying a post's text. The SelectionContainer is wrapped at this
+        // ENTRY POINT only, never inside the recursive PostBlocksRenderer (Quote/Spoiler): a nested
+        // SelectionContainer silently breaks selection. Links (LinkAnnotation.Url) stay tappable
+        // inside a SelectionContainer; inline media carry a U+FFFC placeholder that can pollute a
+        // copied selection spanning them (known, acceptable limitation).
+        SelectionContainer(modifier = modifier) {
+            PostBlocksRenderer(blocks = content.blocks, quoteDepth = 0)
+        }
+    } else {
+        PostBlocksRenderer(blocks = content.blocks, modifier = modifier, quoteDepth = 0)
+    }
 }
 
 @Composable

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -136,7 +136,10 @@ internal fun isBareQuote(quote: PostBlock.Quote): Boolean =
 fun PostRenderer(
     content: PostContent,
     modifier: Modifier = Modifier,
-    selectable: Boolean = true,
+    // #281 — opt-in, default OFF so callers make the choice explicitly and we never silently change
+    // surfaces outside scope (the editor BBCode preview and private-message thread keep their prior
+    // non-selectable behaviour). Topic posts pass `selectable = true`.
+    selectable: Boolean = false,
 ) {
     if (selectable) {
         // #281 — allow selecting / copying a post's text. The SelectionContainer is wrapped at this

--- a/docs/specs/scope.md
+++ b/docs/specs/scope.md
@@ -80,7 +80,7 @@ Quand `docs/specs/roadmap.md` tranche explicitement une phase, cette page s'alig
 
 ### Personnalisation
 
-- **Choisir un thème** — 3 thèmes v1 (seed `#A62C2C`, dynamic OFF, cf. [#9](https://github.com/ForumHFR/redface2/issues/9)). Phase 1.
+- **Choisir un thème** — sélecteur clair / sombre / système + thème AMOLED (seed `#A62C2C`, dynamic OFF, cf. [#9](https://github.com/ForumHFR/redface2/issues/9), [#286](https://github.com/ForumHFR/redface2/issues/286)). Livré (Phase 5).
 - **Régler les préférences** — `postsPerPage`, avatars, signatures, timezone, langue (lus depuis HFR). Phase 2.
 - **Mode data saver** — désactive le chargement auto des images lourdes. Phase 1.
 - **Gérer le cache** — purge manuelle. Phase 2.

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorIntent.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorIntent.kt
@@ -57,11 +57,13 @@ sealed interface PostEditorIntent {
 sealed interface PostEditorEffect {
     /**
      * The reply / quote / edit was accepted by HFR. The receiver navigates back
-     * to the topic and refreshes the page if [targetPage] is known. For Phase 2D
-     * edit, [scrollTo] additionally tells the topic screen which `numreponse` to
-     * scroll to after the refresh — reply / quote always leave it null (HFR's
-     * refresh URL anchors `#bas`, scrolling to the bottom of the page, which is
-     * already what `TopicScreen` does by default for an unanchored navigation).
+     * to the topic and refreshes the page if [targetPage] is known. [scrollTo] tells
+     * the topic screen which `numreponse` to scroll to after the refresh: HFR's success
+     * URL anchors `#t{numreponse}` for **quote and edit** (the parser exposes it as
+     * `result.numreponse`), so those carry a non-null [scrollTo]; a **plain reply** anchors
+     * `#bas` (no numreponse), so [scrollTo] stays null and `TopicScreen` scrolls to the
+     * bottom by default. The #226 overflow guard relies on this: only the null-[scrollTo]
+     * (plain-reply) path can re-route to a freshly created last page.
      */
     data class SubmitSucceeded(
         val targetPage: Int?,

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -5,14 +5,19 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
@@ -241,12 +246,16 @@ internal fun EditorSubmitBar(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    // navigationBarsPadding() BEFORE imePadding(): keyboard closed → the bar clears the
-                    // gesture nav bar; keyboard open → Compose's inset consumption makes imePadding()
-                    // contribute only (ime - navBar), so the bar rides exactly on top of the keyboard
-                    // with no double-padding. Relies on windowSoftInputMode=adjustResize (AndroidManifest).
-                    .navigationBarsPadding()
-                    .imePadding()
+                    // Single bottom inset = max(navBar, ime); union() takes the larger so the two never
+                    // stack into a phantom gap. Keyboard closed → bar clears the gesture nav bar; keyboard
+                    // open → bar rides exactly on top of the IME. Requires windowSoftInputMode=adjustNothing
+                    // (AndroidManifest) so the OEM does NOT also resize the window — the resize+imePadding
+                    // double-shift was the Samsung One UI bug (#624).
+                    .windowInsetsPadding(
+                        WindowInsets.navigationBars
+                            .union(WindowInsets.ime)
+                            .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom),
+                    )
                     .padding(horizontal = 16.dp, vertical = 8.dp),
                 horizontalArrangement = Arrangement.End,
                 verticalAlignment = Alignment.CenterVertically,

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -4,12 +4,15 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
@@ -78,122 +81,120 @@ private fun PostEditorContent(
 ) {
     val openSmileyPickerDescription = stringResource(R.string.editor_smiley_open_description)
     var imageUrlDialogOpen by remember { mutableStateOf(false) }
+    // Reply (#145), Quote (#146) and Edit (#147) submit through HFR's reply/edit form ; the other
+    // (defensive) modes show a disabled note instead of a submit bar.
+    val showSubmitBar = state.mode == PostEditorMode.Reply || state.mode == PostEditorMode.Edit
     Surface(
         modifier = modifier.fillMaxSize(),
         color = MaterialTheme.colorScheme.surface,
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .statusBarsPadding()
-                .navigationBarsPadding()
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 16.dp, vertical = 12.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Text(
-                text = stringResource(state.mode.titleResId),
-                style = MaterialTheme.typography.titleLarge,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-
-            BbcodeToolbar(
-                onAction = { action -> onIntent(PostEditorIntent.ToolbarActionClicked(action)) },
-                onImageUrlRequested = { imageUrlDialogOpen = true },
-            )
-
-            // Phase 2F-B (#11) — quick access to the smiley picker. Lives next to the BBCode
-            // toolbar rather than inside it because smileys are point-insertions, not wrappers,
-            // and the underlying `BbcodeAction` model is wrap-only.
-            TextButton(
-                onClick = { onIntent(PostEditorIntent.SmileyPickerOpened) },
-                modifier = Modifier.semantics {
-                    contentDescription = openSmileyPickerDescription
-                },
+        Column(modifier = Modifier.fillMaxSize().statusBarsPadding()) {
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                Text(text = stringResource(R.string.editor_smiley_open))
-            }
+                Text(
+                    text = stringResource(state.mode.titleResId),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
 
-            BbcodeTextField(
-                value = state.draft,
-                onValueChange = { value -> onIntent(PostEditorIntent.ContentChanged(value)) },
-                label = stringResource(R.string.editor_field_label),
-                placeholder = stringResource(R.string.editor_field_placeholder),
-            )
+                BbcodeToolbar(
+                    onAction = { action -> onIntent(PostEditorIntent.ToolbarActionClicked(action)) },
+                    onImageUrlRequested = { imageUrlDialogOpen = true },
+                )
 
-            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
-                TextButton(onClick = { onIntent(PostEditorIntent.TogglePreview) }) {
+                // Phase 2F-B (#11) — quick access to the smiley picker. Lives next to the BBCode
+                // toolbar rather than inside it because smileys are point-insertions, not wrappers,
+                // and the underlying `BbcodeAction` model is wrap-only.
+                TextButton(
+                    onClick = { onIntent(PostEditorIntent.SmileyPickerOpened) },
+                    modifier = Modifier.semantics {
+                        contentDescription = openSmileyPickerDescription
+                    },
+                ) {
+                    Text(text = stringResource(R.string.editor_smiley_open))
+                }
+
+                BbcodeTextField(
+                    value = state.draft,
+                    onValueChange = { value -> onIntent(PostEditorIntent.ContentChanged(value)) },
+                    label = stringResource(R.string.editor_field_label),
+                    placeholder = stringResource(R.string.editor_field_placeholder),
+                )
+
+                Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
+                    TextButton(onClick = { onIntent(PostEditorIntent.TogglePreview) }) {
+                        Text(
+                            text = stringResource(
+                                if (state.isPreviewVisible) {
+                                    R.string.editor_preview_hide
+                                } else {
+                                    R.string.editor_preview_show
+                                },
+                            ),
+                        )
+                    }
+                }
+
+                if (state.isPreviewVisible) {
+                    HorizontalDivider()
+                    BbcodePreview(content = state.preview)
+                }
+
+                state.submitError?.let { error ->
                     Text(
-                        text = stringResource(
-                            if (state.isPreviewVisible) R.string.editor_preview_hide else R.string.editor_preview_show,
-                        ),
+                        text = stringResource(error.bannerResId),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                    TextButton(onClick = { onIntent(PostEditorIntent.ErrorDismissed) }) {
+                        Text(text = stringResource(R.string.editor_error_dismiss))
+                    }
+                }
+
+                if (showSubmitBar) {
+                    // HFR per-post option toggles. Defaults come from `ReplyForm.options`
+                    // (the `checked` attribute of each HTML checkbox HFR rendered for
+                    // this user / topic). The repository only adds the matching POST
+                    // field when the toggle is on — mirroring how a browser submits.
+                    // Phase 2D (#147) — Edit shares the same options surface as Reply:
+                    // both toggles live in `PostEditorState` and the matching
+                    // repository reads them at submit time, so the UI stays identical.
+                    PostEditorOptions(
+                        signatureEnabled = state.signatureEnabled,
+                        smileyDisabled = state.smileyDisabled,
+                        emailNotificationEnabled = state.emailNotificationEnabled,
+                        enabled = !state.isSubmitting && !state.isLoadingForm,
+                        onSignatureChanged = { onIntent(PostEditorIntent.ToggleSignature(it)) },
+                        onSmileyDisabledChanged = { onIntent(PostEditorIntent.ToggleSmileyDisabled(it)) },
+                        onEmailNotificationChanged = { onIntent(PostEditorIntent.ToggleEmailNotification(it)) },
+                    )
+                } else {
+                    // Defensive fallback for future post-level modes. Reply (#145),
+                    // Quote (#146) and Edit (#147) all go through the branch above ;
+                    // topic-level create/edit flows are handled by TopicFormScreen.
+                    Text(
+                        text = stringResource(R.string.editor_submit_disabled),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             }
-
-            if (state.isPreviewVisible) {
-                HorizontalDivider()
-                BbcodePreview(content = state.preview)
-            }
-
-            state.submitError?.let { error ->
-                Text(
-                    text = stringResource(error.bannerResId),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error,
-                )
-                TextButton(onClick = { onIntent(PostEditorIntent.ErrorDismissed) }) {
-                    Text(text = stringResource(R.string.editor_error_dismiss))
-                }
-            }
-
-            if (state.mode == PostEditorMode.Reply || state.mode == PostEditorMode.Edit) {
-                // HFR per-post option toggles. Defaults come from `ReplyForm.options`
-                // (the `checked` attribute of each HTML checkbox HFR rendered for
-                // this user / topic). The repository only adds the matching POST
-                // field when the toggle is on — mirroring how a browser submits.
-                // Phase 2D (#147) — Edit shares the same options surface as Reply:
-                // both toggles live in `PostEditorState` and the matching
-                // repository reads them at submit time, so the UI stays identical.
-                PostEditorOptions(
-                    signatureEnabled = state.signatureEnabled,
-                    smileyDisabled = state.smileyDisabled,
-                    emailNotificationEnabled = state.emailNotificationEnabled,
-                    enabled = !state.isSubmitting && !state.isLoadingForm,
-                    onSignatureChanged = { onIntent(PostEditorIntent.ToggleSignature(it)) },
-                    onSmileyDisabledChanged = { onIntent(PostEditorIntent.ToggleSmileyDisabled(it)) },
-                    onEmailNotificationChanged = { onIntent(PostEditorIntent.ToggleEmailNotification(it)) },
-                )
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    if (state.isLoadingForm) {
-                        CircularProgressIndicator(modifier = Modifier.size(20.dp))
-                    }
-                    Button(
-                        enabled = state.canSubmit,
-                        onClick = { onIntent(PostEditorIntent.SubmitClicked) },
-                    ) {
-                        if (state.isSubmitting) {
-                            CircularProgressIndicator(
-                                modifier = Modifier.size(18.dp),
-                                color = MaterialTheme.colorScheme.onPrimary,
-                            )
-                        } else {
-                            Text(text = stringResource(R.string.editor_submit))
-                        }
-                    }
-                }
-            } else {
-                // Defensive fallback for future post-level modes. Reply (#145),
-                // Quote (#146) and Edit (#147) all go through the branch above ;
-                // topic-level create/edit flows are handled by TopicFormScreen.
-                Text(
-                    text = stringResource(R.string.editor_submit_disabled),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+            // Send-button accessibility — the submit action is pinned to the bottom of the screen
+            // (not buried at the end of the scrolled column) and lifted above the IME so the user
+            // never has to dismiss the keyboard to reach « Envoyer ». Only Reply / Edit submit here;
+            // the defensive fallback mode keeps its disabled note inside the scroll.
+            if (showSubmitBar) {
+                EditorSubmitBar(
+                    canSubmit = state.canSubmit,
+                    isSubmitting = state.isSubmitting,
+                    isLoadingForm = state.isLoadingForm,
+                    onSubmit = { onIntent(PostEditorIntent.SubmitClicked) },
                 )
             }
         }
@@ -216,6 +217,58 @@ private fun PostEditorContent(
                 onDismiss = { imageUrlDialogOpen = false },
                 onInsert = { url -> onIntent(PostEditorIntent.ImageUrlInserted(url)) },
             )
+        }
+    }
+}
+
+/**
+ * Submit action pinned to the bottom of an editor screen, lifted above the IME so the user never has
+ * to dismiss the keyboard to reach « Envoyer ». Shared by [PostEditorContent] and `TopicFormContent`.
+ */
+@Composable
+internal fun EditorSubmitBar(
+    canSubmit: Boolean,
+    isSubmitting: Boolean,
+    isLoadingForm: Boolean,
+    onSubmit: () -> Unit,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        tonalElevation = 3.dp,
+    ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            HorizontalDivider()
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    // navigationBarsPadding() BEFORE imePadding(): keyboard closed → the bar clears the
+                    // gesture nav bar; keyboard open → Compose's inset consumption makes imePadding()
+                    // contribute only (ime - navBar), so the bar rides exactly on top of the keyboard
+                    // with no double-padding. Relies on windowSoftInputMode=adjustResize (AndroidManifest).
+                    .navigationBarsPadding()
+                    .imePadding()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (isLoadingForm) {
+                    CircularProgressIndicator(modifier = Modifier.size(20.dp))
+                    Spacer(modifier = Modifier.width(12.dp))
+                }
+                Button(
+                    enabled = canSubmit,
+                    onClick = onSubmit,
+                ) {
+                    if (isSubmitting) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(18.dp),
+                            color = MaterialTheme.colorScheme.onPrimary,
+                        )
+                    } else {
+                        Text(text = stringResource(R.string.editor_submit))
+                    }
+                }
+            }
         }
     }
 }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormScreen.kt
@@ -6,15 +6,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
@@ -135,127 +131,115 @@ internal fun TopicFormContent(
         modifier = modifier.fillMaxSize(),
         color = MaterialTheme.colorScheme.surface,
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .statusBarsPadding()
-                .navigationBarsPadding()
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 16.dp, vertical = 12.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Text(
-                text = stringResource(state.mode.titleResId),
-                style = MaterialTheme.typography.titleLarge,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            OutlinedTextField(
-                value = state.subject,
-                onValueChange = { onIntent(TopicFormIntent.SubjectChanged(it)) },
-                singleLine = true,
-                modifier = Modifier.fillMaxWidth(),
-                enabled = !state.isSubmitting,
-                label = { Text(stringResource(R.string.editor_topic_subject_label)) },
-                // #237 — sentence capitalization (parité RF1) like the body field.
-                keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
-            )
-            // #213 — a category WITHOUT a sub-category (e.g. IA, cat=32) renders no
-            // `<select name=subcat>` on HFR's form (`hasSubcategorySelect = false`), so
-            // posting there uses subcat=0. Hide the picker entirely in that case rather
-            // than showing an empty « choisir une sous-catégorie » dropdown the user
-            // cannot act on (dogfood feedback @XaaT). Categories WITH sub-categories keep it.
-            if (state.hasSubcategorySelect) {
-                SubcategoryDropdown(
-                    choices = state.subcategoryChoices,
-                    selectedSubcat = state.selectedSubcat,
-                    enabled = !state.isSubmitting && !state.isLoadingForm,
-                    onSelect = { id -> onIntent(TopicFormIntent.SubcatSelected(id)) },
-                )
-            }
-            BbcodeToolbar(
-                onAction = { onIntent(TopicFormIntent.ToolbarActionClicked(it)) },
-                onImageUrlRequested = { imageUrlDialogOpen = true },
-            )
-            // Phase 2F-C (#11 partial) — quick access to the smiley picker. Same placement
-            // and rationale as `PostEditorScreen` : smileys are point-insertions, not
-            // wrappers, so they don't fit the wrap-only `BbcodeAction` toolbar model.
-            TextButton(
-                onClick = { onIntent(TopicFormIntent.SmileyPickerOpened) },
-                modifier = Modifier.semantics {
-                    contentDescription = openSmileyPickerDescription
-                },
+        Column(modifier = Modifier.fillMaxSize().statusBarsPadding()) {
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                Text(text = stringResource(R.string.editor_smiley_open))
-            }
-            BbcodeTextField(
-                value = state.draft,
-                onValueChange = { onIntent(TopicFormIntent.ContentChanged(it)) },
-                label = stringResource(R.string.editor_field_label),
-                modifier = Modifier.fillMaxWidth(),
-            )
-            TextButton(onClick = { onIntent(TopicFormIntent.TogglePreview) }) {
                 Text(
-                    text = if (state.isPreviewVisible) {
-                        stringResource(R.string.editor_preview_hide)
-                    } else {
-                        stringResource(R.string.editor_preview_show)
+                    text = stringResource(state.mode.titleResId),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                OutlinedTextField(
+                    value = state.subject,
+                    onValueChange = { onIntent(TopicFormIntent.SubjectChanged(it)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = !state.isSubmitting,
+                    label = { Text(stringResource(R.string.editor_topic_subject_label)) },
+                    // #237 — sentence capitalization (parité RF1) like the body field.
+                    keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
+                )
+                // #213 — a category WITHOUT a sub-category (e.g. IA, cat=32) renders no
+                // `<select name=subcat>` on HFR's form (`hasSubcategorySelect = false`), so
+                // posting there uses subcat=0. Hide the picker entirely in that case rather
+                // than showing an empty « choisir une sous-catégorie » dropdown the user
+                // cannot act on (dogfood feedback @XaaT). Categories WITH sub-categories keep it.
+                if (state.hasSubcategorySelect) {
+                    SubcategoryDropdown(
+                        choices = state.subcategoryChoices,
+                        selectedSubcat = state.selectedSubcat,
+                        enabled = !state.isSubmitting && !state.isLoadingForm,
+                        onSelect = { id -> onIntent(TopicFormIntent.SubcatSelected(id)) },
+                    )
+                }
+                BbcodeToolbar(
+                    onAction = { onIntent(TopicFormIntent.ToolbarActionClicked(it)) },
+                    onImageUrlRequested = { imageUrlDialogOpen = true },
+                )
+                // Phase 2F-C (#11 partial) — quick access to the smiley picker. Same placement
+                // and rationale as `PostEditorScreen` : smileys are point-insertions, not
+                // wrappers, so they don't fit the wrap-only `BbcodeAction` toolbar model.
+                TextButton(
+                    onClick = { onIntent(TopicFormIntent.SmileyPickerOpened) },
+                    modifier = Modifier.semantics {
+                        contentDescription = openSmileyPickerDescription
                     },
-                )
-            }
-            if (state.isPreviewVisible) {
-                BbcodePreview(content = state.preview, modifier = Modifier.fillMaxWidth())
-            }
-            HorizontalDivider()
-            TopicFormOptionsBlock(
-                signatureEnabled = state.signatureEnabled,
-                smileyDisabled = state.smileyDisabled,
-                emailNotificationEnabled = state.emailNotificationEnabled,
-                enabled = !state.isSubmitting && !state.isLoadingForm,
-                onSignatureChanged = { onIntent(TopicFormIntent.ToggleSignature(it)) },
-                onSmileyDisabledChanged = { onIntent(TopicFormIntent.ToggleSmileyDisabled(it)) },
-                onEmailNotificationChanged = { onIntent(TopicFormIntent.ToggleEmailNotification(it)) },
-            )
-            if (state.pollPresent && !state.pollEditable) {
-                // Honest copy : the topic has a poll, but Phase 2D #148 does
-                // not edit poll fields — they are preserved verbatim on POST.
-                Text(
-                    text = stringResource(R.string.editor_topic_poll_readonly_note),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            state.submitError?.let { error ->
-                Text(
-                    text = stringResource(error.bannerResId),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error,
-                )
-                TextButton(onClick = { onIntent(TopicFormIntent.ErrorDismissed) }) {
-                    Text(text = stringResource(R.string.editor_error_dismiss))
-                }
-            }
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                if (state.isLoadingForm) {
-                    CircularProgressIndicator(modifier = Modifier.size(20.dp))
-                }
-                Button(
-                    enabled = state.canSubmit,
-                    onClick = { onIntent(TopicFormIntent.SubmitClicked) },
                 ) {
-                    if (state.isSubmitting) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(18.dp),
-                            color = MaterialTheme.colorScheme.onPrimary,
-                        )
-                    } else {
-                        Text(text = stringResource(R.string.editor_submit))
+                    Text(text = stringResource(R.string.editor_smiley_open))
+                }
+                BbcodeTextField(
+                    value = state.draft,
+                    onValueChange = { onIntent(TopicFormIntent.ContentChanged(it)) },
+                    label = stringResource(R.string.editor_field_label),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                TextButton(onClick = { onIntent(TopicFormIntent.TogglePreview) }) {
+                    Text(
+                        text = if (state.isPreviewVisible) {
+                            stringResource(R.string.editor_preview_hide)
+                        } else {
+                            stringResource(R.string.editor_preview_show)
+                        },
+                    )
+                }
+                if (state.isPreviewVisible) {
+                    BbcodePreview(content = state.preview, modifier = Modifier.fillMaxWidth())
+                }
+                HorizontalDivider()
+                TopicFormOptionsBlock(
+                    signatureEnabled = state.signatureEnabled,
+                    smileyDisabled = state.smileyDisabled,
+                    emailNotificationEnabled = state.emailNotificationEnabled,
+                    enabled = !state.isSubmitting && !state.isLoadingForm,
+                    onSignatureChanged = { onIntent(TopicFormIntent.ToggleSignature(it)) },
+                    onSmileyDisabledChanged = { onIntent(TopicFormIntent.ToggleSmileyDisabled(it)) },
+                    onEmailNotificationChanged = { onIntent(TopicFormIntent.ToggleEmailNotification(it)) },
+                )
+                if (state.pollPresent && !state.pollEditable) {
+                    // Honest copy : the topic has a poll, but Phase 2D #148 does
+                    // not edit poll fields — they are preserved verbatim on POST.
+                    Text(
+                        text = stringResource(R.string.editor_topic_poll_readonly_note),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                state.submitError?.let { error ->
+                    Text(
+                        text = stringResource(error.bannerResId),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                    TextButton(onClick = { onIntent(TopicFormIntent.ErrorDismissed) }) {
+                        Text(text = stringResource(R.string.editor_error_dismiss))
                     }
                 }
             }
+            // Send-button accessibility — pin « Envoyer » to the bottom, above the IME, so the user
+            // never has to dismiss the keyboard to submit a new topic / first-post edit (shared
+            // EditorSubmitBar with PostEditorScreen).
+            EditorSubmitBar(
+                canSubmit = state.canSubmit,
+                isSubmitting = state.isSubmitting,
+                isLoadingForm = state.isLoadingForm,
+                onSubmit = { onIntent(TopicFormIntent.SubmitClicked) },
+            )
         }
     }
     if (imageUrlDialogOpen) {

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -10,6 +10,7 @@ import fr.forumhfr.redface2.core.domain.forum.ForumRepository
 import fr.forumhfr.redface2.core.domain.forum.ForumResult
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
+import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.Category
@@ -1376,6 +1377,15 @@ class FlagsViewModelTest {
             }
             perTypeUnread.getValue(type).value = enabled
         }
+
+        // #286 — theme prefs are irrelevant to FlagsViewModel; stubbed at their defaults.
+        override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
+
+        override suspend fun setThemeMode(mode: ThemeMode) = Unit
+
+        override fun observeAmoledEnabled(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setAmoledEnabled(enabled: Boolean) = Unit
 
         fun setGroupBy(value: Boolean) {
             groupBy.value = value

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.feature.settings
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -19,6 +20,9 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -33,6 +37,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 
 @Composable
 fun SettingsScreen(
@@ -171,6 +176,11 @@ internal fun SettingsContent(
                 }
             }
 
+            ThemePreferencesCard(
+                state = state,
+                onIntent = onIntent,
+            )
+
             FlagsPreferencesCard(
                 state = state,
                 onIntent = onIntent,
@@ -188,6 +198,73 @@ internal fun SettingsContent(
             onConfirm = { onIntent(SettingsIntent.ClearTopicCacheConfirmed) },
             onDismiss = { onIntent(SettingsIntent.ClearTopicCacheDismissed) },
         )
+    }
+}
+
+/**
+ * Theme preferences (#286): a 3-way Clair / Système / Sombre selector (SYSTEM follows the OS),
+ * plus an AMOLED true-black toggle that only applies when the effective theme is dark. Persisted via
+ * DataStore; the selection is observed at the app root ([fr.forumhfr.redface2.navigation.RedfaceApp])
+ * so a change here re-themes the whole app live.
+ */
+@Composable
+private fun ThemePreferencesCard(
+    state: SettingsState,
+    onIntent: (SettingsIntent) -> Unit,
+) {
+    // The AMOLED toggle is only meaningful when the app will actually render dark — forced DARK, or
+    // SYSTEM while the OS is in dark mode. Computed here so the switch is disabled otherwise.
+    val effectiveDark = when (state.themeMode) {
+        ThemeMode.LIGHT -> false
+        ThemeMode.DARK -> true
+        ThemeMode.SYSTEM -> isSystemInDarkTheme()
+    }
+    val options = listOf(
+        ThemeMode.LIGHT to stringResource(R.string.settings_theme_light),
+        ThemeMode.SYSTEM to stringResource(R.string.settings_theme_system),
+        ThemeMode.DARK to stringResource(R.string.settings_theme_dark),
+    )
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_theme_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = stringResource(R.string.settings_theme_intro),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                options.forEachIndexed { index, (mode, label) ->
+                    SegmentedButton(
+                        selected = state.themeMode == mode,
+                        enabled = state.canChangeThemeMode,
+                        onClick = { onIntent(SettingsIntent.ThemeModeChanged(mode)) },
+                        shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
+                    ) {
+                        Text(label)
+                    }
+                }
+            }
+            if (state.themeModeError) {
+                PreferencePersistError(R.string.settings_theme_persist_failed)
+            }
+            PreferenceSwitchRow(
+                title = stringResource(R.string.settings_theme_amoled_title),
+                description = stringResource(R.string.settings_theme_amoled_description),
+                checked = state.amoledEnabled,
+                enabled = state.canToggleAmoled && effectiveDark,
+                onCheckedChange = { onIntent(SettingsIntent.AmoledEnabledChanged(it)) },
+            )
+            if (state.amoledError) {
+                PreferencePersistError(R.string.settings_theme_amoled_persist_failed)
+            }
+        }
     }
 }
 

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -4,12 +4,18 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
@@ -66,7 +72,14 @@ internal fun SettingsContent(
             modifier = Modifier
                 .fillMaxSize()
                 .statusBarsPadding()
-                .navigationBarsPadding()
+                // Applied OUTSIDE verticalScroll so the keyboard inset shrinks the scroll viewport: a
+                // focused proxy field then stays above the IME (adjustNothing means the OEM no longer
+                // resizes the window for us, cf. #624). union() keeps navBar clearance when closed.
+                .windowInsetsPadding(
+                    WindowInsets.navigationBars
+                        .union(WindowInsets.ime)
+                        .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom),
+                )
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = 24.dp, vertical = 16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -1,5 +1,7 @@
 package fr.forumhfr.redface2.feature.settings
 
+import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
+
 data class SettingsState(
     val proxyEnabled: Boolean = false,
     val proxyHost: String = "",
@@ -48,6 +50,19 @@ data class SettingsState(
     val isUpdatingFlagsPerTabOverride: Boolean = false,
     val flagsPerTabOverrideError: Boolean = false,
     val flagsPerTabOverrideTouchedLocally: Boolean = false,
+    // Theme preferences (#286). Same optimistic-flip + startup-race-guard machinery as the flags
+    // toggles: `themeMode`/`amoledEnabled` are the displayed values, `isUpdating*` gates the control
+    // while DataStore writes, `*Error` surfaces a persist failure, and `*TouchedLocally` forbids a
+    // late `init` hydration from clobbering a fast user change. Defaults match the DataStore defaults
+    // (SYSTEM, amoled off).
+    val themeMode: ThemeMode = ThemeMode.SYSTEM,
+    val isUpdatingThemeMode: Boolean = false,
+    val themeModeError: Boolean = false,
+    val themeModeTouchedLocally: Boolean = false,
+    val amoledEnabled: Boolean = false,
+    val isUpdatingAmoled: Boolean = false,
+    val amoledError: Boolean = false,
+    val amoledTouchedLocally: Boolean = false,
 ) {
     val canSave: Boolean
         get() = !isSaving
@@ -69,6 +84,13 @@ data class SettingsState(
 
     val canToggleFlagsPerTabOverride: Boolean
         get() = !isUpdatingFlagsPerTabOverride
+
+    // #286 — theme controls are gated only by their own in-flight write.
+    val canChangeThemeMode: Boolean
+        get() = !isUpdatingThemeMode
+
+    val canToggleAmoled: Boolean
+        get() = !isUpdatingAmoled
 }
 
 sealed interface SettingsError {
@@ -114,4 +136,9 @@ sealed interface SettingsIntent {
 
     // #309 — per-tab display override master switch.
     data class FlagsPerTabOverrideChanged(val enabled: Boolean) : SettingsIntent
+
+    // #286 — theme preferences. `mode` is the desired selection, `enabled` the desired AMOLED state;
+    // both applied optimistically with revert-on-failure, like the flags toggles.
+    data class ThemeModeChanged(val mode: ThemeMode) : SettingsIntent
+    data class AmoledEnabledChanged(val enabled: Boolean) : SettingsIntent
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.cache.TopicCacheMaintenance
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
+import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -77,8 +78,29 @@ class SettingsViewModel @Inject constructor(
                 }
             }
         }
+        viewModelScope.launch {
+            val mode = userPreferencesRepository.observeThemeMode().first()
+            _state.update { current ->
+                if (current.themeModeTouchedLocally || current.isUpdatingThemeMode) {
+                    current
+                } else {
+                    current.copy(themeMode = mode)
+                }
+            }
+        }
+        viewModelScope.launch {
+            val amoled = userPreferencesRepository.observeAmoledEnabled().first()
+            _state.update { current ->
+                if (current.amoledTouchedLocally || current.isUpdatingAmoled) {
+                    current
+                } else {
+                    current.copy(amoledEnabled = amoled)
+                }
+            }
+        }
     }
 
+    @Suppress("CyclomaticComplexMethod") // MVI when-dispatch over the SettingsIntent variants ; flat by design.
     fun submit(intent: SettingsIntent) {
         when (intent) {
             is SettingsIntent.ProxyEnabledChanged ->
@@ -106,6 +128,8 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.FlagsGroupByCategoryChanged -> updateFlagsGroupByCategory(intent.enabled)
             is SettingsIntent.FlagsHideReadCategoriesChanged -> updateFlagsHideReadCategories(intent.enabled)
             is SettingsIntent.FlagsPerTabOverrideChanged -> updateFlagsPerTabOverride(intent.enabled)
+            is SettingsIntent.ThemeModeChanged -> updateThemeMode(intent.mode)
+            is SettingsIntent.AmoledEnabledChanged -> updateAmoled(intent.enabled)
         }
     }
 
@@ -290,6 +314,58 @@ class SettingsViewModel @Inject constructor(
                 }
             },
             persist = userPreferencesRepository::setFlagsPerTabOverride,
+        )
+    }
+
+    // #286 — theme mode is an enum, so it uses the bespoke optimistic-flip shape (like
+    // updateIgnoreTopicCache) rather than updateBooleanPreference. previous is captured for revert.
+    private fun updateThemeMode(desired: ThemeMode) {
+        val previous = _state.value.themeMode
+        _state.update {
+            it.copy(
+                themeMode = desired,
+                isUpdatingThemeMode = true,
+                themeModeError = false,
+                themeModeTouchedLocally = true,
+            )
+        }
+        viewModelScope.launch {
+            runCatching { userPreferencesRepository.setThemeMode(desired) }
+                .onSuccess {
+                    _state.update { it.copy(themeMode = desired, isUpdatingThemeMode = false) }
+                }
+                .onFailure {
+                    _state.update {
+                        it.copy(
+                            themeMode = previous,
+                            isUpdatingThemeMode = false,
+                            themeModeError = true,
+                        )
+                    }
+                }
+        }
+    }
+
+    private fun updateAmoled(desired: Boolean) {
+        val previous = _state.value.amoledEnabled
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    amoledEnabled = desired,
+                    isUpdatingAmoled = true,
+                    amoledError = false,
+                    amoledTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(amoledEnabled = desired, isUpdatingAmoled = false)
+                } else {
+                    state.copy(amoledEnabled = previous, isUpdatingAmoled = false, amoledError = true)
+                }
+            },
+            persist = userPreferencesRepository::setAmoledEnabled,
         )
     }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -52,4 +52,16 @@
     <string name="settings_flags_per_tab_override_title">Réglages différents par onglet</string>
     <string name="settings_flags_per_tab_override_description">Chaque onglet (Mes sujets, Lu, Favoris) garde son propre affichage. Les réglages ci-dessus deviennent les valeurs par défaut ; ajustez chaque onglet depuis le menu d\'affichage de l\'écran Drapeaux.</string>
     <string name="settings_flags_per_tab_override_persist_failed">Impossible de mémoriser le réglage par onglet. Réessayez.</string>
+
+    <!-- #286 — Thème. Sélecteur Clair/Système/Sombre (Système = suit l'OS) + thème AMOLED (vrai
+         noir), persistés en DataStore et appliqués à toute l'app en direct. -->
+    <string name="settings_theme_title">Thème</string>
+    <string name="settings_theme_intro">Choisissez l\'apparence de l\'app. « Système » suit le réglage clair/sombre du téléphone.</string>
+    <string name="settings_theme_light">Clair</string>
+    <string name="settings_theme_system">Système</string>
+    <string name="settings_theme_dark">Sombre</string>
+    <string name="settings_theme_persist_failed">Impossible de mémoriser le thème. Réessayez.</string>
+    <string name="settings_theme_amoled_title">Thème AMOLED (vrai noir)</string>
+    <string name="settings_theme_amoled_description">Fond noir pur pour les écrans OLED. S\'applique uniquement en thème sombre.</string>
+    <string name="settings_theme_amoled_persist_failed">Impossible de mémoriser le réglage AMOLED. Réessayez.</string>
 </resources>

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -3,6 +3,7 @@ package fr.forumhfr.redface2.feature.settings
 import fr.forumhfr.redface2.core.domain.cache.TopicCacheMaintenance
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
+import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.model.FlagType
 import kotlinx.coroutines.CompletableDeferred
@@ -520,6 +521,74 @@ class SettingsViewModelTest {
         assertTrue("init must hydrate the per-tab override from DataStore", viewModel.state.value.flagsPerTabOverride)
     }
 
+    // ──────────────────────────────────────────────────────────────────────
+    // Theme preferences (#286)
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `init hydrates theme preferences from storage`() = runTest {
+        repository.emitThemeMode(ThemeMode.DARK)
+        repository.emitAmoledEnabled(true)
+
+        val viewModel = newViewModel()
+        val state = viewModel.state.value
+
+        assertEquals(ThemeMode.DARK, state.themeMode)
+        assertTrue(state.amoledEnabled)
+    }
+
+    @Test
+    fun `ThemeModeChanged persists the new mode and clears the updating flag`() = runTest {
+        val viewModel = newViewModel()
+        assertEquals("SYSTEM is the default", ThemeMode.SYSTEM, viewModel.state.value.themeMode)
+
+        viewModel.submit(SettingsIntent.ThemeModeChanged(ThemeMode.DARK))
+
+        val state = viewModel.state.value
+        assertEquals(ThemeMode.DARK, state.themeMode)
+        assertFalse(state.isUpdatingThemeMode)
+        assertFalse(state.themeModeError)
+        assertEquals(1, repository.themeModeSetCalls)
+        assertEquals(ThemeMode.DARK, repository.lastThemeModeSet)
+    }
+
+    @Test
+    fun `ThemeModeChanged reverts to the previous mode and raises the error flag on persist failure`() = runTest {
+        repository.failOnThemeModeSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.ThemeModeChanged(ThemeMode.LIGHT))
+
+        val state = viewModel.state.value
+        assertEquals("must revert to the previous mode on failure", ThemeMode.SYSTEM, state.themeMode)
+        assertFalse(state.isUpdatingThemeMode)
+        assertTrue(state.themeModeError)
+    }
+
+    @Test
+    fun `AmoledEnabledChanged persists the flip`() = runTest {
+        val viewModel = newViewModel()
+        assertFalse("AMOLED is off by default", viewModel.state.value.amoledEnabled)
+
+        viewModel.submit(SettingsIntent.AmoledEnabledChanged(true))
+
+        assertTrue(viewModel.state.value.amoledEnabled)
+        assertFalse(viewModel.state.value.isUpdatingAmoled)
+        assertEquals(1, repository.amoledSetCalls)
+    }
+
+    @Test
+    fun `AmoledEnabledChanged reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnAmoledSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.AmoledEnabledChanged(true))
+
+        assertFalse("must revert to the previous value on failure", viewModel.state.value.amoledEnabled)
+        assertFalse(viewModel.state.value.isUpdatingAmoled)
+        assertTrue(viewModel.state.value.amoledError)
+    }
+
     private fun newViewModel(): SettingsViewModel =
         SettingsViewModel(repository, topicCacheMaintenance)
 
@@ -612,6 +681,44 @@ class SettingsViewModelTest {
             flagsPerTabOverrideSetCalls += 1
             check(!failOnFlagsPerTabOverrideSet) { "boom" }
             flagsPerTabOverride.value = enabled
+        }
+
+        // #286 — theme preferences. Same optimistic-flip seams as the flags toggles.
+        private val themeMode = MutableStateFlow(ThemeMode.SYSTEM)
+        var themeModeSetCalls: Int = 0
+            private set
+        var lastThemeModeSet: ThemeMode? = null
+            private set
+        var failOnThemeModeSet: Boolean = false
+
+        private val amoledEnabled = MutableStateFlow(false)
+        var amoledSetCalls: Int = 0
+            private set
+        var failOnAmoledSet: Boolean = false
+
+        override fun observeThemeMode(): Flow<ThemeMode> = themeMode
+
+        override suspend fun setThemeMode(mode: ThemeMode) {
+            themeModeSetCalls += 1
+            check(!failOnThemeModeSet) { "boom" }
+            lastThemeModeSet = mode
+            themeMode.value = mode
+        }
+
+        override fun observeAmoledEnabled(): Flow<Boolean> = amoledEnabled
+
+        override suspend fun setAmoledEnabled(enabled: Boolean) {
+            amoledSetCalls += 1
+            check(!failOnAmoledSet) { "boom" }
+            amoledEnabled.value = enabled
+        }
+
+        fun emitThemeMode(value: ThemeMode) {
+            themeMode.value = value
+        }
+
+        fun emitAmoledEnabled(value: Boolean) {
+            amoledEnabled.value = value
         }
 
         // Per-type resolution / writes are exercised by the Flags ViewModel, not Settings; stubbed.

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -589,6 +589,42 @@ class SettingsViewModelTest {
         assertTrue(viewModel.state.value.amoledError)
     }
 
+    @Test
+    fun `theme hydration race - a stale initial DataStore emission must not overwrite a local mode change`() =
+        runTest {
+            // Mirror of the ignoreTopicCache startup-race test for ThemeMode (#286, Codex nit): init
+            // subscribes to observeThemeMode() and suspends on .first() (override emits nothing yet),
+            // the user picks DARK locally (optimistic + write succeeds, touchedLocally = true), then the
+            // still-suspended init resumes with a stale SYSTEM — the guard must skip the apply.
+            val initialHydrationFlow = MutableSharedFlow<ThemeMode>(replay = 0)
+            repository.themeModeObserveOverride = initialHydrationFlow
+            val viewModel = newViewModel()
+
+            viewModel.submit(SettingsIntent.ThemeModeChanged(ThemeMode.DARK))
+            assertEquals(
+                "optimistic flip must reach the state synchronously",
+                ThemeMode.DARK,
+                viewModel.state.value.themeMode,
+            )
+            assertTrue(viewModel.state.value.themeModeTouchedLocally)
+            assertFalse(viewModel.state.value.isUpdatingThemeMode)
+
+            // Late, stale hydration produces SYSTEM. On the buggy code this overwrites the local DARK;
+            // on the fixed code the touchedLocally guard skips the apply.
+            initialHydrationFlow.emit(ThemeMode.SYSTEM)
+
+            val finalState = viewModel.state.value
+            assertEquals(
+                "stale initial DataStore hydration must NOT overwrite the local mode change",
+                ThemeMode.DARK,
+                finalState.themeMode,
+            )
+            assertFalse(finalState.isUpdatingThemeMode)
+            assertFalse(finalState.themeModeError)
+            assertEquals(1, repository.themeModeSetCalls)
+            assertEquals(ThemeMode.DARK, repository.lastThemeModeSet)
+        }
+
     private fun newViewModel(): SettingsViewModel =
         SettingsViewModel(repository, topicCacheMaintenance)
 
@@ -696,7 +732,14 @@ class SettingsViewModelTest {
             private set
         var failOnAmoledSet: Boolean = false
 
-        override fun observeThemeMode(): Flow<ThemeMode> = themeMode
+        /**
+         * Test seam for the theme startup-race test (#286), mirroring [ignoreTopicCacheObserveOverride]:
+         * when non-null, `observeThemeMode()` returns this flow so the test can hold the init `.first()`
+         * suspension, perform a local mode change, then release a stale emission to prove the guard skips it.
+         */
+        var themeModeObserveOverride: Flow<ThemeMode>? = null
+
+        override fun observeThemeMode(): Flow<ThemeMode> = themeModeObserveOverride ?: themeMode
 
         override suspend fun setThemeMode(mode: ThemeMode) {
             themeModeSetCalls += 1

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/CitationIndex.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/CitationIndex.kt
@@ -1,0 +1,46 @@
+package fr.forumhfr.redface2.feature.topic
+
+import fr.forumhfr.redface2.core.model.Post
+import fr.forumhfr.redface2.core.model.PostBlock
+
+/**
+ * #239 — count, per post `numreponse`, how many DISTINCT posts on the current page cite it.
+ *
+ * A "citation" is a [PostBlock.Quote] carrying the cited post's `numreponse`. We descend into
+ * spoilers (a quote can sit inside a `[spoiler]`) but NOT into a quote's own content: a quote
+ * re-quoted inside another quote is part of the quoted material, not a fresh citation by the current
+ * post. De-duplicated per post, so quoting the same post twice in one message counts once — the badge
+ * reads « cité N fois » meaning "by N posts of this page".
+ *
+ * Scope is the loaded page only: a citation from another page is not counted (that page is not in
+ * memory). This is an intentional, documented limitation of the per-page reading badge; a global
+ * count would need a server-side index HFR does not expose.
+ */
+internal fun citationCountsByNumreponse(posts: List<Post>): Map<Int, Int> {
+    val counts = HashMap<Int, Int>()
+    posts.forEach { post ->
+        post.citedNumreponses().forEach { cited ->
+            counts[cited] = (counts[cited] ?: 0) + 1
+        }
+    }
+    return counts
+}
+
+/** Distinct `numreponse`s this post directly cites (top-level quotes + quotes inside spoilers). */
+private fun Post.citedNumreponses(): Set<Int> {
+    val acc = LinkedHashSet<Int>()
+    collectDirectCitations(content.blocks, acc)
+    return acc
+}
+
+private fun collectDirectCitations(blocks: List<PostBlock>, acc: MutableSet<Int>) {
+    blocks.forEach { block ->
+        when (block) {
+            // Record the cited post but do NOT recurse into block.content: a quote nested inside this
+            // quote is quoted material, not a fresh citation by the current post.
+            is PostBlock.Quote -> block.numreponse?.let(acc::add)
+            is PostBlock.Spoiler -> collectDirectCitations(block.content.blocks, acc)
+            else -> Unit
+        }
+    }
+}

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -8,9 +8,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -22,12 +20,16 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -45,6 +47,8 @@ import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
@@ -109,6 +113,18 @@ fun TopicScreen(
      */
     onEditFirstPost: (subcat: Int, page: Int, numreponse: Int) -> Unit,
     onOpenPage: (Int) -> Unit,
+    /**
+     * #285 — leave the topic and go back to the screen that opened it (topic list / flags).
+     * Wired to a back-stack pop in `:app`. Surfaced as an explicit back arrow in the top app
+     * bar so the user never has to rely on the system / gesture back to exit a topic.
+     */
+    onBack: () -> Unit,
+    /**
+     * #226 — after a plain reply that overflowed onto a freshly created page, re-route to that
+     * last page : the post the user just published lives there, not on the page the reply form
+     * was anchored to. `:app` replaces the current TopicRoute in place with the target page.
+     */
+    onNavigateToLastPage: (page: Int) -> Unit,
     /**
      * Phase 2 finish (#208) — emitted when the user taps on a post avatar or author name.
      * Carries the numeric user id (canonical key for profile navigation) plus display hints
@@ -189,6 +205,13 @@ fun TopicScreen(
                         android.widget.Toast.LENGTH_LONG,
                     ).show()
                 }
+                is TopicEffect.NavigateToLastPage -> {
+                    // #226 — the plain reply overflowed onto a freshly created last page. Hand the
+                    // target page to `:app`, which replaces the current TopicRoute in place so the
+                    // user lands on the page that actually holds their new post (the ViewModel for
+                    // that route then anchors #bas → ScrollToEndOfPage as usual).
+                    onNavigateToLastPage(effect.page)
+                }
             }
         }
     }
@@ -197,6 +220,7 @@ fun TopicScreen(
         state = state,
         listState = lazyListState,
         onIntent = viewModel::send,
+        onBack = onBack,
         onReply = onReply,
         onQuote = onQuote,
         onEdit = onEdit,
@@ -332,12 +356,14 @@ private const val REANCHOR_MIN_FRAMES = 60
 /** Frames the target position must hold still before we treat the layout as settled. */
 private const val REANCHOR_STABLE_FRAMES = 3
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 @Suppress("LongParameterList") // state-hoisted Composable : each param has a distinct call-site.
 internal fun TopicContent(
     state: TopicUiState,
     listState: LazyListState,
     onIntent: (TopicIntent) -> Unit,
+    onBack: () -> Unit,
     onReply: (subcat: Int, page: Int) -> Unit,
     onQuote: (subcat: Int, page: Int, quotedNumreponse: Int, quoteRef: Int?) -> Unit,
     onEdit: (subcat: Int, page: Int, numreponse: Int) -> Unit,
@@ -345,58 +371,99 @@ internal fun TopicContent(
     onOpenPage: (Int) -> Unit,
     onOpenProfile: (userId: Int, pseudo: String, avatarUrl: String?) -> Unit = { _, _, _ -> },
 ) {
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.surface,
-    ) {
-        when (val mode = state.mode) {
-            TopicUiState.Mode.Loading -> {
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .statusBarsPadding()
-                        .navigationBarsPadding()
-                        .padding(24.dp),
-                    verticalArrangement = Arrangement.spacedBy(16.dp),
-                ) {
-                    CircularProgressIndicator()
-                    Text(
-                        text = stringResource(R.string.topic_loading),
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
-                }
-            }
-
-            is TopicUiState.Mode.Error -> {
-                RedfacePlaceholderScreen(
-                    title = stringResource(R.string.topic_error_title),
-                    body = stringResource(R.string.topic_error_body, state.request.page, mode.message),
-                ) {
-                    TopicPageNavigation(
-                        currentPage = state.request.page,
-                        availablePages = state.availablePages,
-                        canGoPrevious = state.canGoPrevious,
-                        canGoNext = state.canGoNext,
-                        onOpenPage = onOpenPage,
-                    )
-                    OutlinedButton(onClick = { onIntent(TopicIntent.Retry) }) {
-                        Text(text = stringResource(R.string.topic_retry))
+    // #285 — the topic title and #284 — the page counter live in a persistent top app bar so they
+    // stay visible while the user scrolls (the in-card title/caption scrolls away). When the page
+    // is still loading / errored, fall back to a generic title and the requested page.
+    val loaded = state.mode as? TopicUiState.Mode.Loaded
+    val barTitle = loaded?.topic?.title?.takeIf { it.isNotBlank() }
+        ?: stringResource(R.string.topic_topbar_fallback_title)
+    val barCurrentPage = loaded?.topic?.page ?: state.request.page
+    val barTotalPages = loaded?.topic?.totalPages
+        ?: state.availablePages.lastOrNull()
+        ?: state.request.page
+    val backLabel = stringResource(R.string.topic_back)
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Column {
+                        Text(
+                            text = barTitle,
+                            style = MaterialTheme.typography.titleMedium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            text = stringResource(R.string.topic_page_indicator, barCurrentPage, barTotalPages),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.semantics { contentDescription = backLabel },
+                    ) {
+                        Text("←")
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Surface(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            color = MaterialTheme.colorScheme.surface,
+        ) {
+            when (val mode = state.mode) {
+                TopicUiState.Mode.Loading -> {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(24.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                    ) {
+                        CircularProgressIndicator()
+                        Text(
+                            text = stringResource(R.string.topic_loading),
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
                     }
                 }
-            }
 
-            is TopicUiState.Mode.Loaded -> {
-                TopicLoadedContent(
-                    state = state,
-                    topic = mode.topic,
-                    onReply = onReply,
-                    onQuote = onQuote,
-                    onEdit = onEdit,
-                    onEditFirstPost = onEditFirstPost,
-                    onOpenPage = onOpenPage,
-                    onOpenProfile = onOpenProfile,
-                    listState = listState,
-                )
+                is TopicUiState.Mode.Error -> {
+                    RedfacePlaceholderScreen(
+                        title = stringResource(R.string.topic_error_title),
+                        body = stringResource(R.string.topic_error_body, state.request.page, mode.message),
+                    ) {
+                        TopicPageNavigation(
+                            currentPage = state.request.page,
+                            availablePages = state.availablePages,
+                            canGoPrevious = state.canGoPrevious,
+                            canGoNext = state.canGoNext,
+                            onOpenPage = onOpenPage,
+                        )
+                        OutlinedButton(onClick = { onIntent(TopicIntent.Retry) }) {
+                            Text(text = stringResource(R.string.topic_retry))
+                        }
+                    }
+                }
+
+                is TopicUiState.Mode.Loaded -> {
+                    TopicLoadedContent(
+                        state = state,
+                        topic = mode.topic,
+                        onReply = onReply,
+                        onQuote = onQuote,
+                        onEdit = onEdit,
+                        onEditFirstPost = onEditFirstPost,
+                        onOpenPage = onOpenPage,
+                        onOpenProfile = onOpenProfile,
+                        listState = listState,
+                    )
+                }
             }
         }
     }
@@ -446,8 +513,9 @@ private fun TopicLoadedContent(
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .statusBarsPadding()
-            .navigationBarsPadding()
+            // #285 — system-bar insets (status + navigation) are now consumed by the Scaffold/TopAppBar
+            // in TopicContent and applied via the content Surface's padding(innerPadding); the list no
+            // longer adds statusBarsPadding()/navigationBarsPadding() here to avoid double-insetting.
             // #282 — horizontal swipe changes page via the existing route-driven onOpenPage, with
             // drag-follow feedback: the page tracks the finger (graphicsLayer inside topicPageSwipe)
             // and topicPageSwipeEdge paints an edge glow as the swipe arms. topicPageSwipeEdge must

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
@@ -483,6 +484,9 @@ private fun TopicLoadedContent(
     listState: LazyListState,
 ) {
     val highlight = state.request.scrollTo
+    // #239 — how many posts of THIS page cite each post, computed once per loaded post list. Drives
+    // the « cité N fois » badge below. Pure + page-scoped (cf. citationCountsByNumreponse KDoc).
+    val citationCounts = remember(topic.posts) { citationCountsByNumreponse(topic.posts) }
     // #282 — shared offset between the gesture (drives translationX) and the edge glow. A plain
     // MutableFloatState: the gesture writes it synchronously per frame (no coroutine/alloc), the draw
     // phase reads it; an Animatable inside the gesture handles only release transitions. Lives in the
@@ -613,6 +617,7 @@ private fun TopicLoadedContent(
             TopicPostCard(
                 post = post,
                 highlighted = highlight == post.numreponse,
+                citedCount = citationCounts[post.numreponse] ?: 0,
                 onQuote = quoteAction,
                 onEdit = editAction,
                 onOpenProfile = profileAction,
@@ -859,9 +864,14 @@ private fun TopicPollCard(poll: Poll) {
 }
 
 @Composable
+@Suppress("LongParameterList") // state-hoisted Composable : each param has a distinct call-site.
 private fun TopicPostCard(
     post: Post,
     highlighted: Boolean,
+    /**
+     * #239 — number of posts on the current page that cite this one. 0 hides the badge.
+     */
+    citedCount: Int,
     onQuote: (() -> Unit)?,
     onEdit: (() -> Unit)?,
     /**
@@ -976,6 +986,25 @@ private fun TopicPostCard(
                         style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
+                    if (citedCount > 0) {
+                        // #239 — sober pill: how many posts of THIS page cite this one. Page-scoped
+                        // (cf. citationCountsByNumreponse); jumping to the citing posts is a follow-up.
+                        Surface(
+                            color = MaterialTheme.colorScheme.secondaryContainer,
+                            shape = MaterialTheme.shapes.small,
+                        ) {
+                            Text(
+                                text = pluralStringResource(
+                                    R.plurals.topic_post_cited_count,
+                                    citedCount,
+                                    citedCount,
+                                ),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+                            )
+                        }
+                    }
                 }
             }
             PostRenderer(content = post.content)

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1007,7 +1007,8 @@ private fun TopicPostCard(
                     }
                 }
             }
-            PostRenderer(content = post.content)
+            // #281 — topic posts are selectable/copyable (opt-in; default is OFF in PostRenderer).
+            PostRenderer(content = post.content, selectable = true)
             if (onQuote != null || onEdit != null) {
                 // Actions row at the bottom of the post card, sober TextButtons
                 // so they stay subordinate to the post content. « Modifier »

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -92,4 +92,16 @@ sealed interface TopicEffect {
      * the submit silently failed.
      */
     data object PostSubmitRefreshFailed : TopicEffect
+
+    /**
+     * Issue #226 — emitted after a plain-reply submit when the reply overflowed the topic onto a
+     * newly-created page but HFR's success URL anchored the OLD page (the one the form was on). The
+     * ViewModel detects this in `forceRefreshCurrentPage`: the force-refreshed page reports a
+     * `totalPages` greater than `request.page` while `scrollTo` is null (plain reply — quote/edit
+     * carry a `#t{N}` scrollTo and are excluded). The screen re-routes to [page] (= the new
+     * `totalPages`) with a fresh `submitSignal` + `scrollTo = null`, so the new ViewModel
+     * force-refreshes that last page and [ScrollToEndOfPage] lands on the freshly-published post.
+     * Defensive: works whether HFR anchored the old page (the bug) or the new one.
+     */
+    data class NavigateToLastPage(val page: Int) : TopicEffect
 }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -223,6 +223,10 @@ class TopicViewModel @AssistedInject constructor(
                 // carry a #t{N} scrollTo and are excluded), the fresh post lives on the last page, not
                 // here. Re-route there instead of scrolling this stale page. A same-page reply keeps
                 // totalPages == request.page and falls through to the #200 ScrollToEndOfPage path.
+                // Best-effort under concurrency: HFR's #bas success URL carries NO numreponse, so we
+                // cannot tell our own overflow from a concurrent poster's new page — we send the user
+                // to the last page either way (a reasonable landing). The redirect target route omits
+                // submitSignal precisely so we don't re-enter this guard and chase a moving tail.
                 if (request.scrollTo == null && topic.totalPages > request.page) {
                     _effects.send(TopicEffect.NavigateToLastPage(topic.totalPages))
                     return@launch

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -217,6 +217,16 @@ class TopicViewModel @AssistedInject constructor(
                     )
                 }
                 endFirstContentSectionIfNeeded()
+                // #226 — plain-reply overflow: the reply created a new page but HFR anchored the page
+                // the form was on (request.page). The force-refreshed page reports the up-to-date
+                // totalPages; if it now exceeds request.page (plain reply → scrollTo null; quote/edit
+                // carry a #t{N} scrollTo and are excluded), the fresh post lives on the last page, not
+                // here. Re-route there instead of scrolling this stale page. A same-page reply keeps
+                // totalPages == request.page and falls through to the #200 ScrollToEndOfPage path.
+                if (request.scrollTo == null && topic.totalPages > request.page) {
+                    _effects.send(TopicEffect.NavigateToLastPage(topic.totalPages))
+                    return@launch
+                }
                 maybeEmitScroll(topic.posts.map { it.numreponse })
                 // Skip the page+1 warmup here — the user just submitted and is unlikely to need
                 // page+1 immediately; the next normal navigation will trigger the warmup through

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -2,6 +2,10 @@
     <string name="topic_scroll_to">Scroll ciblé demandé vers le post %1$d.</string>
     <string name="topic_reply">Répondre depuis ce topic</string>
     <string name="topic_loading">Chargement…</string>
+    <!-- #285 — top app bar : back affordance (content description) + fallback title shown while
+         the topic page has not loaded yet (or errored), so the bar never reads blank. -->
+    <string name="topic_back">Retour</string>
+    <string name="topic_topbar_fallback_title">Sujet</string>
     <string name="topic_error_title">Erreur de chargement</string>
     <string name="topic_error_body">Impossible d’ouvrir la page %1$d.\n\n%2$s</string>
     <string name="topic_caption">post %1$d • page %2$d / %3$d</string>

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -11,6 +11,11 @@
     <string name="topic_caption">post %1$d • page %2$d / %3$d</string>
     <string name="topic_post_index_prefix">#%1$d • </string>
     <string name="topic_post_numreponse_suffix"> • n°%1$d</string>
+    <!-- #239 — badge on a post showing how many posts of the CURRENT page cite it. -->
+    <plurals name="topic_post_cited_count">
+        <item quantity="one">cité %1$d fois</item>
+        <item quantity="other">cité %1$d fois</item>
+    </plurals>
     <string name="topic_poll_option">%1$s — %2$.1f%% (%3$d votes)</string>
     <string name="topic_poll_summary">%1$d votes au total • %2$s</string>
     <string name="topic_poll_multiple_choices">multi-choix</string>

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/CitationIndexTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/CitationIndexTest.kt
@@ -1,0 +1,96 @@
+package fr.forumhfr.redface2.feature.topic
+
+import fr.forumhfr.redface2.core.model.Post
+import fr.forumhfr.redface2.core.model.PostBlock
+import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.model.PostInline
+import java.time.Instant
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CitationIndexTest {
+
+    @Test
+    fun `counts distinct citing posts per cited numreponse`() {
+        val posts = listOf(
+            post(1, listOf(paragraph("hello"))),
+            post(2, listOf(quote(citing = 1), paragraph("re"))),
+            post(3, listOf(quote(citing = 1))),
+        )
+
+        val counts = citationCountsByNumreponse(posts)
+
+        assertEquals(2, counts[1])
+        assertNull("a post nobody cites is absent from the map", counts[2])
+    }
+
+    @Test
+    fun `quoting the same post twice in one message counts that message once`() {
+        val posts = listOf(
+            post(1, listOf(paragraph("x"))),
+            post(2, listOf(quote(citing = 1), paragraph("a"), quote(citing = 1))),
+        )
+
+        assertEquals(1, citationCountsByNumreponse(posts)[1])
+    }
+
+    @Test
+    fun `a quote nested inside another quote is not a fresh citation`() {
+        // post 3 quotes post 2, whose quote had itself re-quoted post 1 (nested). Only 2 is cited by 3.
+        val nested = PostBlock.Quote(
+            author = "B",
+            numreponse = 2,
+            page = 1,
+            content = PostContent(listOf(quote(citing = 1), paragraph("inner"))),
+        )
+        val posts = listOf(post(3, listOf(nested)))
+
+        val counts = citationCountsByNumreponse(posts)
+
+        assertEquals(1, counts[2])
+        assertNull("the nested re-quote of post 1 must not count", counts[1])
+    }
+
+    @Test
+    fun `a quote inside a spoiler still counts`() {
+        val spoiler = PostBlock.Spoiler(
+            label = null,
+            content = PostContent(listOf(quote(citing = 5))),
+        )
+        val posts = listOf(post(6, listOf(spoiler)))
+
+        assertEquals(1, citationCountsByNumreponse(posts)[5])
+    }
+
+    @Test
+    fun `a bare quote with no numreponse is ignored`() {
+        val bareQuote = PostBlock.Quote(
+            author = null,
+            numreponse = null,
+            page = null,
+            content = PostContent(emptyList()),
+        )
+        val posts = listOf(post(7, listOf(bareQuote)))
+
+        assertEquals(emptyMap<Int, Int>(), citationCountsByNumreponse(posts))
+    }
+
+    private fun post(numreponse: Int, blocks: List<PostBlock>): Post = Post(
+        numreponse = numreponse,
+        author = "user$numreponse",
+        date = Instant.EPOCH,
+        content = PostContent(blocks),
+        avatarUrl = null,
+        isEditable = false,
+        isOwnPost = false,
+        quotedAuthors = emptyList(),
+        postIndex = null,
+    )
+
+    private fun paragraph(text: String): PostBlock.Paragraph =
+        PostBlock.Paragraph(listOf(PostInline.Text(text)))
+
+    private fun quote(citing: Int): PostBlock.Quote =
+        PostBlock.Quote(author = "u$citing", numreponse = citing, page = 1, content = PostContent(emptyList()))
+}

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -480,6 +480,35 @@ class TopicViewModelTest {
     }
 
     @Test
+    fun `submitSignal without scrollTo on an overflowed reply emits NavigateToLastPage (#226)`() = runTest {
+        // #226 — the plain reply was submitted from page 20's form, but it overflowed onto a freshly
+        // created page 21. HFR anchored the form's page (20) so the force refresh of page 20 reports
+        // an up-to-date totalPages = 21 > request.page = 20. The new post lives on page 21, not here,
+        // so the ViewModel must re-route there (NavigateToLastPage) rather than ScrollToEndOfPage on
+        // the stale page 20 (which would scroll to the pre-overflow last post and confuse the user).
+        val overflowedTopic = fakeTopic(
+            page = 20,
+            totalPages = 21,
+            posts = listOf(fakePost(1), fakePost(2), fakePost(3)),
+        )
+        val repository = FakeTopicRepository(
+            flowsToReturn = emptyList(),
+            refreshTopicsToReturn = listOf(overflowedTopic),
+        )
+
+        val viewModel = TopicViewModel(
+            request = topicRequest(page = 20, scrollTo = null, submitSignal = 123L),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+
+        viewModel.effects.test {
+            assertEquals(TopicEffect.NavigateToLastPage(21), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `normal load without submitSignal does not emit ScrollToEndOfPage`() = runTest {
         // Regression guard: ScrollToEndOfPage is gated on submitSignal != null. A normal
         // deep-link navigation (cache-aside) must never emit it, even when scrollTo is null,


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Batch de chantiers indépendants issus du dogfood Phase 5. Livré d'abord sur le **canal dev** ; **ne pas merger sur main sans validation explicite**.

## Chantiers

### Thème (#286)
- Sélecteur **Clair / Système / Sombre** + bascule **AMOLED**, persistés en DataStore, appliqués à toute l'app en direct (commit `4e0d2fe`).
- Suivi de revue Codex (`2d12c87`) : contraste des barres système synchronisé avec le thème **effectif** (et non l'uiMode OS) via `Context.findActivity()` défensif ; test de race d'hydratation.

### Lecture topic (#285 / #284 / #281 / #226)
- **#285** : `TopAppBar` persistant avec le **titre du sujet** + flèche **retour** explicite (insets gérés par le Scaffold).
- **#284** : **compteur « page X/Y »** en sous-titre, toujours visible.
- **#281** : **sélection / copie** du texte des posts (`SelectionContainer` au point d'entrée).
- **#226** : un reply qui **déborde sur une nouvelle page** re-route vers la dernière page (atterrissage sur le post fraîchement publié), au lieu de rester sur la page du formulaire. Test de régression.

### Bouton « Envoyer » (éditeur)
- Le bouton était noyé en bas de la colonne scrollée → **caché par le clavier**. Extrait dans une **barre épinglée** levée au-dessus de l'IME (`navigationBarsPadding()` + `imePadding()`), partagée par `PostEditorScreen` (répondre / citer / éditer) et `TopicFormScreen` (créer / éditer le 1er post). `windowSoftInputMode=adjustResize` ajouté.

### Pseudo & citations
- **#260** : pseudo à espace décodé à la capture (cookie `md_user` form-urlencodé → « Dintr-un+lemn » devenait visible). Test ajouté.
- **#239** : badge **« cité N fois »** sur les posts, comptant les citations **de la page courante** (fonction pure testée ; portée page assumée, liens vers les citations = follow-up).

## Validation locale
`detektAll lintDebug test testDebugUnitTest :app:lintProdDebug :app:assembleProdDebug` — vert. Revue Codex 5.5 xhigh sur le thème : aucun bloquant (3 nits appliqués).

Closes #286
Closes #285
Closes #284
Closes #281
Closes #226
Closes #260
Closes #239