### PR TITLE
fix(ui): flèche retour en icône vectorielle 24dp (remplace le glyphe texte instable)

### DIFF
--- a/core/ui/src/main/res/drawable/ic_arrow_back.xml
+++ b/core/ui/src/main/res/drawable/ic_arrow_back.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:autoMirrored="true">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8l8,8l1.41,-1.41L7.83,13H20v-2z" />
+</vector>

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -34,6 +35,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -144,7 +146,13 @@ private fun ReplyHeader(onBack: () -> Unit) {
             onClick = onBack,
             modifier = Modifier.semantics { contentDescription = backLabel },
         ) {
-            Text("←")
+            // dp-sized vector instead of a text « ← » glyph (font/baseline-dependent, cf. Codex
+            // review). a11y label on the IconButton; the icon is decorative.
+            Icon(
+                painter = painterResource(fr.forumhfr.redface2.core.ui.R.drawable.ic_arrow_back),
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+            )
         }
         Text(
             text = stringResource(R.string.messages_reply_title),

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
@@ -16,6 +17,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -27,6 +29,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -113,7 +116,13 @@ fun PrivateMessageThreadScreen(
                         onClick = onBack,
                         modifier = Modifier.semantics { contentDescription = backLabel },
                     ) {
-                        Text("←")
+                        // dp-sized vector instead of a text « ← » glyph (font/baseline-dependent, cf.
+                        // Codex review). a11y label on the IconButton; the icon is decorative.
+                        Icon(
+                            painter = painterResource(fr.forumhfr.redface2.core.ui.R.drawable.ic_arrow_back),
+                            contentDescription = null,
+                            modifier = Modifier.size(24.dp),
+                        )
                     }
                 },
                 actions = { topBarActions?.invoke() },

--- a/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -24,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -102,21 +104,23 @@ internal fun ProfileScreen(
                     )
                 },
                 navigationIcon = {
-                    // Review feedback C2: the previous `Text("←")` had no
-                    // contentDescription, which made the back button silent to
-                    // TalkBack and a generic « Bouton » to LiveCaptions. The detekt
-                    // ForbiddenImport rule blocks `androidx.compose.material.*` (Material 2
-                    // surface, which includes `material-icons-core`), so we cannot use
-                    // `Icons.AutoMirrored.Filled.ArrowBack`. Instead we keep the « ← »
-                    // glyph but attach a proper a11y label via
-                    // `Modifier.semantics { contentDescription = … }` on the IconButton.
-                    // TalkBack now announces « Retour, bouton » as expected.
+                    // detekt ForbiddenImport blocks `androidx.compose.material.*` (incl.
+                    // `material-icons-core`), so `Icons.AutoMirrored.Filled.ArrowBack` is off-limits.
+                    // A text « ← » glyph proved unstable as an icon (size depends on the system font,
+                    // baseline and font-scale — cf. Codex review), so use a local dp-sized vector
+                    // drawable rendered with material3 `Icon` (allowed: material3, not material). The
+                    // a11y label stays on the IconButton; the icon is decorative (contentDescription
+                    // = null) to avoid duplicate semantics. TalkBack still announces « Retour, bouton ».
                     val backLabel = stringResource(R.string.profile_back)
                     IconButton(
                         onClick = onBack,
                         modifier = Modifier.semantics { contentDescription = backLabel },
                     ) {
-                        Text("←")
+                        Icon(
+                            painter = painterResource(fr.forumhfr.redface2.core.ui.R.drawable.ic_arrow_back),
+                            contentDescription = null,
+                            modifier = Modifier.size(24.dp),
+                        )
                     }
                 },
             )

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -24,6 +25,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -52,6 +54,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -505,11 +508,16 @@ internal fun TopicContent(
                         onClick = onBack,
                         modifier = Modifier.semantics { contentDescription = backLabel },
                     ) {
-                        // The bare `←` glyph rendered oversized next to the title (it fills the em box
-                        // in the project font, so matching the title's point size still looked too big).
-                        // Down-size it to a normal body text size so it sits naturally beside the title;
-                        // the IconButton keeps the 48dp touch target regardless of the glyph size.
-                        Text("←", style = MaterialTheme.typography.bodySmall)
+                        // A text glyph used as an icon was unstable: its size depended on the system
+                        // font's `←` rendering, the baseline and the font-scale, never matching the
+                        // title cleanly (cf. Codex review). Use a dp-sized vector instead — optically
+                        // centred by the IconButton, font-independent. The a11y label stays on the
+                        // IconButton, so the icon itself is decorative (contentDescription = null).
+                        Icon(
+                            painter = painterResource(fr.forumhfr.redface2.core.ui.R.drawable.ic_arrow_back),
+                            contentDescription = null,
+                            modifier = Modifier.size(24.dp),
+                        )
                     }
                 },
                 scrollBehavior = scrollBehavior,


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

## Contexte

Retours bêta successifs (builds 98/99) sur la flèche retour de la top bar : à 16sp elle paraissait trop grosse, à 12sp trop petite. Aucun `sp` ne « tombait juste ». **Avis Codex** demandé → confirme une cause **structurelle**, pas un réglage de taille.

## Cause racine (confirmée par Codex)

`Text("←")` est un **caractère texte servant d'icône**. Sa taille/position visuelle dépend du rendu de **U+2190 par la police système** de l'appareil (One UI ≠ Roboto), du baseline texte, et du **font-scale d'accessibilité**. Caler le point-size sur le titre ne matche que la taille d'em, pas la taille optique du glyphe → instable et device-dépendant.

## Fix

Vraie **icône vectorielle dimensionnée en dp** :
- nouveau drawable partagé `core:ui` `R.drawable.ic_arrow_back` (path Material standard, `autoMirrored`) ;
- rendu via `Icon(painterResource(...), contentDescription = null, Modifier.size(24.dp))` dans l'`IconButton` existant ;
- appliqué à **toutes les flèches retour** : topic, profil, et les 2 écrans MP (réponse + conversation) ;
- label d'accessibilité conservé sur l'`IconButton` (icône décorative → pas de double sémantique) ;
- **autorisé par detekt** : la règle `ForbiddenImport` ne bloque que `androidx.compose.material.*` ; `androidx.compose.material3.Icon` + un drawable local sont OK.

Indépendant de la police, optiquement centré, insensible au font-scale. Les glyphes FAB `‹ › ✎` ont la même faiblesse technique mais sont laissés tels quels (validés visuellement, containers FAB dimensionnés) — follow-up éventuel.

## Validation locale

- `detektAll :app:assembleProdDebug` → **BUILD SUCCESSFUL** (compile cross-module `core:ui` R)
- `lintDebug :app:lintProdDebug` → **BUILD SUCCESSFUL**

## Lien

Conclut la série back-arrow (#355/#356). Cible `dev`.
