### PR TITLE
feat(topic): pull-to-refresh d'une page de topic (#335)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.minimumInteractiveComponentSize
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -161,6 +162,8 @@ fun TopicScreen(
     // suspending lambda but the surrounding scope is still a Composable). Capturing the message
     // upfront keeps the rule happy and avoids re-resolving on every effect.
     val refreshFailedMsg = stringResource(R.string.topic_post_submit_refresh_failed)
+    // #335 — manual pull-to-refresh failure message (resolved upfront, same rationale).
+    val refreshManualFailedMsg = stringResource(R.string.topic_refresh_failed)
     // #292 — delete feedback messages, resolved upfront (same rationale as refreshFailedMsg).
     val deleteSuccessMsg = stringResource(R.string.topic_post_delete_success)
     val deleteFailedLoginMsg = stringResource(R.string.topic_post_delete_failed_login)
@@ -230,6 +233,15 @@ fun TopicScreen(
                     android.widget.Toast.makeText(
                         context,
                         refreshFailedMsg,
+                        android.widget.Toast.LENGTH_LONG,
+                    ).show()
+                }
+                TopicEffect.RefreshFailed -> {
+                    // #335 — manual pull-to-refresh could not reach HFR; the page stays on screen
+                    // (cache-first) and the Toast invites a retry.
+                    android.widget.Toast.makeText(
+                        context,
+                        refreshManualFailedMsg,
                         android.widget.Toast.LENGTH_LONG,
                     ).show()
                 }
@@ -539,18 +551,29 @@ internal fun TopicContent(
                 }
 
                 is TopicUiState.Mode.Loaded -> {
-                    TopicLoadedContent(
-                        state = state,
-                        topic = mode.topic,
-                        onReply = onReply,
-                        onQuote = onQuote,
-                        onEdit = onEdit,
-                        onEditFirstPost = onEditFirstPost,
-                        onOpenPage = onOpenPage,
-                        onOpenProfile = onOpenProfile,
-                        onDeleteRequest = onDeleteRequest,
-                        listState = listState,
-                    )
+                    // #335 — pull-to-refresh only wraps the loaded content (Loading/Error don't need
+                    // it). PullToRefreshBox layers a vertical nested-scroll connection on top of the
+                    // top-bar enterAlways behaviour (#338) and the horizontal page swipe (#282); the
+                    // pull only engages on overscroll at the top of the list, so the read position is
+                    // preserved on refresh (the ViewModel emits no scroll effect).
+                    PullToRefreshBox(
+                        isRefreshing = state.isRefreshing,
+                        onRefresh = { onIntent(TopicIntent.Refresh) },
+                        modifier = Modifier.fillMaxSize(),
+                    ) {
+                        TopicLoadedContent(
+                            state = state,
+                            topic = mode.topic,
+                            onReply = onReply,
+                            onQuote = onQuote,
+                            onEdit = onEdit,
+                            onEditFirstPost = onEditFirstPost,
+                            onOpenPage = onOpenPage,
+                            onOpenProfile = onOpenProfile,
+                            onDeleteRequest = onDeleteRequest,
+                            listState = listState,
+                        )
+                    }
                 }
             }
         }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -31,6 +31,13 @@ data class TopicUiState(
      * always-visible behaviour). Flips on the first preference emission.
      */
     val topBarAutoHide: Boolean = false,
+    /**
+     * #335 — `true` while a manual pull-to-refresh of the current page is in flight. Drives the
+     * Material3 `PullToRefreshBox` spinner. Set on the `Refresh` intent, cleared in the refresh
+     * coroutine's `finally` (so a cancellation — e.g. a delete starting mid-refresh — never leaves
+     * the indicator stuck).
+     */
+    val isRefreshing: Boolean = false,
 ) {
     /**
      * Helper used by the screen / ViewModel : `true` when the user has navigated to a
@@ -69,6 +76,13 @@ data class TopicUiState(
 
 sealed interface TopicIntent {
     data object Retry : TopicIntent
+
+    /**
+     * #335 — manual pull-to-refresh of the currently open page. Re-fetches over the network and
+     * updates the loaded page in place, without the post-submit overflow redirect (#226) or any
+     * scroll effect, so the user keeps their reading position.
+     */
+    data object Refresh : TopicIntent
 
     /**
      * #292 — confirmed deletion of one of the user's own (normal) posts. The screen shows a
@@ -128,6 +142,12 @@ sealed interface TopicEffect {
      * the submit silently failed.
      */
     data object PostSubmitRefreshFailed : TopicEffect
+
+    /**
+     * #335 — emitted when a manual pull-to-refresh (`Refresh` intent) failed to reach HFR. The
+     * current page stays on screen (cache-first); the screen surfaces a Toast inviting a retry.
+     */
+    data object RefreshFailed : TopicEffect
 
     /**
      * Issue #226 — emitted after a plain-reply submit when the reply overflowed the topic onto a

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -116,6 +116,51 @@ class TopicViewModel @AssistedInject constructor(
             // to recover from a transient error.
             TopicIntent.Retry -> loadCurrentPage()
             is TopicIntent.DeletePost -> deletePost(intent.numreponse)
+            TopicIntent.Refresh -> refresh()
+        }
+    }
+
+    /**
+     * #335 — manual pull-to-refresh of the current page. Re-fetches over the network and replaces the
+     * loaded page in place, WITHOUT the post-submit overflow redirect (#226) or any scroll effect, so
+     * the user keeps their reading position. NO-OP unless a page is already loaded and no refresh is
+     * in flight (guards a double pull). `isRefreshing` is cleared in `finally` so a cancellation —
+     * e.g. a delete's `refreshAfterDelete` re-assigning `loadJob` mid-refresh — never leaves the
+     * spinner stuck.
+     *
+     * konsist:bypass-prefetch-guard — cancels the in-flight prefetch and force-fetches the page; this
+     * is an explicit user-initiated authenticated refresh, not an anonymous warmup escalating to
+     * authenticated (same justification as `forceRefreshCurrentPage`).
+     */
+    private fun refresh() {
+        if (_state.value.mode !is TopicUiState.Mode.Loaded || _state.value.isRefreshing) return
+        loadJob?.cancel()
+        prefetchJob?.cancel()
+        prefetchedPage = null
+        _state.update { it.copy(isRefreshing = true) }
+        loadJob = viewModelScope.launch {
+            try {
+                val topic = topicRepository.refreshTopicPage(request.cat, request.post, request.page)
+                _state.update {
+                    it.copy(
+                        mode = TopicUiState.Mode.Loaded(topic),
+                        availablePages = (1..topic.totalPages).toList(),
+                    )
+                }
+                // Re-arm the page+1 warmup, like `loadCurrentPage` (l. ~219). Unlike the post-submit
+                // `forceRefreshCurrentPage` (which deliberately skips it), a manual mid-page pull is
+                // exactly when the user keeps reading forward, so re-warming page+1 restores the
+                // prefetch benefit lost by the `prefetchedPage = null` reset above.
+                maybeSchedulePrefetch(totalPages = topic.totalPages)
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (@Suppress("TooGenericExceptionCaught") refreshError: Exception) {
+                // Cache-first: keep the page currently on screen and invite a retry via a Toast.
+                android.util.Log.w(LOG_TAG, "Manual refresh failed", refreshError)
+                _effects.send(TopicEffect.RefreshFailed)
+            } finally {
+                _state.update { it.copy(isRefreshing = false) }
+            }
         }
     }
 

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="topic_post_edit">Modifier</string>
     <string name="topic_edit_first_post">Modifier le premier message</string>
     <string name="topic_post_submit_refresh_failed">Message envoyé, mais le rafraîchissement de la page a échoué. Tirez pour réessayer.</string>
+    <string name="topic_refresh_failed">Le rafraîchissement a échoué. Réessayez.</string>
     <string name="topic_open_profile_action">Voir le profil</string>
 
     <!-- #292 — suppression d'un de ses propres posts (post normal). -->

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -17,6 +17,7 @@ import fr.forumhfr.redface2.core.model.Post
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.Topic
 import java.io.IOException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -30,6 +31,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -794,6 +796,213 @@ class TopicViewModelTest {
             }
         }
 
+    // ──────────────────────────────────────────────────────────────────────
+    // #335 — manual pull-to-refresh
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `Refresh re-fetches in place, toggles isRefreshing, emits no nav-or-scroll effect (#335)`() = runTest {
+        val loaded = fakeTopic(page = 2, totalPages = 5, title = "loaded")
+        val refreshed = fakeTopic(page = 2, totalPages = 5, title = "refreshed")
+        val gate = CompletableDeferred<Unit>()
+        val repository = FakeTopicRepository(
+            flowsToReturn = listOf(flow { emit(loaded) }),
+            refreshTopicsToReturn = listOf(refreshed),
+        )
+        repository.refreshHook = { _, _, _ -> gate.await() }
+
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+
+        viewModel.effects.test {
+            viewModel.send(TopicIntent.Refresh)
+            assertTrue("the spinner shows while the refresh is in flight", viewModel.state.value.isRefreshing)
+            gate.complete(Unit)
+            // A successful manual refresh keeps the reading position: no ScrollToEndOfPage and no
+            // NavigateToLastPage (those are post-submit concerns, #200/#226).
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        assertFalse(viewModel.state.value.isRefreshing)
+        assertEquals("refreshed", (viewModel.state.value.mode as TopicUiState.Mode.Loaded).topic.title)
+        assertEquals(1, repository.refreshCalls.size)
+    }
+
+    @Test
+    fun `a second Refresh while one is in flight is collapsed to a single network call (#335)`() = runTest {
+        val loaded = fakeTopic(page = 2, totalPages = 5, title = "loaded")
+        val refreshed = fakeTopic(page = 2, totalPages = 5, title = "refreshed")
+        val gate = CompletableDeferred<Unit>()
+        val repository = FakeTopicRepository(
+            flowsToReturn = listOf(flow { emit(loaded) }),
+            refreshTopicsToReturn = listOf(refreshed),
+        )
+        repository.refreshHook = { _, _, _ -> gate.await() }
+
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+
+        viewModel.send(TopicIntent.Refresh) // suspends in the hook → isRefreshing = true
+        viewModel.send(TopicIntent.Refresh) // must be ignored: a refresh is already running
+        assertEquals("the in-flight guard collapses a double pull to one fetch", 1, repository.refreshCalls.size)
+
+        gate.complete(Unit)
+        assertFalse(viewModel.state.value.isRefreshing)
+    }
+
+    @Test
+    fun `Refresh failure keeps the current page and emits RefreshFailed (#335)`() = runTest {
+        val loaded = fakeTopic(page = 2, totalPages = 5, title = "loaded")
+        val repository = FakeTopicRepository(
+            flowsToReturn = listOf(flow { emit(loaded) }),
+            refreshErrorToThrow = IOException("network"),
+        )
+
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+
+        viewModel.effects.test {
+            viewModel.send(TopicIntent.Refresh)
+            assertEquals(TopicEffect.RefreshFailed, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertFalse(viewModel.state.value.isRefreshing)
+        assertEquals(
+            "the page on screen is unchanged after a failed refresh",
+            "loaded",
+            (viewModel.state.value.mode as TopicUiState.Mode.Loaded).topic.title,
+        )
+    }
+
+    @Test
+    fun `Refresh is a no-op while the page is still loading (#335)`() = runTest {
+        // observeTopicPage never emits → state stays Loading; a pull-to-refresh must not fire.
+        val repository = FakeTopicRepository(flowsToReturn = listOf(flow { }))
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+
+        viewModel.send(TopicIntent.Refresh)
+
+        assertTrue("no refresh call while not loaded", repository.refreshCalls.isEmpty())
+        assertFalse(viewModel.state.value.isRefreshing)
+    }
+
+    @Test
+    fun `Refresh revealing a new page updates availablePages but emits no navigation effect (#335)`() = runTest {
+        // A manual refresh must surface a grown page count WITHOUT yanking the user to the last page
+        // (#226 NavigateToLastPage is a post-submit concern only).
+        val loaded = fakeTopic(page = 2, totalPages = 5, title = "loaded")
+        val refreshed = fakeTopic(page = 2, totalPages = 6, title = "refreshed")
+        val repository = FakeTopicRepository(
+            flowsToReturn = listOf(flow { emit(loaded) }),
+            refreshTopicsToReturn = listOf(refreshed),
+        )
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+
+        viewModel.effects.test {
+            viewModel.send(TopicIntent.Refresh)
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals((1..6).toList(), viewModel.state.value.availablePages)
+    }
+
+    @Test
+    fun `a delete cancelling an in-flight refresh clears isRefreshing (#335)`() = runTest {
+        // The `finally { isRefreshing = false }` in refresh() exists precisely so another path
+        // cancelling the refresh job mid-flight never strands the spinner. DeletePost →
+        // refreshAfterDelete() does exactly that (loadJob?.cancel()). Pin that guarantee.
+        val loaded = fakeTopic(
+            page = 2,
+            totalPages = 3,
+            posts = listOf(fakePost(numreponse = 777, isEditable = true)),
+        )
+        val afterDelete = fakeTopic(page = 2, totalPages = 3, title = "after-delete")
+        val gate = CompletableDeferred<Unit>()
+        val repository = FakeTopicRepository(
+            flowsToReturn = listOf(flow { emit(loaded) }),
+            refreshTopicsToReturn = listOf(afterDelete),
+        )
+        repository.refreshHook = { _, _, _ -> gate.await() }
+        val deleteRepo = FakeDeletePostRepository(DeletePostResult.Success(deletedWholeTopic = false))
+
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            deletePostRepository = deleteRepo,
+        )
+
+        viewModel.send(TopicIntent.Refresh)
+        assertTrue("the spinner shows while the manual refresh is in flight", viewModel.state.value.isRefreshing)
+
+        // Let the post-delete refetch run to completion instead of suspending on the same gate.
+        // The gated refresh recorded its call but never reached the refreshQueue dequeue, so the
+        // `afterDelete` topic is still queued for refreshAfterDelete().
+        repository.refreshHook = null
+        viewModel.send(TopicIntent.DeletePost(777))
+
+        assertFalse(
+            "a delete cancelling the refresh must clear isRefreshing (finally guard)",
+            viewModel.state.value.isRefreshing,
+        )
+        assertEquals(
+            "the post-delete refetch lands the fresh page",
+            "after-delete",
+            (viewModel.state.value.mode as TopicUiState.Mode.Loaded).topic.title,
+        )
+    }
+
+    @Test
+    fun `Refresh re-arms the page+1 prefetch (#335)`() = runTest {
+        // A successful manual pull on an intermediate page re-arms the page+1 warmup (the user keeps
+        // reading forward) — unlike the post-submit force refresh which deliberately skips it. Expect
+        // two prefetches of page+1: one on the initial load, one after the Refresh re-fetch.
+        val loaded = fakeTopic(page = 2, totalPages = 5, title = "loaded")
+        val refreshed = fakeTopic(page = 2, totalPages = 5, title = "refreshed")
+        val repository = FakeTopicRepository(
+            flowsToReturn = listOf(flow { emit(loaded) }),
+            refreshTopicsToReturn = listOf(refreshed),
+        )
+
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+
+        assertEquals(
+            "the initial load warms page+1 once",
+            listOf(Triple(SAMPLE_CAT, SAMPLE_POST, 3)),
+            repository.prefetches,
+        )
+
+        viewModel.send(TopicIntent.Refresh)
+
+        assertEquals(
+            "a manual refresh re-arms the page+1 warmup",
+            listOf(Triple(SAMPLE_CAT, SAMPLE_POST, 3), Triple(SAMPLE_CAT, SAMPLE_POST, 3)),
+            repository.prefetches,
+        )
+    }
+
     @Test
     fun `normal load without submitSignal does not emit ScrollToEndOfPage`() = runTest {
         // Regression guard: ScrollToEndOfPage is gated on submitSignal != null. A normal
@@ -958,6 +1167,14 @@ private class FakeTopicRepository(
     var lastForceRefresh: Boolean? = null
         private set
 
+    /**
+     * Optional hook to suspend or fail inside `refreshTopicPage(...)` — symmetric with
+     * [prefetchHook]. #335 pull-to-refresh tests install a `CompletableDeferred`-backed hook to
+     * observe the in-flight `isRefreshing` window and assert anti-double-trigger (a second refresh
+     * while the first is suspended must not issue a second call). Default keeps the fake fast.
+     */
+    var refreshHook: (suspend (cat: Int, post: Int, page: Int) -> Unit)? = null
+
     override fun observeTopicPage(cat: Int, post: Int, page: Int, forceRefresh: Boolean): Flow<Topic> {
         calls += Triple(cat, post, page)
         lastForceRefresh = forceRefresh
@@ -966,6 +1183,7 @@ private class FakeTopicRepository(
 
     override suspend fun refreshTopicPage(cat: Int, post: Int, page: Int): Topic {
         refreshCalls += Triple(cat, post, page)
+        refreshHook?.invoke(cat, post, page)
         refreshErrorToThrow?.let { throw it }
         return refreshQueue.removeFirstOrNull()
             ?: error("No more refresh topics queued (issue #200 post-submit force fetch path)")


### PR DESCRIPTION
## Résumé

Ajoute un **pull-to-refresh** sur la page d'un topic ouvert (`PullToRefreshBox` M3). Tirer vers le bas re-fetche la page courante sur le réseau et la remplace **en place**, sans la redirection post-submit (#226) ni aucun effet de scroll, donc la **position de lecture est conservée** (le `LazyListState` est hoisté au-dessus du `PullToRefreshBox`).

## Détails

- `TopicIntent.Refresh` / `TopicUiState.isRefreshing` / `TopicEffect.RefreshFailed`.
- `refresh()` : guard double-pull + hors-`Loaded` ; `finally { isRefreshing = false }` (le spinner n'est jamais coincé, même si un delete annule le job en vol via `refreshAfterDelete`) ; **réarme le prefetch page+1** comme `loadCurrentPage` — un pull manuel mid-page est exactement quand l'utilisateur continue sa lecture (contrairement au skip volontaire post-submit de `forceRefreshCurrentPage`). Le warmup reste anonyme (`TopicRepository.prefetch`).
- Échec réseau : cache-first, la page reste à l'écran + Toast `RefreshFailed` (vouvoiement, cohérent avec `topic_post_submit_refresh_failed`).
- `konsist:bypass-prefetch-guard` documenté sur `refresh()`.

## Tests (7, `:feature:topic:testDebugUnitTest`)

succès en place sans effet nav/scroll · double-pull collapse à 1 appel · échec réseau + page préservée · no-op pendant `Loading` · `totalPages` grandi sans `NavigateToLastPage` · **annulation mid-refresh (delete) vide `isRefreshing`** · **réarmement prefetch page+1 après refresh**.

## Validation

- Local : `detektAll test testDebugUnitTest :app:assembleProdDebug --rerun-tasks` ✅ + `lintDebug :app:lintProdDebug` ✅ (BUILD SUCCESSFUL).
- Review 4-flavor (4 agents Opus, seuil 60) + arbitrage **Codex 5.5 xhigh** : F-A (test annulation), F-B (réarmement prefetch), F-D (vouvoiement) appliqués ; F-C (test double-trigger) et F-E (`PullToRefreshBox.enabled`) rejetés (faux positif / redondant avec le guard ViewModel). **Review Codex finale : PRÊT À MERGER, aucun bloquant.**

Closes #335

> Action par Claude Opus 4.8 (demandée par @XaaT)
