### PR TITLE
feat(topic): supprimer un de ses propres posts (#292)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultDeletePostRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultDeletePostRepository.kt
@@ -1,0 +1,163 @@
+package fr.forumhfr.redface2.core.data.write
+
+import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
+import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
+import fr.forumhfr.redface2.core.domain.write.DeletePostRepository
+import fr.forumhfr.redface2.core.domain.write.DeletePostResult
+import fr.forumhfr.redface2.core.model.write.EditPostContext
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
+import fr.forumhfr.redface2.core.model.write.ReplyForm
+import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
+import fr.forumhfr.redface2.core.network.HfrClient
+import fr.forumhfr.redface2.core.network.HfrConstants
+import fr.forumhfr.redface2.core.parser.write.ReplyFormParser
+import fr.forumhfr.redface2.core.parser.write.ReplySubmitResponseParser
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import okhttp3.FormBody
+
+/**
+ * Default [DeletePostRepository] (#292). Deletion reuses the **edit form** (`bdd.php`) plus a
+ * `delete=1` field — there is no dedicated HFR delete endpoint. The flow is a single
+ * fetch-then-submit:
+ *
+ * 1. GET the edit form for the post (same `message.php?…&numreponse={N}` request as the editor),
+ *    which yields a fresh `hash_check` and all the hidden fields HFR expects back.
+ * 2. POST `bdd.php?config=hfr.inc` with those fields **plus `delete=1`** (content is irrelevant —
+ *    `delete=1` short-circuits HFR's "message must not be empty" check).
+ *
+ * Because the fetch and the submit are back-to-back, the token can never go stale (unlike the
+ * editor, where the user types between load and submit), so no invalid-token refetch loop is needed.
+ *
+ * The POST response is classified by the shared [ReplySubmitResponseParser] (« Message effacé avec
+ * succès ! »). Whether a whole topic was deleted is read from the success refresh URL: a normal-post
+ * delete refreshes to the topic (`sujet_{id}_{page}` → `topicId` non-null); a first-post delete
+ * removes the whole topic and refreshes to the listing (`liste_sujet` → `topicId` null).
+ */
+@Singleton
+class DefaultDeletePostRepository @Inject constructor(
+    private val hfrClient: HfrClient,
+    private val replyFormParser: ReplyFormParser,
+    private val replySubmitResponseParser: ReplySubmitResponseParser,
+    private val diagnostics: DiagnosticsLog,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) : DeletePostRepository {
+
+    override suspend fun deletePost(context: EditPostContext): DeletePostResult {
+        diagnostics.record(
+            DiagnosticsLog.Level.INFO,
+            LOG_TAG,
+            "delete cat=${context.cat} subcat=${context.subcat} " +
+                "post=${context.topicId} page=${context.page}",
+        )
+        return try {
+            withContext(ioDispatcher) {
+                val formHtml = hfrClient.getEditPostForm(
+                    cat = context.cat,
+                    subcat = context.subcat,
+                    post = context.topicId,
+                    page = context.page,
+                    numreponse = context.numreponse,
+                )
+                val form = replyFormParser.parse(formHtml).getOrElse { error ->
+                    diagnostics.record(
+                        DiagnosticsLog.Level.WARN,
+                        LOG_TAG,
+                        "delete form parse FAILED: ${error.message ?: error::class.simpleName}",
+                    )
+                    return@withContext DeletePostResult.Failure(ReplyFailureReason.Unknown)
+                }
+                if (form.isAnonymous) {
+                    // HFR served the anonymous composer — the session is not (or no longer)
+                    // authenticated, so the delete would silently no-op. Surface a login CTA.
+                    return@withContext DeletePostResult.Failure(ReplyFailureReason.LoginRequired)
+                }
+                if (form.hashCheck.isBlank()) {
+                    return@withContext DeletePostResult.Failure(ReplyFailureReason.InvalidHashCheck)
+                }
+                val responseHtml = hfrClient.submitEditPost(buildDeleteFormBody(context, form))
+                val outcome = replySubmitResponseParser.parse(responseHtml)
+                outcome.toDeleteResult().also { result ->
+                    diagnostics.record(
+                        DiagnosticsLog.Level.INFO,
+                        LOG_TAG,
+                        when (result) {
+                            is DeletePostResult.Success ->
+                                "delete Success wholeTopic=${result.deletedWholeTopic}"
+                            is DeletePostResult.Failure ->
+                                "delete Failure reason=${result.reason::class.simpleName}"
+                        },
+                    )
+                }
+            }
+        } catch (cancel: CancellationException) {
+            throw cancel
+        } catch (error: SessionExpiredException) {
+            diagnostics.record(
+                DiagnosticsLog.Level.WARN,
+                LOG_TAG,
+                "delete SessionExpired: ${error.message ?: "(no message)"}",
+            )
+            DeletePostResult.Failure(ReplyFailureReason.LoginRequired)
+        } catch (@Suppress("TooGenericExceptionCaught") error: Throwable) {
+            diagnostics.record(
+                DiagnosticsLog.Level.WARN,
+                LOG_TAG,
+                "delete FAILED: ${error::class.simpleName}: ${error.message ?: "(no message)"}",
+            )
+            DeletePostResult.Failure(ReplyFailureReason.Unknown)
+        }
+    }
+
+    private fun ReplySubmitResult.toDeleteResult(): DeletePostResult = when (this) {
+        // On a normal-post delete HFR refreshes to the topic (`sujet_{id}_{page}` → topicId
+        // non-null). On a first-post / whole-topic delete it refreshes to the sub-category listing
+        // (`liste_sujet` → no topicId), which is how we flag a whole-topic deletion. The UI only
+        // offers delete on normal posts today, so `deletedWholeTopic` is a defensive read.
+        is ReplySubmitResult.Success -> DeletePostResult.Success(deletedWholeTopic = topicId == null)
+        is ReplySubmitResult.Failure -> DeletePostResult.Failure(reason)
+    }
+
+    private fun buildDeleteFormBody(context: EditPostContext, form: ReplyForm): FormBody {
+        val builder = FormBody.Builder(Charsets.UTF_8)
+        val overrides = buildMap {
+            put("hash_check", form.hashCheck)
+            put("verifrequet", HfrConstants.VERIF_REQUET)
+            // Forward the post's current content verbatim. HFR ignores it when `delete=1` is set,
+            // but sending the real form value keeps the POST shape identical to a browser submit.
+            put("content_form", form.initialContent)
+            put("numreponse", context.numreponse.toString())
+            put("numrep", "")
+            put("cat", context.cat.toString())
+            put("subcat", context.subcat.toString())
+            put("post", context.topicId.toString())
+            put("page", context.page.toString())
+            put("sujet", form.sujet)
+            // THE delete flag — the one field that distinguishes this POST from an edit.
+            put("delete", "1")
+            form.msgIcon?.let { put("MsgIcon", it) }
+        }
+        val emitted = mutableSetOf<String>()
+        overrides.forEach { (key, value) ->
+            builder.add(key, value)
+            emitted += key
+        }
+        form.hiddenFields.forEach { (key, value) ->
+            if (key in emitted) return@forEach
+            // Hard deny `password` (belt-and-braces; the parser already filters it). `delete` is set
+            // explicitly above, so it can never be present here, but guard anyway for symmetry.
+            if (key == "password" || key == "delete") return@forEach
+            builder.add(key, value)
+            emitted += key
+        }
+        return builder.build()
+    }
+
+    private companion object {
+        private const val LOG_TAG = "DeletePostRepository"
+    }
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/ReplyRepositoryModule.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/ReplyRepositoryModule.kt
@@ -5,6 +5,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import fr.forumhfr.redface2.core.domain.write.DeletePostRepository
 import fr.forumhfr.redface2.core.domain.write.EditPostRepository
 import fr.forumhfr.redface2.core.domain.write.ReplyRepository
 import fr.forumhfr.redface2.core.domain.write.TopicFormRepository
@@ -31,6 +32,10 @@ abstract class ReplyRepositoryModule {
     @Binds
     @Singleton
     abstract fun bindEditPostRepository(impl: DefaultEditPostRepository): EditPostRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindDeletePostRepository(impl: DefaultDeletePostRepository): DeletePostRepository
 
     @Binds
     @Singleton

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/write/DefaultDeletePostRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/write/DefaultDeletePostRepositoryTest.kt
@@ -1,0 +1,131 @@
+package fr.forumhfr.redface2.core.data.write
+
+import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
+import fr.forumhfr.redface2.core.domain.write.DeletePostResult
+import fr.forumhfr.redface2.core.model.write.EditPostContext
+import fr.forumhfr.redface2.core.network.HfrClient
+import fr.forumhfr.redface2.core.parser.write.ReplyFormParser
+import fr.forumhfr.redface2.core.parser.write.ReplySubmitResponseParser
+import java.net.URLDecoder
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Repository-level tests for the #292 delete wire contract. Deletion reuses the edit form
+ * (`message.php?…&numreponse={N}` to fetch, `bdd.php` to submit) but adds the distinguishing
+ * `delete=1` field, and classifies « Message effacé avec succès ! » as success. The success
+ * refresh URL decides whether a whole topic was removed (listing redirect) or just a post
+ * (topic redirect).
+ */
+class DefaultDeletePostRepositoryTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: HfrClient
+    private lateinit var repository: DefaultDeletePostRepository
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().apply { start() }
+        val okHttp = OkHttpClient.Builder().build()
+        client = HfrClient(
+            authenticated = okHttp,
+            anonymous = okHttp,
+            baseUrl = server.url("/"),
+            ioDispatcher = Dispatchers.Unconfined,
+        )
+        repository = DefaultDeletePostRepository(
+            hfrClient = client,
+            replyFormParser = ReplyFormParser(),
+            replySubmitResponseParser = ReplySubmitResponseParser(),
+            diagnostics = DiagnosticsLog(),
+            ioDispatcher = Dispatchers.Unconfined,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `delete posts to bdd_php with delete=1 and the edit fields, returns a normal-post Success`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("write_delete_post_form.html")))
+        server.enqueue(MockResponse().setBody(fixture("write_delete_post_success_response.html")))
+        val context = EditPostContext(
+            cat = 23,
+            subcat = 550,
+            topicId = 35_395,
+            page = 20,
+            numreponse = 2_784_595,
+        )
+
+        val result = repository.deletePost(context)
+
+        assertTrue("delete must classify as Success — got $result", result is DeletePostResult.Success)
+        assertFalse(
+            "a normal-post delete (topic refresh) is not a whole-topic delete",
+            (result as DeletePostResult.Success).deletedWholeTopic,
+        )
+
+        // Drop the GET, inspect the POST.
+        server.takeRequest()
+        val recorded = server.takeRequest()
+        assertEquals("POST", recorded.method)
+        assertEquals("bdd.php", recorded.requestUrl?.pathSegments?.first())
+
+        val body = parseFormBody(recorded.body.readUtf8())
+        assertEquals("the delete flag must be set", "1", body["delete"])
+        assertEquals("delete must echo the post via numreponse", "2784595", body["numreponse"])
+        assertEquals("", body["numrep"])
+        assertEquals("23", body["cat"])
+        assertEquals("550", body["subcat"])
+        assertEquals("35395", body["post"])
+        assertEquals("20", body["page"])
+        assertFalse("password must never be transmitted", body.containsKey("password"))
+    }
+
+    @Test
+    fun `whole-topic delete success flags deletedWholeTopic`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("write_delete_topic_form.html")))
+        server.enqueue(MockResponse().setBody(fixture("write_delete_topic_success_response.html")))
+        val context = EditPostContext(
+            cat = 23,
+            subcat = 550,
+            topicId = 35_395,
+            page = 1,
+            numreponse = 2_784_595,
+        )
+
+        val result = repository.deletePost(context)
+
+        assertTrue("delete must classify as Success — got $result", result is DeletePostResult.Success)
+        assertTrue(
+            "a whole-topic delete (listing refresh) must set deletedWholeTopic",
+            (result as DeletePostResult.Success).deletedWholeTopic,
+        )
+    }
+
+    private fun fixture(name: String): String {
+        val stream = requireNotNull(
+            DefaultDeletePostRepositoryTest::class.java.classLoader?.getResourceAsStream("fixtures/$name"),
+        ) { "Fixture not found: fixtures/$name" }
+        return stream.bufferedReader().use { it.readText() }
+    }
+
+    private fun parseFormBody(body: String): Map<String, String> =
+        body.split('&')
+            .filter { it.isNotEmpty() }
+            .associate { pair ->
+                val (key, value) = pair.split('=', limit = 2).let { it[0] to (it.getOrNull(1) ?: "") }
+                URLDecoder.decode(key, "UTF-8") to URLDecoder.decode(value, "UTF-8")
+            }
+}

--- a/core/data/src/test/resources/fixtures/write_delete_post_form.html
+++ b/core/data/src/test/resources/fixtures/write_delete_post_form.html
@@ -1,0 +1,403 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+	<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr" lang="fr">
+	<head>
+	<title>FORUM HardWare.fr - Répondre / éditer un message</title><link type="text/css" rel="stylesheet" href="/include/the_style1.php?color_key=FFFFFF/DEDFDF/000080/C2C3F4/001932/FFFFFF/FFFFFF/000000/000080/000000/000080/F7F7F7/DEDFDF/F7F7F7/DEDFDF/C0C0C0/C0C0C0/FFFFFF/000000/000000/0000FF/EEEEFF/DDDDEE/000000/FFEEEE/000000/FFFFFF/FF0000/FFFFFF/0/1/https%3A%40%40forum-images.hardware.fr/NULL/&amp;abs_img_path=%40data%40sites%40forum%40www%40static%40&amp;hide_bg_onglet=0&amp;v=11102781422" /><style type="text/css">
+<!--
+.fastsearchMain{ width: 330px; }
+.fastsearchInput{ width: 70px; border: 1px solid black; }
+.fastsearchSubmit{ background-color: ; border: 0px;}
+.header2 { background-image: url(/img/forum3_1.gif);background-repeat: repeat-x; }
+.menuExt { font-family: Arial, Helvetica, sans-serif; font-size: 10px; color:#000; }
+.menuExt a { color:#000;text-decoration:none; }
+.menuExt a:hover { color:#000;text-decoration:underline; }
+form { display: inline; }
+.header { background-image: url(//forum-images.hardware.fr/img/header-bg.gif); background-repeat: repeat-x; }
+.tdmenu { width: 1px;height: 1px;color: #000000; }
+.hfrheadmenu { font-family: Arial, Helvetica, sans-serif;font-size:13px;font-weight:bold; }
+.hfrheadmenu span {color:;}
+.hfrheadmenu a { color:;text-decoration: none; }
+.hfrheadmenu a:hover { color:;text-decoration: underline; }
+.concours { font-family: Arial, Helvetica, sans-serif;color:;font-size: 16px;text-decoration: none;font-weight: bold;}
+.concours:hover { font-family: Arial, Helvetica, sans-serif;color:;font-size: 16px;text-decoration: underline;font-weight: bold; }
+.searchmenu { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: none;font-weight: bold; }
+.fastsearch { display: none; }
+.fastsearchHeader { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: none;font-weight: bold; }
+.fastsearchHeader:hover { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: underline;font-weight: bold; }
+-->
+</style>
+<script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+<script>
+  window.googletag = window.googletag || {cmd: []};
+  googletag.cmd.push(function() {
+    googletag.defineSlot('/2172442/forum_discussions_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-11').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-12').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-13').addService(googletag.pubads());
+    googletag.pubads().enableSingleRequest();
+    googletag.enableServices();
+  });
+</script>
+<script type='text/javascript'>
+     (function(){
+       var loc = window.location.href;
+       var dd = document.createElement('script');
+       dd.type = 'text/javascript'; dd.src = '//static.digidip.net/hardware.js?loc=' + loc;
+       var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(dd, s);
+     })();
+</script><script type="text/javascript">
+
+var hash_check = "&hash_check=REDACTED_HASH_CHECK";
+var _adresseRecherche = "/user/message-aj.php";
+var adresseFindSmiley = "/message-smi-mp-aj.php";
+var tempo_smilies= 0;
+
+var img_path= "https://forum-images.hardware.fr";
+
+function verif_join_form() {
+	if ((document.getElementById('submit_upload')) && (document.getElementById('submit_upload').style.fontWeight == 'bold')) {
+		return confirm('Attention : vous n\'avez pas joint l\'image que vous avez sélectionnée');
+	}
+	return true;
+}
+
+function verif_not_empty() {
+	if (document.getElementById('delete').checked == true) {
+		return true;
+	}
+	if (document.hop.sujet && trim(document.hop.sujet.value) =='') {
+		alert('Vous devez remplir tous les champs avant de poster ce message');
+		return false;
+	}
+	if (document.hop.content_form && trim(document.hop.content_form.value) == '') {
+		alert('Vous devez remplir tous les champs avant de poster ce message');
+		return false;
+	}
+	if (document.hop.codecaptcha && trim(document.hop.codecaptcha.value) == '') {
+		alert('Vous devez remplir tous les champs avant de poster ce message');
+		return false;
+	}
+	if (document.getElementById('have_sondage') && document.getElementById('have_sondage').checked == true && document.getElementById('annee').value && document.getElementById('annee').value.length != 4) {
+		alert('L\'année du sondage doit être sur 4 chiffres');
+		return false;
+	}
+
+	return true;
+}
+
+function trim(string) {
+	return string.replace(/(^\s*)|(\s*$)/g,"");
+}
+</script><script language="javascript" type="text/javascript">
+	<!--
+ var opera=0;
+	function putSmiley(tt,src) {
+TAinsert(" "+tt+" ","");
+}
+	//-->
+	</script><link type="text/css" rel="stylesheet" href="https://forum-images.hardware.fr/compressed/the_style.css?v=11102781422" />
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta http-equiv="Pragma" content="no-cache" />
+	<meta http-equiv="Cache-Control" content="no-cache, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+	<meta http-equiv="Imagetoolbar" content="no" />
+	<meta name="Robots" content="noindex, nofollow" />
+<script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/editPost.js?v=11102781422"></script><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/message.js?v=11102781422"></script><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/common.js?v=11102781422"></script></head><body id="category__redaction_form__form_message"  > <table cellspacing="0" cellpadding="0" width="98%" bgcolor="#000000" border="0" align="center" class="hfrheadmenu" style="border:1px solid #000;border-top:0;">
+        <tr>
+          <td style="vertical-align: top">
+            <table cellspacing="0" cellpadding="0" width="100%" border="0">
+              <tr>
+                <td style="width: 100%" align="left" valign="middle" colspan="2" class="header2"><span class="md_cryptlink45CBCBC0C22D1F1FCCCCCC19454AC14BCC4AC1431944C1"><img src="/img/forum_logo.gif" width="900" height="71" border="0" alt="" /></span></td>
+              </tr>
+              <tr>
+                <td style="background-color:#001932">
+                  <table cellspacing="0" cellpadding="2" width="100%" border="0">
+                    <tr>
+                      <td>&nbsp;<a class="cHeader" href="/">Forum</a>&nbsp;|&nbsp;
+<a class="cHeader" href="https://www.hardware.fr/">HardWare.fr</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/html/news/">News</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/html/articles/">Articles</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/articles/786-1/guide-pc-hardware-fr.html">PC</a>&nbsp;|&nbsp;<span class="md_cryptlink1FC349484F4C19C045C02F424F4944464C2E454AC14BCC4AC14344C11946494214424F4B434543C52E2443252B234A232C4B24254B4B2B254B2B252B2A43444B2A442B252420212C20">Se d&eacute;connecter</span>&nbsp;|&nbsp;<span class="md_cryptlink1FC3C243C11F434B46CBC0C14F44464819C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">Profil</span>&nbsp;|&nbsp;<a class="cHeader" href="https://shop.hardware.fr/" target="_blank" style="position: relative; padding: 0 21px 0 0;display: inline-block;">Shop <img src="/img/shop.png" style="height: 17px; display: inline; position: absolute; right: 0; top: -2px; "></a></td>
+<td align="right"><a class="cHeader" href="/search.php?config=hardwarefr.inc&cat=10&subcat=388">Recherche <img src="//forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif"></a></td>
+                    </tr>
+                    </table></td></tr></table>
+</td></tr></table><div style="width: 99%" align="right">
+<span class="s2Ext menuExt"><span class="md_cryptlink1F4F494846494319C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">4153 connect&eacute;s&nbsp;</span></span></div><br /><script language="javascript" type="text/javascript">
+			<!--
+			writeCookie('md_users_res');
+			//-->
+			</script><div class="container"><div class="mesdiscussions" id="mesdiscussions"><div class="arbo">
+<span  id="md_arbo_tree_1" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/" class="Ext">FORUM HardWare.fr</a></span>
+<br />
+<span  id="md_arbo_tree_2" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/hfr/Programmation/liste_sujet-1.htm" class="Ext">Programmation</a></span>
+<br />
+<span  id="md_arbo_tree_3" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline3.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/hfr/Programmation/Divers-6/liste_sujet-1.htm" class="Ext">Divers</a></span>
+<br />
+<h1  id="md_arbo_tree_4" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline4.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/hfr/Programmation/Divers-6/redface2-temporaire-ecriture-sujet_148749_1.htm" class="Ext">[Redface2] Topic temporaire de test ecriture</a></h1>
+</div><div class="rightbutton fastsearch"><table class="main fastsearchMain" cellspacing="0" cellpadding="2"><tr class="cBackHeader fondForumDescription"><th><form method="post" id="fastsearch" action="/forum1.php"><input type="hidden" name="hash_check" value="REDACTED_HASH_CHECK" /><label for="fastsearchinputid"><a rel="nofollow" href="/search.php?config=hfr.inc&amp;cat=10&amp;subcat=388" class="cHeader fastsearchHeader">Recherche :</a>&nbsp;<input type="text" name="search" id="fastsearchinputid" value="" class="fastsearchInput" alt="Search string" /></label><input type="hidden" name="recherches" value="1" /><input type="hidden" name="searchtype" value="1" /><input type="hidden" name="titre" value="3" /><input type="hidden" name="resSearch" value="200" /><input type="hidden" name="orderSearch" value="1" /><input type="hidden" name="config" value="hfr.inc" /><input type="hidden" name="cat" value="10" /><input type="hidden" name="subcat" value="388" />&nbsp;<input type="image" src="https://forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif" class="fastsearchSubmit" title="Lancer une recherche" alt="Lancer une recherche" /></form></th></tr></table></div><div class="spacer">&nbsp;</div><br /><div></div><br /><table class="main" style="margin:auto;" cellspacing="0" cellpadding="4">
+				<tr class="cBackHeader">
+				<th colspan="2">Dernière réponse</th>
+			</tr>
+			<tr class="reponse">
+				<th colspan="2">
+					Sujet : [Redface2] Topic temporaire de test ecriture</th>
+			</tr><tr class="reponse">
+				<td class="messCase1bis" width="160" valign="top">xatelitte</td>
+				<td>Test technique Redface2 #81 : réponse jetable pour capturer le formulaire de suppression d'un post.</p>&nbsp;<p>Ce message doit être supprimé pendant le test.</p>&nbsp;<p><em>Post par GPT-5 Codex</em><div style="clear: both;"> </div></td>
+			</tr>
+			</table><br /><a name="formulaire"></a><form name="hop" id="hop" action="/bdd.php?config=hfr.inc" method="post" onsubmit="
+	return verif_join_form();
+	document.hop.submit.style.visibility='hidden';"><input type="hidden" name="hash_check" value="REDACTED_HASH_CHECK" />	<input type="hidden" name="subcat" value="388" />
+<input type="hidden" name="parents" value="" />
+<input type="hidden" name="post" value="148749" />
+<input type="hidden" name="stickold" value="0" />
+<input type="hidden" name="new" value="0" />
+<input type="hidden" name="cat" id="catid" value="10" />
+<input type="hidden" name="numreponse" value="2523830" />
+<input type="hidden" name="numrep" value="" />
+<input type="hidden" name="page" value="1" />
+<input type="hidden" name="verifrequet" value="1100" />
+<input type="hidden" name="p" value="1" />
+<input type="hidden" name="sondage" value="0" />
+<input type="hidden" name="sond" value="0" />
+<input type="hidden" name="cache" value="cache" />
+<input type="hidden" name="owntopic" value="0" />
+<input type="hidden" name="config" id="configid" value="hfr.inc" />
+<input type="hidden" name="sujet" value="[Redface2] Topic temporaire de test ecriture" /><table class="main" cellspacing="0" cellpadding="4" width="100%">
+	<tr class="cBackHeader">
+		<th colspan="2" style="text-align:center">Votre réponse</th>
+	</tr>
+	<tr class="reponse pseudoform" id="pseudoform">
+		<th class="repCase1">Nom d'utilisateur</th>
+		<td class="repCase2">
+			<input maxlength="25" accesskey="p" size="25" name="pseudo" value="xatelitte" onfocus="passfocus()" />		&nbsp;&nbsp; <a href="/inscription.php?config=hfr.inc" class="Topic">Pour poster, vous devez être inscrit sur ce forum .... si ce n'est pas le cas, cliquez ici !</a>	</td>
+	</tr><tr class="reponse" style="display:none; display:none; " id="passf">
+		<th class="repCase1">Mot de passe</th>
+		<td class="repCase2">			<input type="password" maxlength="40" size="25" name="password" value="" />
+			&nbsp;&nbsp; <a href="/password.php?config=hfr.inc" class="Topic">Vous avez perdu votre mot de passe ? Cliquez ici !</a>
+		</td>
+	</tr><tr class="reponse">
+				<th class="repCase1">Le ton de votre message</th>
+					<td class="repCase2"><input id="icone1" type="radio" value="1" name="MsgIcon" checked="checked" />
+					&nbsp;<label for="icone1"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></label>&nbsp;<input id="icone2" type="radio" value="2" name="MsgIcon" />
+					&nbsp;<label for="icone2"><img src="https://forum-images.hardware.fr/icones/message/icon2.gif" alt="" /></label>&nbsp;<input id="icone3" type="radio" value="3" name="MsgIcon" />
+					&nbsp;<label for="icone3"><img src="https://forum-images.hardware.fr/icones/message/icon3.gif" alt="" /></label>&nbsp;<input id="icone4" type="radio" value="4" name="MsgIcon" />
+					&nbsp;<label for="icone4"><img src="https://forum-images.hardware.fr/icones/message/icon4.gif" alt="" /></label>&nbsp;<input id="icone5" type="radio" value="5" name="MsgIcon" />
+					&nbsp;<label for="icone5"><img src="https://forum-images.hardware.fr/icones/message/icon5.gif" alt="" /></label>&nbsp;<input id="icone6" type="radio" value="6" name="MsgIcon" />
+					&nbsp;<label for="icone6"><img src="https://forum-images.hardware.fr/icones/message/icon6.gif" alt="" /></label>&nbsp;<input id="icone7" type="radio" value="7" name="MsgIcon" />
+					&nbsp;<label for="icone7"><img src="https://forum-images.hardware.fr/icones/message/icon7.gif" alt="" /></label>&nbsp;<input id="icone8" type="radio" value="8" name="MsgIcon" />
+					&nbsp;<label for="icone8"><img src="https://forum-images.hardware.fr/icones/message/icon8.gif" alt="" /></label>&nbsp;<br /><input id="icone9" type="radio" value="9" name="MsgIcon" />
+					&nbsp;<label for="icone9"><img src="https://forum-images.hardware.fr/icones/message/icon9.gif" alt="" /></label>&nbsp;<input id="icone10" type="radio" value="10" name="MsgIcon" />
+					&nbsp;<label for="icone10"><img src="https://forum-images.hardware.fr/icones/message/icon10.gif" alt="" /></label>&nbsp;<input id="icone11" type="radio" value="11" name="MsgIcon" />
+					&nbsp;<label for="icone11"><img src="https://forum-images.hardware.fr/icones/message/icon11.gif" alt="" /></label>&nbsp;<input id="icone12" type="radio" value="12" name="MsgIcon" />
+					&nbsp;<label for="icone12"><img src="https://forum-images.hardware.fr/icones/message/icon12.gif" alt="" /></label>&nbsp;<input id="icone13" type="radio" value="13" name="MsgIcon" />
+					&nbsp;<label for="icone13"><img src="https://forum-images.hardware.fr/icones/message/icon13.gif" alt="" /></label>&nbsp;<input id="icone14" type="radio" value="14" name="MsgIcon" />
+					&nbsp;<label for="icone14"><img src="https://forum-images.hardware.fr/icones/message/icon14.gif" alt="" /></label>&nbsp;<input id="icone15" type="radio" value="15" name="MsgIcon" />
+					&nbsp;<label for="icone15"><img src="https://forum-images.hardware.fr/icones/message/icon15.gif" alt="" /></label>&nbsp;<input id="icone16" type="radio" value="16" name="MsgIcon" />
+					&nbsp;<label for="icone16"><img src="https://forum-images.hardware.fr/icones/message/icon16.gif" alt="" /></label>&nbsp;</td>
+			</tr><tr class="reponse">
+		<th class="repCase1">Votre réponse<br /><br /><br />
+			<div><div class="center">	<a target="_blank" href="/smilies.php?config=hfr.inc" class="s1Topic">Smilies</a>
+				<br />&nbsp;
+				<div class="smiley">
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/smilies/pfff.gif" alt=":pfff:" title=":pfff:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/ange.gif" alt=":ange:" title=":ange:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/non.gif" alt=":non:" title=":non:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/bounce.gif" alt=":bounce:" title=":bounce:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/smile.gif" alt=":)" title=":)" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/frown.gif" alt=":(" title=":(" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/biggrin.gif" alt=":D" title=":D" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/wink.gif" alt=";)" title=";)" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/ouch.gif" alt=":ouch:" title=":ouch:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/redface.gif" alt=":o" title=":o" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/confused.gif" alt=":??:" title=":??:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/tongue.gif" alt=":p" title=":p" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/na.gif" alt=":na:" title=":na:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/sarcastic.gif" alt=":sarcastic:" title=":sarcastic:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/smilies/fou.gif" alt=":fou:" title=":fou:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/jap.gif" alt=":jap:" title=":jap:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/lol.gif" alt=":lol:" title=":lol:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/wahoo.gif" alt=":wahoo:" title=":wahoo:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/kaola.gif" alt=":kaola:" title=":kaola:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/smilies/love.gif" alt=":love:" title=":love:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/heink.gif" alt=":heink:" title=":heink:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/cry.gif" alt=":cry:" title=":cry:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/whistle.gif" alt=":whistle:" title=":whistle:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/sol.gif" alt=":sol:" title=":sol:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/smilies/pt1cable.gif" alt=":pt1cable:" title=":pt1cable:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/sleep.gif" alt=":sleep:" title=":sleep:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/sweat.gif" alt=":sweat:" title=":sweat:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/hello.gif" alt=":hello:" title=":hello:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+				</div>
+				<div class="spacer">&nbsp;</div>
+				<br /><a href="/wikismilies.php?config=hfr.inc&amp;threecol=1" target="_blank" class="s1Topic">Liste des smilies perso</a><br /><a target="_blank" href="/wikismilies.php?config=hfr.inc" class="s1Topic">Wiki smilies</a><br /><span class="small">Chercher un smiley<br /><input type="text" value="" name="search_smilies" id="search_smilies" size="10" onkeyup="find_smilies_timer('hfr.inc',1214571)"/></span><br /><div id="dynamic_smilies"></div></div></div></th><td class="repCase2" valign="top">		<div class="left">
+				<img style="cursor:pointer" class="text_bold" onclick="TAinsert('[b]','[/b]');" title="Mettre en gras le texte. Syntaxe : [b]texte[/b]" alt="[b]" src="https://forum-images.hardware.fr/icones/message/bold.gif" width="27" height="28" /><img
+				style="cursor:pointer" class="text_ita" onclick="TAinsert('[i]','[/i]');" title="Mettre en italique le texte. Syntaxe : [i]texte[/i]" alt="[i]" src="https://forum-images.hardware.fr/icones/message/italic.gif" width="25" height="28" /><img
+				style="cursor:pointer" class="text_under" onclick="TAinsert('[u]','[/u]');" title="Souligner le texte. Syntaxe : [u]texte[/u]" alt="[u]" src="https://forum-images.hardware.fr/icones/message/underline.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_strike" onclick="TAinsert('[strike]','[/strike]');" title="Barrer le texte. Syntaxe : [strike]texte[/strike]" alt="[strike]" src="https://forum-images.hardware.fr/icones/message/strike.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_spoiler" onclick="TAinsert('[spoiler]','[/spoiler]');" title="Masquer le texte. Syntaxe : [spoiler]texte[/spoiler]" alt="[spoiler]" src="https://forum-images.hardware.fr/icones/message/spoiler.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_fixed" onclick="TAinsert('[fixed]','[/fixed]');" title="Ecrire avec une police de taille fixe. Syntaxe : [fixed]texte[/fixed]" alt="[fixed]" src="https://forum-images.hardware.fr/icones/message/fixe.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="cpp" onclick="TAinsert('[cpp]','[/cpp]');" title="Insérer du code C/C++. Syntaxe : [cpp]texte[/cpp]" alt="[cpp]" src="https://forum-images.hardware.fr/icones/message/c.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_url" onclick="TAinsert('[url]','[/url]');" title="Insérer une URL. Syntaxe : [url]texte[/url]" alt="[url]" src="https://forum-images.hardware.fr/icones/message/url.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_email" onclick="TAinsert('[email]','[/email]');" title="Insérer une adresse email. Syntaxe : [email]email@hostname.com[/email]" alt="[email]" src="https://forum-images.hardware.fr/icones/message/email.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="image" onclick="TAinsert('[img]','[/img]');" title="Insérer une image. Syntaxe : [img]http://www.exemple.com/exemple.jpg[/img]" alt="[img]" src="https://forum-images.hardware.fr/icones/message/image.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_puce" onclick="TAinsert('[*]','');" title="Insérer une puce. Syntaxe : [*]texte" alt="[*]" src="https://forum-images.hardware.fr/icones/message/puce.gif" width="23" height="28" />
+				&nbsp;&nbsp;
+			</div>
+			<div class="left" style="width:270px;">
+				<table class="none" style="margin-top:6px; border:0px" id="ColorPanel" cellspacing="0" cellpadding="0">
+					<tr>
+						<td style="margin:0; padding:0; line-height:10px; cursor:pointer; width:15px; border:1px solid #000000" id="ColorUsed" title="Dernière couleur sélectionnée"><img src="https://forum-images.hardware.fr/icones/trans.gif" alt="" width="15" height="17" onclick="TAinsert('['+document.getElementById('ColorUsed').bgColor+']','[/'+document.getElementById('ColorUsed').bgColor+']');" style="padding:0; margin:0" /><input type="hidden" value="" name="ColorUsedMem" id="ColorUsedMem" /></td>
+						<td width="5" style="margin:0; padding:0">&nbsp;
+							<script language="JavaScript" type="text/javascript">
+								rgb(0,col0,0,'https://forum-images.hardware.fr/icones/trans.gif','Mettre du texte en couleur');
+								rgb(18,col1,50,'https://forum-images.hardware.fr/icones/trans.gif','Mettre du texte en couleur');
+								rgb(36,col2,100,'https://forum-images.hardware.fr/icones/trans.gif','Mettre du texte en couleur');
+								rgb(0,col3,150,'https://forum-images.hardware.fr/icones/trans.gif','Mettre du texte en couleur');
+							</script>
+						</td>
+					</tr>
+				</table>
+			</div>
+			<div class="left">
+				&nbsp;&nbsp;
+				<img style="cursor:pointer" onclick="TAinsert('[quote]','[/quote]');" title="Insérer une citation. Syntaxe : [quote]texte[/quote]" alt="[quote]" src="https://forum-images.hardware.fr/icones/message/citation.gif" width="69" height="28" />
+			</div>
+			<div class="spacer">&nbsp;</div>
+	<br /><textarea cols="75" rows="14" class="contenu" name="content_form" id="content_form" accesskey="c">Test technique Redface2 #81 : réponse jetable pour capturer le formulaire de suppression d'un post.
+
+Ce message doit être supprimé pendant le test.
+
+[i]Post par GPT-5 Codex[/i]</textarea><input type="hidden" name="wysiwyg" value="0" />
+<input onclick=" return verif_not_empty()" type="submit" accesskey="s" value="Valider votre message" name="submit" /><input type="button" accesskey="a" value="Aperçu" onclick="apercevoir();" />		<div id="addCommentMessage"></div>
+		</td>
+	</tr>
+	<tr class="reponse">
+		<th class="repCase1">Options</th>
+		<td class="repCase2" style="font-weight:bold">	<input class="checkbox opt" type="checkbox" value="1" name="signature" checked="checked" id="signature" /><label for="signature">Activer votre signature</label>
+	<br /><input class="checkbox opt" type="checkbox" value="1" name="smiley" id="smiley" /><label for="smiley">Désactiver les smilies</label>
+	<br /><input class="checkbox opt" type="checkbox" value="1" name="emaill" id="emaill" /><label for="emaill">Activer la notification par email du sujet</label>
+	<br /><br /><input class="checkbox" type="checkbox" value="1" name="delete" id="delete" /><label for="delete">Effacer ce message</label>&nbsp;</td></tr></table></form><table class="main" cellspacing="0" cellpadding="4" width="100%">		<tr style="display:none" id="apercu" class="reponse">
+			<th class="repCase1">Aperçu</th>
+			<th class="repCase2"><iframe name="apercu_frame" id="apercu_frame" style="border:0px" src=""></iframe></th>
+		</tr>
+	</table><form action="/apercu.php" target="apercu_frame" method="post" name="apercu_form" id="apercu_form">
+<input type="hidden" name="hash_check" value="REDACTED_HASH_CHECK" /><input type="hidden" name="apercu_contenu" id="apercu_contenu" value="" />
+<input type="hidden" name="apercu_smiley" id="apercu_smiley" value="" />
+<input type="hidden" name="config" value="hfr.inc" />
+</form>
+<a href="/password.php?config=hfr.inc" class="s2Ext">Vous avez perdu votre mot de passe ?</a>
+<br />
+<br />
+
+<br /><table class="main" cellspacing="0" cellpadding="4" width="100%">
+			<tr class="cBackHeader">
+				<th class="padding">Vue Rapide de la discussion</th>
+			</tr>
+		</table>		<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#DEDFDF">
+						<td class="messCase1bis" width="160" valign="top">xatelitte</td>
+			<td>Test technique Redface2 #81 : réponse jetable pour capturer le formulaire de suppression d'un post.</p>&nbsp;<p>Ce message doit être supprimé pendant le test.</p>&nbsp;<p><em>Post par GPT-5 Codex</em><div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+			<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#F7F7F7">
+						<td class="messCase1bis" width="160" valign="top">xatelitte</td>
+			<td>Test technique Redface2 #81 : capture des flux d'écriture HFR.</p>&nbsp;<p>Edition FP technique : formulaire premier post valide.</p>&nbsp;<p>Ce topic temporaire sera supprime a la fin du test si HFR l'autorise.</p>&nbsp;<p><em>Post par GPT-5 Codex</em><div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+
+<div class="copyright">
+<br /><a href="http://www.mesdiscussions.net" target="_blank" class="copyright">Forum MesDiscussions.Net</a>, Version 2010.2 <br />(c) 2000-2011 Doctissimo<br /></div>
+</div>
+</div>
+<center><font color="#000000" size="1" face="Arial, Helvetica, sans-serif"><br />Copyright © 1997-2025 Groupe <a href="https://www.ldlc.com" title="Achat de materiel Informatique">LDLC</a> (<a href="https://www.hardware.fr/html/donnees_personnelles/">Signaler un contenu illicite / Données personnelles</a>)</font></center>
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://tracking.groupe-ldlc.com/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '26']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<noscript><p><img src="https://tracking.groupe-ldlc.com/matomo.php?idsite=26&rec=1" style="border:0;" alt="" /></p></noscript>
+<!-- End Matomo Code --><script type="text/javascript">
+md_forum_decryptlink.init();
+</script>
+<script type="text/javascript">
+md_forum_decryptlink.init();
+</script>
+<script type="text/javascript">
+var md_url_img_shadow= 'https://forum-images.hardware.fr';
+var md_tabs_menu_shadow= 1;
+</script>
+<script type="text/javascript">
+
+		window.onload = function(){aff_add_img_js();};
+
+	function warning() {
+		if (alert('Vous devez spécifier une sous-catégorie !')) {
+			return false;
+		} else {
+			return false;
+		}
+	}
+	function add_join_img() {
+	var addform= 0;
+	for (i=0;i<10;i++) {
+		if ((!document.getElementById('add_image'+i)) && (addform == 0)) {
+			//var inner_add_form= document.getElementById('add_image_form').innerHTML;
+			//document.getElementById('add_image_form').innerHTML= inner_add_form+ '<br /><input type="file" name="add_image'+i+'" id="add_image'+i+'" onchange="document.join_form.sub.style.fontWeight=\'bold\'" />';
+			addform= 1;
+			var addFile=document.createElement("DIV");
+			addFile.innerHTML= '<input type="file" name="add_image'+i+'" id="add_image'+i+'" onchange="document.join_form.sub.style.fontWeight=\'bold\'" />';
+		    document.getElementById('add_image_form').appendChild(addFile)
+			if (i == 9) {
+				document.getElementById('add_img_js').style.display= 'none';
+			}
+		}
+	}
+}
+
+function aff_add_img_js() {
+	if (document.getElementById('add_img_js')) {
+		document.getElementById('add_img_js').style.display= 'block';
+	}
+}
+function message_upload_img() {
+	no_image= 1;
+	for (i=0;i<10;i++) {
+		if ((document.getElementById('add_image'+i)) && (document.getElementById('add_image'+i).value != '')) {
+			no_image= 0;
+		}
+	}
+	if (no_image == 1) {
+		alert('Vous n\'avez pas choisi d\'image à joindre');
+		return false;
+	}
+	document.getElementById('add_img_js').style.display= 'none';
+	document.getElementById('add_image_form').style.display= 'none';
+	document.getElementById('submit_upload').style.display= 'none';
+	document.getElementById('join_form').action= '/user/join_image_b.php?config=hfr.inc';
+	document.getElementById('upload_frame').style.display= '';
+	document.getElementById('join_form').target= 'upload_frame';
+	document.getElementById('img_wait_upload_img').style.display= '';
+	document.getElementById('join_form').submit();
+	document.getElementById('submit_upload').style.fontWeight= 'normal';
+}
+</script>
+</body>
+</html>

--- a/core/data/src/test/resources/fixtures/write_delete_post_form.source.txt
+++ b/core/data/src/test/resources/fixtures/write_delete_post_form.source.txt
@@ -1,0 +1,6 @@
+Source: forum.hardware.fr
+Captured: 2026-05-17 with authenticated XaTelitte session
+URL: https://forum.hardware.fr/message.php?config=hfr.inc&cat=10&post=148749&numreponse=2523830&page=1&p=1&subcat=388&sondage=0&owntopic=0#formulaire
+Notes: GET edit form for a non-first owned post in the controlled temporary topic. The form exposes delete=1 labelled "Effacer ce message".
+Sanitization: hash_check/codehex redacted; MP unread target id and MP count redacted when present; no cookies stored.
+Test context: Temporary owned topic cat=10 post=148749 subcat=388; disposable reply numreponse=2523830.

--- a/core/data/src/test/resources/fixtures/write_delete_post_success_response.html
+++ b/core/data/src/test/resources/fixtures/write_delete_post_success_response.html
@@ -1,0 +1,31 @@
+	<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+	<html>
+	<head>
+	<title>FORUM HardWare.fr</title>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta http-equiv="Pragma" content="no-cache" />
+	<meta http-equiv="Cache-Control" content="no-cache, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+	<meta http-equiv="Imagetoolbar" content="no" />
+	<meta name="Robots" content="noindex, follow" />
+	<link rel="stylesheet" type="text/css" href="/include/the_style1.php?color_key=FFFFFF/DEDFDF/000080/C2C3F4/001932/FFFFFF/FFFFFF/000000/000080/000000/000080/F7F7F7/DEDFDF/F7F7F7/DEDFDF/C0C0C0/C0C0C0/FFFFFF/000000/000000/0000FF/EEEEFF/DDDDEE/000000/FFEEEE/000000/FFFFFF/FF0000/FFFFFF/0/1/https%3A%40%40forum-images.hardware.fr/NULL/&amp;abs_img_path=%40data%40sites%40forum%40www%40static%40&amp;hide_bg_onglet=0&amp;v=11102781422" />
+	<link type="text/css" rel="stylesheet" href="https://forum-images.hardware.fr/compressed/the_style.css?v=11102781422" />	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta http-equiv="Refresh" content="1; url=/hfr/Programmation/Divers-6/sujet_148749_1.htm" />	<style type="text/css">
+	.hop{			background-color: #F7F7F7;
+			color: #000000;
+			margin:auto;
+			text-align: center;
+			width:50%;
+			border: 1px solid #C0C0C0;}
+	</style>
+	</head>
+
+	<body>
+			<div class="container">
+	<div class="mesdiscussions" id="mesdiscussions">
+	<br /><br />
+	<div class="hop">
+	Message effacé avec succès !		</div>
+	</div>
+	</div>
+	</body></html>

--- a/core/data/src/test/resources/fixtures/write_delete_post_success_response.source.txt
+++ b/core/data/src/test/resources/fixtures/write_delete_post_success_response.source.txt
@@ -1,0 +1,6 @@
+Source: forum.hardware.fr
+Captured: 2026-05-17 with authenticated XaTelitte session
+URL: POST https://forum.hardware.fr/bdd.php?config=hfr.inc
+Notes: Server response after submitting delete=1 from the non-first post edit form.
+Sanitization: hash_check/codehex redacted; MP unread target id and MP count redacted when present; no cookies stored.
+Test context: Temporary owned topic cat=10 post=148749 subcat=388; disposable reply numreponse=2523830.

--- a/core/data/src/test/resources/fixtures/write_delete_topic_form.html
+++ b/core/data/src/test/resources/fixtures/write_delete_topic_form.html
@@ -1,0 +1,415 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+	<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr" lang="fr">
+	<head>
+	<title>FORUM HardWare.fr - Répondre / éditer un message</title><link type="text/css" rel="stylesheet" href="/include/the_style1.php?color_key=FFFFFF/DEDFDF/000080/C2C3F4/001932/FFFFFF/FFFFFF/000000/000080/000000/000080/F7F7F7/DEDFDF/F7F7F7/DEDFDF/C0C0C0/C0C0C0/FFFFFF/000000/000000/0000FF/EEEEFF/DDDDEE/000000/FFEEEE/000000/FFFFFF/FF0000/FFFFFF/0/1/https%3A%40%40forum-images.hardware.fr/NULL/&amp;abs_img_path=%40data%40sites%40forum%40www%40static%40&amp;hide_bg_onglet=0&amp;v=11102781422" /><style type="text/css">
+<!--
+.fastsearchMain{ width: 330px; }
+.fastsearchInput{ width: 70px; border: 1px solid black; }
+.fastsearchSubmit{ background-color: ; border: 0px;}
+.header2 { background-image: url(/img/forum3_1.gif);background-repeat: repeat-x; }
+.menuExt { font-family: Arial, Helvetica, sans-serif; font-size: 10px; color:#000; }
+.menuExt a { color:#000;text-decoration:none; }
+.menuExt a:hover { color:#000;text-decoration:underline; }
+form { display: inline; }
+.header { background-image: url(//forum-images.hardware.fr/img/header-bg.gif); background-repeat: repeat-x; }
+.tdmenu { width: 1px;height: 1px;color: #000000; }
+.hfrheadmenu { font-family: Arial, Helvetica, sans-serif;font-size:13px;font-weight:bold; }
+.hfrheadmenu span {color:;}
+.hfrheadmenu a { color:;text-decoration: none; }
+.hfrheadmenu a:hover { color:;text-decoration: underline; }
+.concours { font-family: Arial, Helvetica, sans-serif;color:;font-size: 16px;text-decoration: none;font-weight: bold;}
+.concours:hover { font-family: Arial, Helvetica, sans-serif;color:;font-size: 16px;text-decoration: underline;font-weight: bold; }
+.searchmenu { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: none;font-weight: bold; }
+.fastsearch { display: none; }
+.fastsearchHeader { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: none;font-weight: bold; }
+.fastsearchHeader:hover { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: underline;font-weight: bold; }
+-->
+</style>
+<script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+<script>
+  window.googletag = window.googletag || {cmd: []};
+  googletag.cmd.push(function() {
+    googletag.defineSlot('/2172442/forum_discussions_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-11').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-12').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-13').addService(googletag.pubads());
+    googletag.pubads().enableSingleRequest();
+    googletag.enableServices();
+  });
+</script>
+<script type='text/javascript'>
+     (function(){
+       var loc = window.location.href;
+       var dd = document.createElement('script');
+       dd.type = 'text/javascript'; dd.src = '//static.digidip.net/hardware.js?loc=' + loc;
+       var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(dd, s);
+     })();
+</script><script type="text/javascript">
+
+var hash_check = "&hash_check=REDACTED_HASH_CHECK";
+var _adresseRecherche = "/user/message-aj.php";
+var adresseFindSmiley = "/message-smi-mp-aj.php";
+var tempo_smilies= 0;
+
+var img_path= "https://forum-images.hardware.fr";
+
+function verif_join_form() {
+	if ((document.getElementById('submit_upload')) && (document.getElementById('submit_upload').style.fontWeight == 'bold')) {
+		return confirm('Attention : vous n\'avez pas joint l\'image que vous avez sélectionnée');
+	}
+	return true;
+}
+
+function verif_not_empty() {
+	if (document.getElementById('delete').checked == true) {
+		return true;
+	}
+	if (document.hop.sujet && trim(document.hop.sujet.value) =='') {
+		alert('Vous devez remplir tous les champs avant de poster ce message');
+		return false;
+	}
+	if (document.hop.content_form && trim(document.hop.content_form.value) == '') {
+		alert('Vous devez remplir tous les champs avant de poster ce message');
+		return false;
+	}
+	if (document.hop.codecaptcha && trim(document.hop.codecaptcha.value) == '') {
+		alert('Vous devez remplir tous les champs avant de poster ce message');
+		return false;
+	}
+	if (document.getElementById('have_sondage') && document.getElementById('have_sondage').checked == true && document.getElementById('annee').value && document.getElementById('annee').value.length != 4) {
+		alert('L\'année du sondage doit être sur 4 chiffres');
+		return false;
+	}
+
+	return true;
+}
+
+function trim(string) {
+	return string.replace(/(^\s*)|(\s*$)/g,"");
+}
+</script><script language="javascript" type="text/javascript">
+	<!--
+ var opera=0;
+	function putSmiley(tt,src) {
+TAinsert(" "+tt+" ","");
+}
+	//-->
+	</script><link type="text/css" rel="stylesheet" href="https://forum-images.hardware.fr/compressed/the_style.css?v=11102781422" />
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta http-equiv="Pragma" content="no-cache" />
+	<meta http-equiv="Cache-Control" content="no-cache, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+	<meta http-equiv="Imagetoolbar" content="no" />
+	<meta name="Robots" content="noindex, nofollow" />
+<script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/editPost.js?v=11102781422"></script><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/message.js?v=11102781422"></script><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/common.js?v=11102781422"></script></head><body id="category__redaction_form__form_message"  > <table cellspacing="0" cellpadding="0" width="98%" bgcolor="#000000" border="0" align="center" class="hfrheadmenu" style="border:1px solid #000;border-top:0;">
+        <tr>
+          <td style="vertical-align: top">
+            <table cellspacing="0" cellpadding="0" width="100%" border="0">
+              <tr>
+                <td style="width: 100%" align="left" valign="middle" colspan="2" class="header2"><span class="md_cryptlink45CBCBC0C22D1F1FCCCCCC19454AC14BCC4AC1431944C1"><img src="/img/forum_logo.gif" width="900" height="71" border="0" alt="" /></span></td>
+              </tr>
+              <tr>
+                <td style="background-color:#001932">
+                  <table cellspacing="0" cellpadding="2" width="100%" border="0">
+                    <tr>
+                      <td>&nbsp;<a class="cHeader" href="/">Forum</a>&nbsp;|&nbsp;
+<a class="cHeader" href="https://www.hardware.fr/">HardWare.fr</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/html/news/">News</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/html/articles/">Articles</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/articles/786-1/guide-pc-hardware-fr.html">PC</a>&nbsp;|&nbsp;<span class="md_cryptlink1FC349484F4C19C045C02F424F4944464C2E454AC14BCC4AC14344C11946494214424F4B434543C52E2443252B234A232C4B24254B4B2B254B2B252B2A43444B2A442B252420212C20">Se d&eacute;connecter</span>&nbsp;|&nbsp;<span class="md_cryptlink1FC3C243C11F434B46CBC0C14F44464819C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">Profil</span>&nbsp;|&nbsp;<a class="cHeader" href="https://shop.hardware.fr/" target="_blank" style="position: relative; padding: 0 21px 0 0;display: inline-block;">Shop <img src="/img/shop.png" style="height: 17px; display: inline; position: absolute; right: 0; top: -2px; "></a></td>
+<td align="right"><a class="cHeader" href="/search.php?config=hardwarefr.inc&cat=10&subcat=388">Recherche <img src="//forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif"></a></td>
+                    </tr>
+                    </table></td></tr></table>
+</td></tr></table><div style="width: 99%" align="right">
+<span class="s2Ext menuExt"><span class="md_cryptlink1F4F494846494319C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">4084 connect&eacute;s&nbsp;</span></span></div><br /><script language="javascript" type="text/javascript">
+			<!--
+			writeCookie('md_users_res');
+			//-->
+			</script><div class="container"><div class="mesdiscussions" id="mesdiscussions"><div class="arbo">
+<span  id="md_arbo_tree_1" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/" class="Ext">FORUM HardWare.fr</a></span>
+<br />
+<span  id="md_arbo_tree_2" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/hfr/Programmation/liste_sujet-1.htm" class="Ext">Programmation</a></span>
+<br />
+<span  id="md_arbo_tree_3" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline3.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/hfr/Programmation/Divers-6/liste_sujet-1.htm" class="Ext">Divers</a></span>
+<br />
+<h1  id="md_arbo_tree_4" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline4.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/hfr/Programmation/Divers-6/redface2-temporaire-ecriture-sujet_148749_1.htm" class="Ext">[Redface2] Topic temporaire de test ecriture</a></h1>
+</div><div class="rightbutton fastsearch"><table class="main fastsearchMain" cellspacing="0" cellpadding="2"><tr class="cBackHeader fondForumDescription"><th><form method="post" id="fastsearch" action="/forum1.php"><input type="hidden" name="hash_check" value="REDACTED_HASH_CHECK" /><label for="fastsearchinputid"><a rel="nofollow" href="/search.php?config=hfr.inc&amp;cat=10&amp;subcat=388" class="cHeader fastsearchHeader">Recherche :</a>&nbsp;<input type="text" name="search" id="fastsearchinputid" value="" class="fastsearchInput" alt="Search string" /></label><input type="hidden" name="recherches" value="1" /><input type="hidden" name="searchtype" value="1" /><input type="hidden" name="titre" value="3" /><input type="hidden" name="resSearch" value="200" /><input type="hidden" name="orderSearch" value="1" /><input type="hidden" name="config" value="hfr.inc" /><input type="hidden" name="cat" value="10" /><input type="hidden" name="subcat" value="388" />&nbsp;<input type="image" src="https://forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif" class="fastsearchSubmit" title="Lancer une recherche" alt="Lancer une recherche" /></form></th></tr></table></div><div class="spacer">&nbsp;</div><br /><div></div><br /><table class="main" style="margin:auto;" cellspacing="0" cellpadding="4">
+				<tr class="cBackHeader">
+				<th colspan="2">Dernière réponse</th>
+			</tr>
+			<tr class="reponse">
+				<th colspan="2">
+					Sujet : [Redface2] Topic temporaire de test ecriture</th>
+			</tr><tr class="reponse">
+				<td class="messCase1bis" width="160" valign="top">xatelitte</td>
+				<td>Test technique Redface2 #81 : capture des flux d'écriture HFR.</p>&nbsp;<p>Edition FP technique : formulaire premier post valide.</p>&nbsp;<p>Ce topic temporaire sera supprime a la fin du test si HFR l'autorise.</p>&nbsp;<p><em>Post par GPT-5 Codex</em><div style="clear: both;"> </div></td>
+			</tr>
+			</table><br /><a name="formulaire"></a><form name="hop" id="hop" action="/bdd.php?config=hfr.inc" method="post" onsubmit="
+	return verif_join_form();
+	document.hop.submit.style.visibility='hidden';"><input type="hidden" name="hash_check" value="REDACTED_HASH_CHECK" /><input type="hidden" name="parents" value="" />
+<input type="hidden" name="post" value="148749" />
+<input type="hidden" name="stickold" value="0" />
+<input type="hidden" name="new" value="0" />
+<input type="hidden" name="cat" id="catid" value="10" />
+<input type="hidden" name="numreponse" value="2523829" />
+<input type="hidden" name="numrep" value="" />
+<input type="hidden" name="page" value="1" />
+<input type="hidden" name="verifrequet" value="1100" />
+<input type="hidden" name="p" value="1" />
+<input type="hidden" name="sondage" value="0" />
+<input type="hidden" name="sond" value="0" />
+<input type="hidden" name="cache" value="cache" />
+<input type="hidden" name="owntopic" value="0" />
+<input type="hidden" name="config" id="configid" value="hfr.inc" />
+<table class="main" cellspacing="0" cellpadding="4" width="100%">
+	<tr class="cBackHeader">
+		<th colspan="2" style="text-align:center">Votre réponse</th>
+	</tr>
+	<tr class="reponse pseudoform" id="pseudoform">
+		<th class="repCase1">Nom d'utilisateur</th>
+		<td class="repCase2">
+			<input maxlength="25" accesskey="p" size="25" name="pseudo" value="xatelitte" onfocus="passfocus()" />		&nbsp;&nbsp; <a href="/inscription.php?config=hfr.inc" class="Topic">Pour poster, vous devez être inscrit sur ce forum .... si ce n'est pas le cas, cliquez ici !</a>	</td>
+	</tr><tr class="reponse" style="display:none; display:none; " id="passf">
+		<th class="repCase1">Mot de passe</th>
+		<td class="repCase2">			<input type="password" maxlength="40" size="25" name="password" value="" />
+			&nbsp;&nbsp; <a href="/password.php?config=hfr.inc" class="Topic">Vous avez perdu votre mot de passe ? Cliquez ici !</a>
+		</td>
+	</tr><tr class="reponse">
+				<th class="repCase1">Sujet</th>
+				<td class="repCase2"><input maxlength="70" accesskey="t" size="50" name="sujet" value="[Redface2] Topic temporaire de test ecriture" /></td>
+				</tr><tr class="reponse">
+								<th class="repCase1">Sous-catégorie</th>
+									<td class="repCase2"><select name="subcat"><option value="">Aucune</option><option value="381" >Ada</option><option value="382" >Algo</option><option value="562" >Android</option><option value="518" >API Win32</option><option value="384" >ASM</option><option value="383" >ASP</option><option value="565" >BI/Big Data </option><option value="440" >C</option><option value="405" >C#/.NET managed</option><option value="386" >C++</option><option value="391" >Delphi/Pascal</option><option value="473" >Flash/ActionScript</option><option value="389" >HTML/CSS</option><option value="563" >iOS</option><option value="390" >Java</option><option value="566" >Javascript/Node.js</option><option value="484" >Langages fonctionnels</option><option value="392" >Perl</option><option value="393" >PHP</option><option value="394" >Python</option><option value="483" >Ruby/Rails</option><option value="404" >Shell/Batch</option><option value="395" >SQL/NoSQL</option><option value="396" >VB/VBA/VBS</option><option value="564" >Windows Phone</option><option value="439" >XML/XSL</option><option value="388" selected="selected">Divers</option></select></td></tr><tr class="reponse toberead1">
+							<th class="repCase1">Sujet à lire également</th>
+							<td class="repCase2"><input maxlength="10" size="8" name="toread1" value="" /><input maxlength="10" size="8" name="toread2" value="" /><input maxlength="10" size="8" name="toread3" value="" /><input maxlength="10" size="8" name="toread4" value="" /><input maxlength="10" size="8" name="toread5" value="" />&nbsp;&nbsp; (entrez un ou plusieurs numéros de sujet)</td></tr><tr class="reponse">
+				<th class="repCase1">Le ton de votre message</th>
+					<td class="repCase2"><input id="icone1" type="radio" value="1" name="MsgIcon" checked="checked" />
+					&nbsp;<label for="icone1"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></label>&nbsp;<input id="icone2" type="radio" value="2" name="MsgIcon" />
+					&nbsp;<label for="icone2"><img src="https://forum-images.hardware.fr/icones/message/icon2.gif" alt="" /></label>&nbsp;<input id="icone3" type="radio" value="3" name="MsgIcon" />
+					&nbsp;<label for="icone3"><img src="https://forum-images.hardware.fr/icones/message/icon3.gif" alt="" /></label>&nbsp;<input id="icone4" type="radio" value="4" name="MsgIcon" />
+					&nbsp;<label for="icone4"><img src="https://forum-images.hardware.fr/icones/message/icon4.gif" alt="" /></label>&nbsp;<input id="icone5" type="radio" value="5" name="MsgIcon" />
+					&nbsp;<label for="icone5"><img src="https://forum-images.hardware.fr/icones/message/icon5.gif" alt="" /></label>&nbsp;<input id="icone6" type="radio" value="6" name="MsgIcon" />
+					&nbsp;<label for="icone6"><img src="https://forum-images.hardware.fr/icones/message/icon6.gif" alt="" /></label>&nbsp;<input id="icone7" type="radio" value="7" name="MsgIcon" />
+					&nbsp;<label for="icone7"><img src="https://forum-images.hardware.fr/icones/message/icon7.gif" alt="" /></label>&nbsp;<input id="icone8" type="radio" value="8" name="MsgIcon" />
+					&nbsp;<label for="icone8"><img src="https://forum-images.hardware.fr/icones/message/icon8.gif" alt="" /></label>&nbsp;<br /><input id="icone9" type="radio" value="9" name="MsgIcon" />
+					&nbsp;<label for="icone9"><img src="https://forum-images.hardware.fr/icones/message/icon9.gif" alt="" /></label>&nbsp;<input id="icone10" type="radio" value="10" name="MsgIcon" />
+					&nbsp;<label for="icone10"><img src="https://forum-images.hardware.fr/icones/message/icon10.gif" alt="" /></label>&nbsp;<input id="icone11" type="radio" value="11" name="MsgIcon" />
+					&nbsp;<label for="icone11"><img src="https://forum-images.hardware.fr/icones/message/icon11.gif" alt="" /></label>&nbsp;<input id="icone12" type="radio" value="12" name="MsgIcon" />
+					&nbsp;<label for="icone12"><img src="https://forum-images.hardware.fr/icones/message/icon12.gif" alt="" /></label>&nbsp;<input id="icone13" type="radio" value="13" name="MsgIcon" />
+					&nbsp;<label for="icone13"><img src="https://forum-images.hardware.fr/icones/message/icon13.gif" alt="" /></label>&nbsp;<input id="icone14" type="radio" value="14" name="MsgIcon" />
+					&nbsp;<label for="icone14"><img src="https://forum-images.hardware.fr/icones/message/icon14.gif" alt="" /></label>&nbsp;<input id="icone15" type="radio" value="15" name="MsgIcon" />
+					&nbsp;<label for="icone15"><img src="https://forum-images.hardware.fr/icones/message/icon15.gif" alt="" /></label>&nbsp;<input id="icone16" type="radio" value="16" name="MsgIcon" />
+					&nbsp;<label for="icone16"><img src="https://forum-images.hardware.fr/icones/message/icon16.gif" alt="" /></label>&nbsp;</td>
+			</tr><tr class="reponse">
+		<th class="repCase1">Votre réponse<br /><br /><br />
+			<div><div class="center">	<a target="_blank" href="/smilies.php?config=hfr.inc" class="s1Topic">Smilies</a>
+				<br />&nbsp;
+				<div class="smiley">
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/smilies/pfff.gif" alt=":pfff:" title=":pfff:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/ange.gif" alt=":ange:" title=":ange:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/non.gif" alt=":non:" title=":non:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/bounce.gif" alt=":bounce:" title=":bounce:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/smile.gif" alt=":)" title=":)" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/frown.gif" alt=":(" title=":(" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/biggrin.gif" alt=":D" title=":D" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/wink.gif" alt=";)" title=";)" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/ouch.gif" alt=":ouch:" title=":ouch:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/redface.gif" alt=":o" title=":o" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/confused.gif" alt=":??:" title=":??:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/tongue.gif" alt=":p" title=":p" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/na.gif" alt=":na:" title=":na:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/sarcastic.gif" alt=":sarcastic:" title=":sarcastic:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/smilies/fou.gif" alt=":fou:" title=":fou:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/jap.gif" alt=":jap:" title=":jap:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/lol.gif" alt=":lol:" title=":lol:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/wahoo.gif" alt=":wahoo:" title=":wahoo:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/kaola.gif" alt=":kaola:" title=":kaola:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/smilies/love.gif" alt=":love:" title=":love:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/heink.gif" alt=":heink:" title=":heink:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/cry.gif" alt=":cry:" title=":cry:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/whistle.gif" alt=":whistle:" title=":whistle:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/sol.gif" alt=":sol:" title=":sol:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+					<div>
+						<img src="https://forum-images.hardware.fr/icones/smilies/pt1cable.gif" alt=":pt1cable:" title=":pt1cable:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/sleep.gif" alt=":sleep:" title=":sleep:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/sweat.gif" alt=":sweat:" title=":sweat:" onclick="putSmiley(this.alt,this.src)" /><br />
+						<img src="https://forum-images.hardware.fr/icones/smilies/hello.gif" alt=":hello:" title=":hello:" onclick="putSmiley(this.alt,this.src)" />
+					</div>
+				</div>
+				<div class="spacer">&nbsp;</div>
+				<br /><a href="/wikismilies.php?config=hfr.inc&amp;threecol=1" target="_blank" class="s1Topic">Liste des smilies perso</a><br /><a target="_blank" href="/wikismilies.php?config=hfr.inc" class="s1Topic">Wiki smilies</a><br /><span class="small">Chercher un smiley<br /><input type="text" value="" name="search_smilies" id="search_smilies" size="10" onkeyup="find_smilies_timer('hfr.inc',1214571)"/></span><br /><div id="dynamic_smilies"></div></div></div></th><td class="repCase2" valign="top">		<div class="left">
+				<img style="cursor:pointer" class="text_bold" onclick="TAinsert('[b]','[/b]');" title="Mettre en gras le texte. Syntaxe : [b]texte[/b]" alt="[b]" src="https://forum-images.hardware.fr/icones/message/bold.gif" width="27" height="28" /><img
+				style="cursor:pointer" class="text_ita" onclick="TAinsert('[i]','[/i]');" title="Mettre en italique le texte. Syntaxe : [i]texte[/i]" alt="[i]" src="https://forum-images.hardware.fr/icones/message/italic.gif" width="25" height="28" /><img
+				style="cursor:pointer" class="text_under" onclick="TAinsert('[u]','[/u]');" title="Souligner le texte. Syntaxe : [u]texte[/u]" alt="[u]" src="https://forum-images.hardware.fr/icones/message/underline.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_strike" onclick="TAinsert('[strike]','[/strike]');" title="Barrer le texte. Syntaxe : [strike]texte[/strike]" alt="[strike]" src="https://forum-images.hardware.fr/icones/message/strike.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_spoiler" onclick="TAinsert('[spoiler]','[/spoiler]');" title="Masquer le texte. Syntaxe : [spoiler]texte[/spoiler]" alt="[spoiler]" src="https://forum-images.hardware.fr/icones/message/spoiler.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_fixed" onclick="TAinsert('[fixed]','[/fixed]');" title="Ecrire avec une police de taille fixe. Syntaxe : [fixed]texte[/fixed]" alt="[fixed]" src="https://forum-images.hardware.fr/icones/message/fixe.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="cpp" onclick="TAinsert('[cpp]','[/cpp]');" title="Insérer du code C/C++. Syntaxe : [cpp]texte[/cpp]" alt="[cpp]" src="https://forum-images.hardware.fr/icones/message/c.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_url" onclick="TAinsert('[url]','[/url]');" title="Insérer une URL. Syntaxe : [url]texte[/url]" alt="[url]" src="https://forum-images.hardware.fr/icones/message/url.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_email" onclick="TAinsert('[email]','[/email]');" title="Insérer une adresse email. Syntaxe : [email]email@hostname.com[/email]" alt="[email]" src="https://forum-images.hardware.fr/icones/message/email.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="image" onclick="TAinsert('[img]','[/img]');" title="Insérer une image. Syntaxe : [img]http://www.exemple.com/exemple.jpg[/img]" alt="[img]" src="https://forum-images.hardware.fr/icones/message/image.gif" width="26" height="28" /><img
+				style="cursor:pointer" class="text_puce" onclick="TAinsert('[*]','');" title="Insérer une puce. Syntaxe : [*]texte" alt="[*]" src="https://forum-images.hardware.fr/icones/message/puce.gif" width="23" height="28" />
+				&nbsp;&nbsp;
+			</div>
+			<div class="left" style="width:270px;">
+				<table class="none" style="margin-top:6px; border:0px" id="ColorPanel" cellspacing="0" cellpadding="0">
+					<tr>
+						<td style="margin:0; padding:0; line-height:10px; cursor:pointer; width:15px; border:1px solid #000000" id="ColorUsed" title="Dernière couleur sélectionnée"><img src="https://forum-images.hardware.fr/icones/trans.gif" alt="" width="15" height="17" onclick="TAinsert('['+document.getElementById('ColorUsed').bgColor+']','[/'+document.getElementById('ColorUsed').bgColor+']');" style="padding:0; margin:0" /><input type="hidden" value="" name="ColorUsedMem" id="ColorUsedMem" /></td>
+						<td width="5" style="margin:0; padding:0">&nbsp;
+							<script language="JavaScript" type="text/javascript">
+								rgb(0,col0,0,'https://forum-images.hardware.fr/icones/trans.gif','Mettre du texte en couleur');
+								rgb(18,col1,50,'https://forum-images.hardware.fr/icones/trans.gif','Mettre du texte en couleur');
+								rgb(36,col2,100,'https://forum-images.hardware.fr/icones/trans.gif','Mettre du texte en couleur');
+								rgb(0,col3,150,'https://forum-images.hardware.fr/icones/trans.gif','Mettre du texte en couleur');
+							</script>
+						</td>
+					</tr>
+				</table>
+			</div>
+			<div class="left">
+				&nbsp;&nbsp;
+				<img style="cursor:pointer" onclick="TAinsert('[quote]','[/quote]');" title="Insérer une citation. Syntaxe : [quote]texte[/quote]" alt="[quote]" src="https://forum-images.hardware.fr/icones/message/citation.gif" width="69" height="28" />
+			</div>
+			<div class="spacer">&nbsp;</div>
+	<br /><textarea cols="75" rows="14" class="contenu" name="content_form" id="content_form" accesskey="c">Test technique Redface2 #81 : capture des flux d'écriture HFR.
+
+Edition FP technique : formulaire premier post valide.
+
+Ce topic temporaire sera supprime a la fin du test si HFR l'autorise.
+
+[i]Post par GPT-5 Codex[/i]</textarea><input type="hidden" name="wysiwyg" value="0" />
+	<input onclick="aff_partie_sondage()" type="checkbox" name="have_sondage" value="1" id="have_sondage" /><label for="have_sondage"><b ondblclick="aff_partie_sondage()">Présence d'un sondage sur ce sujet</b></label>
+	<br />
+			<div id="sondagediv" style="display:none">
+			<br />
+			<br /><span class="s2">Question du sondage :</span>
+			<br /><input size="50" maxlength="255" name="textreponse0" value="" />
+			<br />
+			<br /><span class="s2">Liste des réponses du sondage :</span>
+			<br />
+	1 : <input size="50" maxlength="255" name="textreponse1" value="" /><br />2 : <input size="50" maxlength="255" name="textreponse2" value="" /><br />3 : <input size="50" maxlength="255" name="textreponse3" value="" /><br />4 : <input size="50" maxlength="255" name="textreponse4" value="" /><br />5 : <input size="50" maxlength="255" name="textreponse5" value="" /><br />6 : <input size="50" maxlength="255" name="textreponse6" value="" /><br />7 : <input size="50" maxlength="255" name="textreponse7" value="" /><br />8 : <input size="50" maxlength="255" name="textreponse8" value="" /><br />9 : <input size="50" maxlength="255" name="textreponse9" value="" /><br />10 : <input size="49" maxlength="255" name="textreponse10" value="" /><br /><br /><span class="s2">Autoriser les non-inscrits à voter :<input type="checkbox" name="allowvisitor" value="1" /></span><br /><span class="s2">Maximum de choix possibles sur ce sondage :</span> <select name="max_votes"><option value="1" >1</option><option value="2" >2</option><option value="3" >3</option><option value="4" >4</option><option value="5" >5</option><option value="6" >6</option><option value="7" >7</option><option value="8" >8</option><option value="9" >9</option><option value="10" >10</option></select>
+	<br /><span class="s2">Date d'expiration (cloture) du sondage :</span><input type="text" size="2" maxlength="2" name="jour" value="" onclick="if(this.value=='DD') this.value='';" /><input type="text" size="2" maxlength="2" name="mois" value="" onclick="if(this.value=='MM') this.value='';" /><input type="text" size="4" maxlength="4" name="annee" value="" onclick="if(this.value=='YYYY') this.value='';"  id="annee" /> à <input type="text" size="2" maxlength="2" name="heure" value="" /> H <input type="text" size="2" maxlength="2" name="minute" value="" /></div><input onclick=" return verif_not_empty()" type="submit" accesskey="s" value="Valider votre message" name="submit" /><input type="button" accesskey="a" value="Aperçu" onclick="apercevoir();" />		<div id="addCommentMessage"></div>
+		</td>
+	</tr>
+	<tr class="reponse">
+		<th class="repCase1">Options</th>
+		<td class="repCase2" style="font-weight:bold">	<input class="checkbox opt" type="checkbox" value="1" name="signature" checked="checked" id="signature" /><label for="signature">Activer votre signature</label>
+	<br /><input class="checkbox opt" type="checkbox" value="1" name="smiley" id="smiley" /><label for="smiley">Désactiver les smilies</label>
+	<br /><input class="checkbox opt" type="checkbox" value="1" name="emaill" id="emaill" /><label for="emaill">Activer la notification par email du sujet</label>
+	<br /><br /><input class="checkbox" type="checkbox" value="1" name="delete" id="delete" /><label for="delete">Effacer l'intégralité du sujet</label>&nbsp;</td></tr></table></form><table class="main" cellspacing="0" cellpadding="4" width="100%">		<tr style="display:none" id="apercu" class="reponse">
+			<th class="repCase1">Aperçu</th>
+			<th class="repCase2"><iframe name="apercu_frame" id="apercu_frame" style="border:0px" src=""></iframe></th>
+		</tr>
+	</table><form action="/apercu.php" target="apercu_frame" method="post" name="apercu_form" id="apercu_form">
+<input type="hidden" name="hash_check" value="REDACTED_HASH_CHECK" /><input type="hidden" name="apercu_contenu" id="apercu_contenu" value="" />
+<input type="hidden" name="apercu_smiley" id="apercu_smiley" value="" />
+<input type="hidden" name="config" value="hfr.inc" />
+</form>
+<a href="/password.php?config=hfr.inc" class="s2Ext">Vous avez perdu votre mot de passe ?</a>
+<br />
+<br />
+
+<br /><table class="main" cellspacing="0" cellpadding="4" width="100%">
+			<tr class="cBackHeader">
+				<th class="padding">Vue Rapide de la discussion</th>
+			</tr>
+		</table>		<table cellspacing="0" cellpadding="4" width="100%">
+					<tr class="message" style="background-color:#DEDFDF">
+						<td class="messCase1bis" width="160" valign="top">xatelitte</td>
+			<td>Test technique Redface2 #81 : capture des flux d'écriture HFR.</p>&nbsp;<p>Edition FP technique : formulaire premier post valide.</p>&nbsp;<p>Ce topic temporaire sera supprime a la fin du test si HFR l'autorise.</p>&nbsp;<p><em>Post par GPT-5 Codex</em><div style="clear: both;"> </div></td>
+			</tr>
+		</table>
+
+<div class="copyright">
+<br /><a href="http://www.mesdiscussions.net" target="_blank" class="copyright">Forum MesDiscussions.Net</a>, Version 2010.2 <br />(c) 2000-2011 Doctissimo<br /></div>
+</div>
+</div>
+<center><font color="#000000" size="1" face="Arial, Helvetica, sans-serif"><br />Copyright © 1997-2025 Groupe <a href="https://www.ldlc.com" title="Achat de materiel Informatique">LDLC</a> (<a href="https://www.hardware.fr/html/donnees_personnelles/">Signaler un contenu illicite / Données personnelles</a>)</font></center>
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://tracking.groupe-ldlc.com/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '26']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<noscript><p><img src="https://tracking.groupe-ldlc.com/matomo.php?idsite=26&rec=1" style="border:0;" alt="" /></p></noscript>
+<!-- End Matomo Code --><script type="text/javascript">
+md_forum_decryptlink.init();
+</script>
+<script type="text/javascript">
+md_forum_decryptlink.init();
+</script>
+<script type="text/javascript">
+var md_url_img_shadow= 'https://forum-images.hardware.fr';
+var md_tabs_menu_shadow= 1;
+</script>
+<script type="text/javascript">
+
+		window.onload = function(){aff_add_img_js();};
+
+	function warning() {
+		if (alert('Vous devez spécifier une sous-catégorie !')) {
+			return false;
+		} else {
+			return false;
+		}
+	}
+	function add_join_img() {
+	var addform= 0;
+	for (i=0;i<10;i++) {
+		if ((!document.getElementById('add_image'+i)) && (addform == 0)) {
+			//var inner_add_form= document.getElementById('add_image_form').innerHTML;
+			//document.getElementById('add_image_form').innerHTML= inner_add_form+ '<br /><input type="file" name="add_image'+i+'" id="add_image'+i+'" onchange="document.join_form.sub.style.fontWeight=\'bold\'" />';
+			addform= 1;
+			var addFile=document.createElement("DIV");
+			addFile.innerHTML= '<input type="file" name="add_image'+i+'" id="add_image'+i+'" onchange="document.join_form.sub.style.fontWeight=\'bold\'" />';
+		    document.getElementById('add_image_form').appendChild(addFile)
+			if (i == 9) {
+				document.getElementById('add_img_js').style.display= 'none';
+			}
+		}
+	}
+}
+
+function aff_add_img_js() {
+	if (document.getElementById('add_img_js')) {
+		document.getElementById('add_img_js').style.display= 'block';
+	}
+}
+function message_upload_img() {
+	no_image= 1;
+	for (i=0;i<10;i++) {
+		if ((document.getElementById('add_image'+i)) && (document.getElementById('add_image'+i).value != '')) {
+			no_image= 0;
+		}
+	}
+	if (no_image == 1) {
+		alert('Vous n\'avez pas choisi d\'image à joindre');
+		return false;
+	}
+	document.getElementById('add_img_js').style.display= 'none';
+	document.getElementById('add_image_form').style.display= 'none';
+	document.getElementById('submit_upload').style.display= 'none';
+	document.getElementById('join_form').action= '/user/join_image_b.php?config=hfr.inc';
+	document.getElementById('upload_frame').style.display= '';
+	document.getElementById('join_form').target= 'upload_frame';
+	document.getElementById('img_wait_upload_img').style.display= '';
+	document.getElementById('join_form').submit();
+	document.getElementById('submit_upload').style.fontWeight= 'normal';
+}
+</script>
+</body>
+</html>

--- a/core/data/src/test/resources/fixtures/write_delete_topic_form.source.txt
+++ b/core/data/src/test/resources/fixtures/write_delete_topic_form.source.txt
@@ -1,0 +1,6 @@
+Source: forum.hardware.fr
+Captured: 2026-05-17 with authenticated XaTelitte session
+URL: https://forum.hardware.fr/message.php?config=hfr.inc&cat=10&post=148749&numreponse=2523829&page=1&p=1&subcat=388&sondage=0&owntopic=0#formulaire
+Notes: GET edit form for the first post immediately before deleting the controlled temporary topic. The form exposes delete=1 labelled "Effacer l'intégralité du sujet".
+Sanitization: hash_check/codehex redacted; MP unread target id and MP count redacted when present; no cookies stored.
+Test context: Temporary owned topic cat=10 post=148749 subcat=388; first post numreponse=2523829.

--- a/core/data/src/test/resources/fixtures/write_delete_topic_success_response.html
+++ b/core/data/src/test/resources/fixtures/write_delete_topic_success_response.html
@@ -1,0 +1,31 @@
+	<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+	<html>
+	<head>
+	<title>FORUM HardWare.fr</title>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta http-equiv="Pragma" content="no-cache" />
+	<meta http-equiv="Cache-Control" content="no-cache, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+	<meta http-equiv="Imagetoolbar" content="no" />
+	<meta name="Robots" content="noindex, follow" />
+	<link rel="stylesheet" type="text/css" href="/include/the_style1.php?color_key=FFFFFF/DEDFDF/000080/C2C3F4/001932/FFFFFF/FFFFFF/000000/000080/000000/000080/F7F7F7/DEDFDF/F7F7F7/DEDFDF/C0C0C0/C0C0C0/FFFFFF/000000/000000/0000FF/EEEEFF/DDDDEE/000000/FFEEEE/000000/FFFFFF/FF0000/FFFFFF/0/1/https%3A%40%40forum-images.hardware.fr/NULL/&amp;abs_img_path=%40data%40sites%40forum%40www%40static%40&amp;hide_bg_onglet=0&amp;v=11102781422" />
+	<link type="text/css" rel="stylesheet" href="https://forum-images.hardware.fr/compressed/the_style.css?v=11102781422" />	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta http-equiv="Refresh" content="1; url=/hfr/Programmation/Divers-6/liste_sujet-1.htm" />	<style type="text/css">
+	.hop{			background-color: #F7F7F7;
+			color: #000000;
+			margin:auto;
+			text-align: center;
+			width:50%;
+			border: 1px solid #C0C0C0;}
+	</style>
+	</head>
+
+	<body>
+			<div class="container">
+	<div class="mesdiscussions" id="mesdiscussions">
+	<br /><br />
+	<div class="hop">
+	Message effacé avec succès !		</div>
+	</div>
+	</div>
+	</body></html>

--- a/core/data/src/test/resources/fixtures/write_delete_topic_success_response.source.txt
+++ b/core/data/src/test/resources/fixtures/write_delete_topic_success_response.source.txt
@@ -1,0 +1,6 @@
+Source: forum.hardware.fr
+Captured: 2026-05-17 with authenticated XaTelitte session
+URL: POST https://forum.hardware.fr/bdd.php?config=hfr.inc
+Notes: Server response after submitting delete=1 from the first-post edit form. HFR reports a generic "Message effacé avec succès !" and redirects to the subcategory listing.
+Sanitization: hash_check/codehex redacted; MP unread target id and MP count redacted when present; no cookies stored.
+Test context: Temporary owned topic cat=10 post=148749 subcat=388; first post numreponse=2523829.

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/write/DeletePostRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/write/DeletePostRepository.kt
@@ -1,0 +1,37 @@
+package fr.forumhfr.redface2.core.domain.write
+
+import fr.forumhfr.redface2.core.model.write.EditPostContext
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
+
+/**
+ * Deletes one of the user's own posts (#292). HFR has no dedicated delete endpoint: deletion
+ * reuses the **edit form** (`bdd.php?config=hfr.inc`) with an extra `delete=1` field
+ * (cf. `docs/specs/protocol-hfr.md` § « Suppression post/topic »). The implementation therefore
+ * fetches a fresh edit form (for a current `hash_check`) and immediately POSTs it back with
+ * `delete=1` — a single fetch-then-submit so the token is never stale (unlike the editor, where the
+ * form is loaded, edited for a while, then submitted).
+ *
+ * Scope (#292 MVP): **deleting a normal post**. Deleting the *first* post deletes the **entire
+ * topic** on HFR (the success response redirects to the sub-category listing instead of the topic);
+ * that destructive whole-topic path is intentionally **not offered in the UI yet** (the first post
+ * is excluded from the delete affordance). [DeletePostResult.Success.deletedWholeTopic] is still
+ * surfaced as a defensive signal so the caller never tries to reload a topic HFR just removed.
+ */
+interface DeletePostRepository {
+    suspend fun deletePost(context: EditPostContext): DeletePostResult
+}
+
+/** Outcome of a [DeletePostRepository.deletePost] call. */
+sealed interface DeletePostResult {
+    /**
+     * HFR accepted the deletion (« Message effacé avec succès ! »). [deletedWholeTopic] is `true`
+     * when HFR's success redirect points at the sub-category listing (`liste_sujet-*.htm`) rather
+     * than the topic page (`sujet_{id}_{page}.htm`) — i.e. the deleted post was the first post and
+     * the whole topic is now gone. For a normal post it is `false` and the caller refreshes the
+     * current topic page so the removed post disappears.
+     */
+    data class Success(val deletedWholeTopic: Boolean) : DeletePostResult
+
+    /** HFR refused the deletion and surfaced one of the known reasons (reused from the reply flow). */
+    data class Failure(val reason: ReplyFailureReason) : DeletePostResult
+}

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/write/ReplySubmitResponseParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/write/ReplySubmitResponseParser.kt
@@ -67,6 +67,15 @@ class ReplySubmitResponseParser {
             // null topicId/page/numreponse here and the navigation host lands on the listing.
             body.contains(CREATE_SUCCESS_MARKER, ignoreCase = true) -> parseSuccess(html)
 
+            // #292 — delete post/topic success uses its OWN sentence (« Message effacé avec succès ! »),
+            // shared by both the normal-post and the whole-topic delete. The refresh URL shape decides
+            // which happened: a normal-post delete refreshes to `…sujet_{topic}_{page}.htm` (topicId
+            // recoverable), a whole-topic delete refreshes to `…liste_sujet-1.htm` (no sujet_ segment →
+            // topicId stays null). `DefaultDeletePostRepository` reads that null to flag a whole-topic
+            // deletion. Captured live, cf. `write_delete_post_success_response.html` /
+            // `write_delete_topic_success_response.html`.
+            body.contains(DELETE_SUCCESS_MARKER, ignoreCase = true) -> parseSuccess(html)
+
             else -> ReplySubmitResult.Failure(ReplyFailureReason.Unknown)
         }
     }
@@ -128,6 +137,10 @@ class ReplySubmitResponseParser {
         // postée") and edit ("message édité"). HFR refreshes to the category listing
         // here, not to the new topic, so no topic id is recoverable on create.
         private const val CREATE_SUCCESS_MARKER: String = "votre message a été posté avec succès"
+
+        // #292 — delete post/topic success sentence, shared by both delete flavours. Captured live,
+        // cf. `write_delete_post_success_response.html` / `write_delete_topic_success_response.html`.
+        private const val DELETE_SUCCESS_MARKER: String = "message effacé avec succès"
 
         private val META_REFRESH_REGEX: Regex =
             Regex("""<meta[^>]*http-equiv="Refresh"[^>]*content="\d+\s*;\s*url=([^"]+)""", RegexOption.IGNORE_CASE)

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/write/ReplySubmitResponseParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/write/ReplySubmitResponseParserTest.kt
@@ -103,6 +103,33 @@ class ReplySubmitResponseParserTest {
     }
 
     @Test
+    fun `delete post success is classified and refreshes to the topic (#292)`() {
+        // #292 — normal-post delete. Shared marker « Message effacé avec succès ! ». HFR refreshes
+        // to the topic (`sujet_{id}_{page}.htm`), so the thread segment / topic id is recoverable.
+        val html = readFixture("write_delete_post_success_response.html")
+        val result = parser.parse(html)
+        assertTrue("delete success must classify as Success — got $result", result is ReplySubmitResult.Success)
+        val success = result as ReplySubmitResult.Success
+        val refreshUrl = requireNotNull(success.refreshUrl) { "refreshUrl must be present" }
+        assertTrue("normal-post delete refreshes to the topic", refreshUrl.contains("sujet_"))
+        assertNotNull("topic id is recoverable on a normal-post delete", success.topicId)
+    }
+
+    @Test
+    fun `delete whole-topic success refreshes to the listing and exposes no topic id (#292)`() {
+        // #292 — first-post delete removes the whole topic: HFR refreshes to the sub-category
+        // listing (`liste_sujet-1.htm`), so there is no thread segment → topicId is null.
+        // `DefaultDeletePostRepository` reads that null to flag a whole-topic deletion.
+        val html = readFixture("write_delete_topic_success_response.html")
+        val result = parser.parse(html)
+        assertTrue("delete-topic success must classify as Success — got $result", result is ReplySubmitResult.Success)
+        val success = result as ReplySubmitResult.Success
+        val refreshUrl = requireNotNull(success.refreshUrl) { "refreshUrl must be present" }
+        assertTrue("whole-topic delete refreshes to the listing", refreshUrl.contains("liste_sujet"))
+        assertNull("no thread segment on a listing refresh → no topic id", success.topicId)
+    }
+
+    @Test
     fun `a refresh page without any known success marker is not a false success`() {
         // #214 — classification keys on the explicit success sentences (reply/edit/create),
         // NOT on the mere presence of a `<meta refresh>`. A page that redirects somewhere but

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -16,7 +16,9 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -159,6 +161,14 @@ fun TopicScreen(
     // suspending lambda but the surrounding scope is still a Composable). Capturing the message
     // upfront keeps the rule happy and avoids re-resolving on every effect.
     val refreshFailedMsg = stringResource(R.string.topic_post_submit_refresh_failed)
+    // #292 — delete feedback messages, resolved upfront (same rationale as refreshFailedMsg).
+    val deleteSuccessMsg = stringResource(R.string.topic_post_delete_success)
+    val deleteFailedLoginMsg = stringResource(R.string.topic_post_delete_failed_login)
+    val deleteFailedLockedMsg = stringResource(R.string.topic_post_delete_failed_locked)
+    val deleteFailedGenericMsg = stringResource(R.string.topic_post_delete_failed_generic)
+    // #292 — `numreponse` awaiting delete confirmation (null = no dialog). Local UI state: the
+    // confirmation is a pure view concern, only the confirmed deletion reaches the ViewModel.
+    var deleteCandidate by rememberSaveable { mutableStateOf<Int?>(null) }
 
     // Bug fix (build 89) — report the loaded title up so `:app` caches it per topic. The next page
     // (recreated screen) reads it back through `request.titleHint`, keeping the top bar title stable
@@ -230,6 +240,27 @@ fun TopicScreen(
                     // that route then anchors #bas → ScrollToEndOfPage as usual).
                     onNavigateToLastPage(effect.page)
                 }
+                TopicEffect.PostDeleted -> {
+                    // #292 — HFR accepted the deletion; the ViewModel force-refreshes the page so the
+                    // post is already gone by the time this lands. Confirm with a Toast.
+                    android.widget.Toast.makeText(
+                        context,
+                        deleteSuccessMsg,
+                        android.widget.Toast.LENGTH_SHORT,
+                    ).show()
+                }
+                is TopicEffect.PostDeleteFailed -> {
+                    val message = when (effect.reason) {
+                        DeleteFailureReason.LoginRequired -> deleteFailedLoginMsg
+                        DeleteFailureReason.TopicLocked -> deleteFailedLockedMsg
+                        DeleteFailureReason.Generic -> deleteFailedGenericMsg
+                    }
+                    android.widget.Toast.makeText(
+                        context,
+                        message,
+                        android.widget.Toast.LENGTH_LONG,
+                    ).show()
+                }
             }
         }
     }
@@ -245,7 +276,20 @@ fun TopicScreen(
         onEditFirstPost = onEditFirstPost,
         onOpenPage = onOpenPage,
         onOpenProfile = onOpenProfile,
+        onDeleteRequest = { numreponse -> deleteCandidate = numreponse },
     )
+
+    // #292 — confirmation before the (irreversible, no-undo) deletion. Only « Supprimer » sends the
+    // intent; dismissing leaves the post untouched. Mirrors the « Vider le cache » confirm pattern.
+    deleteCandidate?.let { numreponse ->
+        DeletePostConfirmDialog(
+            onConfirm = {
+                viewModel.send(TopicIntent.DeletePost(numreponse))
+                deleteCandidate = null
+            },
+            onDismiss = { deleteCandidate = null },
+        )
+    }
 }
 
 /**
@@ -388,6 +432,9 @@ internal fun TopicContent(
     onEditFirstPost: (subcat: Int, page: Int, numreponse: Int) -> Unit,
     onOpenPage: (Int) -> Unit,
     onOpenProfile: (userId: Int, pseudo: String, avatarUrl: String?) -> Unit = { _, _, _ -> },
+    // #292 — a per-post « Supprimer » tap; the screen owns the confirmation dialog, so this only
+    // requests it (carrying the post's numreponse). Never invoked for the first post (excluded).
+    onDeleteRequest: (numreponse: Int) -> Unit = {},
 ) {
     // #285 — the topic title and #284 — the page counter live in a persistent top app bar so they
     // stay visible while the user scrolls (the in-card title/caption scrolls away). When the page
@@ -501,6 +548,7 @@ internal fun TopicContent(
                         onEditFirstPost = onEditFirstPost,
                         onOpenPage = onOpenPage,
                         onOpenProfile = onOpenProfile,
+                        onDeleteRequest = onDeleteRequest,
                         listState = listState,
                     )
                 }
@@ -520,6 +568,7 @@ private fun TopicLoadedContent(
     onEditFirstPost: (subcat: Int, page: Int, numreponse: Int) -> Unit,
     onOpenPage: (Int) -> Unit,
     onOpenProfile: (userId: Int, pseudo: String, avatarUrl: String?) -> Unit = { _, _, _ -> },
+    onDeleteRequest: (numreponse: Int) -> Unit = {},
     listState: LazyListState,
 ) {
     val highlight = state.request.scrollTo
@@ -647,6 +696,24 @@ private fun TopicLoadedContent(
             } else {
                 null
             }
+            // #292 — « Supprimer » uses the same gate as « Modifier » (HFR allows deletion via the
+            // edit form), EXCEPT it is never offered on the topic's first post: deleting that would
+            // remove the entire topic, an out-of-scope destructive path for this MVP. The first post
+            // is `topic.posts.first()` on page 1.
+            val isFirstPostOfTopic =
+                topic.page == 1 && post.numreponse == topic.posts.firstOrNull()?.numreponse
+            // Disable every delete affordance while a deletion is in flight (state.deletingNumreponse
+            // != null) so a second tap can't queue another POST mid-request (the ViewModel also
+            // guards, but hiding the button is the honest UI signal).
+            val deleteAction: (() -> Unit)? = if (
+                state.deletingNumreponse == null &&
+                !isFirstPostOfTopic &&
+                shouldShowDeleteAction(topic, post, state.isAuthenticated)
+            ) {
+                { onDeleteRequest(post.numreponse) }
+            } else {
+                null
+            }
             // Phase 2 finish (#208) — profile tap is enabled only when HFR exposed
             // a profile link for this post (Post.profileId != null). Posts without a
             // profile link (Publicité rows, anonymous reads) keep the tap hidden.
@@ -659,6 +726,7 @@ private fun TopicLoadedContent(
                 citedCount = citationCounts[post.numreponse] ?: 0,
                 onQuote = quoteAction,
                 onEdit = editAction,
+                onDelete = deleteAction,
                 onOpenProfile = profileAction,
             )
         }
@@ -914,6 +982,11 @@ private fun TopicPostCard(
     onQuote: (() -> Unit)?,
     onEdit: (() -> Unit)?,
     /**
+     * #292 — « Supprimer » this post. Null hides the button (not the user's own post, locked topic,
+     * logged out, or the topic's first post — which is excluded to avoid whole-topic deletion).
+     */
+    onDelete: (() -> Unit)? = null,
+    /**
      * Phase 2 finish (#208) — tapping the avatar or author opens the profile bottom sheet.
      * Null when [Post.profileId] is null (Publicité rows, anonymous reads).
      */
@@ -1048,19 +1121,30 @@ private fun TopicPostCard(
             }
             // #281 — topic posts are selectable/copyable (opt-in; default is OFF in PostRenderer).
             PostRenderer(content = post.content, selectable = true)
-            if (onQuote != null || onEdit != null) {
+            if (onQuote != null || onEdit != null || onDelete != null) {
                 // Actions row at the bottom of the post card, sober TextButtons
                 // so they stay subordinate to the post content. « Modifier »
-                // (Phase 2D, #147) appears only on the user's own editable posts
-                // when the topic is still postable. « Citer » (Phase 2C, #146)
-                // appears whenever the topic is postable, even when the per-post
-                // `quoteRef` link was obfuscated and parsed as null (#227).
-                // Either can be absent — we only render the row at all if at least
-                // one action is provided.
+                // (Phase 2D, #147) and « Supprimer » (#292) appear only on the
+                // user's own editable posts when the topic is still postable
+                // (« Supprimer » additionally excludes the first post). « Citer »
+                // (Phase 2C, #146) appears whenever the topic is postable, even
+                // when the per-post `quoteRef` link was obfuscated and parsed as
+                // null (#227). Any can be absent — we render the row only if at
+                // least one action is provided.
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.End,
                 ) {
+                    if (onDelete != null) {
+                        TextButton(
+                            onClick = onDelete,
+                            colors = ButtonDefaults.textButtonColors(
+                                contentColor = MaterialTheme.colorScheme.error,
+                            ),
+                        ) {
+                            Text(text = stringResource(R.string.topic_post_delete))
+                        }
+                    }
                     if (onEdit != null) {
                         TextButton(onClick = onEdit) {
                             Text(text = stringResource(R.string.topic_post_edit))
@@ -1083,6 +1167,37 @@ private val topicDateFormatter = DateTimeFormatter
 
 private fun java.time.Instant.asTopicDate(): String = topicDateFormatter.format(this)
 
+/**
+ * #292 — confirmation before an irreversible post deletion (HFR offers no undo, cf. the #99 flag
+ * delete). « Supprimer » is styled as a destructive (error-coloured) action; « Annuler » dismisses.
+ */
+@Composable
+private fun DeletePostConfirmDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(R.string.topic_post_delete_confirm_title)) },
+        text = { Text(text = stringResource(R.string.topic_post_delete_confirm_message)) },
+        confirmButton = {
+            TextButton(
+                onClick = onConfirm,
+                colors = ButtonDefaults.textButtonColors(
+                    contentColor = MaterialTheme.colorScheme.error,
+                ),
+            ) {
+                Text(text = stringResource(R.string.topic_post_delete_confirm_action))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(R.string.topic_post_delete_confirm_cancel))
+            }
+        },
+    )
+}
+
 // #220 — write affordances additionally require an authenticated session. A logged-out user
 // can still hold a stale cached `canReply = true` row (the topic page cache is intentionally
 // not purged on logout, cf. CacheInvalidator), so these gates consult auth explicitly instead
@@ -1095,6 +1210,12 @@ internal fun shouldShowQuoteAction(topic: Topic, isAuthenticated: Boolean): Bool
     topic.canReply && isAuthenticated
 
 internal fun shouldShowEditAction(topic: Topic, post: Post, isAuthenticated: Boolean): Boolean =
+    post.isEditable && topic.canReply && isAuthenticated
+
+// #292 — « Supprimer » shares the « Modifier » gate: HFR exposes deletion through the same edit
+// form, so any post the user can edit, they can delete. The first-post exclusion (deleting it would
+// remove the whole topic) is applied at the call site by position, not here.
+internal fun shouldShowDeleteAction(topic: Topic, post: Post, isAuthenticated: Boolean): Boolean =
     post.isEditable && topic.canReply && isAuthenticated
 
 // Phase 2D #148 / #220 — « Modifier le premier message ». 6-way conjunction by design: auth,

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -18,6 +18,12 @@ data class TopicUiState(
      */
     val isAuthenticated: Boolean = false,
     /**
+     * #292 — `numreponse` of the post whose deletion is currently in flight, or `null` when no
+     * delete is running. Drives the per-post « Supprimer » affordance (disabled / busy) and guards
+     * against a double-submit. Cleared when the delete settles (success or failure).
+     */
+    val deletingNumreponse: Int? = null,
+    /**
      * Build 89 follow-up — mirrors `UserPreferencesRepository.observeTopicTopBarAutoHide()`.
      * When `true`, the screen wires a Material3 `enterAlways` scroll behaviour on the top app
      * bar (title + page counter) so it collapses while scrolling down through the posts and
@@ -63,6 +69,28 @@ data class TopicUiState(
 
 sealed interface TopicIntent {
     data object Retry : TopicIntent
+
+    /**
+     * #292 — confirmed deletion of one of the user's own (normal) posts. The screen shows a
+     * confirmation dialog first; this intent is only sent once the user confirms. [numreponse]
+     * identifies the post to delete (unique per category).
+     */
+    data class DeletePost(val numreponse: Int) : TopicIntent
+}
+
+/**
+ * #292 — UI-facing classification of a delete failure, mapped from the domain `ReplyFailureReason`
+ * so the screen can pick a specific message without depending on the write model directly.
+ */
+enum class DeleteFailureReason {
+    /** Session not (or no longer) authenticated — surface a login CTA. */
+    LoginRequired,
+
+    /** The topic was closed/locked, so HFR refuses the deletion. */
+    TopicLocked,
+
+    /** Any other refusal (invalid token, unrecognised response, network) — generic message. */
+    Generic,
 }
 
 /**
@@ -112,4 +140,17 @@ sealed interface TopicEffect {
      * Defensive: works whether HFR anchored the old page (the bug) or the new one.
      */
     data class NavigateToLastPage(val page: Int) : TopicEffect
+
+    /**
+     * #292 — emitted after a post was successfully deleted. The screen surfaces a confirmation
+     * toast; the ViewModel separately force-refreshes the current page so the removed post
+     * disappears (unless the deletion removed the whole topic, an out-of-scope path today).
+     */
+    data object PostDeleted : TopicEffect
+
+    /**
+     * #292 — emitted when HFR refused the deletion. The screen surfaces a [reason]-specific toast
+     * and leaves the post in place.
+     */
+    data class PostDeleteFailed(val reason: DeleteFailureReason) : TopicEffect
 }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -10,7 +10,11 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.topic.TopicRepository
+import fr.forumhfr.redface2.core.domain.write.DeletePostRepository
+import fr.forumhfr.redface2.core.domain.write.DeletePostResult
 import fr.forumhfr.redface2.core.model.AuthState
+import fr.forumhfr.redface2.core.model.write.EditPostContext
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -42,6 +46,7 @@ class TopicViewModel @AssistedInject constructor(
     private val topicRepository: TopicRepository,
     private val authRepository: AuthRepository,
     private val userPreferencesRepository: UserPreferencesRepository,
+    private val deletePostRepository: DeletePostRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(TopicUiState.initial(request))
@@ -110,6 +115,7 @@ class TopicViewModel @AssistedInject constructor(
             // refresh — by then the new post has been persisted and the user just wants
             // to recover from a transient error.
             TopicIntent.Retry -> loadCurrentPage()
+            is TopicIntent.DeletePost -> deletePost(intent.numreponse)
         }
     }
 
@@ -294,9 +300,107 @@ class TopicViewModel @AssistedInject constructor(
         }
     }
 
+    /**
+     * #292 — deletes one of the user's own posts. The screen confirms first; this runs only after
+     * the user accepts. We resolve `subcat` from the loaded topic (the route carries only
+     * `cat`/`post`/`page`) and guard the [EditPostContext] invariants before calling the repository.
+     * On success we force-refresh the current page so the removed post disappears (unless HFR
+     * removed the whole topic — a defensive branch the UI doesn't reach today, since delete is only
+     * offered on normal posts). `deletingNumreponse` gates the affordance and blocks a double-submit.
+     */
+    @Suppress("ComplexCondition") // one conjunction guarding a destructive action; each clause distinct.
+    private fun deletePost(numreponse: Int) {
+        if (_state.value.deletingNumreponse != null) return
+        val topic = (_state.value.mode as? TopicUiState.Mode.Loaded)?.topic ?: return
+        // Re-validate server-side, never trust the UI gate alone for a HFR-mutating delete: a stale
+        // or buggy intent could carry the first post, a non-editable / foreign post, or arrive after
+        // logout. We refuse to POST unless the post is present on the page, editable, the topic is
+        // postable, the session is authenticated, and it is NOT the first post (deleting that removes
+        // the whole topic — out of scope today). `subcat == 0` is a valid HFR value (cat without a
+        // sub-category, cf. EditPostContext), so only the SUBCAT_UNKNOWN sentinel (-1) is rejected.
+        val post = topic.posts.firstOrNull { it.numreponse == numreponse }
+        val isFirstPost = topic.page == 1 && numreponse == topic.posts.firstOrNull()?.numreponse
+        if (post != null && !isFirstPost && post.isEditable && topic.canReply &&
+            _state.value.isAuthenticated && topic.subcat >= 0
+        ) {
+            runDeletion(numreponse, topic.subcat)
+        }
+        // else: stale/invalid request the UI gate should have prevented — silently no-op, no POST.
+    }
+
+    private fun runDeletion(numreponse: Int, subcat: Int) {
+        val context = EditPostContext(
+            cat = request.cat,
+            subcat = subcat,
+            topicId = request.post,
+            page = request.page,
+            numreponse = numreponse,
+        )
+        _state.update { it.copy(deletingNumreponse = numreponse) }
+        viewModelScope.launch {
+            val result = deletePostRepository.deletePost(context)
+            _state.update { it.copy(deletingNumreponse = null) }
+            when (result) {
+                is DeletePostResult.Success -> {
+                    _effects.send(TopicEffect.PostDeleted)
+                    // A normal-post delete keeps the topic alive → refresh so the post vanishes. A
+                    // whole-topic delete (first post) would 404 on reload, so we skip the refetch and
+                    // leave the page; the UI never offers delete on the first post today.
+                    if (!result.deletedWholeTopic) refreshAfterDelete()
+                }
+                is DeletePostResult.Failure ->
+                    _effects.send(TopicEffect.PostDeleteFailed(result.reason.toDeleteFailureReason()))
+            }
+        }
+    }
+
+    /**
+     * Network-first reload of the current page after a successful deletion, so the removed post is
+     * gone immediately (a cache-aside reload would flash the stale cached page that still contains
+     * it). On failure we fall back to the cache-aside path: the delete already succeeded, so the
+     * worst case is a briefly-stale list that the normal refresh reconciles.
+     *
+     * Konsist guard: this function cancels the inflight prefetch AND calls `refreshTopicPage`, so it
+     * carries the `konsist:bypass-prefetch-guard` marker (same allow-list as `forceRefreshCurrentPage`).
+     * The bypass is intentional: this is a deliberate authenticated refetch following an explicit
+     * user-confirmed deletion, not an anonymous warmup escalating to authenticated.
+     */
+    private fun refreshAfterDelete() {
+        loadJob?.cancel()
+        prefetchJob?.cancel()
+        prefetchedPage = null
+        _state.update { it.copy(mode = TopicUiState.Mode.Loading) }
+        loadJob = viewModelScope.launch {
+            try {
+                val topic = topicRepository.refreshTopicPage(request.cat, request.post, request.page)
+                _state.update {
+                    it.copy(
+                        mode = TopicUiState.Mode.Loaded(topic),
+                        availablePages = (1..topic.totalPages).toList(),
+                    )
+                }
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (@Suppress("TooGenericExceptionCaught") refreshError: Exception) {
+                android.util.Log.w(LOG_TAG, "Post-delete refresh failed", refreshError)
+                loadCurrentPage()
+            }
+        }
+    }
+
     @AssistedFactory
     interface Factory {
         fun create(request: TopicRequest): TopicViewModel
+    }
+
+    private fun ReplyFailureReason.toDeleteFailureReason(): DeleteFailureReason = when (this) {
+        ReplyFailureReason.LoginRequired -> DeleteFailureReason.LoginRequired
+        ReplyFailureReason.TopicLocked -> DeleteFailureReason.TopicLocked
+        ReplyFailureReason.EmptyMessage,
+        ReplyFailureReason.InvalidHashCheck,
+        ReplyFailureReason.AntiFlood,
+        ReplyFailureReason.Unknown,
+        -> DeleteFailureReason.Generic
     }
 
     private companion object {

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -33,4 +33,15 @@
     <string name="topic_edit_first_post">Modifier le premier message</string>
     <string name="topic_post_submit_refresh_failed">Message envoyé, mais le rafraîchissement de la page a échoué. Tirez pour réessayer.</string>
     <string name="topic_open_profile_action">Voir le profil</string>
+
+    <!-- #292 — suppression d'un de ses propres posts (post normal). -->
+    <string name="topic_post_delete">Supprimer</string>
+    <string name="topic_post_delete_confirm_title">Effacer ce message ?</string>
+    <string name="topic_post_delete_confirm_message">Cette action est irréversible.</string>
+    <string name="topic_post_delete_confirm_action">Supprimer</string>
+    <string name="topic_post_delete_confirm_cancel">Annuler</string>
+    <string name="topic_post_delete_success">Message supprimé</string>
+    <string name="topic_post_delete_failed_login">Vous devez être connecté pour supprimer ce message.</string>
+    <string name="topic_post_delete_failed_locked">Ce sujet est fermé : suppression impossible.</string>
+    <string name="topic_post_delete_failed_generic">La suppression a échoué. Réessayez.</string>
 </resources>

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -7,8 +7,12 @@ import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.topic.TopicRepository
+import fr.forumhfr.redface2.core.domain.write.DeletePostRepository
+import fr.forumhfr.redface2.core.domain.write.DeletePostResult
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.FlagType
+import fr.forumhfr.redface2.core.model.write.EditPostContext
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
 import fr.forumhfr.redface2.core.model.Post
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.Topic
@@ -383,6 +387,177 @@ class TopicViewModelTest {
     }
 
     @Test
+    fun `DeletePost success emits PostDeleted and force-refreshes the current page (#292)`() = runTest {
+        // Page 2 so the editable post 777 is NOT the first post (the FP lives on page 1 and is
+        // excluded from deletion). Editable + authenticated + canReply → the VM gate lets it through.
+        val loaded = fakeTopic(
+            page = 2,
+            totalPages = 3,
+            posts = listOf(fakePost(numreponse = 777, isEditable = true)),
+        )
+        val refreshed = fakeTopic(page = 2, totalPages = 3, title = "refreshed")
+        val repository = FakeTopicRepository(
+            flowsToReturn = listOf(flow { emit(loaded) }),
+            refreshTopicsToReturn = listOf(refreshed),
+        )
+        val deleteRepo = FakeDeletePostRepository(DeletePostResult.Success(deletedWholeTopic = false))
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            deletePostRepository = deleteRepo,
+        )
+
+        viewModel.effects.test {
+            viewModel.send(TopicIntent.DeletePost(777))
+            assertEquals(TopicEffect.PostDeleted, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(1, deleteRepo.calls.size)
+        assertEquals(777, deleteRepo.calls.single().numreponse)
+        assertEquals(SAMPLE_SUBCAT, deleteRepo.calls.single().subcat)
+        assertEquals(
+            "a successful delete force-refreshes the current page so the post disappears",
+            listOf(Triple(SAMPLE_CAT, SAMPLE_POST, 2)),
+            repository.refreshCalls,
+        )
+    }
+
+    @Test
+    fun `DeletePost failure emits PostDeleteFailed with the mapped reason and does not refresh (#292)`() =
+        runTest {
+            val loaded = fakeTopic(
+                page = 2,
+                totalPages = 3,
+                posts = listOf(fakePost(numreponse = 777, isEditable = true)),
+            )
+            val repository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(loaded) }))
+            val deleteRepo = FakeDeletePostRepository(
+                DeletePostResult.Failure(ReplyFailureReason.TopicLocked),
+            )
+            val viewModel = topicViewModel(
+                request = topicRequest(page = 2),
+                topicRepository = repository,
+                authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+                deletePostRepository = deleteRepo,
+            )
+
+            viewModel.effects.test {
+                viewModel.send(TopicIntent.DeletePost(777))
+                val effect = awaitItem() as TopicEffect.PostDeleteFailed
+                assertEquals(DeleteFailureReason.TopicLocked, effect.reason)
+                cancelAndIgnoreRemainingEvents()
+            }
+            assertTrue("a failed delete must not force-refresh", repository.refreshCalls.isEmpty())
+        }
+
+    @Test
+    fun `DeletePost refuses the first post and never POSTs (#292)`() = runTest {
+        // Page 1, single post → it IS the first post. Even editable, the VM must refuse (deleting the
+        // FP removes the whole topic, out of scope) and never reach the repository.
+        val loaded = fakeTopic(
+            page = 1,
+            totalPages = 1,
+            posts = listOf(fakePost(numreponse = 100, isEditable = true)),
+        )
+        val repository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(loaded) }))
+        val deleteRepo = FakeDeletePostRepository()
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            deletePostRepository = deleteRepo,
+        )
+
+        viewModel.effects.test {
+            viewModel.send(TopicIntent.DeletePost(100))
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertTrue("the first post must never be deleted", deleteRepo.calls.isEmpty())
+    }
+
+    @Test
+    fun `DeletePost refuses a non-editable post and never POSTs (#292)`() = runTest {
+        val loaded = fakeTopic(
+            page = 2,
+            totalPages = 3,
+            posts = listOf(fakePost(numreponse = 777, isEditable = false)),
+        )
+        val repository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(loaded) }))
+        val deleteRepo = FakeDeletePostRepository()
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            deletePostRepository = deleteRepo,
+        )
+
+        viewModel.effects.test {
+            viewModel.send(TopicIntent.DeletePost(777))
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertTrue("a non-editable post must never be deleted", deleteRepo.calls.isEmpty())
+    }
+
+    @Test
+    fun `DeletePost refuses when the session is not authenticated and never POSTs (#292)`() = runTest {
+        val loaded = fakeTopic(
+            page = 2,
+            totalPages = 3,
+            posts = listOf(fakePost(numreponse = 777, isEditable = true)),
+        )
+        val repository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(loaded) }))
+        val deleteRepo = FakeDeletePostRepository()
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Anonymous),
+            deletePostRepository = deleteRepo,
+        )
+
+        viewModel.effects.test {
+            viewModel.send(TopicIntent.DeletePost(777))
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertTrue("a logged-out session must never delete", deleteRepo.calls.isEmpty())
+    }
+
+    @Test
+    fun `DeletePost proceeds for a subcat-0 topic (cat without sub-category) (#292)`() = runTest {
+        // #292 Codex review: subcat=0 is a valid HFR value (cat without sub-category), so the VM must
+        // NOT block it — only the SUBCAT_UNKNOWN sentinel (-1) is rejected.
+        val loaded = fakeTopic(
+            page = 2,
+            totalPages = 3,
+            posts = listOf(fakePost(numreponse = 777, isEditable = true)),
+            subcat = 0,
+        )
+        val refreshed = fakeTopic(page = 2, totalPages = 3, subcat = 0, title = "refreshed")
+        val repository = FakeTopicRepository(
+            flowsToReturn = listOf(flow { emit(loaded) }),
+            refreshTopicsToReturn = listOf(refreshed),
+        )
+        val deleteRepo = FakeDeletePostRepository(DeletePostResult.Success(deletedWholeTopic = false))
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            deletePostRepository = deleteRepo,
+        )
+
+        viewModel.effects.test {
+            viewModel.send(TopicIntent.DeletePost(777))
+            assertEquals(TopicEffect.PostDeleted, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals("subcat=0 must reach the repository", 1, deleteRepo.calls.size)
+        assertEquals(0, deleteRepo.calls.single().subcat)
+    }
+
+    @Test
     fun `forceRefresh from the request is forwarded to observeTopicPage (#231)`() = runTest {
         val repository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) }))
         topicViewModel(
@@ -405,11 +580,13 @@ class TopicViewModelTest {
         topicRepository: TopicRepository,
         authRepository: AuthRepository,
         userPreferencesRepository: UserPreferencesRepository = FakeUserPreferencesRepository(),
+        deletePostRepository: DeletePostRepository = FakeDeletePostRepository(),
     ): TopicViewModel = TopicViewModel(
         request = request,
         topicRepository = topicRepository,
         authRepository = authRepository,
         userPreferencesRepository = userPreferencesRepository,
+        deletePostRepository = deletePostRepository,
     )
 
     private fun topicRequest(
@@ -632,25 +809,29 @@ class TopicViewModelTest {
         totalPages: Int,
         title: String = "fake",
         posts: List<Post> = emptyList(),
+        subcat: Int = SAMPLE_SUBCAT,
     ): Topic = Topic(
         cat = SAMPLE_CAT,
         post = SAMPLE_POST,
-        subcat = SAMPLE_SUBCAT,
+        subcat = subcat,
         title = title,
         posts = posts,
         page = page,
         totalPages = totalPages,
         isFirstPostOwner = false,
+        // Postable by default: the #292 delete gate requires it, and no VM test exercises a
+        // read-only topic (the previous default was the Topic model's `false`, never asserted here).
+        canReply = true,
         poll = null,
     )
 
-    private fun fakePost(numreponse: Int): Post = Post(
+    private fun fakePost(numreponse: Int, isEditable: Boolean = false): Post = Post(
         numreponse = numreponse,
         author = "tester",
         date = java.time.Instant.parse("2026-05-04T12:00:00Z"),
         content = PostContent(blocks = emptyList()),
         avatarUrl = null,
-        isEditable = false,
+        isEditable = isEditable,
         isOwnPost = false,
         quotedAuthors = emptyList(),
         postIndex = null,
@@ -723,6 +904,17 @@ private class FakeTopicRepository(
     override suspend fun prefetch(cat: Int, post: Int, page: Int) {
         prefetches += Triple(cat, post, page)
         prefetchHook?.invoke(cat, post, page)
+    }
+}
+
+private class FakeDeletePostRepository(
+    private val result: DeletePostResult = DeletePostResult.Success(deletedWholeTopic = false),
+) : DeletePostRepository {
+    val calls = mutableListOf<EditPostContext>()
+
+    override suspend fun deletePost(context: EditPostContext): DeletePostResult {
+        calls += context
+        return result
     }
 }
 


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Ajoute une action « Supprimer » sur les **posts normaux** de l'utilisateur dans un sujet (#292 « supprimer un de ses propres posts »).

## Mécanisme HFR

HFR n'a pas d'endpoint de suppression : la suppression réutilise le **formulaire d'édition** (`bdd.php?config=hfr.inc`) avec un champ `delete=1` en plus (cf. `docs/specs/protocol-hfr.md` § Suppression post/topic). `DefaultDeletePostRepository` fait un **fetch-then-submit** en un seul appel : il récupère un formulaire frais (donc un `hash_check` à jour) et le re-POSTe immédiatement avec `delete=1`. Comme le fetch et le submit sont enchaînés, le token ne peut jamais être périmé (contrairement à l'éditeur où l'utilisateur tape entre les deux), donc pas de boucle de refetch invalid-token.

## Flow UX

Bouton « Supprimer » par post (même gate que « Modifier » : `post.isEditable && topic.canReply && isAuthenticated`, couleur `error`) → **dialog de confirmation** (irréversible, sans undo, comme le delflag #99) → `DeletePostRepository`. Au succès, le ViewModel **force-refresh** la page (le post disparaît) + Toast ; à l'échec, Toast spécifique (connexion requise / sujet fermé / générique).

## Scope : posts normaux uniquement

Supprimer le **premier post** supprime le **sujet entier** sur HFR (la réponse succès redirige vers la liste de sous-catégorie). Cette suppression destructrice de topic entier n'est **pas exposée pour l'instant** : le premier post est exclu de l'affordance (`isFirstPostOfTopic` au call-site). `DeletePostResult.deletedWholeTopic` est tout de même remonté **défensivement** (lu depuis l'URL de refresh : `liste_sujet` → topicId null) pour que le VM ne tente jamais de recharger un sujet que HFR vient de supprimer (404). → **Follow-up** : suppression de topic entier avec confirmation renforcée + nav vers la liste.

## Couches

- `core/domain/write/DeletePostRepository.kt` (interface + `DeletePostResult`)
- `core/data/write/DefaultDeletePostRepository.kt` (fetch form → POST `delete=1` → map ; réutilise `ReplyFormParser` + `ReplySubmitResponseParser`)
- `core/parser/write/ReplySubmitResponseParser.kt` : marker `« Message effacé avec succès »`
- `core/data/write/ReplyRepositoryModule.kt` : binding Hilt
- `feature/topic` : `TopicUiState` (intent `DeletePost`, effets `PostDeleted`/`PostDeleteFailed`, `deletingNumreponse`, enum `DeleteFailureReason`), `TopicViewModel` (injection + handler + refresh post-delete), `TopicScreen` (bouton + dialog + Toasts), strings FR

## Tests & validation

- Parser : delete post (refresh topic → topicId présent) + delete whole-topic (refresh listing → topicId null) sur fixtures réelles
- Repository : corps POST `delete=1` + champs édition, flag `deletedWholeTopic`
- ViewModel : succès (effet `PostDeleted` + force-refresh) / échec (effet `PostDeleteFailed` mappé, pas de refresh)
- Validation locale : `detektAll + test + testDebugUnitTest + :app:assembleProdDebug + lintDebug + :app:lintProdDebug`

## Revue Codex (gpt-5.5, xhigh)

0 bloquant. Findings traités :
- **`subcat == 0` refusé à tort** (important) — corrigé : seul le sentinel SUBCAT_UNKNOWN (-1) est rejeté (`subcat >= 0`, cohérent avec `EditPostContext`) ; test `subcat-0` ajouté.
- **intent `DeletePost` non re-validé côté VM** (important) — corrigé : le VM re-vérifie présence du post, `isEditable`, `canReply`, `isAuthenticated` et `!isFirstPost` avant tout POST (la gate UI seule est trop fragile pour une action destructive) ; tests « FP/non-éditable/déconnecté ne POSTent pas » ajoutés.
- **`deletingNumreponse` non consommé par l'UI** (mineur) — corrigé : les boutons « Supprimer » sont désactivés pendant qu'une suppression est en cours.
- **`targetPage` perdu** (mineur) — **différé** : edge-case rare pour un post normal (le sujet garde son FP), et porter `targetPage` impliquerait un remplacement de route (plomberie nav volontairement évitée ici). Le refresh in-place de `request.page` couvre le cas courant. À traiter avec la suppression de topic entier.

Contrat HFR principal validé par Codex (`delete=1` posé, `password` filtré, mapping topic/listing via `topicId == null` conforme aux fixtures).

Closes #292
