### PR TITLE
chore(topic): polish post-review #338/#292 (KDoc, cache titres, tests gates)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -556,8 +556,9 @@ private data class PrivateMessageNavState(
  * replaces the TopicRoute (new nav entry → new ViewModel → Loading with no topic yet), which used to
  * flash the generic « Sujet » title in the top app bar. The `var` backing [titles] lives in
  * [RedfaceApp] so it survives the entry recreation; [onTitleLoaded] writes the freshly-loaded title
- * back and the next page reads it via TopicRequest.titleHint. Keyed by topic id so titles never bleed
- * across topics. Same read-map + onLoaded-callback shape as [PrivateMessageNavState].
+ * back and the next page reads it via TopicRequest.titleHint. Keyed by `(cat, post)` ([TopicTitleKey])
+ * — a topic id is unique only per HFR category — so titles never bleed across categories. Same
+ * read-map + onLoaded-callback shape as [PrivateMessageNavState].
  *
  * @property titles last known title per topic, fed into TopicRequest.titleHint.
  * @property onTitleLoaded records a topic's title once its page has loaded.
@@ -573,13 +574,13 @@ private data class TopicTitleNavState(
  * `(cat, topicId)` composite key in `SearchScreen`), so keying by `post` alone could flash the
  * wrong title across categories while a page loads. Keyed by `(cat, post)` to stay correct.
  */
-private data class TopicTitleKey(val cat: Int, val post: Int)
+internal data class TopicTitleKey(val cat: Int, val post: Int)
 
 // Upper bound on the per-topic title cache (display hint only). A long reading session opens many
 // topics; capping at a generous size keeps the map from growing unbounded for the app's lifetime.
 // Eviction is FIFO (oldest insertions dropped) — losing a stale hint just falls back to « Sujet »
 // for one loading frame, which is harmless.
-private const val TOPIC_TITLE_CACHE_MAX = 128
+internal const val TOPIC_TITLE_CACHE_MAX = 128
 
 /**
  * Inserts [title] for [key] into the per-topic title cache, evicting the oldest entries past
@@ -587,7 +588,11 @@ private const val TOPIC_TITLE_CACHE_MAX = 128
  * the front evicts the least-recently-inserted titles. Extracted from [RedfaceApp] to keep that
  * composable under the cyclomatic-complexity budget.
  */
-private fun Map<TopicTitleKey, String>.withTitle(key: TopicTitleKey, title: String): Map<TopicTitleKey, String> {
+internal fun Map<TopicTitleKey, String>.withTitle(key: TopicTitleKey, title: String): Map<TopicTitleKey, String> {
+    // Short-circuit when the title is unchanged: a page change within the same topic re-emits the
+    // identical loaded title, and re-inserting it would allocate a fresh map + trigger a global
+    // RedfaceApp recomposition for nothing.
+    if (this[key] == title) return this
     val updated = this + (key to title)
     return if (updated.size > TOPIC_TITLE_CACHE_MAX) {
         updated.entries.drop(updated.size - TOPIC_TITLE_CACHE_MAX).associate { it.toPair() }

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/TopicTitleCacheTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/TopicTitleCacheTest.kt
@@ -1,0 +1,68 @@
+package fr.forumhfr.redface2.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers the per-topic title cache helper that fixes the « Sujet » flash on a page change (#338).
+ * The helper is a pure function over an immutable map, so it is unit-testable without Compose.
+ */
+class TopicTitleCacheTest {
+
+    private fun key(cat: Int, post: Int) = TopicTitleKey(cat, post)
+
+    @Test
+    fun `withTitle inserts a new entry`() {
+        val cache = emptyMap<TopicTitleKey, String>().withTitle(key(1, 10), "Sujet A")
+
+        assertEquals("Sujet A", cache[key(1, 10)])
+    }
+
+    @Test
+    fun `withTitle keys by (cat, post) so the same topic id in another category does not collide`() {
+        val cache = emptyMap<TopicTitleKey, String>()
+            .withTitle(key(1, 10), "A in cat 1")
+            .withTitle(key(2, 10), "A in cat 2")
+
+        assertEquals("A in cat 1", cache[key(1, 10)])
+        assertEquals("A in cat 2", cache[key(2, 10)])
+        assertEquals(2, cache.size)
+    }
+
+    @Test
+    fun `withTitle updates the value when the title changed`() {
+        val cache = emptyMap<TopicTitleKey, String>()
+            .withTitle(key(1, 10), "old")
+            .withTitle(key(1, 10), "new")
+
+        assertEquals("new", cache[key(1, 10)])
+        assertEquals(1, cache.size)
+    }
+
+    @Test
+    fun `withTitle returns the same instance when the title is unchanged (no recomposition)`() {
+        val cache = emptyMap<TopicTitleKey, String>().withTitle(key(1, 10), "Sujet A")
+
+        val again = cache.withTitle(key(1, 10), "Sujet A")
+
+        assertSame("an unchanged title must not allocate a new map", cache, again)
+    }
+
+    @Test
+    fun `withTitle evicts the oldest entries past the cap (FIFO)`() {
+        var cache = emptyMap<TopicTitleKey, String>()
+        repeat(TOPIC_TITLE_CACHE_MAX + 10) { i -> cache = cache.withTitle(key(0, i), "title $i") }
+
+        assertEquals(TOPIC_TITLE_CACHE_MAX, cache.size)
+        assertTrue(
+            "the 10 oldest insertions are evicted",
+            (0 until 10).none { cache.containsKey(key(0, it)) },
+        )
+        assertTrue(
+            "the newest insertion is kept",
+            cache.containsKey(key(0, TOPIC_TITLE_CACHE_MAX + 9)),
+        )
+    }
+}

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -700,14 +700,12 @@ private fun TopicLoadedContent(
             // edit form), EXCEPT it is never offered on the topic's first post: deleting that would
             // remove the entire topic, an out-of-scope destructive path for this MVP. The first post
             // is `topic.posts.first()` on page 1.
-            val isFirstPostOfTopic =
-                topic.page == 1 && post.numreponse == topic.posts.firstOrNull()?.numreponse
             // Disable every delete affordance while a deletion is in flight (state.deletingNumreponse
             // != null) so a second tap can't queue another POST mid-request (the ViewModel also
             // guards, but hiding the button is the honest UI signal).
             val deleteAction: (() -> Unit)? = if (
                 state.deletingNumreponse == null &&
-                !isFirstPostOfTopic &&
+                !isFirstPostOfTopic(topic, post) &&
                 shouldShowDeleteAction(topic, post, state.isAuthenticated)
             ) {
                 { onDeleteRequest(post.numreponse) }
@@ -1217,6 +1215,13 @@ internal fun shouldShowEditAction(topic: Topic, post: Post, isAuthenticated: Boo
 // remove the whole topic) is applied at the call site by position, not here.
 internal fun shouldShowDeleteAction(topic: Topic, post: Post, isAuthenticated: Boolean): Boolean =
     post.isEditable && topic.canReply && isAuthenticated
+
+// #292 — the topic's first post is `topic.posts.first()` on page 1. Deleting it would remove the whole
+// topic (out of scope for this MVP), so the call site excludes it from the delete affordance. Position
+// + identity based: `numreponse` is unique per HFR category, so matching it against the page's first
+// row is sufficient within a loaded topic page.
+internal fun isFirstPostOfTopic(topic: Topic, post: Post): Boolean =
+    topic.page == 1 && post.numreponse == topic.posts.firstOrNull()?.numreponse
 
 // Phase 2D #148 / #220 — « Modifier le premier message ». 6-way conjunction by design: auth,
 // FP ownership, postable topic, a real sub-category (FP recategorise is NOT relaxed for subcat=0,

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicActionGatesTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicActionGatesTest.kt
@@ -46,6 +46,38 @@ class TopicActionGatesTest {
     }
 
     @Test
+    fun `delete action shares the edit gate (own editable post, postable topic, authenticated)`() {
+        val editablePost = post(isEditable = true)
+        val postable = topic(canReply = true, posts = listOf(editablePost))
+        val readOnly = topic(canReply = false, posts = listOf(editablePost))
+
+        assertTrue(shouldShowDeleteAction(postable, editablePost, isAuthenticated = true))
+        assertFalse("read-only topic", shouldShowDeleteAction(readOnly, editablePost, isAuthenticated = true))
+        assertFalse(
+            "non-editable post (not the author / no edit link)",
+            shouldShowDeleteAction(topic(canReply = true), post(isEditable = false), isAuthenticated = true),
+        )
+        assertFalse(
+            "#220 — logged-out must never see delete, even on a stale canReply=true row",
+            shouldShowDeleteAction(postable, editablePost, isAuthenticated = false),
+        )
+    }
+
+    @Test
+    fun `first-post exclusion fences the delete affordance to a page-1 position`() {
+        val first = post(isEditable = true, numreponse = 100)
+        val second = post(isEditable = true, numreponse = 200)
+        val page1 = topic(canReply = true, posts = listOf(first, second), page = 1)
+
+        assertTrue("page-1 first post would delete the whole topic → excluded", isFirstPostOfTopic(page1, first))
+        assertFalse("a later post on page 1 is deletable", isFirstPostOfTopic(page1, second))
+        assertFalse(
+            "the same numreponse on page 2 is never the topic's first post",
+            isFirstPostOfTopic(topic(canReply = true, posts = listOf(first, second), page = 2), first),
+        )
+    }
+
+    @Test
     fun `reply is enabled only when the topic is postable AND the session is authenticated (#220)`() {
         assertTrue(shouldEnableReply(topic(canReply = true), isAuthenticated = true))
         assertFalse("read-only topic", shouldEnableReply(topic(canReply = false), isAuthenticated = true))
@@ -102,8 +134,9 @@ class TopicActionGatesTest {
     private fun post(
         isEditable: Boolean = false,
         quoteRef: Int? = 1,
+        numreponse: Int = 16244,
     ): Post = Post(
-        numreponse = 16244,
+        numreponse = numreponse,
         author = "XaTriX",
         date = Instant.EPOCH,
         content = PostContent(blocks = emptyList()),


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Polish issu de la **revue 4-flavor** du candidat à la promotion `dev→main` (#338 top-bar repliable + fix titre, #292 suppression de post). Verdict de la revue : **PRÊT**, 0 bloquant — un finding « Critique » (appel conditionnel de `enterAlwaysScrollBehavior()`) a été **rejeté en faux positif** (les appels `@Composable` conditionnels dans un `if/else` sont légaux ; 3 reviewers sur 4 l'ont blanchi ; l'alternative `canScroll` figerait la barre masquée au toggle). Cette PR ramasse les findings 🟡 mineurs purs, sans changement de comportement.

## Changements

1. **KDoc corrigée** — `TopicTitleNavState` disait « keyed by topic id » alors que la clé est `(cat, post)` (`TopicTitleKey`) : un topic id n'est unique **que par catégorie** sur HFR. Aligne la doc sur le code et sur l'invariant `numreponse`.
2. **Court-circuit du cache de titres** — `Map<TopicTitleKey, String>.withTitle` retourne désormais `this` quand le titre est inchangé. Un changement de page dans le même topic réémet le titre identique ; sans court-circuit, on réallouait une `Map` et on recomposait tout `RedfaceApp`/`NavDisplay` pour rien.
3. **Tests `withTitle`** (nouveau `app/.../navigation/TopicTitleCacheTest.kt`) — le fix titre de #338 n'avait aucun test. Couvre : insertion, clé `(cat, post)` (pas de collision inter-catégories), update, court-circuit (même instance retournée), éviction FIFO au-delà du cap. `TopicTitleKey`/`withTitle`/`TOPIC_TITLE_CACHE_MAX` passés `private`→`internal` pour la testabilité.
4. **Tests des gates delete** — `shouldShowDeleteAction` et l'exclusion du premier post (extraite en `isFirstPostOfTopic(topic, post)`) n'étaient pas couverts au call-site. Ajoute les cas miroir de `shouldShowEditAction` (own+postable+auth → true ; read-only / non-éditable / déconnecté → false) et l'exclusion positionnelle page 1 vs page 2.

## Non inclus (follow-ups assumés)

- **Durcissement détection 1er post vs ligne Pub/sticky** (finding 🟡 62) — nécessite une fixture HFR réelle « page 1 avec pub » + bascule sur `Topic.isFirstPostOwner`. À traiter séparément (proba faible, mitigé par la gate `isEditable && isOwnPost`).
- `EditPostContext` construit hors try/catch (pratiquement inatteignable) ; symétrie du POST delete sur les options cochées (inoffensif, `delete=1` court-circuite) ; test de course d'hydratation dédié pour `topicTopBarAutoHide` (machinerie déjà exercée).

## Validation locale

`detektAll + test + testDebugUnitTest + :app:assembleProdDebug` (--rerun-tasks) + `lintDebug + :app:lintProdDebug` — verts.

Aucun comportement utilisateur modifié (doc + perf micro-opt + tests). Ne ferme aucune issue.
