### PR TITLE
fix(topic): flèche retour top-bar en bodySmall (réduction réelle vs titleMedium)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -505,9 +505,11 @@ internal fun TopicContent(
                         onClick = onBack,
                         modifier = Modifier.semantics { contentDescription = backLabel },
                     ) {
-                        // Match the adjacent title text size (user request) rather than the default,
-                        // oversized glyph. The IconButton still provides the 48dp touch target.
-                        Text("←", style = MaterialTheme.typography.titleMedium)
+                        // The bare `←` glyph rendered oversized next to the title (it fills the em box
+                        // in the project font, so matching the title's point size still looked too big).
+                        // Down-size it to a normal body text size so it sits naturally beside the title;
+                        // the IconButton keeps the 48dp touch target regardless of the glyph size.
+                        Text("←", style = MaterialTheme.typography.bodySmall)
                     }
                 },
                 scrollBehavior = scrollBehavior,


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

## Contexte

Suite au build 98 : la 1ʳᵉ tentative de re-dimensionnement de la flèche retour (calée sur `titleMedium`, la taille du titre) **n'a rien changé visuellement** — le glyphe `←` « remplit » sa case dans la police custom du projet, donc égaliser le point-size avec le titre le laisse paraître surdimensionné.

## Fix

Flèche passée en `bodySmall` (12sp, poids normal) → ~25 % plus petite + plus légère que `titleMedium`, pour qu'elle s'asseye naturellement à côté du titre. L'`IconButton` conserve la cible tactile 48 dp quelle que soit la taille du glyphe.

Note : tentative de validation visuelle sur l'émulateur (AVD Pixel_8) abandonnée — il segfault dans cet environnement (mode GPU headless). Valeur retenue sur raisonnement (métriques de glyphe), à confirmer sur device réel.

## Validation locale

- `detektAll :app:assembleProdDebug` → **BUILD SUCCESSFUL**
- `lintDebug :app:lintProdDebug` → **BUILD SUCCESSFUL**

## Lien

Suite de #355 (retouche back top-bar). Cible `dev`.
