### PR TITLE
feat(topic): fix titre top-bar au changement de page + option masquer la barre en défilant

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -370,6 +370,13 @@ fun RedfaceApp(intent: Intent?) {
         // metadata never outlives the session / account.
         var multiRecipientThreadIds by remember { mutableStateOf(emptySet<Int>()) }
 
+        // Bug fix (build 89) — per-topic title cache keyed by (cat, post). A page change replaces the
+        // TopicRoute (new nav entry → new ViewModel → Loading with no topic), which used to flash the
+        // generic « Sujet » title in the top bar. The topic screen reports its loaded title here; the
+        // next page reads it back via TopicRequest.titleHint. Hoisted above NavDisplay so it survives
+        // the entry recreation; keyed by (cat, post) so titles never bleed across categories.
+        var topicTitleCache by remember { mutableStateOf(emptyMap<TopicTitleKey, String>()) }
+
         LaunchedEffect(authState) {
             when (authState) {
                 null -> Unit
@@ -438,6 +445,12 @@ fun RedfaceApp(intent: Intent?) {
                         },
                         onThreadOpenedAsMulti = { threadId ->
                             multiRecipientThreadIds = multiRecipientThreadIds + threadId
+                        },
+                    ),
+                    topicTitleNavState = TopicTitleNavState(
+                        titles = topicTitleCache,
+                        onTitleLoaded = { cat, post, title ->
+                            topicTitleCache = topicTitleCache.withTitle(TopicTitleKey(cat, post), title)
                         },
                     ),
                     onOpenProfile = { userId, pseudo, avatarUrl ->
@@ -538,6 +551,51 @@ private data class PrivateMessageNavState(
     val onThreadOpenedAsMulti: (Int) -> Unit,
 )
 
+/**
+ * Bug fix (build 89) — per-topic title cache plumbed into [RedfaceNavHost]. A topic page change
+ * replaces the TopicRoute (new nav entry → new ViewModel → Loading with no topic yet), which used to
+ * flash the generic « Sujet » title in the top app bar. The `var` backing [titles] lives in
+ * [RedfaceApp] so it survives the entry recreation; [onTitleLoaded] writes the freshly-loaded title
+ * back and the next page reads it via TopicRequest.titleHint. Keyed by topic id so titles never bleed
+ * across topics. Same read-map + onLoaded-callback shape as [PrivateMessageNavState].
+ *
+ * @property titles last known title per topic, fed into TopicRequest.titleHint.
+ * @property onTitleLoaded records a topic's title once its page has loaded.
+ */
+private data class TopicTitleNavState(
+    val titles: Map<TopicTitleKey, String>,
+    val onTitleLoaded: (cat: Int, post: Int, title: String) -> Unit,
+)
+
+/**
+ * Composite cache key for [TopicTitleNavState]. A topic id (`post`) is unique only **per HFR
+ * category**, not globally — two categories can theoretically expose the same id (cf. the same
+ * `(cat, topicId)` composite key in `SearchScreen`), so keying by `post` alone could flash the
+ * wrong title across categories while a page loads. Keyed by `(cat, post)` to stay correct.
+ */
+private data class TopicTitleKey(val cat: Int, val post: Int)
+
+// Upper bound on the per-topic title cache (display hint only). A long reading session opens many
+// topics; capping at a generous size keeps the map from growing unbounded for the app's lifetime.
+// Eviction is FIFO (oldest insertions dropped) — losing a stale hint just falls back to « Sujet »
+// for one loading frame, which is harmless.
+private const val TOPIC_TITLE_CACHE_MAX = 128
+
+/**
+ * Inserts [title] for [key] into the per-topic title cache, evicting the oldest entries past
+ * [TOPIC_TITLE_CACHE_MAX]. `Map + pair` preserves insertion order (LinkedHashMap), so dropping from
+ * the front evicts the least-recently-inserted titles. Extracted from [RedfaceApp] to keep that
+ * composable under the cyclomatic-complexity budget.
+ */
+private fun Map<TopicTitleKey, String>.withTitle(key: TopicTitleKey, title: String): Map<TopicTitleKey, String> {
+    val updated = this + (key to title)
+    return if (updated.size > TOPIC_TITLE_CACHE_MAX) {
+        updated.entries.drop(updated.size - TOPIC_TITLE_CACHE_MAX).associate { it.toPair() }
+    } else {
+        updated
+    }
+}
+
 @Composable
 @Suppress("CyclomaticComplexMethod") // One entry per top-level route + per-screen navigation callbacks ;
 // splitting the host would just push the same `when` shape one level deeper without reducing complexity.
@@ -545,6 +603,9 @@ private fun RedfaceNavHost(
     backStack: NavBackStack<NavKey>,
     accountMenu: @Composable () -> Unit,
     privateMessageNavState: PrivateMessageNavState,
+    // Bug fix (build 89) — per-topic title cache threaded down from RedfaceApp (where the `var` lives
+    // so it survives entry recreation across page changes). Bundled to keep the param count in check.
+    topicTitleNavState: TopicTitleNavState,
     onOpenProfile: (userId: Int, pseudo: String, avatarUrl: String?) -> Unit = { _, _, _ -> },
 ) {
     NavDisplay(
@@ -759,7 +820,11 @@ private fun RedfaceNavHost(
                         scrollTo = route.scrollTo,
                         submitSignal = route.submitSignal,
                         forceRefresh = route.forceRefresh,
+                        titleHint = topicTitleNavState.titles[TopicTitleKey(route.cat, route.post)],
                     ),
+                    onTitleLoaded = { title ->
+                        topicTitleNavState.onTitleLoaded(route.cat, route.post, title)
+                    },
                     onOpenProfile = onOpenProfile,
                     onReply = { subcat, page ->
                         backStack.add(

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -176,6 +176,21 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeTopicTopBarAutoHide(): Flow<Boolean> =
+        dataStore.data
+            // Default `false`: the topic top bar stays pinned unless the user opts into auto-hide.
+            .map { prefs -> prefs[KEY_TOPIC_TOPBAR_AUTO_HIDE] ?: false }
+            .distinctUntilChanged()
+            .catch { emit(false) }
+
+    override suspend fun setTopicTopBarAutoHide(enabled: Boolean) {
+        withContext(ioDispatcher) {
+            dataStore.edit { prefs ->
+                prefs[KEY_TOPIC_TOPBAR_AUTO_HIDE] = enabled
+            }
+        }
+    }
+
     /**
      * Reads [KEY_THEME_MODE] defensively: an unknown / corrupt stored value (older build with a
      * renamed enum, manual edit) falls back to [ThemeMode.SYSTEM] instead of crashing on
@@ -261,5 +276,8 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         // #286 — app theme selection (ThemeMode.name, defensively parsed) + AMOLED toggle.
         val KEY_THEME_MODE = stringPreferencesKey("theme_mode")
         val KEY_AMOLED_ENABLED = booleanPreferencesKey("amoled_enabled")
+
+        // build 89 follow-up — topic top app bar auto-hide on scroll.
+        val KEY_TOPIC_TOPBAR_AUTO_HIDE = booleanPreferencesKey("topic_topbar_auto_hide")
     }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -351,6 +351,26 @@ class DataStoreUserPreferencesRepositoryTest {
     }
 
     @Test
+    fun `observeTopicTopBarAutoHide defaults to false then persists true and false`() = runTest(dispatcher) {
+        repository.observeTopicTopBarAutoHide().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setTopicTopBarAutoHide(true)
+        repository.observeTopicTopBarAutoHide().test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setTopicTopBarAutoHide(false)
+        repository.observeTopicTopBarAutoHide().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `saving disabled proxy removes optional fields from effective config`() = runTest(dispatcher) {
         repository.saveProxyConfig(
             ProxyConfig(

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -504,5 +504,9 @@ class TopicRepositoryImplTest {
         override fun observeAmoledEnabled(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setAmoledEnabled(enabled: Boolean) = Unit
+
+        override fun observeTopicTopBarAutoHide(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setTopicTopBarAutoHide(enabled: Boolean) = Unit
     }
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -125,4 +125,16 @@ interface UserPreferencesRepository {
 
     /** Persists [observeAmoledEnabled]. Default `false` until the first call. */
     suspend fun setAmoledEnabled(enabled: Boolean)
+
+    /**
+     * Topic top app bar auto-hide (build 89 follow-up): when `true`, the topic top bar (title +
+     * page counter) collapses while the user scrolls down through the posts and re-appears as soon
+     * as they scroll back toward the top — Material3 `enterAlways` behaviour — freeing reading
+     * space. Default `false` (the bar stays pinned). Observed by `:feature:topic`, toggled in
+     * Settings.
+     */
+    fun observeTopicTopBarAutoHide(): Flow<Boolean>
+
+    /** Persists [observeTopicTopBarAutoHide]. Default `false` until the first call. */
+    suspend fun setTopicTopBarAutoHide(enabled: Boolean)
 }

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1387,6 +1387,10 @@ class FlagsViewModelTest {
 
         override suspend fun setAmoledEnabled(enabled: Boolean) = Unit
 
+        override fun observeTopicTopBarAutoHide(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setTopicTopBarAutoHide(enabled: Boolean) = Unit
+
         fun setGroupBy(value: Boolean) {
             groupBy.value = value
         }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -199,6 +199,11 @@ internal fun SettingsContent(
                 onIntent = onIntent,
             )
 
+            TopicPreferencesCard(
+                state = state,
+                onIntent = onIntent,
+            )
+
             MaintenanceCard(
                 state = state,
                 onIntent = onIntent,
@@ -330,6 +335,41 @@ private fun FlagsPreferencesCard(
             )
             if (state.flagsPerTabOverrideError) {
                 PreferencePersistError(R.string.settings_flags_per_tab_override_persist_failed)
+            }
+        }
+    }
+}
+
+/**
+ * Topic reading preferences (build 89 follow-up): the « masquer la barre du haut en défilant »
+ * toggle. When on, the topic top app bar (title + page counter) collapses on scroll-down and snaps
+ * back on the first scroll-up (Material3 `enterAlways`), freeing reading space. Persisted via
+ * DataStore and observed live by the topic screen, so a flip here applies without reopening a topic.
+ */
+@Composable
+private fun TopicPreferencesCard(
+    state: SettingsState,
+    onIntent: (SettingsIntent) -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_topic_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            PreferenceSwitchRow(
+                title = stringResource(R.string.settings_topic_topbar_auto_hide_title),
+                description = stringResource(R.string.settings_topic_topbar_auto_hide_description),
+                checked = state.topicTopBarAutoHide,
+                enabled = state.canToggleTopicTopBarAutoHide,
+                onCheckedChange = { onIntent(SettingsIntent.TopicTopBarAutoHideChanged(it)) },
+            )
+            if (state.topicTopBarAutoHideError) {
+                PreferencePersistError(R.string.settings_topic_topbar_auto_hide_persist_failed)
             }
         }
     }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -63,6 +63,14 @@ data class SettingsState(
     val isUpdatingAmoled: Boolean = false,
     val amoledError: Boolean = false,
     val amoledTouchedLocally: Boolean = false,
+    // Topic reading preferences (build 89 follow-up). Same optimistic-flip + startup-race-guard
+    // machinery: `topicTopBarAutoHide` is the displayed value, `isUpdating*` gates the switch while
+    // DataStore writes, `*Error` surfaces a persist failure, `*TouchedLocally` forbids a late `init`
+    // hydration from clobbering a fast user flip. Default false (top bar pinned).
+    val topicTopBarAutoHide: Boolean = false,
+    val isUpdatingTopicTopBarAutoHide: Boolean = false,
+    val topicTopBarAutoHideError: Boolean = false,
+    val topicTopBarAutoHideTouchedLocally: Boolean = false,
 ) {
     val canSave: Boolean
         get() = !isSaving
@@ -91,6 +99,10 @@ data class SettingsState(
 
     val canToggleAmoled: Boolean
         get() = !isUpdatingAmoled
+
+    // Build 89 follow-up — the topic top-bar auto-hide toggle is gated only by its own write.
+    val canToggleTopicTopBarAutoHide: Boolean
+        get() = !isUpdatingTopicTopBarAutoHide
 }
 
 sealed interface SettingsError {
@@ -141,4 +153,8 @@ sealed interface SettingsIntent {
     // both applied optimistically with revert-on-failure, like the flags toggles.
     data class ThemeModeChanged(val mode: ThemeMode) : SettingsIntent
     data class AmoledEnabledChanged(val enabled: Boolean) : SettingsIntent
+
+    // Build 89 follow-up — topic top-bar auto-hide toggle. Optimistic-flip contract, like the
+    // flags toggles: the boolean is the desired post-flip state.
+    data class TopicTopBarAutoHideChanged(val enabled: Boolean) : SettingsIntent
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -98,6 +98,16 @@ class SettingsViewModel @Inject constructor(
                 }
             }
         }
+        viewModelScope.launch {
+            val autoHide = userPreferencesRepository.observeTopicTopBarAutoHide().first()
+            _state.update { current ->
+                if (current.topicTopBarAutoHideTouchedLocally || current.isUpdatingTopicTopBarAutoHide) {
+                    current
+                } else {
+                    current.copy(topicTopBarAutoHide = autoHide)
+                }
+            }
+        }
     }
 
     @Suppress("CyclomaticComplexMethod") // MVI when-dispatch over the SettingsIntent variants ; flat by design.
@@ -130,6 +140,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.FlagsPerTabOverrideChanged -> updateFlagsPerTabOverride(intent.enabled)
             is SettingsIntent.ThemeModeChanged -> updateThemeMode(intent.mode)
             is SettingsIntent.AmoledEnabledChanged -> updateAmoled(intent.enabled)
+            is SettingsIntent.TopicTopBarAutoHideChanged -> updateTopicTopBarAutoHide(intent.enabled)
         }
     }
 
@@ -366,6 +377,33 @@ class SettingsViewModel @Inject constructor(
                 }
             },
             persist = userPreferencesRepository::setAmoledEnabled,
+        )
+    }
+
+    private fun updateTopicTopBarAutoHide(desired: Boolean) {
+        val previous = _state.value.topicTopBarAutoHide
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    topicTopBarAutoHide = desired,
+                    isUpdatingTopicTopBarAutoHide = true,
+                    topicTopBarAutoHideError = false,
+                    topicTopBarAutoHideTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(topicTopBarAutoHide = desired, isUpdatingTopicTopBarAutoHide = false)
+                } else {
+                    state.copy(
+                        topicTopBarAutoHide = previous,
+                        isUpdatingTopicTopBarAutoHide = false,
+                        topicTopBarAutoHideError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setTopicTopBarAutoHide,
         )
     }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -64,4 +64,11 @@
     <string name="settings_theme_amoled_title">Thème AMOLED (vrai noir)</string>
     <string name="settings_theme_amoled_description">Fond noir pur pour les écrans OLED. S\'applique uniquement en thème sombre.</string>
     <string name="settings_theme_amoled_persist_failed">Impossible de mémoriser le réglage AMOLED. Réessayez.</string>
+
+    <!-- Build 89 follow-up — Lecture des sujets. Masquer la barre du haut (titre + numéro de page)
+         en défilant vers le bas pour libérer de la place ; persisté en DataStore et appliqué en direct. -->
+    <string name="settings_topic_title">Lecture des sujets</string>
+    <string name="settings_topic_topbar_auto_hide_title">Masquer la barre en défilant</string>
+    <string name="settings_topic_topbar_auto_hide_description">La barre du haut (titre du sujet et numéro de page) disparaît quand vous faites défiler vers le bas et réapparaît dès que vous remontez.</string>
+    <string name="settings_topic_topbar_auto_hide_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
 </resources>

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -590,6 +590,30 @@ class SettingsViewModelTest {
     }
 
     @Test
+    fun `TopicTopBarAutoHideChanged persists the flip`() = runTest {
+        val viewModel = newViewModel()
+        assertFalse("auto-hide is off by default", viewModel.state.value.topicTopBarAutoHide)
+
+        viewModel.submit(SettingsIntent.TopicTopBarAutoHideChanged(true))
+
+        assertTrue(viewModel.state.value.topicTopBarAutoHide)
+        assertFalse(viewModel.state.value.isUpdatingTopicTopBarAutoHide)
+        assertEquals(1, repository.topicTopBarAutoHideSetCalls)
+    }
+
+    @Test
+    fun `TopicTopBarAutoHideChanged reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnTopicTopBarAutoHideSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.TopicTopBarAutoHideChanged(true))
+
+        assertFalse("must revert to the previous value on failure", viewModel.state.value.topicTopBarAutoHide)
+        assertFalse(viewModel.state.value.isUpdatingTopicTopBarAutoHide)
+        assertTrue(viewModel.state.value.topicTopBarAutoHideError)
+    }
+
+    @Test
     fun `theme hydration race - a stale initial DataStore emission must not overwrite a local mode change`() =
         runTest {
             // Mirror of the ignoreTopicCache startup-race test for ThemeMode (#286, Codex nit): init
@@ -756,12 +780,30 @@ class SettingsViewModelTest {
             amoledEnabled.value = enabled
         }
 
+        // Build 89 follow-up — topic top-bar auto-hide. Same optimistic-flip seam as amoled.
+        private val topicTopBarAutoHide = MutableStateFlow(false)
+        var topicTopBarAutoHideSetCalls: Int = 0
+            private set
+        var failOnTopicTopBarAutoHideSet: Boolean = false
+
+        override fun observeTopicTopBarAutoHide(): Flow<Boolean> = topicTopBarAutoHide
+
+        override suspend fun setTopicTopBarAutoHide(enabled: Boolean) {
+            topicTopBarAutoHideSetCalls += 1
+            check(!failOnTopicTopBarAutoHideSet) { "boom" }
+            topicTopBarAutoHide.value = enabled
+        }
+
         fun emitThemeMode(value: ThemeMode) {
             themeMode.value = value
         }
 
         fun emitAmoledEnabled(value: Boolean) {
             amoledEnabled.value = value
+        }
+
+        fun emitTopicTopBarAutoHide(value: Boolean) {
+            topicTopBarAutoHide.value = value
         }
 
         // Per-type resolution / writes are exercised by the Flags ViewModel, not Settings; stubbed.

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicRequest.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicRequest.kt
@@ -21,4 +21,12 @@ data class TopicRequest(
      * leaves it `false` to keep back-nav snappy.
      */
     val forceRefresh: Boolean = false,
+    /**
+     * Display-only fallback title for the top app bar while a freshly-navigated page is still
+     * loading. A page change replaces the `TopicRoute` (new nav entry → new ViewModel → `Loading`
+     * with no topic yet), which would otherwise flash the generic « Sujet » fallback. `:app` keeps
+     * a per-topic title cache and feeds the last known title here so the bar stays stable. Never
+     * used once the page is `Loaded` (the real `Topic.title` wins).
+     */
+    val titleHint: String? = null,
 )

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -44,6 +45,7 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -127,6 +129,13 @@ fun TopicScreen(
      */
     onNavigateToLastPage: (page: Int) -> Unit,
     /**
+     * Bug fix (build 89) — reports the loaded topic title up to `:app` so it can keep a per-topic
+     * title cache. On a page change the screen is recreated and starts in `Loading`; `:app` feeds
+     * the cached title back via [TopicRequest.titleHint] so the top app bar no longer flashes the
+     * generic « Sujet » fallback between pages.
+     */
+    onTitleLoaded: (String) -> Unit = {},
+    /**
      * Phase 2 finish (#208) — emitted when the user taps on a post avatar or author name.
      * Carries the numeric user id (canonical key for profile navigation) plus display hints
      * [pseudo] and [avatarUrl] that `:app` can show immediately while the profile loads.
@@ -150,6 +159,14 @@ fun TopicScreen(
     // suspending lambda but the surrounding scope is still a Composable). Capturing the message
     // upfront keeps the rule happy and avoids re-resolving on every effect.
     val refreshFailedMsg = stringResource(R.string.topic_post_submit_refresh_failed)
+
+    // Bug fix (build 89) — report the loaded title up so `:app` caches it per topic. The next page
+    // (recreated screen) reads it back through `request.titleHint`, keeping the top bar title stable
+    // instead of flashing « Sujet » during the load.
+    val loadedTitle = (state.mode as? TopicUiState.Mode.Loaded)?.topic?.title
+    LaunchedEffect(loadedTitle) {
+        loadedTitle?.takeIf { it.isNotBlank() }?.let(onTitleLoaded)
+    }
 
     // Single-shot scroll : `effects` emits `ScrollToPost` exactly once per request,
     // when the ViewModel has loaded a page that contains the requested numreponse.
@@ -376,14 +393,35 @@ internal fun TopicContent(
     // stay visible while the user scrolls (the in-card title/caption scrolls away). When the page
     // is still loading / errored, fall back to a generic title and the requested page.
     val loaded = state.mode as? TopicUiState.Mode.Loaded
-    val barTitle = loaded?.topic?.title?.takeIf { it.isNotBlank() }
-        ?: stringResource(R.string.topic_topbar_fallback_title)
+    val fallbackTitle = stringResource(R.string.topic_topbar_fallback_title)
+    // Honour TopicRequest.titleHint's contract: the cached hint is a LOADING-only stand-in. Once the
+    // page is Loaded, the live Topic.title wins (or the generic fallback if it is somehow blank) — we
+    // never reach back to the stale hint, so a loaded topic can never display another page's title.
+    val barTitle = if (loaded != null) {
+        loaded.topic.title.takeIf { it.isNotBlank() } ?: fallbackTitle
+    } else {
+        state.request.titleHint?.takeIf { it.isNotBlank() } ?: fallbackTitle
+    }
     val barCurrentPage = loaded?.topic?.page ?: state.request.page
     val barTotalPages = loaded?.topic?.totalPages
         ?: state.availablePages.lastOrNull()
         ?: state.request.page
     val backLabel = stringResource(R.string.topic_back)
+    // Build 89 follow-up — when the user opted into auto-hide, give the top bar an `enterAlways`
+    // scroll behaviour (collapses on scroll-down, snaps back on the first scroll-up). Otherwise
+    // leave it `null` so the bar stays pinned (the prior, always-visible behaviour). Toggling the
+    // preference re-enters the other branch, recreating the behaviour expanded — the desired reset.
+    val scrollBehavior = if (state.topBarAutoHide) {
+        TopAppBarDefaults.enterAlwaysScrollBehavior()
+    } else {
+        null
+    }
     Scaffold(
+        modifier = if (scrollBehavior != null) {
+            Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
+        } else {
+            Modifier
+        },
         topBar = {
             TopAppBar(
                 title = {
@@ -409,6 +447,7 @@ internal fun TopicContent(
                         Text("←")
                     }
                 },
+                scrollBehavior = scrollBehavior,
             )
         },
     ) { innerPadding ->

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -17,6 +17,14 @@ data class TopicUiState(
      * in practice the cookie jar is primed at nav-host start so the window rarely shows.
      */
     val isAuthenticated: Boolean = false,
+    /**
+     * Build 89 follow-up — mirrors `UserPreferencesRepository.observeTopicTopBarAutoHide()`.
+     * When `true`, the screen wires a Material3 `enterAlways` scroll behaviour on the top app
+     * bar (title + page counter) so it collapses while scrolling down through the posts and
+     * re-appears on the first upward scroll. Default `false` keeps the bar pinned (the prior,
+     * always-visible behaviour). Flips on the first preference emission.
+     */
+    val topBarAutoHide: Boolean = false,
 ) {
     /**
      * Helper used by the screen / ViewModel : `true` when the user has navigated to a

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -8,6 +8,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.topic.TopicRepository
 import fr.forumhfr.redface2.core.model.AuthState
 import kotlinx.coroutines.CancellationException
@@ -40,6 +41,7 @@ class TopicViewModel @AssistedInject constructor(
     @Assisted private val request: TopicRequest,
     private val topicRepository: TopicRepository,
     private val authRepository: AuthRepository,
+    private val userPreferencesRepository: UserPreferencesRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(TopicUiState.initial(request))
@@ -91,6 +93,13 @@ class TopicViewModel @AssistedInject constructor(
         authRepository.observeAuthState()
             .onEach { authState ->
                 _state.update { it.copy(isAuthenticated = authState is AuthState.Authenticated) }
+            }
+            .launchIn(viewModelScope)
+        // Build 89 follow-up — mirror the top-bar auto-hide preference into state so the screen
+        // can switch between a pinned and an `enterAlways` scroll behaviour without a refetch.
+        userPreferencesRepository.observeTopicTopBarAutoHide()
+            .onEach { autoHide ->
+                _state.update { it.copy(topBarAutoHide = autoHide) }
             }
             .launchIn(viewModelScope)
     }

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -2,8 +2,13 @@ package fr.forumhfr.redface2.feature.topic
 
 import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
+import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
+import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
+import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.topic.TopicRepository
 import fr.forumhfr.redface2.core.model.AuthState
+import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.Post
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.Topic
@@ -43,7 +48,7 @@ class TopicViewModelTest {
         val topic = fakeTopic(page = 2, totalPages = 5)
         val repository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(topic) }))
 
-        val viewModel = TopicViewModel(
+        val viewModel = topicViewModel(
             request = topicRequest(page = 2),
             topicRepository = repository,
             authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
@@ -85,7 +90,7 @@ class TopicViewModelTest {
                 throw cancellation
             }
         }
-        val vm = TopicViewModel(
+        val vm = topicViewModel(
             request = topicRequest(page = 2),
             topicRepository = repository,
             authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
@@ -121,7 +126,7 @@ class TopicViewModelTest {
         val topic = fakeTopic(page = 5, totalPages = 5)
         val repository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(topic) }))
 
-        TopicViewModel(
+        topicViewModel(
             request = topicRequest(page = 5),
             topicRepository = repository,
             authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
@@ -144,7 +149,7 @@ class TopicViewModelTest {
         val controlled = MutableSharedFlow<Topic>(replay = 0)
         val repository = FakeStreamingTopicRepository(controlled)
 
-        val viewModel = TopicViewModel(
+        val viewModel = topicViewModel(
             request = topicRequest(page = 1),
             topicRepository = repository,
             authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
@@ -171,7 +176,7 @@ class TopicViewModelTest {
             flowsToReturn = listOf(flow { throw IOException("network") }),
         )
 
-        val viewModel = TopicViewModel(
+        val viewModel = topicViewModel(
             request = topicRequest(page = 1),
             topicRepository = repository,
             authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
@@ -193,7 +198,7 @@ class TopicViewModelTest {
             ),
         )
 
-        val viewModel = TopicViewModel(
+        val viewModel = topicViewModel(
             request = topicRequest(page = 1),
             topicRepository = repository,
             authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
@@ -213,7 +218,7 @@ class TopicViewModelTest {
         )
         val repository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(topic) }))
 
-        val viewModel = TopicViewModel(
+        val viewModel = topicViewModel(
             request = topicRequest(page = 3, scrollTo = target),
             topicRepository = repository,
             authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
@@ -231,7 +236,7 @@ class TopicViewModelTest {
         val topic = fakeTopic(page = 1, totalPages = 1, posts = listOf(fakePost(numreponse = 555)))
         val repository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(topic) }))
 
-        val viewModel = TopicViewModel(
+        val viewModel = topicViewModel(
             request = topicRequest(page = 1, scrollTo = 999),
             topicRepository = repository,
             authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
@@ -256,7 +261,7 @@ class TopicViewModelTest {
             }),
         )
 
-        val viewModel = TopicViewModel(
+        val viewModel = topicViewModel(
             request = topicRequest(page = 2, scrollTo = target),
             topicRepository = repository,
             authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
@@ -274,7 +279,7 @@ class TopicViewModelTest {
     fun `canGoPrevious is false on page 1 and true otherwise`() = runTest {
         val topic = fakeTopic(page = 1, totalPages = 3)
         val repository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(topic) }))
-        val viewModel = TopicViewModel(
+        val viewModel = topicViewModel(
             request = topicRequest(page = 1),
             topicRepository = repository,
             authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
@@ -287,7 +292,7 @@ class TopicViewModelTest {
     fun `canGoNext is false on the last page`() = runTest {
         val topic = fakeTopic(page = 5, totalPages = 5)
         val repository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(topic) }))
-        val viewModel = TopicViewModel(
+        val viewModel = topicViewModel(
             request = topicRequest(page = 5),
             topicRepository = repository,
             authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
@@ -306,7 +311,7 @@ class TopicViewModelTest {
             ),
         )
 
-        val viewModel = TopicViewModel(
+        val viewModel = topicViewModel(
             request = topicRequest(page = 2),
             topicRepository = repository,
             authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
@@ -326,14 +331,14 @@ class TopicViewModelTest {
 
     @Test
     fun `state isAuthenticated reflects the auth repository (#220)`() = runTest {
-        val authed = TopicViewModel(
+        val authed = topicViewModel(
             request = topicRequest(page = 1),
             topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) })),
             authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
         )
         assertEquals(true, authed.state.value.isAuthenticated)
 
-        val anon = TopicViewModel(
+        val anon = topicViewModel(
             request = topicRequest(page = 1),
             topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) })),
             authRepository = FakeAuthRepository(AuthState.Anonymous),
@@ -344,7 +349,7 @@ class TopicViewModelTest {
     @Test
     fun `isAuthenticated flips when the session changes while the topic is open (#220)`() = runTest {
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"))
-        val vm = TopicViewModel(
+        val vm = topicViewModel(
             request = topicRequest(page = 1),
             topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) })),
             authRepository = auth,
@@ -359,9 +364,28 @@ class TopicViewModelTest {
     }
 
     @Test
+    fun `state topBarAutoHide reflects the user preference (build 89)`() = runTest {
+        val on = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            userPreferencesRepository = FakeUserPreferencesRepository(topicTopBarAutoHide = true),
+        )
+        assertEquals(true, on.state.value.topBarAutoHide)
+
+        val off = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            userPreferencesRepository = FakeUserPreferencesRepository(topicTopBarAutoHide = false),
+        )
+        assertEquals(false, off.state.value.topBarAutoHide)
+    }
+
+    @Test
     fun `forceRefresh from the request is forwarded to observeTopicPage (#231)`() = runTest {
         val repository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) }))
-        TopicViewModel(
+        topicViewModel(
             request = topicRequest(page = 1).copy(forceRefresh = true),
             topicRepository = repository,
             authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
@@ -372,6 +396,21 @@ class TopicViewModelTest {
             repository.lastForceRefresh,
         )
     }
+
+    // Construction seam: the ViewModel now also takes a UserPreferencesRepository (for the build 89
+    // top-bar auto-hide preference) which none of these tests exercise, so it defaults to a no-op
+    // fake. Keeps every existing call site unchanged bar the constructor → helper rename.
+    private fun topicViewModel(
+        request: TopicRequest,
+        topicRepository: TopicRepository,
+        authRepository: AuthRepository,
+        userPreferencesRepository: UserPreferencesRepository = FakeUserPreferencesRepository(),
+    ): TopicViewModel = TopicViewModel(
+        request = request,
+        topicRepository = topicRepository,
+        authRepository = authRepository,
+        userPreferencesRepository = userPreferencesRepository,
+    )
 
     private fun topicRequest(
         page: Int,
@@ -401,7 +440,7 @@ class TopicViewModelTest {
             refreshTopicsToReturn = listOf(freshTopic),
         )
 
-        val viewModel = TopicViewModel(
+        val viewModel = topicViewModel(
             request = topicRequest(page = 2, submitSignal = 1_700_000_000_000L),
             topicRepository = repository,
             authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
@@ -440,7 +479,7 @@ class TopicViewModelTest {
             refreshTopicsToReturn = listOf(freshTopic),
         )
 
-        val viewModel = TopicViewModel(
+        val viewModel = topicViewModel(
             request = topicRequest(page = 1, scrollTo = targetNumreponse, submitSignal = 42L),
             topicRepository = repository,
             authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
@@ -467,7 +506,7 @@ class TopicViewModelTest {
             refreshTopicsToReturn = listOf(freshTopic),
         )
 
-        val viewModel = TopicViewModel(
+        val viewModel = topicViewModel(
             request = topicRequest(page = 20, scrollTo = null, submitSignal = 99L),
             topicRepository = repository,
             authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
@@ -496,7 +535,7 @@ class TopicViewModelTest {
             refreshTopicsToReturn = listOf(overflowedTopic),
         )
 
-        val viewModel = TopicViewModel(
+        val viewModel = topicViewModel(
             request = topicRequest(page = 20, scrollTo = null, submitSignal = 123L),
             topicRepository = repository,
             authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
@@ -516,7 +555,7 @@ class TopicViewModelTest {
         val topic = fakeTopic(page = 1, totalPages = 1, posts = listOf(fakePost(1)))
         val repository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(topic) }))
 
-        val viewModel = TopicViewModel(
+        val viewModel = topicViewModel(
             request = topicRequest(page = 1, scrollTo = null, submitSignal = null),
             topicRepository = repository,
             authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
@@ -553,7 +592,7 @@ class TopicViewModelTest {
             refreshErrorToThrow = IOException("force refresh transient failure"),
         )
 
-        val viewModel = TopicViewModel(
+        val viewModel = topicViewModel(
             request = topicRequest(page = 2, submitSignal = 7L),
             topicRepository = repository,
             authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
@@ -699,4 +738,57 @@ private class FakeStreamingTopicRepository(
     override suspend fun prefetch(cat: Int, post: Int, page: Int) {
         // no-op for streaming tests
     }
+}
+
+/**
+ * No-op preferences fake for the topic ViewModel tests. Only [observeTopicTopBarAutoHide] is read by
+ * [TopicViewModel] (build 89 follow-up) — everything else returns the DataStore default so the fake
+ * stays a thin stand-in. The single relevant value is constructor-injectable for any future test that
+ * wants to assert the auto-hide flag reaches state.
+ */
+private class FakeUserPreferencesRepository(
+    private val topicTopBarAutoHide: Boolean = false,
+) : UserPreferencesRepository {
+    override fun observeProxyConfig(): Flow<ProxyConfig> = MutableStateFlow(ProxyConfig())
+
+    override suspend fun saveProxyConfig(config: ProxyConfig) = Unit
+
+    override fun readProxyConfigForNetworkBootstrap(): ProxyConfig = ProxyConfig()
+
+    override fun observeIgnoreTopicCache(): Flow<Boolean> = MutableStateFlow(false)
+
+    override suspend fun setIgnoreTopicCache(enabled: Boolean) = Unit
+
+    override fun observeFlagsGroupByCategory(): Flow<Boolean> = MutableStateFlow(true)
+
+    override suspend fun setFlagsGroupByCategory(enabled: Boolean) = Unit
+
+    override fun observeFlagsHideReadCategories(): Flow<Boolean> = MutableStateFlow(false)
+
+    override suspend fun setFlagsHideReadCategories(enabled: Boolean) = Unit
+
+    override fun observeFlagsPerTabOverride(): Flow<Boolean> = MutableStateFlow(false)
+
+    override suspend fun setFlagsPerTabOverride(enabled: Boolean) = Unit
+
+    override fun observeFlagsViewSettings(type: FlagType): Flow<FlagsViewSettings> =
+        MutableStateFlow(FlagsViewSettings())
+
+    override suspend fun setFlagsGroupByCategoryForType(type: FlagType, enabled: Boolean) = Unit
+
+    override suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean) = Unit
+
+    override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) = Unit
+
+    override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
+
+    override suspend fun setThemeMode(mode: ThemeMode) = Unit
+
+    override fun observeAmoledEnabled(): Flow<Boolean> = MutableStateFlow(false)
+
+    override suspend fun setAmoledEnabled(enabled: Boolean) = Unit
+
+    override fun observeTopicTopBarAutoHide(): Flow<Boolean> = MutableStateFlow(topicTopBarAutoHide)
+
+    override suspend fun setTopicTopBarAutoHide(enabled: Boolean) = Unit
 }


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Deux correctifs de la top app bar de l'écran de lecture d'un sujet, issus du dogfooding de la build 89.

## 1. Bug — le titre redevenait « Sujet » au changement de page

**Cause racine (structurelle, pas un cas Samsung).** Un changement de page *remplace* la `TopicRoute` dans le back stack (nouvelle entrée nav → nouveau `ViewModel` → état `Loading` sans `Topic`). Le temps du chargement, `state.mode` n'est plus `Loaded`, donc le titre retombait sur le fallback générique « Sujet ».

**Fix.** `RedfaceApp` maintient un cache de titre par sujet, **clé composite `(cat, post)`** (un `post`/topicId n'est unique que *par catégorie* sur HFR — même raison que la clé `(cat, topicId)` de `SearchScreen`). Le cache est hoisté au-dessus de `NavDisplay` (il survit à la recréation de l'entrée), borné en FIFO à 128 entrées, et threadé dans `RedfaceNavHost` via une data class `TopicTitleNavState` (même forme `read-map + onLoaded-callback` que `PrivateMessageNavState`). La top bar lit le dernier titre connu via `TopicRequest.titleHint` pendant le chargement.

`titleHint` est **strictement loading-only** : une fois `Loaded`, le vrai `Topic.title` (ou le fallback générique s'il est vide) gagne — jamais le hint périmé.

## 2. Option — « Masquer la barre en défilant » (défaut OFF = épinglée)

Quand activée, la top bar (titre + numéro de page) utilise `TopAppBarDefaults.enterAlwaysScrollBehavior()` de Material 3 : elle se replie en défilant vers le bas et réapparaît dès qu'on remonte, libérant de la place à la lecture. Câblage : `UserPreferencesRepository.observeTopicTopBarAutoHide()` → `TopicUiState.topBarAutoHide` → `TopicScreen`. Toggle Settings avec le pattern optimistic-flip + startup-race-guard identique à AMOLED (#286).

## Tests & validation

- DataStore round-trip (`observeTopicTopBarAutoHide` défaut false → true → false)
- Settings persist + revert-on-failure (2 tests)
- `TopicViewModel` reflète la préférence (`topBarAutoHide mirrors preference`)
- Validation locale verte : `detektAll + test + testDebugUnitTest + :app:assembleProdDebug + lintDebug + :app:lintProdDebug`

## Revue Codex (gpt-5.5, xhigh)

0 bloquant. Findings traités :
- **clé composite `(cat, post)`** (important) — appliqué
- **contrat `titleHint` loading-only** (important) — appliqué (branchement explicite sur `Loaded`)
- **cache borné FIFO** (mineur) — appliqué (cap 128, helper `withTitle` extrait pour la complexité)
- **test mirror VM** (mineur) — appliqué
- **overload `enterAlwaysScrollBehavior(lazyListState=...)`** (important) — **rejeté motivé** : l'overload n'existe que dans le `current.txt` de material3 (main), pas en 1.2→1.4 (Context7) ; incertain sur le BOM 2026.05.01 (risque de non-compilation, cf. leçon `currentWindowAdaptiveInfoV2`). De plus l'overload plain est *préférable* ici : barre visible à l'ouverture puis masquée au scroll — l'overload LazyListState la ferait démarrer repliée sur un deep-link mi-page.

Pas d'issue GitHub associée (retours de dogfooding build 89 en direct).
