### PR TITLE
fix: corrections post-review Codex (#301 options MP, #288 catalogue Réglages) + bump 0.7.0

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,30 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## v101 — `0.7.0` — 2026-06-09
+
+**Statut** : `open` (track open testing) + F-Droid `.beta`
+**Commit** : tag `app-v101` (versionCode alloué par le registre de tags, plancher 72)
+**Fichier** : AAB `bundleProdRelease` (`fr.forumhfr.redface2`) → **track open testing** + tag pour F-Droid beta
+
+**Deuxième batch de fonctionnalités** dogfoodé sur le canal dev (v93 → v100) : écriture MP, ascenseur fast-scroll, pull-to-refresh, accès rapide poster, écran Réglages. Promotion `dev → main` puis ship beta.
+
+### Added
+- **Répondre à une conversation privée** (#301) — éditeur BBCode complet (barre d'outils, aperçu, options signature/smiley/notification e-mail), bouton « Envoyer » épinglé au-dessus du clavier ; calqué sur l'éditeur de post. La composition d'un nouveau MP depuis zéro reste à venir.
+- **Ascenseur (scrollbar) de sujet** (#300) — indicateur de position + fast-scroll par glisser. Modèle de pouce à taille fixe avec ancrage intra-post fluide (pas d'à-coups, pas de « respiration » de la hauteur).
+- **Pull-to-refresh d'une page de sujet** (#335) — tirer vers le bas recharge la page courante.
+- **Accès rapide « poster » + changement de page en bas de sujet** (#283).
+- **Écran Réglages « menu vitrine »** (#288) — catalogue des réglages présents et à venir (grisés, étiquetés par issue ou phase).
+
+### Fixed
+- **Flèche retour incohérente** (#355/#356/#357) — remplacement du glyphe texte « ← » (taille dépendante de la police et de la baseline système) par une icône vectorielle 24 dp rendue via material3 `Icon`, sur les écrans sujet, profil et messages privés.
+
+### Changed
+- **`versionName` 0.6.0 → 0.7.0**.
+- Post-review Codex : le refetch silencieux après `hash_check` expiré en réponse MP **ne réécrase plus** les options choisies par l'utilisateur (#301, garde `optionsHydratedFromForm` alignée sur l'éditeur de post) ; le catalogue Réglages n'annonce plus l'écriture MP comme « à venir » (reformulé vers la composition d'un nouveau MP).
+
+---
+
 ## v92 — `0.6.0` — 2026-06-08
 
 **Statut** : `open` (track open testing) + F-Droid `.beta`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.6.0"
+        versionName = "0.7.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyUiState.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyUiState.kt
@@ -25,6 +25,12 @@ data class PrivateMessageReplyUiState(
     val signatureEnabled: Boolean = false,
     val smileyDisabled: Boolean = false,
     val emailNotificationEnabled: Boolean = false,
+    /**
+     * True once the option toggles have been hydrated from a parsed form. Mirrors the post editor's
+     * `optionsHydratedFromForm`: a silent refetch after an expired `hash_check` must not re-hydrate
+     * (and thus clobber) a toggle the user changed in between.
+     */
+    val optionsHydratedFromForm: Boolean = false,
     val isSubmitting: Boolean = false,
     val submitError: PrivateMessageReplyError? = null,
 ) {

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
@@ -87,21 +87,35 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
                 }
                 loadedForm = form
                 _state.update { current ->
+                    // HFR's private "quick reply" form carries the per-post options as plain hidden
+                    // inputs (e.g. `signature=1`), not checkboxes — so `ReplyForm.options` (read from
+                    // `checked` attributes) is all-false here. Hydrate from the hidden fields too,
+                    // OR'ing with the checkbox view, so the user keeps HFR's default (signature on).
+                    //
+                    // Hydrate ONLY on the first successful load: a silent refetch after an expired
+                    // `hash_check` (InvalidHashCheck) must not reset a toggle the user changed in
+                    // between — mirror the post editor's `optionsHydratedFromForm` guard.
+                    val hydrateOptions = !current.optionsHydratedFromForm
                     current.copy(
                         isLoadingForm = false,
                         formAvailable = true,
                         formError = false,
-                        // HFR's private "quick reply" form carries the per-post options as plain
-                        // hidden inputs (e.g. `signature=1`), not checkboxes — so `ReplyForm.options`
-                        // (read from `checked` attributes) is all-false here. Hydrate from the hidden
-                        // fields too, OR'ing with the checkbox view, so the user keeps HFR's default
-                        // (signature on) instead of silently dropping it on submit.
-                        signatureEnabled = form.options.signatureEnabled ||
-                            form.hiddenFields["signature"] == "1",
-                        smileyDisabled = form.options.smileyDisabled ||
-                            form.hiddenFields["smiley"] == "1",
-                        emailNotificationEnabled = form.options.emailNotificationEnabled ||
-                            form.hiddenFields["emaill"] == "1",
+                        signatureEnabled = if (hydrateOptions) {
+                            form.options.signatureEnabled || form.hiddenFields["signature"] == "1"
+                        } else {
+                            current.signatureEnabled
+                        },
+                        smileyDisabled = if (hydrateOptions) {
+                            form.options.smileyDisabled || form.hiddenFields["smiley"] == "1"
+                        } else {
+                            current.smileyDisabled
+                        },
+                        emailNotificationEnabled = if (hydrateOptions) {
+                            form.options.emailNotificationEnabled || form.hiddenFields["emaill"] == "1"
+                        } else {
+                            current.emailNotificationEnabled
+                        },
+                        optionsHydratedFromForm = true,
                     )
                 }
             } catch (cancellation: CancellationException) {

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
@@ -132,6 +132,28 @@ class PrivateMessageReplyViewModelTest {
     }
 
     @Test
+    fun `invalid hash check refetch preserves the user option toggles`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form()
+        coEvery { repository.submitReply(any(), any(), any(), any()) } returns
+            ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)
+
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+        // First load hydrates signature ON (hidden `signature=1`); the user turns it OFF.
+        viewModel.onToggleSignature(false)
+        viewModel.onContentChanged(TextFieldValue("hello"))
+        viewModel.onSubmit()
+
+        // The silent refetch after the expired hash_check must NOT re-hydrate the toggle back to
+        // HFR's default — the user's choice survives into the second submit.
+        assertFalse(
+            "InvalidHashCheck refetch must preserve the user's signature toggle",
+            viewModel.state.value.signatureEnabled,
+        )
+        coVerify(exactly = 2) { repository.fetchReplyForm(any()) }
+    }
+
+    @Test
     fun `unknown response maps to the non-destructive unexpected banner`() = runTest {
         val repository = mockk<PrivateMessageWriteRepository>()
         coEvery { repository.fetchReplyForm(any()) } returns form()

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -29,7 +29,9 @@
     <string name="settings_future_prefetch">Préchargement de la page suivante</string>
     <string name="settings_future_submit_confirm">Confirmation avant publication</string>
     <string name="settings_future_signature">Signature automatique et notification e-mail</string>
-    <string name="settings_future_mp_write">Écriture des messages privés</string>
+    <!-- #301 — la réponse à une conversation existante est livrée ; reste « à venir » la
+         composition d'un nouveau MP depuis zéro (new-MP), encore non observée côté HFR. -->
+    <string name="settings_future_mp_write">Composer un nouveau message privé</string>
     <string name="settings_future_mp_notifications">Notifications et badge de MP non lus</string>
     <string name="settings_future_data_saver">Mode économie de données</string>
     <string name="settings_future_clear_image_cache">Vider le cache des images</string>


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Corrections issues de la **review Codex** de la promotion `dev → main`, + bump de version pour la bêta.

## Fix IMPORTANT — refetch `InvalidHashCheck` réécrasait les options MP (#301)

En réponse à une conversation privée, le refetch silencieux du formulaire après un `hash_check` expiré réhydratait `signature` / `smiley` / `notification e-mail` depuis les défauts HFR. Scénario : l'utilisateur désactive la signature → submit → hash expiré → refetch → signature **rallumée** avant le 2e envoi, à l'insu de l'utilisateur.

Fix : garde `optionsHydratedFromForm` ajoutée à l'état (mirror exact de `PostEditorViewModel.withFormHydration`) — les options ne sont hydratées qu'au **premier** chargement réussi ; un refetch préserve les toggles. Test de régression `invalid hash check refetch preserves the user option toggles` ajouté.

## Fix MINEUR — catalogue Réglages incohérent (#288)

Le « menu vitrine » annonçait encore « Écriture des messages privés » comme réglage **à venir** (#301) alors que la réponse MP est livrée par ce batch. Reformulé en « Composer un nouveau message privé » (la composition d'un nouveau MP depuis zéro reste effectivement future — `#301` reste ouverte comme tracker).

## Release prep

- `versionName` **0.6.0 → 0.7.0** (bump mineur : batch de features — écriture MP, ascenseur, pull-to-refresh, accès rapide poster, réglages).
- Entrée `app/CHANGELOG.md` **v101 / 0.7.0** détaillée (Added / Fixed / Changed).

## Validation locale

- `detektAll test testDebugUnitTest :app:assembleProdDebug --rerun-tasks` → **BUILD SUCCESSFUL** (test messages exécuté).
- `lintDebug :app:lintProdDebug` → **BUILD SUCCESSFUL**.

Référence #301, #288. Ne ferme aucune issue (PR vers `dev`).