### PR TITLE
fix(topic): FAB Répondre à la taille des FAB page + flèche retour à la taille du titre

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -506,7 +505,9 @@ internal fun TopicContent(
                         onClick = onBack,
                         modifier = Modifier.semantics { contentDescription = backLabel },
                     ) {
-                        Text("←")
+                        // Match the adjacent title text size (user request) rather than the default,
+                        // oversized glyph. The IconButton still provides the 48dp touch target.
+                        Text("←", style = MaterialTheme.typography.titleMedium)
                     }
                 },
                 scrollBehavior = scrollBehavior,
@@ -1311,8 +1312,15 @@ private fun PageFab(
 
 @Composable
 private fun ReplyFab(onClick: () -> Unit) {
-    ExtendedFloatingActionButton(onClick = onClick) {
-        Text(text = stringResource(R.string.topic_fab_reply))
+    // Same SmallFloatingActionButton footprint as the page FABs (user request): the « Répondre » label
+    // rides on contentDescription for TalkBack and the glyph is decorative (no Material icons — detekt
+    // ForbiddenImport blocks androidx.compose.material.*), mirroring PageFab and the top-bar back button.
+    val replyLabel = stringResource(R.string.topic_fab_reply)
+    SmallFloatingActionButton(
+        onClick = onClick,
+        modifier = Modifier.semantics { contentDescription = replyLabel },
+    ) {
+        Text("✎")
     }
 }
 


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

## Contexte

Deux retouches UI demandées sur retour bêta (screens à l'appui) de l'écran topic.

## Changements

1. **Bouton « Répondre » flottant** — était un `ExtendedFloatingActionButton` (pill large), hors d'échelle à côté des petits FAB de page (`‹`/`›`). Devient un `SmallFloatingActionButton` avec glyphe `✎`, label porté par `contentDescription` (TalkBack) → les 3 boutons du cluster bas partagent la même taille.
2. **Flèche retour de la top bar** — utilisait le style texte par défaut et s'affichait surdimensionnée à côté du titre. Calée sur `titleMedium` pour correspondre au texte du titre adjacent. L'`IconButton` conserve la cible tactile 48 dp.

Pas de logique métier touchée, pas d'icône Material (detekt `ForbiddenImport`) — glyphes texte, comme le reste de l'écran.

## Validation locale

- `detektAll test testDebugUnitTest :app:assembleProdDebug` → **BUILD SUCCESSFUL**
- `lintDebug :app:lintProdDebug` → **BUILD SUCCESSFUL**

## Lien

Polish des features bottom-actions (#283) et back top-bar (#285). Cible `dev`.
