### PR TITLE
fix(topic): force-refresh overflow landing after reply (#226)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -139,6 +139,16 @@ data class TopicRoute(
      * `false` on ordinary navigation (forum / deep link / back-nav) to keep the cache snappy.
      */
     val forceRefresh: Boolean = false,
+    /**
+     * #226 — `true` only on the route re-pushed by [onNavigateToLastPage] after a plain reply
+     * overflowed onto a freshly created last page. Forwarded to `TopicRequest.postSubmitOverflowLanding`.
+     * Always paired with a fresh [submitSignal] (force-fetch, no stale cache) and tells the ViewModel
+     * this is the overflow *landing*: scroll to the end of the fresh page, do NOT redirect again to
+     * yet another last page (anti-chase under concurrent posting). Default `false` keeps every other
+     * route — including the initial post-submit refresh — unaffected; defaulted so older serialised
+     * back stacks deserialise without the field.
+     */
+    val postSubmitOverflowLanding: Boolean = false,
 ) : RedfaceNavKey
 
 @Serializable
@@ -825,6 +835,7 @@ private fun RedfaceNavHost(
                         scrollTo = route.scrollTo,
                         submitSignal = route.submitSignal,
                         forceRefresh = route.forceRefresh,
+                        postSubmitOverflowLanding = route.postSubmitOverflowLanding,
                         titleHint = topicTitleNavState.titles[TopicTitleKey(route.cat, route.post)],
                     ),
                     onTitleLoaded = { title ->
@@ -915,17 +926,22 @@ private fun RedfaceNavHost(
                     },
                     onNavigateToLastPage = { lastPage ->
                         // #226 — the plain reply overflowed onto a freshly created page; land the user
-                        // there (their reply lives on the last page, not the stale form page). We do
-                        // NOT carry a submitSignal here: a second force-refresh would re-run the overflow
-                        // guard and, if a concurrent post created yet another page during the refresh
-                        // window, keep chasing the moving tail (review finding). A plain cache-aside load
-                        // surfaces the reply without re-triggering the redirect. Indexed set (not
-                        // removeAt + add) for the same single-mutation reason as onOpenPage (#282).
+                        // there (their reply lives on the last page, not the stale form page). Carry a
+                        // fresh submitSignal so the destination ViewModel force-fetches the page — a
+                        // plain cache-aside load could serve a TTL-fresh row that pre-dates the reply
+                        // (the original #226 failure). The `postSubmitOverflowLanding` flag is what
+                        // keeps the old anti-chase guarantee WITHOUT dropping the refresh: the landing
+                        // ViewModel scrolls to the end but never re-emits NavigateToLastPage, so a
+                        // concurrent post that pushes totalPages further during the refresh window does
+                        // not start a moving-tail chase. Indexed set (not removeAt + add) for the same
+                        // single-mutation reason as onOpenPage (#282).
                         backStack[backStack.lastIndex] = TopicRoute(
                             cat = route.cat,
                             post = route.post,
                             page = lastPage,
                             scrollTo = null,
+                            submitSignal = System.currentTimeMillis(),
+                            postSubmitOverflowLanding = true,
                         )
                     },
                 )
@@ -972,6 +988,10 @@ private fun RedfaceNavHost(
                                     // is silently suppressed (it gates on `target == null`).
                                     scrollTo = scrollTo,
                                     submitSignal = System.currentTimeMillis(),
+                                    // #226 — a fresh submit may itself overflow, so it must be allowed
+                                    // to redirect once. Reset the landing flag the previous route may
+                                    // have carried (topicEntry could already be an overflow landing).
+                                    postSubmitOverflowLanding = false,
                                 ),
                             )
                         }
@@ -1014,6 +1034,10 @@ private fun RedfaceNavHost(
                                     // is silently suppressed (it gates on `target == null`).
                                     scrollTo = scrollTo,
                                     submitSignal = System.currentTimeMillis(),
+                                    // #226 — a fresh submit may itself overflow, so it must be allowed
+                                    // to redirect once. Reset the landing flag the previous route may
+                                    // have carried (topicEntry could already be an overflow landing).
+                                    postSubmitOverflowLanding = false,
                                 ),
                             )
                         }

--- a/docs/specs/navigation.md
+++ b/docs/specs/navigation.md
@@ -278,6 +278,12 @@ Implémentation via **Compose Navigation 3** (1.1.0+, stable depuis 08/04/2026).
                                           // appeler `refreshTopicPage` (skip cache) pour que le post
                                           // fraîchement publié soit visible. Reste null sur tous les autres
                                           // chemins (deep link, pagination, retour Flags/Forum).
+    val postSubmitOverflowLanding: Boolean = false, // #226 — true seulement sur la route re-poussée
+                                          // après qu'une réponse simple a débordé sur une nouvelle
+                                          // dernière page. Couplé à un submitSignal frais (force-fetch,
+                                          // jamais de cache stale) ; signale au ViewModel que c'est
+                                          // l'atterrissage d'overflow : scroller en bas SANS re-rediriger
+                                          // (anti-chase si un post concurrent pousse encore totalPages).
 ) : RedfaceNavKey
 @Serializable data class PostEditorRoute(
     val mode: PostEditorMode,

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicRequest.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicRequest.kt
@@ -29,4 +29,15 @@ data class TopicRequest(
      * used once the page is `Loaded` (the real `Topic.title` wins).
      */
     val titleHint: String? = null,
+    /**
+     * #226 — `true` only on the route the navigation host re-pushes after a plain reply overflowed
+     * onto a freshly created last page (see `TopicEffect.NavigateToLastPage`). It is paired with a
+     * fresh [submitSignal] so the ViewModel force-fetches that page (never a stale cache-aside row —
+     * the original #226 failure), but it marks this as the overflow **landing**: the ViewModel must
+     * NOT re-emit `NavigateToLastPage` even if a concurrent post pushed `totalPages` further while we
+     * refreshed (that would chase a moving tail). It scrolls to the end instead, surfacing the freshly
+     * published reply. `false` on every other path — including the initial post-submit refresh, which
+     * is the route allowed to redirect once.
+     */
+    val postSubmitOverflowLanding: Boolean = false,
 )

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -134,10 +134,14 @@ sealed interface TopicEffect {
      * newly-created page but HFR's success URL anchored the OLD page (the one the form was on). The
      * ViewModel detects this in `forceRefreshCurrentPage`: the force-refreshed page reports a
      * `totalPages` greater than `request.page` while `scrollTo` is null (plain reply — quote/edit
-     * carry a `#t{N}` scrollTo and are excluded). The screen re-routes to [page] (= the new
-     * `totalPages`) with a fresh `submitSignal` + `scrollTo = null`, so the new ViewModel
-     * force-refreshes that last page and [ScrollToEndOfPage] lands on the freshly-published post.
-     * Defensive: works whether HFR anchored the old page (the bug) or the new one.
+     * carry a `#t{N}` scrollTo and are excluded). The navigation host re-routes to [page] (= the new
+     * `totalPages`) with `scrollTo = null`, a **fresh `submitSignal`** AND
+     * `postSubmitOverflowLanding = true` (cf. `TopicRequest`). The fresh `submitSignal` makes the new
+     * ViewModel force-fetch that last page — never a stale cache-aside row — and the landing flag
+     * makes it emit [ScrollToEndOfPage] (surfacing the freshly-published post) **without** re-emitting
+     * `NavigateToLastPage`: if a concurrent post bumped `totalPages` further during the refresh, the
+     * flag breaks the moving-tail chase. Defensive: works whether HFR anchored the old page (the bug)
+     * or the new one.
      */
     data class NavigateToLastPage(val page: Int) : TopicEffect
 

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -240,9 +240,16 @@ class TopicViewModel @AssistedInject constructor(
                 // totalPages == request.page and falls through to the #200 ScrollToEndOfPage path.
                 // Best-effort under concurrency: HFR's #bas success URL carries NO numreponse, so we
                 // cannot tell our own overflow from a concurrent poster's new page — we send the user
-                // to the last page either way (a reasonable landing). The redirect target route omits
-                // submitSignal precisely so we don't re-enter this guard and chase a moving tail.
-                if (request.scrollTo == null && topic.totalPages > request.page) {
+                // to the last page either way (a reasonable landing). `postSubmitOverflowLanding`
+                // guards re-entry: once the host re-routes us onto that last page it sets the flag (and
+                // a fresh submitSignal so we STILL force-fetch it — no stale cache). On that landing we
+                // must NOT redirect again, or a concurrent post bumping totalPages during our refresh
+                // would start a moving-tail chase. The flagged landing falls through to
+                // ScrollToEndOfPage below.
+                if (request.scrollTo == null &&
+                    topic.totalPages > request.page &&
+                    !request.postSubmitOverflowLanding
+                ) {
                     _effects.send(TopicEffect.NavigateToLastPage(topic.totalPages))
                     return@launch
                 }

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -593,12 +593,14 @@ class TopicViewModelTest {
         page: Int,
         scrollTo: Int? = null,
         submitSignal: Long? = null,
+        postSubmitOverflowLanding: Boolean = false,
     ): TopicRequest = TopicRequest(
         cat = SAMPLE_CAT,
         post = SAMPLE_POST,
         page = page,
         scrollTo = scrollTo,
         submitSignal = submitSignal,
+        postSubmitOverflowLanding = postSubmitOverflowLanding,
     )
 
     // ──────────────────────────────────────────────────────────────────────
@@ -723,6 +725,74 @@ class TopicViewModelTest {
             cancelAndIgnoreRemainingEvents()
         }
     }
+
+    @Test
+    fun `overflow landing force-refreshes and scrolls to end without re-redirecting (#226)`() = runTest {
+        // #226 — the host re-routed us onto the freshly created last page (21) with a fresh
+        // submitSignal AND postSubmitOverflowLanding = true. The force refresh still runs (submitSignal
+        // != null) so the page is never a stale cache-aside row — the original #226 failure — but the
+        // landing flag means we stop here: emit ScrollToEndOfPage to surface the new reply, NOT another
+        // NavigateToLastPage. (totalPages == request.page, the normal post-overflow shape.)
+        val landedTopic = fakeTopic(
+            page = 21,
+            totalPages = 21,
+            posts = listOf(fakePost(40), fakePost(41)),
+        )
+        val repository = FakeTopicRepository(
+            flowsToReturn = emptyList(),
+            refreshTopicsToReturn = listOf(landedTopic),
+        )
+
+        val viewModel = topicViewModel(
+            request = topicRequest(
+                page = 21,
+                scrollTo = null,
+                submitSignal = 456L,
+                postSubmitOverflowLanding = true,
+            ),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+
+        viewModel.effects.test {
+            assertEquals(TopicEffect.ScrollToEndOfPage, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `overflow landing does not chase a moving tail when a concurrent post grows totalPages (#226)`() =
+        runTest {
+            // #226 anti-chase — on the overflow landing (page 21, flag set), a concurrent poster
+            // created page 22 during our refresh, so the fresh page reports totalPages = 22 >
+            // request.page = 21. Without the flag the ViewModel would NavigateToLastPage(22) and keep
+            // chasing the moving tail. The flag pins us here: ScrollToEndOfPage, never NavigateToLastPage.
+            val landedTopic = fakeTopic(
+                page = 21,
+                totalPages = 22,
+                posts = listOf(fakePost(40), fakePost(41)),
+            )
+            val repository = FakeTopicRepository(
+                flowsToReturn = emptyList(),
+                refreshTopicsToReturn = listOf(landedTopic),
+            )
+
+            val viewModel = topicViewModel(
+                request = topicRequest(
+                    page = 21,
+                    scrollTo = null,
+                    submitSignal = 789L,
+                    postSubmitOverflowLanding = true,
+                ),
+                topicRepository = repository,
+                authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            )
+
+            viewModel.effects.test {
+                assertEquals(TopicEffect.ScrollToEndOfPage, awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
 
     @Test
     fun `normal load without submitSignal does not emit ScrollToEndOfPage`() = runTest {


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Bloquant beta identifié sur la PR de promotion #342 (suivi du correctif #226). Après une **réponse simple qui déborde** sur une nouvelle dernière page, l'utilisateur pouvait **rester sur l'ancienne page** (ou atterrir sans voir son post). Fix ciblé, pas de refacto large.

## Cause racine

Le re-route `onNavigateToLastPage` ne portait **ni `submitSignal` ni `forceRefresh`** (suppression volontaire pour casser une boucle « moving tail »). Conséquences :
1. **Cache stale** : sur la dernière page, `observeTopicPage` pouvait servir une ligne Room *fraîche au sens TTL* mais antérieure au post → réponse acceptée par HFR mais invisible. C'est exactement ce que #226/#200 voulaient éviter.
2. **Pas de scroll** : sans `submitSignal`, `maybeEmitScroll` n'émettait rien → atterrissage en haut de la page.
3. **KDoc menteur** : `NavigateToLastPage` (`TopicUiState.kt`) prétendait un re-route « with fresh submitSignal → ScrollToEndOfPage », contredit par `RedfaceNavigation`.

## Stratégie retenue

Plutôt que de réutiliser `forceRefresh` comme flag caché anti-boucle, **contrat de navigation explicite** : nouveau champ `postSubmitOverflowLanding: Boolean = false` sur `TopicRoute` **et** `TopicRequest`.

- **Refresh initial post-submit** (page N, `postSubmitOverflowLanding = false`) : si `totalPages > request.page` et `scrollTo == null` → émet `NavigateToLastPage(totalPages)` (inchangé).
- **`onNavigateToLastPage(lastPage)`** : re-route en place avec `scrollTo = null`, **`submitSignal` frais** (→ force-fetch, plus de cache stale) **et `postSubmitOverflowLanding = true`**.
- **Landing ViewModel** (dernière page, flag `true`) : force-fetch grâce au `submitSignal`, puis **`ScrollToEndOfPage`** (montre le post), et **ne ré-émet PAS `NavigateToLastPage`** même si un post concurrent a poussé `totalPages` plus loin pendant le refresh (anti-chase préservé, sans sacrifier le refresh).
- `onSubmitSucceeded` (reply + edit-FP) **reset le flag à `false`** : un nouveau submit qui déborde doit pouvoir rediriger une fois (sinon le `.copy()` héritait `true`).

Quote/edit (porteurs d'un `#t{N}` → `scrollTo != null`) restent prioritaires sur `ScrollToPost`, inchangés.

## Fichiers

- `feature/topic/.../TopicRequest.kt`, `.../TopicUiState.kt` (KDoc corrigée), `.../TopicViewModel.kt` (guard `!postSubmitOverflowLanding`)
- `app/.../navigation/RedfaceNavigation.kt` (champ `TopicRoute`, mapping, `onNavigateToLastPage`, reset dans les 2 `onSubmitSucceeded`)
- `docs/specs/navigation.md` (champ sérialisé aligné)

## Tests (TopicViewModelTest)

1. **Overflow initial inchangé** — `flag=false`, refresh page 20 → `totalPages=21` → `NavigateToLastPage(21)` (test existant).
2. **Landing force-refresh + scroll bas** (NEW) — `flag=true`, refresh page 21 → `totalPages=21` → `ScrollToEndOfPage`, pas `NavigateToLastPage`.
3. **Anti-chase concurrent** (NEW) — `flag=true`, refresh page 21 → `totalPages=22` → `ScrollToEndOfPage`, jamais `NavigateToLastPage(22)`.
4. **Quote/edit** — `scrollTo != null` → `ScrollToPost` prioritaire (test existant).
5. **Route mapping** — `onNavigateToLastPage` est une lambda inline de l'`entryProvider` (pas de fonction extraite) ; le projet n'a aucun test Compose/NavDisplay → non couvert par un test unitaire simple, couvert par revue de code (le mapping `TopicRoute → TopicRequest` est un pass-through 1:1) + les tests VM 2/3.

## Validation

`detektAll + test + testDebugUnitTest + :app:assembleProdDebug` (--rerun-tasks) + `lintDebug + :app:lintProdDebug` — **verts** en local.

## Non traité (volontaire)

`versionName` reste `0.5.1` (le bump beta sera fait avant le dispatch). Pas de refacto cache/routes/repo. Dettes non bloquantes (adjustNothing dogfood clavier, warnings Kotlin 2.4 core/parser, import déprécié `hiltViewModel`) non mélangées au fix.
