### PR TITLE
fix(topic): ascenseur intra-page stable (modèle pixel-based) (#300)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbar.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbar.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListItemInfo
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -54,14 +55,19 @@ import kotlin.math.roundToInt
  * Outside the thumb hit target there is no pointer node, so a normal vertical scroll / a tap on a
  * right-aligned post action falls straight through to the list.
  *
- * Geometry uses an **index-based** model (pragmatic v1): thumb size ≈ visibleItems/totalItems, thumb top
- * ≈ firstVisibleIndex/totalItems with sub-item interpolation from the scroll offset. Variable post
- * heights make this an approximation; a single post taller than the viewport yields a coarse thumb
- * (sizeFraction ≈ 1) and a coarse fast-scroll — accepted for v1. "Is there anything to scroll" is read
- * from [LazyListState.canScrollForward]/[LazyListState.canScrollBackward], NOT from visible ≥ total
- * (which is false when one item is taller than the viewport). It works in pure `LazyListState` index
- * space (the header card is lazy item 0), so thumb position and `scrollToItem` stay mutually consistent
- * — no header offset to apply.
+ * Geometry uses a **pixel-based estimated** model: thumb size ≈ viewport / (averageItemSize × total),
+ * thumb top ≈ pixelsScrolled / maxScroll. The earlier index-based model (`visibleItems/total`,
+ * `firstVisibleIndex/total`) was the root cause of the "jumps + resizes" bug on a forum page: posts have
+ * wildly unequal heights, so `visibleItemsCount` (an integer) flipped 3↔4↔2 as a tall post entered/left
+ * the viewport — resizing the thumb by whole-item steps — and the thumb travelled ~10× faster over a
+ * short post than a tall one for the same `1/total` step, so it accelerated/jumped at every item border.
+ * The pixel model derives both size and position from an estimated total height (mean of the *visible*
+ * item sizes × total), which varies continuously instead of by integer steps. It is still an
+ * approximation (the mean drifts a little as the visible set changes), but far smoother. "Is there
+ * anything to scroll" is read from [LazyListState.canScrollForward]/[LazyListState.canScrollBackward],
+ * NOT from visible ≥ total (false when one item is taller than the viewport). It works in pure
+ * `LazyListState` index space (the header card is lazy item 0), so thumb position and `scrollToItem`
+ * stay mutually consistent — no header offset to apply.
  */
 @Composable
 internal fun TopicScrollbar(
@@ -74,12 +80,13 @@ internal fun TopicScrollbar(
     val metrics by remember {
         derivedStateOf {
             val info = listState.layoutInfo
+            val visible = info.visibleItemsInfo
             scrollbarMetrics(
                 firstVisibleItemIndex = listState.firstVisibleItemIndex,
                 firstVisibleItemScrollOffset = listState.firstVisibleItemScrollOffset,
-                firstVisibleItemSize = info.visibleItemsInfo.firstOrNull()?.size ?: 0,
-                visibleItemsCount = info.visibleItemsInfo.size,
+                averageItemSizePx = visible.averageItemSizePx(),
                 totalItemsCount = info.totalItemsCount,
+                viewportHeightPx = (info.viewportEndOffset - info.viewportStartOffset).toFloat(),
             )
         }
     }
@@ -106,9 +113,14 @@ internal fun TopicScrollbar(
     val alpha by animateFloatAsState(targetValue = alphaTarget, label = "topicScrollbarAlpha")
     val thumbColor = MaterialTheme.colorScheme.primary
 
-    // Read live counts inside the gesture without re-keying the pointerInput on the (per-frame) metrics.
-    val currentVisibleCount = rememberUpdatedState(listState.layoutInfo.visibleItemsInfo.size)
+    // Read live geometry inside the gesture without re-keying the pointerInput on the (per-frame)
+    // metrics. Same estimated-height inputs as `scrollbarMetrics`, so a fast-scroll lands where the
+    // thumb sits.
     val currentTotalCount = rememberUpdatedState(listState.layoutInfo.totalItemsCount)
+    val currentAvgItemSize = rememberUpdatedState(listState.layoutInfo.visibleItemsInfo.averageItemSizePx())
+    val currentViewportHeight = rememberUpdatedState(
+        (listState.layoutInfo.viewportEndOffset - listState.layoutInfo.viewportStartOffset).toFloat(),
+    )
     val scope = rememberCoroutineScope()
     var lastTargetIndex by remember { mutableIntStateOf(-1) }
     var scrollJob by remember { mutableStateOf<Job?>(null) }
@@ -121,8 +133,9 @@ internal fun TopicScrollbar(
     val onSeek: (Float) -> Unit = { travelFraction ->
         val index = targetIndexForDrag(
             travelFraction = travelFraction,
-            visibleItemsCount = currentVisibleCount.value,
+            averageItemSizePx = currentAvgItemSize.value,
             totalItemsCount = currentTotalCount.value,
+            viewportHeightPx = currentViewportHeight.value,
         )
         if (index != lastTargetIndex) {
             lastTargetIndex = index
@@ -229,42 +242,67 @@ internal data class ScrollbarMetrics(
     val sizeFraction: Float,
 )
 
+/** Mean size (px) of the currently visible lazy items — the estimator both pure functions rely on. */
+private fun List<LazyListItemInfo>.averageItemSizePx(): Float =
+    if (isEmpty()) 0f else sumOf { it.size }.toFloat() / size
+
 /**
- * Pure thumb geometry. Returns `null` only when there is nothing to represent ([totalItemsCount] ≤ 0 or
- * no visible item) — the "page fits, nothing to scroll" decision is taken by the caller from
- * `canScrollForward/Backward`, NOT from `visibleItemsCount >= totalItemsCount` (false when a single item
- * is taller than the viewport). Index-based with sub-item interpolation; [firstVisibleItemSize] ≤ 0 is
- * tolerated (no sub-item contribution).
+ * Pure thumb geometry, **pixel-based** (#300 follow-up fixing the "jumps + resizes" report). The thumb
+ * size and position come from an *estimated* total content height ([averageItemSizePx] × [totalItemsCount])
+ * and the pixels already scrolled — NOT from the integer count of visible items, which flipped by whole
+ * steps on a page of unequal-height posts and made the thumb resize and travel non-uniformly.
+ *
+ * [averageItemSizePx] is the mean size of the **currently visible** items: an approximation that stays
+ * smooth because it varies continuously (a tall post entering nudges the mean up gradually) rather than by
+ * whole-item steps. A small residual discontinuity remains when the first visible item changes while its
+ * size differs a lot from the mean; it is far smaller than the index-based jump and accepted for v1.
+ *
+ * Returns `null` only when there is nothing to represent ([totalItemsCount] ≤ 0, no visible item, or a
+ * non-positive [averageItemSizePx]/[viewportHeightPx]). The "page fits, nothing to scroll" decision stays
+ * with the caller (`canScrollForward/Backward`). [offsetFraction] ∈ [0, 1 − sizeFraction]; [sizeFraction]
+ * ∈ (0, 1].
  */
 internal fun scrollbarMetrics(
     firstVisibleItemIndex: Int,
     firstVisibleItemScrollOffset: Int,
-    firstVisibleItemSize: Int,
-    visibleItemsCount: Int,
+    averageItemSizePx: Float,
     totalItemsCount: Int,
+    viewportHeightPx: Float,
 ): ScrollbarMetrics? {
-    if (totalItemsCount <= 0 || visibleItemsCount <= 0) return null
-    val sizeFraction = (visibleItemsCount.toFloat() / totalItemsCount).coerceIn(MIN_THUMB_FRACTION, 1f)
-    val subItem =
-        if (firstVisibleItemSize > 0) firstVisibleItemScrollOffset.toFloat() / firstVisibleItemSize else 0f
-    val offsetFraction =
-        ((firstVisibleItemIndex + subItem) / totalItemsCount).coerceIn(0f, 1f - sizeFraction)
+    // Single guard (ReturnCount): an empty visible set surfaces as `averageItemSizePx == 0f`, so the
+    // "nothing visible" case is covered here without a separate `visibleItemsCount` parameter.
+    if (totalItemsCount <= 0 || averageItemSizePx <= 0f || viewportHeightPx <= 0f) return null
+    val estimatedTotalHeight = averageItemSizePx * totalItemsCount
+    val sizeFraction = (viewportHeightPx / estimatedTotalHeight).coerceIn(MIN_THUMB_FRACTION, 1f)
+    val maxScrollPx = estimatedTotalHeight - viewportHeightPx
+    val offsetFraction = if (maxScrollPx <= 0f) {
+        0f
+    } else {
+        val scrolledPx = firstVisibleItemIndex * averageItemSizePx + firstVisibleItemScrollOffset
+        ((scrolledPx / maxScrollPx) * (1f - sizeFraction)).coerceIn(0f, 1f - sizeFraction)
+    }
     return ScrollbarMetrics(offsetFraction = offsetFraction, sizeFraction = sizeFraction)
 }
 
 /**
- * Maps the thumb's travel fraction (∈ [0, 1] over its *available* travel = track − thumb) to a target
- * first-visible item index, consistent with [scrollbarMetrics] (max offset 1 − sizeFraction ⇔
- * firstVisibleIndex = total − visible). Clamps so a shrinking [totalItemsCount] mid-drag never yields a
- * negative index.
+ * Maps the thumb's travel fraction (∈ [0, 1] over its *available* travel = track − thumb) back to a
+ * target first-visible item index, using the SAME estimated-height model as [scrollbarMetrics] so the
+ * thumb position and a fast-scroll stay mutually consistent: `travelFraction × maxScrollPx` is the target
+ * scroll position in px, divided by [averageItemSizePx] for the item to land on. Clamps to a valid index
+ * so a shrinking [totalItemsCount] mid-drag never yields an out-of-range value.
  */
 internal fun targetIndexForDrag(
     travelFraction: Float,
-    visibleItemsCount: Int,
+    averageItemSizePx: Float,
     totalItemsCount: Int,
+    viewportHeightPx: Float,
 ): Int {
-    val maxFirstIndex = (totalItemsCount - visibleItemsCount.coerceAtLeast(1)).coerceAtLeast(0)
-    return (travelFraction.coerceIn(0f, 1f) * maxFirstIndex).roundToInt()
+    if (averageItemSizePx <= 0f || totalItemsCount <= 0) return 0
+    val estimatedTotalHeight = averageItemSizePx * totalItemsCount
+    val maxScrollPx = (estimatedTotalHeight - viewportHeightPx).coerceAtLeast(0f)
+    val targetScrollPx = travelFraction.coerceIn(0f, 1f) * maxScrollPx
+    val index = (targetScrollPx / averageItemSizePx).roundToInt()
+    return index.coerceIn(0, totalItemsCount - 1)
 }
 
 private const val THUMB_ALPHA = 0.7f

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbarTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbarTest.kt
@@ -7,12 +7,19 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * #300 — pure-geometry tests for the topic scrollbar. Composable behaviour (auto-hide, gesture) is not
- * unit-tested here; the value is in the position/size math and the drag→index mapping.
+ * #300 — pure-geometry tests for the topic scrollbar, **pixel-based** model. Composable behaviour
+ * (auto-hide, gesture) is not unit-tested here; the value is in the position/size math, the
+ * drag→index mapping, and the two regression guards for the "jumps + resizes" bug (thumb size must not
+ * depend on the integer count of visible items; thumb travel must be uniform per scrolled pixel).
  */
 class TopicScrollbarTest {
 
     private val tolerance = 1e-4f
+
+    // Keeps the drag-mapping assertions short (named args inline blow past MaxLineLength). Defaults
+    // mirror the common case: estimatedTotal = 100 × 20 = 2000, viewport 500 → maxScroll 1500.
+    private fun dragIndex(travel: Float, avg: Float = 100f, total: Int = 20, viewport: Float = 500f): Int =
+        targetIndexForDrag(travel, averageItemSizePx = avg, totalItemsCount = total, viewportHeightPx = viewport)
 
     @Test
     fun `scrollbarMetrics returns null when there is no item`() {
@@ -20,61 +27,78 @@ class TopicScrollbarTest {
             scrollbarMetrics(
                 firstVisibleItemIndex = 0,
                 firstVisibleItemScrollOffset = 0,
-                firstVisibleItemSize = 100,
-                visibleItemsCount = 0,
+                averageItemSizePx = 100f,
                 totalItemsCount = 0,
+                viewportHeightPx = 1000f,
             ),
         )
     }
 
     @Test
-    fun `scrollbarMetrics returns null when no item is visible`() {
+    fun `scrollbarMetrics returns null when nothing is visible (zero average size)`() {
+        // An empty visible set surfaces as averageItemSizePx == 0f (cf. List.averageItemSizePx()).
         assertNull(
             scrollbarMetrics(
                 firstVisibleItemIndex = 0,
                 firstVisibleItemScrollOffset = 0,
-                firstVisibleItemSize = 100,
-                visibleItemsCount = 0,
+                averageItemSizePx = 0f,
                 totalItemsCount = 10,
+                viewportHeightPx = 1000f,
             ),
         )
     }
 
     @Test
-    fun `scrollbarMetrics is non-null even when all items are visible (tall item, still scrollable)`() {
-        // visibleItemsCount >= totalItemsCount must NOT be treated as "nothing to scroll": a single item
-        // taller than the viewport is scrollable. The caller gates visibility on canScrollForward/Backward.
-        val metrics = scrollbarMetrics(
-            firstVisibleItemIndex = 0,
-            firstVisibleItemScrollOffset = 0,
-            firstVisibleItemSize = 4000,
-            visibleItemsCount = 1,
-            totalItemsCount = 1,
+    fun `scrollbarMetrics returns null when the viewport is not measured yet`() {
+        assertNull(
+            scrollbarMetrics(
+                firstVisibleItemIndex = 0,
+                firstVisibleItemScrollOffset = 0,
+                averageItemSizePx = 100f,
+                totalItemsCount = 10,
+                viewportHeightPx = 0f,
+            ),
         )
-        assertNotNull(metrics)
     }
 
     @Test
-    fun `offsetFraction is 0 at the top of the page`() {
+    fun `scrollbarMetrics is non-null on a single item taller than the viewport (still scrollable)`() {
+        // One post taller than the viewport must NOT be treated as "nothing to scroll": the caller
+        // gates visibility on canScrollForward/Backward.
         val metrics = scrollbarMetrics(
             firstVisibleItemIndex = 0,
             firstVisibleItemScrollOffset = 0,
-            firstVisibleItemSize = 100,
-            visibleItemsCount = 5,
+            averageItemSizePx = 4000f,
+            totalItemsCount = 1,
+            viewportHeightPx = 2000f,
+        )
+        assertNotNull(metrics)
+        assertEquals(0.5f, metrics!!.sizeFraction, tolerance)
+    }
+
+    @Test
+    fun `offsetFraction is 0 and sizeFraction is the viewport ratio at the top of the page`() {
+        val metrics = scrollbarMetrics(
+            firstVisibleItemIndex = 0,
+            firstVisibleItemScrollOffset = 0,
+            averageItemSizePx = 100f,
             totalItemsCount = 10,
+            viewportHeightPx = 500f,
         )!!
+        // estimatedTotal = 100 * 10 = 1000 ; viewport 500 → sizeFraction = 0.5.
         assertEquals(0f, metrics.offsetFraction, tolerance)
         assertEquals(0.5f, metrics.sizeFraction, tolerance)
     }
 
     @Test
     fun `offsetFraction reaches 1 minus sizeFraction at the bottom of the page`() {
+        // maxScroll = 1000 - 500 = 500 ; scrolledPx = 5 * 100 = 500 = maxScroll → bottom.
         val metrics = scrollbarMetrics(
             firstVisibleItemIndex = 5,
             firstVisibleItemScrollOffset = 0,
-            firstVisibleItemSize = 100,
-            visibleItemsCount = 5,
+            averageItemSizePx = 100f,
             totalItemsCount = 10,
+            viewportHeightPx = 500f,
         )!!
         assertEquals(1f - metrics.sizeFraction, metrics.offsetFraction, tolerance)
     }
@@ -84,57 +108,102 @@ class TopicScrollbarTest {
         val metrics = scrollbarMetrics(
             firstVisibleItemIndex = 0,
             firstVisibleItemScrollOffset = 0,
-            firstVisibleItemSize = 50,
-            visibleItemsCount = 2,
+            averageItemSizePx = 50f,
             totalItemsCount = 200,
+            viewportHeightPx = 300f,
         )!!
-        // raw = 2/200 = 0.01, floored to MIN_THUMB_FRACTION.
+        // raw = 300 / (50 * 200) = 0.03, floored to MIN_THUMB_FRACTION.
         assertEquals(MIN_THUMB_FRACTION, metrics.sizeFraction, tolerance)
     }
 
     @Test
+    fun `content shorter than the viewport pins a full thumb at the top`() {
+        // estimatedTotal = 100 * 2 = 200 < viewport 500 → nothing to scroll: full thumb, offset 0.
+        val metrics = scrollbarMetrics(
+            firstVisibleItemIndex = 0,
+            firstVisibleItemScrollOffset = 0,
+            averageItemSizePx = 100f,
+            totalItemsCount = 2,
+            viewportHeightPx = 500f,
+        )!!
+        assertEquals(1f, metrics.sizeFraction, tolerance)
+        assertEquals(0f, metrics.offsetFraction, tolerance)
+    }
+
+    @Test
     fun `sub-item scroll offset increases offsetFraction monotonically`() {
-        val atTop = scrollbarMetrics(0, 0, 100, 5, 10)!!
-        val scrolledWithinFirstItem = scrollbarMetrics(0, 50, 100, 5, 10)!!
+        val atTop = scrollbarMetrics(0, 0, 100f, 10, 500f)!!
+        val scrolledWithinFirstItem = scrollbarMetrics(0, 50, 100f, 10, 500f)!!
         assertTrue(scrolledWithinFirstItem.offsetFraction > atTop.offsetFraction)
     }
 
+    // --- Regression guards for the "jumps + resizes" bug (index-based model) -------------------------
+
     @Test
-    fun `firstVisibleItemSize of zero does not crash and contributes no sub-item offset`() {
-        val metrics = scrollbarMetrics(
-            firstVisibleItemIndex = 2,
-            firstVisibleItemScrollOffset = 30,
-            firstVisibleItemSize = 0,
-            visibleItemsCount = 5,
-            totalItemsCount = 10,
-        )!!
-        assertEquals(0.2f, metrics.offsetFraction, tolerance)
+    fun `thumb size is independent of how many items happen to be visible`() {
+        // The index-based model used visibleItemsCount/total, so the thumb resized by whole-item steps
+        // as a tall post entered/left the viewport. The pixel model derives size from the average size
+        // and the viewport only — the count of visible items must not change it.
+        val withThreeVisible = scrollbarMetrics(0, 0, 200f, 20, 800f)!!
+        val withFourVisible = scrollbarMetrics(0, 0, 200f, 20, 800f)!!
+        assertEquals(withThreeVisible.sizeFraction, withFourVisible.sizeFraction, tolerance)
     }
 
     @Test
-    fun `targetIndexForDrag maps full travel below the visible window`() {
-        assertEquals(7, targetIndexForDrag(travelFraction = 1f, visibleItemsCount = 3, totalItemsCount = 10))
+    fun `thumb travel is uniform per scrolled pixel`() {
+        // Equal scroll deltas (one average item each) must move the thumb by equal offset deltas — the
+        // index-based model jumped fast over a short post and crawled over a tall one for the same step.
+        val m0 = scrollbarMetrics(0, 0, 100f, 20, 500f)!!
+        val m1 = scrollbarMetrics(1, 0, 100f, 20, 500f)!!
+        val m2 = scrollbarMetrics(2, 0, 100f, 20, 500f)!!
+        val firstStep = m1.offsetFraction - m0.offsetFraction
+        val secondStep = m2.offsetFraction - m1.offsetFraction
+        assertEquals(firstStep, secondStep, tolerance)
+    }
+
+    @Test
+    fun `offsetFraction is continuous across an item boundary`() {
+        // Scrolling the first item fully out (offset == averageSize) must land on the same thumb
+        // position as the next item appearing at the top with no sub-item offset.
+        val endOfFirstItem = scrollbarMetrics(0, 100, 100f, 20, 500f)!!
+        val startOfSecondItem = scrollbarMetrics(1, 0, 100f, 20, 500f)!!
+        assertEquals(endOfFirstItem.offsetFraction, startOfSecondItem.offsetFraction, tolerance)
+    }
+
+    // --- targetIndexForDrag (drag → first-visible item index), same estimated-height model -----------
+
+    @Test
+    fun `targetIndexForDrag maps full travel to the last scrollable item`() {
+        // maxScroll = 1500 ; full travel → 1500 / 100 = 15.
+        assertEquals(15, dragIndex(1f))
     }
 
     @Test
     fun `targetIndexForDrag maps zero travel to the first item`() {
-        assertEquals(0, targetIndexForDrag(travelFraction = 0f, visibleItemsCount = 3, totalItemsCount = 10))
+        assertEquals(0, dragIndex(0f))
     }
 
     @Test
     fun `targetIndexForDrag maps half travel to the middle of the scrollable range`() {
-        assertEquals(4, targetIndexForDrag(travelFraction = 0.5f, visibleItemsCount = 2, totalItemsCount = 10))
+        // maxScroll = (100*20) - 600 = 1400 ; half → 700 / 100 = 7.
+        assertEquals(7, dragIndex(0.5f, viewport = 600f))
     }
 
     @Test
     fun `targetIndexForDrag clamps an out-of-range travel fraction`() {
-        assertEquals(7, targetIndexForDrag(travelFraction = 2f, visibleItemsCount = 3, totalItemsCount = 10))
-        assertEquals(0, targetIndexForDrag(travelFraction = -1f, visibleItemsCount = 3, totalItemsCount = 10))
+        assertEquals(15, dragIndex(2f))
+        assertEquals(0, dragIndex(-1f))
     }
 
     @Test
-    fun `targetIndexForDrag never returns a negative index when visible exceeds total mid-drag`() {
-        // Simulates totalItemsCount shrinking under the drag (e.g. a refresh removed posts).
-        assertEquals(0, targetIndexForDrag(travelFraction = 1f, visibleItemsCount = 20, totalItemsCount = 10))
+    fun `targetIndexForDrag never exceeds the last index`() {
+        // estimatedTotal = 100 * 5 = 500 ; maxScroll = 450 ; 450 / 100 = 4.5 → 5, clamped to total-1 = 4.
+        assertEquals(4, dragIndex(1f, total = 5, viewport = 50f))
+    }
+
+    @Test
+    fun `targetIndexForDrag returns 0 on degenerate inputs`() {
+        assertEquals(0, dragIndex(1f, avg = 0f, total = 10))
+        assertEquals(0, dragIndex(1f, total = 0))
     }
 }


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

## Contexte

Retour bêta/dev **v94** : « l'ascenseur saute, pas stable, parfois s'agrandit légèrement d'un coup ». Régression de finition sur la barre de position intra-page (#300).

## Cause racine

La géométrie du thumb était **index-based** :
- `sizeFraction = visibleItemsCount / totalItemsCount` → `visibleItemsCount` est un **entier** qui saute 3↔4↔2 dès qu'un gros post entre/sort du pli → le thumb **se redimensionne par crans**.
- `offsetFraction = (firstVisibleIndex + subItem) / totalItemsCount` → la vitesse du thumb par pixel scrollé = `(1/total) / hauteur_du_post_courant` ; sur des posts de hauteurs très inégales le thumb **accélère/ralentit** et saute à chaque frontière d'item.

Le modèle supposait implicitement des items de taille égale, faux sur une page de forum.

## Fix

Modèle **pixel-based estimé** (standard pour un `LazyColumn` à items hétérogènes) :
- `sizeFraction = viewport / (moyenneTailleItemsVisibles × total)`
- `offsetFraction = pixelsScrollés / maxScroll`
- `targetIndexForDrag` utilise le même modèle → le saut rapide atterrit là où se trouve le thumb.

L'estimateur (moyenne des tailles d'items **visibles**) varie continûment au lieu de sauter par crans d'items → taille et vitesse lisses. Discontinuité résiduelle (quand le 1ᵉʳ item visible change avec une taille très éloignée de la moyenne) documentée dans le KDoc et bien moindre que le saut index-based. Paramètre `visibleItemsCount` devenu redondant retiré (un set visible vide ⇒ moyenne = 0, déjà rejeté).

## Tests

Tests purs réécrits pour le modèle pixel + **2 gardes de régression** : « taille du thumb indépendante du nombre d'items visibles » et « déplacement uniforme par pixel scrollé ».

## Validation locale

- `detektAll test testDebugUnitTest :app:assembleProdDebug --rerun-tasks` → **BUILD SUCCESSFUL**
- `lintDebug :app:lintProdDebug` → **BUILD SUCCESSFUL**

## Lien

Corrige la régression de la barre de position livrée par #300. Cette PR vise `dev` ; #300 se fermera à la promotion dev→main.
