### PR TITLE
feat(messages): répondre à une conversation privée (écriture MP) (#301)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -67,6 +67,8 @@ import fr.forumhfr.redface2.feature.forum.CategoryRequest
 import fr.forumhfr.redface2.feature.forum.ForumCategoryScreen
 import fr.forumhfr.redface2.feature.forum.ForumScreen
 import fr.forumhfr.redface2.feature.messages.MessagesScreen
+import fr.forumhfr.redface2.feature.messages.PrivateMessageReplyRequest
+import fr.forumhfr.redface2.feature.messages.PrivateMessageReplyScreen
 import fr.forumhfr.redface2.feature.messages.PrivateMessageThreadRequest
 import fr.forumhfr.redface2.feature.messages.PrivateMessageThreadScreen
 import fr.forumhfr.redface2.feature.profile.ProfilePreviewSheet
@@ -98,7 +100,29 @@ data object MessagesRoute : RedfaceNavKey
 data class PrivateMessageThreadRoute(
     val threadId: Int,
     val page: Int = 1,
+    /**
+     * #301 — bumped to `System.currentTimeMillis()` by the navigation host when the private-message
+     * reply editor pops back after a successful send. The new value invalidates the route key so a
+     * fresh [PrivateMessageThreadViewModel] is created and re-fetches the conversation (there is no MP
+     * cache, so a new entry always hits the network) — without it, returning to the retained entry
+     * would show the conversation as it was before the reply. `null` on every normal nav path.
+     */
+    val submitSignal: Long? = null,
 ) : RedfaceNavKey
+
+@Serializable
+data class PrivateMessageReplyRoute(
+    val threadId: Int,
+    val page: Int = 1,
+) : RedfaceNavKey
+
+/**
+ * Full-screen editor routes hide the navigation suite so their IME-pinned submit bar sits at the
+ * window bottom (and to avoid dropping the draft on a tab switch). Extracted from `RedfaceApp` to
+ * keep its cyclomatic complexity in check.
+ */
+private fun NavKey?.hidesNavigationSuite(): Boolean =
+    this is PostEditorRoute || this is TopicFormRoute || this is PrivateMessageReplyRoute
 
 @Serializable
 data class CategoryRoute(
@@ -409,7 +433,7 @@ fun RedfaceApp(intent: Intent?) {
         // routes makes the editor full-screen: its submit bar then sits at the window bottom and the IME
         // inset lands exactly on the keyboard. Bonus UX: no tab switching mid-compose (would drop the draft).
         val topRoute = backStacks.getValue(currentDestination).lastOrNull()
-        val navLayoutType = if (topRoute is PostEditorRoute || topRoute is TopicFormRoute) {
+        val navLayoutType = if (topRoute.hidesNavigationSuite()) {
             NavigationSuiteType.None
         } else {
             NavigationSuiteScaffoldDefaults.calculateFromAdaptiveInfo(currentWindowAdaptiveInfo())
@@ -757,7 +781,41 @@ private fun RedfaceNavHost(
                             backStack.removeAt(backStack.lastIndex)
                         }
                     },
+                    onReply = { threadId, page ->
+                        backStack.add(PrivateMessageReplyRoute(threadId = threadId, page = page))
+                    },
                     topBarActions = accountMenu,
+                )
+            }
+            entry<PrivateMessageReplyRoute> { route ->
+                PrivateMessageReplyScreen(
+                    request = PrivateMessageReplyRequest(
+                        threadId = route.threadId,
+                        page = route.page,
+                    ),
+                    onSubmitSucceeded = { threadId, page ->
+                        // Pop the editor, then replace the conversation entry with a fresh key
+                        // (bumped submitSignal) so the thread re-fetches and shows the sent message.
+                        // Mirrors PostEditorRoute.onSubmitSucceeded. Never collapse below the tab root.
+                        if (backStack.size > 1) {
+                            backStack.removeAt(backStack.lastIndex)
+                        }
+                        val threadEntry = backStack.lastOrNull() as? PrivateMessageThreadRoute
+                        if (threadEntry != null) {
+                            backStack.removeAt(backStack.lastIndex)
+                            backStack.add(
+                                threadEntry.copy(
+                                    page = page,
+                                    submitSignal = System.currentTimeMillis(),
+                                ),
+                            )
+                        }
+                    },
+                    onBack = {
+                        if (backStack.size > 1) {
+                            backStack.removeAt(backStack.lastIndex)
+                        }
+                    },
                 )
             }
             entry<SettingsRoute> {

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultPrivateMessageWriteRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultPrivateMessageWriteRepository.kt
@@ -1,0 +1,205 @@
+package fr.forumhfr.redface2.core.data.write
+
+import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
+import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
+import fr.forumhfr.redface2.core.domain.write.PrivateMessageWriteRepository
+import fr.forumhfr.redface2.core.model.write.PrivateMessageReplyContext
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
+import fr.forumhfr.redface2.core.model.write.ReplyForm
+import fr.forumhfr.redface2.core.model.write.ReplyFormOptions
+import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
+import fr.forumhfr.redface2.core.network.HfrClient
+import fr.forumhfr.redface2.core.network.HfrConstants
+import fr.forumhfr.redface2.core.parser.write.ReplyFormParser
+import fr.forumhfr.redface2.core.parser.write.ReplySubmitResponseParser
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import okhttp3.FormBody
+
+/**
+ * Default [PrivateMessageWriteRepository] implementation (#301). Replies to an HFR private
+ * conversation reuse the topic-reply machinery:
+ *
+ * 1. GET the conversation page (`forum2.php?cat=prive&post={threadId}&page={page}`) — HFR embeds a
+ *    `bddpost.php` reply form there (verified on the real fixture `private_message_thread.html`) —
+ *    and parse it with the shared [ReplyFormParser] to grab a fresh `hash_check` + every hidden field.
+ * 2. POST `bddpost.php` (the same endpoint a topic reply uses) and classify the response with the
+ *    shared [ReplySubmitResponseParser].
+ *
+ * The crucial difference from [DefaultReplyRepository] is the POST body: a private conversation
+ * carries `cat=prive` (a String), `post={threadId}`, `subcat=0` and a server-prefilled `numrep`
+ * (the last post of the current page — **not** a quote reference) inside the form's hidden fields.
+ * [buildFormBody] therefore overrides only the three fields HFR validates (`hash_check`,
+ * `verifrequet`, `content_form`) plus the opt-in option toggles, and forwards everything else
+ * verbatim — it must never re-assert `cat`/`subcat`/`post`/`numrep` from a typed context, or it would
+ * turn `cat=prive` into a number and blank the conversation's `numrep`.
+ */
+@Singleton
+class DefaultPrivateMessageWriteRepository @Inject constructor(
+    private val hfrClient: HfrClient,
+    private val replyFormParser: ReplyFormParser,
+    private val replySubmitResponseParser: ReplySubmitResponseParser,
+    private val diagnostics: DiagnosticsLog,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) : PrivateMessageWriteRepository {
+
+    override suspend fun fetchReplyForm(context: PrivateMessageReplyContext): ReplyForm {
+        diagnostics.record(
+            DiagnosticsLog.Level.INFO,
+            LOG_TAG,
+            "GET MP reply form post=${context.threadId} page=${context.page}",
+        )
+        return try {
+            withContext(ioDispatcher) {
+                // The conversation page already embeds the bddpost.php reply form; no dedicated
+                // message.php GET is needed (and there is no anonymous variant — a session-expired
+                // GET surfaces SessionExpiredException via the authenticated client).
+                val html = hfrClient.getPrivateMessageThreadPage(
+                    threadId = context.threadId,
+                    page = context.page,
+                )
+                replyFormParser.parse(html).fold(
+                    onSuccess = { form ->
+                        diagnostics.record(
+                            DiagnosticsLog.Level.DEBUG,
+                            LOG_TAG,
+                            "MP reply form parsed: hiddenFields=${form.hiddenFields.size} " +
+                                "anonymous=${form.isAnonymous}",
+                        )
+                        form
+                    },
+                    onFailure = { error ->
+                        // No raw HTML excerpt is logged here, unlike DefaultReplyRepository: a private
+                        // conversation page can embed the correspondent's pseudo / the private URL
+                        // (#316), so we only record the failure class — never a body snapshot.
+                        diagnostics.record(
+                            DiagnosticsLog.Level.WARN,
+                            LOG_TAG,
+                            "MP reply form parse FAILED: ${error.message ?: error::class.simpleName}",
+                        )
+                        throw error
+                    },
+                )
+            }
+        } catch (cancel: CancellationException) {
+            throw cancel
+        } catch (error: SessionExpiredException) {
+            diagnostics.record(DiagnosticsLog.Level.WARN, LOG_TAG, "GET MP reply form SessionExpired")
+            throw error
+        } catch (@Suppress("TooGenericExceptionCaught") error: Throwable) {
+            diagnostics.record(
+                DiagnosticsLog.Level.WARN,
+                LOG_TAG,
+                "GET MP reply form FAILED: ${error::class.simpleName}",
+            )
+            throw error
+        }
+    }
+
+    override suspend fun submitReply(
+        context: PrivateMessageReplyContext,
+        form: ReplyForm,
+        bbcodeContent: String,
+        options: ReplyFormOptions,
+    ): ReplySubmitResult {
+        guardAgainstInvalidSubmission(form, bbcodeContent)?.let { early ->
+            diagnostics.record(
+                DiagnosticsLog.Level.WARN,
+                LOG_TAG,
+                "MP POST short-circuited: ${early.reason::class.simpleName}",
+            )
+            return early
+        }
+
+        diagnostics.record(
+            DiagnosticsLog.Level.INFO,
+            LOG_TAG,
+            "POST MP reply post=${context.threadId} page=${context.page} bbcode.length=${bbcodeContent.length}",
+        )
+        val formBody = buildFormBody(form, bbcodeContent, options)
+        return try {
+            withContext(ioDispatcher) {
+                // Same endpoint as a topic reply: bddpost.php?config=hfr.inc. All MP routing
+                // (cat=prive, post=threadId, numrep, subcat) travels in the form body.
+                val responseHtml = hfrClient.submitReply(formBody)
+                val outcome = replySubmitResponseParser.parse(responseHtml)
+                when (outcome) {
+                    is ReplySubmitResult.Success ->
+                        diagnostics.record(DiagnosticsLog.Level.INFO, LOG_TAG, "POST MP reply Success")
+                    is ReplySubmitResult.Failure ->
+                        diagnostics.record(
+                            DiagnosticsLog.Level.WARN,
+                            LOG_TAG,
+                            "POST MP reply Failure reason=${outcome.reason::class.simpleName}",
+                        )
+                }
+                outcome
+            }
+        } catch (cancel: CancellationException) {
+            throw cancel
+        } catch (error: SessionExpiredException) {
+            diagnostics.record(DiagnosticsLog.Level.WARN, LOG_TAG, "POST MP reply SessionExpired")
+            throw error
+        } catch (@Suppress("TooGenericExceptionCaught") error: Throwable) {
+            diagnostics.record(
+                DiagnosticsLog.Level.WARN,
+                LOG_TAG,
+                "POST MP reply FAILED: ${error::class.simpleName}",
+            )
+            throw error
+        }
+    }
+
+    private fun guardAgainstInvalidSubmission(
+        form: ReplyForm,
+        bbcodeContent: String,
+    ): ReplySubmitResult.Failure? = when {
+        form.isAnonymous -> ReplySubmitResult.Failure(ReplyFailureReason.LoginRequired)
+        form.hashCheck.isBlank() -> ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)
+        bbcodeContent.isBlank() -> ReplySubmitResult.Failure(ReplyFailureReason.EmptyMessage)
+        else -> null
+    }
+
+    /**
+     * Assembles the private-message POST payload. Only [hash_check][HfrConstants], `verifrequet` and
+     * `content_form` are overridden, plus the three opt-in option fields (`signature` / `smiley` /
+     * `emaill`). **Everything else is forwarded verbatim from [ReplyForm.hiddenFields]** — chiefly
+     * `cat=prive`, `post` (=threadId), `numrep` (the conversation's last-post id HFR prefilled, kept
+     * as-is — it is NOT a quote reference), `subcat=0`, `page`, `sujet`, `pseudo`. `password` is never
+     * relayed. This deliberately does not reuse [DefaultReplyRepository.buildFormBody], whose typed
+     * `cat`/`numrep` overrides would corrupt the private-message contract.
+     */
+    private fun buildFormBody(
+        form: ReplyForm,
+        bbcodeContent: String,
+        options: ReplyFormOptions,
+    ): FormBody {
+        val builder = FormBody.Builder(Charsets.UTF_8)
+        builder.add("hash_check", form.hashCheck)
+        builder.add("verifrequet", HfrConstants.VERIF_REQUET)
+        builder.add("content_form", bbcodeContent)
+        // Browser-style opt-in: a field is only present when the user enabled it (`emaill` keeps
+        // HFR's own two-`l` spelling). The matching keys are marked emitted so the verbatim
+        // forwarder below cannot resurrect a stale `value="1"` default from the parsed checkbox.
+        if (options.signatureEnabled) builder.add("signature", "1")
+        if (options.smileyDisabled) builder.add("smiley", "1")
+        if (options.emailNotificationEnabled) builder.add("emaill", "1")
+        val emitted = mutableSetOf("hash_check", "verifrequet", "content_form", "signature", "smiley", "emaill")
+        form.hiddenFields.forEach { (key, value) ->
+            if (key in emitted) return@forEach
+            // Belt-and-braces: ReplyFormParser already drops `password`, never relay it.
+            if (key == "password") return@forEach
+            builder.add(key, value)
+            emitted += key
+        }
+        return builder.build()
+    }
+
+    private companion object {
+        private const val LOG_TAG = "MpWriteRepository"
+    }
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/ReplyRepositoryModule.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/ReplyRepositoryModule.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import fr.forumhfr.redface2.core.domain.write.DeletePostRepository
 import fr.forumhfr.redface2.core.domain.write.EditPostRepository
+import fr.forumhfr.redface2.core.domain.write.PrivateMessageWriteRepository
 import fr.forumhfr.redface2.core.domain.write.ReplyRepository
 import fr.forumhfr.redface2.core.domain.write.TopicFormRepository
 import fr.forumhfr.redface2.core.parser.write.ReplyFormParser
@@ -40,6 +41,12 @@ abstract class ReplyRepositoryModule {
     @Binds
     @Singleton
     abstract fun bindTopicFormRepository(impl: DefaultTopicFormRepository): TopicFormRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindPrivateMessageWriteRepository(
+        impl: DefaultPrivateMessageWriteRepository,
+    ): PrivateMessageWriteRepository
 
     companion object {
         @Provides

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/write/DefaultPrivateMessageWriteRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/write/DefaultPrivateMessageWriteRepositoryTest.kt
@@ -1,0 +1,212 @@
+package fr.forumhfr.redface2.core.data.write
+
+import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
+import fr.forumhfr.redface2.core.model.write.PrivateMessageReplyContext
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
+import fr.forumhfr.redface2.core.model.write.ReplyForm
+import fr.forumhfr.redface2.core.model.write.ReplyFormOptions
+import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
+import fr.forumhfr.redface2.core.network.HfrClient
+import fr.forumhfr.redface2.core.parser.write.ReplyFormParser
+import fr.forumhfr.redface2.core.parser.write.ReplySubmitResponseParser
+import java.net.URLDecoder
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * #301 — private-message reply repository. The decisive contract is the POST body shape: a private
+ * conversation carries `cat=prive` (String), `post={threadId}`, `subcat=0` and a server-prefilled
+ * `numrep` inside the form's hidden fields, and [DefaultPrivateMessageWriteRepository] must forward
+ * them verbatim — never re-asserting `cat`/`numrep` from a typed context the way the topic reply
+ * repository does. Tests use a real [HfrClient] over a [MockWebServer], mirroring
+ * `DefaultReplyRepositoryTest`.
+ */
+class DefaultPrivateMessageWriteRepositoryTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: HfrClient
+    private lateinit var repository: DefaultPrivateMessageWriteRepository
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().apply { start() }
+        val okHttp = OkHttpClient.Builder().build()
+        client = HfrClient(
+            authenticated = okHttp,
+            anonymous = okHttp,
+            baseUrl = server.url("/"),
+            ioDispatcher = Dispatchers.Unconfined,
+        )
+        repository = DefaultPrivateMessageWriteRepository(
+            hfrClient = client,
+            replyFormParser = ReplyFormParser(),
+            replySubmitResponseParser = ReplySubmitResponseParser(),
+            diagnostics = DiagnosticsLog(),
+            ioDispatcher = Dispatchers.Unconfined,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private val context = PrivateMessageReplyContext(threadId = 3195237, page = 1)
+
+    @Test
+    fun `fetchReplyForm GETs the conversation page on forum2_php with cat=prive`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("private_message_thread.html")))
+
+        val form = repository.fetchReplyForm(context)
+
+        assertFalse(form.isAnonymous)
+        assertEquals("prive", form.hiddenFields["cat"])
+
+        val url = requireNotNull(server.takeRequest().requestUrl)
+        assertEquals("forum2.php", url.pathSegments.first())
+        assertEquals("prive", url.queryParameter("cat"))
+        assertEquals("3195237", url.queryParameter("post"))
+        assertEquals("1", url.queryParameter("page"))
+    }
+
+    @Test
+    fun `submitReply forwards cat=prive, post, numrep, subcat verbatim and never overwrites them`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("private_message_thread.html")))
+        server.enqueue(MockResponse().setBody(fixture("write_reply_success_response.html")))
+
+        val form = repository.fetchReplyForm(context)
+        val result = repository.submitReply(context, form, bbcodeContent = "Coucou en privé.")
+
+        assertTrue("Expected success, got $result", result is ReplySubmitResult.Success)
+
+        server.takeRequest() // drop the GET
+        val recorded = server.takeRequest()
+        assertEquals("POST", recorded.method)
+        assertEquals("bddpost.php", requireNotNull(recorded.requestUrl).pathSegments.first())
+
+        val body = parseFormBody(recorded.body.readUtf8())
+        // The three private-message contract fields, carried verbatim from the form.
+        assertEquals("prive", body["cat"])
+        assertEquals("3195237", body["post"])
+        // numrep is the conversation's prefilled last-post id — must NOT be blanked (the topic
+        // repository would set it to "" for a simple reply; the MP repository must not).
+        assertEquals("1980677227", body["numrep"])
+        assertEquals("0", body["subcat"])
+        assertEquals("1", body["page"])
+        // The fields HFR validates, added by the repository.
+        assertEquals("0", body["hash_check"])
+        assertEquals("1100", body["verifrequet"])
+        assertEquals("Coucou en privé.", body["content_form"])
+        // password must never reach HFR.
+        assertFalse("password must never be transmitted", body.containsKey("password"))
+    }
+
+    @Test
+    fun `submitReply adds signature only when the option is enabled`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("private_message_thread.html")))
+        server.enqueue(MockResponse().setBody(fixture("write_reply_success_response.html")))
+
+        val form = repository.fetchReplyForm(context)
+        repository.submitReply(
+            context,
+            form,
+            bbcodeContent = "Avec signature.",
+            options = ReplyFormOptions(signatureEnabled = true),
+        )
+
+        server.takeRequest()
+        val body = parseFormBody(server.takeRequest().body.readUtf8())
+        assertEquals("1", body["signature"])
+    }
+
+    @Test
+    fun `submitReply omits signature when the option is disabled`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("private_message_thread.html")))
+        server.enqueue(MockResponse().setBody(fixture("write_reply_success_response.html")))
+
+        val form = repository.fetchReplyForm(context)
+        // Default options = all off ; the form's hidden `signature=1` must not leak back as a
+        // browser would omit an unchecked field.
+        repository.submitReply(context, form, bbcodeContent = "Sans signature.")
+
+        server.takeRequest()
+        val body = parseFormBody(server.takeRequest().body.readUtf8())
+        assertFalse("signature must be omitted when disabled", body.containsKey("signature"))
+    }
+
+    @Test
+    fun `submitReply never relays a password hidden field`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("write_reply_success_response.html")))
+
+        val form = ReplyForm(
+            hashCheck = "h",
+            sujet = "s",
+            hiddenFields = mapOf("cat" to "prive", "post" to "3195237", "password" to "secret"),
+            isAnonymous = false,
+        )
+        repository.submitReply(context, form, bbcodeContent = "hi")
+
+        val body = parseFormBody(server.takeRequest().body.readUtf8())
+        assertFalse("password must never be transmitted", body.containsKey("password"))
+        assertEquals("prive", body["cat"])
+    }
+
+    @Test
+    fun `submitReply refuses a blank body without any network call`() = runTest {
+        val form = ReplyForm(hashCheck = "h", sujet = "s", hiddenFields = emptyMap(), isAnonymous = false)
+
+        val result = repository.submitReply(context, form, bbcodeContent = "   ")
+
+        assertEquals(ReplySubmitResult.Failure(ReplyFailureReason.EmptyMessage), result)
+        assertEquals("no POST should be sent for a blank body", 0, server.requestCount)
+    }
+
+    @Test
+    fun `submitReply refuses to POST an anonymous form`() = runTest {
+        val form = ReplyForm(hashCheck = "h", sujet = "s", hiddenFields = emptyMap(), isAnonymous = true)
+
+        val result = repository.submitReply(context, form, bbcodeContent = "hi")
+
+        assertEquals(ReplySubmitResult.Failure(ReplyFailureReason.LoginRequired), result)
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun `submitReply classifies the empty-message error response`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("write_empty_message_error.html")))
+
+        val form = ReplyForm(
+            hashCheck = "h",
+            sujet = "s",
+            hiddenFields = mapOf("cat" to "prive"),
+            isAnonymous = false,
+        )
+        val result = repository.submitReply(context, form, bbcodeContent = "non-blank content")
+
+        assertEquals(ReplySubmitResult.Failure(ReplyFailureReason.EmptyMessage), result)
+    }
+
+    private fun fixture(name: String): String {
+        val stream = requireNotNull(
+            DefaultPrivateMessageWriteRepositoryTest::class.java.classLoader?.getResourceAsStream("fixtures/$name"),
+        ) { "Fixture not found: fixtures/$name" }
+        return stream.bufferedReader().use { it.readText() }
+    }
+
+    private fun parseFormBody(body: String): Map<String, String> =
+        body.split('&')
+            .filter { it.isNotEmpty() }
+            .associate { pair ->
+                val (key, value) = pair.split('=', limit = 2).let { it[0] to (it.getOrNull(1) ?: "") }
+                URLDecoder.decode(key, "UTF-8") to URLDecoder.decode(value, "UTF-8")
+            }
+}

--- a/core/data/src/test/resources/fixtures/private_message_thread.html
+++ b/core/data/src/test/resources/fixtures/private_message_thread.html
@@ -1,0 +1,210 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr" lang="fr"><head><title>Sujet prive de test - Messages privés - FORUM HardWare.fr</title><link type="text/css" rel="stylesheet" href="/include/the_style1.php?color_key=f2f3ef/DEDFDF/000080/C2C3F4/d5e6e1/000080/000080/000000/000080/000000/000080/f7f7f7/f0eee9/f7f7f7/f0eee9/C0C0C0/C0C0C0/FFFFFF/000000/000000/0000FF/EEEEFF/DDDDEE/000000/FFEEEE/000000/FFFFFF/FF0000/FFFFFF/0/1/https%3A%40%40forum-images.hardware.fr/NULL/&amp;abs_img_path=%40data%40sites%40forum%40www%40static%40&amp;hide_bg_onglet=0&amp;v=11102781422" /><link type="text/css" rel="stylesheet" href="https://forum-images.hardware.fr/compressed/the_style.css?v=11102781422" /><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/tabs.js?v=11102781422"></script><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/forum2.js?v=11102781422"></script><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/common.js?v=11102781422"></script><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /><meta name="Robots" content="noindex, follow" /><meta name="Description" content="" /><style type="text/css">
+<!--
+.fastsearchMain{ width: 330px; }
+.fastsearchInput{ width: 70px; border: 1px solid black; }
+.fastsearchSubmit{ background-color: ; border: 0px;}
+.header2 { background-image: url(/img/forum3_1.gif);background-repeat: repeat-x; }
+.menuExt { font-family: Arial, Helvetica, sans-serif; font-size: 10px; color:#000; }
+.menuExt a { color:#000;text-decoration:none; }
+.menuExt a:hover { color:#000;text-decoration:underline; }
+form { display: inline; }
+.header { background-image: url(//forum-images.hardware.fr/img/header-bg.gif); background-repeat: repeat-x; }
+.tdmenu { width: 1px;height: 1px;color: #000000; }
+.hfrheadmenu { font-family: Arial, Helvetica, sans-serif;font-size:13px;font-weight:bold; }
+.hfrheadmenu span {color:;}
+.hfrheadmenu a { color:;text-decoration: none; }
+.hfrheadmenu a:hover { color:;text-decoration: underline; }
+.concours { font-family: Arial, Helvetica, sans-serif;color:;font-size: 16px;text-decoration: none;font-weight: bold;}
+.concours:hover { font-family: Arial, Helvetica, sans-serif;color:;font-size: 16px;text-decoration: underline;font-weight: bold; }
+.searchmenu { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: none;font-weight: bold; }
+.fastsearch { display: none; }
+.fastsearchHeader { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: none;font-weight: bold; }
+.fastsearchHeader:hover { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: underline;font-weight: bold; }
+-->
+</style>
+<script async='async' src='https://www.googletagservices.com/tag/js/gpt.js'></script>
+<script>
+  var googletag = googletag || {};
+  googletag.cmd = googletag.cmd || [];
+</script>
+
+<script>
+  googletag.cmd.push(function() {
+    googletag.defineSlot('/2172442/forum_accueil_banniere', [728, 90], 'div-gpt-ad-1511901001563-0').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_achats_ventes_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-1').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_achats_ventes_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-2').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_achats_ventes_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-3').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_achats_ventes_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-4').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_apple_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-5').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_apple_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-6').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_apple_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-7').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_apple_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-8').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_banniere_jpdc', [728, 90], 'div-gpt-ad-1511901001563-9').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-10').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-11').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-12').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-13').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_emploi_etude_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-14').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_emploi_etude_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-15').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_emploi_etude_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-16').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_emploi_etude_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-17').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_graphisme_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-18').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_graphisme_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-19').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_graphisme_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-20').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_graphisme_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-21').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_banniere', [728, 90], 'div-gpt-ad-1511901001563-22').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-23').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-24').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-25').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-26').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_peripheriques_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-27').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_peripheriques_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-28').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_peripheriques_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-29').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_peripheriques_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-30').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_jeux_video_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-31').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_jeux_video_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-32').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_jeux_video_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-33').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_jeux_video_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-34').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_ordinateurs_portables_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-35').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_ordinateurs_portables_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-36').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_ordinateurs_portables_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-37').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_ordinateurs_portables_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-38').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_os_alternatif_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-39').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_os_alternatif_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-40').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_os_alternatif_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-41').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_os_alternatif_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-42').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_overclocking_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-43').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_overclocking_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-44').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_overclocking_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-45').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_overclocking_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-46').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_photo_numerique_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-47').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_photo_numerique_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-48').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_photo_numerique_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-49').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_photo_numerique_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-50').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_programmation_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-51').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_programmation_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-52').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_programmation_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-53').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_programmation_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-54').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_reseaux_grand_public_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-55').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_reseaux_grand_public_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-56').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_reseaux_grand_public_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-57').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_reseaux_grand_public_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-58').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_seti_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-59').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_seti_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-60').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_seti_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-61').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_seti_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-62').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_systemes_reseaux_pro_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-63').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_systemes_reseaux_pro_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-64').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_systemes_reseaux_pro_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-65').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_systemes_reseaux_pro_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-66').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_technologies_mobiles_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-67').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_technologies_mobiles_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-68').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_technologies_mobiles_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-69').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_technologies_mobiles_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-70').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_video_son_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-71').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_video_son_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-72').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_video_son_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-73').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_video_son_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-74').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_windows_software_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-75').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_windows_software_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-76').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_windows_software_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-77').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_windows_software_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-78').addService(googletag.pubads());
+    googletag.pubads().enableSingleRequest();
+    googletag.enableServices();
+  });
+</script>
+<script type='text/javascript'>
+     (function(){
+       var loc = window.location.href;
+       var dd = document.createElement('script');
+       dd.type = 'text/javascript'; dd.src = '//static.digidip.net/hardware.js?loc=' + loc;
+       var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(dd, s);
+     })();
+</script></head><body id="unique__inside_topics__private_thread"  > <table cellspacing="0" cellpadding="0" width="98%" bgcolor="#000000" border="0" align="center" class="hfrheadmenu" style="border:1px solid #000;border-top:0;">
+        <tr>
+          <td style="vertical-align: top">
+            <table cellspacing="0" cellpadding="0" width="100%" border="0">
+              <tr>
+                <td style="width: 100%" align="left" valign="middle" colspan="2" class="header2"><span class="md_cryptlink45CBCBC0C22D1F1FCCCCCC19454AC14BCC4AC1431944C1"><img src="/img/forum_logo.gif" width="900" height="71" border="0" alt="" /></span></td>
+              </tr>
+              <tr>
+                <td style="background-color:#d5e6e1">
+                  <table cellspacing="0" cellpadding="2" width="100%" border="0">
+                    <tr>
+                      <td>&nbsp;<a class="cHeader" href="/">Forum</a>&nbsp;|&nbsp;
+<a class="cHeader" href="https://www.hardware.fr/">HardWare.fr</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/html/news/">News</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/html/articles/">Articles</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/articles/786-1/guide-pc-hardware-fr.html">PC</a>&nbsp;|&nbsp;<span class="md_cryptlink1FC349484F4C19C045C02F424F4944464C2E454AC14BCC4AC14344C11946494214424F4B434543C52E2341434A21264B2A4A424B422625422B252122212C44204321442C2C2A2A2142">Se d&eacute;connecter</span>&nbsp;|&nbsp;<span class="md_cryptlink1FC3C243C11F434B46CBC0C14F44464819C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">Profil</span>&nbsp;|&nbsp;<a class="cHeader" href="https://shop.hardware.fr/" target="_blank" style="position: relative; padding: 0 21px 0 0;display: inline-block;">Shop <img src="/img/shop.png" style="height: 17px; display: inline; position: absolute; right: 0; top: -2px; "></a></td>
+<td align="right"><a class="cHeader" href="/search.php?config=hardwarefr.inc&cat=prive&subcat=0">Recherche <img src="//forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif"></a></td>
+                    </tr>
+                    </table></td></tr></table>
+</td></tr></table><div style="width: 99%" align="right">
+<span class="s2Ext menuExt"><span class="md_cryptlink1F4F494846494319C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">11334 connect&eacute;s&nbsp;</span></span></div><br /><script language="javascript" type="text/javascript">
+			<!--
+			writeCookie('md_users_res');
+			//-->
+			</script><div class="container"><div class="mesdiscussions" id="mesdiscussions"><div class="arbo" id="md_arbo_top">
+<span  id="md_arbo_tree_1" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/" class="Ext">FORUM HardWare.fr</a></span>
+<br />
+<span  id="md_arbo_tree_2" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/forum1.php?config=hfr.inc&amp;cat=prive&amp;page=1&amp;subcat=&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;moderation=0&amp;new=0&amp;nojs=0&amp;subcatgroup=0" class="Ext">Messages&nbsp;privés</a></span>
+<br />
+<h1  id="md_arbo_tree_3" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline3.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;Sujet prive de test</h1>
+</div><div class="rightbutton fastsearch"><table class="main fastsearchMain" cellspacing="0" cellpadding="2"><tr class="cBackHeader fondForumDescription"><th><form method="post" id="fastsearch" action="/forum1.php"><input type="hidden" name="hash_check" value="0" /><label for="fastsearchinputid"><a rel="nofollow" href="/search.php?config=hfr.inc&amp;cat=prive&amp;subcat=0" class="cHeader fastsearchHeader">Recherche :</a>&nbsp;<input type="text" name="search" id="fastsearchinputid" value="" class="fastsearchInput" alt="Search string" /></label><input type="hidden" name="recherches" value="1" /><input type="hidden" name="searchtype" value="1" /><input type="hidden" name="titre" value="3" /><input type="hidden" name="resSearch" value="200" /><input type="hidden" name="orderSearch" value="1" /><input type="hidden" name="config" value="hfr.inc" /><input type="hidden" name="cat" value="prive" />&nbsp;<input type="image" src="https://forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif" class="fastsearchSubmit" title="Lancer une recherche" alt="Lancer une recherche" /></form></th></tr></table></div><div class="spacer">&nbsp;</div><br /><div class="s1Ext"></div><table class="none" style="border:0px" cellspacing="0" cellpadding="0"><tr><td style="vertical-align:bottom"><div class="cadreonglet"><div class="beforongletsel" id="befor1" >&nbsp;</div><a href="/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=3195237&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=0&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0" class="ongletsel" id="onglet1" title="Filtres" rel="nofollow"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/global.gif" title="Filtres" alt="Filtres" /></a><div class="afterongletsel" id="after1">&nbsp;</div><div class="beforonglet" id="befor2"  >&nbsp;</div><a href="/search.php?config=hfr.inc&amp;cat=prive&amp;subcat=0" class="onglet" id="onglet2" title="Rechercher" rel="nofollow"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif" title="Rechercher" alt="Search" /></a><div class="afteronglet" id="after2">&nbsp;</div></div></td><td style="vertical-align:bottom"></td></tr></table><a name="haut"></a><table class="main" cellspacing="0" cellpadding="4"><tr class="cBackHeader fondForum2Fonctions"><th class="padding" colspan="2"><form action="/transsearch.php" method="post"><input type="hidden" name="hash_check" value="0" /><input type="hidden" name="post"	value="3195237" /><input type="hidden" name="cat"	value="prive" /><input type="hidden" name="config"	value="hfr.inc" /><input type="hidden" name="p"		value="1" /><input type="hidden" name="sondage"	value="0" /><input type="hidden" name="owntopic" value="0" /><div class="left">&nbsp;Mot : <input type="text" name="word" value="" size="10" id="md_search_word" /><input class="checkbox" type="checkbox" name="filter" id="filter" value="1"  /><label for="filter" title="N'afficher que les messages correspondant à la recherche">Filtrer</label>&nbsp;<input type="submit" onclick="document.getElementById('currentnum').value=''; return true;" value="Rechercher" class="boutton" /><input type="hidden" name="dep" value="0" /><input type="hidden" value="1980664234" name="firstnum" /></div></form><div class="right" style="margin-top:2px"><a href="javascript:void(0)" onclick="vider_liste('quoteshardwarefr-prive-3195237')" class="cHeader"><img style="display:none" id="viderliste" src="https://forum-images.hardware.fr/themes_static/images_forum/1/viderliste.gif" alt="Vider la liste des messages à citer" title="Vider la liste des messages à citer" /></a>&nbsp;&nbsp;<a href="/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=3195237&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=1&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0" class="cHeader" target="_blank"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/print.gif" alt="Afficher le sujet en intégralité" title="Afficher le sujet en intégralité" /></a>&nbsp;&nbsp;<a href="/user/email.php?config=hfr.inc&amp;cat=prive&amp;subcat=0&amp;post=3195237&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;new=0" class="cHeader"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/subscribe.gif" alt="Activer la notification par email du sujet" title="Activer la notification par email du sujet" /></a>&nbsp;&nbsp;<a href="/user/nonlu.php?config=hfr.inc&amp;cat=prive&amp;subcat=0&amp;post=3195237&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;new=0" class="cHeader"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/oeil.gif" alt="Marquer le message comme non lu" title="Marquer le message comme non lu" /></a> &nbsp;</div></th></tr><tr class="cBackHeader fondForum2PagesHaut"><th class="padding" colspan="2"><a href="#bas" class="cHeader">Bas de page</a></th></tr><tr class="cBackHeader fondForum2Title"><th scope="col" class="messCase1" width="180">Auteur</th><th scope="col" class="padding">&nbsp;Sujet : <h3>Sujet prive de test</h3></th></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message cBackCouleurTab2"><td class="messCase1" width="180" valign="top" rowspan="1"><a name="t1980664234"></a><div class="right"><a href="#t1980664234" rel="nofollow"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" title="n°1980664234" alt="n°1980664234" /></a></div><div><b class="s2">TestUser</b></div><div class="avatar_center" style="clear:both"><img src="https://forum-images.hardware.fr/images/mesdiscussions-990002.png" alt="" /></div></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 24-05-2026&nbsp;à&nbsp;14:29:15&nbsp;&nbsp;<a href="/hfr/profil-990002.htm" target="_blank" rel="nofollow"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil (Etat inconnu)" alt="profil" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2EC0C146C44314C04FC2CB2E222A262321222C1449C34EC143C04F49C2432E2A26252024242B21222B14C04A4C432E2A14C02E2A14C2C341424ACB2E2014C24F494B4A4C432E20144FCC49CB4FC046422E2012444FC14EC3484A46C143"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/edit.gif" title="Editer le message" alt="edit" /></span><a rel="nofollow" href="/message.php?config=hfr.inc&amp;cat=prive&amp;post=3195237&amp;numreponse=1980664234&amp;page=1&amp;p=1&amp;subcat=0&amp;sondage=0&amp;owntopic=0#formulaire" onclick="edit_in('hfr.inc','prive',3195237,1980664234,''); return false"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/edit-in.gif" title="Edition rapide" alt="Edition rapide" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2EC0C146C44314C04FC2CB2E222A262321222C1449C34EC143C02E2A26252024242B21222B14C143442E2A14C04A4C432E2A14C02E2A14C2C341424ACB2E2014C24F494B4A4C432E20144FCC49CB4FC046422E20144943CC2E2012444FC14EC3484A46C143"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></span><a rel="nofollow" onclick="quoter('hardwarefr','prive',3195237,1980664234); return false;" href="/message.php?config=hfr.inc&amp;cat=prive&amp;post=3195237&amp;numrep=1980664234&amp;ref=1&amp;page=1&amp;p=1&amp;subcat=0&amp;sondage=0&amp;owntopic=0&amp;new=0#formulaire"><img id="plus1980664234" src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote+.gif" title="Ajouter à la liste des messages cités" alt="answer +" /><img id="moins1980664234" style="display:none" src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote-.gif" title="Retirer de la liste des messages cités" alt="answer -" /></a><a href="/configuration.php?config=hfr.inc&amp;pseudo=TestUser" target="_blank"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/config.gif" title="Configuration matérielle" alt="config" /></a></div><div class="spacer">&nbsp;</div></div><div id="para1980664234">Message prive de test (contenu remplace).</div></td></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message cBackCouleurTab1"><td class="messCase1" width="180" valign="top" rowspan="1"><a name="t1980664235"></a><div class="right"><a href="#t1980664235" rel="nofollow"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" title="n°1980664235" alt="n°1980664235" /></a></div><div><b class="s2">TestUser</b></div><div class="avatar_center" style="clear:both"><img src="https://forum-images.hardware.fr/images/mesdiscussions-990002.png" alt="" /></div></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 24-05-2026&nbsp;à&nbsp;14:29:58&nbsp;&nbsp;<a href="/hfr/profil-990002.htm" target="_blank" rel="nofollow"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil (Etat inconnu)" alt="profil" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2EC0C146C44314C04FC2CB2E222A262321222C1449C34EC143C04F49C2432E2A26252024242B21222314C04A4C432E2A14C02E2A14C2C341424ACB2E2014C24F494B4A4C432E20144FCC49CB4FC046422E2012444FC14EC3484A46C143"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/edit.gif" title="Editer le message" alt="edit" /></span><a rel="nofollow" href="/message.php?config=hfr.inc&amp;cat=prive&amp;post=3195237&amp;numreponse=1980664235&amp;page=1&amp;p=1&amp;subcat=0&amp;sondage=0&amp;owntopic=0#formulaire" onclick="edit_in('hfr.inc','prive',3195237,1980664235,''); return false"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/edit-in.gif" title="Edition rapide" alt="Edition rapide" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2EC0C146C44314C04FC2CB2E222A262321222C1449C34EC143C02E2A26252024242B21222314C143442E2114C04A4C432E2A14C02E2A14C2C341424ACB2E2014C24F494B4A4C432E20144FCC49CB4FC046422E20144943CC2E2012444FC14EC3484A46C143"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></span><a rel="nofollow" onclick="quoter('hardwarefr','prive',3195237,1980664235); return false;" href="/message.php?config=hfr.inc&amp;cat=prive&amp;post=3195237&amp;numrep=1980664235&amp;ref=2&amp;page=1&amp;p=1&amp;subcat=0&amp;sondage=0&amp;owntopic=0&amp;new=0#formulaire"><img id="plus1980664235" src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote+.gif" title="Ajouter à la liste des messages cités" alt="answer +" /><img id="moins1980664235" style="display:none" src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote-.gif" title="Retirer de la liste des messages cités" alt="answer -" /></a><a href="/configuration.php?config=hfr.inc&amp;pseudo=TestUser" target="_blank"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/config.gif" title="Configuration matérielle" alt="config" /></a></div><div class="spacer">&nbsp;</div></div><div id="para1980664235">Message prive de test (contenu remplace).</div></td></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message cBackCouleurTab2"><td class="messCase1" width="180" valign="top" rowspan="1"><a name="t1980677218"></a><div class="right"><a href="#t1980677218" rel="nofollow"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" title="n°1980677218" alt="n°1980677218" /></a></div><div><b class="s2">TestUser</b></div><div class="avatar_center" style="clear:both"><img src="https://forum-images.hardware.fr/images/mesdiscussions-990002.png" alt="" /></div></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 03-06-2026&nbsp;à&nbsp;18:55:48&nbsp;&nbsp;<a href="/hfr/profil-990002.htm" target="_blank" rel="nofollow"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil (Etat inconnu)" alt="profil" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2EC0C146C44314C04FC2CB2E222A262321222C1449C34EC143C04F49C2432E2A262520242C2C212A2514C04A4C432E2A14C02E2A14C2C341424ACB2E2014C24F494B4A4C432E20144FCC49CB4FC046422E2012444FC14EC3484A46C143"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/edit.gif" title="Editer le message" alt="edit" /></span><a rel="nofollow" href="/message.php?config=hfr.inc&amp;cat=prive&amp;post=3195237&amp;numreponse=1980677218&amp;page=1&amp;p=1&amp;subcat=0&amp;sondage=0&amp;owntopic=0#formulaire" onclick="edit_in('hfr.inc','prive',3195237,1980677218,''); return false"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/edit-in.gif" title="Edition rapide" alt="Edition rapide" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2EC0C146C44314C04FC2CB2E222A262321222C1449C34EC143C02E2A262520242C2C212A2514C143442E2214C04A4C432E2A14C02E2A14C2C341424ACB2E2014C24F494B4A4C432E20144FCC49CB4FC046422E20144943CC2E2012444FC14EC3484A46C143"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></span><a rel="nofollow" onclick="quoter('hardwarefr','prive',3195237,1980677218); return false;" href="/message.php?config=hfr.inc&amp;cat=prive&amp;post=3195237&amp;numrep=1980677218&amp;ref=3&amp;page=1&amp;p=1&amp;subcat=0&amp;sondage=0&amp;owntopic=0&amp;new=0#formulaire"><img id="plus1980677218" src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote+.gif" title="Ajouter à la liste des messages cités" alt="answer +" /><img id="moins1980677218" style="display:none" src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote-.gif" title="Retirer de la liste des messages cités" alt="answer -" /></a><a href="/configuration.php?config=hfr.inc&amp;pseudo=TestUser" target="_blank"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/config.gif" title="Configuration matérielle" alt="config" /></a></div><div class="spacer">&nbsp;</div></div><div id="para1980677218">Message prive de test (contenu remplace).</div></td></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message cBackCouleurTab1"><td class="messCase1" width="180" valign="top" rowspan="1"><a name="t1980677227"></a><a name="bas"></a><div class="right"><a href="#t1980677227" rel="nofollow"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" title="n°1980677227" alt="n°1980677227" /></a></div><div><b class="s2">Correspondant</b></div><div class="avatar_center" style="clear:both"><img src="https://forum-images.hardware.fr/images/mesdiscussions-990001.jpg" alt="" /></div></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 03-06-2026&nbsp;à&nbsp;19:01:40&nbsp;&nbsp;<a href="/hfr/profil-990001.htm" target="_blank" rel="nofollow"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil (Etat inconnu)" alt="profil" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2EC0C146C44314C04FC2CB2E222A262321222C1449C34EC143C02E2A262520242C2C21212C14C143442E2B14C04A4C432E2A14C02E2A14C2C341424ACB2E2014C24F494B4A4C432E20144FCC49CB4FC046422E20144943CC2E2012444FC14EC3484A46C143"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></span><a rel="nofollow" onclick="quoter('hardwarefr','prive',3195237,1980677227); return false;" href="/message.php?config=hfr.inc&amp;cat=prive&amp;post=3195237&amp;numrep=1980677227&amp;ref=4&amp;page=1&amp;p=1&amp;subcat=0&amp;sondage=0&amp;owntopic=0&amp;new=0#formulaire"><img id="plus1980677227" src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote+.gif" title="Ajouter à la liste des messages cités" alt="answer +" /><img id="moins1980677227" style="display:none" src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote-.gif" title="Retirer de la liste des messages cités" alt="answer -" /></a><a rel="nofollow" href="/message.php?config=hfr.inc&amp;cat=prive&amp;sond=&amp;p=1&amp;subcat=&amp;dest=Correspondant&amp;subcatgroup=0"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/pv.gif" title="Envoyer un message privé à Correspondant" alt="MP" /></a><a href="/user/contactlist.php?adduser=990001&amp;comeback=1"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/put_contact.gif" title="Ajouter  Correspondant à votre liste de contacts" alt="Ajouter  Correspondant à votre liste de contacts" /></a></div><div class="spacer">&nbsp;</div></div><div id="para1980677227">Message prive de test (contenu remplace).</div></td></tr></table><br /><script language="javascript" type="text/javascript">var listenumreponse=new Array("1980664234","1980664235","1980677218","1980677227")</script><form action="/forum1.php" method="get" id="goto"><input type="hidden" name="hash_check" value="0" />
+		<div class="nombres">
+		<b>Aller à : </b>
+		<input type="hidden" name="config" value="hfr.inc" />
+		<select name="cat" onchange="document.getElementById('goto').submit()"><option value="1" >Hardware</option><option value="16" >Hardware - Périphériques</option><option value="15" >Ordinateurs portables</option><option value="2" >Overclocking, Cooling &amp; Modding</option><option value="30" >Electronique, domotique, DIY</option><option value="23" >Technologies Mobiles</option><option value="25" >Apple</option><option value="3" >Video &amp; Son</option><option value="14" >Photo numérique</option><option value="5" >Jeux Video</option><option value="4" >Windows &amp; Software</option><option value="22" >Réseaux grand public / SoHo</option><option value="21" >Systèmes &amp; Réseaux Pro</option><option value="11" >Linux et OS Alternatifs</option><option value="10" >Programmation</option><option value="32" >Intelligence Artificielle</option><option value="12" >Graphisme</option><option value="6" >Achats &amp; Ventes</option><option value="8" >Emploi &amp; Etudes</option><option value="13" >Discussions</option><option value="24" >Blabla - Divers ( back to life )</option><option value="prive" selected="selected">Messages privés</option></select>
+			<input type="submit" value="Go" />
+			</div></form><div class="left"><form action="/message.php?config=hfr.inc&amp;cat=prive&amp;post=3195237&amp;page=1&amp;p=1&amp;subcat=0&amp;sondage=0&amp;owntopic=0&amp;new=0" method="post" name="repondre_form" id="repondre_form"><input type="hidden" name="hash_check" value="0" /><input type="hidden" name="repondre_contenu" id="repondre_contenu" value="" />
+					<a rel="nofollow" href="/message.php?config=hfr.inc&amp;cat=prive&amp;post=3195237&amp;page=1&amp;p=1&amp;subcat=0&amp;sondage=0&amp;owntopic=0&amp;new=0" onclick="choper_reponse_rapide(0,0); return false;" accesskey="r"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/repondre.gif" title="Ajouter une réponse" alt="Ajouter une réponse" /></a>
+					</form>
+					</div><div class="arbo" style="margin:0px 0px 0px 20px;" id="md_arbo_bottom">
+<span  id="md_arbo_tree_b_1" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/" class="Ext">FORUM HardWare.fr</a></span>
+<br />
+<span  id="md_arbo_tree_b_2" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/forum1.php?config=hfr.inc&amp;cat=prive&amp;page=1&amp;subcat=&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;moderation=0&amp;new=0&amp;nojs=0&amp;subcatgroup=0" class="Ext">Messages&nbsp;privés</a></span>
+<br />
+<h1  id="md_arbo_tree_b_3" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline3.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;Sujet prive de test</h1>
+</div><div class="spacer">&nbsp;</div><form name="hop" action="/bddpost.php" method="post" onsubmit="document.hop.submit.style.visibility='hidden';"><input type="hidden" name="hash_check" value="0" /><div class="s2Ext" id="md_fast_search"><b>Réponse rapide</b>
+						<br /><div id="addComment"></div><textarea rows="5" cols="60" name="content_form" class="reponserapide" id="content_form" accesskey="c"></textarea><br />
+						<input type="submit" accesskey="s" value="Valider votre message" name="submit" id="submitreprap"/>
+						<input type="hidden" name="new" value="0" />
+						<input type="hidden" name="post" value="3195237" /><input type="hidden" name="numrep" value="1980677227" /><input type="hidden" name="cat" value="prive" />
+						<input type="hidden" name="subcat" value="0" />
+						<input type="hidden" name="page" value="1" />
+						<input type="hidden" name="verifrequet" value="1100" />
+						<input type="hidden" name="p" value="1" />
+						<input type="hidden" name="sondage" value="0" />
+						<input type="hidden" name="cache" value="" />
+						<input type="hidden" name="owntopic" value="0" />
+						<input type="hidden" name="config" value="hfr.inc" />
+						<input type="hidden" name="emaill" value="" />
+						<input type="hidden" name="pseudo" value="TestUser" />
+						<input type="hidden" name="sujet" value="Sujet prive de test" />
+						<input type="hidden" value="1" name="signature" />
+					</div></form><br />
+			<div class="copyright">
+			<a href="http://www.mesdiscussions.net" target="_blank" class="copyright">Forum MesDiscussions.Net</a>, Version 2010.2 <br />(c) 2000-2011 Doctissimo<br /><div class='gene'>Page générée en  0.037 secondes</div></div></div></div><center><font color="#000000" size="1" face="Arial, Helvetica, sans-serif"><br />Copyright © 1997-2025 Groupe <a href="https://www.ldlc.com" title="Achat de materiel Informatique">LDLC</a> (<a href="https://www.hardware.fr/html/donnees_personnelles/">Signaler un contenu illicite / Données personnelles</a>)</font></center>
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://tracking.groupe-ldlc.com/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '26']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<noscript><p><img src="https://tracking.groupe-ldlc.com/matomo.php?idsite=26&rec=1" style="border:0;" alt="" /></p></noscript>
+<!-- End Matomo Code --><script type="text/javascript">
+md_forum_decryptlink.init();
+</script>
+<script type="text/javascript">
+md_forum_decryptlink.init();
+</script>
+<script type="text/javascript">
+var md_url_img_shadow= 'https://forum-images.hardware.fr';
+var md_tabs_menu_shadow= 1;
+</script>
+</body></html>

--- a/core/data/src/test/resources/fixtures/private_message_thread.source.txt
+++ b/core/data/src/test/resources/fixtures/private_message_thread.source.txt
@@ -1,0 +1,4 @@
+Source: forum.hardware.fr (capture authentifiee live, compte XaTriX). @XaaT 2026-06-03
+Captured page: forum2.php?config=hfr.inc&cat=prive&post=3195237&page=1
+Notes: conversation MP (4 messages : 3 de l'utilisateur courant, 1 du correspondant ; 1 seule page). Capturee en HTTP authentifie car hfr_read (MCP) n'accepte cat qu'en entier et ne peut pas lire cat=prive.
+Privacy (#298) : MP prive, scrubbe avant commit. Pseudo de l'utilisateur courant -> "TestUser", correspondant -> "Correspondant", sujet (h3) -> "Sujet prive de test", corps de chaque message -> placeholder "Message prive de test (contenu remplace).", userids de profil + fichiers avatar remappes vers des ids factices, hash_check neutralise. Conserves (non sensibles) : structure DOM, threadId (post=3195237), numreponse, dates, liens d'edition obfusques (md_*cryptlink) qui pilotent isOwnPost.

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/write/PrivateMessageWriteRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/write/PrivateMessageWriteRepository.kt
@@ -1,0 +1,38 @@
+package fr.forumhfr.redface2.core.domain.write
+
+import fr.forumhfr.redface2.core.model.write.PrivateMessageReplyContext
+import fr.forumhfr.redface2.core.model.write.ReplyForm
+import fr.forumhfr.redface2.core.model.write.ReplyFormOptions
+import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
+
+/**
+ * Repository surface for replying to an HFR private-message conversation (#301).
+ *
+ * The wire shape is the same family as a topic reply — HFR embeds a `bddpost.php` form in the
+ * conversation page (`forum2.php?cat=prive&post={threadId}`) and the POST goes to the same
+ * `bddpost.php` endpoint — so this reuses the generic [ReplyForm] / [ReplySubmitResult] models and
+ * the shared form / response parsers. It is kept as a **separate** interface from [ReplyRepository]
+ * because a private conversation has no numeric `cat` / `subcat` / quote semantics: the routing
+ * lives entirely in the form's hidden fields (`cat=prive`, `post`, `numrep`, `subcat=0`, …), which
+ * the implementation forwards verbatim rather than re-asserting from a typed context.
+ *
+ * - [fetchReplyForm] GETs the conversation page and parses the embedded `bddpost.php` form (fresh
+ *   `hash_check`). It returns a [ReplyForm] even when HFR served the anonymous composer (caller
+ *   inspects [ReplyForm.isAnonymous]); transport / session-expiry failures are raised.
+ * - [submitReply] POSTs the reply and classifies the response into a [ReplySubmitResult]. The
+ *   private-message POST success sentence is not pinned by a live fixture (a real send to a third
+ *   party was intentionally avoided), so callers must treat an unrecognised
+ *   ([fr.forumhfr.redface2.core.model.write.ReplyFailureReason.Unknown]) response as non-destructive
+ *   — keep the draft and let the user verify the conversation — rather than asserting a hard failure.
+ */
+interface PrivateMessageWriteRepository {
+
+    suspend fun fetchReplyForm(context: PrivateMessageReplyContext): ReplyForm
+
+    suspend fun submitReply(
+        context: PrivateMessageReplyContext,
+        form: ReplyForm,
+        bbcodeContent: String,
+        options: ReplyFormOptions = ReplyFormOptions(),
+    ): ReplySubmitResult
+}

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/write/PrivateMessageReplyContext.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/write/PrivateMessageReplyContext.kt
@@ -1,0 +1,25 @@
+package fr.forumhfr.redface2.core.model.write
+
+/**
+ * Identifies the private-message conversation page the user is about to reply to (#301). Built from
+ * a loaded `PrivateMessageThread` (only opens once `PrivateMessageThread.canReply` is true) and
+ * passed to the private-message write repository.
+ *
+ * Unlike [ReplyContext] there is **no** `cat: Int` here: a private conversation lives under HFR's
+ * `cat=prive` (a String, not a numeric category id), and the whole routing tuple — `cat=prive`,
+ * `post={threadId}`, `subcat=0`, `numrep`, `pseudo`, `sujet` — is carried verbatim inside the
+ * `bddpost.php` form HFR embeds in the thread page (cf. fixture `private_message_thread.html`). The
+ * repository forwards those hidden fields untouched; this context only tells it which thread page to
+ * fetch the form from.
+ */
+data class PrivateMessageReplyContext(
+    /** HFR `post` id of the conversation (the thread id). */
+    val threadId: Int,
+    /** 1-based page of the conversation the user is viewing — the page whose form HFR pre-fills. */
+    val page: Int,
+) {
+    init {
+        require(threadId > 0) { "threadId must be > 0, was $threadId" }
+        require(page >= 1) { "page must be >= 1, was $page" }
+    }
+}

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/write/PrivateMessageReplyFormParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/write/PrivateMessageReplyFormParserTest.kt
@@ -1,0 +1,55 @@
+package fr.forumhfr.redface2.core.parser.write
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #301 — proves the shared [ReplyFormParser] parses HFR's private-message reply form (the
+ * `bddpost.php` form embedded in a `cat=prive` conversation page) without any topic-specific
+ * assumption. Pinned against the real, scrubbed fixture `private_message_thread.html` captured for
+ * #298. The two contract bits that make a private reply different from a topic reply are asserted
+ * explicitly: `cat=prive` (a String, not a numeric id) and the server-prefilled `numrep` (the last
+ * post of the page — NOT a quote reference) must be carried verbatim in the hidden fields.
+ */
+class PrivateMessageReplyFormParserTest {
+
+    private val parser = ReplyFormParser()
+
+    @Test
+    fun `parses the private-message reply form embedded in the conversation page`() {
+        val form = parser.parse(fixture("private_message_thread.html")).getOrThrow()
+
+        assertFalse("authenticated MP form is never anonymous", form.isAnonymous)
+        assertEquals("0", form.hashCheck)
+        // A fresh reply has an empty composer textarea (no quote prefill).
+        assertEquals("", form.initialContent)
+
+        // Private-message routing lives entirely in the hidden fields, forwarded verbatim on POST.
+        assertEquals("prive", form.hiddenFields["cat"])
+        assertEquals("3195237", form.hiddenFields["post"])
+        // numrep is the conversation's last-post id HFR prefilled — must be preserved as-is.
+        assertEquals("1980677227", form.hiddenFields["numrep"])
+        assertEquals("0", form.hiddenFields["subcat"])
+        assertEquals("1", form.hiddenFields["page"])
+        assertEquals("hfr.inc", form.hiddenFields["config"])
+        assertEquals("1100", form.hiddenFields["verifrequet"])
+        // Authenticated form echoes the user's pseudo; never a password.
+        assertEquals("TestUser", form.hiddenFields["pseudo"])
+        assertFalse("password must never be collected", form.hiddenFields.containsKey("password"))
+        // sujet is exposed both via the typed field and the hidden map.
+        assertEquals("Sujet prive de test", form.sujet)
+        // The quick-reply form carries `signature=1` as a hidden input (not a checkbox), so it lands
+        // in the hidden fields rather than ReplyForm.options — the ViewModel hydrates from both.
+        assertEquals("1", form.hiddenFields["signature"])
+        assertTrue("hidden fields should not be empty", form.hiddenFields.isNotEmpty())
+    }
+
+    private fun fixture(name: String): String {
+        val stream = requireNotNull(
+            PrivateMessageReplyFormParserTest::class.java.classLoader?.getResourceAsStream("fixtures/$name"),
+        ) { "Fixture not found: fixtures/$name" }
+        return stream.bufferedReader().use { it.readText() }
+    }
+}

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyRequest.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyRequest.kt
@@ -1,0 +1,14 @@
+package fr.forumhfr.redface2.feature.messages
+
+/**
+ * Route arguments for [PrivateMessageReplyViewModel] (#301). Plain data class so route values pass
+ * through Hilt assisted injection, mirroring [PrivateMessageThreadRequest].
+ *
+ * Only opaque route data is carried (thread id + the page the user is replying from). The form's
+ * `hash_check`, hidden fields, subject and the user's pseudo are read from the freshly-fetched
+ * `forum2.php?cat=prive` page so no private metadata is serialised into the back stack.
+ */
+data class PrivateMessageReplyRequest(
+    val threadId: Int,
+    val page: Int = 1,
+)

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
@@ -1,0 +1,363 @@
+package fr.forumhfr.redface2.feature.messages
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.ui.editor.BbcodeAction
+import fr.forumhfr.redface2.core.ui.editor.BbcodePreview
+import fr.forumhfr.redface2.core.ui.editor.BbcodeTextField
+import fr.forumhfr.redface2.core.ui.editor.BbcodeToolbar
+
+/**
+ * Reply editor for a private-message conversation (#301). Reuses the shared `:core:ui` BBCode
+ * toolbar / text field / preview and a send button pinned above the IME (same window-insets pattern
+ * as the post editor, which requires `windowSoftInputMode=adjustNothing`). Submission goes through
+ * [PrivateMessageReplyViewModel]; a successful send raises [PrivateMessageReplyEffect.SubmitSucceeded]
+ * which the navigation host turns into a back navigation + a forced conversation reload.
+ */
+@Composable
+fun PrivateMessageReplyScreen(
+    request: PrivateMessageReplyRequest,
+    onSubmitSucceeded: (threadId: Int, page: Int) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val viewModel = hiltViewModel<PrivateMessageReplyViewModel, PrivateMessageReplyViewModel.Factory>(
+        creationCallback = { factory -> factory.create(request) },
+    )
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    LaunchedEffect(viewModel) {
+        viewModel.effects.collect { effect ->
+            when (effect) {
+                is PrivateMessageReplyEffect.SubmitSucceeded ->
+                    onSubmitSucceeded(effect.threadId, effect.page)
+            }
+        }
+    }
+    PrivateMessageReplyContent(
+        state = state,
+        onBack = onBack,
+        onContentChanged = viewModel::onContentChanged,
+        onToolbarAction = viewModel::onToolbarAction,
+        onTogglePreview = viewModel::onTogglePreview,
+        onToggleSignature = viewModel::onToggleSignature,
+        onToggleSmileyDisabled = viewModel::onToggleSmileyDisabled,
+        onToggleEmailNotification = viewModel::onToggleEmailNotification,
+        onErrorDismissed = viewModel::onErrorDismissed,
+        onSubmit = viewModel::onSubmit,
+        onRetryFormLoad = viewModel::retryFormLoad,
+        modifier = modifier,
+    )
+}
+
+@Composable
+@Suppress("LongParameterList") // One callback per editor action — each is wired to a distinct VM method.
+private fun PrivateMessageReplyContent(
+    state: PrivateMessageReplyUiState,
+    onBack: () -> Unit,
+    onContentChanged: (TextFieldValue) -> Unit,
+    onToolbarAction: (BbcodeAction) -> Unit,
+    onTogglePreview: () -> Unit,
+    onToggleSignature: (Boolean) -> Unit,
+    onToggleSmileyDisabled: (Boolean) -> Unit,
+    onToggleEmailNotification: (Boolean) -> Unit,
+    onErrorDismissed: () -> Unit,
+    onSubmit: () -> Unit,
+    onRetryFormLoad: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(modifier = modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surface) {
+        Column(modifier = Modifier.fillMaxSize().statusBarsPadding()) {
+            ReplyHeader(onBack = onBack)
+            when {
+                state.formError -> FormErrorState(onRetry = onRetryFormLoad)
+                state.isLoadingForm && !state.formAvailable -> FormLoadingState()
+                else -> {
+                    ReplyEditorBody(
+                        state = state,
+                        onContentChanged = onContentChanged,
+                        onToolbarAction = onToolbarAction,
+                        onTogglePreview = onTogglePreview,
+                        onToggleSignature = onToggleSignature,
+                        onToggleSmileyDisabled = onToggleSmileyDisabled,
+                        onToggleEmailNotification = onToggleEmailNotification,
+                        onErrorDismissed = onErrorDismissed,
+                        modifier = Modifier.weight(1f),
+                    )
+                    ReplySubmitBar(
+                        canSubmit = state.canSubmit,
+                        isSubmitting = state.isSubmitting,
+                        onSubmit = onSubmit,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReplyHeader(onBack: () -> Unit) {
+    val backLabel = stringResource(R.string.messages_back)
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(
+            onClick = onBack,
+            modifier = Modifier.semantics { contentDescription = backLabel },
+        ) {
+            Text("←")
+        }
+        Text(
+            text = stringResource(R.string.messages_reply_title),
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+@Composable
+private fun FormLoadingState() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun FormErrorState(onRetry: () -> Unit) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.padding(horizontal = 24.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.messages_reply_form_error),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.error,
+            )
+            Button(onClick = onRetry) {
+                Text(text = stringResource(R.string.messages_retry))
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("LongParameterList") // Editor body mirrors the post editor surface; each callback is distinct.
+private fun ReplyEditorBody(
+    state: PrivateMessageReplyUiState,
+    onContentChanged: (TextFieldValue) -> Unit,
+    onToolbarAction: (BbcodeAction) -> Unit,
+    onTogglePreview: () -> Unit,
+    onToggleSignature: (Boolean) -> Unit,
+    onToggleSmileyDisabled: (Boolean) -> Unit,
+    onToggleEmailNotification: (Boolean) -> Unit,
+    onErrorDismissed: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        BbcodeToolbar(onAction = onToolbarAction)
+
+        BbcodeTextField(
+            value = state.draft,
+            onValueChange = onContentChanged,
+            label = stringResource(R.string.messages_reply_field_label),
+            placeholder = stringResource(R.string.messages_reply_field_placeholder),
+        )
+
+        Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
+            TextButton(onClick = onTogglePreview) {
+                Text(
+                    text = stringResource(
+                        if (state.isPreviewVisible) {
+                            R.string.messages_reply_preview_hide
+                        } else {
+                            R.string.messages_reply_preview_show
+                        },
+                    ),
+                )
+            }
+        }
+
+        if (state.isPreviewVisible) {
+            HorizontalDivider()
+            BbcodePreview(content = state.preview)
+        }
+
+        state.submitError?.let { error ->
+            Text(
+                text = stringResource(error.bannerResId),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error,
+            )
+            TextButton(onClick = onErrorDismissed) {
+                Text(text = stringResource(R.string.messages_reply_error_dismiss))
+            }
+        }
+
+        ReplyOptions(
+            signatureEnabled = state.signatureEnabled,
+            smileyDisabled = state.smileyDisabled,
+            emailNotificationEnabled = state.emailNotificationEnabled,
+            enabled = !state.isSubmitting && !state.isLoadingForm,
+            onSignatureChanged = onToggleSignature,
+            onSmileyDisabledChanged = onToggleSmileyDisabled,
+            onEmailNotificationChanged = onToggleEmailNotification,
+        )
+    }
+}
+
+/**
+ * Send button pinned to the bottom, lifted above the IME so the user never dismisses the keyboard to
+ * reach « Envoyer ». Mirrors the post editor's submit bar (the editor's `EditorSubmitBar` is module-
+ * private, so the window-insets pattern is replicated here). Requires `windowSoftInputMode=adjustNothing`.
+ */
+@Composable
+private fun ReplySubmitBar(
+    canSubmit: Boolean,
+    isSubmitting: Boolean,
+    onSubmit: () -> Unit,
+) {
+    Surface(color = MaterialTheme.colorScheme.surfaceContainer, tonalElevation = 3.dp) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            HorizontalDivider()
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    // Single bottom inset = max(navBar, ime) via union(), so the two never stack into a
+                    // phantom gap. Keyboard closed → clears the gesture nav bar; open → rides on the IME.
+                    .windowInsetsPadding(
+                        WindowInsets.navigationBars
+                            .union(WindowInsets.ime)
+                            .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom),
+                    )
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (isSubmitting) {
+                    CircularProgressIndicator(modifier = Modifier.size(20.dp))
+                    Spacer(modifier = Modifier.width(12.dp))
+                }
+                Button(enabled = canSubmit, onClick = onSubmit) {
+                    Text(text = stringResource(R.string.messages_reply_submit))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("LongParameterList") // 3 toggles + 3 callbacks + enabled — each call-site distinct.
+private fun ReplyOptions(
+    signatureEnabled: Boolean,
+    smileyDisabled: Boolean,
+    emailNotificationEnabled: Boolean,
+    enabled: Boolean,
+    onSignatureChanged: (Boolean) -> Unit,
+    onSmileyDisabledChanged: (Boolean) -> Unit,
+    onEmailNotificationChanged: (Boolean) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp), modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.messages_reply_options_title),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        OptionToggle(
+            label = stringResource(R.string.messages_reply_option_signature),
+            checked = signatureEnabled,
+            enabled = enabled,
+            onCheckedChange = onSignatureChanged,
+        )
+        OptionToggle(
+            label = stringResource(R.string.messages_reply_option_smiley_disabled),
+            checked = smileyDisabled,
+            enabled = enabled,
+            onCheckedChange = onSmileyDisabledChanged,
+        )
+        OptionToggle(
+            label = stringResource(R.string.messages_reply_option_email_notification),
+            checked = emailNotificationEnabled,
+            enabled = enabled,
+            onCheckedChange = onEmailNotificationChanged,
+        )
+    }
+}
+
+@Composable
+private fun OptionToggle(
+    label: String,
+    checked: Boolean,
+    enabled: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(end = 16.dp),
+        )
+        Switch(checked = checked, enabled = enabled, onCheckedChange = onCheckedChange)
+    }
+}
+
+private val PrivateMessageReplyError.bannerResId: Int
+    get() = when (this) {
+        PrivateMessageReplyError.Empty -> R.string.messages_reply_error_empty
+        PrivateMessageReplyError.InvalidHashCheck -> R.string.messages_reply_error_invalid_hash
+        PrivateMessageReplyError.AntiFlood -> R.string.messages_reply_error_anti_flood
+        PrivateMessageReplyError.LoginRequired -> R.string.messages_reply_error_login_required
+        PrivateMessageReplyError.Network -> R.string.messages_reply_error_network
+        PrivateMessageReplyError.SessionExpired -> R.string.messages_reply_error_session_expired
+        PrivateMessageReplyError.Unexpected -> R.string.messages_reply_error_unexpected
+    }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyUiState.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyUiState.kt
@@ -1,0 +1,51 @@
+package fr.forumhfr.redface2.feature.messages
+
+import androidx.compose.ui.text.input.TextFieldValue
+import fr.forumhfr.redface2.core.model.PostContent
+
+/**
+ * MVI state of the private-message reply editor (#301). Mirrors the post editor's shape (draft +
+ * parsed preview AST + the three HFR per-post option toggles) but is scoped to a private
+ * conversation, so it carries no `cat`/`subcat`/quote fields.
+ *
+ * The parsed [fr.forumhfr.redface2.core.model.write.ReplyForm] (with its `hash_check` and hidden
+ * fields) is held privately by the ViewModel and never exposed here, so no private metadata leaks
+ * into a state snapshot.
+ */
+data class PrivateMessageReplyUiState(
+    /** True while the initial `bddpost.php` form GET is in flight (and during a silent refetch). */
+    val isLoadingForm: Boolean = true,
+    /** True once a non-anonymous form has been parsed; gates submission. */
+    val formAvailable: Boolean = false,
+    /** True when the form GET failed (network / session / parse / anonymous) → show retry. */
+    val formError: Boolean = false,
+    val draft: TextFieldValue = TextFieldValue(),
+    val isPreviewVisible: Boolean = false,
+    val preview: PostContent = PostContent(blocks = emptyList()),
+    val signatureEnabled: Boolean = false,
+    val smileyDisabled: Boolean = false,
+    val emailNotificationEnabled: Boolean = false,
+    val isSubmitting: Boolean = false,
+    val submitError: PrivateMessageReplyError? = null,
+) {
+    val canSubmit: Boolean
+        get() = formAvailable && !isLoadingForm && !isSubmitting && draft.text.isNotBlank()
+}
+
+/**
+ * Submit-phase errors surfaced as a banner over the editor (the draft is always preserved). HFR
+ * reuses the same `bddpost.php` failure sentences for private messages as for topics, so the
+ * recognised reasons map 1:1 — except [Unexpected], which is the non-destructive fallback for an
+ * unrecognised response: the private-message POST success sentence is not pinned by a live fixture
+ * (a real send to a third party was intentionally avoided), so the UI invites the user to verify the
+ * conversation rather than claiming a hard failure.
+ */
+sealed interface PrivateMessageReplyError {
+    data object Empty : PrivateMessageReplyError
+    data object InvalidHashCheck : PrivateMessageReplyError
+    data object AntiFlood : PrivateMessageReplyError
+    data object LoginRequired : PrivateMessageReplyError
+    data object Network : PrivateMessageReplyError
+    data object SessionExpired : PrivateMessageReplyError
+    data object Unexpected : PrivateMessageReplyError
+}

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
@@ -1,0 +1,269 @@
+package fr.forumhfr.redface2.feature.messages
+
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
+import fr.forumhfr.redface2.core.domain.write.PrivateMessageWriteRepository
+import fr.forumhfr.redface2.core.model.write.PrivateMessageReplyContext
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
+import fr.forumhfr.redface2.core.model.write.ReplyForm
+import fr.forumhfr.redface2.core.model.write.ReplyFormOptions
+import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
+import fr.forumhfr.redface2.core.ui.editor.BbcodeAction
+import fr.forumhfr.redface2.core.ui.editor.applyBbcodeAction
+import java.io.IOException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel for replying to a private-message conversation (#301). Receives its route arguments via
+ * Hilt assisted injection ([PrivateMessageReplyRequest]). On creation it GETs the conversation page
+ * to parse the embedded `bddpost.php` reply form (fresh `hash_check` + hidden fields), then lets the
+ * user compose a BBCode reply with the shared toolbar/preview and submit it.
+ *
+ * Two private-message specifics drive the design (cf. the #301 design notes / independent review):
+ *  - The HFR POST success sentence for a private reply is not pinned by a live fixture, so an
+ *    unrecognised response maps to [PrivateMessageReplyError.Unexpected] (non-destructive: the draft
+ *    is kept and the banner invites the user to verify the conversation), never a hard failure.
+ *  - An expired `hash_check` is recovered by silently refetching the form so the user can re-submit,
+ *    mirroring the post editor.
+ */
+@HiltViewModel(assistedFactory = PrivateMessageReplyViewModel.Factory::class)
+class PrivateMessageReplyViewModel @AssistedInject constructor(
+    @Assisted private val request: PrivateMessageReplyRequest,
+    private val repository: PrivateMessageWriteRepository,
+    private val previewParser: BbcodePreviewParser,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(PrivateMessageReplyUiState())
+    val state: StateFlow<PrivateMessageReplyUiState> = _state.asStateFlow()
+
+    private val _effects: Channel<PrivateMessageReplyEffect> = Channel(capacity = Channel.BUFFERED)
+    val effects: Flow<PrivateMessageReplyEffect> = _effects.receiveAsFlow()
+
+    private val context = PrivateMessageReplyContext(
+        threadId = request.threadId,
+        page = request.page.coerceAtLeast(1),
+    )
+
+    private var loadedForm: ReplyForm? = null
+    private var formJob: Job? = null
+    private var submitJob: Job? = null
+
+    init {
+        loadForm()
+    }
+
+    fun retryFormLoad() = loadForm()
+
+    private fun loadForm() {
+        formJob?.cancel()
+        _state.update { it.copy(isLoadingForm = true, formError = false) }
+        formJob = viewModelScope.launch {
+            try {
+                val form = repository.fetchReplyForm(context)
+                if (form.isAnonymous) {
+                    // Session vanished between opening the thread and replying — treat like a form
+                    // error so the user re-authenticates (the reply route is only reachable while
+                    // authenticated, so this is rare).
+                    loadedForm = null
+                    _state.update { it.copy(isLoadingForm = false, formAvailable = false, formError = true) }
+                    return@launch
+                }
+                loadedForm = form
+                _state.update { current ->
+                    current.copy(
+                        isLoadingForm = false,
+                        formAvailable = true,
+                        formError = false,
+                        // HFR's private "quick reply" form carries the per-post options as plain
+                        // hidden inputs (e.g. `signature=1`), not checkboxes — so `ReplyForm.options`
+                        // (read from `checked` attributes) is all-false here. Hydrate from the hidden
+                        // fields too, OR'ing with the checkbox view, so the user keeps HFR's default
+                        // (signature on) instead of silently dropping it on submit.
+                        signatureEnabled = form.options.signatureEnabled ||
+                            form.hiddenFields["signature"] == "1",
+                        smileyDisabled = form.options.smileyDisabled ||
+                            form.hiddenFields["smiley"] == "1",
+                        emailNotificationEnabled = form.options.emailNotificationEnabled ||
+                            form.hiddenFields["emaill"] == "1",
+                    )
+                }
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (
+                @Suppress("TooGenericExceptionCaught", "SwallowedException") error: Exception,
+            ) {
+                // No raw message reaches the UI (#316): a private form GET can embed the private URL.
+                loadedForm = null
+                _state.update { it.copy(isLoadingForm = false, formAvailable = false, formError = true) }
+            }
+        }
+    }
+
+    fun onContentChanged(value: TextFieldValue) {
+        _state.update { it.withDraftPreview(value) }
+    }
+
+    fun onToolbarAction(action: BbcodeAction) {
+        _state.update { current ->
+            val outcome = applyBbcodeAction(
+                action = action,
+                text = current.draft.text,
+                selectionStart = current.draft.selection.start,
+                selectionEnd = current.draft.selection.end,
+            )
+            current.withDraftPreview(
+                TextFieldValue(
+                    text = outcome.text,
+                    selection = TextRange(outcome.selectionStart, outcome.selectionEnd),
+                ),
+            )
+        }
+    }
+
+    fun onTogglePreview() {
+        _state.update { current ->
+            val nextVisible = !current.isPreviewVisible
+            current.copy(
+                isPreviewVisible = nextVisible,
+                preview = if (nextVisible) previewParser.parsePreview(current.draft.text) else current.preview,
+            )
+        }
+    }
+
+    fun onToggleSignature(enabled: Boolean) = _state.update { it.copy(signatureEnabled = enabled) }
+
+    fun onToggleSmileyDisabled(disabled: Boolean) = _state.update { it.copy(smileyDisabled = disabled) }
+
+    fun onToggleEmailNotification(enabled: Boolean) =
+        _state.update { it.copy(emailNotificationEnabled = enabled) }
+
+    fun onErrorDismissed() = _state.update { it.copy(submitError = null) }
+
+    @Suppress("ReturnCount") // Guard clauses are the natural shape of the submit dispatcher.
+    fun onSubmit() {
+        val snapshot = _state.value
+        if (!snapshot.canSubmit) return
+        val form = loadedForm ?: run {
+            loadForm()
+            return
+        }
+        if (form.isAnonymous) {
+            _state.update { it.copy(submitError = PrivateMessageReplyError.LoginRequired) }
+            return
+        }
+        if (submitJob?.isActive == true) return
+
+        val options = ReplyFormOptions(
+            signatureEnabled = snapshot.signatureEnabled,
+            smileyDisabled = snapshot.smileyDisabled,
+            emailNotificationEnabled = snapshot.emailNotificationEnabled,
+        )
+        _state.update { it.copy(isSubmitting = true, submitError = null) }
+        submitJob = viewModelScope.launch {
+            val outcome = runCatching {
+                repository.submitReply(
+                    context = context,
+                    form = form,
+                    bbcodeContent = snapshot.draft.text,
+                    options = options,
+                )
+            }
+            outcome.fold(
+                onSuccess = ::handleSubmitOutcome,
+                onFailure = ::handleSubmitFailure,
+            )
+        }
+    }
+
+    private fun handleSubmitOutcome(result: ReplySubmitResult) {
+        when (result) {
+            is ReplySubmitResult.Success -> {
+                _state.update { it.copy(isSubmitting = false, submitError = null) }
+                _effects.trySend(
+                    PrivateMessageReplyEffect.SubmitSucceeded(
+                        threadId = context.threadId,
+                        page = context.page,
+                    ),
+                )
+            }
+            is ReplySubmitResult.Failure -> {
+                if (result.reason == ReplyFailureReason.InvalidHashCheck) {
+                    // Cached form's hash_check expired — refetch silently and let the user re-submit.
+                    loadedForm = null
+                    loadForm()
+                }
+                _state.update { it.copy(isSubmitting = false, submitError = result.reason.toReplyError()) }
+            }
+        }
+    }
+
+    private fun handleSubmitFailure(error: Throwable) {
+        if (error is CancellationException) {
+            _state.update { it.copy(isSubmitting = false) }
+            throw error
+        }
+        val mapped = when (error) {
+            is SessionExpiredException -> PrivateMessageReplyError.SessionExpired
+            is IOException -> PrivateMessageReplyError.Network
+            // Any other throwable is surfaced as the non-destructive "unexpected response" banner;
+            // the draft is preserved so nothing is lost.
+            else -> PrivateMessageReplyError.Unexpected
+        }
+        _state.update { it.copy(isSubmitting = false, submitError = mapped) }
+    }
+
+    private fun ReplyFailureReason.toReplyError(): PrivateMessageReplyError = when (this) {
+        ReplyFailureReason.EmptyMessage -> PrivateMessageReplyError.Empty
+        ReplyFailureReason.InvalidHashCheck -> PrivateMessageReplyError.InvalidHashCheck
+        ReplyFailureReason.AntiFlood -> PrivateMessageReplyError.AntiFlood
+        ReplyFailureReason.LoginRequired -> PrivateMessageReplyError.LoginRequired
+        // TopicLocked has no private-message analogue, and Unknown is the unrecognised-response
+        // fallback: both map to the non-destructive "verify the conversation" banner.
+        ReplyFailureReason.TopicLocked, ReplyFailureReason.Unknown -> PrivateMessageReplyError.Unexpected
+    }
+
+    private fun PrivateMessageReplyUiState.withDraftPreview(updated: TextFieldValue): PrivateMessageReplyUiState =
+        copy(
+            draft = updated,
+            preview = if (isPreviewVisible) previewParser.parsePreview(updated.text) else preview,
+        )
+
+    @AssistedFactory
+    interface Factory {
+        fun create(request: PrivateMessageReplyRequest): PrivateMessageReplyViewModel
+    }
+}
+
+/**
+ * One-shot effects from [PrivateMessageReplyViewModel]. [SubmitSucceeded] tells the navigation host
+ * to pop the editor and re-open the conversation (force-reload) so the freshly-sent message shows.
+ *
+ * [page] is the page the reply was composed from (the live thread page). v1 limitation: HFR's MP POST
+ * response is not parsed for a landing page (its refresh URL is not topic-shaped), so a reply that
+ * overflows onto a brand-new last page lands the user back on the source page — they page forward to
+ * see it. MP threads are short, so this is rare; a topic-style overflow redirect (#226) is not ported.
+ *
+ * Note: an unrecognised POST response (`Unknown`) deliberately does NOT raise this effect — it keeps
+ * the draft and surfaces a "verify the conversation" banner instead of bouncing the user away, since
+ * the MP success sentence is not pinned by a live fixture.
+ */
+sealed interface PrivateMessageReplyEffect {
+    data class SubmitSucceeded(val threadId: Int, val page: Int) : PrivateMessageReplyEffect
+}

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -49,6 +50,7 @@ import java.util.Locale
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
+@Suppress("LongParameterList") // Screen host: route request + 3 nav callbacks + multi-recipient hint + actions slot.
 fun PrivateMessageThreadScreen(
     request: PrivateMessageThreadRequest,
     // Ephemeral UI hint from the inbox row (the route stays opaque, carrying only threadId/page).
@@ -57,6 +59,7 @@ fun PrivateMessageThreadScreen(
     isMultiRecipientHint: Boolean,
     onLoaded: () -> Unit,
     onBack: () -> Unit,
+    onReply: (threadId: Int, page: Int) -> Unit,
     topBarActions: @Composable (() -> Unit)? = null,
 ) {
     val viewModel = hiltViewModel<PrivateMessageThreadViewModel, PrivateMessageThreadViewModel.Factory>(
@@ -115,6 +118,20 @@ fun PrivateMessageThreadScreen(
                 },
                 actions = { topBarActions?.invoke() },
             )
+        },
+        floatingActionButton = {
+            // #301 — reply affordance, shown only once the page proved a reply form is available
+            // (`canReply`). Carries the page the user is viewing so the form HFR pre-fills (and its
+            // `numrep`) matches what's on screen.
+            val content = mode as? PrivateMessageThreadUiState.Mode.Content
+            if (content?.thread?.canReply == true) {
+                val replyLabel = stringResource(R.string.messages_reply)
+                ExtendedFloatingActionButton(
+                    text = { Text(replyLabel) },
+                    icon = { Text("✎") },
+                    onClick = { onReply(request.threadId, state.page) },
+                )
+            }
         },
     ) { innerPadding ->
         Box(

--- a/feature/messages/src/main/res/values/strings.xml
+++ b/feature/messages/src/main/res/values/strings.xml
@@ -15,4 +15,26 @@
     <string name="messages_pager_previous">Précédent</string>
     <string name="messages_pager_next">Suivant</string>
     <string name="messages_pager_position">Page %1$d / %2$d</string>
+
+    <!-- #301 — réponse à une conversation privée (écriture MP). -->
+    <string name="messages_reply">Répondre</string>
+    <string name="messages_reply_title">Répondre</string>
+    <string name="messages_reply_field_label">Votre réponse</string>
+    <string name="messages_reply_field_placeholder">Écrivez votre message…</string>
+    <string name="messages_reply_preview_show">Aperçu</string>
+    <string name="messages_reply_preview_hide">Masquer l\'aperçu</string>
+    <string name="messages_reply_submit">Envoyer</string>
+    <string name="messages_reply_options_title">Options</string>
+    <string name="messages_reply_option_signature">Activer la signature</string>
+    <string name="messages_reply_option_smiley_disabled">Désactiver les smileys</string>
+    <string name="messages_reply_option_email_notification">Notification par e-mail</string>
+    <string name="messages_reply_error_dismiss">Ignorer</string>
+    <string name="messages_reply_form_error">Impossible d\'ouvrir le formulaire de réponse. Réessayez.</string>
+    <string name="messages_reply_error_empty">Le message est vide. Écrivez quelque chose avant d\'envoyer.</string>
+    <string name="messages_reply_error_invalid_hash">La session a expiré. Le formulaire a été rechargé : renvoyez votre message.</string>
+    <string name="messages_reply_error_anti_flood">Trop de messages envoyés coup sur coup. Patientez quelques minutes.</string>
+    <string name="messages_reply_error_login_required">Vous devez être connecté pour répondre.</string>
+    <string name="messages_reply_error_network">Problème de connexion. Vérifiez votre réseau puis réessayez.</string>
+    <string name="messages_reply_error_session_expired">La session a expiré. Reconnectez-vous puis réessayez.</string>
+    <string name="messages_reply_error_unexpected">Réponse inattendue de HFR. Votre message a peut-être été envoyé : vérifiez la conversation.</string>
 </resources>

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
@@ -1,0 +1,182 @@
+package fr.forumhfr.redface2.feature.messages
+
+import androidx.compose.ui.text.input.TextFieldValue
+import app.cash.turbine.test
+import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
+import fr.forumhfr.redface2.core.domain.write.PrivateMessageWriteRepository
+import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.model.write.PrivateMessageReplyContext
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
+import fr.forumhfr.redface2.core.model.write.ReplyForm
+import fr.forumhfr.redface2.core.model.write.ReplyFormOptions
+import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.io.IOException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PrivateMessageReplyViewModelTest {
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private val request = PrivateMessageReplyRequest(threadId = 3195237, page = 1)
+
+    private val previewParser = BbcodePreviewParser { PostContent(blocks = emptyList()) }
+
+    private fun form(
+        hashCheck: String = "abc",
+        hiddenFields: Map<String, String> = mapOf(
+            "cat" to "prive",
+            "post" to "3195237",
+            "numrep" to "1980677227",
+            "signature" to "1",
+        ),
+        isAnonymous: Boolean = false,
+    ): ReplyForm = ReplyForm(
+        hashCheck = hashCheck,
+        sujet = "Sujet prive de test",
+        hiddenFields = hiddenFields,
+        isAnonymous = isAnonymous,
+    )
+
+    @Test
+    fun `loads the form on init and hydrates signature from the hidden field`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form()
+
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+
+        val state = viewModel.state.value
+        assertFalse(state.isLoadingForm)
+        assertTrue(state.formAvailable)
+        assertFalse(state.formError)
+        // The quick-reply form carries signature as a hidden `=1`, so the toggle defaults on.
+        assertTrue("signature default should be hydrated from the hidden field", state.signatureEnabled)
+    }
+
+    @Test
+    fun `submit success raises SubmitSucceeded for the conversation`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form()
+        coEvery { repository.submitReply(any(), any(), any(), any()) } returns
+            ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
+
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+        viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
+
+        viewModel.effects.test {
+            viewModel.onSubmit()
+            assertEquals(
+                PrivateMessageReplyEffect.SubmitSucceeded(threadId = 3195237, page = 1),
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertFalse(viewModel.state.value.isSubmitting)
+        assertNull(viewModel.state.value.submitError)
+    }
+
+    @Test
+    fun `empty-message failure shows the banner and keeps the draft`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form()
+        coEvery { repository.submitReply(any(), any(), any(), any()) } returns
+            ReplySubmitResult.Failure(ReplyFailureReason.EmptyMessage)
+
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+        viewModel.onContentChanged(TextFieldValue("non-blank"))
+        viewModel.onSubmit()
+
+        val state = viewModel.state.value
+        assertEquals(PrivateMessageReplyError.Empty, state.submitError)
+        assertEquals("non-blank", state.draft.text)
+        assertFalse(state.isSubmitting)
+    }
+
+    @Test
+    fun `invalid hash check refetches the form silently`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form()
+        coEvery { repository.submitReply(any(), any(), any(), any()) } returns
+            ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)
+
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+        viewModel.onContentChanged(TextFieldValue("hello"))
+        viewModel.onSubmit()
+
+        assertEquals(PrivateMessageReplyError.InvalidHashCheck, viewModel.state.value.submitError)
+        // init fetch + the silent refetch after the expired hash_check.
+        coVerify(exactly = 2) { repository.fetchReplyForm(any()) }
+    }
+
+    @Test
+    fun `unknown response maps to the non-destructive unexpected banner`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form()
+        coEvery { repository.submitReply(any(), any(), any(), any()) } returns
+            ReplySubmitResult.Failure(ReplyFailureReason.Unknown)
+
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+        viewModel.onContentChanged(TextFieldValue("hello"))
+        viewModel.onSubmit()
+
+        val state = viewModel.state.value
+        assertEquals(PrivateMessageReplyError.Unexpected, state.submitError)
+        // Non-destructive: the draft survives so the user can verify and retry.
+        assertEquals("hello", state.draft.text)
+    }
+
+    @Test
+    fun `form fetch failure shows the retry state`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } throws IOException("network down")
+
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+
+        val state = viewModel.state.value
+        assertTrue(state.formError)
+        assertFalse(state.formAvailable)
+        assertFalse(state.isLoadingForm)
+    }
+
+    @Test
+    fun `anonymous form is treated as a form error`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form(isAnonymous = true)
+
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+
+        assertTrue(viewModel.state.value.formError)
+        assertFalse(viewModel.state.value.formAvailable)
+    }
+
+    @Test
+    fun `context carries the request thread and page`() {
+        // Guards the route → context mapping the repository relies on.
+        val context = PrivateMessageReplyContext(threadId = request.threadId, page = request.page)
+        assertEquals(3195237, context.threadId)
+        assertEquals(1, context.page)
+    }
+}


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

## Contexte

La **lecture** des MP (#298) existait. Cette PR ajoute la **réponse à une conversation privée existante** — le cas d'usage dominant de l'écriture MP. La **composition d'un nouveau MP** (écrire à un destinataire sans conversation préalable) est **différée** : `#301` reste ouverte pour la suivre (voir « Scope différé » plus bas).

## Contrat HFR (prouvé sur fixture réelle)

Le formulaire de réponse MP est **embarqué dans la page de conversation** (`forum2.php?cat=prive&post={threadId}`, fixture réelle `private_message_thread.html` de #298) et poste sur le **même `bddpost.php`** qu'une réponse de topic. Tout le routing vit dans les hidden fields, transmis **verbatim** :
- `cat=prive` (une **String**, pas un id numérique → `ReplyContext` incompatible, d'où un contexte dédié) ;
- `post={threadId}`, `subcat=0` ;
- `numrep` = dernier post de la page, **pré-rempli par HFR**, **sans rapport avec une citation** — préservé tel quel, jamais vidé.

## Changement

- **core:model** `PrivateMessageReplyContext` (threadId, page).
- **core:domain** `PrivateMessageWriteRepository` + **core:data** `DefaultPrivateMessageWriteRepository` : GET la page de conversation, parse via le `ReplyFormParser` **partagé**, POST via `submitReply` **partagé**. `buildFormBody` MP n'override QUE `hash_check` / `verifrequet` / `content_form` + les options opt-in ; `cat=prive` et `numrep` ne sont **jamais** écrasés ni vidés (≠ `buildFormBody` topic).
- **feature:messages** `PrivateMessageReplyViewModel`/`Screen`/`UiState` **dédiés** (l'éditeur de post est trop couplé à `cat:Int`) ; réutilise la toolbar/preview BBCode `:core:ui` et la **barre d'envoi épinglée au-dessus du clavier**. FAB « Répondre » sur le thread quand `canReply`. **Refetch silencieux** du form sur `hash_check` expiré.
- **Succès POST non capturé en live** (aucun chemin read-only MCP pour `cat=prive` ; **aucun MP non sollicité envoyé**) : une réponse non reconnue (`Unknown`) est traitée comme **non destructive** (brouillon conservé + bandeau « vérifiez la conversation »), jamais comme un échec dur. Après succès, le thread est rechargé (route re-poussée avec `submitSignal`, même mécanisme que `TopicRoute`).

## Tests

17 nouveaux tests verts :
- **Parser** sur la **vraie fixture** : `cat=prive` + `numrep` préservés, `hash_check` extrait, `content_form` vide.
- **Repository** : `buildFormBody` ne réécrit pas `cat`, ne vide pas `numrep`, forwarde `post`/`subcat` verbatim, filtre `password`, ajoute/omet `signature` selon l'option, classifie les erreurs partagées.
- **ViewModel** : succès → effet ; `EmptyMessage` non destructif ; refetch sur `InvalidHashCheck` ; `Unknown` → bandeau non destructif (brouillon conservé) ; échec form → retry.

## Validation locale

- `detektAll test testDebugUnitTest :app:assembleProdDebug` → BUILD SUCCESSFUL
- `lintDebug :app:lintProdDebug` → BUILD SUCCESSFUL

## Revue

Passe 4-flavor (feature-dev:code-reviewer + agents adversariaux/plan↔code) + revue finale, seuil 60. Findings arbitrés : les patterns nav (`as? PrivateMessageThreadRoute`) et VM (`runCatching`+rethrow `CancellationException`) **calquent à l'identique** `PostEditorRoute`/`PostEditorViewModel` (acceptés) ; limites v1 documentées (réponse atterrit sur la page source, pas de redirect overflow ; `Unknown` garde le brouillon plutôt que recharger). i18n/Hilt/a11y/régression : propres.

## Scope différé (reste dans #301)

Composition d'un **nouveau** MP : endpoint `message.php?cat=prive&pseudo={dest}` jamais observé (form + réponse + erreur destinataire). À faire = **capturer d'abord les fixtures réelles** (charte « le réel prime »), puis étendre `PrivateMessageWriteRepository` + UI « Nouveau MP » depuis l'inbox. L'infra de cette PR est réutilisable telle quelle.

Advances #301.
