### PR TITLE
fix(topic): lissage de l'à-coup par post — interpolation intra-post (#300)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbar.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbar.kt
@@ -57,22 +57,22 @@ import kotlin.math.roundToInt
  * Outside the thumb hit target there is no pointer node, so a normal vertical scroll / a tap on a
  * right-aligned post action falls straight through to the list.
  *
- * Geometry uses a **fixed-size, ordinal** model: the thumb is a constant fraction of the track
- * ([THUMB_SIZE_FRACTION]) and its position comes purely from the list ordinal
- * `firstVisibleItemIndex / (totalItemsCount − 1)`. It deliberately does NOT read any measured item
- * size. Two earlier attempts both tied the thumb to a *moving estimate* of total content height and
- * failed: an index-based one (size = `visibleItemsCount/total`, an integer flipping 3↔4↔2) and a
- * pixel-estimated one (size = `viewport / (avgVisibleItemSize × total)`). On a forum page — unequal
- * post heights, plus block images that grow 160→480dp once Coil decodes them (#197) and inline media
- * that resizes after measurement — the estimated total "breathes", so the thumb resized and jumped
- * (the average of the *visible* items rewrites the assumed height of every item before the viewport),
- * even while idle. Decoupling the geometry from measured sizes is the only stable option.
+ * Geometry uses a **fixed-size ordinal model with sub-item interpolation** (cf. [scrollbarMetrics]):
+ * a constant thumb size ([THUMB_SIZE_FRACTION]) and a position from `(firstVisibleItemIndex +
+ * itemFraction) / (totalItemsCount − 1)`, where `itemFraction` interpolates within the current top post
+ * using only that post's own offset/size. Two earlier attempts tied the thumb to a *moving estimate* of
+ * total content height and failed: an index-based one (size = `visibleItemsCount/total`, an integer
+ * flipping 3↔4↔2) and a pixel-estimated one (size = `viewport / (avgVisibleItemSize × total)`). On a
+ * forum page — unequal post heights, plus block images that grow 160→480dp once Coil decodes them (#197)
+ * — the estimated total "breathes", so the thumb resized and jumped even while idle. Keeping the size
+ * constant (never measured) kills that; interpolating the position with only the *current* top item's
+ * size keeps it continuous (no per-post "à-coup") while bounding any residual #197 wobble to one ordinal
+ * step.
  *
- * Trade-off (per the Codex review): the thumb is no longer proportional to true scroll length — a tall
- * image post and a one-liner are one ordinal step each — but it is rock-stable and matches the
- * fast-scroll use case ("where am I / jump near another post"). A spring on the drawn offset softens
- * the coarse per-item steps; the thumb drag snaps (no animation) so it never lags under the finger.
- * "Is there anything to scroll" is still read from
+ * Trade-off (per the Codex review): the thumb size is not proportional to true scroll length and the
+ * within-post speed is non-uniform, but it is stable and matches the fast-scroll use case ("where am I /
+ * jump near another post"). The drawn offset SNAPS while scrolling/dragging (tracks the finger exactly)
+ * and springs only on the idle settle. "Is there anything to scroll" is still read from
  * [LazyListState.canScrollForward]/[LazyListState.canScrollBackward]. Pure `LazyListState` index space
  * (the header card is lazy item 0), so thumb position and `scrollToItem` stay mutually consistent.
  */
@@ -86,9 +86,12 @@ internal fun TopicScrollbar(
     }
     val metrics by remember {
         derivedStateOf {
+            val info = listState.layoutInfo
             scrollbarMetrics(
                 firstVisibleItemIndex = listState.firstVisibleItemIndex,
-                totalItemsCount = listState.layoutInfo.totalItemsCount,
+                firstVisibleItemScrollOffset = listState.firstVisibleItemScrollOffset,
+                firstVisibleItemSize = info.visibleItemsInfo.firstOrNull()?.size ?: 0,
+                totalItemsCount = info.totalItemsCount,
             )
         }
     }
@@ -105,13 +108,12 @@ internal fun TopicScrollbar(
     )
     val thumbColor = MaterialTheme.colorScheme.primary
 
-    // Soften the coarse ordinal steps (the position jumps by 1/(total-1) each time the first visible
-    // item changes): a spring chases the moving target while scrolling/settling, but the thumb drag
-    // snaps (no animation) so the thumb never lags under the finger during a fast-scroll.
-    val animatedOffset by animateFloatAsState(
-        targetValue = metrics?.offsetFraction ?: 0f,
-        animationSpec = if (isDragging) snap() else spring(stiffness = Spring.StiffnessMediumLow),
-        label = "topicScrollbarOffset",
+    // Sub-item interpolation already makes the offset continuous during a scroll, so it SNAPS (tracks
+    // the finger exactly) while scrolling/dragging — a spring there would only lag the live input — and
+    // springs only on the idle settle. Extracted to rememberScrollbarDrawOffset (spec per Codex review).
+    val animatedOffset = rememberScrollbarDrawOffset(
+        targetOffset = metrics?.offsetFraction ?: 0f,
+        snapping = isDragging || listState.isScrollInProgress,
     )
     val drawnMetrics = metrics?.copy(offsetFraction = animatedOffset)
 
@@ -193,6 +195,28 @@ private fun rememberScrollbarAlpha(
 }
 
 /**
+ * Drawn thumb offset: snaps to [targetOffset] while [snapping] (the thumb is dragged or the list is
+ * scrolling — sub-item interpolation already makes that continuous, and a spring would only lag the
+ * live input), and springs gently on the idle settle so a `scrollToItem` landing eases in.
+ */
+@Composable
+private fun rememberScrollbarDrawOffset(
+    targetOffset: Float,
+    snapping: Boolean,
+): Float {
+    val offset by animateFloatAsState(
+        targetValue = targetOffset,
+        animationSpec = if (snapping) {
+            snap()
+        } else {
+            spring(stiffness = Spring.StiffnessMedium, dampingRatio = Spring.DampingRatioNoBouncy)
+        },
+        label = "topicScrollbarOffset",
+    )
+    return offset
+}
+
+/**
  * The thumb-only drag surface. Placed at the thumb's current vertical offset (± [GRAB_PADDING]) so it is
  * the *only* pointer node in the gutter — everything else stays scrollable/tappable. The drag maps the
  * finger's absolute track position back from the live hit-target top: `trackY = hitTop + localY`, which
@@ -266,32 +290,48 @@ internal data class ScrollbarMetrics(
 )
 
 /**
- * Pure thumb geometry, **fixed-size + ordinal** (#300 follow-up fixing the "jumps + grows suddenly"
- * report). The thumb size is the constant [THUMB_SIZE_FRACTION] of the track, and its position is the
- * pure list ordinal `firstVisibleItemIndex / (totalItemsCount − 1)` mapped onto the available travel
- * `1 − sizeFraction`. It reads **no measured item size**, so neither a changing visible set during
- * scroll nor a post-decode image growth (#197) can resize or move the thumb on its own — only an actual
- * change of the first-visible ordinal does.
+ * Pure thumb geometry, **fixed-size ordinal with sub-item interpolation** (#300). The thumb size is the
+ * constant [THUMB_SIZE_FRACTION] of the track; its position is the list ordinal
+ * `(firstVisibleItemIndex + itemFraction) / (totalItemsCount − 1)` mapped onto the available travel
+ * `1 − sizeFraction`, where `itemFraction = firstVisibleItemScrollOffset / firstVisibleItemSize` ∈ [0, 1)
+ * interpolates *within the current top post*.
  *
- * Returns `null` when an ordinal position is meaningless ([totalItemsCount] ≤ 1): a single (possibly
- * tall) item carries no ordinal progress. A topic page always has the header card (item 0) plus posts,
- * so this only hides the bar on a degenerate one-item list. The "page fits, nothing to scroll" decision
- * stays with the caller (`canScrollForward/Backward`). [offsetFraction] ∈ [0, 1 − sizeFraction];
+ * Why this shape (two earlier models failed):
+ *  - **size** never reads a measured height (constant), so a changing visible set or a post-decode image
+ *    growth (#197) can't resize the thumb — that killed the "grows suddenly" symptom.
+ *  - **position** interpolates within a post using ONLY the current top item's own offset/size, so it is
+ *    continuous within a post and (near-)continuous across the boundary — no per-post step/"à-coup".
+ *    The single measured input ([firstVisibleItemSize]) is local: a #197 growth of the top post wobbles
+ *    the thumb by at most one ordinal step (`(1−size)/(total−1)`), never the global "×N rewrite of every
+ *    prior item" that the average-of-visible-items estimate caused.
+ *
+ * Guards (cf. the Codex review): `totalItemsCount ≤ 1 → null` (a single, possibly tall, item has no
+ * ordinal progress); the index is clamped; [firstVisibleItemScrollOffset] is clamped to the item so the
+ * fraction stays in [0, 1); the **last** ordinal forces `itemFraction = 0` so progress never exceeds 1.
+ *
+ * Trade-off: within a post the speed is non-uniform (tall posts crawl, short posts race) — inherent to
+ * exact anchoring, and accepted because the anchoring is wanted. [offsetFraction] ∈ [0, 1 − sizeFraction];
  * [sizeFraction] is constant.
- *
- * Trade-off: a tall post and a one-liner are one ordinal step each, so the thumb is not proportional to
- * true scroll length — accepted for stability (cf. the Codex review). At the very bottom the first
- * ordinal is `total − visibleCount`, so the thumb rests slightly above the end; a drag to the bottom
- * still lands there via [targetIndexForDrag] (`scrollToItem(total − 1)`).
  */
 internal fun scrollbarMetrics(
     firstVisibleItemIndex: Int,
+    firstVisibleItemScrollOffset: Int,
+    firstVisibleItemSize: Int,
     totalItemsCount: Int,
 ): ScrollbarMetrics? {
     if (totalItemsCount <= 1) return null
-    val progress = (firstVisibleItemIndex.toFloat() / (totalItemsCount - 1)).coerceIn(0f, 1f)
-    val offsetFraction = progress * (1f - THUMB_SIZE_FRACTION)
-    return ScrollbarMetrics(offsetFraction = offsetFraction, sizeFraction = THUMB_SIZE_FRACTION)
+    val lastIndex = totalItemsCount - 1
+    val index = firstVisibleItemIndex.coerceIn(0, lastIndex)
+    val itemFraction = if (firstVisibleItemSize > 0 && index < lastIndex) {
+        firstVisibleItemScrollOffset.coerceIn(0, firstVisibleItemSize - 1).toFloat() / firstVisibleItemSize
+    } else {
+        0f
+    }
+    val progress = ((index + itemFraction) / lastIndex).coerceIn(0f, 1f)
+    return ScrollbarMetrics(
+        offsetFraction = progress * (1f - THUMB_SIZE_FRACTION),
+        sizeFraction = THUMB_SIZE_FRACTION,
+    )
 }
 
 /**

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbarTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbarTest.kt
@@ -6,71 +6,117 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * #300 — pure-geometry tests for the topic scrollbar, **fixed-size + ordinal** model. Composable
- * behaviour (auto-hide, gesture, the spring on the drawn offset) is not unit-tested here; the value is
- * in the position math, the drag→index inverse, and the regression guards for the "jumps + grows
- * suddenly" bug: the thumb size must be constant (never derived from content) and the position must be
- * a pure ordinal of the first-visible index (never derived from measured item sizes).
+ * #300 — pure-geometry tests for the topic scrollbar, **fixed-size ordinal + sub-item interpolation**.
+ * Composable behaviour (auto-hide, gesture, the offset spring) is not unit-tested here; the value is in
+ * the position math, the drag→index inverse, and the regression guards: the thumb size is constant
+ * (never derived from content), the position interpolates continuously within a post (no per-post step),
+ * and a #197-style growth of the top post can move the thumb by at most one ordinal step.
  */
 class TopicScrollbarTest {
 
     private val tolerance = 1e-4f
 
+    // Keeps the 4-arg calls short. Defaults: a 10-item page, 100px items, at the very top.
+    private fun metrics(index: Int, offset: Int = 0, size: Int = 100, total: Int = 10) =
+        scrollbarMetrics(
+            firstVisibleItemIndex = index,
+            firstVisibleItemScrollOffset = offset,
+            firstVisibleItemSize = size,
+            totalItemsCount = total,
+        )
+
+    private fun oneOrdinalStep(total: Int) = (1f / (total - 1)) * (1f - THUMB_SIZE_FRACTION)
+
     @Test
-    fun `scrollbarMetrics returns null for a single item (no ordinal progress)`() {
-        assertNull(scrollbarMetrics(firstVisibleItemIndex = 0, totalItemsCount = 1))
+    fun `returns null for a single item (no ordinal progress)`() {
+        assertNull(metrics(index = 0, total = 1))
     }
 
     @Test
-    fun `scrollbarMetrics returns null when there is no item`() {
-        assertNull(scrollbarMetrics(firstVisibleItemIndex = 0, totalItemsCount = 0))
+    fun `returns null when there is no item`() {
+        assertNull(metrics(index = 0, total = 0))
     }
 
     @Test
-    fun `offsetFraction is 0 at the top of the page`() {
-        val metrics = scrollbarMetrics(firstVisibleItemIndex = 0, totalItemsCount = 10)!!
-        assertEquals(0f, metrics.offsetFraction, tolerance)
+    fun `offsetFraction is 0 at the very top`() {
+        assertEquals(0f, metrics(0)!!.offsetFraction, tolerance)
     }
 
     @Test
     fun `offsetFraction reaches 1 minus sizeFraction at the last ordinal`() {
-        val metrics = scrollbarMetrics(firstVisibleItemIndex = 9, totalItemsCount = 10)!!
-        assertEquals(1f - metrics.sizeFraction, metrics.offsetFraction, tolerance)
+        val m = metrics(9)!!
+        assertEquals(1f - m.sizeFraction, m.offsetFraction, tolerance)
     }
 
     @Test
     fun `offsetFraction clamps a transient out-of-range index`() {
-        // firstVisibleItemIndex should never exceed total, but a transient layoutInfo must not overshoot.
-        val metrics = scrollbarMetrics(firstVisibleItemIndex = 20, totalItemsCount = 10)!!
-        assertEquals(1f - metrics.sizeFraction, metrics.offsetFraction, tolerance)
+        val m = metrics(20)!!
+        assertEquals(1f - m.sizeFraction, m.offsetFraction, tolerance)
     }
 
-    // --- Regression guards for the "jumps + grows suddenly" bug -------------------------------------
+    // --- Regression guards --------------------------------------------------------------------------
 
     @Test
-    fun `thumb size is a constant, independent of the page or position`() {
-        // The two earlier models tied the size to a moving estimate (visible count, or viewport/estTotal);
-        // that was the "grows suddenly" symptom. The fixed model must return the same size everywhere.
-        assertEquals(THUMB_SIZE_FRACTION, scrollbarMetrics(0, 10)!!.sizeFraction, tolerance)
-        assertEquals(THUMB_SIZE_FRACTION, scrollbarMetrics(5, 10)!!.sizeFraction, tolerance)
-        assertEquals(THUMB_SIZE_FRACTION, scrollbarMetrics(500, 1000)!!.sizeFraction, tolerance)
+    fun `thumb size is a constant, independent of page or position`() {
+        assertEquals(THUMB_SIZE_FRACTION, metrics(0)!!.sizeFraction, tolerance)
+        assertEquals(THUMB_SIZE_FRACTION, metrics(5)!!.sizeFraction, tolerance)
+        assertEquals(THUMB_SIZE_FRACTION, metrics(500, total = 1000)!!.sizeFraction, tolerance)
     }
 
     @Test
-    fun `position advances by equal ordinal steps`() {
-        // Pure ordinal: each first-visible-index increment moves the thumb by the same amount,
-        // (1/(total-1)) * (1 - sizeFraction) — no dependence on measured item heights.
-        val m0 = scrollbarMetrics(0, 10)!!
-        val m1 = scrollbarMetrics(1, 10)!!
-        val m2 = scrollbarMetrics(2, 10)!!
-        val firstStep = m1.offsetFraction - m0.offsetFraction
-        val secondStep = m2.offsetFraction - m1.offsetFraction
-        assertTrue("position is monotonic with the index", firstStep > 0f)
-        assertEquals(firstStep, secondStep, tolerance)
-        assertEquals((1f / 9f) * (1f - THUMB_SIZE_FRACTION), firstStep, tolerance)
+    fun `sub-item interpolation moves the thumb continuously within a post`() {
+        // Scrolling within the first post (offset 0 → mid) advances the thumb, but stays inside the
+        // first ordinal step (never reaches the next anchor).
+        val top = metrics(0, offset = 0)!!.offsetFraction
+        val mid = metrics(0, offset = 50)!!.offsetFraction
+        val nextAnchor = metrics(1, offset = 0)!!.offsetFraction
+        assertTrue("interpolates upward within the post", mid > top)
+        assertTrue("stays below the next anchor", mid < nextAnchor)
     }
 
-    // --- targetIndexForDrag (drag → first-visible item index), inverse of the ordinal mapping --------
+    @Test
+    fun `position is near-continuous across a post boundary (no per-post step)`() {
+        // End of post 0 (offset clamped to size-1) vs start of post 1: the gap must be a tiny fraction
+        // of one ordinal step, NOT a full step — that is what removes the "à-coup".
+        val endOfFirst = metrics(0, offset = 99, size = 100)!!.offsetFraction
+        val startOfSecond = metrics(1, offset = 0, size = 100)!!.offsetFraction
+        val gap = startOfSecond - endOfFirst
+        assertTrue("monotonic across the boundary", gap >= 0f)
+        assertTrue("gap is far smaller than one ordinal step", gap < oneOrdinalStep(10) * 0.1f)
+    }
+
+    @Test
+    fun `the last post ignores sub-item offset so progress never exceeds 1`() {
+        // index == lastIndex forces itemFraction = 0; a non-zero offset must not push offset past the end.
+        assertEquals(metrics(9, offset = 0)!!.offsetFraction, metrics(9, offset = 50)!!.offsetFraction, tolerance)
+        assertEquals(1f - THUMB_SIZE_FRACTION, metrics(9, offset = 50)!!.offsetFraction, tolerance)
+    }
+
+    @Test
+    fun `a zero item size falls back to the pure ordinal anchor`() {
+        // size 0 (item not measured yet) must not divide by zero; itemFraction = 0.
+        val ordinal = metrics(2, offset = 0)!!.offsetFraction
+        val unmeasured = metrics(2, offset = 30, size = 0)!!.offsetFraction
+        assertEquals(ordinal, unmeasured, tolerance)
+    }
+
+    @Test
+    fun `an oversized offset is clamped within one ordinal step`() {
+        // A transient offset larger than the item can't push the thumb past the next anchor.
+        val clamped = metrics(0, offset = 10_000, size = 100)!!.offsetFraction
+        assertTrue(clamped < metrics(1, offset = 0)!!.offsetFraction)
+    }
+
+    @Test
+    fun `a top-post growth wobbles the thumb by less than one ordinal step`() {
+        // #197 bound: same scroll offset, the top post grows 160→480 (px proxy). The thumb moves by less
+        // than one ordinal step while that post is on top — acceptable vs the per-post jerk it removes.
+        val before = metrics(3, offset = 120, size = 160)!!.offsetFraction
+        val after = metrics(3, offset = 120, size = 480)!!.offsetFraction
+        assertTrue(kotlin.math.abs(after - before) < oneOrdinalStep(10))
+    }
+
+    // --- targetIndexForDrag (drag → first-visible item index), inverse of the ordinal anchors --------
 
     @Test
     fun `targetIndexForDrag maps full travel to the last item`() {
@@ -84,7 +130,6 @@ class TopicScrollbarTest {
 
     @Test
     fun `targetIndexForDrag maps half travel to the middle ordinal`() {
-        // 0.5 * (11 - 1) = 5.
         assertEquals(5, targetIndexForDrag(travelFraction = 0.5f, totalItemsCount = 11))
     }
 
@@ -101,13 +146,13 @@ class TopicScrollbarTest {
     }
 
     @Test
-    fun `drag and position are mutual inverses`() {
-        // The thumb-travel fraction of ordinal i is offsetFraction / (1 - sizeFraction) = i / (total-1);
-        // feeding it back must recover i.
+    fun `drag and the post-anchor position are mutual inverses`() {
+        // At a post anchor (offset 0) the thumb-travel fraction is offsetFraction / (1 - sizeFraction) =
+        // i / (total-1); feeding it back must recover i.
         val total = 10
         for (i in 0 until total) {
-            val metrics = scrollbarMetrics(firstVisibleItemIndex = i, totalItemsCount = total)!!
-            val travelFraction = metrics.offsetFraction / (1f - metrics.sizeFraction)
+            val m = metrics(index = i, offset = 0, total = total)!!
+            val travelFraction = m.offsetFraction / (1f - m.sizeFraction)
             assertEquals(i, targetIndexForDrag(travelFraction, total))
         }
     }


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

## Contexte

Retour testeur sur le build 96 (ascenseur ordinal taille fixe) : le bug de fond est réglé, la hauteur fixe « fait un peu bizarre mais OK », **mais** la position fait un petit à-coup à chaque passage de post (l'ancrage est apprécié, l'à-coup non). Cause : en ordinal pur, la position ne change qu'au changement d'item (par pas de `1/(total-1)`), donc elle « marche » par crans. Avis Codex re-sollicité → valide la solution ci-dessous et en borne le risque.

## Fix — interpolation intra-post

Position interpolée **dans le post courant** avec **seulement** la taille de ce post :
```
progress = (firstVisibleItemIndex + firstVisibleItemScrollOffset / firstVisibleItemSize) / (total - 1)
```
- **taille du thumb inchangée** (constante) → le fix « grandit d'un coup » du build 96 reste intact.
- position **continue dans un post** et **quasi-continue à la frontière** → plus de cran/à-coup, ancrage préservé.
- seul input mesuré réintroduit = la taille du **post courant** → un grossissement d'image #197 fait bouger le thumb d'**au plus un cran d'ordinal** tant que ce post est en tête (borne prouvée par Codex : `< (1−size)/(total−1)`), jamais la réécriture globale `×N` de l'ancien modèle moyenne-des-visibles.

**Animation** : l'offset dessiné **snap** pendant scroll/drag (déjà continu, un spring ne ferait que laguer l'input live) et ne **spring** qu'au repos (settle après `scrollToItem`).

**Gardes (Codex)** : `total ≤ 1 → null` ; index clampé ; `size > 0` requis ; offset clampé à `0..size-1` ; le **dernier** ordinal force `fraction = 0` (progress ne dépasse jamais 1).

**Compromis assumé** : vitesse non-uniforme *dans* un post (gros post = lent, petit = rapide) — inhérent à l'ancrage exact, et voulu.

## Tests

Gardes de régression ajoutées : continuité intra-post, quasi-continuité à la frontière (gap ≪ un cran), dernier post sans débordement, fallback taille 0, wobble #197 borné à < 1 cran, drag↔ancre inverses. Helpers `rememberScrollbarDrawOffset`/`rememberScrollbarAlpha` extraits (complexité cyclomatique).

## Validation locale

- `detektAll test testDebugUnitTest :app:assembleProdDebug --rerun-tasks` → **BUILD SUCCESSFUL**
- `lintDebug :app:lintProdDebug` → **BUILD SUCCESSFUL**

## Lien

Affine #300 (build 96). Cible `dev` ; #300 se fermera à la promotion dev→main.
