### PR TITLE
feat(settings): écran Réglages « menu vitrine » — catalogue + réglages à venir grisés (#288)

### DIFF
--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -89,6 +89,16 @@ internal fun SettingsContent(
                 style = MaterialTheme.typography.headlineMedium,
                 color = MaterialTheme.colorScheme.onSurface,
             )
+            // #288 — distinguish local (DataStore) preferences from HFR-account settings, and frame the
+            // screen as the full catalogue: shipped settings are interactive, planned ones are shown
+            // greyed with a phase/issue tag (a showcase of the roadmap, cf. the issue's design notes).
+            Text(
+                text = stringResource(R.string.settings_intro),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            SettingsSectionHeader(stringResource(R.string.settings_section_network))
             Card(modifier = Modifier.fillMaxWidth()) {
                 Column(
                     modifier = Modifier.padding(16.dp),
@@ -189,24 +199,102 @@ internal fun SettingsContent(
                 }
             }
 
+            MaintenanceCard(
+                state = state,
+                onIntent = onIntent,
+            )
+            FutureSettingsCard(
+                items = listOf(
+                    R.string.settings_future_data_saver to issueTag(310),
+                    R.string.settings_future_clear_image_cache to issueTag(314),
+                ),
+            )
+
+            SettingsSectionHeader(stringResource(R.string.settings_section_display))
             ThemePreferencesCard(
                 state = state,
                 onIntent = onIntent,
             )
+            FutureSettingsCard(
+                items = listOf(
+                    R.string.settings_future_reading_density to issueTag(287),
+                    R.string.settings_future_ui_colors to issueTag(296),
+                    R.string.settings_future_material_you to stringResource(R.string.settings_phase_future),
+                    R.string.settings_future_classic_theme to stringResource(R.string.settings_phase_future_far),
+                ),
+            )
 
+            SettingsSectionHeader(stringResource(R.string.settings_section_flags))
             FlagsPreferencesCard(
                 state = state,
                 onIntent = onIntent,
             )
+            FutureSettingsCard(
+                items = listOf(
+                    R.string.settings_future_flags_on_listing to issueTag(297),
+                ),
+            )
 
+            SettingsSectionHeader(stringResource(R.string.settings_section_topic))
             TopicPreferencesCard(
                 state = state,
                 onIntent = onIntent,
             )
+            FutureSettingsCard(
+                items = listOf(
+                    R.string.settings_future_scroll_memory to issueTag(307),
+                    R.string.settings_future_prefetch to stringResource(R.string.settings_phase_future),
+                ),
+            )
 
-            MaintenanceCard(
-                state = state,
-                onIntent = onIntent,
+            SettingsSectionHeader(stringResource(R.string.settings_section_editing))
+            FutureSettingsCard(
+                items = listOf(
+                    R.string.settings_future_submit_confirm to issueTag(312),
+                    R.string.settings_future_signature to stringResource(R.string.settings_phase_planned),
+                ),
+            )
+
+            SettingsSectionHeader(stringResource(R.string.settings_section_mp))
+            FutureSettingsCard(
+                items = listOf(
+                    R.string.settings_future_mp_write to issueTag(301),
+                    R.string.settings_future_mp_notifications to issueTag(313),
+                ),
+            )
+
+            SettingsSectionHeader(stringResource(R.string.settings_section_hfr_account))
+            Text(
+                text = stringResource(R.string.settings_hfr_account_note),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            FutureSettingsCard(
+                items = listOf(
+                    R.string.settings_future_hfr_profile to issueTag(311),
+                ),
+            )
+
+            SettingsSectionHeader(stringResource(R.string.settings_section_notifications))
+            FutureSettingsCard(
+                items = listOf(
+                    R.string.settings_future_notifications to stringResource(R.string.settings_phase_5),
+                ),
+            )
+
+            SettingsSectionHeader(stringResource(R.string.settings_section_accessibility))
+            FutureSettingsCard(
+                items = listOf(
+                    R.string.settings_future_timezone to stringResource(R.string.settings_phase_future),
+                    R.string.settings_future_multilang to stringResource(R.string.settings_phase_future),
+                ),
+            )
+
+            SettingsSectionHeader(stringResource(R.string.settings_section_extensions))
+            FutureSettingsCard(
+                items = listOf(
+                    R.string.settings_future_extensions to issueTag(7),
+                ),
             )
         }
     }
@@ -216,6 +304,79 @@ internal fun SettingsContent(
             onConfirm = { onIntent(SettingsIntent.ClearTopicCacheConfirmed) },
             onDismiss = { onIntent(SettingsIntent.ClearTopicCacheDismissed) },
         )
+    }
+}
+
+/**
+ * #288 — a section header that structures the catalogue by area (Affichage, Drapeaux, …).
+ */
+@Composable
+private fun SettingsSectionHeader(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(top = 8.dp),
+    )
+}
+
+/**
+ * #288 — formats the tag pill for a planned setting backed by a GitHub issue (e.g. `#310`). The
+ * issue number is a technical identifier, but the `#` prefix still goes through a string resource to
+ * keep all displayed text localizable. Phase words ("À venir", "Phase 5", …) are passed directly.
+ */
+@Composable
+private fun issueTag(number: Int): String = stringResource(R.string.settings_future_issue_tag, number)
+
+/**
+ * #288 — a card grouping planned (not-yet-shipped) settings as non-interactive, greyed rows so the
+ * screen shows the full roadmap "for free". Each [items] entry pairs a title string-res with a tag
+ * (an issue reference via [issueTag], or a localized phase word resolved at the call site). Renders
+ * nothing for an empty list so callers never produce a stray empty card.
+ */
+@Composable
+private fun FutureSettingsCard(items: List<Pair<Int, String>>) {
+    if (items.isEmpty()) return
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            items.forEach { (titleRes, tag) ->
+                FutureSettingRow(title = stringResource(titleRes), tag = tag)
+            }
+        }
+    }
+}
+
+/**
+ * One planned setting: title in the muted `onSurfaceVariant` colour (the M3 idiom for "not active",
+ * preferred over a blanket `Modifier.alpha`) and a small tag pill. Non-interactive by design.
+ */
+@Composable
+private fun FutureSettingRow(title: String, tag: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f, fill = false),
+        )
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceContainerHighest,
+            shape = MaterialTheme.shapes.small,
+        ) {
+            Text(
+                text = tag,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+            )
+        }
     }
 }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -1,5 +1,43 @@
 <resources>
     <string name="settings_title">Paramètres</string>
+    <!-- #288 — « menu vitrine » : intro distinguant prefs locales vs compte HFR, sections par aire,
+         et catalogue des réglages futurs (grisés, avec tag d’issue ou de phase). -->
+    <string name="settings_intro">La plupart des réglages sont enregistrés sur cet appareil. Ceux du compte HFR (section dédiée) seront synchronisés depuis votre profil et arriveront plus tard. Les réglages à venir sont affichés en grisé avec leur étiquette.</string>
+    <string name="settings_section_network">Réseau et cache</string>
+    <string name="settings_section_display">Affichage</string>
+    <string name="settings_section_flags">Drapeaux</string>
+    <string name="settings_section_topic">Sujet et lecture</string>
+    <string name="settings_section_editing">Édition et publication</string>
+    <string name="settings_section_mp">Messages privés</string>
+    <string name="settings_section_hfr_account">Compte HFR</string>
+    <string name="settings_section_notifications">Notifications</string>
+    <string name="settings_section_accessibility">Accessibilité</string>
+    <string name="settings_section_extensions">Extensions et filtrage</string>
+    <string name="settings_hfr_account_note">Ces réglages proviennent de votre profil HFR (editprofil.php) et arriveront plus tard.</string>
+    <string name="settings_phase_future">À venir</string>
+    <string name="settings_phase_future_far">Plus tard</string>
+    <string name="settings_phase_planned">Planifié</string>
+    <string name="settings_phase_5">Phase 5</string>
+    <!-- Pastille de tag d'un réglage à venir rattaché à une issue GitHub (identifiant technique). -->
+    <string name="settings_future_issue_tag">#%1$d</string>
+    <string name="settings_future_reading_density">Densité et compacité de lecture</string>
+    <string name="settings_future_ui_colors">Personnalisation des couleurs</string>
+    <string name="settings_future_material_you">Material You (thème dynamique)</string>
+    <string name="settings_future_classic_theme">Thème HFR Classique</string>
+    <string name="settings_future_flags_on_listing">Poser les drapeaux en listant une catégorie</string>
+    <string name="settings_future_scroll_memory">Retenir la position de lecture par page</string>
+    <string name="settings_future_prefetch">Préchargement de la page suivante</string>
+    <string name="settings_future_submit_confirm">Confirmation avant publication</string>
+    <string name="settings_future_signature">Signature automatique et notification e-mail</string>
+    <string name="settings_future_mp_write">Écriture des messages privés</string>
+    <string name="settings_future_mp_notifications">Notifications et badge de MP non lus</string>
+    <string name="settings_future_data_saver">Mode économie de données</string>
+    <string name="settings_future_clear_image_cache">Vider le cache des images</string>
+    <string name="settings_future_hfr_profile">Avatars, signatures, messages par page</string>
+    <string name="settings_future_notifications">Relève configurable, filtres, mode Ne pas déranger</string>
+    <string name="settings_future_timezone">Fuseau horaire d’affichage</string>
+    <string name="settings_future_multilang">Multilingue</string>
+    <string name="settings_future_extensions">Blacklist, Color Tag, ignore-list, Qualitay, Redflag</string>
     <string name="settings_proxy_title">Proxy utilisateur</string>
     <string name="settings_proxy_intro">Route les requêtes HFR via votre proxy. Le changement peut nécessiter un redémarrage de l’app.</string>
     <string name="settings_proxy_enabled">Activer le proxy</string>


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

## Contexte

L'écran Réglages **existait déjà** et est fonctionnel (Proxy, Thème #286, Drapeaux #179/#309, Lecture des sujets, Maintenance) avec un MVI complet. #288 (umbrella) n'est donc pas « créer l'écran » mais réaliser sa **vision « menu vitrine »** : montrer le catalogue complet des réglages, les futurs **grisés** avec un tag de phase/issue, et **distinguer** les préférences locales (DataStore, livrées) des réglages du **compte HFR** (à venir).

## Changement

Purement présentation, **additif**, aucune modif MVI (State/Intent/ViewModel) :

- **Intro** distinguant prefs locales (DataStore) vs compte HFR (`editprofil.php`, à venir).
- **Sections par aire** (`SettingsSectionHeader`) : Réseau et cache, Affichage, Drapeaux, Sujet et lecture, Édition, Messages privés, Compte HFR, Notifications, Accessibilité, Extensions.
- **Catalogue des réglages à venir** (`FutureSettingsCard` / `FutureSettingRow`) : rows grisées non actionnables, chacune avec une pastille de tag — référence d'issue (`#NNN`, localisée via `settings_future_issue_tag`) ou mot de phase (« À venir », « Plus tard », « Planifié », « Phase 5 »).
- Pastille sur `surfaceContainerHighest` (idiome M3, `surfaceVariant` étant soft-deprecated).
- `MaintenanceCard` regroupée sous « Réseau et cache ».

## Tests

Présentation statique → **aucun nouveau test unitaire** (rien de logique ajouté). Les cards livrées et leur câblage MVI sont inchangés.

## Validation locale

- `detektAll test testDebugUnitTest :app:assembleProdDebug` → BUILD SUCCESSFUL
- `lintDebug :app:lintProdDebug` → BUILD SUCCESSFUL

## Revue

Passe 4-flavor (reviewers Opus/agents, seuil 60) + revue finale indépendante : verdict PRÊT, findings corrigés (tag pill `surfaceContainerHighest`, tags d'issue localisés via format string, Notifications re-taguées « Phase 5 » conformément à la roadmap, garde-fou liste vide sur `FutureSettingsCard`).

Closes #288
