### PR TITLE
feat(topic): indicateur de position + fast-scroll intra-page (#300)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -3,6 +3,7 @@ package fr.forumhfr.redface2.feature.topic
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -561,18 +562,27 @@ internal fun TopicContent(
                         onRefresh = { onIntent(TopicIntent.Refresh) },
                         modifier = Modifier.fillMaxSize(),
                     ) {
-                        TopicLoadedContent(
-                            state = state,
-                            topic = mode.topic,
-                            onReply = onReply,
-                            onQuote = onQuote,
-                            onEdit = onEdit,
-                            onEditFirstPost = onEditFirstPost,
-                            onOpenPage = onOpenPage,
-                            onOpenProfile = onOpenProfile,
-                            onDeleteRequest = onDeleteRequest,
-                            listState = listState,
-                        )
+                        // #300 — wrap the list in a Box so the intra-page scrollbar can overlay its
+                        // right edge. The scrollbar is pure UI derived from `listState`; it never moves
+                        // the read position on its own — only an explicit thumb drag fast-scrolls.
+                        Box(modifier = Modifier.fillMaxSize()) {
+                            TopicLoadedContent(
+                                state = state,
+                                topic = mode.topic,
+                                onReply = onReply,
+                                onQuote = onQuote,
+                                onEdit = onEdit,
+                                onEditFirstPost = onEditFirstPost,
+                                onOpenPage = onOpenPage,
+                                onOpenProfile = onOpenProfile,
+                                onDeleteRequest = onDeleteRequest,
+                                listState = listState,
+                            )
+                            TopicScrollbar(
+                                listState = listState,
+                                modifier = Modifier.align(Alignment.CenterEnd),
+                            )
+                        }
                     }
                 }
             }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbar.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbar.kt
@@ -1,0 +1,275 @@
+package fr.forumhfr.redface2.feature.topic
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+/**
+ * #300 — intra-page position indicator + fast-scroll for a topic page.
+ *
+ * A thin, auto-hiding scrollbar overlaid on the right edge of the topic [LazyColumn]. It shows the
+ * reading position within the *current* page (between-page navigation is out of scope — #284/#283 cover
+ * that) and lets the user fast-scroll by dragging the thumb. Pure UI derived from [LazyListState] — no
+ * MVI/ViewModel/repository change.
+ *
+ * Two layers, deliberately separated (Compose pointer nodes don't share with siblings by default, so a
+ * full-height pointer overlay would swallow the list's own scroll/taps on the whole right strip):
+ *  - a full-height [Canvas] that only **draws** the thumb (no pointer input), and
+ *  - a small **hit target** placed only over the thumb (± a grab padding) that carries the drag gesture.
+ * Outside the thumb hit target there is no pointer node, so a normal vertical scroll / a tap on a
+ * right-aligned post action falls straight through to the list.
+ *
+ * Geometry uses an **index-based** model (pragmatic v1): thumb size ≈ visibleItems/totalItems, thumb top
+ * ≈ firstVisibleIndex/totalItems with sub-item interpolation from the scroll offset. Variable post
+ * heights make this an approximation; a single post taller than the viewport yields a coarse thumb
+ * (sizeFraction ≈ 1) and a coarse fast-scroll — accepted for v1. "Is there anything to scroll" is read
+ * from [LazyListState.canScrollForward]/[LazyListState.canScrollBackward], NOT from visible ≥ total
+ * (which is false when one item is taller than the viewport). It works in pure `LazyListState` index
+ * space (the header card is lazy item 0), so thumb position and `scrollToItem` stay mutually consistent
+ * — no header offset to apply.
+ */
+@Composable
+internal fun TopicScrollbar(
+    listState: LazyListState,
+    modifier: Modifier = Modifier,
+) {
+    val canScroll by remember {
+        derivedStateOf { listState.canScrollForward || listState.canScrollBackward }
+    }
+    val metrics by remember {
+        derivedStateOf {
+            val info = listState.layoutInfo
+            scrollbarMetrics(
+                firstVisibleItemIndex = listState.firstVisibleItemIndex,
+                firstVisibleItemScrollOffset = listState.firstVisibleItemScrollOffset,
+                firstVisibleItemSize = info.visibleItemsInfo.firstOrNull()?.size ?: 0,
+                visibleItemsCount = info.visibleItemsInfo.size,
+                totalItemsCount = info.totalItemsCount,
+            )
+        }
+    }
+
+    var isDragging by remember { mutableStateOf(false) }
+    val active = canScroll && metrics != null
+
+    // Visible while scrolling or dragging; otherwise a brief show-then-fade. The idle branch also fires
+    // on the first composition of a scrollable page (initial flash → discoverability of the fast-scroll
+    // affordance) and after a scroll settles (post-scroll hold). The LaunchedEffect restarts on every
+    // (active / scroll / drag) change, so a scroll resuming within the hold cancels the pending fade.
+    var alphaTarget by remember { mutableStateOf(0f) }
+    LaunchedEffect(active, listState.isScrollInProgress, isDragging) {
+        when {
+            !active -> alphaTarget = 0f
+            listState.isScrollInProgress || isDragging -> alphaTarget = 1f
+            else -> {
+                alphaTarget = 1f
+                delay(HIDE_DELAY_MS)
+                alphaTarget = 0f
+            }
+        }
+    }
+    val alpha by animateFloatAsState(targetValue = alphaTarget, label = "topicScrollbarAlpha")
+    val thumbColor = MaterialTheme.colorScheme.primary
+
+    // Read live counts inside the gesture without re-keying the pointerInput on the (per-frame) metrics.
+    val currentVisibleCount = rememberUpdatedState(listState.layoutInfo.visibleItemsInfo.size)
+    val currentTotalCount = rememberUpdatedState(listState.layoutInfo.totalItemsCount)
+    val scope = rememberCoroutineScope()
+    var lastTargetIndex by remember { mutableIntStateOf(-1) }
+    var scrollJob by remember { mutableStateOf<Job?>(null) }
+
+    // Hoisted out of the layout tree so the `if` they contain doesn't add nesting depth below.
+    val onDraggingChange: (Boolean) -> Unit = { dragging ->
+        isDragging = dragging
+        if (dragging) lastTargetIndex = -1 // a fresh grab always re-evaluates the target
+    }
+    val onSeek: (Float) -> Unit = { travelFraction ->
+        val index = targetIndexForDrag(
+            travelFraction = travelFraction,
+            visibleItemsCount = currentVisibleCount.value,
+            totalItemsCount = currentTotalCount.value,
+        )
+        if (index != lastTargetIndex) {
+            lastTargetIndex = index
+            scrollJob?.cancel()
+            scrollJob = scope.launch { listState.scrollToItem(index) }
+        }
+    }
+
+    BoxWithConstraints(
+        modifier = modifier
+            .width(SCROLLBAR_GUTTER_WIDTH)
+            .fillMaxHeight(),
+    ) {
+        val trackHeightPx = constraints.maxHeight.toFloat()
+        Canvas(modifier = Modifier.fillMaxSize().clearAndSetSemantics { }) {
+            val m = metrics
+            if (alpha > 0f && m != null) {
+                drawScrollbarThumb(metrics = m, alpha = alpha, color = thumbColor)
+            }
+        }
+        val m = metrics
+        if (active && m != null) {
+            ThumbHitTarget(
+                listState = listState,
+                trackHeightPx = trackHeightPx,
+                metrics = m,
+                onDraggingChange = onDraggingChange,
+                onSeek = onSeek,
+            )
+        }
+    }
+}
+
+/**
+ * The thumb-only drag surface. Placed at the thumb's current vertical offset (± [GRAB_PADDING]) so it is
+ * the *only* pointer node in the gutter — everything else stays scrollable/tappable. The drag maps the
+ * finger's absolute track position back from the live hit-target top: `trackY = hitTop + localY`, which
+ * stays correct frame-to-frame even as the thumb (and this surface) moves under the finger.
+ */
+@Composable
+private fun ThumbHitTarget(
+    listState: LazyListState,
+    trackHeightPx: Float,
+    metrics: ScrollbarMetrics,
+    onDraggingChange: (Boolean) -> Unit,
+    onSeek: (Float) -> Unit,
+) {
+    val padPx = with(LocalDensity.current) { GRAB_PADDING.toPx() }
+    val thumbTopPx = metrics.offsetFraction * trackHeightPx
+    val thumbHeightPx = metrics.sizeFraction * trackHeightPx
+    val hitTopPx = (thumbTopPx - padPx).coerceAtLeast(0f)
+    val hitHeight = with(LocalDensity.current) { (thumbHeightPx + 2f * padPx).toDp() }
+    val liveMetrics = rememberUpdatedState(metrics)
+    val liveSeek = rememberUpdatedState(onSeek)
+    val liveDragging = rememberUpdatedState(onDraggingChange)
+
+    Box(
+        modifier = Modifier
+            .offset { IntOffset(x = 0, y = hitTopPx.roundToInt()) }
+            .fillMaxWidth()
+            .height(hitHeight)
+            .pointerInput(listState) {
+                detectVerticalDragGestures(
+                    onDragStart = { liveDragging.value(true) },
+                    onDragEnd = { liveDragging.value(false) },
+                    onDragCancel = { liveDragging.value(false) },
+                ) { change, _ ->
+                    change.consume()
+                    val thumbH = liveMetrics.value.sizeFraction * trackHeightPx
+                    val hitTopNow = (liveMetrics.value.offsetFraction * trackHeightPx - padPx).coerceAtLeast(0f)
+                    val trackY = hitTopNow + change.position.y
+                    val travel = (trackHeightPx - thumbH).coerceAtLeast(1f)
+                    val top = (trackY - thumbH / 2f).coerceIn(0f, travel)
+                    liveSeek.value(top / travel)
+                }
+            },
+    )
+}
+
+private fun DrawScope.drawScrollbarThumb(
+    metrics: ScrollbarMetrics,
+    alpha: Float,
+    color: Color,
+) {
+    val trackHeightPx = size.height
+    val thumbHeightPx = metrics.sizeFraction * trackHeightPx
+    val thumbTopPx = metrics.offsetFraction * trackHeightPx
+    val thumbWidthPx = THUMB_WIDTH.toPx()
+    drawRoundRect(
+        color = color.copy(alpha = THUMB_ALPHA * alpha),
+        topLeft = Offset(size.width - thumbWidthPx, thumbTopPx),
+        size = Size(thumbWidthPx, thumbHeightPx),
+        cornerRadius = CornerRadius(thumbWidthPx / 2f, thumbWidthPx / 2f),
+    )
+}
+
+/**
+ * Geometry of the scrollbar thumb, derived from the lazy list. [offsetFraction] ∈ [0, 1] is the top of
+ * the thumb as a fraction of the track; [sizeFraction] ∈ (0, 1] is the thumb height as a fraction of the
+ * track.
+ */
+internal data class ScrollbarMetrics(
+    val offsetFraction: Float,
+    val sizeFraction: Float,
+)
+
+/**
+ * Pure thumb geometry. Returns `null` only when there is nothing to represent ([totalItemsCount] ≤ 0 or
+ * no visible item) — the "page fits, nothing to scroll" decision is taken by the caller from
+ * `canScrollForward/Backward`, NOT from `visibleItemsCount >= totalItemsCount` (false when a single item
+ * is taller than the viewport). Index-based with sub-item interpolation; [firstVisibleItemSize] ≤ 0 is
+ * tolerated (no sub-item contribution).
+ */
+internal fun scrollbarMetrics(
+    firstVisibleItemIndex: Int,
+    firstVisibleItemScrollOffset: Int,
+    firstVisibleItemSize: Int,
+    visibleItemsCount: Int,
+    totalItemsCount: Int,
+): ScrollbarMetrics? {
+    if (totalItemsCount <= 0 || visibleItemsCount <= 0) return null
+    val sizeFraction = (visibleItemsCount.toFloat() / totalItemsCount).coerceIn(MIN_THUMB_FRACTION, 1f)
+    val subItem =
+        if (firstVisibleItemSize > 0) firstVisibleItemScrollOffset.toFloat() / firstVisibleItemSize else 0f
+    val offsetFraction =
+        ((firstVisibleItemIndex + subItem) / totalItemsCount).coerceIn(0f, 1f - sizeFraction)
+    return ScrollbarMetrics(offsetFraction = offsetFraction, sizeFraction = sizeFraction)
+}
+
+/**
+ * Maps the thumb's travel fraction (∈ [0, 1] over its *available* travel = track − thumb) to a target
+ * first-visible item index, consistent with [scrollbarMetrics] (max offset 1 − sizeFraction ⇔
+ * firstVisibleIndex = total − visible). Clamps so a shrinking [totalItemsCount] mid-drag never yields a
+ * negative index.
+ */
+internal fun targetIndexForDrag(
+    travelFraction: Float,
+    visibleItemsCount: Int,
+    totalItemsCount: Int,
+): Int {
+    val maxFirstIndex = (totalItemsCount - visibleItemsCount.coerceAtLeast(1)).coerceAtLeast(0)
+    return (travelFraction.coerceIn(0f, 1f) * maxFirstIndex).roundToInt()
+}
+
+private const val THUMB_ALPHA = 0.7f
+internal const val MIN_THUMB_FRACTION = 0.08f
+private const val HIDE_DELAY_MS = 800L
+private val SCROLLBAR_GUTTER_WIDTH = 24.dp
+private val THUMB_WIDTH = 6.dp
+private val GRAB_PADDING = 12.dp

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbarTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbarTest.kt
@@ -1,0 +1,140 @@
+package fr.forumhfr.redface2.feature.topic
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #300 — pure-geometry tests for the topic scrollbar. Composable behaviour (auto-hide, gesture) is not
+ * unit-tested here; the value is in the position/size math and the drag→index mapping.
+ */
+class TopicScrollbarTest {
+
+    private val tolerance = 1e-4f
+
+    @Test
+    fun `scrollbarMetrics returns null when there is no item`() {
+        assertNull(
+            scrollbarMetrics(
+                firstVisibleItemIndex = 0,
+                firstVisibleItemScrollOffset = 0,
+                firstVisibleItemSize = 100,
+                visibleItemsCount = 0,
+                totalItemsCount = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun `scrollbarMetrics returns null when no item is visible`() {
+        assertNull(
+            scrollbarMetrics(
+                firstVisibleItemIndex = 0,
+                firstVisibleItemScrollOffset = 0,
+                firstVisibleItemSize = 100,
+                visibleItemsCount = 0,
+                totalItemsCount = 10,
+            ),
+        )
+    }
+
+    @Test
+    fun `scrollbarMetrics is non-null even when all items are visible (tall item, still scrollable)`() {
+        // visibleItemsCount >= totalItemsCount must NOT be treated as "nothing to scroll": a single item
+        // taller than the viewport is scrollable. The caller gates visibility on canScrollForward/Backward.
+        val metrics = scrollbarMetrics(
+            firstVisibleItemIndex = 0,
+            firstVisibleItemScrollOffset = 0,
+            firstVisibleItemSize = 4000,
+            visibleItemsCount = 1,
+            totalItemsCount = 1,
+        )
+        assertNotNull(metrics)
+    }
+
+    @Test
+    fun `offsetFraction is 0 at the top of the page`() {
+        val metrics = scrollbarMetrics(
+            firstVisibleItemIndex = 0,
+            firstVisibleItemScrollOffset = 0,
+            firstVisibleItemSize = 100,
+            visibleItemsCount = 5,
+            totalItemsCount = 10,
+        )!!
+        assertEquals(0f, metrics.offsetFraction, tolerance)
+        assertEquals(0.5f, metrics.sizeFraction, tolerance)
+    }
+
+    @Test
+    fun `offsetFraction reaches 1 minus sizeFraction at the bottom of the page`() {
+        val metrics = scrollbarMetrics(
+            firstVisibleItemIndex = 5,
+            firstVisibleItemScrollOffset = 0,
+            firstVisibleItemSize = 100,
+            visibleItemsCount = 5,
+            totalItemsCount = 10,
+        )!!
+        assertEquals(1f - metrics.sizeFraction, metrics.offsetFraction, tolerance)
+    }
+
+    @Test
+    fun `sizeFraction respects the minimum thumb floor on a very long page`() {
+        val metrics = scrollbarMetrics(
+            firstVisibleItemIndex = 0,
+            firstVisibleItemScrollOffset = 0,
+            firstVisibleItemSize = 50,
+            visibleItemsCount = 2,
+            totalItemsCount = 200,
+        )!!
+        // raw = 2/200 = 0.01, floored to MIN_THUMB_FRACTION.
+        assertEquals(MIN_THUMB_FRACTION, metrics.sizeFraction, tolerance)
+    }
+
+    @Test
+    fun `sub-item scroll offset increases offsetFraction monotonically`() {
+        val atTop = scrollbarMetrics(0, 0, 100, 5, 10)!!
+        val scrolledWithinFirstItem = scrollbarMetrics(0, 50, 100, 5, 10)!!
+        assertTrue(scrolledWithinFirstItem.offsetFraction > atTop.offsetFraction)
+    }
+
+    @Test
+    fun `firstVisibleItemSize of zero does not crash and contributes no sub-item offset`() {
+        val metrics = scrollbarMetrics(
+            firstVisibleItemIndex = 2,
+            firstVisibleItemScrollOffset = 30,
+            firstVisibleItemSize = 0,
+            visibleItemsCount = 5,
+            totalItemsCount = 10,
+        )!!
+        assertEquals(0.2f, metrics.offsetFraction, tolerance)
+    }
+
+    @Test
+    fun `targetIndexForDrag maps full travel below the visible window`() {
+        assertEquals(7, targetIndexForDrag(travelFraction = 1f, visibleItemsCount = 3, totalItemsCount = 10))
+    }
+
+    @Test
+    fun `targetIndexForDrag maps zero travel to the first item`() {
+        assertEquals(0, targetIndexForDrag(travelFraction = 0f, visibleItemsCount = 3, totalItemsCount = 10))
+    }
+
+    @Test
+    fun `targetIndexForDrag maps half travel to the middle of the scrollable range`() {
+        assertEquals(4, targetIndexForDrag(travelFraction = 0.5f, visibleItemsCount = 2, totalItemsCount = 10))
+    }
+
+    @Test
+    fun `targetIndexForDrag clamps an out-of-range travel fraction`() {
+        assertEquals(7, targetIndexForDrag(travelFraction = 2f, visibleItemsCount = 3, totalItemsCount = 10))
+        assertEquals(0, targetIndexForDrag(travelFraction = -1f, visibleItemsCount = 3, totalItemsCount = 10))
+    }
+
+    @Test
+    fun `targetIndexForDrag never returns a negative index when visible exceeds total mid-drag`() {
+        // Simulates totalItemsCount shrinking under the drag (e.g. a refresh removed posts).
+        assertEquals(0, targetIndexForDrag(travelFraction = 1f, visibleItemsCount = 20, totalItemsCount = 10))
+    }
+}


### PR DESCRIPTION
## Résumé

Ajoute un **indicateur de position + fast-scroll intra-page** (scrollbar) sur le bord droit de la page d'un topic. La scrollbar fine s'auto-masque et montre la position de lecture dans la page courante ; on peut **fast-scroller** en glissant le thumb. UI pure dérivée du `LazyListState` — **zéro changement MVI/ViewModel/repository**.

## Architecture (clé)

Les pointer nodes Compose ne partagent pas avec les siblings par défaut ; un overlay pleine hauteur volerait le scroll/les taps de la liste sur toute la bande droite. Donc **deux couches séparées** :
- un `Canvas` pleine hauteur qui **dessine** seulement le thumb (sans `pointerInput`),
- une **hit-target placée uniquement sur le thumb** (± marge de prise) qui porte le geste de drag.

Hors thumb → aucun node pointer → scroll/tap de la liste passent normalement.

## Détails

- Géométrie **index-based** (fonctions pures testées) : thumb size ≈ visible/total, position ≈ firstVisibleIndex/total + interpolation sous-item. Espace d'index lazy (header = item 0) cohérent avec `scrollToItem`.
- Visibilité « rien à scroller » via `canScrollForward/Backward` (pas `visible>=total`, faux si un post est plus haut que le viewport).
- Auto-hide : flash initial (découvrabilité) + hold post-scroll puis fade.
- Drag : reconstruction `trackY = hitTopLive + change.position.y` (lue live), skip same-index, un seul job de scroll en vol.
- `clearAndSetSemantics` (affordance pointer-only, la liste annonce la position).
- Limitation v1 documentée : un post unique plus haut que le viewport donne un thumb/fast-scroll grossier.

## Tests

`TopicScrollbarTest` (JUnit pur, 13 cas) : null-cases, plancher thumb, post tall (canScroll), interpolation sous-item monotone, `firstVisibleItemSize=0` sans crash, mapping drag (full/zero/half travel, clamps, shrink mid-drag).

## Validation

- Local : `detektAll test testDebugUnitTest :app:assembleProdDebug --rerun-tasks` ✅ + `lintDebug :app:lintProdDebug` ✅ (BUILD SUCCESSFUL).
- Review 4-flavor (4 agents Opus, seuil 60) → 1 bloquant (gouttière volant le scroll, F7) + 1 majeur (flash initial, F5). Arbitrage Codex 5.5 xhigh sur les findings (architecture Canvas+hitbox-thumb) → F7/F5 appliqués ; BUG2 (offset header) rejeté (espace lazy cohérent), BUG3 (post tall) accepté comme limitation v1. Review finale indépendante : PRÊT À MERGER, aucun finding ≥70.

Closes #300

> Action par Claude Opus 4.8 (demandée par @XaaT)
