### PR TITLE
chore(ci): router Dependabot vers dev + CI sur push dev (rollout git-flow-lite)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,9 @@ version: 2
 updates:
   - package-ecosystem: "gradle"
     directory: "/"
+    # Bumps land on the `dev` integration branch first so they ride a dev-channel
+    # dogfood build before being promoted to `main` (beta/prod). cf. git-flow-lite.
+    target-branch: "dev"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
@@ -73,6 +76,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - dev
   pull_request:
 
 concurrency:


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Infra du **rollout `dev` (git-flow allégé)** décidé en chat : `feature → dev → main`, Dependabot sur `dev`, promotion `dev → main` en **merge-commit (no-ff)** aux cuts beta. `main` reste *promote-only* (le canal beta en part).

## Changements
- **`.github/dependabot.yml`** : `target-branch: "dev"` sur les 2 écosystèmes (gradle + github-actions) → les bumps atterrissent sur la branche d'intégration et passent un build dogfood canal dev avant promotion vers `main`.
- **`.github/workflows/ci.yml`** : la CI tourne aussi sur `push` vers `dev` (les PR sont déjà couvertes) → `dev` HEAD toujours vérifié après un merge de promotion.

## ⚠️ Ordre de merge (pourquoi cette PR est en DRAFT)
1. Dependabot lit `dependabot.yml` depuis la branche **par défaut (`main`)** ; le `target-branch: dev` ne s'active donc qu'une fois mergé sur `main`, **et** la branche `dev` doit **exister** avant (sinon Dependabot erre).
2. Séquence recommandée : (a) merger **#336 → main** (candidat beta, déjà reviewé base main, fait jouer ses `Closes`) → (b) couper `dev` depuis `main` → (c) **merger cette PR** → (d) features & Dependabot ciblent `dev`.

## Autre point à acter (hors de cette PR)
- Les mots-clés `Closes #N` ne ferment l'issue qu'au merge sur la branche **par défaut (`main`)**. Dans le modèle `dev`, une feature mergée sur `dev` ne fermera ses issues qu'à la **promotion `dev → main`** → porter les `Closes` sur la PR de promotion (ou accepter la fermeture au cut beta). À documenter dans `AGENTS.md` au moment de couper `dev`.

Pas de `Closes` ici (infra pure).