### PR TITLE
feat(topic): menu contextuel de post — numéro, copier le lien, édité le, citations (#362)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicMappers.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicMappers.kt
@@ -99,6 +99,7 @@ internal object TopicMappers {
         authMode = authMode,
         quoteRef = quoteRef,
         profileId = profileId,
+        editedAt = editedAt,
     )
 
     private fun PostEntity.toDomain(): Post = Post(
@@ -113,6 +114,7 @@ internal object TopicMappers {
         postIndex = postIndex,
         quoteRef = quoteRef,
         profileId = profileId,
+        editedAt = editedAt,
     )
 
     /**

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -328,6 +328,40 @@ class TopicRepositoryImplTest {
         assertEquals("fresh cache hit must not trigger a refresh", 1, server.requestCount)
     }
 
+    @Test
+    fun `observeTopicPage fresh cache preserves editedAt without network refresh`() = runTest {
+        // #362 regression : Post.editedAt is persisted in Room v8 (MIGRATION_7_8). Without
+        // the column + mapper round-trip, every fresh cache hit (the common case once a
+        // topic has been refreshed once) would silently reset the edit marker to null and
+        // the « Édité le … » menu line would vanish. The khakha p2 fixture carries both
+        // edited and never-edited posts, so the cache re-emission is checked on both.
+        server.enqueue(MockResponse().setBody(fixtureHtml("topic_khakha_page_2.html")))
+        val repo = repository(now = Instant.parse("2026-04-26T18:00:00Z"))
+        val fresh = repo.refreshTopicPage(13, 84_540, 2)
+        assertEquals("warmup must issue exactly one network request", 1, server.requestCount)
+
+        // n°16628102 = reelooz10, « Message cité 2 fois » + edited 03-11-2008 à 21:43:47
+        // (CET = UTC+1) ; n°16628071 = Mora1651, never edited.
+        val freshEdited = fresh.posts.first { it.numreponse == 16_628_102 }
+        assertEquals(Instant.parse("2008-11-03T20:43:47Z"), freshEdited.editedAt)
+
+        // Same clock → fresh cache → no network refresh.
+        repo.observeTopicPage(13, 84_540, 2).test {
+            val cached = awaitItem()
+            awaitComplete()
+            assertEquals(
+                "editedAt must round-trip Room v8 unchanged on cache hit",
+                freshEdited.editedAt,
+                cached.posts.first { it.numreponse == 16_628_102 }.editedAt,
+            )
+            assertNull(
+                "never-edited post must keep editedAt null on cache hit",
+                cached.posts.first { it.numreponse == 16_628_071 }.editedAt,
+            )
+        }
+        assertEquals("fresh cache hit must not trigger a refresh", 1, server.requestCount)
+    }
+
     // ──────────────────────────────────────────────────────────────────────
     // Alpha "Ignorer le cache topic" toggle — bypass tests
     // ──────────────────────────────────────────────────────────────────────

--- a/core/database/schemas/fr.forumhfr.redface2.core.database.RedfaceDatabase/8.json
+++ b/core/database/schemas/fr.forumhfr.redface2.core.database.RedfaceDatabase/8.json
@@ -1,0 +1,345 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 8,
+    "identityHash": "21cce4434dbc3467f3add7307e02fdd7",
+    "entities": [
+      {
+        "tableName": "topic_pages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cat` INTEGER NOT NULL, `post` INTEGER NOT NULL, `page` INTEGER NOT NULL, `title` TEXT NOT NULL, `totalPages` INTEGER NOT NULL, `isFirstPostOwner` INTEGER NOT NULL, `pollJson` TEXT, `numreponses` TEXT NOT NULL, `fetchedAt` INTEGER NOT NULL, `authMode` TEXT NOT NULL, `subcat` INTEGER NOT NULL, `canReply` INTEGER NOT NULL, PRIMARY KEY(`cat`, `post`, `page`))",
+        "fields": [
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "post",
+            "columnName": "post",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPages",
+            "columnName": "totalPages",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFirstPostOwner",
+            "columnName": "isFirstPostOwner",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pollJson",
+            "columnName": "pollJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "numreponses",
+            "columnName": "numreponses",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authMode",
+            "columnName": "authMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subcat",
+            "columnName": "subcat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canReply",
+            "columnName": "canReply",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cat",
+            "post",
+            "page"
+          ]
+        }
+      },
+      {
+        "tableName": "posts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cat` INTEGER NOT NULL, `numreponse` INTEGER NOT NULL, `post` INTEGER NOT NULL, `author` TEXT NOT NULL, `date` INTEGER NOT NULL, `content` TEXT NOT NULL, `avatarUrl` TEXT, `isEditable` INTEGER NOT NULL, `isOwnPost` INTEGER NOT NULL, `quotedAuthors` TEXT NOT NULL, `postIndex` INTEGER, `fetchedAt` INTEGER NOT NULL, `authMode` TEXT NOT NULL, `quoteRef` INTEGER, `profileId` INTEGER, `editedAt` INTEGER, PRIMARY KEY(`cat`, `numreponse`))",
+        "fields": [
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numreponse",
+            "columnName": "numreponse",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "post",
+            "columnName": "post",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isEditable",
+            "columnName": "isEditable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOwnPost",
+            "columnName": "isOwnPost",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quotedAuthors",
+            "columnName": "quotedAuthors",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postIndex",
+            "columnName": "postIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authMode",
+            "columnName": "authMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quoteRef",
+            "columnName": "quoteRef",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "editedAt",
+            "columnName": "editedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cat",
+            "numreponse"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_posts_cat_post",
+            "unique": false,
+            "columnNames": [
+              "cat",
+              "post"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_posts_cat_post` ON `${TABLE_NAME}` (`cat`, `post`)"
+          }
+        ]
+      },
+      {
+        "tableName": "flag_topics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `type` TEXT NOT NULL, `cat` INTEGER NOT NULL, `subcat` INTEGER, `topicId` INTEGER NOT NULL, `title` TEXT NOT NULL, `totalPages` INTEGER NOT NULL, `replyCount` INTEGER NOT NULL, `hasUnread` INTEGER NOT NULL, `lastReadPage` INTEGER NOT NULL, `lastPostReadId` INTEGER, `firstPostAuthor` TEXT NOT NULL, `lastReplyAuthor` TEXT NOT NULL, `lastReplyAt` TEXT NOT NULL, `fetchedAt` INTEGER NOT NULL, `authMode` TEXT NOT NULL, PRIMARY KEY(`userId`, `type`, `cat`, `topicId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subcat",
+            "columnName": "subcat",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "topicId",
+            "columnName": "topicId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPages",
+            "columnName": "totalPages",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "replyCount",
+            "columnName": "replyCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasUnread",
+            "columnName": "hasUnread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadPage",
+            "columnName": "lastReadPage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPostReadId",
+            "columnName": "lastPostReadId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "firstPostAuthor",
+            "columnName": "firstPostAuthor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReplyAuthor",
+            "columnName": "lastReplyAuthor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReplyAt",
+            "columnName": "lastReplyAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authMode",
+            "columnName": "authMode",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "type",
+            "cat",
+            "topicId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_flag_topics_userId_type",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_flag_topics_userId_type` ON `${TABLE_NAME}` (`userId`, `type`)"
+          },
+          {
+            "name": "index_flag_topics_userId_fetchedAt",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "fetchedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_flag_topics_userId_fetchedAt` ON `${TABLE_NAME}` (`userId`, `fetchedAt`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '21cce4434dbc3467f3add7307e02fdd7')"
+    ]
+  }
+}

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/RedfaceDatabase.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/RedfaceDatabase.kt
@@ -12,7 +12,7 @@ import fr.forumhfr.redface2.core.database.entities.TopicEntity
 
 @Database(
     entities = [TopicEntity::class, PostEntity::class, FlagTopicEntity::class],
-    version = 7,
+    version = 8,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/di/DatabaseModule.kt
@@ -16,6 +16,7 @@ import fr.forumhfr.redface2.core.database.migrations.MIGRATION_3_4
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_4_5
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_5_6
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_6_7
+import fr.forumhfr.redface2.core.database.migrations.MIGRATION_7_8
 import javax.inject.Singleton
 
 @Module
@@ -37,6 +38,7 @@ object DatabaseModule {
             MIGRATION_4_5,
             MIGRATION_5_6,
             MIGRATION_6_7,
+            MIGRATION_7_8,
         )
         .build()
 

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/entities/PostEntity.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/entities/PostEntity.kt
@@ -66,4 +66,15 @@ data class PostEntity(
      * - future HFR changes may stop rendering the link for some post types.
      */
     val profileId: Int? = null,
+    /**
+     * #362 — last-edit timestamp parsed from the post's `div.edited` trailer
+     * (« Message édité par <auteur> le DD-MM-YYYY à HH:MM:SS »). Persisted in
+     * Room v8 (`MIGRATION_7_8`) so a cache hit keeps the « Édité le … » line of
+     * the post menu without a network round-trip. Nullable on disk:
+     *
+     * - pre-v8 rows backfill to `NULL` (recovered on the next live fetch);
+     * - never-edited posts legitimately carry no edit trailer — including posts
+     *   whose `div.edited` only holds the « Message cité N fois » citation link.
+     */
+    val editedAt: Instant? = null,
 )

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/migrations/Migrations.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/migrations/Migrations.kt
@@ -218,3 +218,25 @@ val MIGRATION_6_7: Migration = object : Migration(6, 7) {
         db.execSQL("UPDATE topic_pages SET fetchedAt = 0")
     }
 }
+
+/**
+ * v7 → v8 (#362):
+ *
+ * Adds `editedAt` to `posts`. Stores the last-edit timestamp parsed from the post's
+ * `div.edited` trailer (« Message édité par <auteur> le DD-MM-YYYY à HH:MM:SS »), so
+ * the « Édité le … » line of the per-post menu survives a cache hit without a network
+ * round-trip.
+ *
+ * Nullable on disk because:
+ * - pre-v8 rows backfill to `NULL` (the next live fetch sets the real value);
+ * - never-edited posts legitimately carry no edit trailer — including cited-but-never-
+ *   edited posts whose `div.edited` only holds the « Message cité N fois » link.
+ *
+ * Pure DDL, no row rewrite — posts are short-lived cache (stored as epoch millis via
+ * the `Instant` type converter, hence `INTEGER`).
+ */
+val MIGRATION_7_8: Migration = object : Migration(7, 8) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE posts ADD COLUMN editedAt INTEGER")
+    }
+}

--- a/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/migrations/MigrationTest.kt
+++ b/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/migrations/MigrationTest.kt
@@ -21,10 +21,11 @@ import org.robolectric.annotation.Config
 /**
  * Robolectric-driven migration tests for every hand-written Room migration in the schema
  * — currently `MIGRATION_1_2`, `MIGRATION_2_3`, `MIGRATION_3_4`, `MIGRATION_4_5`,
- * `MIGRATION_5_6` (Phase 2 finish #208 added `Post.profileId` in v6) and `MIGRATION_6_7`
- * (#213 added `Topic.canReply` in v7). Without these tests a typo (missing column, wrong
- * index name, wrong default) would only crash on a real upgrade-in-place install, where
- * the diagnostic loop is days long. The tests take seconds.
+ * `MIGRATION_5_6` (Phase 2 finish #208 added `Post.profileId` in v6), `MIGRATION_6_7`
+ * (#213 added `Topic.canReply` in v7) and `MIGRATION_7_8` (#362 added `Post.editedAt`
+ * in v8). Without these tests a typo (missing column, wrong index name, wrong default)
+ * would only crash on a real upgrade-in-place install, where the diagnostic loop is
+ * days long. The tests take seconds.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, sdk = [33])
@@ -113,6 +114,7 @@ class MigrationTest {
                 MIGRATION_4_5,
                 MIGRATION_5_6,
                 MIGRATION_6_7,
+                MIGRATION_7_8,
             )
             .build()
 
@@ -250,6 +252,7 @@ class MigrationTest {
                 MIGRATION_4_5,
                 MIGRATION_5_6,
                 MIGRATION_6_7,
+                MIGRATION_7_8,
             )
             .build()
 
@@ -347,6 +350,7 @@ class MigrationTest {
                 MIGRATION_4_5,
                 MIGRATION_5_6,
                 MIGRATION_6_7,
+                MIGRATION_7_8,
             )
             .build()
 
@@ -416,6 +420,7 @@ class MigrationTest {
                 MIGRATION_4_5,
                 MIGRATION_5_6,
                 MIGRATION_6_7,
+                MIGRATION_7_8,
             )
             .build()
 
@@ -481,6 +486,7 @@ class MigrationTest {
                 MIGRATION_4_5,
                 MIGRATION_5_6,
                 MIGRATION_6_7,
+                MIGRATION_7_8,
             )
             .build()
 
@@ -537,6 +543,7 @@ class MigrationTest {
                 MIGRATION_4_5,
                 MIGRATION_5_6,
                 MIGRATION_6_7,
+                MIGRATION_7_8,
             )
             .build()
 
@@ -555,6 +562,68 @@ class MigrationTest {
                     0L,
                     cursor.getLong(1),
                 )
+            }
+        } finally {
+            migrated.close()
+        }
+    }
+
+    /**
+     * #362 — v7 → v8 adds nullable `editedAt` to `posts`.
+     *
+     * Verifies:
+     * 1. The migration runs cleanly against the v7 fixture.
+     * 2. Pre-existing post rows survive the migration.
+     * 3. The new column defaults to NULL on old rows (recovered on the next live fetch).
+     */
+    @Test
+    fun migrate_7_to_8_adds_nullable_editedAt_to_posts() {
+        val dbName = "migration_7_8_test"
+
+        // 1. Create a v7 database and insert a posts row that pre-dates `editedAt`.
+        helper.createDatabase(dbName, 7).apply {
+            execSQL(
+                """INSERT INTO topic_pages (cat, post, page, title, totalPages, isFirstPostOwner,
+                   numreponses, fetchedAt, authMode, subcat, canReply)
+                   VALUES (23, 35395, 1, 'v7 cached topic', 10, 0, '[]', 1000, 'AUTHENTICATED', 550, 1)""",
+            )
+            execSQL(
+                """INSERT INTO posts (cat, numreponse, post, author, date, content, avatarUrl,
+                   isEditable, isOwnPost, quotedAuthors, postIndex, fetchedAt, authMode, quoteRef,
+                   profileId)
+                   VALUES (23, 100, 35395, 'XaTriX', 1000,
+                   '{"blocks":[]}', NULL, 0, 0, '[]', 1, 1000, 'AUTHENTICATED', NULL, NULL)""",
+            )
+            close()
+        }
+
+        // 2. Run MIGRATION_7_8 and validate against the v8 schema.
+        helper.runMigrationsAndValidate(dbName, 8, true, MIGRATION_7_8).close()
+
+        // 3. Open the production Room database (which chains every migration).
+        val migrated = Room.databaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            RedfaceDatabase::class.java,
+            dbName,
+        )
+            .allowMainThreadQueries()
+            .addMigrations(
+                MIGRATION_1_2,
+                MIGRATION_2_3,
+                MIGRATION_3_4,
+                MIGRATION_4_5,
+                MIGRATION_5_6,
+                MIGRATION_6_7,
+                MIGRATION_7_8,
+            )
+            .build()
+
+        try {
+            migrated.openHelper.readableDatabase.query(
+                "SELECT editedAt FROM posts WHERE cat = 23 AND numreponse = 100",
+            ).use { cursor ->
+                assertTrue("pre-v8 post row must survive MIGRATION_7_8", cursor.moveToFirst())
+                assertTrue("editedAt must be NULL for pre-v8 rows", cursor.isNull(0))
             }
         } finally {
             migrated.close()

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/Post.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/Post.kt
@@ -45,4 +45,15 @@ data class Post(
      * profile tap available without a network round-trip.
      */
     val profileId: Int? = null,
+    /**
+     * #362 — when HFR marks the post as edited, the timestamp of the last edit,
+     * parsed from the `div.edited` trailer (`Message édité par <auteur> le
+     * DD-MM-YYYY à HH:MM:SS`). `null` when the post was never edited — including
+     * the case where `div.edited` exists but only carries the « Message cité N
+     * fois » citation link (a cited-but-never-edited post).
+     *
+     * Persisted in Room v8 (cf. `MIGRATION_7_8`) so cache hits keep the edit
+     * marker; pre-v8 rows backfill to `NULL` and recover on the next live fetch.
+     */
+    val editedAt: Instant? = null,
 )

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostsParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostsParser.kt
@@ -3,6 +3,7 @@ package fr.forumhfr.redface2.core.parser
 import fr.forumhfr.redface2.core.model.Post
 import fr.forumhfr.redface2.core.parser.common.HfrDateParser
 import fr.forumhfr.redface2.core.parser.common.HfrSelectors
+import java.time.Instant
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 
@@ -80,8 +81,23 @@ class PostsParser(
             postIndex = null,
             quoteRef = parseQuoteRef(postTable),
             profileId = parseProfileId(postTable),
+            editedAt = parseEditedAt(postTable),
         )
     }
+
+    /**
+     * #362 — last-edit timestamp from the post's `div.edited` trailer, or `null` when the
+     * post was never edited. The lookup is **scoped to the current post's table** so the
+     * `div.edited` of another post on the page can never bleed in. The trailer may carry
+     * only the « Message cité N fois » citation link (cited-but-never-edited post) — the
+     * date parser returns `null` for that text. Reading the live DOM here is safe even
+     * though [PostContentParser] strips `div.edited` from the rendered content: it clones
+     * the content element before its `remove()`, so the original document is not mutated.
+     */
+    private fun parseEditedAt(postTable: Element): Instant? =
+        postTable.selectFirst(HfrSelectors.POST_EDITED)
+            ?.text()
+            ?.let(dateParser::parseEditedAtOrNull)
 
     /**
      * Phase 2D (#147) / #227 — returns `true` when the post's left toolbar exposes an

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/common/HfrDateParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/common/HfrDateParser.kt
@@ -63,12 +63,43 @@ class HfrDateParser(
         ).atZone(zoneId).toInstant()
     }
 
+    /**
+     * #362 — parses the last-edit timestamp from a post's `div.edited` trailer text:
+     * `Message édité par <auteur> le DD-MM-YYYY à HH:MM:SS` (same `à` + seconds shape
+     * as [parsePostedAt]). The regex is deliberately **not** anchored at the start of
+     * the string: the trailer can be prefixed by the optional « Message cité N fois »
+     * citation link (`Message cité 2 fois Message édité par … le …`).
+     *
+     * Returns `null` when the text holds no edit marker — including the real-fixture
+     * case of a `div.edited` that only carries the citation link (post cited but
+     * never edited), and the empty string.
+     */
+    fun parseEditedAtOrNull(text: String): Instant? {
+        val normalized = text
+            .replace('\u00A0', ' ')
+            .replace(Regex("\\s+"), " ")
+
+        val match = EDITED_AT_REGEX.find(normalized) ?: return null
+
+        return LocalDateTime.of(
+            match.groupValues[3].toInt(),
+            match.groupValues[2].toInt(),
+            match.groupValues[1].toInt(),
+            match.groupValues[4].toInt(),
+            match.groupValues[5].toInt(),
+            match.groupValues[6].toInt(),
+        ).atZone(zoneId).toInstant()
+    }
+
     private companion object {
         val POSTED_AT_REGEX = Regex(
             """Posté le (\d{2})-(\d{2})-(\d{4}) à (\d{2}):(\d{2}):(\d{2})""",
         )
         val LIST_DATE_REGEX = Regex(
             """(\d{2})-(\d{2})-(\d{4}) à (\d{2}):(\d{2})""",
+        )
+        val EDITED_AT_REGEX = Regex(
+            """Message édité par .+ le (\d{2})-(\d{2})-(\d{4}) à (\d{2}):(\d{2}):(\d{2})""",
         )
     }
 }

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/TopicPageParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/TopicPageParserTest.kt
@@ -691,6 +691,57 @@ class TopicPageParserTest {
         assertNull("quote-less post must expose null quoteRef", post.quoteRef)
     }
 
+    // ─── editedAt (#362) ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `editedAt is parsed from the div edited trailer on khakha page 2`() {
+        // Real-fixture contract on `topic_khakha_page_2.html`, covering every shape of
+        // the `div.edited` trailer (cf. the per-post mapping below) :
+        //   - n°16628102 : « Message cité 2 fois » + « Message édité par reelooz10 le
+        //     03-11-2008 à 21:43:47 » → the edit date must be found BEHIND the citation
+        //     link prefix (non-anchored regex).
+        //   - n°16628775 : edit trailer alone (no citation link) → parsed too.
+        //   - n°16628222 : citation link alone (cited but never edited) → null.
+        //   - n°16628071 : no div.edited at all → null.
+        // 2008-11-03 is CET (UTC+1) in Europe/Paris.
+        val topic = parser.parse(fixture("topic_khakha_page_2.html"))
+        val byNumreponse = topic.posts.associateBy { it.numreponse }
+
+        assertEquals(
+            "cited + edited post must surface the edit date behind the citation prefix",
+            java.time.Instant.parse("2008-11-03T20:43:47Z"),
+            byNumreponse[16628102]?.editedAt,
+        )
+        assertEquals(
+            "edited-only post must surface its edit date",
+            java.time.Instant.parse("2008-11-03T21:45:52Z"),
+            byNumreponse[16628775]?.editedAt,
+        )
+        assertNull(
+            "cited-but-never-edited post must keep editedAt null",
+            byNumreponse[16628222]?.editedAt,
+        )
+        assertNull(
+            "post without div.edited must keep editedAt null",
+            byNumreponse[16628071]?.editedAt,
+        )
+    }
+
+    @Test
+    fun `editedAt stays scoped to its own post table`() {
+        // The page mixes edited and non-edited posts : if the parser ever matched a
+        // div.edited outside the current post's table, one of the 33 non-edited posts of
+        // this fixture would pick up a neighbour's date. Pin the exact distribution
+        // instead of a single example (8 edited posts out of the 41 on this capture).
+        val topic = parser.parse(fixture("topic_khakha_page_2.html"))
+
+        val editedNumreponses = topic.posts.filter { it.editedAt != null }.map { it.numreponse }
+        assertEquals(
+            listOf(16628102, 16628106, 16628775, 16631302, 16631323, 16631394, 16632446, 16632858),
+            editedNumreponses,
+        )
+    }
+
     // ─── profileId (#208) ───────────────────────────────────────────────────────
 
     @Test

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/common/HfrDateParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/common/HfrDateParserTest.kt
@@ -1,0 +1,65 @@
+package fr.forumhfr.redface2.core.parser.common
+
+import java.time.Instant
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #362 — contract of [HfrDateParser.parseEditedAtOrNull] against the real `div.edited`
+ * text shapes observed in the committed fixtures (`topic_page_single.html`,
+ * `topic_khakha_page_2.html`):
+ *
+ * - `Message édité par <auteur> le DD-MM-YYYY à HH:MM:SS` (plain edit trailer);
+ * - the same with `&nbsp;` (U+00A0) around the `à`, which is how HFR actually ships it;
+ * - prefixed by the optional « Message cité N fois » citation link text;
+ * - the citation link ALONE (post cited but never edited) → null;
+ * - empty text → null.
+ */
+class HfrDateParserTest {
+    private val parser = HfrDateParser()
+
+    @Test
+    fun `parseEditedAtOrNull parses a plain edit trailer`() {
+        val editedAt = parser.parseEditedAtOrNull(
+            "Message édité par jubjub le 14-03-2016 à 12:09:00",
+        )
+
+        // 2016-03-14 is CET (UTC+1) in Europe/Paris.
+        assertEquals(Instant.parse("2016-03-14T11:09:00Z"), editedAt)
+    }
+
+    @Test
+    fun `parseEditedAtOrNull normalizes the non-breaking spaces HFR ships around the a`() {
+        // Raw fixture shape: `…le 14-03-2016&nbsp;à&nbsp;12:09:00` — Jsoup's text()
+        // surfaces the entities as U+00A0, which the parser must normalize to spaces.
+        val editedAt = parser.parseEditedAtOrNull(
+            "Message édité par Mitch2Pain le 16-03-2016\u00A0à\u00A012:35:19",
+        )
+
+        assertEquals(Instant.parse("2016-03-16T11:35:19Z"), editedAt)
+    }
+
+    @Test
+    fun `parseEditedAtOrNull finds the edit trailer behind a citation link prefix`() {
+        // The « Message cité N fois » link is part of the same div.edited, so the
+        // edit marker is NOT at the start of the text — the regex must not be anchored.
+        val editedAt = parser.parseEditedAtOrNull(
+            "Message cité 2 fois Message édité par fafarex le 16-03-2016\u00A0à\u00A015:43:43",
+        )
+
+        assertEquals(Instant.parse("2016-03-16T14:43:43Z"), editedAt)
+    }
+
+    @Test
+    fun `parseEditedAtOrNull returns null for a citation-only trailer`() {
+        // Real case (topic_khakha_page_2.html, n°16628222): div.edited carries only the
+        // citation link because the post is cited but was never edited.
+        assertNull(parser.parseEditedAtOrNull("Message cité 1 fois"))
+    }
+
+    @Test
+    fun `parseEditedAtOrNull returns null for empty text`() {
+        assertNull(parser.parseEditedAtOrNull(""))
+    }
+}

--- a/docs/specs/models.md
+++ b/docs/specs/models.md
@@ -94,6 +94,8 @@ classDiagram
         +List~String~ quotedAuthors
         +Int? postIndex
         +Int? quoteRef
+        +Int? profileId
+        +Instant? editedAt
     }
 
     class PostContent {
@@ -279,6 +281,8 @@ data class Post(
     val quotedAuthors: List<String>,     // dérivé de PostContent pour recherche, filtres et décorateurs
     val postIndex: Int?,                 // (page-1) * postsPerPage + position — null quand le parser n'a pas le contexte page/postsPerPage (preview, fixtures isolées). postsPerPage vient des préférences HFR de l'utilisateur, PAS une constante (voir UserSettings)
     val quoteRef: Int? = null,           // Phase 2C (#146/#227) : `ref` opaque parsé depuis le href du lien quote HFR (`message.php?…&numrep=…&ref=N`) quand il est en clair. Null = ref absent/obfusqué/locked/anonyme. Persisté en Room v5 (`MIGRATION_4_5`) pour préserver le `ref` best-effort ; le bouton « Citer » dépend de `Topic.canReply`, pas de ce champ.
+    val profileId: Int? = null,          // Phase 2 finish (#208) : id numérique HFR du lien profil toolbar (cf. note en tête de page). Persisté en Room v6 (`MIGRATION_5_6`).
+    val editedAt: Instant? = null,       // #362 : date de dernière édition parsée depuis le trailer `div.edited` (« Message édité par <auteur> le DD-MM-YYYY à HH:MM:SS »). Null = jamais édité — y compris un div.edited ne portant que le lien « Message cité N fois » (post cité jamais édité). Persisté en Room v8 (`MIGRATION_7_8`). Affiché dans le menu contextuel de post (« Édité le … »).
 )
 
 data class PostContent(

--- a/docs/specs/protocol-hfr.md
+++ b/docs/specs/protocol-hfr.md
@@ -596,7 +596,7 @@ Confirmé par Corran Horn sur le topic HFR Redface 2 : *« en utilisant un cooki
 
 ### Posts édités
 
-Pattern dans le HTML des posts : `Message édité par <auteur> le DD-MM-YYYY à HH:MM:SS`. Extraire côté parser en champ `Post.editedAt: Instant?`.
+Marqueur dans le HTML des posts : un `div.edited` en fin de contenu, ex. `<div class="edited"><a …>Message cité 1 fois</a><br />Message édité par jubjub le 14-03-2016&nbsp;à&nbsp;12:09:00</div>`. Le lien « Message cité N fois » est optionnel et peut exister **sans** ligne « Message édité » (post cité jamais édité) — et inversement. Extrait côté parser (#362) en champ `Post.editedAt: Instant?` via `HfrDateParser.parseEditedAtOrNull` (regex non ancrée, le préfixe citation est toléré ; null si pas de marqueur d'édition). Le `div.edited` reste par ailleurs retiré du contenu rendu (`PostContentParser`).
 
 ### Posts supprimés / modérés
 

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostMenuSheet.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostMenuSheet.kt
@@ -1,0 +1,172 @@
+package fr.forumhfr.redface2.feature.topic
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Build
+import android.widget.Toast
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.model.Post
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * #362 — per-post contextual menu, opened from the `⋯` trigger in the post header
+ * ([TopicPostCard]). Carries:
+ *
+ * - an identity header: author + « Post n°{numreponse} » (the post number moved here
+ *   from the header bar) + post date;
+ * - the « Copier le lien de ce post » action — copies the canonical permalink
+ *   ([buildPostPermalink]) and closes the sheet. Feedback follows the Diagnostics
+ *   clipboard pattern: Android 13+ shows the system clipboard overlay natively, older
+ *   devices get a Toast;
+ * - an « Édité le … » info line when [Post.editedAt] is non-null;
+ * - a « Cité N fois sur cette page » info line when [citedCount] > 0 (hidden at 0 —
+ *   same page-scoped #239 count as the badge, which stays on the card).
+ *
+ * Lives in `:feature:topic` (local UI state in `TopicScreen`, no ViewModel): unlike
+ * `ProfilePreviewSheet`, hoisted in `:app` only because it needs a Hilt ViewModel,
+ * this menu has no async data.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun PostMenuSheet(
+    post: Post,
+    permalink: String,
+    citedCount: Int,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState()
+    val coroutineScope = rememberCoroutineScope()
+    val context = LocalContext.current
+    // Resolved at composition time — the copy callback runs outside composition.
+    val copiedFeedback = stringResource(R.string.topic_post_menu_link_copied)
+    val copyLabel = stringResource(R.string.topic_post_menu_copy_link)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .navigationBarsPadding(),
+        ) {
+            Text(
+                text = post.author,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = stringResource(R.string.topic_post_menu_number, post.numreponse),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = post.date.asTopicDate(),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(Modifier.height(8.dp))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+
+            Text(
+                text = copyLabel,
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(
+                        // Copy immediately, then play the hide animation before releasing the
+                        // state (cf. ProfilePreviewSheet's hideThenNavigate) — « au plus
+                        // simple »: the clipboard write has no reason to wait for the sheet.
+                        onClick = {
+                            copyPermalinkToClipboard(context, permalink, copiedFeedback)
+                            hideThenDismiss(coroutineScope, sheetState, onDismiss)
+                        },
+                        role = Role.Button,
+                        onClickLabel = copyLabel,
+                    )
+                    .padding(vertical = 14.dp),
+            )
+
+            post.editedAt?.let { editedAt ->
+                Text(
+                    text = stringResource(R.string.topic_post_menu_edited, editedAt.asTopicDate()),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(vertical = 4.dp),
+                )
+            }
+            if (citedCount > 0) {
+                Text(
+                    text = pluralStringResource(
+                        R.plurals.topic_post_menu_cited_on_page,
+                        citedCount,
+                        citedCount,
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(vertical = 4.dp),
+                )
+            }
+
+            Spacer(Modifier.height(8.dp))
+        }
+    }
+}
+
+/**
+ * Clipboard write + feedback, mirroring the Diagnostics export pattern
+ * (`DiagnosticsViewModel`): Android 13+ (T) shows the system « copié » overlay on its
+ * own, so the Toast is only raised on older API levels to avoid double feedback.
+ */
+private fun copyPermalinkToClipboard(context: Context, permalink: String, feedback: String) {
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    clipboard.setPrimaryClip(ClipData.newPlainText("redface2 post link", permalink))
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+        Toast.makeText(context, feedback, Toast.LENGTH_SHORT).show()
+    }
+}
+
+/**
+ * Plays the sheet's hide animation, then invokes [onDismiss] once the sheet is actually
+ * off-screen — same Material 3 « animated dismiss » idiom as ProfilePreviewSheet's
+ * `hideThenNavigate`.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+private fun hideThenDismiss(
+    coroutineScope: CoroutineScope,
+    sheetState: SheetState,
+    onDismiss: () -> Unit,
+) {
+    coroutineScope.launch { sheetState.hide() }
+        .invokeOnCompletion {
+            if (!sheetState.isVisible) {
+                onDismiss()
+            }
+        }
+}

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostPermalink.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostPermalink.kt
@@ -1,0 +1,19 @@
+package fr.forumhfr.redface2.feature.topic
+
+/**
+ * #362 — canonical HFR permalink to a single post, copied to the clipboard from the
+ * per-post menu ([PostMenuSheet]).
+ *
+ * Shape: the topic-page read URL documented in `docs/specs/protocol-hfr.md`
+ * (`/forum2.php?config=hfr.inc&cat={cat}&post={post}&page={page}`) plus the per-post
+ * anchor `#t{numreponse}` HFR renders on every post (`<a name="t{numreponse}">`), the
+ * same fragment shape the app itself consumes in deep links (cf.
+ * `docs/specs/navigation.md` § lien vers un post spécifique). The host is hardcoded:
+ * the permalink targets the real forum for sharing, never a test override base URL.
+ *
+ * Pure top-level function (same spirit as [citationCountsByNumreponse]) so the URL
+ * contract is unit-testable without Compose.
+ */
+internal fun buildPostPermalink(cat: Int, post: Int, page: Int, numreponse: Int): String =
+    "https://forum.hardware.fr/forum2.php?config=hfr.inc" +
+        "&cat=$cat&post=$post&page=$page#t$numreponse"

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -642,6 +642,12 @@ private fun TopicLoadedContent(
     // #239 — how many posts of THIS page cite each post, computed once per loaded post list. Drives
     // the « cité N fois » badge below. Pure + page-scoped (cf. citationCountsByNumreponse KDoc).
     val citationCounts = remember(topic.posts) { citationCountsByNumreponse(topic.posts) }
+    // #362 — post whose contextual menu is open (null = closed). Plain local UI state at the
+    // Loaded level: the menu carries no async data, so no ViewModel/hoisting is needed — the
+    // sheet lives in :feature:topic (unlike ProfilePreviewSheet, hoisted in :app only because
+    // it needs a Hilt ViewModel). Deliberately NOT rememberSaveable: Post is not Parcelable
+    // and losing an open overflow menu across process death is acceptable.
+    var menuPost by remember { mutableStateOf<Post?>(null) }
     // #282 — shared offset between the gesture (drives translationX) and the edge glow. A plain
     // MutableFloatState: the gesture writes it synchronously per frame (no coroutine/alloc), the draw
     // phase reads it; an Animatable inside the gesture handles only release transitions. Lives in the
@@ -796,8 +802,25 @@ private fun TopicLoadedContent(
                 onEdit = editAction,
                 onDelete = deleteAction,
                 onOpenProfile = profileAction,
+                onOpenMenu = { menuPost = post },
             )
         }
+    }
+    // #362 — per-post contextual menu. The permalink is rebuilt from the LOADED topic's
+    // (cat, post, page) — not the request — so it always reflects the page HFR actually
+    // served (HFR clamps out-of-range pages). citedCount reuses the page-scoped #239 index.
+    menuPost?.let { post ->
+        PostMenuSheet(
+            post = post,
+            permalink = buildPostPermalink(
+                cat = topic.cat,
+                post = topic.post,
+                page = topic.page,
+                numreponse = post.numreponse,
+            ),
+            citedCount = citationCounts[post.numreponse] ?: 0,
+            onDismiss = { menuPost = null },
+        )
     }
 }
 
@@ -1059,6 +1082,11 @@ private fun TopicPostCard(
      * Null when [Post.profileId] is null (Publicité rows, anonymous reads).
      */
     onOpenProfile: (() -> Unit)? = null,
+    /**
+     * #362 — opens the per-post contextual menu ([PostMenuSheet]): post number (moved out
+     * of the header bar), permalink copy, edit marker, citation count.
+     */
+    onOpenMenu: () -> Unit = {},
 ) {
     Card(
         colors = CardDefaults.cardColors(
@@ -1118,6 +1146,7 @@ private fun TopicPostCard(
                 Modifier
             }
             Row(
+                modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 // Centre the avatar against the name+date block so the identity line reads as one
                 // tidy unit (the previous Top alignment + the inflated pseudo made the pseudo look
@@ -1130,7 +1159,9 @@ private fun TopicPostCard(
                     modifier = avatarModifier,
                 )
                 Column(
-                    modifier = Modifier.fillMaxWidth(),
+                    // #362 — weight(1f) instead of fillMaxWidth so the menu button below gets its
+                    // slot at the right edge of the header; the pseudo keeps its own weight inside.
+                    modifier = Modifier.weight(1f),
                     verticalArrangement = Arrangement.spacedBy(2.dp),
                 ) {
                     Row(
@@ -1150,15 +1181,10 @@ private fun TopicPostCard(
                             fontWeight = FontWeight.SemiBold,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
-                            // Clickable on the pseudo only — post number and date stay inert.
+                            // Clickable on the pseudo only — the date stays inert.
                             modifier = Modifier
                                 .weight(weight = 1f, fill = false)
                                 .then(pseudoModifier),
-                        )
-                        Text(
-                            text = stringResource(R.string.topic_post_numreponse_suffix, post.numreponse),
-                            style = MaterialTheme.typography.titleSmall,
-                            fontWeight = FontWeight.SemiBold,
                         )
                     }
                     Text(
@@ -1186,6 +1212,27 @@ private fun TopicPostCard(
                         }
                     }
                 }
+                // #362 — per-post contextual menu trigger, flush right of the header. The post
+                // number that used to trail the pseudo lives in the menu now. A text glyph, not a
+                // Material icon (detekt ForbiddenImport blocks androidx.compose.material.*) — same
+                // pattern as PageFab/ReplyFab. Sits in the OUTER row (next to the whole
+                // avatar+name+date block) so its 48dp touch target never inflates the pseudo line
+                // (cf. the pseudo minimumInteractiveComponentSize note above).
+                val menuLabel = stringResource(R.string.topic_post_menu_action)
+                Text(
+                    text = "⋯",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier
+                        .minimumInteractiveComponentSize()
+                        .clickable(
+                            onClick = onOpenMenu,
+                            role = Role.Button,
+                            onClickLabel = menuLabel,
+                        )
+                        .semantics { contentDescription = menuLabel },
+                )
             }
             // #281 — topic posts are selectable/copyable (opt-in; default is OFF in PostRenderer).
             PostRenderer(content = post.content, selectable = true)
@@ -1233,7 +1280,9 @@ private val topicDateFormatter = DateTimeFormatter
     .ofPattern("dd/MM/yyyy HH:mm:ss", Locale.FRANCE)
     .withZone(ZoneId.of("Europe/Paris"))
 
-private fun java.time.Instant.asTopicDate(): String = topicDateFormatter.format(this)
+// `internal` (#362): PostMenuSheet renders the post date and the « Édité le … » line with the
+// exact same format as the post header, so both surfaces always agree.
+internal fun java.time.Instant.asTopicDate(): String = topicDateFormatter.format(this)
 
 /**
  * #292 — confirmation before an irreversible post deletion (HFR offers no undo, cf. the #99 flag

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -14,7 +14,16 @@
     <string name="topic_error_body">Impossible d’ouvrir la page %1$d.\n\n%2$s</string>
     <string name="topic_caption">post %1$d • page %2$d / %3$d</string>
     <string name="topic_post_index_prefix">#%1$d • </string>
-    <string name="topic_post_numreponse_suffix"> • n°%1$d</string>
+    <!-- #362 — per-post contextual menu (post number, permalink copy, edit marker, citations). -->
+    <string name="topic_post_menu_action">Options du post</string>
+    <string name="topic_post_menu_number">Post n°%1$d</string>
+    <string name="topic_post_menu_copy_link">Copier le lien de ce post</string>
+    <string name="topic_post_menu_link_copied">Lien copié</string>
+    <string name="topic_post_menu_edited">Édité le %1$s</string>
+    <plurals name="topic_post_menu_cited_on_page">
+        <item quantity="one">Cité %1$d fois sur cette page</item>
+        <item quantity="other">Cité %1$d fois sur cette page</item>
+    </plurals>
     <!-- #239 — badge on a post showing how many posts of the CURRENT page cite it. -->
     <plurals name="topic_post_cited_count">
         <item quantity="one">cité %1$d fois</item>

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/PostPermalinkTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/PostPermalinkTest.kt
@@ -1,0 +1,28 @@
+package fr.forumhfr.redface2.feature.topic
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #362 — pins the permalink contract: the documented topic-page read URL
+ * (`protocol-hfr.md`) + the `#t{numreponse}` post anchor.
+ */
+class PostPermalinkTest {
+    @Test
+    fun `builds the canonical forum2 URL with the post anchor`() {
+        assertEquals(
+            "https://forum.hardware.fr/forum2.php?config=hfr.inc" +
+                "&cat=13&post=84540&page=2#t16628102",
+            buildPostPermalink(cat = 13, post = 84540, page = 2, numreponse = 16628102),
+        )
+    }
+
+    @Test
+    fun `keeps page 1 explicit so the anchor always resolves on the served page`() {
+        assertEquals(
+            "https://forum.hardware.fr/forum2.php?config=hfr.inc" +
+                "&cat=23&post=21748&page=1#t520051",
+            buildPostPermalink(cat = 23, post = 21748, page = 1, numreponse = 520051),
+        )
+    }
+}


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaaT)

Closes #362

## Menu contextuel de post (vue lecture topic)

- **Post bar** : le numéro de post quitte l'en-tête ; une icône `⋯` accessible (48dp, `Role.Button`, `onClickLabel`) à droite ouvre une `ModalBottomSheet` par post (pattern du menu profil avatar, état local — pas de VM). Le badge citations #239 reste visible sur la carte.
- **Menu** : pseudo + « Post n°X » + date ; « Copier le lien de ce post » (permalien canonique `forum2.php?…#t{numreponse}`, fonction pure `buildPostPermalink` testée, clipboard pattern Diagnostics avec Toast < API 33) ; « Édité le … » (si édité) ; « Cité N fois sur cette page » (réutilise #239, masqué à 0).
- **Parser** : `Post.editedAt` extrait de `div.edited` (regex non ancrée — le préfixe « Message cité N fois » est géré ; cas cité-sans-édité → null). `HfrDateParser.parseEditedAtOrNull`, testé sur les fixtures réelles existantes (8 posts édités épinglés exactement sur khakha p2).
- **Room v7→v8** : colonne `posts.editedAt` nullable, `MIGRATION_7_8` pure DDL + test de migration + chaînes existantes étendues, schéma `8.json` committé, mappers aller-retour testés. Les rows pré-v8 restent `editedAt = NULL` jusqu'au prochain fetch (backfill impossible, `div.edited` n'était pas persisté) — assumé.
- **Docs** : `models.md` (champ `editedAt` + diagramme, + correction d'une incohérence préexistante `profileId`), `protocol-hfr.md` (§ posts édités, contrat `div.edited`).
- Icône de ton réelle par post : différée (fallback générique validé dans l'issue) — amélioration possible en follow-up.

## Validation

- `detektAll test testDebugUnitTest :app:assembleProdDebug --rerun-tasks` : **BUILD SUCCESSFUL in 3m 24s** (538 tâches)
- `lintDebug :app:lintProdDebug` : **BUILD SUCCESSFUL** (exit 0)
- Review multi-agent 4 saveurs (bugs / conventions / UX-contrats / conformité plan↔code) : **0 finding ≥ 60** (9 mineurs < 40)
- Review Codex finale : **SHIP**, aucun bloquant

## Mono-maintainer

Merge `--squash --admin` prévu après CI verte : pas de reviewer humain disponible sur ce repo pseudonyme (convention AGENTS.md « Review en mono-maintainer »).
