### PR TITLE
Release 0.7.0 — batch Phase 5 (écriture MP, ascenseur, pull-to-refresh, réglages, accès rapide poster)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,30 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## v101 — `0.7.0` — 2026-06-09
+
+**Statut** : `open` (track open testing) + F-Droid `.beta`
+**Commit** : tag `app-v101` (versionCode alloué par le registre de tags, plancher 72)
+**Fichier** : AAB `bundleProdRelease` (`fr.forumhfr.redface2`) → **track open testing** + tag pour F-Droid beta
+
+**Deuxième batch de fonctionnalités** dogfoodé sur le canal dev (v93 → v100) : écriture MP, ascenseur fast-scroll, pull-to-refresh, accès rapide poster, écran Réglages. Promotion `dev → main` puis ship beta.
+
+### Added
+- **Répondre à une conversation privée** (#301) — éditeur BBCode complet (barre d'outils, aperçu, options signature/smiley/notification e-mail), bouton « Envoyer » épinglé au-dessus du clavier ; calqué sur l'éditeur de post. La composition d'un nouveau MP depuis zéro reste à venir.
+- **Ascenseur (scrollbar) de sujet** (#300) — indicateur de position + fast-scroll par glisser. Modèle de pouce à taille fixe avec ancrage intra-post fluide (pas d'à-coups, pas de « respiration » de la hauteur).
+- **Pull-to-refresh d'une page de sujet** (#335) — tirer vers le bas recharge la page courante.
+- **Accès rapide « poster » + changement de page en bas de sujet** (#283).
+- **Écran Réglages « menu vitrine »** (#288) — catalogue des réglages présents et à venir (grisés, étiquetés par issue ou phase).
+
+### Fixed
+- **Flèche retour incohérente** (#355/#356/#357) — remplacement du glyphe texte « ← » (taille dépendante de la police et de la baseline système) par une icône vectorielle 24 dp rendue via material3 `Icon`, sur les écrans sujet, profil et messages privés.
+
+### Changed
+- **`versionName` 0.6.0 → 0.7.0**.
+- Post-review Codex : le refetch silencieux après `hash_check` expiré en réponse MP **ne réécrase plus** les options choisies par l'utilisateur (#301, garde `optionsHydratedFromForm` alignée sur l'éditeur de post) ; le catalogue Réglages n'annonce plus l'écriture MP comme « à venir » (reformulé vers la composition d'un nouveau MP).
+
+---
+
 ## v92 — `0.6.0` — 2026-06-08
 
 **Statut** : `open` (track open testing) + F-Droid `.beta`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.6.0"
+        versionName = "0.7.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -67,6 +67,8 @@ import fr.forumhfr.redface2.feature.forum.CategoryRequest
 import fr.forumhfr.redface2.feature.forum.ForumCategoryScreen
 import fr.forumhfr.redface2.feature.forum.ForumScreen
 import fr.forumhfr.redface2.feature.messages.MessagesScreen
+import fr.forumhfr.redface2.feature.messages.PrivateMessageReplyRequest
+import fr.forumhfr.redface2.feature.messages.PrivateMessageReplyScreen
 import fr.forumhfr.redface2.feature.messages.PrivateMessageThreadRequest
 import fr.forumhfr.redface2.feature.messages.PrivateMessageThreadScreen
 import fr.forumhfr.redface2.feature.profile.ProfilePreviewSheet
@@ -98,7 +100,29 @@ data object MessagesRoute : RedfaceNavKey
 data class PrivateMessageThreadRoute(
     val threadId: Int,
     val page: Int = 1,
+    /**
+     * #301 — bumped to `System.currentTimeMillis()` by the navigation host when the private-message
+     * reply editor pops back after a successful send. The new value invalidates the route key so a
+     * fresh [PrivateMessageThreadViewModel] is created and re-fetches the conversation (there is no MP
+     * cache, so a new entry always hits the network) — without it, returning to the retained entry
+     * would show the conversation as it was before the reply. `null` on every normal nav path.
+     */
+    val submitSignal: Long? = null,
 ) : RedfaceNavKey
+
+@Serializable
+data class PrivateMessageReplyRoute(
+    val threadId: Int,
+    val page: Int = 1,
+) : RedfaceNavKey
+
+/**
+ * Full-screen editor routes hide the navigation suite so their IME-pinned submit bar sits at the
+ * window bottom (and to avoid dropping the draft on a tab switch). Extracted from `RedfaceApp` to
+ * keep its cyclomatic complexity in check.
+ */
+private fun NavKey?.hidesNavigationSuite(): Boolean =
+    this is PostEditorRoute || this is TopicFormRoute || this is PrivateMessageReplyRoute
 
 @Serializable
 data class CategoryRoute(
@@ -409,7 +433,7 @@ fun RedfaceApp(intent: Intent?) {
         // routes makes the editor full-screen: its submit bar then sits at the window bottom and the IME
         // inset lands exactly on the keyboard. Bonus UX: no tab switching mid-compose (would drop the draft).
         val topRoute = backStacks.getValue(currentDestination).lastOrNull()
-        val navLayoutType = if (topRoute is PostEditorRoute || topRoute is TopicFormRoute) {
+        val navLayoutType = if (topRoute.hidesNavigationSuite()) {
             NavigationSuiteType.None
         } else {
             NavigationSuiteScaffoldDefaults.calculateFromAdaptiveInfo(currentWindowAdaptiveInfo())
@@ -757,7 +781,41 @@ private fun RedfaceNavHost(
                             backStack.removeAt(backStack.lastIndex)
                         }
                     },
+                    onReply = { threadId, page ->
+                        backStack.add(PrivateMessageReplyRoute(threadId = threadId, page = page))
+                    },
                     topBarActions = accountMenu,
+                )
+            }
+            entry<PrivateMessageReplyRoute> { route ->
+                PrivateMessageReplyScreen(
+                    request = PrivateMessageReplyRequest(
+                        threadId = route.threadId,
+                        page = route.page,
+                    ),
+                    onSubmitSucceeded = { threadId, page ->
+                        // Pop the editor, then replace the conversation entry with a fresh key
+                        // (bumped submitSignal) so the thread re-fetches and shows the sent message.
+                        // Mirrors PostEditorRoute.onSubmitSucceeded. Never collapse below the tab root.
+                        if (backStack.size > 1) {
+                            backStack.removeAt(backStack.lastIndex)
+                        }
+                        val threadEntry = backStack.lastOrNull() as? PrivateMessageThreadRoute
+                        if (threadEntry != null) {
+                            backStack.removeAt(backStack.lastIndex)
+                            backStack.add(
+                                threadEntry.copy(
+                                    page = page,
+                                    submitSignal = System.currentTimeMillis(),
+                                ),
+                            )
+                        }
+                    },
+                    onBack = {
+                        if (backStack.size > 1) {
+                            backStack.removeAt(backStack.lastIndex)
+                        }
+                    },
                 )
             }
             entry<SettingsRoute> {

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultPrivateMessageWriteRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultPrivateMessageWriteRepository.kt
@@ -1,0 +1,205 @@
+package fr.forumhfr.redface2.core.data.write
+
+import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
+import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
+import fr.forumhfr.redface2.core.domain.write.PrivateMessageWriteRepository
+import fr.forumhfr.redface2.core.model.write.PrivateMessageReplyContext
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
+import fr.forumhfr.redface2.core.model.write.ReplyForm
+import fr.forumhfr.redface2.core.model.write.ReplyFormOptions
+import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
+import fr.forumhfr.redface2.core.network.HfrClient
+import fr.forumhfr.redface2.core.network.HfrConstants
+import fr.forumhfr.redface2.core.parser.write.ReplyFormParser
+import fr.forumhfr.redface2.core.parser.write.ReplySubmitResponseParser
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import okhttp3.FormBody
+
+/**
+ * Default [PrivateMessageWriteRepository] implementation (#301). Replies to an HFR private
+ * conversation reuse the topic-reply machinery:
+ *
+ * 1. GET the conversation page (`forum2.php?cat=prive&post={threadId}&page={page}`) — HFR embeds a
+ *    `bddpost.php` reply form there (verified on the real fixture `private_message_thread.html`) —
+ *    and parse it with the shared [ReplyFormParser] to grab a fresh `hash_check` + every hidden field.
+ * 2. POST `bddpost.php` (the same endpoint a topic reply uses) and classify the response with the
+ *    shared [ReplySubmitResponseParser].
+ *
+ * The crucial difference from [DefaultReplyRepository] is the POST body: a private conversation
+ * carries `cat=prive` (a String), `post={threadId}`, `subcat=0` and a server-prefilled `numrep`
+ * (the last post of the current page — **not** a quote reference) inside the form's hidden fields.
+ * [buildFormBody] therefore overrides only the three fields HFR validates (`hash_check`,
+ * `verifrequet`, `content_form`) plus the opt-in option toggles, and forwards everything else
+ * verbatim — it must never re-assert `cat`/`subcat`/`post`/`numrep` from a typed context, or it would
+ * turn `cat=prive` into a number and blank the conversation's `numrep`.
+ */
+@Singleton
+class DefaultPrivateMessageWriteRepository @Inject constructor(
+    private val hfrClient: HfrClient,
+    private val replyFormParser: ReplyFormParser,
+    private val replySubmitResponseParser: ReplySubmitResponseParser,
+    private val diagnostics: DiagnosticsLog,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) : PrivateMessageWriteRepository {
+
+    override suspend fun fetchReplyForm(context: PrivateMessageReplyContext): ReplyForm {
+        diagnostics.record(
+            DiagnosticsLog.Level.INFO,
+            LOG_TAG,
+            "GET MP reply form post=${context.threadId} page=${context.page}",
+        )
+        return try {
+            withContext(ioDispatcher) {
+                // The conversation page already embeds the bddpost.php reply form; no dedicated
+                // message.php GET is needed (and there is no anonymous variant — a session-expired
+                // GET surfaces SessionExpiredException via the authenticated client).
+                val html = hfrClient.getPrivateMessageThreadPage(
+                    threadId = context.threadId,
+                    page = context.page,
+                )
+                replyFormParser.parse(html).fold(
+                    onSuccess = { form ->
+                        diagnostics.record(
+                            DiagnosticsLog.Level.DEBUG,
+                            LOG_TAG,
+                            "MP reply form parsed: hiddenFields=${form.hiddenFields.size} " +
+                                "anonymous=${form.isAnonymous}",
+                        )
+                        form
+                    },
+                    onFailure = { error ->
+                        // No raw HTML excerpt is logged here, unlike DefaultReplyRepository: a private
+                        // conversation page can embed the correspondent's pseudo / the private URL
+                        // (#316), so we only record the failure class — never a body snapshot.
+                        diagnostics.record(
+                            DiagnosticsLog.Level.WARN,
+                            LOG_TAG,
+                            "MP reply form parse FAILED: ${error.message ?: error::class.simpleName}",
+                        )
+                        throw error
+                    },
+                )
+            }
+        } catch (cancel: CancellationException) {
+            throw cancel
+        } catch (error: SessionExpiredException) {
+            diagnostics.record(DiagnosticsLog.Level.WARN, LOG_TAG, "GET MP reply form SessionExpired")
+            throw error
+        } catch (@Suppress("TooGenericExceptionCaught") error: Throwable) {
+            diagnostics.record(
+                DiagnosticsLog.Level.WARN,
+                LOG_TAG,
+                "GET MP reply form FAILED: ${error::class.simpleName}",
+            )
+            throw error
+        }
+    }
+
+    override suspend fun submitReply(
+        context: PrivateMessageReplyContext,
+        form: ReplyForm,
+        bbcodeContent: String,
+        options: ReplyFormOptions,
+    ): ReplySubmitResult {
+        guardAgainstInvalidSubmission(form, bbcodeContent)?.let { early ->
+            diagnostics.record(
+                DiagnosticsLog.Level.WARN,
+                LOG_TAG,
+                "MP POST short-circuited: ${early.reason::class.simpleName}",
+            )
+            return early
+        }
+
+        diagnostics.record(
+            DiagnosticsLog.Level.INFO,
+            LOG_TAG,
+            "POST MP reply post=${context.threadId} page=${context.page} bbcode.length=${bbcodeContent.length}",
+        )
+        val formBody = buildFormBody(form, bbcodeContent, options)
+        return try {
+            withContext(ioDispatcher) {
+                // Same endpoint as a topic reply: bddpost.php?config=hfr.inc. All MP routing
+                // (cat=prive, post=threadId, numrep, subcat) travels in the form body.
+                val responseHtml = hfrClient.submitReply(formBody)
+                val outcome = replySubmitResponseParser.parse(responseHtml)
+                when (outcome) {
+                    is ReplySubmitResult.Success ->
+                        diagnostics.record(DiagnosticsLog.Level.INFO, LOG_TAG, "POST MP reply Success")
+                    is ReplySubmitResult.Failure ->
+                        diagnostics.record(
+                            DiagnosticsLog.Level.WARN,
+                            LOG_TAG,
+                            "POST MP reply Failure reason=${outcome.reason::class.simpleName}",
+                        )
+                }
+                outcome
+            }
+        } catch (cancel: CancellationException) {
+            throw cancel
+        } catch (error: SessionExpiredException) {
+            diagnostics.record(DiagnosticsLog.Level.WARN, LOG_TAG, "POST MP reply SessionExpired")
+            throw error
+        } catch (@Suppress("TooGenericExceptionCaught") error: Throwable) {
+            diagnostics.record(
+                DiagnosticsLog.Level.WARN,
+                LOG_TAG,
+                "POST MP reply FAILED: ${error::class.simpleName}",
+            )
+            throw error
+        }
+    }
+
+    private fun guardAgainstInvalidSubmission(
+        form: ReplyForm,
+        bbcodeContent: String,
+    ): ReplySubmitResult.Failure? = when {
+        form.isAnonymous -> ReplySubmitResult.Failure(ReplyFailureReason.LoginRequired)
+        form.hashCheck.isBlank() -> ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)
+        bbcodeContent.isBlank() -> ReplySubmitResult.Failure(ReplyFailureReason.EmptyMessage)
+        else -> null
+    }
+
+    /**
+     * Assembles the private-message POST payload. Only [hash_check][HfrConstants], `verifrequet` and
+     * `content_form` are overridden, plus the three opt-in option fields (`signature` / `smiley` /
+     * `emaill`). **Everything else is forwarded verbatim from [ReplyForm.hiddenFields]** — chiefly
+     * `cat=prive`, `post` (=threadId), `numrep` (the conversation's last-post id HFR prefilled, kept
+     * as-is — it is NOT a quote reference), `subcat=0`, `page`, `sujet`, `pseudo`. `password` is never
+     * relayed. This deliberately does not reuse [DefaultReplyRepository.buildFormBody], whose typed
+     * `cat`/`numrep` overrides would corrupt the private-message contract.
+     */
+    private fun buildFormBody(
+        form: ReplyForm,
+        bbcodeContent: String,
+        options: ReplyFormOptions,
+    ): FormBody {
+        val builder = FormBody.Builder(Charsets.UTF_8)
+        builder.add("hash_check", form.hashCheck)
+        builder.add("verifrequet", HfrConstants.VERIF_REQUET)
+        builder.add("content_form", bbcodeContent)
+        // Browser-style opt-in: a field is only present when the user enabled it (`emaill` keeps
+        // HFR's own two-`l` spelling). The matching keys are marked emitted so the verbatim
+        // forwarder below cannot resurrect a stale `value="1"` default from the parsed checkbox.
+        if (options.signatureEnabled) builder.add("signature", "1")
+        if (options.smileyDisabled) builder.add("smiley", "1")
+        if (options.emailNotificationEnabled) builder.add("emaill", "1")
+        val emitted = mutableSetOf("hash_check", "verifrequet", "content_form", "signature", "smiley", "emaill")
+        form.hiddenFields.forEach { (key, value) ->
+            if (key in emitted) return@forEach
+            // Belt-and-braces: ReplyFormParser already drops `password`, never relay it.
+            if (key == "password") return@forEach
+            builder.add(key, value)
+            emitted += key
+        }
+        return builder.build()
+    }
+
+    private companion object {
+        private const val LOG_TAG = "MpWriteRepository"
+    }
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/ReplyRepositoryModule.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/ReplyRepositoryModule.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import fr.forumhfr.redface2.core.domain.write.DeletePostRepository
 import fr.forumhfr.redface2.core.domain.write.EditPostRepository
+import fr.forumhfr.redface2.core.domain.write.PrivateMessageWriteRepository
 import fr.forumhfr.redface2.core.domain.write.ReplyRepository
 import fr.forumhfr.redface2.core.domain.write.TopicFormRepository
 import fr.forumhfr.redface2.core.parser.write.ReplyFormParser
@@ -40,6 +41,12 @@ abstract class ReplyRepositoryModule {
     @Binds
     @Singleton
     abstract fun bindTopicFormRepository(impl: DefaultTopicFormRepository): TopicFormRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindPrivateMessageWriteRepository(
+        impl: DefaultPrivateMessageWriteRepository,
+    ): PrivateMessageWriteRepository
 
     companion object {
         @Provides

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/write/DefaultPrivateMessageWriteRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/write/DefaultPrivateMessageWriteRepositoryTest.kt
@@ -1,0 +1,212 @@
+package fr.forumhfr.redface2.core.data.write
+
+import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
+import fr.forumhfr.redface2.core.model.write.PrivateMessageReplyContext
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
+import fr.forumhfr.redface2.core.model.write.ReplyForm
+import fr.forumhfr.redface2.core.model.write.ReplyFormOptions
+import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
+import fr.forumhfr.redface2.core.network.HfrClient
+import fr.forumhfr.redface2.core.parser.write.ReplyFormParser
+import fr.forumhfr.redface2.core.parser.write.ReplySubmitResponseParser
+import java.net.URLDecoder
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * #301 — private-message reply repository. The decisive contract is the POST body shape: a private
+ * conversation carries `cat=prive` (String), `post={threadId}`, `subcat=0` and a server-prefilled
+ * `numrep` inside the form's hidden fields, and [DefaultPrivateMessageWriteRepository] must forward
+ * them verbatim — never re-asserting `cat`/`numrep` from a typed context the way the topic reply
+ * repository does. Tests use a real [HfrClient] over a [MockWebServer], mirroring
+ * `DefaultReplyRepositoryTest`.
+ */
+class DefaultPrivateMessageWriteRepositoryTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: HfrClient
+    private lateinit var repository: DefaultPrivateMessageWriteRepository
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().apply { start() }
+        val okHttp = OkHttpClient.Builder().build()
+        client = HfrClient(
+            authenticated = okHttp,
+            anonymous = okHttp,
+            baseUrl = server.url("/"),
+            ioDispatcher = Dispatchers.Unconfined,
+        )
+        repository = DefaultPrivateMessageWriteRepository(
+            hfrClient = client,
+            replyFormParser = ReplyFormParser(),
+            replySubmitResponseParser = ReplySubmitResponseParser(),
+            diagnostics = DiagnosticsLog(),
+            ioDispatcher = Dispatchers.Unconfined,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private val context = PrivateMessageReplyContext(threadId = 3195237, page = 1)
+
+    @Test
+    fun `fetchReplyForm GETs the conversation page on forum2_php with cat=prive`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("private_message_thread.html")))
+
+        val form = repository.fetchReplyForm(context)
+
+        assertFalse(form.isAnonymous)
+        assertEquals("prive", form.hiddenFields["cat"])
+
+        val url = requireNotNull(server.takeRequest().requestUrl)
+        assertEquals("forum2.php", url.pathSegments.first())
+        assertEquals("prive", url.queryParameter("cat"))
+        assertEquals("3195237", url.queryParameter("post"))
+        assertEquals("1", url.queryParameter("page"))
+    }
+
+    @Test
+    fun `submitReply forwards cat=prive, post, numrep, subcat verbatim and never overwrites them`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("private_message_thread.html")))
+        server.enqueue(MockResponse().setBody(fixture("write_reply_success_response.html")))
+
+        val form = repository.fetchReplyForm(context)
+        val result = repository.submitReply(context, form, bbcodeContent = "Coucou en privé.")
+
+        assertTrue("Expected success, got $result", result is ReplySubmitResult.Success)
+
+        server.takeRequest() // drop the GET
+        val recorded = server.takeRequest()
+        assertEquals("POST", recorded.method)
+        assertEquals("bddpost.php", requireNotNull(recorded.requestUrl).pathSegments.first())
+
+        val body = parseFormBody(recorded.body.readUtf8())
+        // The three private-message contract fields, carried verbatim from the form.
+        assertEquals("prive", body["cat"])
+        assertEquals("3195237", body["post"])
+        // numrep is the conversation's prefilled last-post id — must NOT be blanked (the topic
+        // repository would set it to "" for a simple reply; the MP repository must not).
+        assertEquals("1980677227", body["numrep"])
+        assertEquals("0", body["subcat"])
+        assertEquals("1", body["page"])
+        // The fields HFR validates, added by the repository.
+        assertEquals("0", body["hash_check"])
+        assertEquals("1100", body["verifrequet"])
+        assertEquals("Coucou en privé.", body["content_form"])
+        // password must never reach HFR.
+        assertFalse("password must never be transmitted", body.containsKey("password"))
+    }
+
+    @Test
+    fun `submitReply adds signature only when the option is enabled`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("private_message_thread.html")))
+        server.enqueue(MockResponse().setBody(fixture("write_reply_success_response.html")))
+
+        val form = repository.fetchReplyForm(context)
+        repository.submitReply(
+            context,
+            form,
+            bbcodeContent = "Avec signature.",
+            options = ReplyFormOptions(signatureEnabled = true),
+        )
+
+        server.takeRequest()
+        val body = parseFormBody(server.takeRequest().body.readUtf8())
+        assertEquals("1", body["signature"])
+    }
+
+    @Test
+    fun `submitReply omits signature when the option is disabled`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("private_message_thread.html")))
+        server.enqueue(MockResponse().setBody(fixture("write_reply_success_response.html")))
+
+        val form = repository.fetchReplyForm(context)
+        // Default options = all off ; the form's hidden `signature=1` must not leak back as a
+        // browser would omit an unchecked field.
+        repository.submitReply(context, form, bbcodeContent = "Sans signature.")
+
+        server.takeRequest()
+        val body = parseFormBody(server.takeRequest().body.readUtf8())
+        assertFalse("signature must be omitted when disabled", body.containsKey("signature"))
+    }
+
+    @Test
+    fun `submitReply never relays a password hidden field`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("write_reply_success_response.html")))
+
+        val form = ReplyForm(
+            hashCheck = "h",
+            sujet = "s",
+            hiddenFields = mapOf("cat" to "prive", "post" to "3195237", "password" to "secret"),
+            isAnonymous = false,
+        )
+        repository.submitReply(context, form, bbcodeContent = "hi")
+
+        val body = parseFormBody(server.takeRequest().body.readUtf8())
+        assertFalse("password must never be transmitted", body.containsKey("password"))
+        assertEquals("prive", body["cat"])
+    }
+
+    @Test
+    fun `submitReply refuses a blank body without any network call`() = runTest {
+        val form = ReplyForm(hashCheck = "h", sujet = "s", hiddenFields = emptyMap(), isAnonymous = false)
+
+        val result = repository.submitReply(context, form, bbcodeContent = "   ")
+
+        assertEquals(ReplySubmitResult.Failure(ReplyFailureReason.EmptyMessage), result)
+        assertEquals("no POST should be sent for a blank body", 0, server.requestCount)
+    }
+
+    @Test
+    fun `submitReply refuses to POST an anonymous form`() = runTest {
+        val form = ReplyForm(hashCheck = "h", sujet = "s", hiddenFields = emptyMap(), isAnonymous = true)
+
+        val result = repository.submitReply(context, form, bbcodeContent = "hi")
+
+        assertEquals(ReplySubmitResult.Failure(ReplyFailureReason.LoginRequired), result)
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun `submitReply classifies the empty-message error response`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("write_empty_message_error.html")))
+
+        val form = ReplyForm(
+            hashCheck = "h",
+            sujet = "s",
+            hiddenFields = mapOf("cat" to "prive"),
+            isAnonymous = false,
+        )
+        val result = repository.submitReply(context, form, bbcodeContent = "non-blank content")
+
+        assertEquals(ReplySubmitResult.Failure(ReplyFailureReason.EmptyMessage), result)
+    }
+
+    private fun fixture(name: String): String {
+        val stream = requireNotNull(
+            DefaultPrivateMessageWriteRepositoryTest::class.java.classLoader?.getResourceAsStream("fixtures/$name"),
+        ) { "Fixture not found: fixtures/$name" }
+        return stream.bufferedReader().use { it.readText() }
+    }
+
+    private fun parseFormBody(body: String): Map<String, String> =
+        body.split('&')
+            .filter { it.isNotEmpty() }
+            .associate { pair ->
+                val (key, value) = pair.split('=', limit = 2).let { it[0] to (it.getOrNull(1) ?: "") }
+                URLDecoder.decode(key, "UTF-8") to URLDecoder.decode(value, "UTF-8")
+            }
+}

--- a/core/data/src/test/resources/fixtures/private_message_thread.html
+++ b/core/data/src/test/resources/fixtures/private_message_thread.html
@@ -1,0 +1,210 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr" lang="fr"><head><title>Sujet prive de test - Messages privés - FORUM HardWare.fr</title><link type="text/css" rel="stylesheet" href="/include/the_style1.php?color_key=f2f3ef/DEDFDF/000080/C2C3F4/d5e6e1/000080/000080/000000/000080/000000/000080/f7f7f7/f0eee9/f7f7f7/f0eee9/C0C0C0/C0C0C0/FFFFFF/000000/000000/0000FF/EEEEFF/DDDDEE/000000/FFEEEE/000000/FFFFFF/FF0000/FFFFFF/0/1/https%3A%40%40forum-images.hardware.fr/NULL/&amp;abs_img_path=%40data%40sites%40forum%40www%40static%40&amp;hide_bg_onglet=0&amp;v=11102781422" /><link type="text/css" rel="stylesheet" href="https://forum-images.hardware.fr/compressed/the_style.css?v=11102781422" /><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/tabs.js?v=11102781422"></script><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/forum2.js?v=11102781422"></script><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/common.js?v=11102781422"></script><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /><meta name="Robots" content="noindex, follow" /><meta name="Description" content="" /><style type="text/css">
+<!--
+.fastsearchMain{ width: 330px; }
+.fastsearchInput{ width: 70px; border: 1px solid black; }
+.fastsearchSubmit{ background-color: ; border: 0px;}
+.header2 { background-image: url(/img/forum3_1.gif);background-repeat: repeat-x; }
+.menuExt { font-family: Arial, Helvetica, sans-serif; font-size: 10px; color:#000; }
+.menuExt a { color:#000;text-decoration:none; }
+.menuExt a:hover { color:#000;text-decoration:underline; }
+form { display: inline; }
+.header { background-image: url(//forum-images.hardware.fr/img/header-bg.gif); background-repeat: repeat-x; }
+.tdmenu { width: 1px;height: 1px;color: #000000; }
+.hfrheadmenu { font-family: Arial, Helvetica, sans-serif;font-size:13px;font-weight:bold; }
+.hfrheadmenu span {color:;}
+.hfrheadmenu a { color:;text-decoration: none; }
+.hfrheadmenu a:hover { color:;text-decoration: underline; }
+.concours { font-family: Arial, Helvetica, sans-serif;color:;font-size: 16px;text-decoration: none;font-weight: bold;}
+.concours:hover { font-family: Arial, Helvetica, sans-serif;color:;font-size: 16px;text-decoration: underline;font-weight: bold; }
+.searchmenu { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: none;font-weight: bold; }
+.fastsearch { display: none; }
+.fastsearchHeader { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: none;font-weight: bold; }
+.fastsearchHeader:hover { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: underline;font-weight: bold; }
+-->
+</style>
+<script async='async' src='https://www.googletagservices.com/tag/js/gpt.js'></script>
+<script>
+  var googletag = googletag || {};
+  googletag.cmd = googletag.cmd || [];
+</script>
+
+<script>
+  googletag.cmd.push(function() {
+    googletag.defineSlot('/2172442/forum_accueil_banniere', [728, 90], 'div-gpt-ad-1511901001563-0').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_achats_ventes_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-1').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_achats_ventes_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-2').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_achats_ventes_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-3').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_achats_ventes_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-4').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_apple_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-5').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_apple_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-6').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_apple_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-7').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_apple_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-8').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_banniere_jpdc', [728, 90], 'div-gpt-ad-1511901001563-9').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-10').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-11').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-12').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-13').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_emploi_etude_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-14').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_emploi_etude_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-15').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_emploi_etude_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-16').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_emploi_etude_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-17').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_graphisme_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-18').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_graphisme_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-19').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_graphisme_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-20').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_graphisme_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-21').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_banniere', [728, 90], 'div-gpt-ad-1511901001563-22').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-23').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-24').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-25').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-26').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_peripheriques_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-27').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_peripheriques_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-28').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_peripheriques_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-29').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_peripheriques_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-30').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_jeux_video_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-31').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_jeux_video_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-32').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_jeux_video_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-33').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_jeux_video_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-34').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_ordinateurs_portables_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-35').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_ordinateurs_portables_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-36').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_ordinateurs_portables_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-37').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_ordinateurs_portables_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-38').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_os_alternatif_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-39').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_os_alternatif_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-40').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_os_alternatif_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-41').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_os_alternatif_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-42').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_overclocking_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-43').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_overclocking_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-44').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_overclocking_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-45').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_overclocking_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-46').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_photo_numerique_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-47').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_photo_numerique_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-48').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_photo_numerique_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-49').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_photo_numerique_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-50').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_programmation_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-51').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_programmation_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-52').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_programmation_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-53').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_programmation_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-54').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_reseaux_grand_public_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-55').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_reseaux_grand_public_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-56').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_reseaux_grand_public_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-57').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_reseaux_grand_public_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-58').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_seti_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-59').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_seti_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-60').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_seti_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-61').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_seti_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-62').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_systemes_reseaux_pro_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-63').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_systemes_reseaux_pro_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-64').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_systemes_reseaux_pro_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-65').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_systemes_reseaux_pro_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-66').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_technologies_mobiles_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-67').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_technologies_mobiles_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-68').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_technologies_mobiles_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-69').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_technologies_mobiles_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-70').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_video_son_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-71').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_video_son_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-72').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_video_son_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-73').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_video_son_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-74').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_windows_software_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-75').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_windows_software_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-76').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_windows_software_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-77').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_windows_software_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-78').addService(googletag.pubads());
+    googletag.pubads().enableSingleRequest();
+    googletag.enableServices();
+  });
+</script>
+<script type='text/javascript'>
+     (function(){
+       var loc = window.location.href;
+       var dd = document.createElement('script');
+       dd.type = 'text/javascript'; dd.src = '//static.digidip.net/hardware.js?loc=' + loc;
+       var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(dd, s);
+     })();
+</script></head><body id="unique__inside_topics__private_thread"  > <table cellspacing="0" cellpadding="0" width="98%" bgcolor="#000000" border="0" align="center" class="hfrheadmenu" style="border:1px solid #000;border-top:0;">
+        <tr>
+          <td style="vertical-align: top">
+            <table cellspacing="0" cellpadding="0" width="100%" border="0">
+              <tr>
+                <td style="width: 100%" align="left" valign="middle" colspan="2" class="header2"><span class="md_cryptlink45CBCBC0C22D1F1FCCCCCC19454AC14BCC4AC1431944C1"><img src="/img/forum_logo.gif" width="900" height="71" border="0" alt="" /></span></td>
+              </tr>
+              <tr>
+                <td style="background-color:#d5e6e1">
+                  <table cellspacing="0" cellpadding="2" width="100%" border="0">
+                    <tr>
+                      <td>&nbsp;<a class="cHeader" href="/">Forum</a>&nbsp;|&nbsp;
+<a class="cHeader" href="https://www.hardware.fr/">HardWare.fr</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/html/news/">News</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/html/articles/">Articles</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/articles/786-1/guide-pc-hardware-fr.html">PC</a>&nbsp;|&nbsp;<span class="md_cryptlink1FC349484F4C19C045C02F424F4944464C2E454AC14BCC4AC14344C11946494214424F4B434543C52E2341434A21264B2A4A424B422625422B252122212C44204321442C2C2A2A2142">Se d&eacute;connecter</span>&nbsp;|&nbsp;<span class="md_cryptlink1FC3C243C11F434B46CBC0C14F44464819C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">Profil</span>&nbsp;|&nbsp;<a class="cHeader" href="https://shop.hardware.fr/" target="_blank" style="position: relative; padding: 0 21px 0 0;display: inline-block;">Shop <img src="/img/shop.png" style="height: 17px; display: inline; position: absolute; right: 0; top: -2px; "></a></td>
+<td align="right"><a class="cHeader" href="/search.php?config=hardwarefr.inc&cat=prive&subcat=0">Recherche <img src="//forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif"></a></td>
+                    </tr>
+                    </table></td></tr></table>
+</td></tr></table><div style="width: 99%" align="right">
+<span class="s2Ext menuExt"><span class="md_cryptlink1F4F494846494319C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">11334 connect&eacute;s&nbsp;</span></span></div><br /><script language="javascript" type="text/javascript">
+			<!--
+			writeCookie('md_users_res');
+			//-->
+			</script><div class="container"><div class="mesdiscussions" id="mesdiscussions"><div class="arbo" id="md_arbo_top">
+<span  id="md_arbo_tree_1" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/" class="Ext">FORUM HardWare.fr</a></span>
+<br />
+<span  id="md_arbo_tree_2" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/forum1.php?config=hfr.inc&amp;cat=prive&amp;page=1&amp;subcat=&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;moderation=0&amp;new=0&amp;nojs=0&amp;subcatgroup=0" class="Ext">Messages&nbsp;privés</a></span>
+<br />
+<h1  id="md_arbo_tree_3" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline3.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;Sujet prive de test</h1>
+</div><div class="rightbutton fastsearch"><table class="main fastsearchMain" cellspacing="0" cellpadding="2"><tr class="cBackHeader fondForumDescription"><th><form method="post" id="fastsearch" action="/forum1.php"><input type="hidden" name="hash_check" value="0" /><label for="fastsearchinputid"><a rel="nofollow" href="/search.php?config=hfr.inc&amp;cat=prive&amp;subcat=0" class="cHeader fastsearchHeader">Recherche :</a>&nbsp;<input type="text" name="search" id="fastsearchinputid" value="" class="fastsearchInput" alt="Search string" /></label><input type="hidden" name="recherches" value="1" /><input type="hidden" name="searchtype" value="1" /><input type="hidden" name="titre" value="3" /><input type="hidden" name="resSearch" value="200" /><input type="hidden" name="orderSearch" value="1" /><input type="hidden" name="config" value="hfr.inc" /><input type="hidden" name="cat" value="prive" />&nbsp;<input type="image" src="https://forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif" class="fastsearchSubmit" title="Lancer une recherche" alt="Lancer une recherche" /></form></th></tr></table></div><div class="spacer">&nbsp;</div><br /><div class="s1Ext"></div><table class="none" style="border:0px" cellspacing="0" cellpadding="0"><tr><td style="vertical-align:bottom"><div class="cadreonglet"><div class="beforongletsel" id="befor1" >&nbsp;</div><a href="/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=3195237&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=0&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0" class="ongletsel" id="onglet1" title="Filtres" rel="nofollow"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/global.gif" title="Filtres" alt="Filtres" /></a><div class="afterongletsel" id="after1">&nbsp;</div><div class="beforonglet" id="befor2"  >&nbsp;</div><a href="/search.php?config=hfr.inc&amp;cat=prive&amp;subcat=0" class="onglet" id="onglet2" title="Rechercher" rel="nofollow"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif" title="Rechercher" alt="Search" /></a><div class="afteronglet" id="after2">&nbsp;</div></div></td><td style="vertical-align:bottom"></td></tr></table><a name="haut"></a><table class="main" cellspacing="0" cellpadding="4"><tr class="cBackHeader fondForum2Fonctions"><th class="padding" colspan="2"><form action="/transsearch.php" method="post"><input type="hidden" name="hash_check" value="0" /><input type="hidden" name="post"	value="3195237" /><input type="hidden" name="cat"	value="prive" /><input type="hidden" name="config"	value="hfr.inc" /><input type="hidden" name="p"		value="1" /><input type="hidden" name="sondage"	value="0" /><input type="hidden" name="owntopic" value="0" /><div class="left">&nbsp;Mot : <input type="text" name="word" value="" size="10" id="md_search_word" /><input class="checkbox" type="checkbox" name="filter" id="filter" value="1"  /><label for="filter" title="N'afficher que les messages correspondant à la recherche">Filtrer</label>&nbsp;<input type="submit" onclick="document.getElementById('currentnum').value=''; return true;" value="Rechercher" class="boutton" /><input type="hidden" name="dep" value="0" /><input type="hidden" value="1980664234" name="firstnum" /></div></form><div class="right" style="margin-top:2px"><a href="javascript:void(0)" onclick="vider_liste('quoteshardwarefr-prive-3195237')" class="cHeader"><img style="display:none" id="viderliste" src="https://forum-images.hardware.fr/themes_static/images_forum/1/viderliste.gif" alt="Vider la liste des messages à citer" title="Vider la liste des messages à citer" /></a>&nbsp;&nbsp;<a href="/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=3195237&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=1&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0" class="cHeader" target="_blank"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/print.gif" alt="Afficher le sujet en intégralité" title="Afficher le sujet en intégralité" /></a>&nbsp;&nbsp;<a href="/user/email.php?config=hfr.inc&amp;cat=prive&amp;subcat=0&amp;post=3195237&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;new=0" class="cHeader"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/subscribe.gif" alt="Activer la notification par email du sujet" title="Activer la notification par email du sujet" /></a>&nbsp;&nbsp;<a href="/user/nonlu.php?config=hfr.inc&amp;cat=prive&amp;subcat=0&amp;post=3195237&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;new=0" class="cHeader"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/oeil.gif" alt="Marquer le message comme non lu" title="Marquer le message comme non lu" /></a> &nbsp;</div></th></tr><tr class="cBackHeader fondForum2PagesHaut"><th class="padding" colspan="2"><a href="#bas" class="cHeader">Bas de page</a></th></tr><tr class="cBackHeader fondForum2Title"><th scope="col" class="messCase1" width="180">Auteur</th><th scope="col" class="padding">&nbsp;Sujet : <h3>Sujet prive de test</h3></th></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message cBackCouleurTab2"><td class="messCase1" width="180" valign="top" rowspan="1"><a name="t1980664234"></a><div class="right"><a href="#t1980664234" rel="nofollow"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" title="n°1980664234" alt="n°1980664234" /></a></div><div><b class="s2">TestUser</b></div><div class="avatar_center" style="clear:both"><img src="https://forum-images.hardware.fr/images/mesdiscussions-990002.png" alt="" /></div></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 24-05-2026&nbsp;à&nbsp;14:29:15&nbsp;&nbsp;<a href="/hfr/profil-990002.htm" target="_blank" rel="nofollow"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil (Etat inconnu)" alt="profil" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2EC0C146C44314C04FC2CB2E222A262321222C1449C34EC143C04F49C2432E2A26252024242B21222B14C04A4C432E2A14C02E2A14C2C341424ACB2E2014C24F494B4A4C432E20144FCC49CB4FC046422E2012444FC14EC3484A46C143"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/edit.gif" title="Editer le message" alt="edit" /></span><a rel="nofollow" href="/message.php?config=hfr.inc&amp;cat=prive&amp;post=3195237&amp;numreponse=1980664234&amp;page=1&amp;p=1&amp;subcat=0&amp;sondage=0&amp;owntopic=0#formulaire" onclick="edit_in('hfr.inc','prive',3195237,1980664234,''); return false"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/edit-in.gif" title="Edition rapide" alt="Edition rapide" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2EC0C146C44314C04FC2CB2E222A262321222C1449C34EC143C02E2A26252024242B21222B14C143442E2A14C04A4C432E2A14C02E2A14C2C341424ACB2E2014C24F494B4A4C432E20144FCC49CB4FC046422E20144943CC2E2012444FC14EC3484A46C143"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></span><a rel="nofollow" onclick="quoter('hardwarefr','prive',3195237,1980664234); return false;" href="/message.php?config=hfr.inc&amp;cat=prive&amp;post=3195237&amp;numrep=1980664234&amp;ref=1&amp;page=1&amp;p=1&amp;subcat=0&amp;sondage=0&amp;owntopic=0&amp;new=0#formulaire"><img id="plus1980664234" src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote+.gif" title="Ajouter à la liste des messages cités" alt="answer +" /><img id="moins1980664234" style="display:none" src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote-.gif" title="Retirer de la liste des messages cités" alt="answer -" /></a><a href="/configuration.php?config=hfr.inc&amp;pseudo=TestUser" target="_blank"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/config.gif" title="Configuration matérielle" alt="config" /></a></div><div class="spacer">&nbsp;</div></div><div id="para1980664234">Message prive de test (contenu remplace).</div></td></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message cBackCouleurTab1"><td class="messCase1" width="180" valign="top" rowspan="1"><a name="t1980664235"></a><div class="right"><a href="#t1980664235" rel="nofollow"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" title="n°1980664235" alt="n°1980664235" /></a></div><div><b class="s2">TestUser</b></div><div class="avatar_center" style="clear:both"><img src="https://forum-images.hardware.fr/images/mesdiscussions-990002.png" alt="" /></div></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 24-05-2026&nbsp;à&nbsp;14:29:58&nbsp;&nbsp;<a href="/hfr/profil-990002.htm" target="_blank" rel="nofollow"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil (Etat inconnu)" alt="profil" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2EC0C146C44314C04FC2CB2E222A262321222C1449C34EC143C04F49C2432E2A26252024242B21222314C04A4C432E2A14C02E2A14C2C341424ACB2E2014C24F494B4A4C432E20144FCC49CB4FC046422E2012444FC14EC3484A46C143"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/edit.gif" title="Editer le message" alt="edit" /></span><a rel="nofollow" href="/message.php?config=hfr.inc&amp;cat=prive&amp;post=3195237&amp;numreponse=1980664235&amp;page=1&amp;p=1&amp;subcat=0&amp;sondage=0&amp;owntopic=0#formulaire" onclick="edit_in('hfr.inc','prive',3195237,1980664235,''); return false"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/edit-in.gif" title="Edition rapide" alt="Edition rapide" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2EC0C146C44314C04FC2CB2E222A262321222C1449C34EC143C02E2A26252024242B21222314C143442E2114C04A4C432E2A14C02E2A14C2C341424ACB2E2014C24F494B4A4C432E20144FCC49CB4FC046422E20144943CC2E2012444FC14EC3484A46C143"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></span><a rel="nofollow" onclick="quoter('hardwarefr','prive',3195237,1980664235); return false;" href="/message.php?config=hfr.inc&amp;cat=prive&amp;post=3195237&amp;numrep=1980664235&amp;ref=2&amp;page=1&amp;p=1&amp;subcat=0&amp;sondage=0&amp;owntopic=0&amp;new=0#formulaire"><img id="plus1980664235" src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote+.gif" title="Ajouter à la liste des messages cités" alt="answer +" /><img id="moins1980664235" style="display:none" src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote-.gif" title="Retirer de la liste des messages cités" alt="answer -" /></a><a href="/configuration.php?config=hfr.inc&amp;pseudo=TestUser" target="_blank"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/config.gif" title="Configuration matérielle" alt="config" /></a></div><div class="spacer">&nbsp;</div></div><div id="para1980664235">Message prive de test (contenu remplace).</div></td></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message cBackCouleurTab2"><td class="messCase1" width="180" valign="top" rowspan="1"><a name="t1980677218"></a><div class="right"><a href="#t1980677218" rel="nofollow"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" title="n°1980677218" alt="n°1980677218" /></a></div><div><b class="s2">TestUser</b></div><div class="avatar_center" style="clear:both"><img src="https://forum-images.hardware.fr/images/mesdiscussions-990002.png" alt="" /></div></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 03-06-2026&nbsp;à&nbsp;18:55:48&nbsp;&nbsp;<a href="/hfr/profil-990002.htm" target="_blank" rel="nofollow"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil (Etat inconnu)" alt="profil" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2EC0C146C44314C04FC2CB2E222A262321222C1449C34EC143C04F49C2432E2A262520242C2C212A2514C04A4C432E2A14C02E2A14C2C341424ACB2E2014C24F494B4A4C432E20144FCC49CB4FC046422E2012444FC14EC3484A46C143"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/edit.gif" title="Editer le message" alt="edit" /></span><a rel="nofollow" href="/message.php?config=hfr.inc&amp;cat=prive&amp;post=3195237&amp;numreponse=1980677218&amp;page=1&amp;p=1&amp;subcat=0&amp;sondage=0&amp;owntopic=0#formulaire" onclick="edit_in('hfr.inc','prive',3195237,1980677218,''); return false"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/edit-in.gif" title="Edition rapide" alt="Edition rapide" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2EC0C146C44314C04FC2CB2E222A262321222C1449C34EC143C02E2A262520242C2C212A2514C143442E2214C04A4C432E2A14C02E2A14C2C341424ACB2E2014C24F494B4A4C432E20144FCC49CB4FC046422E20144943CC2E2012444FC14EC3484A46C143"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></span><a rel="nofollow" onclick="quoter('hardwarefr','prive',3195237,1980677218); return false;" href="/message.php?config=hfr.inc&amp;cat=prive&amp;post=3195237&amp;numrep=1980677218&amp;ref=3&amp;page=1&amp;p=1&amp;subcat=0&amp;sondage=0&amp;owntopic=0&amp;new=0#formulaire"><img id="plus1980677218" src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote+.gif" title="Ajouter à la liste des messages cités" alt="answer +" /><img id="moins1980677218" style="display:none" src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote-.gif" title="Retirer de la liste des messages cités" alt="answer -" /></a><a href="/configuration.php?config=hfr.inc&amp;pseudo=TestUser" target="_blank"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/config.gif" title="Configuration matérielle" alt="config" /></a></div><div class="spacer">&nbsp;</div></div><div id="para1980677218">Message prive de test (contenu remplace).</div></td></tr></table><table cellspacing="0" cellpadding="4" width="100%" class="messagetable"><tr class="message cBackCouleurTab1"><td class="messCase1" width="180" valign="top" rowspan="1"><a name="t1980677227"></a><a name="bas"></a><div class="right"><a href="#t1980677227" rel="nofollow"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" title="n°1980677227" alt="n°1980677227" /></a></div><div><b class="s2">Correspondant</b></div><div class="avatar_center" style="clear:both"><img src="https://forum-images.hardware.fr/images/mesdiscussions-990001.jpg" alt="" /></div></td><td class="messCase2" valign="top" ><div class="toolbar"><div class="left">Posté le 03-06-2026&nbsp;à&nbsp;19:01:40&nbsp;&nbsp;<a href="/hfr/profil-990001.htm" target="_blank" rel="nofollow"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/profile.gif" title="Voir son profil (Etat inconnu)" alt="profil" /></a><span class="md_noclass_cryptlink1F4E43C2C24A4C4319C045C02F424F4944464C2E4544C11946494214424ACB2EC0C146C44314C04FC2CB2E222A262321222C1449C34EC143C02E2A262520242C2C21212C14C143442E2B14C04A4C432E2A14C02E2A14C2C341424ACB2E2014C24F494B4A4C432E20144FCC49CB4FC046422E20144943CC2E2012444FC14EC3484A46C143"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote.gif" title="Répondre à ce message" alt="answer" /></span><a rel="nofollow" onclick="quoter('hardwarefr','prive',3195237,1980677227); return false;" href="/message.php?config=hfr.inc&amp;cat=prive&amp;post=3195237&amp;numrep=1980677227&amp;ref=4&amp;page=1&amp;p=1&amp;subcat=0&amp;sondage=0&amp;owntopic=0&amp;new=0#formulaire"><img id="plus1980677227" src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote+.gif" title="Ajouter à la liste des messages cités" alt="answer +" /><img id="moins1980677227" style="display:none" src="https://forum-images.hardware.fr/themes_static/images_forum/1/quote-.gif" title="Retirer de la liste des messages cités" alt="answer -" /></a><a rel="nofollow" href="/message.php?config=hfr.inc&amp;cat=prive&amp;sond=&amp;p=1&amp;subcat=&amp;dest=Correspondant&amp;subcatgroup=0"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/pv.gif" title="Envoyer un message privé à Correspondant" alt="MP" /></a><a href="/user/contactlist.php?adduser=990001&amp;comeback=1"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/put_contact.gif" title="Ajouter  Correspondant à votre liste de contacts" alt="Ajouter  Correspondant à votre liste de contacts" /></a></div><div class="spacer">&nbsp;</div></div><div id="para1980677227">Message prive de test (contenu remplace).</div></td></tr></table><br /><script language="javascript" type="text/javascript">var listenumreponse=new Array("1980664234","1980664235","1980677218","1980677227")</script><form action="/forum1.php" method="get" id="goto"><input type="hidden" name="hash_check" value="0" />
+		<div class="nombres">
+		<b>Aller à : </b>
+		<input type="hidden" name="config" value="hfr.inc" />
+		<select name="cat" onchange="document.getElementById('goto').submit()"><option value="1" >Hardware</option><option value="16" >Hardware - Périphériques</option><option value="15" >Ordinateurs portables</option><option value="2" >Overclocking, Cooling &amp; Modding</option><option value="30" >Electronique, domotique, DIY</option><option value="23" >Technologies Mobiles</option><option value="25" >Apple</option><option value="3" >Video &amp; Son</option><option value="14" >Photo numérique</option><option value="5" >Jeux Video</option><option value="4" >Windows &amp; Software</option><option value="22" >Réseaux grand public / SoHo</option><option value="21" >Systèmes &amp; Réseaux Pro</option><option value="11" >Linux et OS Alternatifs</option><option value="10" >Programmation</option><option value="32" >Intelligence Artificielle</option><option value="12" >Graphisme</option><option value="6" >Achats &amp; Ventes</option><option value="8" >Emploi &amp; Etudes</option><option value="13" >Discussions</option><option value="24" >Blabla - Divers ( back to life )</option><option value="prive" selected="selected">Messages privés</option></select>
+			<input type="submit" value="Go" />
+			</div></form><div class="left"><form action="/message.php?config=hfr.inc&amp;cat=prive&amp;post=3195237&amp;page=1&amp;p=1&amp;subcat=0&amp;sondage=0&amp;owntopic=0&amp;new=0" method="post" name="repondre_form" id="repondre_form"><input type="hidden" name="hash_check" value="0" /><input type="hidden" name="repondre_contenu" id="repondre_contenu" value="" />
+					<a rel="nofollow" href="/message.php?config=hfr.inc&amp;cat=prive&amp;post=3195237&amp;page=1&amp;p=1&amp;subcat=0&amp;sondage=0&amp;owntopic=0&amp;new=0" onclick="choper_reponse_rapide(0,0); return false;" accesskey="r"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/repondre.gif" title="Ajouter une réponse" alt="Ajouter une réponse" /></a>
+					</form>
+					</div><div class="arbo" style="margin:0px 0px 0px 20px;" id="md_arbo_bottom">
+<span  id="md_arbo_tree_b_1" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/" class="Ext">FORUM HardWare.fr</a></span>
+<br />
+<span  id="md_arbo_tree_b_2" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/forum1.php?config=hfr.inc&amp;cat=prive&amp;page=1&amp;subcat=&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;moderation=0&amp;new=0&amp;nojs=0&amp;subcatgroup=0" class="Ext">Messages&nbsp;privés</a></span>
+<br />
+<h1  id="md_arbo_tree_b_3" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline3.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;Sujet prive de test</h1>
+</div><div class="spacer">&nbsp;</div><form name="hop" action="/bddpost.php" method="post" onsubmit="document.hop.submit.style.visibility='hidden';"><input type="hidden" name="hash_check" value="0" /><div class="s2Ext" id="md_fast_search"><b>Réponse rapide</b>
+						<br /><div id="addComment"></div><textarea rows="5" cols="60" name="content_form" class="reponserapide" id="content_form" accesskey="c"></textarea><br />
+						<input type="submit" accesskey="s" value="Valider votre message" name="submit" id="submitreprap"/>
+						<input type="hidden" name="new" value="0" />
+						<input type="hidden" name="post" value="3195237" /><input type="hidden" name="numrep" value="1980677227" /><input type="hidden" name="cat" value="prive" />
+						<input type="hidden" name="subcat" value="0" />
+						<input type="hidden" name="page" value="1" />
+						<input type="hidden" name="verifrequet" value="1100" />
+						<input type="hidden" name="p" value="1" />
+						<input type="hidden" name="sondage" value="0" />
+						<input type="hidden" name="cache" value="" />
+						<input type="hidden" name="owntopic" value="0" />
+						<input type="hidden" name="config" value="hfr.inc" />
+						<input type="hidden" name="emaill" value="" />
+						<input type="hidden" name="pseudo" value="TestUser" />
+						<input type="hidden" name="sujet" value="Sujet prive de test" />
+						<input type="hidden" value="1" name="signature" />
+					</div></form><br />
+			<div class="copyright">
+			<a href="http://www.mesdiscussions.net" target="_blank" class="copyright">Forum MesDiscussions.Net</a>, Version 2010.2 <br />(c) 2000-2011 Doctissimo<br /><div class='gene'>Page générée en  0.037 secondes</div></div></div></div><center><font color="#000000" size="1" face="Arial, Helvetica, sans-serif"><br />Copyright © 1997-2025 Groupe <a href="https://www.ldlc.com" title="Achat de materiel Informatique">LDLC</a> (<a href="https://www.hardware.fr/html/donnees_personnelles/">Signaler un contenu illicite / Données personnelles</a>)</font></center>
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://tracking.groupe-ldlc.com/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '26']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<noscript><p><img src="https://tracking.groupe-ldlc.com/matomo.php?idsite=26&rec=1" style="border:0;" alt="" /></p></noscript>
+<!-- End Matomo Code --><script type="text/javascript">
+md_forum_decryptlink.init();
+</script>
+<script type="text/javascript">
+md_forum_decryptlink.init();
+</script>
+<script type="text/javascript">
+var md_url_img_shadow= 'https://forum-images.hardware.fr';
+var md_tabs_menu_shadow= 1;
+</script>
+</body></html>

--- a/core/data/src/test/resources/fixtures/private_message_thread.source.txt
+++ b/core/data/src/test/resources/fixtures/private_message_thread.source.txt
@@ -1,0 +1,4 @@
+Source: forum.hardware.fr (capture authentifiee live, compte XaTriX). @XaaT 2026-06-03
+Captured page: forum2.php?config=hfr.inc&cat=prive&post=3195237&page=1
+Notes: conversation MP (4 messages : 3 de l'utilisateur courant, 1 du correspondant ; 1 seule page). Capturee en HTTP authentifie car hfr_read (MCP) n'accepte cat qu'en entier et ne peut pas lire cat=prive.
+Privacy (#298) : MP prive, scrubbe avant commit. Pseudo de l'utilisateur courant -> "TestUser", correspondant -> "Correspondant", sujet (h3) -> "Sujet prive de test", corps de chaque message -> placeholder "Message prive de test (contenu remplace).", userids de profil + fichiers avatar remappes vers des ids factices, hash_check neutralise. Conserves (non sensibles) : structure DOM, threadId (post=3195237), numreponse, dates, liens d'edition obfusques (md_*cryptlink) qui pilotent isOwnPost.

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/write/PrivateMessageWriteRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/write/PrivateMessageWriteRepository.kt
@@ -1,0 +1,38 @@
+package fr.forumhfr.redface2.core.domain.write
+
+import fr.forumhfr.redface2.core.model.write.PrivateMessageReplyContext
+import fr.forumhfr.redface2.core.model.write.ReplyForm
+import fr.forumhfr.redface2.core.model.write.ReplyFormOptions
+import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
+
+/**
+ * Repository surface for replying to an HFR private-message conversation (#301).
+ *
+ * The wire shape is the same family as a topic reply — HFR embeds a `bddpost.php` form in the
+ * conversation page (`forum2.php?cat=prive&post={threadId}`) and the POST goes to the same
+ * `bddpost.php` endpoint — so this reuses the generic [ReplyForm] / [ReplySubmitResult] models and
+ * the shared form / response parsers. It is kept as a **separate** interface from [ReplyRepository]
+ * because a private conversation has no numeric `cat` / `subcat` / quote semantics: the routing
+ * lives entirely in the form's hidden fields (`cat=prive`, `post`, `numrep`, `subcat=0`, …), which
+ * the implementation forwards verbatim rather than re-asserting from a typed context.
+ *
+ * - [fetchReplyForm] GETs the conversation page and parses the embedded `bddpost.php` form (fresh
+ *   `hash_check`). It returns a [ReplyForm] even when HFR served the anonymous composer (caller
+ *   inspects [ReplyForm.isAnonymous]); transport / session-expiry failures are raised.
+ * - [submitReply] POSTs the reply and classifies the response into a [ReplySubmitResult]. The
+ *   private-message POST success sentence is not pinned by a live fixture (a real send to a third
+ *   party was intentionally avoided), so callers must treat an unrecognised
+ *   ([fr.forumhfr.redface2.core.model.write.ReplyFailureReason.Unknown]) response as non-destructive
+ *   — keep the draft and let the user verify the conversation — rather than asserting a hard failure.
+ */
+interface PrivateMessageWriteRepository {
+
+    suspend fun fetchReplyForm(context: PrivateMessageReplyContext): ReplyForm
+
+    suspend fun submitReply(
+        context: PrivateMessageReplyContext,
+        form: ReplyForm,
+        bbcodeContent: String,
+        options: ReplyFormOptions = ReplyFormOptions(),
+    ): ReplySubmitResult
+}

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/write/PrivateMessageReplyContext.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/write/PrivateMessageReplyContext.kt
@@ -1,0 +1,25 @@
+package fr.forumhfr.redface2.core.model.write
+
+/**
+ * Identifies the private-message conversation page the user is about to reply to (#301). Built from
+ * a loaded `PrivateMessageThread` (only opens once `PrivateMessageThread.canReply` is true) and
+ * passed to the private-message write repository.
+ *
+ * Unlike [ReplyContext] there is **no** `cat: Int` here: a private conversation lives under HFR's
+ * `cat=prive` (a String, not a numeric category id), and the whole routing tuple — `cat=prive`,
+ * `post={threadId}`, `subcat=0`, `numrep`, `pseudo`, `sujet` — is carried verbatim inside the
+ * `bddpost.php` form HFR embeds in the thread page (cf. fixture `private_message_thread.html`). The
+ * repository forwards those hidden fields untouched; this context only tells it which thread page to
+ * fetch the form from.
+ */
+data class PrivateMessageReplyContext(
+    /** HFR `post` id of the conversation (the thread id). */
+    val threadId: Int,
+    /** 1-based page of the conversation the user is viewing — the page whose form HFR pre-fills. */
+    val page: Int,
+) {
+    init {
+        require(threadId > 0) { "threadId must be > 0, was $threadId" }
+        require(page >= 1) { "page must be >= 1, was $page" }
+    }
+}

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/write/PrivateMessageReplyFormParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/write/PrivateMessageReplyFormParserTest.kt
@@ -1,0 +1,55 @@
+package fr.forumhfr.redface2.core.parser.write
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #301 — proves the shared [ReplyFormParser] parses HFR's private-message reply form (the
+ * `bddpost.php` form embedded in a `cat=prive` conversation page) without any topic-specific
+ * assumption. Pinned against the real, scrubbed fixture `private_message_thread.html` captured for
+ * #298. The two contract bits that make a private reply different from a topic reply are asserted
+ * explicitly: `cat=prive` (a String, not a numeric id) and the server-prefilled `numrep` (the last
+ * post of the page — NOT a quote reference) must be carried verbatim in the hidden fields.
+ */
+class PrivateMessageReplyFormParserTest {
+
+    private val parser = ReplyFormParser()
+
+    @Test
+    fun `parses the private-message reply form embedded in the conversation page`() {
+        val form = parser.parse(fixture("private_message_thread.html")).getOrThrow()
+
+        assertFalse("authenticated MP form is never anonymous", form.isAnonymous)
+        assertEquals("0", form.hashCheck)
+        // A fresh reply has an empty composer textarea (no quote prefill).
+        assertEquals("", form.initialContent)
+
+        // Private-message routing lives entirely in the hidden fields, forwarded verbatim on POST.
+        assertEquals("prive", form.hiddenFields["cat"])
+        assertEquals("3195237", form.hiddenFields["post"])
+        // numrep is the conversation's last-post id HFR prefilled — must be preserved as-is.
+        assertEquals("1980677227", form.hiddenFields["numrep"])
+        assertEquals("0", form.hiddenFields["subcat"])
+        assertEquals("1", form.hiddenFields["page"])
+        assertEquals("hfr.inc", form.hiddenFields["config"])
+        assertEquals("1100", form.hiddenFields["verifrequet"])
+        // Authenticated form echoes the user's pseudo; never a password.
+        assertEquals("TestUser", form.hiddenFields["pseudo"])
+        assertFalse("password must never be collected", form.hiddenFields.containsKey("password"))
+        // sujet is exposed both via the typed field and the hidden map.
+        assertEquals("Sujet prive de test", form.sujet)
+        // The quick-reply form carries `signature=1` as a hidden input (not a checkbox), so it lands
+        // in the hidden fields rather than ReplyForm.options — the ViewModel hydrates from both.
+        assertEquals("1", form.hiddenFields["signature"])
+        assertTrue("hidden fields should not be empty", form.hiddenFields.isNotEmpty())
+    }
+
+    private fun fixture(name: String): String {
+        val stream = requireNotNull(
+            PrivateMessageReplyFormParserTest::class.java.classLoader?.getResourceAsStream("fixtures/$name"),
+        ) { "Fixture not found: fixtures/$name" }
+        return stream.bufferedReader().use { it.readText() }
+    }
+}

--- a/core/ui/src/main/res/drawable/ic_arrow_back.xml
+++ b/core/ui/src/main/res/drawable/ic_arrow_back.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:autoMirrored="true">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8l8,8l1.41,-1.41L7.83,13H20v-2z" />
+</vector>

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyRequest.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyRequest.kt
@@ -1,0 +1,14 @@
+package fr.forumhfr.redface2.feature.messages
+
+/**
+ * Route arguments for [PrivateMessageReplyViewModel] (#301). Plain data class so route values pass
+ * through Hilt assisted injection, mirroring [PrivateMessageThreadRequest].
+ *
+ * Only opaque route data is carried (thread id + the page the user is replying from). The form's
+ * `hash_check`, hidden fields, subject and the user's pseudo are read from the freshly-fetched
+ * `forum2.php?cat=prive` page so no private metadata is serialised into the back stack.
+ */
+data class PrivateMessageReplyRequest(
+    val threadId: Int,
+    val page: Int = 1,
+)

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -34,6 +35,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -144,7 +146,13 @@ private fun ReplyHeader(onBack: () -> Unit) {
             onClick = onBack,
             modifier = Modifier.semantics { contentDescription = backLabel },
         ) {
-            Text("←")
+            // dp-sized vector instead of a text « ← » glyph (font/baseline-dependent, cf. Codex
+            // review). a11y label on the IconButton; the icon is decorative.
+            Icon(
+                painter = painterResource(fr.forumhfr.redface2.core.ui.R.drawable.ic_arrow_back),
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+            )
         }
         Text(
             text = stringResource(R.string.messages_reply_title),

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
@@ -1,0 +1,363 @@
+package fr.forumhfr.redface2.feature.messages
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.ui.editor.BbcodeAction
+import fr.forumhfr.redface2.core.ui.editor.BbcodePreview
+import fr.forumhfr.redface2.core.ui.editor.BbcodeTextField
+import fr.forumhfr.redface2.core.ui.editor.BbcodeToolbar
+
+/**
+ * Reply editor for a private-message conversation (#301). Reuses the shared `:core:ui` BBCode
+ * toolbar / text field / preview and a send button pinned above the IME (same window-insets pattern
+ * as the post editor, which requires `windowSoftInputMode=adjustNothing`). Submission goes through
+ * [PrivateMessageReplyViewModel]; a successful send raises [PrivateMessageReplyEffect.SubmitSucceeded]
+ * which the navigation host turns into a back navigation + a forced conversation reload.
+ */
+@Composable
+fun PrivateMessageReplyScreen(
+    request: PrivateMessageReplyRequest,
+    onSubmitSucceeded: (threadId: Int, page: Int) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val viewModel = hiltViewModel<PrivateMessageReplyViewModel, PrivateMessageReplyViewModel.Factory>(
+        creationCallback = { factory -> factory.create(request) },
+    )
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    LaunchedEffect(viewModel) {
+        viewModel.effects.collect { effect ->
+            when (effect) {
+                is PrivateMessageReplyEffect.SubmitSucceeded ->
+                    onSubmitSucceeded(effect.threadId, effect.page)
+            }
+        }
+    }
+    PrivateMessageReplyContent(
+        state = state,
+        onBack = onBack,
+        onContentChanged = viewModel::onContentChanged,
+        onToolbarAction = viewModel::onToolbarAction,
+        onTogglePreview = viewModel::onTogglePreview,
+        onToggleSignature = viewModel::onToggleSignature,
+        onToggleSmileyDisabled = viewModel::onToggleSmileyDisabled,
+        onToggleEmailNotification = viewModel::onToggleEmailNotification,
+        onErrorDismissed = viewModel::onErrorDismissed,
+        onSubmit = viewModel::onSubmit,
+        onRetryFormLoad = viewModel::retryFormLoad,
+        modifier = modifier,
+    )
+}
+
+@Composable
+@Suppress("LongParameterList") // One callback per editor action — each is wired to a distinct VM method.
+private fun PrivateMessageReplyContent(
+    state: PrivateMessageReplyUiState,
+    onBack: () -> Unit,
+    onContentChanged: (TextFieldValue) -> Unit,
+    onToolbarAction: (BbcodeAction) -> Unit,
+    onTogglePreview: () -> Unit,
+    onToggleSignature: (Boolean) -> Unit,
+    onToggleSmileyDisabled: (Boolean) -> Unit,
+    onToggleEmailNotification: (Boolean) -> Unit,
+    onErrorDismissed: () -> Unit,
+    onSubmit: () -> Unit,
+    onRetryFormLoad: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(modifier = modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surface) {
+        Column(modifier = Modifier.fillMaxSize().statusBarsPadding()) {
+            ReplyHeader(onBack = onBack)
+            when {
+                state.formError -> FormErrorState(onRetry = onRetryFormLoad)
+                state.isLoadingForm && !state.formAvailable -> FormLoadingState()
+                else -> {
+                    ReplyEditorBody(
+                        state = state,
+                        onContentChanged = onContentChanged,
+                        onToolbarAction = onToolbarAction,
+                        onTogglePreview = onTogglePreview,
+                        onToggleSignature = onToggleSignature,
+                        onToggleSmileyDisabled = onToggleSmileyDisabled,
+                        onToggleEmailNotification = onToggleEmailNotification,
+                        onErrorDismissed = onErrorDismissed,
+                        modifier = Modifier.weight(1f),
+                    )
+                    ReplySubmitBar(
+                        canSubmit = state.canSubmit,
+                        isSubmitting = state.isSubmitting,
+                        onSubmit = onSubmit,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReplyHeader(onBack: () -> Unit) {
+    val backLabel = stringResource(R.string.messages_back)
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(
+            onClick = onBack,
+            modifier = Modifier.semantics { contentDescription = backLabel },
+        ) {
+            Text("←")
+        }
+        Text(
+            text = stringResource(R.string.messages_reply_title),
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+@Composable
+private fun FormLoadingState() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun FormErrorState(onRetry: () -> Unit) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.padding(horizontal = 24.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.messages_reply_form_error),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.error,
+            )
+            Button(onClick = onRetry) {
+                Text(text = stringResource(R.string.messages_retry))
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("LongParameterList") // Editor body mirrors the post editor surface; each callback is distinct.
+private fun ReplyEditorBody(
+    state: PrivateMessageReplyUiState,
+    onContentChanged: (TextFieldValue) -> Unit,
+    onToolbarAction: (BbcodeAction) -> Unit,
+    onTogglePreview: () -> Unit,
+    onToggleSignature: (Boolean) -> Unit,
+    onToggleSmileyDisabled: (Boolean) -> Unit,
+    onToggleEmailNotification: (Boolean) -> Unit,
+    onErrorDismissed: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        BbcodeToolbar(onAction = onToolbarAction)
+
+        BbcodeTextField(
+            value = state.draft,
+            onValueChange = onContentChanged,
+            label = stringResource(R.string.messages_reply_field_label),
+            placeholder = stringResource(R.string.messages_reply_field_placeholder),
+        )
+
+        Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
+            TextButton(onClick = onTogglePreview) {
+                Text(
+                    text = stringResource(
+                        if (state.isPreviewVisible) {
+                            R.string.messages_reply_preview_hide
+                        } else {
+                            R.string.messages_reply_preview_show
+                        },
+                    ),
+                )
+            }
+        }
+
+        if (state.isPreviewVisible) {
+            HorizontalDivider()
+            BbcodePreview(content = state.preview)
+        }
+
+        state.submitError?.let { error ->
+            Text(
+                text = stringResource(error.bannerResId),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error,
+            )
+            TextButton(onClick = onErrorDismissed) {
+                Text(text = stringResource(R.string.messages_reply_error_dismiss))
+            }
+        }
+
+        ReplyOptions(
+            signatureEnabled = state.signatureEnabled,
+            smileyDisabled = state.smileyDisabled,
+            emailNotificationEnabled = state.emailNotificationEnabled,
+            enabled = !state.isSubmitting && !state.isLoadingForm,
+            onSignatureChanged = onToggleSignature,
+            onSmileyDisabledChanged = onToggleSmileyDisabled,
+            onEmailNotificationChanged = onToggleEmailNotification,
+        )
+    }
+}
+
+/**
+ * Send button pinned to the bottom, lifted above the IME so the user never dismisses the keyboard to
+ * reach « Envoyer ». Mirrors the post editor's submit bar (the editor's `EditorSubmitBar` is module-
+ * private, so the window-insets pattern is replicated here). Requires `windowSoftInputMode=adjustNothing`.
+ */
+@Composable
+private fun ReplySubmitBar(
+    canSubmit: Boolean,
+    isSubmitting: Boolean,
+    onSubmit: () -> Unit,
+) {
+    Surface(color = MaterialTheme.colorScheme.surfaceContainer, tonalElevation = 3.dp) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            HorizontalDivider()
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    // Single bottom inset = max(navBar, ime) via union(), so the two never stack into a
+                    // phantom gap. Keyboard closed → clears the gesture nav bar; open → rides on the IME.
+                    .windowInsetsPadding(
+                        WindowInsets.navigationBars
+                            .union(WindowInsets.ime)
+                            .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom),
+                    )
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (isSubmitting) {
+                    CircularProgressIndicator(modifier = Modifier.size(20.dp))
+                    Spacer(modifier = Modifier.width(12.dp))
+                }
+                Button(enabled = canSubmit, onClick = onSubmit) {
+                    Text(text = stringResource(R.string.messages_reply_submit))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("LongParameterList") // 3 toggles + 3 callbacks + enabled — each call-site distinct.
+private fun ReplyOptions(
+    signatureEnabled: Boolean,
+    smileyDisabled: Boolean,
+    emailNotificationEnabled: Boolean,
+    enabled: Boolean,
+    onSignatureChanged: (Boolean) -> Unit,
+    onSmileyDisabledChanged: (Boolean) -> Unit,
+    onEmailNotificationChanged: (Boolean) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp), modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.messages_reply_options_title),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        OptionToggle(
+            label = stringResource(R.string.messages_reply_option_signature),
+            checked = signatureEnabled,
+            enabled = enabled,
+            onCheckedChange = onSignatureChanged,
+        )
+        OptionToggle(
+            label = stringResource(R.string.messages_reply_option_smiley_disabled),
+            checked = smileyDisabled,
+            enabled = enabled,
+            onCheckedChange = onSmileyDisabledChanged,
+        )
+        OptionToggle(
+            label = stringResource(R.string.messages_reply_option_email_notification),
+            checked = emailNotificationEnabled,
+            enabled = enabled,
+            onCheckedChange = onEmailNotificationChanged,
+        )
+    }
+}
+
+@Composable
+private fun OptionToggle(
+    label: String,
+    checked: Boolean,
+    enabled: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(end = 16.dp),
+        )
+        Switch(checked = checked, enabled = enabled, onCheckedChange = onCheckedChange)
+    }
+}
+
+private val PrivateMessageReplyError.bannerResId: Int
+    get() = when (this) {
+        PrivateMessageReplyError.Empty -> R.string.messages_reply_error_empty
+        PrivateMessageReplyError.InvalidHashCheck -> R.string.messages_reply_error_invalid_hash
+        PrivateMessageReplyError.AntiFlood -> R.string.messages_reply_error_anti_flood
+        PrivateMessageReplyError.LoginRequired -> R.string.messages_reply_error_login_required
+        PrivateMessageReplyError.Network -> R.string.messages_reply_error_network
+        PrivateMessageReplyError.SessionExpired -> R.string.messages_reply_error_session_expired
+        PrivateMessageReplyError.Unexpected -> R.string.messages_reply_error_unexpected
+    }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyUiState.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyUiState.kt
@@ -25,6 +25,12 @@ data class PrivateMessageReplyUiState(
     val signatureEnabled: Boolean = false,
     val smileyDisabled: Boolean = false,
     val emailNotificationEnabled: Boolean = false,
+    /**
+     * True once the option toggles have been hydrated from a parsed form. Mirrors the post editor's
+     * `optionsHydratedFromForm`: a silent refetch after an expired `hash_check` must not re-hydrate
+     * (and thus clobber) a toggle the user changed in between.
+     */
+    val optionsHydratedFromForm: Boolean = false,
     val isSubmitting: Boolean = false,
     val submitError: PrivateMessageReplyError? = null,
 ) {

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyUiState.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyUiState.kt
@@ -1,0 +1,51 @@
+package fr.forumhfr.redface2.feature.messages
+
+import androidx.compose.ui.text.input.TextFieldValue
+import fr.forumhfr.redface2.core.model.PostContent
+
+/**
+ * MVI state of the private-message reply editor (#301). Mirrors the post editor's shape (draft +
+ * parsed preview AST + the three HFR per-post option toggles) but is scoped to a private
+ * conversation, so it carries no `cat`/`subcat`/quote fields.
+ *
+ * The parsed [fr.forumhfr.redface2.core.model.write.ReplyForm] (with its `hash_check` and hidden
+ * fields) is held privately by the ViewModel and never exposed here, so no private metadata leaks
+ * into a state snapshot.
+ */
+data class PrivateMessageReplyUiState(
+    /** True while the initial `bddpost.php` form GET is in flight (and during a silent refetch). */
+    val isLoadingForm: Boolean = true,
+    /** True once a non-anonymous form has been parsed; gates submission. */
+    val formAvailable: Boolean = false,
+    /** True when the form GET failed (network / session / parse / anonymous) → show retry. */
+    val formError: Boolean = false,
+    val draft: TextFieldValue = TextFieldValue(),
+    val isPreviewVisible: Boolean = false,
+    val preview: PostContent = PostContent(blocks = emptyList()),
+    val signatureEnabled: Boolean = false,
+    val smileyDisabled: Boolean = false,
+    val emailNotificationEnabled: Boolean = false,
+    val isSubmitting: Boolean = false,
+    val submitError: PrivateMessageReplyError? = null,
+) {
+    val canSubmit: Boolean
+        get() = formAvailable && !isLoadingForm && !isSubmitting && draft.text.isNotBlank()
+}
+
+/**
+ * Submit-phase errors surfaced as a banner over the editor (the draft is always preserved). HFR
+ * reuses the same `bddpost.php` failure sentences for private messages as for topics, so the
+ * recognised reasons map 1:1 — except [Unexpected], which is the non-destructive fallback for an
+ * unrecognised response: the private-message POST success sentence is not pinned by a live fixture
+ * (a real send to a third party was intentionally avoided), so the UI invites the user to verify the
+ * conversation rather than claiming a hard failure.
+ */
+sealed interface PrivateMessageReplyError {
+    data object Empty : PrivateMessageReplyError
+    data object InvalidHashCheck : PrivateMessageReplyError
+    data object AntiFlood : PrivateMessageReplyError
+    data object LoginRequired : PrivateMessageReplyError
+    data object Network : PrivateMessageReplyError
+    data object SessionExpired : PrivateMessageReplyError
+    data object Unexpected : PrivateMessageReplyError
+}

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
@@ -87,21 +87,35 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
                 }
                 loadedForm = form
                 _state.update { current ->
+                    // HFR's private "quick reply" form carries the per-post options as plain hidden
+                    // inputs (e.g. `signature=1`), not checkboxes — so `ReplyForm.options` (read from
+                    // `checked` attributes) is all-false here. Hydrate from the hidden fields too,
+                    // OR'ing with the checkbox view, so the user keeps HFR's default (signature on).
+                    //
+                    // Hydrate ONLY on the first successful load: a silent refetch after an expired
+                    // `hash_check` (InvalidHashCheck) must not reset a toggle the user changed in
+                    // between — mirror the post editor's `optionsHydratedFromForm` guard.
+                    val hydrateOptions = !current.optionsHydratedFromForm
                     current.copy(
                         isLoadingForm = false,
                         formAvailable = true,
                         formError = false,
-                        // HFR's private "quick reply" form carries the per-post options as plain
-                        // hidden inputs (e.g. `signature=1`), not checkboxes — so `ReplyForm.options`
-                        // (read from `checked` attributes) is all-false here. Hydrate from the hidden
-                        // fields too, OR'ing with the checkbox view, so the user keeps HFR's default
-                        // (signature on) instead of silently dropping it on submit.
-                        signatureEnabled = form.options.signatureEnabled ||
-                            form.hiddenFields["signature"] == "1",
-                        smileyDisabled = form.options.smileyDisabled ||
-                            form.hiddenFields["smiley"] == "1",
-                        emailNotificationEnabled = form.options.emailNotificationEnabled ||
-                            form.hiddenFields["emaill"] == "1",
+                        signatureEnabled = if (hydrateOptions) {
+                            form.options.signatureEnabled || form.hiddenFields["signature"] == "1"
+                        } else {
+                            current.signatureEnabled
+                        },
+                        smileyDisabled = if (hydrateOptions) {
+                            form.options.smileyDisabled || form.hiddenFields["smiley"] == "1"
+                        } else {
+                            current.smileyDisabled
+                        },
+                        emailNotificationEnabled = if (hydrateOptions) {
+                            form.options.emailNotificationEnabled || form.hiddenFields["emaill"] == "1"
+                        } else {
+                            current.emailNotificationEnabled
+                        },
+                        optionsHydratedFromForm = true,
                     )
                 }
             } catch (cancellation: CancellationException) {

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
@@ -1,0 +1,269 @@
+package fr.forumhfr.redface2.feature.messages
+
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
+import fr.forumhfr.redface2.core.domain.write.PrivateMessageWriteRepository
+import fr.forumhfr.redface2.core.model.write.PrivateMessageReplyContext
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
+import fr.forumhfr.redface2.core.model.write.ReplyForm
+import fr.forumhfr.redface2.core.model.write.ReplyFormOptions
+import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
+import fr.forumhfr.redface2.core.ui.editor.BbcodeAction
+import fr.forumhfr.redface2.core.ui.editor.applyBbcodeAction
+import java.io.IOException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel for replying to a private-message conversation (#301). Receives its route arguments via
+ * Hilt assisted injection ([PrivateMessageReplyRequest]). On creation it GETs the conversation page
+ * to parse the embedded `bddpost.php` reply form (fresh `hash_check` + hidden fields), then lets the
+ * user compose a BBCode reply with the shared toolbar/preview and submit it.
+ *
+ * Two private-message specifics drive the design (cf. the #301 design notes / independent review):
+ *  - The HFR POST success sentence for a private reply is not pinned by a live fixture, so an
+ *    unrecognised response maps to [PrivateMessageReplyError.Unexpected] (non-destructive: the draft
+ *    is kept and the banner invites the user to verify the conversation), never a hard failure.
+ *  - An expired `hash_check` is recovered by silently refetching the form so the user can re-submit,
+ *    mirroring the post editor.
+ */
+@HiltViewModel(assistedFactory = PrivateMessageReplyViewModel.Factory::class)
+class PrivateMessageReplyViewModel @AssistedInject constructor(
+    @Assisted private val request: PrivateMessageReplyRequest,
+    private val repository: PrivateMessageWriteRepository,
+    private val previewParser: BbcodePreviewParser,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(PrivateMessageReplyUiState())
+    val state: StateFlow<PrivateMessageReplyUiState> = _state.asStateFlow()
+
+    private val _effects: Channel<PrivateMessageReplyEffect> = Channel(capacity = Channel.BUFFERED)
+    val effects: Flow<PrivateMessageReplyEffect> = _effects.receiveAsFlow()
+
+    private val context = PrivateMessageReplyContext(
+        threadId = request.threadId,
+        page = request.page.coerceAtLeast(1),
+    )
+
+    private var loadedForm: ReplyForm? = null
+    private var formJob: Job? = null
+    private var submitJob: Job? = null
+
+    init {
+        loadForm()
+    }
+
+    fun retryFormLoad() = loadForm()
+
+    private fun loadForm() {
+        formJob?.cancel()
+        _state.update { it.copy(isLoadingForm = true, formError = false) }
+        formJob = viewModelScope.launch {
+            try {
+                val form = repository.fetchReplyForm(context)
+                if (form.isAnonymous) {
+                    // Session vanished between opening the thread and replying — treat like a form
+                    // error so the user re-authenticates (the reply route is only reachable while
+                    // authenticated, so this is rare).
+                    loadedForm = null
+                    _state.update { it.copy(isLoadingForm = false, formAvailable = false, formError = true) }
+                    return@launch
+                }
+                loadedForm = form
+                _state.update { current ->
+                    current.copy(
+                        isLoadingForm = false,
+                        formAvailable = true,
+                        formError = false,
+                        // HFR's private "quick reply" form carries the per-post options as plain
+                        // hidden inputs (e.g. `signature=1`), not checkboxes — so `ReplyForm.options`
+                        // (read from `checked` attributes) is all-false here. Hydrate from the hidden
+                        // fields too, OR'ing with the checkbox view, so the user keeps HFR's default
+                        // (signature on) instead of silently dropping it on submit.
+                        signatureEnabled = form.options.signatureEnabled ||
+                            form.hiddenFields["signature"] == "1",
+                        smileyDisabled = form.options.smileyDisabled ||
+                            form.hiddenFields["smiley"] == "1",
+                        emailNotificationEnabled = form.options.emailNotificationEnabled ||
+                            form.hiddenFields["emaill"] == "1",
+                    )
+                }
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (
+                @Suppress("TooGenericExceptionCaught", "SwallowedException") error: Exception,
+            ) {
+                // No raw message reaches the UI (#316): a private form GET can embed the private URL.
+                loadedForm = null
+                _state.update { it.copy(isLoadingForm = false, formAvailable = false, formError = true) }
+            }
+        }
+    }
+
+    fun onContentChanged(value: TextFieldValue) {
+        _state.update { it.withDraftPreview(value) }
+    }
+
+    fun onToolbarAction(action: BbcodeAction) {
+        _state.update { current ->
+            val outcome = applyBbcodeAction(
+                action = action,
+                text = current.draft.text,
+                selectionStart = current.draft.selection.start,
+                selectionEnd = current.draft.selection.end,
+            )
+            current.withDraftPreview(
+                TextFieldValue(
+                    text = outcome.text,
+                    selection = TextRange(outcome.selectionStart, outcome.selectionEnd),
+                ),
+            )
+        }
+    }
+
+    fun onTogglePreview() {
+        _state.update { current ->
+            val nextVisible = !current.isPreviewVisible
+            current.copy(
+                isPreviewVisible = nextVisible,
+                preview = if (nextVisible) previewParser.parsePreview(current.draft.text) else current.preview,
+            )
+        }
+    }
+
+    fun onToggleSignature(enabled: Boolean) = _state.update { it.copy(signatureEnabled = enabled) }
+
+    fun onToggleSmileyDisabled(disabled: Boolean) = _state.update { it.copy(smileyDisabled = disabled) }
+
+    fun onToggleEmailNotification(enabled: Boolean) =
+        _state.update { it.copy(emailNotificationEnabled = enabled) }
+
+    fun onErrorDismissed() = _state.update { it.copy(submitError = null) }
+
+    @Suppress("ReturnCount") // Guard clauses are the natural shape of the submit dispatcher.
+    fun onSubmit() {
+        val snapshot = _state.value
+        if (!snapshot.canSubmit) return
+        val form = loadedForm ?: run {
+            loadForm()
+            return
+        }
+        if (form.isAnonymous) {
+            _state.update { it.copy(submitError = PrivateMessageReplyError.LoginRequired) }
+            return
+        }
+        if (submitJob?.isActive == true) return
+
+        val options = ReplyFormOptions(
+            signatureEnabled = snapshot.signatureEnabled,
+            smileyDisabled = snapshot.smileyDisabled,
+            emailNotificationEnabled = snapshot.emailNotificationEnabled,
+        )
+        _state.update { it.copy(isSubmitting = true, submitError = null) }
+        submitJob = viewModelScope.launch {
+            val outcome = runCatching {
+                repository.submitReply(
+                    context = context,
+                    form = form,
+                    bbcodeContent = snapshot.draft.text,
+                    options = options,
+                )
+            }
+            outcome.fold(
+                onSuccess = ::handleSubmitOutcome,
+                onFailure = ::handleSubmitFailure,
+            )
+        }
+    }
+
+    private fun handleSubmitOutcome(result: ReplySubmitResult) {
+        when (result) {
+            is ReplySubmitResult.Success -> {
+                _state.update { it.copy(isSubmitting = false, submitError = null) }
+                _effects.trySend(
+                    PrivateMessageReplyEffect.SubmitSucceeded(
+                        threadId = context.threadId,
+                        page = context.page,
+                    ),
+                )
+            }
+            is ReplySubmitResult.Failure -> {
+                if (result.reason == ReplyFailureReason.InvalidHashCheck) {
+                    // Cached form's hash_check expired — refetch silently and let the user re-submit.
+                    loadedForm = null
+                    loadForm()
+                }
+                _state.update { it.copy(isSubmitting = false, submitError = result.reason.toReplyError()) }
+            }
+        }
+    }
+
+    private fun handleSubmitFailure(error: Throwable) {
+        if (error is CancellationException) {
+            _state.update { it.copy(isSubmitting = false) }
+            throw error
+        }
+        val mapped = when (error) {
+            is SessionExpiredException -> PrivateMessageReplyError.SessionExpired
+            is IOException -> PrivateMessageReplyError.Network
+            // Any other throwable is surfaced as the non-destructive "unexpected response" banner;
+            // the draft is preserved so nothing is lost.
+            else -> PrivateMessageReplyError.Unexpected
+        }
+        _state.update { it.copy(isSubmitting = false, submitError = mapped) }
+    }
+
+    private fun ReplyFailureReason.toReplyError(): PrivateMessageReplyError = when (this) {
+        ReplyFailureReason.EmptyMessage -> PrivateMessageReplyError.Empty
+        ReplyFailureReason.InvalidHashCheck -> PrivateMessageReplyError.InvalidHashCheck
+        ReplyFailureReason.AntiFlood -> PrivateMessageReplyError.AntiFlood
+        ReplyFailureReason.LoginRequired -> PrivateMessageReplyError.LoginRequired
+        // TopicLocked has no private-message analogue, and Unknown is the unrecognised-response
+        // fallback: both map to the non-destructive "verify the conversation" banner.
+        ReplyFailureReason.TopicLocked, ReplyFailureReason.Unknown -> PrivateMessageReplyError.Unexpected
+    }
+
+    private fun PrivateMessageReplyUiState.withDraftPreview(updated: TextFieldValue): PrivateMessageReplyUiState =
+        copy(
+            draft = updated,
+            preview = if (isPreviewVisible) previewParser.parsePreview(updated.text) else preview,
+        )
+
+    @AssistedFactory
+    interface Factory {
+        fun create(request: PrivateMessageReplyRequest): PrivateMessageReplyViewModel
+    }
+}
+
+/**
+ * One-shot effects from [PrivateMessageReplyViewModel]. [SubmitSucceeded] tells the navigation host
+ * to pop the editor and re-open the conversation (force-reload) so the freshly-sent message shows.
+ *
+ * [page] is the page the reply was composed from (the live thread page). v1 limitation: HFR's MP POST
+ * response is not parsed for a landing page (its refresh URL is not topic-shaped), so a reply that
+ * overflows onto a brand-new last page lands the user back on the source page — they page forward to
+ * see it. MP threads are short, so this is rare; a topic-style overflow redirect (#226) is not ported.
+ *
+ * Note: an unrecognised POST response (`Unknown`) deliberately does NOT raise this effect — it keeps
+ * the draft and surfaces a "verify the conversation" banner instead of bouncing the user away, since
+ * the MP success sentence is not pinned by a live fixture.
+ */
+sealed interface PrivateMessageReplyEffect {
+    data class SubmitSucceeded(val threadId: Int, val page: Int) : PrivateMessageReplyEffect
+}

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
@@ -16,6 +17,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -27,6 +29,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -113,7 +116,13 @@ fun PrivateMessageThreadScreen(
                         onClick = onBack,
                         modifier = Modifier.semantics { contentDescription = backLabel },
                     ) {
-                        Text("←")
+                        // dp-sized vector instead of a text « ← » glyph (font/baseline-dependent, cf.
+                        // Codex review). a11y label on the IconButton; the icon is decorative.
+                        Icon(
+                            painter = painterResource(fr.forumhfr.redface2.core.ui.R.drawable.ic_arrow_back),
+                            contentDescription = null,
+                            modifier = Modifier.size(24.dp),
+                        )
                     }
                 },
                 actions = { topBarActions?.invoke() },

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -49,6 +50,7 @@ import java.util.Locale
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
+@Suppress("LongParameterList") // Screen host: route request + 3 nav callbacks + multi-recipient hint + actions slot.
 fun PrivateMessageThreadScreen(
     request: PrivateMessageThreadRequest,
     // Ephemeral UI hint from the inbox row (the route stays opaque, carrying only threadId/page).
@@ -57,6 +59,7 @@ fun PrivateMessageThreadScreen(
     isMultiRecipientHint: Boolean,
     onLoaded: () -> Unit,
     onBack: () -> Unit,
+    onReply: (threadId: Int, page: Int) -> Unit,
     topBarActions: @Composable (() -> Unit)? = null,
 ) {
     val viewModel = hiltViewModel<PrivateMessageThreadViewModel, PrivateMessageThreadViewModel.Factory>(
@@ -115,6 +118,20 @@ fun PrivateMessageThreadScreen(
                 },
                 actions = { topBarActions?.invoke() },
             )
+        },
+        floatingActionButton = {
+            // #301 — reply affordance, shown only once the page proved a reply form is available
+            // (`canReply`). Carries the page the user is viewing so the form HFR pre-fills (and its
+            // `numrep`) matches what's on screen.
+            val content = mode as? PrivateMessageThreadUiState.Mode.Content
+            if (content?.thread?.canReply == true) {
+                val replyLabel = stringResource(R.string.messages_reply)
+                ExtendedFloatingActionButton(
+                    text = { Text(replyLabel) },
+                    icon = { Text("✎") },
+                    onClick = { onReply(request.threadId, state.page) },
+                )
+            }
         },
     ) { innerPadding ->
         Box(

--- a/feature/messages/src/main/res/values/strings.xml
+++ b/feature/messages/src/main/res/values/strings.xml
@@ -15,4 +15,26 @@
     <string name="messages_pager_previous">Précédent</string>
     <string name="messages_pager_next">Suivant</string>
     <string name="messages_pager_position">Page %1$d / %2$d</string>
+
+    <!-- #301 — réponse à une conversation privée (écriture MP). -->
+    <string name="messages_reply">Répondre</string>
+    <string name="messages_reply_title">Répondre</string>
+    <string name="messages_reply_field_label">Votre réponse</string>
+    <string name="messages_reply_field_placeholder">Écrivez votre message…</string>
+    <string name="messages_reply_preview_show">Aperçu</string>
+    <string name="messages_reply_preview_hide">Masquer l\'aperçu</string>
+    <string name="messages_reply_submit">Envoyer</string>
+    <string name="messages_reply_options_title">Options</string>
+    <string name="messages_reply_option_signature">Activer la signature</string>
+    <string name="messages_reply_option_smiley_disabled">Désactiver les smileys</string>
+    <string name="messages_reply_option_email_notification">Notification par e-mail</string>
+    <string name="messages_reply_error_dismiss">Ignorer</string>
+    <string name="messages_reply_form_error">Impossible d\'ouvrir le formulaire de réponse. Réessayez.</string>
+    <string name="messages_reply_error_empty">Le message est vide. Écrivez quelque chose avant d\'envoyer.</string>
+    <string name="messages_reply_error_invalid_hash">La session a expiré. Le formulaire a été rechargé : renvoyez votre message.</string>
+    <string name="messages_reply_error_anti_flood">Trop de messages envoyés coup sur coup. Patientez quelques minutes.</string>
+    <string name="messages_reply_error_login_required">Vous devez être connecté pour répondre.</string>
+    <string name="messages_reply_error_network">Problème de connexion. Vérifiez votre réseau puis réessayez.</string>
+    <string name="messages_reply_error_session_expired">La session a expiré. Reconnectez-vous puis réessayez.</string>
+    <string name="messages_reply_error_unexpected">Réponse inattendue de HFR. Votre message a peut-être été envoyé : vérifiez la conversation.</string>
 </resources>

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
@@ -132,6 +132,28 @@ class PrivateMessageReplyViewModelTest {
     }
 
     @Test
+    fun `invalid hash check refetch preserves the user option toggles`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form()
+        coEvery { repository.submitReply(any(), any(), any(), any()) } returns
+            ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)
+
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+        // First load hydrates signature ON (hidden `signature=1`); the user turns it OFF.
+        viewModel.onToggleSignature(false)
+        viewModel.onContentChanged(TextFieldValue("hello"))
+        viewModel.onSubmit()
+
+        // The silent refetch after the expired hash_check must NOT re-hydrate the toggle back to
+        // HFR's default — the user's choice survives into the second submit.
+        assertFalse(
+            "InvalidHashCheck refetch must preserve the user's signature toggle",
+            viewModel.state.value.signatureEnabled,
+        )
+        coVerify(exactly = 2) { repository.fetchReplyForm(any()) }
+    }
+
+    @Test
     fun `unknown response maps to the non-destructive unexpected banner`() = runTest {
         val repository = mockk<PrivateMessageWriteRepository>()
         coEvery { repository.fetchReplyForm(any()) } returns form()

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
@@ -1,0 +1,182 @@
+package fr.forumhfr.redface2.feature.messages
+
+import androidx.compose.ui.text.input.TextFieldValue
+import app.cash.turbine.test
+import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
+import fr.forumhfr.redface2.core.domain.write.PrivateMessageWriteRepository
+import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.model.write.PrivateMessageReplyContext
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
+import fr.forumhfr.redface2.core.model.write.ReplyForm
+import fr.forumhfr.redface2.core.model.write.ReplyFormOptions
+import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.io.IOException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PrivateMessageReplyViewModelTest {
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private val request = PrivateMessageReplyRequest(threadId = 3195237, page = 1)
+
+    private val previewParser = BbcodePreviewParser { PostContent(blocks = emptyList()) }
+
+    private fun form(
+        hashCheck: String = "abc",
+        hiddenFields: Map<String, String> = mapOf(
+            "cat" to "prive",
+            "post" to "3195237",
+            "numrep" to "1980677227",
+            "signature" to "1",
+        ),
+        isAnonymous: Boolean = false,
+    ): ReplyForm = ReplyForm(
+        hashCheck = hashCheck,
+        sujet = "Sujet prive de test",
+        hiddenFields = hiddenFields,
+        isAnonymous = isAnonymous,
+    )
+
+    @Test
+    fun `loads the form on init and hydrates signature from the hidden field`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form()
+
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+
+        val state = viewModel.state.value
+        assertFalse(state.isLoadingForm)
+        assertTrue(state.formAvailable)
+        assertFalse(state.formError)
+        // The quick-reply form carries signature as a hidden `=1`, so the toggle defaults on.
+        assertTrue("signature default should be hydrated from the hidden field", state.signatureEnabled)
+    }
+
+    @Test
+    fun `submit success raises SubmitSucceeded for the conversation`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form()
+        coEvery { repository.submitReply(any(), any(), any(), any()) } returns
+            ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
+
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+        viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
+
+        viewModel.effects.test {
+            viewModel.onSubmit()
+            assertEquals(
+                PrivateMessageReplyEffect.SubmitSucceeded(threadId = 3195237, page = 1),
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertFalse(viewModel.state.value.isSubmitting)
+        assertNull(viewModel.state.value.submitError)
+    }
+
+    @Test
+    fun `empty-message failure shows the banner and keeps the draft`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form()
+        coEvery { repository.submitReply(any(), any(), any(), any()) } returns
+            ReplySubmitResult.Failure(ReplyFailureReason.EmptyMessage)
+
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+        viewModel.onContentChanged(TextFieldValue("non-blank"))
+        viewModel.onSubmit()
+
+        val state = viewModel.state.value
+        assertEquals(PrivateMessageReplyError.Empty, state.submitError)
+        assertEquals("non-blank", state.draft.text)
+        assertFalse(state.isSubmitting)
+    }
+
+    @Test
+    fun `invalid hash check refetches the form silently`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form()
+        coEvery { repository.submitReply(any(), any(), any(), any()) } returns
+            ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)
+
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+        viewModel.onContentChanged(TextFieldValue("hello"))
+        viewModel.onSubmit()
+
+        assertEquals(PrivateMessageReplyError.InvalidHashCheck, viewModel.state.value.submitError)
+        // init fetch + the silent refetch after the expired hash_check.
+        coVerify(exactly = 2) { repository.fetchReplyForm(any()) }
+    }
+
+    @Test
+    fun `unknown response maps to the non-destructive unexpected banner`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form()
+        coEvery { repository.submitReply(any(), any(), any(), any()) } returns
+            ReplySubmitResult.Failure(ReplyFailureReason.Unknown)
+
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+        viewModel.onContentChanged(TextFieldValue("hello"))
+        viewModel.onSubmit()
+
+        val state = viewModel.state.value
+        assertEquals(PrivateMessageReplyError.Unexpected, state.submitError)
+        // Non-destructive: the draft survives so the user can verify and retry.
+        assertEquals("hello", state.draft.text)
+    }
+
+    @Test
+    fun `form fetch failure shows the retry state`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } throws IOException("network down")
+
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+
+        val state = viewModel.state.value
+        assertTrue(state.formError)
+        assertFalse(state.formAvailable)
+        assertFalse(state.isLoadingForm)
+    }
+
+    @Test
+    fun `anonymous form is treated as a form error`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form(isAnonymous = true)
+
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+
+        assertTrue(viewModel.state.value.formError)
+        assertFalse(viewModel.state.value.formAvailable)
+    }
+
+    @Test
+    fun `context carries the request thread and page`() {
+        // Guards the route → context mapping the repository relies on.
+        val context = PrivateMessageReplyContext(threadId = request.threadId, page = request.page)
+        assertEquals(3195237, context.threadId)
+        assertEquals(1, context.page)
+    }
+}

--- a/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -24,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -102,21 +104,23 @@ internal fun ProfileScreen(
                     )
                 },
                 navigationIcon = {
-                    // Review feedback C2: the previous `Text("←")` had no
-                    // contentDescription, which made the back button silent to
-                    // TalkBack and a generic « Bouton » to LiveCaptions. The detekt
-                    // ForbiddenImport rule blocks `androidx.compose.material.*` (Material 2
-                    // surface, which includes `material-icons-core`), so we cannot use
-                    // `Icons.AutoMirrored.Filled.ArrowBack`. Instead we keep the « ← »
-                    // glyph but attach a proper a11y label via
-                    // `Modifier.semantics { contentDescription = … }` on the IconButton.
-                    // TalkBack now announces « Retour, bouton » as expected.
+                    // detekt ForbiddenImport blocks `androidx.compose.material.*` (incl.
+                    // `material-icons-core`), so `Icons.AutoMirrored.Filled.ArrowBack` is off-limits.
+                    // A text « ← » glyph proved unstable as an icon (size depends on the system font,
+                    // baseline and font-scale — cf. Codex review), so use a local dp-sized vector
+                    // drawable rendered with material3 `Icon` (allowed: material3, not material). The
+                    // a11y label stays on the IconButton; the icon is decorative (contentDescription
+                    // = null) to avoid duplicate semantics. TalkBack still announces « Retour, bouton ».
                     val backLabel = stringResource(R.string.profile_back)
                     IconButton(
                         onClick = onBack,
                         modifier = Modifier.semantics { contentDescription = backLabel },
                     ) {
-                        Text("←")
+                        Icon(
+                            painter = painterResource(fr.forumhfr.redface2.core.ui.R.drawable.ic_arrow_back),
+                            contentDescription = null,
+                            modifier = Modifier.size(24.dp),
+                        )
                     }
                 },
             )

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -89,6 +89,16 @@ internal fun SettingsContent(
                 style = MaterialTheme.typography.headlineMedium,
                 color = MaterialTheme.colorScheme.onSurface,
             )
+            // #288 — distinguish local (DataStore) preferences from HFR-account settings, and frame the
+            // screen as the full catalogue: shipped settings are interactive, planned ones are shown
+            // greyed with a phase/issue tag (a showcase of the roadmap, cf. the issue's design notes).
+            Text(
+                text = stringResource(R.string.settings_intro),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            SettingsSectionHeader(stringResource(R.string.settings_section_network))
             Card(modifier = Modifier.fillMaxWidth()) {
                 Column(
                     modifier = Modifier.padding(16.dp),
@@ -189,24 +199,102 @@ internal fun SettingsContent(
                 }
             }
 
+            MaintenanceCard(
+                state = state,
+                onIntent = onIntent,
+            )
+            FutureSettingsCard(
+                items = listOf(
+                    R.string.settings_future_data_saver to issueTag(310),
+                    R.string.settings_future_clear_image_cache to issueTag(314),
+                ),
+            )
+
+            SettingsSectionHeader(stringResource(R.string.settings_section_display))
             ThemePreferencesCard(
                 state = state,
                 onIntent = onIntent,
             )
+            FutureSettingsCard(
+                items = listOf(
+                    R.string.settings_future_reading_density to issueTag(287),
+                    R.string.settings_future_ui_colors to issueTag(296),
+                    R.string.settings_future_material_you to stringResource(R.string.settings_phase_future),
+                    R.string.settings_future_classic_theme to stringResource(R.string.settings_phase_future_far),
+                ),
+            )
 
+            SettingsSectionHeader(stringResource(R.string.settings_section_flags))
             FlagsPreferencesCard(
                 state = state,
                 onIntent = onIntent,
             )
+            FutureSettingsCard(
+                items = listOf(
+                    R.string.settings_future_flags_on_listing to issueTag(297),
+                ),
+            )
 
+            SettingsSectionHeader(stringResource(R.string.settings_section_topic))
             TopicPreferencesCard(
                 state = state,
                 onIntent = onIntent,
             )
+            FutureSettingsCard(
+                items = listOf(
+                    R.string.settings_future_scroll_memory to issueTag(307),
+                    R.string.settings_future_prefetch to stringResource(R.string.settings_phase_future),
+                ),
+            )
 
-            MaintenanceCard(
-                state = state,
-                onIntent = onIntent,
+            SettingsSectionHeader(stringResource(R.string.settings_section_editing))
+            FutureSettingsCard(
+                items = listOf(
+                    R.string.settings_future_submit_confirm to issueTag(312),
+                    R.string.settings_future_signature to stringResource(R.string.settings_phase_planned),
+                ),
+            )
+
+            SettingsSectionHeader(stringResource(R.string.settings_section_mp))
+            FutureSettingsCard(
+                items = listOf(
+                    R.string.settings_future_mp_write to issueTag(301),
+                    R.string.settings_future_mp_notifications to issueTag(313),
+                ),
+            )
+
+            SettingsSectionHeader(stringResource(R.string.settings_section_hfr_account))
+            Text(
+                text = stringResource(R.string.settings_hfr_account_note),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            FutureSettingsCard(
+                items = listOf(
+                    R.string.settings_future_hfr_profile to issueTag(311),
+                ),
+            )
+
+            SettingsSectionHeader(stringResource(R.string.settings_section_notifications))
+            FutureSettingsCard(
+                items = listOf(
+                    R.string.settings_future_notifications to stringResource(R.string.settings_phase_5),
+                ),
+            )
+
+            SettingsSectionHeader(stringResource(R.string.settings_section_accessibility))
+            FutureSettingsCard(
+                items = listOf(
+                    R.string.settings_future_timezone to stringResource(R.string.settings_phase_future),
+                    R.string.settings_future_multilang to stringResource(R.string.settings_phase_future),
+                ),
+            )
+
+            SettingsSectionHeader(stringResource(R.string.settings_section_extensions))
+            FutureSettingsCard(
+                items = listOf(
+                    R.string.settings_future_extensions to issueTag(7),
+                ),
             )
         }
     }
@@ -216,6 +304,79 @@ internal fun SettingsContent(
             onConfirm = { onIntent(SettingsIntent.ClearTopicCacheConfirmed) },
             onDismiss = { onIntent(SettingsIntent.ClearTopicCacheDismissed) },
         )
+    }
+}
+
+/**
+ * #288 — a section header that structures the catalogue by area (Affichage, Drapeaux, …).
+ */
+@Composable
+private fun SettingsSectionHeader(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(top = 8.dp),
+    )
+}
+
+/**
+ * #288 — formats the tag pill for a planned setting backed by a GitHub issue (e.g. `#310`). The
+ * issue number is a technical identifier, but the `#` prefix still goes through a string resource to
+ * keep all displayed text localizable. Phase words ("À venir", "Phase 5", …) are passed directly.
+ */
+@Composable
+private fun issueTag(number: Int): String = stringResource(R.string.settings_future_issue_tag, number)
+
+/**
+ * #288 — a card grouping planned (not-yet-shipped) settings as non-interactive, greyed rows so the
+ * screen shows the full roadmap "for free". Each [items] entry pairs a title string-res with a tag
+ * (an issue reference via [issueTag], or a localized phase word resolved at the call site). Renders
+ * nothing for an empty list so callers never produce a stray empty card.
+ */
+@Composable
+private fun FutureSettingsCard(items: List<Pair<Int, String>>) {
+    if (items.isEmpty()) return
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            items.forEach { (titleRes, tag) ->
+                FutureSettingRow(title = stringResource(titleRes), tag = tag)
+            }
+        }
+    }
+}
+
+/**
+ * One planned setting: title in the muted `onSurfaceVariant` colour (the M3 idiom for "not active",
+ * preferred over a blanket `Modifier.alpha`) and a small tag pill. Non-interactive by design.
+ */
+@Composable
+private fun FutureSettingRow(title: String, tag: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f, fill = false),
+        )
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceContainerHighest,
+            shape = MaterialTheme.shapes.small,
+        ) {
+            Text(
+                text = tag,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+            )
+        }
     }
 }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -1,5 +1,43 @@
 <resources>
     <string name="settings_title">Paramètres</string>
+    <!-- #288 — « menu vitrine » : intro distinguant prefs locales vs compte HFR, sections par aire,
+         et catalogue des réglages futurs (grisés, avec tag d’issue ou de phase). -->
+    <string name="settings_intro">La plupart des réglages sont enregistrés sur cet appareil. Ceux du compte HFR (section dédiée) seront synchronisés depuis votre profil et arriveront plus tard. Les réglages à venir sont affichés en grisé avec leur étiquette.</string>
+    <string name="settings_section_network">Réseau et cache</string>
+    <string name="settings_section_display">Affichage</string>
+    <string name="settings_section_flags">Drapeaux</string>
+    <string name="settings_section_topic">Sujet et lecture</string>
+    <string name="settings_section_editing">Édition et publication</string>
+    <string name="settings_section_mp">Messages privés</string>
+    <string name="settings_section_hfr_account">Compte HFR</string>
+    <string name="settings_section_notifications">Notifications</string>
+    <string name="settings_section_accessibility">Accessibilité</string>
+    <string name="settings_section_extensions">Extensions et filtrage</string>
+    <string name="settings_hfr_account_note">Ces réglages proviennent de votre profil HFR (editprofil.php) et arriveront plus tard.</string>
+    <string name="settings_phase_future">À venir</string>
+    <string name="settings_phase_future_far">Plus tard</string>
+    <string name="settings_phase_planned">Planifié</string>
+    <string name="settings_phase_5">Phase 5</string>
+    <!-- Pastille de tag d'un réglage à venir rattaché à une issue GitHub (identifiant technique). -->
+    <string name="settings_future_issue_tag">#%1$d</string>
+    <string name="settings_future_reading_density">Densité et compacité de lecture</string>
+    <string name="settings_future_ui_colors">Personnalisation des couleurs</string>
+    <string name="settings_future_material_you">Material You (thème dynamique)</string>
+    <string name="settings_future_classic_theme">Thème HFR Classique</string>
+    <string name="settings_future_flags_on_listing">Poser les drapeaux en listant une catégorie</string>
+    <string name="settings_future_scroll_memory">Retenir la position de lecture par page</string>
+    <string name="settings_future_prefetch">Préchargement de la page suivante</string>
+    <string name="settings_future_submit_confirm">Confirmation avant publication</string>
+    <string name="settings_future_signature">Signature automatique et notification e-mail</string>
+    <string name="settings_future_mp_write">Écriture des messages privés</string>
+    <string name="settings_future_mp_notifications">Notifications et badge de MP non lus</string>
+    <string name="settings_future_data_saver">Mode économie de données</string>
+    <string name="settings_future_clear_image_cache">Vider le cache des images</string>
+    <string name="settings_future_hfr_profile">Avatars, signatures, messages par page</string>
+    <string name="settings_future_notifications">Relève configurable, filtres, mode Ne pas déranger</string>
+    <string name="settings_future_timezone">Fuseau horaire d’affichage</string>
+    <string name="settings_future_multilang">Multilingue</string>
+    <string name="settings_future_extensions">Blacklist, Color Tag, ignore-list, Qualitay, Redflag</string>
     <string name="settings_proxy_title">Proxy utilisateur</string>
     <string name="settings_proxy_intro">Route les requêtes HFR via votre proxy. Le changement peut nécessiter un redémarrage de l’app.</string>
     <string name="settings_proxy_enabled">Activer le proxy</string>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -29,7 +29,9 @@
     <string name="settings_future_prefetch">Préchargement de la page suivante</string>
     <string name="settings_future_submit_confirm">Confirmation avant publication</string>
     <string name="settings_future_signature">Signature automatique et notification e-mail</string>
-    <string name="settings_future_mp_write">Écriture des messages privés</string>
+    <!-- #301 — la réponse à une conversation existante est livrée ; reste « à venir » la
+         composition d'un nouveau MP depuis zéro (new-MP), encore non observée côté HFR. -->
+    <string name="settings_future_mp_write">Composer un nouveau message privé</string>
     <string name="settings_future_mp_notifications">Notifications et badge de MP non lus</string>
     <string name="settings_future_data_saver">Mode économie de données</string>
     <string name="settings_future_clear_image_cache">Vider le cache des images</string>

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -24,11 +24,13 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -510,6 +512,27 @@ internal fun TopicContent(
                 scrollBehavior = scrollBehavior,
             )
         },
+        floatingActionButton = {
+            // #283 + bonus — quick access to "poster" and page-change without scrolling back to the
+            // header. Only in Loaded mode (needs subcat/page/canReply). The Scaffold applies the
+            // navigation-bar insets to this slot, so no manual padding here. Coexists with the #300
+            // scrollbar (right edge, auto-hiding) — a slight bottom-right overlap is acceptable.
+            val current = loaded
+            if (current != null) {
+                TopicBottomActions(
+                    showReply = shouldEnableReply(current.topic, state.isAuthenticated),
+                    canGoPrevious = state.canGoPrevious,
+                    canGoNext = state.canGoNext,
+                    // Clamp to [1, totalPages]: `canGoPrevious/Next` are derived from `request.page`
+                    // while the target is computed from the parsed `topic.page`; if those ever desync
+                    // (HFR clamps an out-of-range page to the last one), the clamp keeps navigation in
+                    // bounds — same robustness as the header guard and the swipe (#282).
+                    onPreviousPage = { onOpenPage((current.topic.page - 1).coerceAtLeast(1)) },
+                    onNextPage = { onOpenPage((current.topic.page + 1).coerceAtMost(current.topic.totalPages)) },
+                    onReply = { onReply(current.topic.subcat, current.topic.page) },
+                )
+            }
+        },
     ) { innerPadding ->
         Surface(
             modifier = Modifier
@@ -671,7 +694,10 @@ private fun TopicLoadedContent(
                 ),
             ),
         state = listState,
-        contentPadding = PaddingValues(16.dp),
+        // #283 — extra bottom padding so the last post's right-aligned actions clear the floating
+        // bottom-action cluster (the Scaffold FAB slot floats over the content). Harmless extra
+        // breathing room when the cluster is absent (anon + single page).
+        contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 88.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         item {
@@ -1227,6 +1253,67 @@ private fun DeletePostConfirmDialog(
             }
         },
     )
+}
+
+/**
+ * #283 + bonus — the floating bottom-action cluster: previous/next page mini-FABs and a « Répondre »
+ * extended FAB, so posting and page-change are reachable without scrolling back up to the header. Pure
+ * presentation: each affordance is gated on the same flags the header already uses, and reuses the
+ * existing `onReply`/`onOpenPage` callbacks. Renders nothing when nothing is available (anon + single
+ * page), so the Scaffold reserves no FAB space.
+ */
+@Composable
+@Suppress("LongParameterList") // hoisted action cluster, mirrors other hoisted composables in this file
+private fun TopicBottomActions(
+    showReply: Boolean,
+    canGoPrevious: Boolean,
+    canGoNext: Boolean,
+    onPreviousPage: () -> Unit,
+    onNextPage: () -> Unit,
+    onReply: () -> Unit,
+) {
+    val previousLabel = stringResource(R.string.topic_fab_previous_page)
+    val nextLabel = stringResource(R.string.topic_fab_next_page)
+    if (showReply || canGoPrevious || canGoNext) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (canGoPrevious) {
+                PageFab(description = previousLabel, glyph = "‹", onClick = onPreviousPage)
+            }
+            if (canGoNext) {
+                PageFab(description = nextLabel, glyph = "›", onClick = onNextPage)
+            }
+            if (showReply) {
+                ReplyFab(onClick = onReply)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PageFab(
+    description: String,
+    glyph: String,
+    onClick: () -> Unit,
+) {
+    // No Material icons (detekt ForbiddenImport blocks androidx.compose.material.*): the glyph is a
+    // decorative Text and the real label rides on the FAB's `contentDescription` for TalkBack — same
+    // pattern as the top-bar back button.
+    SmallFloatingActionButton(
+        onClick = onClick,
+        modifier = Modifier.semantics { contentDescription = description },
+    ) {
+        Text(glyph)
+    }
+}
+
+@Composable
+private fun ReplyFab(onClick: () -> Unit) {
+    ExtendedFloatingActionButton(onClick = onClick) {
+        Text(text = stringResource(R.string.topic_fab_reply))
+    }
 }
 
 // #220 — write affordances additionally require an authenticated session. A logged-out user

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.minimumInteractiveComponentSize
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -161,6 +162,8 @@ fun TopicScreen(
     // suspending lambda but the surrounding scope is still a Composable). Capturing the message
     // upfront keeps the rule happy and avoids re-resolving on every effect.
     val refreshFailedMsg = stringResource(R.string.topic_post_submit_refresh_failed)
+    // #335 — manual pull-to-refresh failure message (resolved upfront, same rationale).
+    val refreshManualFailedMsg = stringResource(R.string.topic_refresh_failed)
     // #292 — delete feedback messages, resolved upfront (same rationale as refreshFailedMsg).
     val deleteSuccessMsg = stringResource(R.string.topic_post_delete_success)
     val deleteFailedLoginMsg = stringResource(R.string.topic_post_delete_failed_login)
@@ -230,6 +233,15 @@ fun TopicScreen(
                     android.widget.Toast.makeText(
                         context,
                         refreshFailedMsg,
+                        android.widget.Toast.LENGTH_LONG,
+                    ).show()
+                }
+                TopicEffect.RefreshFailed -> {
+                    // #335 — manual pull-to-refresh could not reach HFR; the page stays on screen
+                    // (cache-first) and the Toast invites a retry.
+                    android.widget.Toast.makeText(
+                        context,
+                        refreshManualFailedMsg,
                         android.widget.Toast.LENGTH_LONG,
                     ).show()
                 }
@@ -539,18 +551,29 @@ internal fun TopicContent(
                 }
 
                 is TopicUiState.Mode.Loaded -> {
-                    TopicLoadedContent(
-                        state = state,
-                        topic = mode.topic,
-                        onReply = onReply,
-                        onQuote = onQuote,
-                        onEdit = onEdit,
-                        onEditFirstPost = onEditFirstPost,
-                        onOpenPage = onOpenPage,
-                        onOpenProfile = onOpenProfile,
-                        onDeleteRequest = onDeleteRequest,
-                        listState = listState,
-                    )
+                    // #335 — pull-to-refresh only wraps the loaded content (Loading/Error don't need
+                    // it). PullToRefreshBox layers a vertical nested-scroll connection on top of the
+                    // top-bar enterAlways behaviour (#338) and the horizontal page swipe (#282); the
+                    // pull only engages on overscroll at the top of the list, so the read position is
+                    // preserved on refresh (the ViewModel emits no scroll effect).
+                    PullToRefreshBox(
+                        isRefreshing = state.isRefreshing,
+                        onRefresh = { onIntent(TopicIntent.Refresh) },
+                        modifier = Modifier.fillMaxSize(),
+                    ) {
+                        TopicLoadedContent(
+                            state = state,
+                            topic = mode.topic,
+                            onReply = onReply,
+                            onQuote = onQuote,
+                            onEdit = onEdit,
+                            onEditFirstPost = onEditFirstPost,
+                            onOpenPage = onOpenPage,
+                            onOpenProfile = onOpenProfile,
+                            onDeleteRequest = onDeleteRequest,
+                            listState = listState,
+                        )
+                    }
                 }
             }
         }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -505,9 +505,11 @@ internal fun TopicContent(
                         onClick = onBack,
                         modifier = Modifier.semantics { contentDescription = backLabel },
                     ) {
-                        // Match the adjacent title text size (user request) rather than the default,
-                        // oversized glyph. The IconButton still provides the 48dp touch target.
-                        Text("←", style = MaterialTheme.typography.titleMedium)
+                        // The bare `←` glyph rendered oversized next to the title (it fills the em box
+                        // in the project font, so matching the title's point size still looked too big).
+                        // Down-size it to a normal body text size so it sits naturally beside the title;
+                        // the IconButton keeps the 48dp touch target regardless of the glyph size.
+                        Text("←", style = MaterialTheme.typography.bodySmall)
                     }
                 },
                 scrollBehavior = scrollBehavior,

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -3,6 +3,7 @@ package fr.forumhfr.redface2.feature.topic
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -561,18 +562,27 @@ internal fun TopicContent(
                         onRefresh = { onIntent(TopicIntent.Refresh) },
                         modifier = Modifier.fillMaxSize(),
                     ) {
-                        TopicLoadedContent(
-                            state = state,
-                            topic = mode.topic,
-                            onReply = onReply,
-                            onQuote = onQuote,
-                            onEdit = onEdit,
-                            onEditFirstPost = onEditFirstPost,
-                            onOpenPage = onOpenPage,
-                            onOpenProfile = onOpenProfile,
-                            onDeleteRequest = onDeleteRequest,
-                            listState = listState,
-                        )
+                        // #300 — wrap the list in a Box so the intra-page scrollbar can overlay its
+                        // right edge. The scrollbar is pure UI derived from `listState`; it never moves
+                        // the read position on its own — only an explicit thumb drag fast-scrolls.
+                        Box(modifier = Modifier.fillMaxSize()) {
+                            TopicLoadedContent(
+                                state = state,
+                                topic = mode.topic,
+                                onReply = onReply,
+                                onQuote = onQuote,
+                                onEdit = onEdit,
+                                onEditFirstPost = onEditFirstPost,
+                                onOpenPage = onOpenPage,
+                                onOpenProfile = onOpenProfile,
+                                onDeleteRequest = onDeleteRequest,
+                                listState = listState,
+                            )
+                            TopicScrollbar(
+                                listState = listState,
+                                modifier = Modifier.align(Alignment.CenterEnd),
+                            )
+                        }
                     }
                 }
             }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -24,6 +25,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -52,6 +54,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -505,11 +508,16 @@ internal fun TopicContent(
                         onClick = onBack,
                         modifier = Modifier.semantics { contentDescription = backLabel },
                     ) {
-                        // The bare `←` glyph rendered oversized next to the title (it fills the em box
-                        // in the project font, so matching the title's point size still looked too big).
-                        // Down-size it to a normal body text size so it sits naturally beside the title;
-                        // the IconButton keeps the 48dp touch target regardless of the glyph size.
-                        Text("←", style = MaterialTheme.typography.bodySmall)
+                        // A text glyph used as an icon was unstable: its size depended on the system
+                        // font's `←` rendering, the baseline and the font-scale, never matching the
+                        // title cleanly (cf. Codex review). Use a dp-sized vector instead — optically
+                        // centred by the IconButton, font-independent. The a11y label stays on the
+                        // IconButton, so the icon itself is decorative (contentDescription = null).
+                        Icon(
+                            painter = painterResource(fr.forumhfr.redface2.core.ui.R.drawable.ic_arrow_back),
+                            contentDescription = null,
+                            modifier = Modifier.size(24.dp),
+                        )
                     }
                 },
                 scrollBehavior = scrollBehavior,

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -506,7 +505,9 @@ internal fun TopicContent(
                         onClick = onBack,
                         modifier = Modifier.semantics { contentDescription = backLabel },
                     ) {
-                        Text("←")
+                        // Match the adjacent title text size (user request) rather than the default,
+                        // oversized glyph. The IconButton still provides the 48dp touch target.
+                        Text("←", style = MaterialTheme.typography.titleMedium)
                     }
                 },
                 scrollBehavior = scrollBehavior,
@@ -1311,8 +1312,15 @@ private fun PageFab(
 
 @Composable
 private fun ReplyFab(onClick: () -> Unit) {
-    ExtendedFloatingActionButton(onClick = onClick) {
-        Text(text = stringResource(R.string.topic_fab_reply))
+    // Same SmallFloatingActionButton footprint as the page FABs (user request): the « Répondre » label
+    // rides on contentDescription for TalkBack and the glyph is decorative (no Material icons — detekt
+    // ForbiddenImport blocks androidx.compose.material.*), mirroring PageFab and the top-bar back button.
+    val replyLabel = stringResource(R.string.topic_fab_reply)
+    SmallFloatingActionButton(
+        onClick = onClick,
+        modifier = Modifier.semantics { contentDescription = replyLabel },
+    ) {
+        Text("✎")
     }
 }
 

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbar.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbar.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListItemInfo
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -54,14 +55,19 @@ import kotlin.math.roundToInt
  * Outside the thumb hit target there is no pointer node, so a normal vertical scroll / a tap on a
  * right-aligned post action falls straight through to the list.
  *
- * Geometry uses an **index-based** model (pragmatic v1): thumb size ≈ visibleItems/totalItems, thumb top
- * ≈ firstVisibleIndex/totalItems with sub-item interpolation from the scroll offset. Variable post
- * heights make this an approximation; a single post taller than the viewport yields a coarse thumb
- * (sizeFraction ≈ 1) and a coarse fast-scroll — accepted for v1. "Is there anything to scroll" is read
- * from [LazyListState.canScrollForward]/[LazyListState.canScrollBackward], NOT from visible ≥ total
- * (which is false when one item is taller than the viewport). It works in pure `LazyListState` index
- * space (the header card is lazy item 0), so thumb position and `scrollToItem` stay mutually consistent
- * — no header offset to apply.
+ * Geometry uses a **pixel-based estimated** model: thumb size ≈ viewport / (averageItemSize × total),
+ * thumb top ≈ pixelsScrolled / maxScroll. The earlier index-based model (`visibleItems/total`,
+ * `firstVisibleIndex/total`) was the root cause of the "jumps + resizes" bug on a forum page: posts have
+ * wildly unequal heights, so `visibleItemsCount` (an integer) flipped 3↔4↔2 as a tall post entered/left
+ * the viewport — resizing the thumb by whole-item steps — and the thumb travelled ~10× faster over a
+ * short post than a tall one for the same `1/total` step, so it accelerated/jumped at every item border.
+ * The pixel model derives both size and position from an estimated total height (mean of the *visible*
+ * item sizes × total), which varies continuously instead of by integer steps. It is still an
+ * approximation (the mean drifts a little as the visible set changes), but far smoother. "Is there
+ * anything to scroll" is read from [LazyListState.canScrollForward]/[LazyListState.canScrollBackward],
+ * NOT from visible ≥ total (false when one item is taller than the viewport). It works in pure
+ * `LazyListState` index space (the header card is lazy item 0), so thumb position and `scrollToItem`
+ * stay mutually consistent — no header offset to apply.
  */
 @Composable
 internal fun TopicScrollbar(
@@ -74,12 +80,13 @@ internal fun TopicScrollbar(
     val metrics by remember {
         derivedStateOf {
             val info = listState.layoutInfo
+            val visible = info.visibleItemsInfo
             scrollbarMetrics(
                 firstVisibleItemIndex = listState.firstVisibleItemIndex,
                 firstVisibleItemScrollOffset = listState.firstVisibleItemScrollOffset,
-                firstVisibleItemSize = info.visibleItemsInfo.firstOrNull()?.size ?: 0,
-                visibleItemsCount = info.visibleItemsInfo.size,
+                averageItemSizePx = visible.averageItemSizePx(),
                 totalItemsCount = info.totalItemsCount,
+                viewportHeightPx = (info.viewportEndOffset - info.viewportStartOffset).toFloat(),
             )
         }
     }
@@ -106,9 +113,14 @@ internal fun TopicScrollbar(
     val alpha by animateFloatAsState(targetValue = alphaTarget, label = "topicScrollbarAlpha")
     val thumbColor = MaterialTheme.colorScheme.primary
 
-    // Read live counts inside the gesture without re-keying the pointerInput on the (per-frame) metrics.
-    val currentVisibleCount = rememberUpdatedState(listState.layoutInfo.visibleItemsInfo.size)
+    // Read live geometry inside the gesture without re-keying the pointerInput on the (per-frame)
+    // metrics. Same estimated-height inputs as `scrollbarMetrics`, so a fast-scroll lands where the
+    // thumb sits.
     val currentTotalCount = rememberUpdatedState(listState.layoutInfo.totalItemsCount)
+    val currentAvgItemSize = rememberUpdatedState(listState.layoutInfo.visibleItemsInfo.averageItemSizePx())
+    val currentViewportHeight = rememberUpdatedState(
+        (listState.layoutInfo.viewportEndOffset - listState.layoutInfo.viewportStartOffset).toFloat(),
+    )
     val scope = rememberCoroutineScope()
     var lastTargetIndex by remember { mutableIntStateOf(-1) }
     var scrollJob by remember { mutableStateOf<Job?>(null) }
@@ -121,8 +133,9 @@ internal fun TopicScrollbar(
     val onSeek: (Float) -> Unit = { travelFraction ->
         val index = targetIndexForDrag(
             travelFraction = travelFraction,
-            visibleItemsCount = currentVisibleCount.value,
+            averageItemSizePx = currentAvgItemSize.value,
             totalItemsCount = currentTotalCount.value,
+            viewportHeightPx = currentViewportHeight.value,
         )
         if (index != lastTargetIndex) {
             lastTargetIndex = index
@@ -229,42 +242,67 @@ internal data class ScrollbarMetrics(
     val sizeFraction: Float,
 )
 
+/** Mean size (px) of the currently visible lazy items — the estimator both pure functions rely on. */
+private fun List<LazyListItemInfo>.averageItemSizePx(): Float =
+    if (isEmpty()) 0f else sumOf { it.size }.toFloat() / size
+
 /**
- * Pure thumb geometry. Returns `null` only when there is nothing to represent ([totalItemsCount] ≤ 0 or
- * no visible item) — the "page fits, nothing to scroll" decision is taken by the caller from
- * `canScrollForward/Backward`, NOT from `visibleItemsCount >= totalItemsCount` (false when a single item
- * is taller than the viewport). Index-based with sub-item interpolation; [firstVisibleItemSize] ≤ 0 is
- * tolerated (no sub-item contribution).
+ * Pure thumb geometry, **pixel-based** (#300 follow-up fixing the "jumps + resizes" report). The thumb
+ * size and position come from an *estimated* total content height ([averageItemSizePx] × [totalItemsCount])
+ * and the pixels already scrolled — NOT from the integer count of visible items, which flipped by whole
+ * steps on a page of unequal-height posts and made the thumb resize and travel non-uniformly.
+ *
+ * [averageItemSizePx] is the mean size of the **currently visible** items: an approximation that stays
+ * smooth because it varies continuously (a tall post entering nudges the mean up gradually) rather than by
+ * whole-item steps. A small residual discontinuity remains when the first visible item changes while its
+ * size differs a lot from the mean; it is far smaller than the index-based jump and accepted for v1.
+ *
+ * Returns `null` only when there is nothing to represent ([totalItemsCount] ≤ 0, no visible item, or a
+ * non-positive [averageItemSizePx]/[viewportHeightPx]). The "page fits, nothing to scroll" decision stays
+ * with the caller (`canScrollForward/Backward`). [offsetFraction] ∈ [0, 1 − sizeFraction]; [sizeFraction]
+ * ∈ (0, 1].
  */
 internal fun scrollbarMetrics(
     firstVisibleItemIndex: Int,
     firstVisibleItemScrollOffset: Int,
-    firstVisibleItemSize: Int,
-    visibleItemsCount: Int,
+    averageItemSizePx: Float,
     totalItemsCount: Int,
+    viewportHeightPx: Float,
 ): ScrollbarMetrics? {
-    if (totalItemsCount <= 0 || visibleItemsCount <= 0) return null
-    val sizeFraction = (visibleItemsCount.toFloat() / totalItemsCount).coerceIn(MIN_THUMB_FRACTION, 1f)
-    val subItem =
-        if (firstVisibleItemSize > 0) firstVisibleItemScrollOffset.toFloat() / firstVisibleItemSize else 0f
-    val offsetFraction =
-        ((firstVisibleItemIndex + subItem) / totalItemsCount).coerceIn(0f, 1f - sizeFraction)
+    // Single guard (ReturnCount): an empty visible set surfaces as `averageItemSizePx == 0f`, so the
+    // "nothing visible" case is covered here without a separate `visibleItemsCount` parameter.
+    if (totalItemsCount <= 0 || averageItemSizePx <= 0f || viewportHeightPx <= 0f) return null
+    val estimatedTotalHeight = averageItemSizePx * totalItemsCount
+    val sizeFraction = (viewportHeightPx / estimatedTotalHeight).coerceIn(MIN_THUMB_FRACTION, 1f)
+    val maxScrollPx = estimatedTotalHeight - viewportHeightPx
+    val offsetFraction = if (maxScrollPx <= 0f) {
+        0f
+    } else {
+        val scrolledPx = firstVisibleItemIndex * averageItemSizePx + firstVisibleItemScrollOffset
+        ((scrolledPx / maxScrollPx) * (1f - sizeFraction)).coerceIn(0f, 1f - sizeFraction)
+    }
     return ScrollbarMetrics(offsetFraction = offsetFraction, sizeFraction = sizeFraction)
 }
 
 /**
- * Maps the thumb's travel fraction (∈ [0, 1] over its *available* travel = track − thumb) to a target
- * first-visible item index, consistent with [scrollbarMetrics] (max offset 1 − sizeFraction ⇔
- * firstVisibleIndex = total − visible). Clamps so a shrinking [totalItemsCount] mid-drag never yields a
- * negative index.
+ * Maps the thumb's travel fraction (∈ [0, 1] over its *available* travel = track − thumb) back to a
+ * target first-visible item index, using the SAME estimated-height model as [scrollbarMetrics] so the
+ * thumb position and a fast-scroll stay mutually consistent: `travelFraction × maxScrollPx` is the target
+ * scroll position in px, divided by [averageItemSizePx] for the item to land on. Clamps to a valid index
+ * so a shrinking [totalItemsCount] mid-drag never yields an out-of-range value.
  */
 internal fun targetIndexForDrag(
     travelFraction: Float,
-    visibleItemsCount: Int,
+    averageItemSizePx: Float,
     totalItemsCount: Int,
+    viewportHeightPx: Float,
 ): Int {
-    val maxFirstIndex = (totalItemsCount - visibleItemsCount.coerceAtLeast(1)).coerceAtLeast(0)
-    return (travelFraction.coerceIn(0f, 1f) * maxFirstIndex).roundToInt()
+    if (averageItemSizePx <= 0f || totalItemsCount <= 0) return 0
+    val estimatedTotalHeight = averageItemSizePx * totalItemsCount
+    val maxScrollPx = (estimatedTotalHeight - viewportHeightPx).coerceAtLeast(0f)
+    val targetScrollPx = travelFraction.coerceIn(0f, 1f) * maxScrollPx
+    val index = (targetScrollPx / averageItemSizePx).roundToInt()
+    return index.coerceIn(0, totalItemsCount - 1)
 }
 
 private const val THUMB_ALPHA = 0.7f

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbar.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbar.kt
@@ -57,22 +57,22 @@ import kotlin.math.roundToInt
  * Outside the thumb hit target there is no pointer node, so a normal vertical scroll / a tap on a
  * right-aligned post action falls straight through to the list.
  *
- * Geometry uses a **fixed-size, ordinal** model: the thumb is a constant fraction of the track
- * ([THUMB_SIZE_FRACTION]) and its position comes purely from the list ordinal
- * `firstVisibleItemIndex / (totalItemsCount − 1)`. It deliberately does NOT read any measured item
- * size. Two earlier attempts both tied the thumb to a *moving estimate* of total content height and
- * failed: an index-based one (size = `visibleItemsCount/total`, an integer flipping 3↔4↔2) and a
- * pixel-estimated one (size = `viewport / (avgVisibleItemSize × total)`). On a forum page — unequal
- * post heights, plus block images that grow 160→480dp once Coil decodes them (#197) and inline media
- * that resizes after measurement — the estimated total "breathes", so the thumb resized and jumped
- * (the average of the *visible* items rewrites the assumed height of every item before the viewport),
- * even while idle. Decoupling the geometry from measured sizes is the only stable option.
+ * Geometry uses a **fixed-size ordinal model with sub-item interpolation** (cf. [scrollbarMetrics]):
+ * a constant thumb size ([THUMB_SIZE_FRACTION]) and a position from `(firstVisibleItemIndex +
+ * itemFraction) / (totalItemsCount − 1)`, where `itemFraction` interpolates within the current top post
+ * using only that post's own offset/size. Two earlier attempts tied the thumb to a *moving estimate* of
+ * total content height and failed: an index-based one (size = `visibleItemsCount/total`, an integer
+ * flipping 3↔4↔2) and a pixel-estimated one (size = `viewport / (avgVisibleItemSize × total)`). On a
+ * forum page — unequal post heights, plus block images that grow 160→480dp once Coil decodes them (#197)
+ * — the estimated total "breathes", so the thumb resized and jumped even while idle. Keeping the size
+ * constant (never measured) kills that; interpolating the position with only the *current* top item's
+ * size keeps it continuous (no per-post "à-coup") while bounding any residual #197 wobble to one ordinal
+ * step.
  *
- * Trade-off (per the Codex review): the thumb is no longer proportional to true scroll length — a tall
- * image post and a one-liner are one ordinal step each — but it is rock-stable and matches the
- * fast-scroll use case ("where am I / jump near another post"). A spring on the drawn offset softens
- * the coarse per-item steps; the thumb drag snaps (no animation) so it never lags under the finger.
- * "Is there anything to scroll" is still read from
+ * Trade-off (per the Codex review): the thumb size is not proportional to true scroll length and the
+ * within-post speed is non-uniform, but it is stable and matches the fast-scroll use case ("where am I /
+ * jump near another post"). The drawn offset SNAPS while scrolling/dragging (tracks the finger exactly)
+ * and springs only on the idle settle. "Is there anything to scroll" is still read from
  * [LazyListState.canScrollForward]/[LazyListState.canScrollBackward]. Pure `LazyListState` index space
  * (the header card is lazy item 0), so thumb position and `scrollToItem` stay mutually consistent.
  */
@@ -86,9 +86,12 @@ internal fun TopicScrollbar(
     }
     val metrics by remember {
         derivedStateOf {
+            val info = listState.layoutInfo
             scrollbarMetrics(
                 firstVisibleItemIndex = listState.firstVisibleItemIndex,
-                totalItemsCount = listState.layoutInfo.totalItemsCount,
+                firstVisibleItemScrollOffset = listState.firstVisibleItemScrollOffset,
+                firstVisibleItemSize = info.visibleItemsInfo.firstOrNull()?.size ?: 0,
+                totalItemsCount = info.totalItemsCount,
             )
         }
     }
@@ -105,13 +108,12 @@ internal fun TopicScrollbar(
     )
     val thumbColor = MaterialTheme.colorScheme.primary
 
-    // Soften the coarse ordinal steps (the position jumps by 1/(total-1) each time the first visible
-    // item changes): a spring chases the moving target while scrolling/settling, but the thumb drag
-    // snaps (no animation) so the thumb never lags under the finger during a fast-scroll.
-    val animatedOffset by animateFloatAsState(
-        targetValue = metrics?.offsetFraction ?: 0f,
-        animationSpec = if (isDragging) snap() else spring(stiffness = Spring.StiffnessMediumLow),
-        label = "topicScrollbarOffset",
+    // Sub-item interpolation already makes the offset continuous during a scroll, so it SNAPS (tracks
+    // the finger exactly) while scrolling/dragging — a spring there would only lag the live input — and
+    // springs only on the idle settle. Extracted to rememberScrollbarDrawOffset (spec per Codex review).
+    val animatedOffset = rememberScrollbarDrawOffset(
+        targetOffset = metrics?.offsetFraction ?: 0f,
+        snapping = isDragging || listState.isScrollInProgress,
     )
     val drawnMetrics = metrics?.copy(offsetFraction = animatedOffset)
 
@@ -193,6 +195,28 @@ private fun rememberScrollbarAlpha(
 }
 
 /**
+ * Drawn thumb offset: snaps to [targetOffset] while [snapping] (the thumb is dragged or the list is
+ * scrolling — sub-item interpolation already makes that continuous, and a spring would only lag the
+ * live input), and springs gently on the idle settle so a `scrollToItem` landing eases in.
+ */
+@Composable
+private fun rememberScrollbarDrawOffset(
+    targetOffset: Float,
+    snapping: Boolean,
+): Float {
+    val offset by animateFloatAsState(
+        targetValue = targetOffset,
+        animationSpec = if (snapping) {
+            snap()
+        } else {
+            spring(stiffness = Spring.StiffnessMedium, dampingRatio = Spring.DampingRatioNoBouncy)
+        },
+        label = "topicScrollbarOffset",
+    )
+    return offset
+}
+
+/**
  * The thumb-only drag surface. Placed at the thumb's current vertical offset (± [GRAB_PADDING]) so it is
  * the *only* pointer node in the gutter — everything else stays scrollable/tappable. The drag maps the
  * finger's absolute track position back from the live hit-target top: `trackY = hitTop + localY`, which
@@ -266,32 +290,48 @@ internal data class ScrollbarMetrics(
 )
 
 /**
- * Pure thumb geometry, **fixed-size + ordinal** (#300 follow-up fixing the "jumps + grows suddenly"
- * report). The thumb size is the constant [THUMB_SIZE_FRACTION] of the track, and its position is the
- * pure list ordinal `firstVisibleItemIndex / (totalItemsCount − 1)` mapped onto the available travel
- * `1 − sizeFraction`. It reads **no measured item size**, so neither a changing visible set during
- * scroll nor a post-decode image growth (#197) can resize or move the thumb on its own — only an actual
- * change of the first-visible ordinal does.
+ * Pure thumb geometry, **fixed-size ordinal with sub-item interpolation** (#300). The thumb size is the
+ * constant [THUMB_SIZE_FRACTION] of the track; its position is the list ordinal
+ * `(firstVisibleItemIndex + itemFraction) / (totalItemsCount − 1)` mapped onto the available travel
+ * `1 − sizeFraction`, where `itemFraction = firstVisibleItemScrollOffset / firstVisibleItemSize` ∈ [0, 1)
+ * interpolates *within the current top post*.
  *
- * Returns `null` when an ordinal position is meaningless ([totalItemsCount] ≤ 1): a single (possibly
- * tall) item carries no ordinal progress. A topic page always has the header card (item 0) plus posts,
- * so this only hides the bar on a degenerate one-item list. The "page fits, nothing to scroll" decision
- * stays with the caller (`canScrollForward/Backward`). [offsetFraction] ∈ [0, 1 − sizeFraction];
+ * Why this shape (two earlier models failed):
+ *  - **size** never reads a measured height (constant), so a changing visible set or a post-decode image
+ *    growth (#197) can't resize the thumb — that killed the "grows suddenly" symptom.
+ *  - **position** interpolates within a post using ONLY the current top item's own offset/size, so it is
+ *    continuous within a post and (near-)continuous across the boundary — no per-post step/"à-coup".
+ *    The single measured input ([firstVisibleItemSize]) is local: a #197 growth of the top post wobbles
+ *    the thumb by at most one ordinal step (`(1−size)/(total−1)`), never the global "×N rewrite of every
+ *    prior item" that the average-of-visible-items estimate caused.
+ *
+ * Guards (cf. the Codex review): `totalItemsCount ≤ 1 → null` (a single, possibly tall, item has no
+ * ordinal progress); the index is clamped; [firstVisibleItemScrollOffset] is clamped to the item so the
+ * fraction stays in [0, 1); the **last** ordinal forces `itemFraction = 0` so progress never exceeds 1.
+ *
+ * Trade-off: within a post the speed is non-uniform (tall posts crawl, short posts race) — inherent to
+ * exact anchoring, and accepted because the anchoring is wanted. [offsetFraction] ∈ [0, 1 − sizeFraction];
  * [sizeFraction] is constant.
- *
- * Trade-off: a tall post and a one-liner are one ordinal step each, so the thumb is not proportional to
- * true scroll length — accepted for stability (cf. the Codex review). At the very bottom the first
- * ordinal is `total − visibleCount`, so the thumb rests slightly above the end; a drag to the bottom
- * still lands there via [targetIndexForDrag] (`scrollToItem(total − 1)`).
  */
 internal fun scrollbarMetrics(
     firstVisibleItemIndex: Int,
+    firstVisibleItemScrollOffset: Int,
+    firstVisibleItemSize: Int,
     totalItemsCount: Int,
 ): ScrollbarMetrics? {
     if (totalItemsCount <= 1) return null
-    val progress = (firstVisibleItemIndex.toFloat() / (totalItemsCount - 1)).coerceIn(0f, 1f)
-    val offsetFraction = progress * (1f - THUMB_SIZE_FRACTION)
-    return ScrollbarMetrics(offsetFraction = offsetFraction, sizeFraction = THUMB_SIZE_FRACTION)
+    val lastIndex = totalItemsCount - 1
+    val index = firstVisibleItemIndex.coerceIn(0, lastIndex)
+    val itemFraction = if (firstVisibleItemSize > 0 && index < lastIndex) {
+        firstVisibleItemScrollOffset.coerceIn(0, firstVisibleItemSize - 1).toFloat() / firstVisibleItemSize
+    } else {
+        0f
+    }
+    val progress = ((index + itemFraction) / lastIndex).coerceIn(0f, 1f)
+    return ScrollbarMetrics(
+        offsetFraction = progress * (1f - THUMB_SIZE_FRACTION),
+        sizeFraction = THUMB_SIZE_FRACTION,
+    )
 }
 
 /**

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbar.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbar.kt
@@ -1,6 +1,9 @@
 package fr.forumhfr.redface2.feature.topic
 
+import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Box
@@ -11,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyListItemInfo
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -55,19 +57,24 @@ import kotlin.math.roundToInt
  * Outside the thumb hit target there is no pointer node, so a normal vertical scroll / a tap on a
  * right-aligned post action falls straight through to the list.
  *
- * Geometry uses a **pixel-based estimated** model: thumb size ≈ viewport / (averageItemSize × total),
- * thumb top ≈ pixelsScrolled / maxScroll. The earlier index-based model (`visibleItems/total`,
- * `firstVisibleIndex/total`) was the root cause of the "jumps + resizes" bug on a forum page: posts have
- * wildly unequal heights, so `visibleItemsCount` (an integer) flipped 3↔4↔2 as a tall post entered/left
- * the viewport — resizing the thumb by whole-item steps — and the thumb travelled ~10× faster over a
- * short post than a tall one for the same `1/total` step, so it accelerated/jumped at every item border.
- * The pixel model derives both size and position from an estimated total height (mean of the *visible*
- * item sizes × total), which varies continuously instead of by integer steps. It is still an
- * approximation (the mean drifts a little as the visible set changes), but far smoother. "Is there
- * anything to scroll" is read from [LazyListState.canScrollForward]/[LazyListState.canScrollBackward],
- * NOT from visible ≥ total (false when one item is taller than the viewport). It works in pure
- * `LazyListState` index space (the header card is lazy item 0), so thumb position and `scrollToItem`
- * stay mutually consistent — no header offset to apply.
+ * Geometry uses a **fixed-size, ordinal** model: the thumb is a constant fraction of the track
+ * ([THUMB_SIZE_FRACTION]) and its position comes purely from the list ordinal
+ * `firstVisibleItemIndex / (totalItemsCount − 1)`. It deliberately does NOT read any measured item
+ * size. Two earlier attempts both tied the thumb to a *moving estimate* of total content height and
+ * failed: an index-based one (size = `visibleItemsCount/total`, an integer flipping 3↔4↔2) and a
+ * pixel-estimated one (size = `viewport / (avgVisibleItemSize × total)`). On a forum page — unequal
+ * post heights, plus block images that grow 160→480dp once Coil decodes them (#197) and inline media
+ * that resizes after measurement — the estimated total "breathes", so the thumb resized and jumped
+ * (the average of the *visible* items rewrites the assumed height of every item before the viewport),
+ * even while idle. Decoupling the geometry from measured sizes is the only stable option.
+ *
+ * Trade-off (per the Codex review): the thumb is no longer proportional to true scroll length — a tall
+ * image post and a one-liner are one ordinal step each — but it is rock-stable and matches the
+ * fast-scroll use case ("where am I / jump near another post"). A spring on the drawn offset softens
+ * the coarse per-item steps; the thumb drag snaps (no animation) so it never lags under the finger.
+ * "Is there anything to scroll" is still read from
+ * [LazyListState.canScrollForward]/[LazyListState.canScrollBackward]. Pure `LazyListState` index space
+ * (the header card is lazy item 0), so thumb position and `scrollToItem` stay mutually consistent.
  */
 @Composable
 internal fun TopicScrollbar(
@@ -79,14 +86,9 @@ internal fun TopicScrollbar(
     }
     val metrics by remember {
         derivedStateOf {
-            val info = listState.layoutInfo
-            val visible = info.visibleItemsInfo
             scrollbarMetrics(
                 firstVisibleItemIndex = listState.firstVisibleItemIndex,
-                firstVisibleItemScrollOffset = listState.firstVisibleItemScrollOffset,
-                averageItemSizePx = visible.averageItemSizePx(),
-                totalItemsCount = info.totalItemsCount,
-                viewportHeightPx = (info.viewportEndOffset - info.viewportStartOffset).toFloat(),
+                totalItemsCount = listState.layoutInfo.totalItemsCount,
             )
         }
     }
@@ -94,33 +96,27 @@ internal fun TopicScrollbar(
     var isDragging by remember { mutableStateOf(false) }
     val active = canScroll && metrics != null
 
-    // Visible while scrolling or dragging; otherwise a brief show-then-fade. The idle branch also fires
-    // on the first composition of a scrollable page (initial flash → discoverability of the fast-scroll
-    // affordance) and after a scroll settles (post-scroll hold). The LaunchedEffect restarts on every
-    // (active / scroll / drag) change, so a scroll resuming within the hold cancels the pending fade.
-    var alphaTarget by remember { mutableStateOf(0f) }
-    LaunchedEffect(active, listState.isScrollInProgress, isDragging) {
-        when {
-            !active -> alphaTarget = 0f
-            listState.isScrollInProgress || isDragging -> alphaTarget = 1f
-            else -> {
-                alphaTarget = 1f
-                delay(HIDE_DELAY_MS)
-                alphaTarget = 0f
-            }
-        }
-    }
-    val alpha by animateFloatAsState(targetValue = alphaTarget, label = "topicScrollbarAlpha")
+    // Auto-hide alpha extracted to rememberScrollbarAlpha to keep this composable under the cyclomatic
+    // complexity threshold; visible while scrolling/dragging, brief show-then-fade otherwise.
+    val alpha = rememberScrollbarAlpha(
+        active = active,
+        isScrollInProgress = listState.isScrollInProgress,
+        isDragging = isDragging,
+    )
     val thumbColor = MaterialTheme.colorScheme.primary
 
-    // Read live geometry inside the gesture without re-keying the pointerInput on the (per-frame)
-    // metrics. Same estimated-height inputs as `scrollbarMetrics`, so a fast-scroll lands where the
-    // thumb sits.
-    val currentTotalCount = rememberUpdatedState(listState.layoutInfo.totalItemsCount)
-    val currentAvgItemSize = rememberUpdatedState(listState.layoutInfo.visibleItemsInfo.averageItemSizePx())
-    val currentViewportHeight = rememberUpdatedState(
-        (listState.layoutInfo.viewportEndOffset - listState.layoutInfo.viewportStartOffset).toFloat(),
+    // Soften the coarse ordinal steps (the position jumps by 1/(total-1) each time the first visible
+    // item changes): a spring chases the moving target while scrolling/settling, but the thumb drag
+    // snaps (no animation) so the thumb never lags under the finger during a fast-scroll.
+    val animatedOffset by animateFloatAsState(
+        targetValue = metrics?.offsetFraction ?: 0f,
+        animationSpec = if (isDragging) snap() else spring(stiffness = Spring.StiffnessMediumLow),
+        label = "topicScrollbarOffset",
     )
+    val drawnMetrics = metrics?.copy(offsetFraction = animatedOffset)
+
+    // Live total read inside the gesture without re-keying the pointerInput on the (per-frame) metrics.
+    val currentTotalCount = rememberUpdatedState(listState.layoutInfo.totalItemsCount)
     val scope = rememberCoroutineScope()
     var lastTargetIndex by remember { mutableIntStateOf(-1) }
     var scrollJob by remember { mutableStateOf<Job?>(null) }
@@ -133,9 +129,7 @@ internal fun TopicScrollbar(
     val onSeek: (Float) -> Unit = { travelFraction ->
         val index = targetIndexForDrag(
             travelFraction = travelFraction,
-            averageItemSizePx = currentAvgItemSize.value,
             totalItemsCount = currentTotalCount.value,
-            viewportHeightPx = currentViewportHeight.value,
         )
         if (index != lastTargetIndex) {
             lastTargetIndex = index
@@ -151,12 +145,12 @@ internal fun TopicScrollbar(
     ) {
         val trackHeightPx = constraints.maxHeight.toFloat()
         Canvas(modifier = Modifier.fillMaxSize().clearAndSetSemantics { }) {
-            val m = metrics
+            val m = drawnMetrics
             if (alpha > 0f && m != null) {
                 drawScrollbarThumb(metrics = m, alpha = alpha, color = thumbColor)
             }
         }
-        val m = metrics
+        val m = drawnMetrics
         if (active && m != null) {
             ThumbHitTarget(
                 listState = listState,
@@ -167,6 +161,35 @@ internal fun TopicScrollbar(
             )
         }
     }
+}
+
+/**
+ * Auto-hide opacity for the scrollbar: fully visible while [active] and (scrolling or [isDragging]),
+ * otherwise a brief show-then-fade after the last interaction. The idle branch also fires on the first
+ * composition of a scrollable page (initial flash → discoverability) and after a scroll settles. The
+ * [LaunchedEffect] restarts on every (active / scroll / drag) change, so a scroll resuming within the
+ * hold cancels the pending fade.
+ */
+@Composable
+private fun rememberScrollbarAlpha(
+    active: Boolean,
+    isScrollInProgress: Boolean,
+    isDragging: Boolean,
+): Float {
+    var alphaTarget by remember { mutableStateOf(0f) }
+    LaunchedEffect(active, isScrollInProgress, isDragging) {
+        when {
+            !active -> alphaTarget = 0f
+            isScrollInProgress || isDragging -> alphaTarget = 1f
+            else -> {
+                alphaTarget = 1f
+                delay(HIDE_DELAY_MS)
+                alphaTarget = 0f
+            }
+        }
+    }
+    val alpha by animateFloatAsState(targetValue = alphaTarget, label = "topicScrollbarAlpha")
+    return alpha
 }
 
 /**
@@ -242,71 +265,58 @@ internal data class ScrollbarMetrics(
     val sizeFraction: Float,
 )
 
-/** Mean size (px) of the currently visible lazy items — the estimator both pure functions rely on. */
-private fun List<LazyListItemInfo>.averageItemSizePx(): Float =
-    if (isEmpty()) 0f else sumOf { it.size }.toFloat() / size
-
 /**
- * Pure thumb geometry, **pixel-based** (#300 follow-up fixing the "jumps + resizes" report). The thumb
- * size and position come from an *estimated* total content height ([averageItemSizePx] × [totalItemsCount])
- * and the pixels already scrolled — NOT from the integer count of visible items, which flipped by whole
- * steps on a page of unequal-height posts and made the thumb resize and travel non-uniformly.
+ * Pure thumb geometry, **fixed-size + ordinal** (#300 follow-up fixing the "jumps + grows suddenly"
+ * report). The thumb size is the constant [THUMB_SIZE_FRACTION] of the track, and its position is the
+ * pure list ordinal `firstVisibleItemIndex / (totalItemsCount − 1)` mapped onto the available travel
+ * `1 − sizeFraction`. It reads **no measured item size**, so neither a changing visible set during
+ * scroll nor a post-decode image growth (#197) can resize or move the thumb on its own — only an actual
+ * change of the first-visible ordinal does.
  *
- * [averageItemSizePx] is the mean size of the **currently visible** items: an approximation that stays
- * smooth because it varies continuously (a tall post entering nudges the mean up gradually) rather than by
- * whole-item steps. A small residual discontinuity remains when the first visible item changes while its
- * size differs a lot from the mean; it is far smaller than the index-based jump and accepted for v1.
+ * Returns `null` when an ordinal position is meaningless ([totalItemsCount] ≤ 1): a single (possibly
+ * tall) item carries no ordinal progress. A topic page always has the header card (item 0) plus posts,
+ * so this only hides the bar on a degenerate one-item list. The "page fits, nothing to scroll" decision
+ * stays with the caller (`canScrollForward/Backward`). [offsetFraction] ∈ [0, 1 − sizeFraction];
+ * [sizeFraction] is constant.
  *
- * Returns `null` only when there is nothing to represent ([totalItemsCount] ≤ 0, no visible item, or a
- * non-positive [averageItemSizePx]/[viewportHeightPx]). The "page fits, nothing to scroll" decision stays
- * with the caller (`canScrollForward/Backward`). [offsetFraction] ∈ [0, 1 − sizeFraction]; [sizeFraction]
- * ∈ (0, 1].
+ * Trade-off: a tall post and a one-liner are one ordinal step each, so the thumb is not proportional to
+ * true scroll length — accepted for stability (cf. the Codex review). At the very bottom the first
+ * ordinal is `total − visibleCount`, so the thumb rests slightly above the end; a drag to the bottom
+ * still lands there via [targetIndexForDrag] (`scrollToItem(total − 1)`).
  */
 internal fun scrollbarMetrics(
     firstVisibleItemIndex: Int,
-    firstVisibleItemScrollOffset: Int,
-    averageItemSizePx: Float,
     totalItemsCount: Int,
-    viewportHeightPx: Float,
 ): ScrollbarMetrics? {
-    // Single guard (ReturnCount): an empty visible set surfaces as `averageItemSizePx == 0f`, so the
-    // "nothing visible" case is covered here without a separate `visibleItemsCount` parameter.
-    if (totalItemsCount <= 0 || averageItemSizePx <= 0f || viewportHeightPx <= 0f) return null
-    val estimatedTotalHeight = averageItemSizePx * totalItemsCount
-    val sizeFraction = (viewportHeightPx / estimatedTotalHeight).coerceIn(MIN_THUMB_FRACTION, 1f)
-    val maxScrollPx = estimatedTotalHeight - viewportHeightPx
-    val offsetFraction = if (maxScrollPx <= 0f) {
-        0f
-    } else {
-        val scrolledPx = firstVisibleItemIndex * averageItemSizePx + firstVisibleItemScrollOffset
-        ((scrolledPx / maxScrollPx) * (1f - sizeFraction)).coerceIn(0f, 1f - sizeFraction)
-    }
-    return ScrollbarMetrics(offsetFraction = offsetFraction, sizeFraction = sizeFraction)
+    if (totalItemsCount <= 1) return null
+    val progress = (firstVisibleItemIndex.toFloat() / (totalItemsCount - 1)).coerceIn(0f, 1f)
+    val offsetFraction = progress * (1f - THUMB_SIZE_FRACTION)
+    return ScrollbarMetrics(offsetFraction = offsetFraction, sizeFraction = THUMB_SIZE_FRACTION)
 }
 
 /**
  * Maps the thumb's travel fraction (∈ [0, 1] over its *available* travel = track − thumb) back to a
- * target first-visible item index, using the SAME estimated-height model as [scrollbarMetrics] so the
- * thumb position and a fast-scroll stay mutually consistent: `travelFraction × maxScrollPx` is the target
- * scroll position in px, divided by [averageItemSizePx] for the item to land on. Clamps to a valid index
- * so a shrinking [totalItemsCount] mid-drag never yields an out-of-range value.
+ * target first-visible item index, the inverse of [scrollbarMetrics]'s ordinal mapping:
+ * `round(travelFraction × (total − 1))`. Clamps so an out-of-range fraction or a shrinking
+ * [totalItemsCount] mid-drag never yields an out-of-range index.
  */
 internal fun targetIndexForDrag(
     travelFraction: Float,
-    averageItemSizePx: Float,
     totalItemsCount: Int,
-    viewportHeightPx: Float,
 ): Int {
-    if (averageItemSizePx <= 0f || totalItemsCount <= 0) return 0
-    val estimatedTotalHeight = averageItemSizePx * totalItemsCount
-    val maxScrollPx = (estimatedTotalHeight - viewportHeightPx).coerceAtLeast(0f)
-    val targetScrollPx = travelFraction.coerceIn(0f, 1f) * maxScrollPx
-    val index = (targetScrollPx / averageItemSizePx).roundToInt()
+    if (totalItemsCount <= 1) return 0
+    val index = (travelFraction.coerceIn(0f, 1f) * (totalItemsCount - 1)).roundToInt()
     return index.coerceIn(0, totalItemsCount - 1)
 }
 
 private const val THUMB_ALPHA = 0.7f
-internal const val MIN_THUMB_FRACTION = 0.08f
+
+/**
+ * Constant thumb height as a fraction of the track. Fixed on purpose: tying the size to any measured
+ * quantity (visible-item count, or an estimated total height) made it resize as the visible set or image
+ * heights changed — the "grows suddenly" symptom. ~12% gives a comfortable grab target on a phone track.
+ */
+internal const val THUMB_SIZE_FRACTION = 0.12f
 private const val HIDE_DELAY_MS = 800L
 private val SCROLLBAR_GUTTER_WIDTH = 24.dp
 private val THUMB_WIDTH = 6.dp

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbar.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbar.kt
@@ -1,0 +1,275 @@
+package fr.forumhfr.redface2.feature.topic
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+/**
+ * #300 — intra-page position indicator + fast-scroll for a topic page.
+ *
+ * A thin, auto-hiding scrollbar overlaid on the right edge of the topic [LazyColumn]. It shows the
+ * reading position within the *current* page (between-page navigation is out of scope — #284/#283 cover
+ * that) and lets the user fast-scroll by dragging the thumb. Pure UI derived from [LazyListState] — no
+ * MVI/ViewModel/repository change.
+ *
+ * Two layers, deliberately separated (Compose pointer nodes don't share with siblings by default, so a
+ * full-height pointer overlay would swallow the list's own scroll/taps on the whole right strip):
+ *  - a full-height [Canvas] that only **draws** the thumb (no pointer input), and
+ *  - a small **hit target** placed only over the thumb (± a grab padding) that carries the drag gesture.
+ * Outside the thumb hit target there is no pointer node, so a normal vertical scroll / a tap on a
+ * right-aligned post action falls straight through to the list.
+ *
+ * Geometry uses an **index-based** model (pragmatic v1): thumb size ≈ visibleItems/totalItems, thumb top
+ * ≈ firstVisibleIndex/totalItems with sub-item interpolation from the scroll offset. Variable post
+ * heights make this an approximation; a single post taller than the viewport yields a coarse thumb
+ * (sizeFraction ≈ 1) and a coarse fast-scroll — accepted for v1. "Is there anything to scroll" is read
+ * from [LazyListState.canScrollForward]/[LazyListState.canScrollBackward], NOT from visible ≥ total
+ * (which is false when one item is taller than the viewport). It works in pure `LazyListState` index
+ * space (the header card is lazy item 0), so thumb position and `scrollToItem` stay mutually consistent
+ * — no header offset to apply.
+ */
+@Composable
+internal fun TopicScrollbar(
+    listState: LazyListState,
+    modifier: Modifier = Modifier,
+) {
+    val canScroll by remember {
+        derivedStateOf { listState.canScrollForward || listState.canScrollBackward }
+    }
+    val metrics by remember {
+        derivedStateOf {
+            val info = listState.layoutInfo
+            scrollbarMetrics(
+                firstVisibleItemIndex = listState.firstVisibleItemIndex,
+                firstVisibleItemScrollOffset = listState.firstVisibleItemScrollOffset,
+                firstVisibleItemSize = info.visibleItemsInfo.firstOrNull()?.size ?: 0,
+                visibleItemsCount = info.visibleItemsInfo.size,
+                totalItemsCount = info.totalItemsCount,
+            )
+        }
+    }
+
+    var isDragging by remember { mutableStateOf(false) }
+    val active = canScroll && metrics != null
+
+    // Visible while scrolling or dragging; otherwise a brief show-then-fade. The idle branch also fires
+    // on the first composition of a scrollable page (initial flash → discoverability of the fast-scroll
+    // affordance) and after a scroll settles (post-scroll hold). The LaunchedEffect restarts on every
+    // (active / scroll / drag) change, so a scroll resuming within the hold cancels the pending fade.
+    var alphaTarget by remember { mutableStateOf(0f) }
+    LaunchedEffect(active, listState.isScrollInProgress, isDragging) {
+        when {
+            !active -> alphaTarget = 0f
+            listState.isScrollInProgress || isDragging -> alphaTarget = 1f
+            else -> {
+                alphaTarget = 1f
+                delay(HIDE_DELAY_MS)
+                alphaTarget = 0f
+            }
+        }
+    }
+    val alpha by animateFloatAsState(targetValue = alphaTarget, label = "topicScrollbarAlpha")
+    val thumbColor = MaterialTheme.colorScheme.primary
+
+    // Read live counts inside the gesture without re-keying the pointerInput on the (per-frame) metrics.
+    val currentVisibleCount = rememberUpdatedState(listState.layoutInfo.visibleItemsInfo.size)
+    val currentTotalCount = rememberUpdatedState(listState.layoutInfo.totalItemsCount)
+    val scope = rememberCoroutineScope()
+    var lastTargetIndex by remember { mutableIntStateOf(-1) }
+    var scrollJob by remember { mutableStateOf<Job?>(null) }
+
+    // Hoisted out of the layout tree so the `if` they contain doesn't add nesting depth below.
+    val onDraggingChange: (Boolean) -> Unit = { dragging ->
+        isDragging = dragging
+        if (dragging) lastTargetIndex = -1 // a fresh grab always re-evaluates the target
+    }
+    val onSeek: (Float) -> Unit = { travelFraction ->
+        val index = targetIndexForDrag(
+            travelFraction = travelFraction,
+            visibleItemsCount = currentVisibleCount.value,
+            totalItemsCount = currentTotalCount.value,
+        )
+        if (index != lastTargetIndex) {
+            lastTargetIndex = index
+            scrollJob?.cancel()
+            scrollJob = scope.launch { listState.scrollToItem(index) }
+        }
+    }
+
+    BoxWithConstraints(
+        modifier = modifier
+            .width(SCROLLBAR_GUTTER_WIDTH)
+            .fillMaxHeight(),
+    ) {
+        val trackHeightPx = constraints.maxHeight.toFloat()
+        Canvas(modifier = Modifier.fillMaxSize().clearAndSetSemantics { }) {
+            val m = metrics
+            if (alpha > 0f && m != null) {
+                drawScrollbarThumb(metrics = m, alpha = alpha, color = thumbColor)
+            }
+        }
+        val m = metrics
+        if (active && m != null) {
+            ThumbHitTarget(
+                listState = listState,
+                trackHeightPx = trackHeightPx,
+                metrics = m,
+                onDraggingChange = onDraggingChange,
+                onSeek = onSeek,
+            )
+        }
+    }
+}
+
+/**
+ * The thumb-only drag surface. Placed at the thumb's current vertical offset (± [GRAB_PADDING]) so it is
+ * the *only* pointer node in the gutter — everything else stays scrollable/tappable. The drag maps the
+ * finger's absolute track position back from the live hit-target top: `trackY = hitTop + localY`, which
+ * stays correct frame-to-frame even as the thumb (and this surface) moves under the finger.
+ */
+@Composable
+private fun ThumbHitTarget(
+    listState: LazyListState,
+    trackHeightPx: Float,
+    metrics: ScrollbarMetrics,
+    onDraggingChange: (Boolean) -> Unit,
+    onSeek: (Float) -> Unit,
+) {
+    val padPx = with(LocalDensity.current) { GRAB_PADDING.toPx() }
+    val thumbTopPx = metrics.offsetFraction * trackHeightPx
+    val thumbHeightPx = metrics.sizeFraction * trackHeightPx
+    val hitTopPx = (thumbTopPx - padPx).coerceAtLeast(0f)
+    val hitHeight = with(LocalDensity.current) { (thumbHeightPx + 2f * padPx).toDp() }
+    val liveMetrics = rememberUpdatedState(metrics)
+    val liveSeek = rememberUpdatedState(onSeek)
+    val liveDragging = rememberUpdatedState(onDraggingChange)
+
+    Box(
+        modifier = Modifier
+            .offset { IntOffset(x = 0, y = hitTopPx.roundToInt()) }
+            .fillMaxWidth()
+            .height(hitHeight)
+            .pointerInput(listState) {
+                detectVerticalDragGestures(
+                    onDragStart = { liveDragging.value(true) },
+                    onDragEnd = { liveDragging.value(false) },
+                    onDragCancel = { liveDragging.value(false) },
+                ) { change, _ ->
+                    change.consume()
+                    val thumbH = liveMetrics.value.sizeFraction * trackHeightPx
+                    val hitTopNow = (liveMetrics.value.offsetFraction * trackHeightPx - padPx).coerceAtLeast(0f)
+                    val trackY = hitTopNow + change.position.y
+                    val travel = (trackHeightPx - thumbH).coerceAtLeast(1f)
+                    val top = (trackY - thumbH / 2f).coerceIn(0f, travel)
+                    liveSeek.value(top / travel)
+                }
+            },
+    )
+}
+
+private fun DrawScope.drawScrollbarThumb(
+    metrics: ScrollbarMetrics,
+    alpha: Float,
+    color: Color,
+) {
+    val trackHeightPx = size.height
+    val thumbHeightPx = metrics.sizeFraction * trackHeightPx
+    val thumbTopPx = metrics.offsetFraction * trackHeightPx
+    val thumbWidthPx = THUMB_WIDTH.toPx()
+    drawRoundRect(
+        color = color.copy(alpha = THUMB_ALPHA * alpha),
+        topLeft = Offset(size.width - thumbWidthPx, thumbTopPx),
+        size = Size(thumbWidthPx, thumbHeightPx),
+        cornerRadius = CornerRadius(thumbWidthPx / 2f, thumbWidthPx / 2f),
+    )
+}
+
+/**
+ * Geometry of the scrollbar thumb, derived from the lazy list. [offsetFraction] ∈ [0, 1] is the top of
+ * the thumb as a fraction of the track; [sizeFraction] ∈ (0, 1] is the thumb height as a fraction of the
+ * track.
+ */
+internal data class ScrollbarMetrics(
+    val offsetFraction: Float,
+    val sizeFraction: Float,
+)
+
+/**
+ * Pure thumb geometry. Returns `null` only when there is nothing to represent ([totalItemsCount] ≤ 0 or
+ * no visible item) — the "page fits, nothing to scroll" decision is taken by the caller from
+ * `canScrollForward/Backward`, NOT from `visibleItemsCount >= totalItemsCount` (false when a single item
+ * is taller than the viewport). Index-based with sub-item interpolation; [firstVisibleItemSize] ≤ 0 is
+ * tolerated (no sub-item contribution).
+ */
+internal fun scrollbarMetrics(
+    firstVisibleItemIndex: Int,
+    firstVisibleItemScrollOffset: Int,
+    firstVisibleItemSize: Int,
+    visibleItemsCount: Int,
+    totalItemsCount: Int,
+): ScrollbarMetrics? {
+    if (totalItemsCount <= 0 || visibleItemsCount <= 0) return null
+    val sizeFraction = (visibleItemsCount.toFloat() / totalItemsCount).coerceIn(MIN_THUMB_FRACTION, 1f)
+    val subItem =
+        if (firstVisibleItemSize > 0) firstVisibleItemScrollOffset.toFloat() / firstVisibleItemSize else 0f
+    val offsetFraction =
+        ((firstVisibleItemIndex + subItem) / totalItemsCount).coerceIn(0f, 1f - sizeFraction)
+    return ScrollbarMetrics(offsetFraction = offsetFraction, sizeFraction = sizeFraction)
+}
+
+/**
+ * Maps the thumb's travel fraction (∈ [0, 1] over its *available* travel = track − thumb) to a target
+ * first-visible item index, consistent with [scrollbarMetrics] (max offset 1 − sizeFraction ⇔
+ * firstVisibleIndex = total − visible). Clamps so a shrinking [totalItemsCount] mid-drag never yields a
+ * negative index.
+ */
+internal fun targetIndexForDrag(
+    travelFraction: Float,
+    visibleItemsCount: Int,
+    totalItemsCount: Int,
+): Int {
+    val maxFirstIndex = (totalItemsCount - visibleItemsCount.coerceAtLeast(1)).coerceAtLeast(0)
+    return (travelFraction.coerceIn(0f, 1f) * maxFirstIndex).roundToInt()
+}
+
+private const val THUMB_ALPHA = 0.7f
+internal const val MIN_THUMB_FRACTION = 0.08f
+private const val HIDE_DELAY_MS = 800L
+private val SCROLLBAR_GUTTER_WIDTH = 24.dp
+private val THUMB_WIDTH = 6.dp
+private val GRAB_PADDING = 12.dp

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -31,6 +31,13 @@ data class TopicUiState(
      * always-visible behaviour). Flips on the first preference emission.
      */
     val topBarAutoHide: Boolean = false,
+    /**
+     * #335 — `true` while a manual pull-to-refresh of the current page is in flight. Drives the
+     * Material3 `PullToRefreshBox` spinner. Set on the `Refresh` intent, cleared in the refresh
+     * coroutine's `finally` (so a cancellation — e.g. a delete starting mid-refresh — never leaves
+     * the indicator stuck).
+     */
+    val isRefreshing: Boolean = false,
 ) {
     /**
      * Helper used by the screen / ViewModel : `true` when the user has navigated to a
@@ -69,6 +76,13 @@ data class TopicUiState(
 
 sealed interface TopicIntent {
     data object Retry : TopicIntent
+
+    /**
+     * #335 — manual pull-to-refresh of the currently open page. Re-fetches over the network and
+     * updates the loaded page in place, without the post-submit overflow redirect (#226) or any
+     * scroll effect, so the user keeps their reading position.
+     */
+    data object Refresh : TopicIntent
 
     /**
      * #292 — confirmed deletion of one of the user's own (normal) posts. The screen shows a
@@ -128,6 +142,12 @@ sealed interface TopicEffect {
      * the submit silently failed.
      */
     data object PostSubmitRefreshFailed : TopicEffect
+
+    /**
+     * #335 — emitted when a manual pull-to-refresh (`Refresh` intent) failed to reach HFR. The
+     * current page stays on screen (cache-first); the screen surfaces a Toast inviting a retry.
+     */
+    data object RefreshFailed : TopicEffect
 
     /**
      * Issue #226 — emitted after a plain-reply submit when the reply overflowed the topic onto a

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -116,6 +116,51 @@ class TopicViewModel @AssistedInject constructor(
             // to recover from a transient error.
             TopicIntent.Retry -> loadCurrentPage()
             is TopicIntent.DeletePost -> deletePost(intent.numreponse)
+            TopicIntent.Refresh -> refresh()
+        }
+    }
+
+    /**
+     * #335 — manual pull-to-refresh of the current page. Re-fetches over the network and replaces the
+     * loaded page in place, WITHOUT the post-submit overflow redirect (#226) or any scroll effect, so
+     * the user keeps their reading position. NO-OP unless a page is already loaded and no refresh is
+     * in flight (guards a double pull). `isRefreshing` is cleared in `finally` so a cancellation —
+     * e.g. a delete's `refreshAfterDelete` re-assigning `loadJob` mid-refresh — never leaves the
+     * spinner stuck.
+     *
+     * konsist:bypass-prefetch-guard — cancels the in-flight prefetch and force-fetches the page; this
+     * is an explicit user-initiated authenticated refresh, not an anonymous warmup escalating to
+     * authenticated (same justification as `forceRefreshCurrentPage`).
+     */
+    private fun refresh() {
+        if (_state.value.mode !is TopicUiState.Mode.Loaded || _state.value.isRefreshing) return
+        loadJob?.cancel()
+        prefetchJob?.cancel()
+        prefetchedPage = null
+        _state.update { it.copy(isRefreshing = true) }
+        loadJob = viewModelScope.launch {
+            try {
+                val topic = topicRepository.refreshTopicPage(request.cat, request.post, request.page)
+                _state.update {
+                    it.copy(
+                        mode = TopicUiState.Mode.Loaded(topic),
+                        availablePages = (1..topic.totalPages).toList(),
+                    )
+                }
+                // Re-arm the page+1 warmup, like `loadCurrentPage` (l. ~219). Unlike the post-submit
+                // `forceRefreshCurrentPage` (which deliberately skips it), a manual mid-page pull is
+                // exactly when the user keeps reading forward, so re-warming page+1 restores the
+                // prefetch benefit lost by the `prefetchedPage = null` reset above.
+                maybeSchedulePrefetch(totalPages = topic.totalPages)
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (@Suppress("TooGenericExceptionCaught") refreshError: Exception) {
+                // Cache-first: keep the page currently on screen and invite a retry via a Toast.
+                android.util.Log.w(LOG_TAG, "Manual refresh failed", refreshError)
+                _effects.send(TopicEffect.RefreshFailed)
+            } finally {
+                _state.update { it.copy(isRefreshing = false) }
+            }
         }
     }
 

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="topic_post_edit">Modifier</string>
     <string name="topic_edit_first_post">Modifier le premier message</string>
     <string name="topic_post_submit_refresh_failed">Message envoyé, mais le rafraîchissement de la page a échoué. Tirez pour réessayer.</string>
+    <string name="topic_refresh_failed">Le rafraîchissement a échoué. Réessayez.</string>
     <string name="topic_open_profile_action">Voir le profil</string>
 
     <!-- #292 — suppression d'un de ses propres posts (post normal). -->

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -1,6 +1,10 @@
 <resources>
     <string name="topic_scroll_to">Scroll ciblé demandé vers le post %1$d.</string>
     <string name="topic_reply">Répondre depuis ce topic</string>
+    <!-- #283 — bottom floating action cluster: reach reply + page change without scrolling to the header. -->
+    <string name="topic_fab_reply">Répondre</string>
+    <string name="topic_fab_previous_page">Page précédente</string>
+    <string name="topic_fab_next_page">Page suivante</string>
     <string name="topic_loading">Chargement…</string>
     <!-- #285 — top app bar : back affordance (content description) + fallback title shown while
          the topic page has not loaded yet (or errored), so the bar never reads blank. -->

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbarTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbarTest.kt
@@ -1,209 +1,114 @@
 package fr.forumhfr.redface2.feature.topic
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * #300 — pure-geometry tests for the topic scrollbar, **pixel-based** model. Composable behaviour
- * (auto-hide, gesture) is not unit-tested here; the value is in the position/size math, the
- * drag→index mapping, and the two regression guards for the "jumps + resizes" bug (thumb size must not
- * depend on the integer count of visible items; thumb travel must be uniform per scrolled pixel).
+ * #300 — pure-geometry tests for the topic scrollbar, **fixed-size + ordinal** model. Composable
+ * behaviour (auto-hide, gesture, the spring on the drawn offset) is not unit-tested here; the value is
+ * in the position math, the drag→index inverse, and the regression guards for the "jumps + grows
+ * suddenly" bug: the thumb size must be constant (never derived from content) and the position must be
+ * a pure ordinal of the first-visible index (never derived from measured item sizes).
  */
 class TopicScrollbarTest {
 
     private val tolerance = 1e-4f
 
-    // Keeps the drag-mapping assertions short (named args inline blow past MaxLineLength). Defaults
-    // mirror the common case: estimatedTotal = 100 × 20 = 2000, viewport 500 → maxScroll 1500.
-    private fun dragIndex(travel: Float, avg: Float = 100f, total: Int = 20, viewport: Float = 500f): Int =
-        targetIndexForDrag(travel, averageItemSizePx = avg, totalItemsCount = total, viewportHeightPx = viewport)
+    @Test
+    fun `scrollbarMetrics returns null for a single item (no ordinal progress)`() {
+        assertNull(scrollbarMetrics(firstVisibleItemIndex = 0, totalItemsCount = 1))
+    }
 
     @Test
     fun `scrollbarMetrics returns null when there is no item`() {
-        assertNull(
-            scrollbarMetrics(
-                firstVisibleItemIndex = 0,
-                firstVisibleItemScrollOffset = 0,
-                averageItemSizePx = 100f,
-                totalItemsCount = 0,
-                viewportHeightPx = 1000f,
-            ),
-        )
+        assertNull(scrollbarMetrics(firstVisibleItemIndex = 0, totalItemsCount = 0))
     }
 
     @Test
-    fun `scrollbarMetrics returns null when nothing is visible (zero average size)`() {
-        // An empty visible set surfaces as averageItemSizePx == 0f (cf. List.averageItemSizePx()).
-        assertNull(
-            scrollbarMetrics(
-                firstVisibleItemIndex = 0,
-                firstVisibleItemScrollOffset = 0,
-                averageItemSizePx = 0f,
-                totalItemsCount = 10,
-                viewportHeightPx = 1000f,
-            ),
-        )
-    }
-
-    @Test
-    fun `scrollbarMetrics returns null when the viewport is not measured yet`() {
-        assertNull(
-            scrollbarMetrics(
-                firstVisibleItemIndex = 0,
-                firstVisibleItemScrollOffset = 0,
-                averageItemSizePx = 100f,
-                totalItemsCount = 10,
-                viewportHeightPx = 0f,
-            ),
-        )
-    }
-
-    @Test
-    fun `scrollbarMetrics is non-null on a single item taller than the viewport (still scrollable)`() {
-        // One post taller than the viewport must NOT be treated as "nothing to scroll": the caller
-        // gates visibility on canScrollForward/Backward.
-        val metrics = scrollbarMetrics(
-            firstVisibleItemIndex = 0,
-            firstVisibleItemScrollOffset = 0,
-            averageItemSizePx = 4000f,
-            totalItemsCount = 1,
-            viewportHeightPx = 2000f,
-        )
-        assertNotNull(metrics)
-        assertEquals(0.5f, metrics!!.sizeFraction, tolerance)
-    }
-
-    @Test
-    fun `offsetFraction is 0 and sizeFraction is the viewport ratio at the top of the page`() {
-        val metrics = scrollbarMetrics(
-            firstVisibleItemIndex = 0,
-            firstVisibleItemScrollOffset = 0,
-            averageItemSizePx = 100f,
-            totalItemsCount = 10,
-            viewportHeightPx = 500f,
-        )!!
-        // estimatedTotal = 100 * 10 = 1000 ; viewport 500 → sizeFraction = 0.5.
+    fun `offsetFraction is 0 at the top of the page`() {
+        val metrics = scrollbarMetrics(firstVisibleItemIndex = 0, totalItemsCount = 10)!!
         assertEquals(0f, metrics.offsetFraction, tolerance)
-        assertEquals(0.5f, metrics.sizeFraction, tolerance)
     }
 
     @Test
-    fun `offsetFraction reaches 1 minus sizeFraction at the bottom of the page`() {
-        // maxScroll = 1000 - 500 = 500 ; scrolledPx = 5 * 100 = 500 = maxScroll → bottom.
-        val metrics = scrollbarMetrics(
-            firstVisibleItemIndex = 5,
-            firstVisibleItemScrollOffset = 0,
-            averageItemSizePx = 100f,
-            totalItemsCount = 10,
-            viewportHeightPx = 500f,
-        )!!
+    fun `offsetFraction reaches 1 minus sizeFraction at the last ordinal`() {
+        val metrics = scrollbarMetrics(firstVisibleItemIndex = 9, totalItemsCount = 10)!!
         assertEquals(1f - metrics.sizeFraction, metrics.offsetFraction, tolerance)
     }
 
     @Test
-    fun `sizeFraction respects the minimum thumb floor on a very long page`() {
-        val metrics = scrollbarMetrics(
-            firstVisibleItemIndex = 0,
-            firstVisibleItemScrollOffset = 0,
-            averageItemSizePx = 50f,
-            totalItemsCount = 200,
-            viewportHeightPx = 300f,
-        )!!
-        // raw = 300 / (50 * 200) = 0.03, floored to MIN_THUMB_FRACTION.
-        assertEquals(MIN_THUMB_FRACTION, metrics.sizeFraction, tolerance)
+    fun `offsetFraction clamps a transient out-of-range index`() {
+        // firstVisibleItemIndex should never exceed total, but a transient layoutInfo must not overshoot.
+        val metrics = scrollbarMetrics(firstVisibleItemIndex = 20, totalItemsCount = 10)!!
+        assertEquals(1f - metrics.sizeFraction, metrics.offsetFraction, tolerance)
+    }
+
+    // --- Regression guards for the "jumps + grows suddenly" bug -------------------------------------
+
+    @Test
+    fun `thumb size is a constant, independent of the page or position`() {
+        // The two earlier models tied the size to a moving estimate (visible count, or viewport/estTotal);
+        // that was the "grows suddenly" symptom. The fixed model must return the same size everywhere.
+        assertEquals(THUMB_SIZE_FRACTION, scrollbarMetrics(0, 10)!!.sizeFraction, tolerance)
+        assertEquals(THUMB_SIZE_FRACTION, scrollbarMetrics(5, 10)!!.sizeFraction, tolerance)
+        assertEquals(THUMB_SIZE_FRACTION, scrollbarMetrics(500, 1000)!!.sizeFraction, tolerance)
     }
 
     @Test
-    fun `content shorter than the viewport pins a full thumb at the top`() {
-        // estimatedTotal = 100 * 2 = 200 < viewport 500 → nothing to scroll: full thumb, offset 0.
-        val metrics = scrollbarMetrics(
-            firstVisibleItemIndex = 0,
-            firstVisibleItemScrollOffset = 0,
-            averageItemSizePx = 100f,
-            totalItemsCount = 2,
-            viewportHeightPx = 500f,
-        )!!
-        assertEquals(1f, metrics.sizeFraction, tolerance)
-        assertEquals(0f, metrics.offsetFraction, tolerance)
-    }
-
-    @Test
-    fun `sub-item scroll offset increases offsetFraction monotonically`() {
-        val atTop = scrollbarMetrics(0, 0, 100f, 10, 500f)!!
-        val scrolledWithinFirstItem = scrollbarMetrics(0, 50, 100f, 10, 500f)!!
-        assertTrue(scrolledWithinFirstItem.offsetFraction > atTop.offsetFraction)
-    }
-
-    // --- Regression guards for the "jumps + resizes" bug (index-based model) -------------------------
-
-    @Test
-    fun `thumb size is independent of how many items happen to be visible`() {
-        // The index-based model used visibleItemsCount/total, so the thumb resized by whole-item steps
-        // as a tall post entered/left the viewport. The pixel model derives size from the average size
-        // and the viewport only — the count of visible items must not change it.
-        val withThreeVisible = scrollbarMetrics(0, 0, 200f, 20, 800f)!!
-        val withFourVisible = scrollbarMetrics(0, 0, 200f, 20, 800f)!!
-        assertEquals(withThreeVisible.sizeFraction, withFourVisible.sizeFraction, tolerance)
-    }
-
-    @Test
-    fun `thumb travel is uniform per scrolled pixel`() {
-        // Equal scroll deltas (one average item each) must move the thumb by equal offset deltas — the
-        // index-based model jumped fast over a short post and crawled over a tall one for the same step.
-        val m0 = scrollbarMetrics(0, 0, 100f, 20, 500f)!!
-        val m1 = scrollbarMetrics(1, 0, 100f, 20, 500f)!!
-        val m2 = scrollbarMetrics(2, 0, 100f, 20, 500f)!!
+    fun `position advances by equal ordinal steps`() {
+        // Pure ordinal: each first-visible-index increment moves the thumb by the same amount,
+        // (1/(total-1)) * (1 - sizeFraction) — no dependence on measured item heights.
+        val m0 = scrollbarMetrics(0, 10)!!
+        val m1 = scrollbarMetrics(1, 10)!!
+        val m2 = scrollbarMetrics(2, 10)!!
         val firstStep = m1.offsetFraction - m0.offsetFraction
         val secondStep = m2.offsetFraction - m1.offsetFraction
+        assertTrue("position is monotonic with the index", firstStep > 0f)
         assertEquals(firstStep, secondStep, tolerance)
+        assertEquals((1f / 9f) * (1f - THUMB_SIZE_FRACTION), firstStep, tolerance)
     }
 
-    @Test
-    fun `offsetFraction is continuous across an item boundary`() {
-        // Scrolling the first item fully out (offset == averageSize) must land on the same thumb
-        // position as the next item appearing at the top with no sub-item offset.
-        val endOfFirstItem = scrollbarMetrics(0, 100, 100f, 20, 500f)!!
-        val startOfSecondItem = scrollbarMetrics(1, 0, 100f, 20, 500f)!!
-        assertEquals(endOfFirstItem.offsetFraction, startOfSecondItem.offsetFraction, tolerance)
-    }
-
-    // --- targetIndexForDrag (drag → first-visible item index), same estimated-height model -----------
+    // --- targetIndexForDrag (drag → first-visible item index), inverse of the ordinal mapping --------
 
     @Test
-    fun `targetIndexForDrag maps full travel to the last scrollable item`() {
-        // maxScroll = 1500 ; full travel → 1500 / 100 = 15.
-        assertEquals(15, dragIndex(1f))
+    fun `targetIndexForDrag maps full travel to the last item`() {
+        assertEquals(9, targetIndexForDrag(travelFraction = 1f, totalItemsCount = 10))
     }
 
     @Test
     fun `targetIndexForDrag maps zero travel to the first item`() {
-        assertEquals(0, dragIndex(0f))
+        assertEquals(0, targetIndexForDrag(travelFraction = 0f, totalItemsCount = 10))
     }
 
     @Test
-    fun `targetIndexForDrag maps half travel to the middle of the scrollable range`() {
-        // maxScroll = (100*20) - 600 = 1400 ; half → 700 / 100 = 7.
-        assertEquals(7, dragIndex(0.5f, viewport = 600f))
+    fun `targetIndexForDrag maps half travel to the middle ordinal`() {
+        // 0.5 * (11 - 1) = 5.
+        assertEquals(5, targetIndexForDrag(travelFraction = 0.5f, totalItemsCount = 11))
     }
 
     @Test
     fun `targetIndexForDrag clamps an out-of-range travel fraction`() {
-        assertEquals(15, dragIndex(2f))
-        assertEquals(0, dragIndex(-1f))
+        assertEquals(9, targetIndexForDrag(travelFraction = 2f, totalItemsCount = 10))
+        assertEquals(0, targetIndexForDrag(travelFraction = -1f, totalItemsCount = 10))
     }
 
     @Test
-    fun `targetIndexForDrag never exceeds the last index`() {
-        // estimatedTotal = 100 * 5 = 500 ; maxScroll = 450 ; 450 / 100 = 4.5 → 5, clamped to total-1 = 4.
-        assertEquals(4, dragIndex(1f, total = 5, viewport = 50f))
+    fun `targetIndexForDrag returns 0 on a degenerate count`() {
+        assertEquals(0, targetIndexForDrag(travelFraction = 1f, totalItemsCount = 1))
+        assertEquals(0, targetIndexForDrag(travelFraction = 1f, totalItemsCount = 0))
     }
 
     @Test
-    fun `targetIndexForDrag returns 0 on degenerate inputs`() {
-        assertEquals(0, dragIndex(1f, avg = 0f, total = 10))
-        assertEquals(0, dragIndex(1f, total = 0))
+    fun `drag and position are mutual inverses`() {
+        // The thumb-travel fraction of ordinal i is offsetFraction / (1 - sizeFraction) = i / (total-1);
+        // feeding it back must recover i.
+        val total = 10
+        for (i in 0 until total) {
+            val metrics = scrollbarMetrics(firstVisibleItemIndex = i, totalItemsCount = total)!!
+            val travelFraction = metrics.offsetFraction / (1f - metrics.sizeFraction)
+            assertEquals(i, targetIndexForDrag(travelFraction, total))
+        }
     }
 }

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbarTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbarTest.kt
@@ -6,71 +6,117 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * #300 — pure-geometry tests for the topic scrollbar, **fixed-size + ordinal** model. Composable
- * behaviour (auto-hide, gesture, the spring on the drawn offset) is not unit-tested here; the value is
- * in the position math, the drag→index inverse, and the regression guards for the "jumps + grows
- * suddenly" bug: the thumb size must be constant (never derived from content) and the position must be
- * a pure ordinal of the first-visible index (never derived from measured item sizes).
+ * #300 — pure-geometry tests for the topic scrollbar, **fixed-size ordinal + sub-item interpolation**.
+ * Composable behaviour (auto-hide, gesture, the offset spring) is not unit-tested here; the value is in
+ * the position math, the drag→index inverse, and the regression guards: the thumb size is constant
+ * (never derived from content), the position interpolates continuously within a post (no per-post step),
+ * and a #197-style growth of the top post can move the thumb by at most one ordinal step.
  */
 class TopicScrollbarTest {
 
     private val tolerance = 1e-4f
 
+    // Keeps the 4-arg calls short. Defaults: a 10-item page, 100px items, at the very top.
+    private fun metrics(index: Int, offset: Int = 0, size: Int = 100, total: Int = 10) =
+        scrollbarMetrics(
+            firstVisibleItemIndex = index,
+            firstVisibleItemScrollOffset = offset,
+            firstVisibleItemSize = size,
+            totalItemsCount = total,
+        )
+
+    private fun oneOrdinalStep(total: Int) = (1f / (total - 1)) * (1f - THUMB_SIZE_FRACTION)
+
     @Test
-    fun `scrollbarMetrics returns null for a single item (no ordinal progress)`() {
-        assertNull(scrollbarMetrics(firstVisibleItemIndex = 0, totalItemsCount = 1))
+    fun `returns null for a single item (no ordinal progress)`() {
+        assertNull(metrics(index = 0, total = 1))
     }
 
     @Test
-    fun `scrollbarMetrics returns null when there is no item`() {
-        assertNull(scrollbarMetrics(firstVisibleItemIndex = 0, totalItemsCount = 0))
+    fun `returns null when there is no item`() {
+        assertNull(metrics(index = 0, total = 0))
     }
 
     @Test
-    fun `offsetFraction is 0 at the top of the page`() {
-        val metrics = scrollbarMetrics(firstVisibleItemIndex = 0, totalItemsCount = 10)!!
-        assertEquals(0f, metrics.offsetFraction, tolerance)
+    fun `offsetFraction is 0 at the very top`() {
+        assertEquals(0f, metrics(0)!!.offsetFraction, tolerance)
     }
 
     @Test
     fun `offsetFraction reaches 1 minus sizeFraction at the last ordinal`() {
-        val metrics = scrollbarMetrics(firstVisibleItemIndex = 9, totalItemsCount = 10)!!
-        assertEquals(1f - metrics.sizeFraction, metrics.offsetFraction, tolerance)
+        val m = metrics(9)!!
+        assertEquals(1f - m.sizeFraction, m.offsetFraction, tolerance)
     }
 
     @Test
     fun `offsetFraction clamps a transient out-of-range index`() {
-        // firstVisibleItemIndex should never exceed total, but a transient layoutInfo must not overshoot.
-        val metrics = scrollbarMetrics(firstVisibleItemIndex = 20, totalItemsCount = 10)!!
-        assertEquals(1f - metrics.sizeFraction, metrics.offsetFraction, tolerance)
+        val m = metrics(20)!!
+        assertEquals(1f - m.sizeFraction, m.offsetFraction, tolerance)
     }
 
-    // --- Regression guards for the "jumps + grows suddenly" bug -------------------------------------
+    // --- Regression guards --------------------------------------------------------------------------
 
     @Test
-    fun `thumb size is a constant, independent of the page or position`() {
-        // The two earlier models tied the size to a moving estimate (visible count, or viewport/estTotal);
-        // that was the "grows suddenly" symptom. The fixed model must return the same size everywhere.
-        assertEquals(THUMB_SIZE_FRACTION, scrollbarMetrics(0, 10)!!.sizeFraction, tolerance)
-        assertEquals(THUMB_SIZE_FRACTION, scrollbarMetrics(5, 10)!!.sizeFraction, tolerance)
-        assertEquals(THUMB_SIZE_FRACTION, scrollbarMetrics(500, 1000)!!.sizeFraction, tolerance)
+    fun `thumb size is a constant, independent of page or position`() {
+        assertEquals(THUMB_SIZE_FRACTION, metrics(0)!!.sizeFraction, tolerance)
+        assertEquals(THUMB_SIZE_FRACTION, metrics(5)!!.sizeFraction, tolerance)
+        assertEquals(THUMB_SIZE_FRACTION, metrics(500, total = 1000)!!.sizeFraction, tolerance)
     }
 
     @Test
-    fun `position advances by equal ordinal steps`() {
-        // Pure ordinal: each first-visible-index increment moves the thumb by the same amount,
-        // (1/(total-1)) * (1 - sizeFraction) — no dependence on measured item heights.
-        val m0 = scrollbarMetrics(0, 10)!!
-        val m1 = scrollbarMetrics(1, 10)!!
-        val m2 = scrollbarMetrics(2, 10)!!
-        val firstStep = m1.offsetFraction - m0.offsetFraction
-        val secondStep = m2.offsetFraction - m1.offsetFraction
-        assertTrue("position is monotonic with the index", firstStep > 0f)
-        assertEquals(firstStep, secondStep, tolerance)
-        assertEquals((1f / 9f) * (1f - THUMB_SIZE_FRACTION), firstStep, tolerance)
+    fun `sub-item interpolation moves the thumb continuously within a post`() {
+        // Scrolling within the first post (offset 0 → mid) advances the thumb, but stays inside the
+        // first ordinal step (never reaches the next anchor).
+        val top = metrics(0, offset = 0)!!.offsetFraction
+        val mid = metrics(0, offset = 50)!!.offsetFraction
+        val nextAnchor = metrics(1, offset = 0)!!.offsetFraction
+        assertTrue("interpolates upward within the post", mid > top)
+        assertTrue("stays below the next anchor", mid < nextAnchor)
     }
 
-    // --- targetIndexForDrag (drag → first-visible item index), inverse of the ordinal mapping --------
+    @Test
+    fun `position is near-continuous across a post boundary (no per-post step)`() {
+        // End of post 0 (offset clamped to size-1) vs start of post 1: the gap must be a tiny fraction
+        // of one ordinal step, NOT a full step — that is what removes the "à-coup".
+        val endOfFirst = metrics(0, offset = 99, size = 100)!!.offsetFraction
+        val startOfSecond = metrics(1, offset = 0, size = 100)!!.offsetFraction
+        val gap = startOfSecond - endOfFirst
+        assertTrue("monotonic across the boundary", gap >= 0f)
+        assertTrue("gap is far smaller than one ordinal step", gap < oneOrdinalStep(10) * 0.1f)
+    }
+
+    @Test
+    fun `the last post ignores sub-item offset so progress never exceeds 1`() {
+        // index == lastIndex forces itemFraction = 0; a non-zero offset must not push offset past the end.
+        assertEquals(metrics(9, offset = 0)!!.offsetFraction, metrics(9, offset = 50)!!.offsetFraction, tolerance)
+        assertEquals(1f - THUMB_SIZE_FRACTION, metrics(9, offset = 50)!!.offsetFraction, tolerance)
+    }
+
+    @Test
+    fun `a zero item size falls back to the pure ordinal anchor`() {
+        // size 0 (item not measured yet) must not divide by zero; itemFraction = 0.
+        val ordinal = metrics(2, offset = 0)!!.offsetFraction
+        val unmeasured = metrics(2, offset = 30, size = 0)!!.offsetFraction
+        assertEquals(ordinal, unmeasured, tolerance)
+    }
+
+    @Test
+    fun `an oversized offset is clamped within one ordinal step`() {
+        // A transient offset larger than the item can't push the thumb past the next anchor.
+        val clamped = metrics(0, offset = 10_000, size = 100)!!.offsetFraction
+        assertTrue(clamped < metrics(1, offset = 0)!!.offsetFraction)
+    }
+
+    @Test
+    fun `a top-post growth wobbles the thumb by less than one ordinal step`() {
+        // #197 bound: same scroll offset, the top post grows 160→480 (px proxy). The thumb moves by less
+        // than one ordinal step while that post is on top — acceptable vs the per-post jerk it removes.
+        val before = metrics(3, offset = 120, size = 160)!!.offsetFraction
+        val after = metrics(3, offset = 120, size = 480)!!.offsetFraction
+        assertTrue(kotlin.math.abs(after - before) < oneOrdinalStep(10))
+    }
+
+    // --- targetIndexForDrag (drag → first-visible item index), inverse of the ordinal anchors --------
 
     @Test
     fun `targetIndexForDrag maps full travel to the last item`() {
@@ -84,7 +130,6 @@ class TopicScrollbarTest {
 
     @Test
     fun `targetIndexForDrag maps half travel to the middle ordinal`() {
-        // 0.5 * (11 - 1) = 5.
         assertEquals(5, targetIndexForDrag(travelFraction = 0.5f, totalItemsCount = 11))
     }
 
@@ -101,13 +146,13 @@ class TopicScrollbarTest {
     }
 
     @Test
-    fun `drag and position are mutual inverses`() {
-        // The thumb-travel fraction of ordinal i is offsetFraction / (1 - sizeFraction) = i / (total-1);
-        // feeding it back must recover i.
+    fun `drag and the post-anchor position are mutual inverses`() {
+        // At a post anchor (offset 0) the thumb-travel fraction is offsetFraction / (1 - sizeFraction) =
+        // i / (total-1); feeding it back must recover i.
         val total = 10
         for (i in 0 until total) {
-            val metrics = scrollbarMetrics(firstVisibleItemIndex = i, totalItemsCount = total)!!
-            val travelFraction = metrics.offsetFraction / (1f - metrics.sizeFraction)
+            val m = metrics(index = i, offset = 0, total = total)!!
+            val travelFraction = m.offsetFraction / (1f - m.sizeFraction)
             assertEquals(i, targetIndexForDrag(travelFraction, total))
         }
     }

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbarTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbarTest.kt
@@ -7,12 +7,19 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * #300 — pure-geometry tests for the topic scrollbar. Composable behaviour (auto-hide, gesture) is not
- * unit-tested here; the value is in the position/size math and the drag→index mapping.
+ * #300 — pure-geometry tests for the topic scrollbar, **pixel-based** model. Composable behaviour
+ * (auto-hide, gesture) is not unit-tested here; the value is in the position/size math, the
+ * drag→index mapping, and the two regression guards for the "jumps + resizes" bug (thumb size must not
+ * depend on the integer count of visible items; thumb travel must be uniform per scrolled pixel).
  */
 class TopicScrollbarTest {
 
     private val tolerance = 1e-4f
+
+    // Keeps the drag-mapping assertions short (named args inline blow past MaxLineLength). Defaults
+    // mirror the common case: estimatedTotal = 100 × 20 = 2000, viewport 500 → maxScroll 1500.
+    private fun dragIndex(travel: Float, avg: Float = 100f, total: Int = 20, viewport: Float = 500f): Int =
+        targetIndexForDrag(travel, averageItemSizePx = avg, totalItemsCount = total, viewportHeightPx = viewport)
 
     @Test
     fun `scrollbarMetrics returns null when there is no item`() {
@@ -20,61 +27,78 @@ class TopicScrollbarTest {
             scrollbarMetrics(
                 firstVisibleItemIndex = 0,
                 firstVisibleItemScrollOffset = 0,
-                firstVisibleItemSize = 100,
-                visibleItemsCount = 0,
+                averageItemSizePx = 100f,
                 totalItemsCount = 0,
+                viewportHeightPx = 1000f,
             ),
         )
     }
 
     @Test
-    fun `scrollbarMetrics returns null when no item is visible`() {
+    fun `scrollbarMetrics returns null when nothing is visible (zero average size)`() {
+        // An empty visible set surfaces as averageItemSizePx == 0f (cf. List.averageItemSizePx()).
         assertNull(
             scrollbarMetrics(
                 firstVisibleItemIndex = 0,
                 firstVisibleItemScrollOffset = 0,
-                firstVisibleItemSize = 100,
-                visibleItemsCount = 0,
+                averageItemSizePx = 0f,
                 totalItemsCount = 10,
+                viewportHeightPx = 1000f,
             ),
         )
     }
 
     @Test
-    fun `scrollbarMetrics is non-null even when all items are visible (tall item, still scrollable)`() {
-        // visibleItemsCount >= totalItemsCount must NOT be treated as "nothing to scroll": a single item
-        // taller than the viewport is scrollable. The caller gates visibility on canScrollForward/Backward.
-        val metrics = scrollbarMetrics(
-            firstVisibleItemIndex = 0,
-            firstVisibleItemScrollOffset = 0,
-            firstVisibleItemSize = 4000,
-            visibleItemsCount = 1,
-            totalItemsCount = 1,
+    fun `scrollbarMetrics returns null when the viewport is not measured yet`() {
+        assertNull(
+            scrollbarMetrics(
+                firstVisibleItemIndex = 0,
+                firstVisibleItemScrollOffset = 0,
+                averageItemSizePx = 100f,
+                totalItemsCount = 10,
+                viewportHeightPx = 0f,
+            ),
         )
-        assertNotNull(metrics)
     }
 
     @Test
-    fun `offsetFraction is 0 at the top of the page`() {
+    fun `scrollbarMetrics is non-null on a single item taller than the viewport (still scrollable)`() {
+        // One post taller than the viewport must NOT be treated as "nothing to scroll": the caller
+        // gates visibility on canScrollForward/Backward.
         val metrics = scrollbarMetrics(
             firstVisibleItemIndex = 0,
             firstVisibleItemScrollOffset = 0,
-            firstVisibleItemSize = 100,
-            visibleItemsCount = 5,
+            averageItemSizePx = 4000f,
+            totalItemsCount = 1,
+            viewportHeightPx = 2000f,
+        )
+        assertNotNull(metrics)
+        assertEquals(0.5f, metrics!!.sizeFraction, tolerance)
+    }
+
+    @Test
+    fun `offsetFraction is 0 and sizeFraction is the viewport ratio at the top of the page`() {
+        val metrics = scrollbarMetrics(
+            firstVisibleItemIndex = 0,
+            firstVisibleItemScrollOffset = 0,
+            averageItemSizePx = 100f,
             totalItemsCount = 10,
+            viewportHeightPx = 500f,
         )!!
+        // estimatedTotal = 100 * 10 = 1000 ; viewport 500 → sizeFraction = 0.5.
         assertEquals(0f, metrics.offsetFraction, tolerance)
         assertEquals(0.5f, metrics.sizeFraction, tolerance)
     }
 
     @Test
     fun `offsetFraction reaches 1 minus sizeFraction at the bottom of the page`() {
+        // maxScroll = 1000 - 500 = 500 ; scrolledPx = 5 * 100 = 500 = maxScroll → bottom.
         val metrics = scrollbarMetrics(
             firstVisibleItemIndex = 5,
             firstVisibleItemScrollOffset = 0,
-            firstVisibleItemSize = 100,
-            visibleItemsCount = 5,
+            averageItemSizePx = 100f,
             totalItemsCount = 10,
+            viewportHeightPx = 500f,
         )!!
         assertEquals(1f - metrics.sizeFraction, metrics.offsetFraction, tolerance)
     }
@@ -84,57 +108,102 @@ class TopicScrollbarTest {
         val metrics = scrollbarMetrics(
             firstVisibleItemIndex = 0,
             firstVisibleItemScrollOffset = 0,
-            firstVisibleItemSize = 50,
-            visibleItemsCount = 2,
+            averageItemSizePx = 50f,
             totalItemsCount = 200,
+            viewportHeightPx = 300f,
         )!!
-        // raw = 2/200 = 0.01, floored to MIN_THUMB_FRACTION.
+        // raw = 300 / (50 * 200) = 0.03, floored to MIN_THUMB_FRACTION.
         assertEquals(MIN_THUMB_FRACTION, metrics.sizeFraction, tolerance)
     }
 
     @Test
+    fun `content shorter than the viewport pins a full thumb at the top`() {
+        // estimatedTotal = 100 * 2 = 200 < viewport 500 → nothing to scroll: full thumb, offset 0.
+        val metrics = scrollbarMetrics(
+            firstVisibleItemIndex = 0,
+            firstVisibleItemScrollOffset = 0,
+            averageItemSizePx = 100f,
+            totalItemsCount = 2,
+            viewportHeightPx = 500f,
+        )!!
+        assertEquals(1f, metrics.sizeFraction, tolerance)
+        assertEquals(0f, metrics.offsetFraction, tolerance)
+    }
+
+    @Test
     fun `sub-item scroll offset increases offsetFraction monotonically`() {
-        val atTop = scrollbarMetrics(0, 0, 100, 5, 10)!!
-        val scrolledWithinFirstItem = scrollbarMetrics(0, 50, 100, 5, 10)!!
+        val atTop = scrollbarMetrics(0, 0, 100f, 10, 500f)!!
+        val scrolledWithinFirstItem = scrollbarMetrics(0, 50, 100f, 10, 500f)!!
         assertTrue(scrolledWithinFirstItem.offsetFraction > atTop.offsetFraction)
     }
 
+    // --- Regression guards for the "jumps + resizes" bug (index-based model) -------------------------
+
     @Test
-    fun `firstVisibleItemSize of zero does not crash and contributes no sub-item offset`() {
-        val metrics = scrollbarMetrics(
-            firstVisibleItemIndex = 2,
-            firstVisibleItemScrollOffset = 30,
-            firstVisibleItemSize = 0,
-            visibleItemsCount = 5,
-            totalItemsCount = 10,
-        )!!
-        assertEquals(0.2f, metrics.offsetFraction, tolerance)
+    fun `thumb size is independent of how many items happen to be visible`() {
+        // The index-based model used visibleItemsCount/total, so the thumb resized by whole-item steps
+        // as a tall post entered/left the viewport. The pixel model derives size from the average size
+        // and the viewport only — the count of visible items must not change it.
+        val withThreeVisible = scrollbarMetrics(0, 0, 200f, 20, 800f)!!
+        val withFourVisible = scrollbarMetrics(0, 0, 200f, 20, 800f)!!
+        assertEquals(withThreeVisible.sizeFraction, withFourVisible.sizeFraction, tolerance)
     }
 
     @Test
-    fun `targetIndexForDrag maps full travel below the visible window`() {
-        assertEquals(7, targetIndexForDrag(travelFraction = 1f, visibleItemsCount = 3, totalItemsCount = 10))
+    fun `thumb travel is uniform per scrolled pixel`() {
+        // Equal scroll deltas (one average item each) must move the thumb by equal offset deltas — the
+        // index-based model jumped fast over a short post and crawled over a tall one for the same step.
+        val m0 = scrollbarMetrics(0, 0, 100f, 20, 500f)!!
+        val m1 = scrollbarMetrics(1, 0, 100f, 20, 500f)!!
+        val m2 = scrollbarMetrics(2, 0, 100f, 20, 500f)!!
+        val firstStep = m1.offsetFraction - m0.offsetFraction
+        val secondStep = m2.offsetFraction - m1.offsetFraction
+        assertEquals(firstStep, secondStep, tolerance)
+    }
+
+    @Test
+    fun `offsetFraction is continuous across an item boundary`() {
+        // Scrolling the first item fully out (offset == averageSize) must land on the same thumb
+        // position as the next item appearing at the top with no sub-item offset.
+        val endOfFirstItem = scrollbarMetrics(0, 100, 100f, 20, 500f)!!
+        val startOfSecondItem = scrollbarMetrics(1, 0, 100f, 20, 500f)!!
+        assertEquals(endOfFirstItem.offsetFraction, startOfSecondItem.offsetFraction, tolerance)
+    }
+
+    // --- targetIndexForDrag (drag → first-visible item index), same estimated-height model -----------
+
+    @Test
+    fun `targetIndexForDrag maps full travel to the last scrollable item`() {
+        // maxScroll = 1500 ; full travel → 1500 / 100 = 15.
+        assertEquals(15, dragIndex(1f))
     }
 
     @Test
     fun `targetIndexForDrag maps zero travel to the first item`() {
-        assertEquals(0, targetIndexForDrag(travelFraction = 0f, visibleItemsCount = 3, totalItemsCount = 10))
+        assertEquals(0, dragIndex(0f))
     }
 
     @Test
     fun `targetIndexForDrag maps half travel to the middle of the scrollable range`() {
-        assertEquals(4, targetIndexForDrag(travelFraction = 0.5f, visibleItemsCount = 2, totalItemsCount = 10))
+        // maxScroll = (100*20) - 600 = 1400 ; half → 700 / 100 = 7.
+        assertEquals(7, dragIndex(0.5f, viewport = 600f))
     }
 
     @Test
     fun `targetIndexForDrag clamps an out-of-range travel fraction`() {
-        assertEquals(7, targetIndexForDrag(travelFraction = 2f, visibleItemsCount = 3, totalItemsCount = 10))
-        assertEquals(0, targetIndexForDrag(travelFraction = -1f, visibleItemsCount = 3, totalItemsCount = 10))
+        assertEquals(15, dragIndex(2f))
+        assertEquals(0, dragIndex(-1f))
     }
 
     @Test
-    fun `targetIndexForDrag never returns a negative index when visible exceeds total mid-drag`() {
-        // Simulates totalItemsCount shrinking under the drag (e.g. a refresh removed posts).
-        assertEquals(0, targetIndexForDrag(travelFraction = 1f, visibleItemsCount = 20, totalItemsCount = 10))
+    fun `targetIndexForDrag never exceeds the last index`() {
+        // estimatedTotal = 100 * 5 = 500 ; maxScroll = 450 ; 450 / 100 = 4.5 → 5, clamped to total-1 = 4.
+        assertEquals(4, dragIndex(1f, total = 5, viewport = 50f))
+    }
+
+    @Test
+    fun `targetIndexForDrag returns 0 on degenerate inputs`() {
+        assertEquals(0, dragIndex(1f, avg = 0f, total = 10))
+        assertEquals(0, dragIndex(1f, total = 0))
     }
 }

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbarTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicScrollbarTest.kt
@@ -1,0 +1,140 @@
+package fr.forumhfr.redface2.feature.topic
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #300 — pure-geometry tests for the topic scrollbar. Composable behaviour (auto-hide, gesture) is not
+ * unit-tested here; the value is in the position/size math and the drag→index mapping.
+ */
+class TopicScrollbarTest {
+
+    private val tolerance = 1e-4f
+
+    @Test
+    fun `scrollbarMetrics returns null when there is no item`() {
+        assertNull(
+            scrollbarMetrics(
+                firstVisibleItemIndex = 0,
+                firstVisibleItemScrollOffset = 0,
+                firstVisibleItemSize = 100,
+                visibleItemsCount = 0,
+                totalItemsCount = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun `scrollbarMetrics returns null when no item is visible`() {
+        assertNull(
+            scrollbarMetrics(
+                firstVisibleItemIndex = 0,
+                firstVisibleItemScrollOffset = 0,
+                firstVisibleItemSize = 100,
+                visibleItemsCount = 0,
+                totalItemsCount = 10,
+            ),
+        )
+    }
+
+    @Test
+    fun `scrollbarMetrics is non-null even when all items are visible (tall item, still scrollable)`() {
+        // visibleItemsCount >= totalItemsCount must NOT be treated as "nothing to scroll": a single item
+        // taller than the viewport is scrollable. The caller gates visibility on canScrollForward/Backward.
+        val metrics = scrollbarMetrics(
+            firstVisibleItemIndex = 0,
+            firstVisibleItemScrollOffset = 0,
+            firstVisibleItemSize = 4000,
+            visibleItemsCount = 1,
+            totalItemsCount = 1,
+        )
+        assertNotNull(metrics)
+    }
+
+    @Test
+    fun `offsetFraction is 0 at the top of the page`() {
+        val metrics = scrollbarMetrics(
+            firstVisibleItemIndex = 0,
+            firstVisibleItemScrollOffset = 0,
+            firstVisibleItemSize = 100,
+            visibleItemsCount = 5,
+            totalItemsCount = 10,
+        )!!
+        assertEquals(0f, metrics.offsetFraction, tolerance)
+        assertEquals(0.5f, metrics.sizeFraction, tolerance)
+    }
+
+    @Test
+    fun `offsetFraction reaches 1 minus sizeFraction at the bottom of the page`() {
+        val metrics = scrollbarMetrics(
+            firstVisibleItemIndex = 5,
+            firstVisibleItemScrollOffset = 0,
+            firstVisibleItemSize = 100,
+            visibleItemsCount = 5,
+            totalItemsCount = 10,
+        )!!
+        assertEquals(1f - metrics.sizeFraction, metrics.offsetFraction, tolerance)
+    }
+
+    @Test
+    fun `sizeFraction respects the minimum thumb floor on a very long page`() {
+        val metrics = scrollbarMetrics(
+            firstVisibleItemIndex = 0,
+            firstVisibleItemScrollOffset = 0,
+            firstVisibleItemSize = 50,
+            visibleItemsCount = 2,
+            totalItemsCount = 200,
+        )!!
+        // raw = 2/200 = 0.01, floored to MIN_THUMB_FRACTION.
+        assertEquals(MIN_THUMB_FRACTION, metrics.sizeFraction, tolerance)
+    }
+
+    @Test
+    fun `sub-item scroll offset increases offsetFraction monotonically`() {
+        val atTop = scrollbarMetrics(0, 0, 100, 5, 10)!!
+        val scrolledWithinFirstItem = scrollbarMetrics(0, 50, 100, 5, 10)!!
+        assertTrue(scrolledWithinFirstItem.offsetFraction > atTop.offsetFraction)
+    }
+
+    @Test
+    fun `firstVisibleItemSize of zero does not crash and contributes no sub-item offset`() {
+        val metrics = scrollbarMetrics(
+            firstVisibleItemIndex = 2,
+            firstVisibleItemScrollOffset = 30,
+            firstVisibleItemSize = 0,
+            visibleItemsCount = 5,
+            totalItemsCount = 10,
+        )!!
+        assertEquals(0.2f, metrics.offsetFraction, tolerance)
+    }
+
+    @Test
+    fun `targetIndexForDrag maps full travel below the visible window`() {
+        assertEquals(7, targetIndexForDrag(travelFraction = 1f, visibleItemsCount = 3, totalItemsCount = 10))
+    }
+
+    @Test
+    fun `targetIndexForDrag maps zero travel to the first item`() {
+        assertEquals(0, targetIndexForDrag(travelFraction = 0f, visibleItemsCount = 3, totalItemsCount = 10))
+    }
+
+    @Test
+    fun `targetIndexForDrag maps half travel to the middle of the scrollable range`() {
+        assertEquals(4, targetIndexForDrag(travelFraction = 0.5f, visibleItemsCount = 2, totalItemsCount = 10))
+    }
+
+    @Test
+    fun `targetIndexForDrag clamps an out-of-range travel fraction`() {
+        assertEquals(7, targetIndexForDrag(travelFraction = 2f, visibleItemsCount = 3, totalItemsCount = 10))
+        assertEquals(0, targetIndexForDrag(travelFraction = -1f, visibleItemsCount = 3, totalItemsCount = 10))
+    }
+
+    @Test
+    fun `targetIndexForDrag never returns a negative index when visible exceeds total mid-drag`() {
+        // Simulates totalItemsCount shrinking under the drag (e.g. a refresh removed posts).
+        assertEquals(0, targetIndexForDrag(travelFraction = 1f, visibleItemsCount = 20, totalItemsCount = 10))
+    }
+}

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -17,6 +17,7 @@ import fr.forumhfr.redface2.core.model.Post
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.Topic
 import java.io.IOException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -30,6 +31,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -794,6 +796,213 @@ class TopicViewModelTest {
             }
         }
 
+    // ──────────────────────────────────────────────────────────────────────
+    // #335 — manual pull-to-refresh
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `Refresh re-fetches in place, toggles isRefreshing, emits no nav-or-scroll effect (#335)`() = runTest {
+        val loaded = fakeTopic(page = 2, totalPages = 5, title = "loaded")
+        val refreshed = fakeTopic(page = 2, totalPages = 5, title = "refreshed")
+        val gate = CompletableDeferred<Unit>()
+        val repository = FakeTopicRepository(
+            flowsToReturn = listOf(flow { emit(loaded) }),
+            refreshTopicsToReturn = listOf(refreshed),
+        )
+        repository.refreshHook = { _, _, _ -> gate.await() }
+
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+
+        viewModel.effects.test {
+            viewModel.send(TopicIntent.Refresh)
+            assertTrue("the spinner shows while the refresh is in flight", viewModel.state.value.isRefreshing)
+            gate.complete(Unit)
+            // A successful manual refresh keeps the reading position: no ScrollToEndOfPage and no
+            // NavigateToLastPage (those are post-submit concerns, #200/#226).
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        assertFalse(viewModel.state.value.isRefreshing)
+        assertEquals("refreshed", (viewModel.state.value.mode as TopicUiState.Mode.Loaded).topic.title)
+        assertEquals(1, repository.refreshCalls.size)
+    }
+
+    @Test
+    fun `a second Refresh while one is in flight is collapsed to a single network call (#335)`() = runTest {
+        val loaded = fakeTopic(page = 2, totalPages = 5, title = "loaded")
+        val refreshed = fakeTopic(page = 2, totalPages = 5, title = "refreshed")
+        val gate = CompletableDeferred<Unit>()
+        val repository = FakeTopicRepository(
+            flowsToReturn = listOf(flow { emit(loaded) }),
+            refreshTopicsToReturn = listOf(refreshed),
+        )
+        repository.refreshHook = { _, _, _ -> gate.await() }
+
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+
+        viewModel.send(TopicIntent.Refresh) // suspends in the hook → isRefreshing = true
+        viewModel.send(TopicIntent.Refresh) // must be ignored: a refresh is already running
+        assertEquals("the in-flight guard collapses a double pull to one fetch", 1, repository.refreshCalls.size)
+
+        gate.complete(Unit)
+        assertFalse(viewModel.state.value.isRefreshing)
+    }
+
+    @Test
+    fun `Refresh failure keeps the current page and emits RefreshFailed (#335)`() = runTest {
+        val loaded = fakeTopic(page = 2, totalPages = 5, title = "loaded")
+        val repository = FakeTopicRepository(
+            flowsToReturn = listOf(flow { emit(loaded) }),
+            refreshErrorToThrow = IOException("network"),
+        )
+
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+
+        viewModel.effects.test {
+            viewModel.send(TopicIntent.Refresh)
+            assertEquals(TopicEffect.RefreshFailed, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertFalse(viewModel.state.value.isRefreshing)
+        assertEquals(
+            "the page on screen is unchanged after a failed refresh",
+            "loaded",
+            (viewModel.state.value.mode as TopicUiState.Mode.Loaded).topic.title,
+        )
+    }
+
+    @Test
+    fun `Refresh is a no-op while the page is still loading (#335)`() = runTest {
+        // observeTopicPage never emits → state stays Loading; a pull-to-refresh must not fire.
+        val repository = FakeTopicRepository(flowsToReturn = listOf(flow { }))
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+
+        viewModel.send(TopicIntent.Refresh)
+
+        assertTrue("no refresh call while not loaded", repository.refreshCalls.isEmpty())
+        assertFalse(viewModel.state.value.isRefreshing)
+    }
+
+    @Test
+    fun `Refresh revealing a new page updates availablePages but emits no navigation effect (#335)`() = runTest {
+        // A manual refresh must surface a grown page count WITHOUT yanking the user to the last page
+        // (#226 NavigateToLastPage is a post-submit concern only).
+        val loaded = fakeTopic(page = 2, totalPages = 5, title = "loaded")
+        val refreshed = fakeTopic(page = 2, totalPages = 6, title = "refreshed")
+        val repository = FakeTopicRepository(
+            flowsToReturn = listOf(flow { emit(loaded) }),
+            refreshTopicsToReturn = listOf(refreshed),
+        )
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+
+        viewModel.effects.test {
+            viewModel.send(TopicIntent.Refresh)
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals((1..6).toList(), viewModel.state.value.availablePages)
+    }
+
+    @Test
+    fun `a delete cancelling an in-flight refresh clears isRefreshing (#335)`() = runTest {
+        // The `finally { isRefreshing = false }` in refresh() exists precisely so another path
+        // cancelling the refresh job mid-flight never strands the spinner. DeletePost →
+        // refreshAfterDelete() does exactly that (loadJob?.cancel()). Pin that guarantee.
+        val loaded = fakeTopic(
+            page = 2,
+            totalPages = 3,
+            posts = listOf(fakePost(numreponse = 777, isEditable = true)),
+        )
+        val afterDelete = fakeTopic(page = 2, totalPages = 3, title = "after-delete")
+        val gate = CompletableDeferred<Unit>()
+        val repository = FakeTopicRepository(
+            flowsToReturn = listOf(flow { emit(loaded) }),
+            refreshTopicsToReturn = listOf(afterDelete),
+        )
+        repository.refreshHook = { _, _, _ -> gate.await() }
+        val deleteRepo = FakeDeletePostRepository(DeletePostResult.Success(deletedWholeTopic = false))
+
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            deletePostRepository = deleteRepo,
+        )
+
+        viewModel.send(TopicIntent.Refresh)
+        assertTrue("the spinner shows while the manual refresh is in flight", viewModel.state.value.isRefreshing)
+
+        // Let the post-delete refetch run to completion instead of suspending on the same gate.
+        // The gated refresh recorded its call but never reached the refreshQueue dequeue, so the
+        // `afterDelete` topic is still queued for refreshAfterDelete().
+        repository.refreshHook = null
+        viewModel.send(TopicIntent.DeletePost(777))
+
+        assertFalse(
+            "a delete cancelling the refresh must clear isRefreshing (finally guard)",
+            viewModel.state.value.isRefreshing,
+        )
+        assertEquals(
+            "the post-delete refetch lands the fresh page",
+            "after-delete",
+            (viewModel.state.value.mode as TopicUiState.Mode.Loaded).topic.title,
+        )
+    }
+
+    @Test
+    fun `Refresh re-arms the page+1 prefetch (#335)`() = runTest {
+        // A successful manual pull on an intermediate page re-arms the page+1 warmup (the user keeps
+        // reading forward) — unlike the post-submit force refresh which deliberately skips it. Expect
+        // two prefetches of page+1: one on the initial load, one after the Refresh re-fetch.
+        val loaded = fakeTopic(page = 2, totalPages = 5, title = "loaded")
+        val refreshed = fakeTopic(page = 2, totalPages = 5, title = "refreshed")
+        val repository = FakeTopicRepository(
+            flowsToReturn = listOf(flow { emit(loaded) }),
+            refreshTopicsToReturn = listOf(refreshed),
+        )
+
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+
+        assertEquals(
+            "the initial load warms page+1 once",
+            listOf(Triple(SAMPLE_CAT, SAMPLE_POST, 3)),
+            repository.prefetches,
+        )
+
+        viewModel.send(TopicIntent.Refresh)
+
+        assertEquals(
+            "a manual refresh re-arms the page+1 warmup",
+            listOf(Triple(SAMPLE_CAT, SAMPLE_POST, 3), Triple(SAMPLE_CAT, SAMPLE_POST, 3)),
+            repository.prefetches,
+        )
+    }
+
     @Test
     fun `normal load without submitSignal does not emit ScrollToEndOfPage`() = runTest {
         // Regression guard: ScrollToEndOfPage is gated on submitSignal != null. A normal
@@ -958,6 +1167,14 @@ private class FakeTopicRepository(
     var lastForceRefresh: Boolean? = null
         private set
 
+    /**
+     * Optional hook to suspend or fail inside `refreshTopicPage(...)` — symmetric with
+     * [prefetchHook]. #335 pull-to-refresh tests install a `CompletableDeferred`-backed hook to
+     * observe the in-flight `isRefreshing` window and assert anti-double-trigger (a second refresh
+     * while the first is suspended must not issue a second call). Default keeps the fake fast.
+     */
+    var refreshHook: (suspend (cat: Int, post: Int, page: Int) -> Unit)? = null
+
     override fun observeTopicPage(cat: Int, post: Int, page: Int, forceRefresh: Boolean): Flow<Topic> {
         calls += Triple(cat, post, page)
         lastForceRefresh = forceRefresh
@@ -966,6 +1183,7 @@ private class FakeTopicRepository(
 
     override suspend fun refreshTopicPage(cat: Int, post: Int, page: Int): Topic {
         refreshCalls += Triple(cat, post, page)
+        refreshHook?.invoke(cat, post, page)
         refreshErrorToThrow?.let { throw it }
         return refreshQueue.removeFirstOrNull()
             ?: error("No more refresh topics queued (issue #200 post-submit force fetch path)")


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Promotion `dev → main` du 2e batch de fonctionnalités depuis la bêta 0.6.0 (v92). **versionName 0.6.0 → 0.7.0** ; la bêta shippera en **v101**.

## Ce qui ship

- **Répondre à une conversation privée** (#301, partiel) — éditeur BBCode complet, options, bouton Envoyer au-dessus du clavier. La composition d'un **nouveau** MP reste à venir → **#301 reste ouverte**.
- **Ascenseur de sujet** (#300) — indicateur de position + fast-scroll par glisser, pouce à taille fixe + ancrage intra-post fluide.
- **Pull-to-refresh d'une page de sujet** (#335).
- **Accès rapide « poster » + changement de page en bas de sujet** (#283).
- **Écran Réglages « menu vitrine »** (#288) — catalogue présents + à venir.
- **Flèche retour** en icône vectorielle 24 dp (cohérence multi-écrans, PRs #355/#356/#357).
- **Post-review Codex** (PR #358) : garde `optionsHydratedFromForm` en réponse MP, reformulation catalogue Réglages, bump + CHANGELOG.

## Gates franchis

- **Review 4-flavor** (hors dependabot — aucun dans le diff) : 4 findings IMPORTANT, tous vérifiés **faux positifs** (comparaison au mauvais analogue ; la feature MP mirror le post editor).
- **Review Codex complète** du diff `main..dev` : verdict **GO**. 1 IMPORTANT (clobber options MP) + 1 mineur (catalogue) **corrigés** dans #358 (mergé sur dev).
- **Release dev v100 / 0.7.0** (tag `app-v100`, sha 87716e3) : **verte end-to-end** (Play track=internal + F-Droid dev).
- CI de cette PR : en cours.

## Issues

Référence #300, #335, #283, #288, #301. **Aucun mot-clé de fermeture** : les issues seront fermées délibérément après merge (avec vérification de périmètre + commentaire explicatif). #301 **ne sera pas fermée** (new-MP différé).