### PR TITLE
fix(topic): ascenseur stable — modèle taille fixe + ordinal (supersède le pixel) (#300)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbar.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbar.kt
@@ -1,6 +1,9 @@
 package fr.forumhfr.redface2.feature.topic
 
+import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Box
@@ -11,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyListItemInfo
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -55,19 +57,24 @@ import kotlin.math.roundToInt
  * Outside the thumb hit target there is no pointer node, so a normal vertical scroll / a tap on a
  * right-aligned post action falls straight through to the list.
  *
- * Geometry uses a **pixel-based estimated** model: thumb size ≈ viewport / (averageItemSize × total),
- * thumb top ≈ pixelsScrolled / maxScroll. The earlier index-based model (`visibleItems/total`,
- * `firstVisibleIndex/total`) was the root cause of the "jumps + resizes" bug on a forum page: posts have
- * wildly unequal heights, so `visibleItemsCount` (an integer) flipped 3↔4↔2 as a tall post entered/left
- * the viewport — resizing the thumb by whole-item steps — and the thumb travelled ~10× faster over a
- * short post than a tall one for the same `1/total` step, so it accelerated/jumped at every item border.
- * The pixel model derives both size and position from an estimated total height (mean of the *visible*
- * item sizes × total), which varies continuously instead of by integer steps. It is still an
- * approximation (the mean drifts a little as the visible set changes), but far smoother. "Is there
- * anything to scroll" is read from [LazyListState.canScrollForward]/[LazyListState.canScrollBackward],
- * NOT from visible ≥ total (false when one item is taller than the viewport). It works in pure
- * `LazyListState` index space (the header card is lazy item 0), so thumb position and `scrollToItem`
- * stay mutually consistent — no header offset to apply.
+ * Geometry uses a **fixed-size, ordinal** model: the thumb is a constant fraction of the track
+ * ([THUMB_SIZE_FRACTION]) and its position comes purely from the list ordinal
+ * `firstVisibleItemIndex / (totalItemsCount − 1)`. It deliberately does NOT read any measured item
+ * size. Two earlier attempts both tied the thumb to a *moving estimate* of total content height and
+ * failed: an index-based one (size = `visibleItemsCount/total`, an integer flipping 3↔4↔2) and a
+ * pixel-estimated one (size = `viewport / (avgVisibleItemSize × total)`). On a forum page — unequal
+ * post heights, plus block images that grow 160→480dp once Coil decodes them (#197) and inline media
+ * that resizes after measurement — the estimated total "breathes", so the thumb resized and jumped
+ * (the average of the *visible* items rewrites the assumed height of every item before the viewport),
+ * even while idle. Decoupling the geometry from measured sizes is the only stable option.
+ *
+ * Trade-off (per the Codex review): the thumb is no longer proportional to true scroll length — a tall
+ * image post and a one-liner are one ordinal step each — but it is rock-stable and matches the
+ * fast-scroll use case ("where am I / jump near another post"). A spring on the drawn offset softens
+ * the coarse per-item steps; the thumb drag snaps (no animation) so it never lags under the finger.
+ * "Is there anything to scroll" is still read from
+ * [LazyListState.canScrollForward]/[LazyListState.canScrollBackward]. Pure `LazyListState` index space
+ * (the header card is lazy item 0), so thumb position and `scrollToItem` stay mutually consistent.
  */
 @Composable
 internal fun TopicScrollbar(
@@ -79,14 +86,9 @@ internal fun TopicScrollbar(
     }
     val metrics by remember {
         derivedStateOf {
-            val info = listState.layoutInfo
-            val visible = info.visibleItemsInfo
             scrollbarMetrics(
                 firstVisibleItemIndex = listState.firstVisibleItemIndex,
-                firstVisibleItemScrollOffset = listState.firstVisibleItemScrollOffset,
-                averageItemSizePx = visible.averageItemSizePx(),
-                totalItemsCount = info.totalItemsCount,
-                viewportHeightPx = (info.viewportEndOffset - info.viewportStartOffset).toFloat(),
+                totalItemsCount = listState.layoutInfo.totalItemsCount,
             )
         }
     }
@@ -94,33 +96,27 @@ internal fun TopicScrollbar(
     var isDragging by remember { mutableStateOf(false) }
     val active = canScroll && metrics != null
 
-    // Visible while scrolling or dragging; otherwise a brief show-then-fade. The idle branch also fires
-    // on the first composition of a scrollable page (initial flash → discoverability of the fast-scroll
-    // affordance) and after a scroll settles (post-scroll hold). The LaunchedEffect restarts on every
-    // (active / scroll / drag) change, so a scroll resuming within the hold cancels the pending fade.
-    var alphaTarget by remember { mutableStateOf(0f) }
-    LaunchedEffect(active, listState.isScrollInProgress, isDragging) {
-        when {
-            !active -> alphaTarget = 0f
-            listState.isScrollInProgress || isDragging -> alphaTarget = 1f
-            else -> {
-                alphaTarget = 1f
-                delay(HIDE_DELAY_MS)
-                alphaTarget = 0f
-            }
-        }
-    }
-    val alpha by animateFloatAsState(targetValue = alphaTarget, label = "topicScrollbarAlpha")
+    // Auto-hide alpha extracted to rememberScrollbarAlpha to keep this composable under the cyclomatic
+    // complexity threshold; visible while scrolling/dragging, brief show-then-fade otherwise.
+    val alpha = rememberScrollbarAlpha(
+        active = active,
+        isScrollInProgress = listState.isScrollInProgress,
+        isDragging = isDragging,
+    )
     val thumbColor = MaterialTheme.colorScheme.primary
 
-    // Read live geometry inside the gesture without re-keying the pointerInput on the (per-frame)
-    // metrics. Same estimated-height inputs as `scrollbarMetrics`, so a fast-scroll lands where the
-    // thumb sits.
-    val currentTotalCount = rememberUpdatedState(listState.layoutInfo.totalItemsCount)
-    val currentAvgItemSize = rememberUpdatedState(listState.layoutInfo.visibleItemsInfo.averageItemSizePx())
-    val currentViewportHeight = rememberUpdatedState(
-        (listState.layoutInfo.viewportEndOffset - listState.layoutInfo.viewportStartOffset).toFloat(),
+    // Soften the coarse ordinal steps (the position jumps by 1/(total-1) each time the first visible
+    // item changes): a spring chases the moving target while scrolling/settling, but the thumb drag
+    // snaps (no animation) so the thumb never lags under the finger during a fast-scroll.
+    val animatedOffset by animateFloatAsState(
+        targetValue = metrics?.offsetFraction ?: 0f,
+        animationSpec = if (isDragging) snap() else spring(stiffness = Spring.StiffnessMediumLow),
+        label = "topicScrollbarOffset",
     )
+    val drawnMetrics = metrics?.copy(offsetFraction = animatedOffset)
+
+    // Live total read inside the gesture without re-keying the pointerInput on the (per-frame) metrics.
+    val currentTotalCount = rememberUpdatedState(listState.layoutInfo.totalItemsCount)
     val scope = rememberCoroutineScope()
     var lastTargetIndex by remember { mutableIntStateOf(-1) }
     var scrollJob by remember { mutableStateOf<Job?>(null) }
@@ -133,9 +129,7 @@ internal fun TopicScrollbar(
     val onSeek: (Float) -> Unit = { travelFraction ->
         val index = targetIndexForDrag(
             travelFraction = travelFraction,
-            averageItemSizePx = currentAvgItemSize.value,
             totalItemsCount = currentTotalCount.value,
-            viewportHeightPx = currentViewportHeight.value,
         )
         if (index != lastTargetIndex) {
             lastTargetIndex = index
@@ -151,12 +145,12 @@ internal fun TopicScrollbar(
     ) {
         val trackHeightPx = constraints.maxHeight.toFloat()
         Canvas(modifier = Modifier.fillMaxSize().clearAndSetSemantics { }) {
-            val m = metrics
+            val m = drawnMetrics
             if (alpha > 0f && m != null) {
                 drawScrollbarThumb(metrics = m, alpha = alpha, color = thumbColor)
             }
         }
-        val m = metrics
+        val m = drawnMetrics
         if (active && m != null) {
             ThumbHitTarget(
                 listState = listState,
@@ -167,6 +161,35 @@ internal fun TopicScrollbar(
             )
         }
     }
+}
+
+/**
+ * Auto-hide opacity for the scrollbar: fully visible while [active] and (scrolling or [isDragging]),
+ * otherwise a brief show-then-fade after the last interaction. The idle branch also fires on the first
+ * composition of a scrollable page (initial flash → discoverability) and after a scroll settles. The
+ * [LaunchedEffect] restarts on every (active / scroll / drag) change, so a scroll resuming within the
+ * hold cancels the pending fade.
+ */
+@Composable
+private fun rememberScrollbarAlpha(
+    active: Boolean,
+    isScrollInProgress: Boolean,
+    isDragging: Boolean,
+): Float {
+    var alphaTarget by remember { mutableStateOf(0f) }
+    LaunchedEffect(active, isScrollInProgress, isDragging) {
+        when {
+            !active -> alphaTarget = 0f
+            isScrollInProgress || isDragging -> alphaTarget = 1f
+            else -> {
+                alphaTarget = 1f
+                delay(HIDE_DELAY_MS)
+                alphaTarget = 0f
+            }
+        }
+    }
+    val alpha by animateFloatAsState(targetValue = alphaTarget, label = "topicScrollbarAlpha")
+    return alpha
 }
 
 /**
@@ -242,71 +265,58 @@ internal data class ScrollbarMetrics(
     val sizeFraction: Float,
 )
 
-/** Mean size (px) of the currently visible lazy items — the estimator both pure functions rely on. */
-private fun List<LazyListItemInfo>.averageItemSizePx(): Float =
-    if (isEmpty()) 0f else sumOf { it.size }.toFloat() / size
-
 /**
- * Pure thumb geometry, **pixel-based** (#300 follow-up fixing the "jumps + resizes" report). The thumb
- * size and position come from an *estimated* total content height ([averageItemSizePx] × [totalItemsCount])
- * and the pixels already scrolled — NOT from the integer count of visible items, which flipped by whole
- * steps on a page of unequal-height posts and made the thumb resize and travel non-uniformly.
+ * Pure thumb geometry, **fixed-size + ordinal** (#300 follow-up fixing the "jumps + grows suddenly"
+ * report). The thumb size is the constant [THUMB_SIZE_FRACTION] of the track, and its position is the
+ * pure list ordinal `firstVisibleItemIndex / (totalItemsCount − 1)` mapped onto the available travel
+ * `1 − sizeFraction`. It reads **no measured item size**, so neither a changing visible set during
+ * scroll nor a post-decode image growth (#197) can resize or move the thumb on its own — only an actual
+ * change of the first-visible ordinal does.
  *
- * [averageItemSizePx] is the mean size of the **currently visible** items: an approximation that stays
- * smooth because it varies continuously (a tall post entering nudges the mean up gradually) rather than by
- * whole-item steps. A small residual discontinuity remains when the first visible item changes while its
- * size differs a lot from the mean; it is far smaller than the index-based jump and accepted for v1.
+ * Returns `null` when an ordinal position is meaningless ([totalItemsCount] ≤ 1): a single (possibly
+ * tall) item carries no ordinal progress. A topic page always has the header card (item 0) plus posts,
+ * so this only hides the bar on a degenerate one-item list. The "page fits, nothing to scroll" decision
+ * stays with the caller (`canScrollForward/Backward`). [offsetFraction] ∈ [0, 1 − sizeFraction];
+ * [sizeFraction] is constant.
  *
- * Returns `null` only when there is nothing to represent ([totalItemsCount] ≤ 0, no visible item, or a
- * non-positive [averageItemSizePx]/[viewportHeightPx]). The "page fits, nothing to scroll" decision stays
- * with the caller (`canScrollForward/Backward`). [offsetFraction] ∈ [0, 1 − sizeFraction]; [sizeFraction]
- * ∈ (0, 1].
+ * Trade-off: a tall post and a one-liner are one ordinal step each, so the thumb is not proportional to
+ * true scroll length — accepted for stability (cf. the Codex review). At the very bottom the first
+ * ordinal is `total − visibleCount`, so the thumb rests slightly above the end; a drag to the bottom
+ * still lands there via [targetIndexForDrag] (`scrollToItem(total − 1)`).
  */
 internal fun scrollbarMetrics(
     firstVisibleItemIndex: Int,
-    firstVisibleItemScrollOffset: Int,
-    averageItemSizePx: Float,
     totalItemsCount: Int,
-    viewportHeightPx: Float,
 ): ScrollbarMetrics? {
-    // Single guard (ReturnCount): an empty visible set surfaces as `averageItemSizePx == 0f`, so the
-    // "nothing visible" case is covered here without a separate `visibleItemsCount` parameter.
-    if (totalItemsCount <= 0 || averageItemSizePx <= 0f || viewportHeightPx <= 0f) return null
-    val estimatedTotalHeight = averageItemSizePx * totalItemsCount
-    val sizeFraction = (viewportHeightPx / estimatedTotalHeight).coerceIn(MIN_THUMB_FRACTION, 1f)
-    val maxScrollPx = estimatedTotalHeight - viewportHeightPx
-    val offsetFraction = if (maxScrollPx <= 0f) {
-        0f
-    } else {
-        val scrolledPx = firstVisibleItemIndex * averageItemSizePx + firstVisibleItemScrollOffset
-        ((scrolledPx / maxScrollPx) * (1f - sizeFraction)).coerceIn(0f, 1f - sizeFraction)
-    }
-    return ScrollbarMetrics(offsetFraction = offsetFraction, sizeFraction = sizeFraction)
+    if (totalItemsCount <= 1) return null
+    val progress = (firstVisibleItemIndex.toFloat() / (totalItemsCount - 1)).coerceIn(0f, 1f)
+    val offsetFraction = progress * (1f - THUMB_SIZE_FRACTION)
+    return ScrollbarMetrics(offsetFraction = offsetFraction, sizeFraction = THUMB_SIZE_FRACTION)
 }
 
 /**
  * Maps the thumb's travel fraction (∈ [0, 1] over its *available* travel = track − thumb) back to a
- * target first-visible item index, using the SAME estimated-height model as [scrollbarMetrics] so the
- * thumb position and a fast-scroll stay mutually consistent: `travelFraction × maxScrollPx` is the target
- * scroll position in px, divided by [averageItemSizePx] for the item to land on. Clamps to a valid index
- * so a shrinking [totalItemsCount] mid-drag never yields an out-of-range value.
+ * target first-visible item index, the inverse of [scrollbarMetrics]'s ordinal mapping:
+ * `round(travelFraction × (total − 1))`. Clamps so an out-of-range fraction or a shrinking
+ * [totalItemsCount] mid-drag never yields an out-of-range index.
  */
 internal fun targetIndexForDrag(
     travelFraction: Float,
-    averageItemSizePx: Float,
     totalItemsCount: Int,
-    viewportHeightPx: Float,
 ): Int {
-    if (averageItemSizePx <= 0f || totalItemsCount <= 0) return 0
-    val estimatedTotalHeight = averageItemSizePx * totalItemsCount
-    val maxScrollPx = (estimatedTotalHeight - viewportHeightPx).coerceAtLeast(0f)
-    val targetScrollPx = travelFraction.coerceIn(0f, 1f) * maxScrollPx
-    val index = (targetScrollPx / averageItemSizePx).roundToInt()
+    if (totalItemsCount <= 1) return 0
+    val index = (travelFraction.coerceIn(0f, 1f) * (totalItemsCount - 1)).roundToInt()
     return index.coerceIn(0, totalItemsCount - 1)
 }
 
 private const val THUMB_ALPHA = 0.7f
-internal const val MIN_THUMB_FRACTION = 0.08f
+
+/**
+ * Constant thumb height as a fraction of the track. Fixed on purpose: tying the size to any measured
+ * quantity (visible-item count, or an estimated total height) made it resize as the visible set or image
+ * heights changed — the "grows suddenly" symptom. ~12% gives a comfortable grab target on a phone track.
+ */
+internal const val THUMB_SIZE_FRACTION = 0.12f
 private const val HIDE_DELAY_MS = 800L
 private val SCROLLBAR_GUTTER_WIDTH = 24.dp
 private val THUMB_WIDTH = 6.dp

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbarTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbarTest.kt
@@ -1,209 +1,114 @@
 package fr.forumhfr.redface2.feature.topic
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * #300 — pure-geometry tests for the topic scrollbar, **pixel-based** model. Composable behaviour
- * (auto-hide, gesture) is not unit-tested here; the value is in the position/size math, the
- * drag→index mapping, and the two regression guards for the "jumps + resizes" bug (thumb size must not
- * depend on the integer count of visible items; thumb travel must be uniform per scrolled pixel).
+ * #300 — pure-geometry tests for the topic scrollbar, **fixed-size + ordinal** model. Composable
+ * behaviour (auto-hide, gesture, the spring on the drawn offset) is not unit-tested here; the value is
+ * in the position math, the drag→index inverse, and the regression guards for the "jumps + grows
+ * suddenly" bug: the thumb size must be constant (never derived from content) and the position must be
+ * a pure ordinal of the first-visible index (never derived from measured item sizes).
  */
 class TopicScrollbarTest {
 
     private val tolerance = 1e-4f
 
-    // Keeps the drag-mapping assertions short (named args inline blow past MaxLineLength). Defaults
-    // mirror the common case: estimatedTotal = 100 × 20 = 2000, viewport 500 → maxScroll 1500.
-    private fun dragIndex(travel: Float, avg: Float = 100f, total: Int = 20, viewport: Float = 500f): Int =
-        targetIndexForDrag(travel, averageItemSizePx = avg, totalItemsCount = total, viewportHeightPx = viewport)
+    @Test
+    fun `scrollbarMetrics returns null for a single item (no ordinal progress)`() {
+        assertNull(scrollbarMetrics(firstVisibleItemIndex = 0, totalItemsCount = 1))
+    }
 
     @Test
     fun `scrollbarMetrics returns null when there is no item`() {
-        assertNull(
-            scrollbarMetrics(
-                firstVisibleItemIndex = 0,
-                firstVisibleItemScrollOffset = 0,
-                averageItemSizePx = 100f,
-                totalItemsCount = 0,
-                viewportHeightPx = 1000f,
-            ),
-        )
+        assertNull(scrollbarMetrics(firstVisibleItemIndex = 0, totalItemsCount = 0))
     }
 
     @Test
-    fun `scrollbarMetrics returns null when nothing is visible (zero average size)`() {
-        // An empty visible set surfaces as averageItemSizePx == 0f (cf. List.averageItemSizePx()).
-        assertNull(
-            scrollbarMetrics(
-                firstVisibleItemIndex = 0,
-                firstVisibleItemScrollOffset = 0,
-                averageItemSizePx = 0f,
-                totalItemsCount = 10,
-                viewportHeightPx = 1000f,
-            ),
-        )
-    }
-
-    @Test
-    fun `scrollbarMetrics returns null when the viewport is not measured yet`() {
-        assertNull(
-            scrollbarMetrics(
-                firstVisibleItemIndex = 0,
-                firstVisibleItemScrollOffset = 0,
-                averageItemSizePx = 100f,
-                totalItemsCount = 10,
-                viewportHeightPx = 0f,
-            ),
-        )
-    }
-
-    @Test
-    fun `scrollbarMetrics is non-null on a single item taller than the viewport (still scrollable)`() {
-        // One post taller than the viewport must NOT be treated as "nothing to scroll": the caller
-        // gates visibility on canScrollForward/Backward.
-        val metrics = scrollbarMetrics(
-            firstVisibleItemIndex = 0,
-            firstVisibleItemScrollOffset = 0,
-            averageItemSizePx = 4000f,
-            totalItemsCount = 1,
-            viewportHeightPx = 2000f,
-        )
-        assertNotNull(metrics)
-        assertEquals(0.5f, metrics!!.sizeFraction, tolerance)
-    }
-
-    @Test
-    fun `offsetFraction is 0 and sizeFraction is the viewport ratio at the top of the page`() {
-        val metrics = scrollbarMetrics(
-            firstVisibleItemIndex = 0,
-            firstVisibleItemScrollOffset = 0,
-            averageItemSizePx = 100f,
-            totalItemsCount = 10,
-            viewportHeightPx = 500f,
-        )!!
-        // estimatedTotal = 100 * 10 = 1000 ; viewport 500 → sizeFraction = 0.5.
+    fun `offsetFraction is 0 at the top of the page`() {
+        val metrics = scrollbarMetrics(firstVisibleItemIndex = 0, totalItemsCount = 10)!!
         assertEquals(0f, metrics.offsetFraction, tolerance)
-        assertEquals(0.5f, metrics.sizeFraction, tolerance)
     }
 
     @Test
-    fun `offsetFraction reaches 1 minus sizeFraction at the bottom of the page`() {
-        // maxScroll = 1000 - 500 = 500 ; scrolledPx = 5 * 100 = 500 = maxScroll → bottom.
-        val metrics = scrollbarMetrics(
-            firstVisibleItemIndex = 5,
-            firstVisibleItemScrollOffset = 0,
-            averageItemSizePx = 100f,
-            totalItemsCount = 10,
-            viewportHeightPx = 500f,
-        )!!
+    fun `offsetFraction reaches 1 minus sizeFraction at the last ordinal`() {
+        val metrics = scrollbarMetrics(firstVisibleItemIndex = 9, totalItemsCount = 10)!!
         assertEquals(1f - metrics.sizeFraction, metrics.offsetFraction, tolerance)
     }
 
     @Test
-    fun `sizeFraction respects the minimum thumb floor on a very long page`() {
-        val metrics = scrollbarMetrics(
-            firstVisibleItemIndex = 0,
-            firstVisibleItemScrollOffset = 0,
-            averageItemSizePx = 50f,
-            totalItemsCount = 200,
-            viewportHeightPx = 300f,
-        )!!
-        // raw = 300 / (50 * 200) = 0.03, floored to MIN_THUMB_FRACTION.
-        assertEquals(MIN_THUMB_FRACTION, metrics.sizeFraction, tolerance)
+    fun `offsetFraction clamps a transient out-of-range index`() {
+        // firstVisibleItemIndex should never exceed total, but a transient layoutInfo must not overshoot.
+        val metrics = scrollbarMetrics(firstVisibleItemIndex = 20, totalItemsCount = 10)!!
+        assertEquals(1f - metrics.sizeFraction, metrics.offsetFraction, tolerance)
+    }
+
+    // --- Regression guards for the "jumps + grows suddenly" bug -------------------------------------
+
+    @Test
+    fun `thumb size is a constant, independent of the page or position`() {
+        // The two earlier models tied the size to a moving estimate (visible count, or viewport/estTotal);
+        // that was the "grows suddenly" symptom. The fixed model must return the same size everywhere.
+        assertEquals(THUMB_SIZE_FRACTION, scrollbarMetrics(0, 10)!!.sizeFraction, tolerance)
+        assertEquals(THUMB_SIZE_FRACTION, scrollbarMetrics(5, 10)!!.sizeFraction, tolerance)
+        assertEquals(THUMB_SIZE_FRACTION, scrollbarMetrics(500, 1000)!!.sizeFraction, tolerance)
     }
 
     @Test
-    fun `content shorter than the viewport pins a full thumb at the top`() {
-        // estimatedTotal = 100 * 2 = 200 < viewport 500 → nothing to scroll: full thumb, offset 0.
-        val metrics = scrollbarMetrics(
-            firstVisibleItemIndex = 0,
-            firstVisibleItemScrollOffset = 0,
-            averageItemSizePx = 100f,
-            totalItemsCount = 2,
-            viewportHeightPx = 500f,
-        )!!
-        assertEquals(1f, metrics.sizeFraction, tolerance)
-        assertEquals(0f, metrics.offsetFraction, tolerance)
-    }
-
-    @Test
-    fun `sub-item scroll offset increases offsetFraction monotonically`() {
-        val atTop = scrollbarMetrics(0, 0, 100f, 10, 500f)!!
-        val scrolledWithinFirstItem = scrollbarMetrics(0, 50, 100f, 10, 500f)!!
-        assertTrue(scrolledWithinFirstItem.offsetFraction > atTop.offsetFraction)
-    }
-
-    // --- Regression guards for the "jumps + resizes" bug (index-based model) -------------------------
-
-    @Test
-    fun `thumb size is independent of how many items happen to be visible`() {
-        // The index-based model used visibleItemsCount/total, so the thumb resized by whole-item steps
-        // as a tall post entered/left the viewport. The pixel model derives size from the average size
-        // and the viewport only — the count of visible items must not change it.
-        val withThreeVisible = scrollbarMetrics(0, 0, 200f, 20, 800f)!!
-        val withFourVisible = scrollbarMetrics(0, 0, 200f, 20, 800f)!!
-        assertEquals(withThreeVisible.sizeFraction, withFourVisible.sizeFraction, tolerance)
-    }
-
-    @Test
-    fun `thumb travel is uniform per scrolled pixel`() {
-        // Equal scroll deltas (one average item each) must move the thumb by equal offset deltas — the
-        // index-based model jumped fast over a short post and crawled over a tall one for the same step.
-        val m0 = scrollbarMetrics(0, 0, 100f, 20, 500f)!!
-        val m1 = scrollbarMetrics(1, 0, 100f, 20, 500f)!!
-        val m2 = scrollbarMetrics(2, 0, 100f, 20, 500f)!!
+    fun `position advances by equal ordinal steps`() {
+        // Pure ordinal: each first-visible-index increment moves the thumb by the same amount,
+        // (1/(total-1)) * (1 - sizeFraction) — no dependence on measured item heights.
+        val m0 = scrollbarMetrics(0, 10)!!
+        val m1 = scrollbarMetrics(1, 10)!!
+        val m2 = scrollbarMetrics(2, 10)!!
         val firstStep = m1.offsetFraction - m0.offsetFraction
         val secondStep = m2.offsetFraction - m1.offsetFraction
+        assertTrue("position is monotonic with the index", firstStep > 0f)
         assertEquals(firstStep, secondStep, tolerance)
+        assertEquals((1f / 9f) * (1f - THUMB_SIZE_FRACTION), firstStep, tolerance)
     }
 
-    @Test
-    fun `offsetFraction is continuous across an item boundary`() {
-        // Scrolling the first item fully out (offset == averageSize) must land on the same thumb
-        // position as the next item appearing at the top with no sub-item offset.
-        val endOfFirstItem = scrollbarMetrics(0, 100, 100f, 20, 500f)!!
-        val startOfSecondItem = scrollbarMetrics(1, 0, 100f, 20, 500f)!!
-        assertEquals(endOfFirstItem.offsetFraction, startOfSecondItem.offsetFraction, tolerance)
-    }
-
-    // --- targetIndexForDrag (drag → first-visible item index), same estimated-height model -----------
+    // --- targetIndexForDrag (drag → first-visible item index), inverse of the ordinal mapping --------
 
     @Test
-    fun `targetIndexForDrag maps full travel to the last scrollable item`() {
-        // maxScroll = 1500 ; full travel → 1500 / 100 = 15.
-        assertEquals(15, dragIndex(1f))
+    fun `targetIndexForDrag maps full travel to the last item`() {
+        assertEquals(9, targetIndexForDrag(travelFraction = 1f, totalItemsCount = 10))
     }
 
     @Test
     fun `targetIndexForDrag maps zero travel to the first item`() {
-        assertEquals(0, dragIndex(0f))
+        assertEquals(0, targetIndexForDrag(travelFraction = 0f, totalItemsCount = 10))
     }
 
     @Test
-    fun `targetIndexForDrag maps half travel to the middle of the scrollable range`() {
-        // maxScroll = (100*20) - 600 = 1400 ; half → 700 / 100 = 7.
-        assertEquals(7, dragIndex(0.5f, viewport = 600f))
+    fun `targetIndexForDrag maps half travel to the middle ordinal`() {
+        // 0.5 * (11 - 1) = 5.
+        assertEquals(5, targetIndexForDrag(travelFraction = 0.5f, totalItemsCount = 11))
     }
 
     @Test
     fun `targetIndexForDrag clamps an out-of-range travel fraction`() {
-        assertEquals(15, dragIndex(2f))
-        assertEquals(0, dragIndex(-1f))
+        assertEquals(9, targetIndexForDrag(travelFraction = 2f, totalItemsCount = 10))
+        assertEquals(0, targetIndexForDrag(travelFraction = -1f, totalItemsCount = 10))
     }
 
     @Test
-    fun `targetIndexForDrag never exceeds the last index`() {
-        // estimatedTotal = 100 * 5 = 500 ; maxScroll = 450 ; 450 / 100 = 4.5 → 5, clamped to total-1 = 4.
-        assertEquals(4, dragIndex(1f, total = 5, viewport = 50f))
+    fun `targetIndexForDrag returns 0 on a degenerate count`() {
+        assertEquals(0, targetIndexForDrag(travelFraction = 1f, totalItemsCount = 1))
+        assertEquals(0, targetIndexForDrag(travelFraction = 1f, totalItemsCount = 0))
     }
 
     @Test
-    fun `targetIndexForDrag returns 0 on degenerate inputs`() {
-        assertEquals(0, dragIndex(1f, avg = 0f, total = 10))
-        assertEquals(0, dragIndex(1f, total = 0))
+    fun `drag and position are mutual inverses`() {
+        // The thumb-travel fraction of ordinal i is offsetFraction / (1 - sizeFraction) = i / (total-1);
+        // feeding it back must recover i.
+        val total = 10
+        for (i in 0 until total) {
+            val metrics = scrollbarMetrics(firstVisibleItemIndex = i, totalItemsCount = total)!!
+            val travelFraction = metrics.offsetFraction / (1f - metrics.sizeFraction)
+            assertEquals(i, targetIndexForDrag(travelFraction, total))
+        }
     }
 }


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

## Contexte

Le fix précédent de l'ascenseur (#300, build 95, modèle **pixel estimé**) **ne résout pas** le problème : retour testeur « toujours instable ». Avis Codex demandé → confirme ma relecture.

## Cause racine (confirmée par Codex)

Le build 95 dérivait taille **et** position du thumb de `averageItemSizePx` = moyenne des **seuls items visibles**. Cette estimation « respire » :
- au scroll (le set visible change → la moyenne change → `estimatedTotal = avg × total` change → à l'item 40, un petit Δmoyenne déplace le thumb de `40 × Δavg` même si le scroll perçu est fluide → **« saute »**) ;
- **à l'arrêt** : quand une image décode et grandit 160→480dp (#197), la moyenne saute → `sizeFraction = viewport / estimatedTotal` change → le thumb **« grandit d'un coup »**.

Bref : lier le thumb à une **estimation mouvante** de la hauteur totale est la cause unique des deux symptômes. Mon 1er fix (index→pixel) n'avait fait que déplacer le défaut.

## Fix — modèle taille fixe + position ordinale

Découplage total de toute taille mesurée :
- **taille** = fraction constante de la piste (`THUMB_SIZE_FRACTION`) ;
- **position** = ordinal pur `firstVisibleItemIndex / (totalItemsCount - 1)` ;
- **drag** = `round(travelFraction × (total - 1))`, l'inverse exact.
- **spring** sur l'offset dessiné pour adoucir les crans ordinaux ; **snap** pendant le drag du thumb (jamais de lag sous le doigt).

Ni le scroll ni la croissance d'image ne peuvent désormais redimensionner/déplacer le thumb — seul un changement de l'ordinal du 1ᵉʳ item visible le fait.

**Compromis assumé (cf. revue Codex)** : le thumb n'est plus proportionnel à la longueur réelle de page (un gros post image = un cran comme une une-ligne), mais il est **stable et déterministe**, ce qui colle à l'usage fast-scroll (« où suis-je / sauter près d'un post »).

## Tests

Tests purs réécrits + gardes de régression : **taille constante** (indépendante du contenu/position), **position ordinale à pas égaux**, **drag↔position inverses**. Auto-hide alpha extrait dans `rememberScrollbarAlpha` (complexité cyclomatique sous le seuil).

## Validation locale

- `detektAll test testDebugUnitTest :app:assembleProdDebug --rerun-tasks` → **BUILD SUCCESSFUL**
- `lintDebug :app:lintProdDebug` → **BUILD SUCCESSFUL**

## Lien

Supersède l'approche pixel de #300 (build 95). Cible `dev` ; #300 se fermera à la promotion dev→main.
