### PR TITLE
feat(settings): vider le cache des images — Coil memory+disk (#314)

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -36,6 +36,12 @@ dependencies {
     // `rf2.topic.room_write` markers around the topic-page repository pipeline (#117).
     implementation(libs.androidx.tracing)
 
+    // Coil singleton accessor for DefaultImageCacheMaintenance (#314) — the `coil` artifact
+    // carries SingletonImageLoader and exposes ImageLoader/MemoryCache/DiskCache via its
+    // api dependency on coil-core. No compose/network artifacts here: :core:data only
+    // clears caches, it never loads images.
+    implementation(libs.coil.core)
+
     testImplementation(libs.junit4)
     testImplementation(libs.mockk)
     testImplementation(libs.robolectric)

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/cache/DefaultImageCacheMaintenance.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/cache/DefaultImageCacheMaintenance.kt
@@ -1,0 +1,43 @@
+package fr.forumhfr.redface2.core.data.cache
+
+import android.content.Context
+import coil3.SingletonImageLoader
+import dagger.hilt.android.qualifiers.ApplicationContext
+import fr.forumhfr.redface2.core.domain.cache.ImageCacheMaintenance
+import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+
+/**
+ * Default implementation of [ImageCacheMaintenance] — clears the Coil singleton
+ * [coil3.ImageLoader]'s memory and disk caches.
+ *
+ * The loader is resolved lazily at clear time via [SingletonImageLoader.get] on the
+ * injected application context: in production that returns the loader built by
+ * `RedfaceApplication` (which implements `SingletonImageLoader.Factory`), without
+ * introducing a `:core:data → :app` dependency; in tests a fake loader is installed
+ * up-front via `SingletonImageLoader.setUnsafe`.
+ *
+ * The whole clear runs in [withContext] on the IO dispatcher: the disk-cache clear
+ * deletes files (project rule repos-must-wrap-io), and the memory-cache clear is cheap
+ * enough that splitting dispatchers would only add complexity. Both caches are nullable
+ * on the loader (a loader can be configured without either) — null simply means nothing
+ * to clear. Same "no DiagnosticsLog" rationale as [DefaultTopicCacheMaintenance]: the
+ * result is surfaced through `SettingsState` and there is no payload to redact.
+ */
+@Singleton
+class DefaultImageCacheMaintenance @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) : ImageCacheMaintenance {
+
+    override suspend fun clearImageCache() {
+        withContext(ioDispatcher) {
+            val imageLoader = SingletonImageLoader.get(context)
+            imageLoader.memoryCache?.clear()
+            imageLoader.diskCache?.clear()
+        }
+    }
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/cache/ImageCacheMaintenanceModule.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/cache/ImageCacheMaintenanceModule.kt
@@ -1,0 +1,19 @@
+package fr.forumhfr.redface2.core.data.cache
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import fr.forumhfr.redface2.core.domain.cache.ImageCacheMaintenance
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ImageCacheMaintenanceModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindImageCacheMaintenance(
+        impl: DefaultImageCacheMaintenance,
+    ): ImageCacheMaintenance
+}

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/cache/DefaultImageCacheMaintenanceTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/cache/DefaultImageCacheMaintenanceTest.kt
@@ -1,0 +1,228 @@
+package fr.forumhfr.redface2.core.data.cache
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import coil3.ColorImage
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.annotation.DelicateCoilApi
+import coil3.disk.DiskCache
+import coil3.memory.MemoryCache
+import io.mockk.every
+import io.mockk.mockk
+import java.io.File
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toOkioPath
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Round-trip test for the « Vider le cache des images » action (#314), mirroring
+ * [DefaultTopicCacheMaintenanceTest]:
+ *
+ * 1. Build a REAL Coil [ImageLoader] with a real in-process [MemoryCache] and a real
+ *    on-disk [DiskCache], seed both (an entry in memory, a committed editor on disk),
+ *    and install it as the process singleton via [SingletonImageLoader.setUnsafe] —
+ *    the same seam `PostRendererSmileyRoborazziTest` uses. The production code resolves
+ *    the loader with `SingletonImageLoader.get(context)`, so the test exercises the
+ *    exact lookup path used at runtime.
+ * 2. Run `DefaultImageCacheMaintenance.clearImageCache()`.
+ * 3. Assert both caches are empty afterwards.
+ *
+ * The cache-less and failure paths use MockK stubs of the [ImageLoader] interface:
+ * Coil has no built-in "throwing cache" fixture, and hand-rolling full interface fakes
+ * for MemoryCache/DiskCache would couple the test to every member of those interfaces.
+ *
+ * Robolectric so Coil's Android `ImageLoader.Builder(context)` can build — same pattern
+ * as the topic-cache test (Room needed a context there, Coil needs one here).
+ */
+@OptIn(DelicateCoilApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class DefaultImageCacheMaintenanceTest {
+
+    private lateinit var context: Context
+    private var diskCache: DiskCache? = null
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    @After
+    fun tearDown() {
+        // Stop the disk cache's housekeeping and drop the singleton so the next test
+        // starts from a clean slate — setUnsafe leaks across tests otherwise.
+        diskCache?.shutdown()
+        diskCache = null
+        SingletonImageLoader.reset()
+    }
+
+    @Test
+    fun `clearImageCache empties both the memory and the disk cache`() = runTest {
+        val loader = newRealLoader()
+        seedMemoryCache(loader)
+        seedDiskCache(loader)
+        SingletonImageLoader.setUnsafe(loader)
+        val maintenance = DefaultImageCacheMaintenance(context, Dispatchers.Unconfined)
+
+        maintenance.clearImageCache()
+
+        val memoryCache = requireNotNull(loader.memoryCache)
+        assertNull(
+            "memory cache must be empty after clearImageCache",
+            memoryCache.get(MemoryCache.Key(IMAGE_URL)),
+        )
+        assertTrue("memory cache keys must be empty", memoryCache.keys.isEmpty())
+        assertEquals("memory cache size must be 0", 0L, memoryCache.size)
+        val disk = requireNotNull(loader.diskCache)
+        assertNull(
+            "disk cache must be empty after clearImageCache",
+            disk.openSnapshot(IMAGE_URL),
+        )
+        assertEquals("disk cache size must be 0", 0L, disk.size)
+    }
+
+    @Test
+    fun `clearImageCache is idempotent — running it on empty caches does not throw`() = runTest {
+        // No seed — straight to clear, twice. The UI button can be re-tapped right after a
+        // successful clear; the second pass must be a harmless no-op, like the topic mirror.
+        val loader = newRealLoader()
+        SingletonImageLoader.setUnsafe(loader)
+        val maintenance = DefaultImageCacheMaintenance(context, Dispatchers.Unconfined)
+
+        maintenance.clearImageCache()
+        maintenance.clearImageCache()
+
+        assertEquals(0L, requireNotNull(loader.memoryCache).size)
+        assertEquals(0L, requireNotNull(loader.diskCache).size)
+    }
+
+    @Test
+    fun `clearImageCache tolerates a loader configured without caches`() = runTest {
+        // Both caches are nullable on the ImageLoader contract; the null-safe clears must
+        // simply skip them instead of crashing the maintenance action.
+        val loader = mockk<ImageLoader> {
+            every { memoryCache } returns null
+            every { diskCache } returns null
+        }
+        SingletonImageLoader.setUnsafe(loader)
+        val maintenance = DefaultImageCacheMaintenance(context, Dispatchers.Unconfined)
+
+        maintenance.clearImageCache()
+    }
+
+    @Test
+    fun `clearImageCache propagates a cache failure to the caller`() = runTest {
+        // Contract pinned by the interface KDoc: failures must reach the caller so the
+        // SettingsViewModel can surface ImageCacheClearResult.Failure instead of lying
+        // with a success message.
+        val failingMemoryCache = mockk<MemoryCache> {
+            every { clear() } throws IllegalStateException("boom")
+        }
+        val loader = mockk<ImageLoader> {
+            every { memoryCache } returns failingMemoryCache
+            every { diskCache } returns null
+        }
+        SingletonImageLoader.setUnsafe(loader)
+        val maintenance = DefaultImageCacheMaintenance(context, Dispatchers.Unconfined)
+
+        val thrown = runCatching { maintenance.clearImageCache() }.exceptionOrNull()
+
+        assertTrue(
+            "the cache failure must propagate, got: $thrown",
+            thrown is IllegalStateException,
+        )
+    }
+
+    @Test
+    fun `clearImageCache runs the clears through the injected IO dispatcher`() = runTest {
+        // repos-must-wrap-io: the disk clear is file I/O, so the implementation must hop to
+        // the injected dispatcher. A recording dispatcher proves withContext actually
+        // dispatched (Unconfined would hide a missing withContext, cf. the project rule).
+        val recordingDispatcher = RecordingDispatcher()
+        val loader = newRealLoader()
+        seedMemoryCache(loader)
+        SingletonImageLoader.setUnsafe(loader)
+        val maintenance = DefaultImageCacheMaintenance(context, recordingDispatcher)
+
+        maintenance.clearImageCache()
+
+        assertTrue(
+            "clearImageCache must go through withContext(ioDispatcher)",
+            recordingDispatcher.dispatchCount > 0,
+        )
+        assertEquals(0L, requireNotNull(loader.memoryCache).size)
+    }
+
+    /**
+     * A real loader with both caches enabled, sized small but comfortably above the seeded
+     * entries. Unique disk directory per loader so a journal left by a previous test can
+     * never bleed in; the instance is remembered for [tearDown]'s `shutdown()`.
+     */
+    private fun newRealLoader(): ImageLoader {
+        val memoryCache = MemoryCache.Builder()
+            .maxSizeBytes(MEMORY_CACHE_MAX_BYTES)
+            .build()
+        val disk = DiskCache.Builder()
+            .directory(File(context.cacheDir, "coil_test_disk_${System.nanoTime()}").toOkioPath())
+            .maxSizeBytes(DISK_CACHE_MAX_BYTES)
+            .build()
+        diskCache = disk
+        return ImageLoader.Builder(context)
+            .memoryCache { memoryCache }
+            .diskCache { disk }
+            .build()
+    }
+
+    private fun seedMemoryCache(loader: ImageLoader) {
+        val memoryCache = requireNotNull(loader.memoryCache)
+        memoryCache.set(
+            MemoryCache.Key(IMAGE_URL),
+            MemoryCache.Value(ColorImage(SEED_COLOR, width = 16, height = 16, size = SEED_IMAGE_BYTES)),
+        )
+        // Sanity check: the seed actually landed.
+        assertNotNull(memoryCache.get(MemoryCache.Key(IMAGE_URL)))
+        assertEquals(SEED_IMAGE_BYTES, memoryCache.size)
+    }
+
+    private fun seedDiskCache(loader: ImageLoader) {
+        val disk = requireNotNull(loader.diskCache)
+        val editor = requireNotNull(disk.openEditor(IMAGE_URL))
+        disk.fileSystem.write(editor.metadata) { writeUtf8("meta") }
+        disk.fileSystem.write(editor.data) { writeUtf8("gif-bytes") }
+        editor.commit()
+        // Sanity check: the entry is readable and accounted for.
+        requireNotNull(disk.openSnapshot(IMAGE_URL)).close()
+        assertTrue("disk cache must account the seeded entry", disk.size > 0L)
+    }
+
+    private class RecordingDispatcher : CoroutineDispatcher() {
+        var dispatchCount: Int = 0
+            private set
+
+        override fun dispatch(context: CoroutineContext, block: Runnable) {
+            dispatchCount += 1
+            block.run()
+        }
+    }
+
+    private companion object {
+        const val IMAGE_URL = "https://forum.hardware.fr/images/perso/f/franzhermann.gif"
+        val SEED_COLOR = 0xFF1565C0.toInt()
+        const val SEED_IMAGE_BYTES = 1_024L
+        const val MEMORY_CACHE_MAX_BYTES = 1L * 1024 * 1024
+        const val DISK_CACHE_MAX_BYTES = 1L * 1024 * 1024
+    }
+}

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/cache/ImageCacheMaintenance.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/cache/ImageCacheMaintenance.kt
@@ -1,0 +1,29 @@
+package fr.forumhfr.redface2.core.domain.cache
+
+/**
+ * Maintenance handle for the **image cache** (Coil memory + disk caches). Exposes the
+ * narrow "wipe every downloaded image" surface used by Paramètres → Maintenance →
+ * « Vider le cache des images » (#314).
+ *
+ * Mirror of [TopicCacheMaintenance]: a dedicated single-capability interface keeps the
+ * SettingsViewModel seam trivial (it injects exactly the maintenance it needs) and keeps
+ * the image-loading read path (Coil's `AsyncImage` call sites) out of the contract.
+ *
+ * Implementations MUST scope I/O on a background dispatcher and MUST leave every other
+ * subsystem intact:
+ * - **NOT** touched: HFR cookies, auth state, DataStore preferences, Room caches
+ *   (`topic_pages`, `posts`, `flag_topics`, category caches).
+ * - **Touched only**: the Coil memory cache and disk cache (avatars, smileys, `[img]`
+ *   pictures). Cleared images are simply re-downloaded on their next display.
+ */
+interface ImageCacheMaintenance {
+
+    /**
+     * Wipes the Coil memory + disk image caches. Suspending; expected to run on
+     * `Dispatchers.IO` (the implementation owns the dispatcher switch — the disk clear
+     * is file I/O). Throws if the underlying cache clear fails — callers must surface
+     * the error rather than swallowing it so a user can retry instead of staring at a
+     * silently-no-op button.
+     */
+    suspend fun clearImageCache()
+}

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -206,7 +206,6 @@ internal fun SettingsContent(
             FutureSettingsCard(
                 items = listOf(
                     R.string.settings_future_data_saver to issueTag(310),
-                    R.string.settings_future_clear_image_cache to issueTag(314),
                 ),
             )
 
@@ -303,6 +302,12 @@ internal fun SettingsContent(
         ClearTopicCacheConfirmDialog(
             onConfirm = { onIntent(SettingsIntent.ClearTopicCacheConfirmed) },
             onDismiss = { onIntent(SettingsIntent.ClearTopicCacheDismissed) },
+        )
+    }
+    if (state.showClearImageCacheConfirm) {
+        ClearImageCacheConfirmDialog(
+            onConfirm = { onIntent(SettingsIntent.ClearImageCacheConfirmed) },
+            onDismiss = { onIntent(SettingsIntent.ClearImageCacheDismissed) },
         )
     }
 }
@@ -644,6 +649,50 @@ private fun MaintenanceCard(
                 Text(stringResource(R.string.settings_clear_topic_cache_button))
             }
 
+            // #314 — « Vider le cache des images », same confirm → progress → inline-result
+            // flow as the topic clear above, on its own dedicated state fields.
+            Text(
+                text = stringResource(R.string.settings_clear_image_cache_intro),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (state.isClearingImageCache) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                    )
+                    Text(
+                        text = stringResource(R.string.settings_clear_image_cache_in_progress),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            when (state.imageCacheClearResult) {
+                ImageCacheClearResult.Success -> Text(
+                    text = stringResource(R.string.settings_clear_image_cache_success),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                ImageCacheClearResult.Failure -> Text(
+                    text = stringResource(R.string.settings_clear_image_cache_failure),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                )
+                null -> Unit
+            }
+            OutlinedButton(
+                enabled = state.canClearImageCache,
+                onClick = { onIntent(SettingsIntent.ClearImageCacheClicked) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.settings_clear_image_cache_button))
+            }
+
             IgnoreTopicCacheRow(
                 state = state,
                 onIntent = onIntent,
@@ -709,6 +758,28 @@ private fun ClearTopicCacheConfirmDialog(
         dismissButton = {
             TextButton(onClick = onDismiss) {
                 Text(stringResource(R.string.settings_clear_topic_cache_confirm_cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun ClearImageCacheConfirmDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.settings_clear_image_cache_confirm_title)) },
+        text = { Text(stringResource(R.string.settings_clear_image_cache_confirm_body)) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.settings_clear_image_cache_confirm_action))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.settings_clear_image_cache_confirm_cancel))
             }
         },
     )

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -17,6 +17,13 @@ data class SettingsState(
     val showClearTopicCacheConfirm: Boolean = false,
     val isClearingTopicCache: Boolean = false,
     val topicCacheClearResult: TopicCacheClearResult? = null,
+    // Image cache maintenance — « Vider le cache des images » (#314). DEDICATED trio,
+    // strictly mirroring the topic-cache fields above: sharing them would make the two
+    // Maintenance entries collide (a topic clear would flash its result under the image
+    // button and vice versa).
+    val showClearImageCacheConfirm: Boolean = false,
+    val isClearingImageCache: Boolean = false,
+    val imageCacheClearResult: ImageCacheClearResult? = null,
     // Alpha-only "Ignorer le cache topic" toggle (Phase 2 finish). Persisted in DataStore via
     // UserPreferencesRepository — the ViewModel hydrates this field from the persisted value
     // and writes back on user toggle. `isUpdatingIgnoreTopicCache` gates the switch while the
@@ -78,6 +85,9 @@ data class SettingsState(
     val canClearTopicCache: Boolean
         get() = !isClearingTopicCache
 
+    val canClearImageCache: Boolean
+        get() = !isClearingImageCache
+
     val canToggleIgnoreTopicCache: Boolean
         get() = !isUpdatingIgnoreTopicCache
 
@@ -121,6 +131,17 @@ sealed interface TopicCacheClearResult {
     data object Failure : TopicCacheClearResult
 }
 
+/**
+ * Outcome of the latest « Vider le cache des images » click (#314). Dedicated type for
+ * the same reason [TopicCacheClearResult] is separate from the proxy fields: the two
+ * Maintenance actions are unrelated flows and one must never dismiss or repaint the
+ * other's still-visible feedback.
+ */
+sealed interface ImageCacheClearResult {
+    data object Success : ImageCacheClearResult
+    data object Failure : ImageCacheClearResult
+}
+
 sealed interface SettingsIntent {
     data class ProxyEnabledChanged(val enabled: Boolean) : SettingsIntent
     data class ProxyHostChanged(val host: String) : SettingsIntent
@@ -135,6 +156,12 @@ sealed interface SettingsIntent {
     data object ClearTopicCacheClicked : SettingsIntent
     data object ClearTopicCacheConfirmed : SettingsIntent
     data object ClearTopicCacheDismissed : SettingsIntent
+
+    // Image cache maintenance flow (#314) — same three-intent confirm shape as the topic
+    // cache above, operating on the dedicated image-cache state fields.
+    data object ClearImageCacheClicked : SettingsIntent
+    data object ClearImageCacheConfirmed : SettingsIntent
+    data object ClearImageCacheDismissed : SettingsIntent
 
     // Alpha "Ignorer le cache topic" toggle. The boolean is the desired post-flip state; the
     // ViewModel applies it optimistically, then reverts on DataStore failure so the UI never

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -186,6 +186,9 @@ class SettingsViewModel @Inject constructor(
     }
 
     private fun clearTopicCache() {
+        // Re-entrance guard: the dialog's confirm button is not gated by state, so a
+        // double-tap before recomposition would otherwise launch two concurrent clears.
+        if (_state.value.isClearingTopicCache) return
         // Close the confirmation dialog upfront so the user can't double-confirm, then flip
         // `isClearingTopicCache` so the button is disabled while Room runs the transaction.
         _state.update {
@@ -217,6 +220,8 @@ class SettingsViewModel @Inject constructor(
     }
 
     private fun clearImageCache() {
+        // Re-entrance guard, mirror of clearTopicCache() above.
+        if (_state.value.isClearingImageCache) return
         // Mirror of clearTopicCache(): close the dialog upfront so the user can't
         // double-confirm, then gate the button on `isClearingImageCache` while Coil
         // wipes the memory + disk caches.

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -3,6 +3,7 @@ package fr.forumhfr.redface2.feature.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.cache.ImageCacheMaintenance
 import fr.forumhfr.redface2.core.domain.cache.TopicCacheMaintenance
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
@@ -19,6 +20,7 @@ import kotlinx.coroutines.launch
 class SettingsViewModel @Inject constructor(
     private val userPreferencesRepository: UserPreferencesRepository,
     private val topicCacheMaintenance: TopicCacheMaintenance,
+    private val imageCacheMaintenance: ImageCacheMaintenance,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(SettingsState())
@@ -134,6 +136,15 @@ class SettingsViewModel @Inject constructor(
             SettingsIntent.ClearTopicCacheDismissed ->
                 _state.update { it.copy(showClearTopicCacheConfirm = false) }
             SettingsIntent.ClearTopicCacheConfirmed -> clearTopicCache()
+            SettingsIntent.ClearImageCacheClicked ->
+                _state.update {
+                    // Same clean-slate reset as the topic mirror: the dialog must not open
+                    // over a stale "succès" / "échec" label from a previous attempt.
+                    it.copy(showClearImageCacheConfirm = true, imageCacheClearResult = null)
+                }
+            SettingsIntent.ClearImageCacheDismissed ->
+                _state.update { it.copy(showClearImageCacheConfirm = false) }
+            SettingsIntent.ClearImageCacheConfirmed -> clearImageCache()
             is SettingsIntent.IgnoreTopicCacheChanged -> updateIgnoreTopicCache(intent.enabled)
             is SettingsIntent.FlagsGroupByCategoryChanged -> updateFlagsGroupByCategory(intent.enabled)
             is SettingsIntent.FlagsHideReadCategoriesChanged -> updateFlagsHideReadCategories(intent.enabled)
@@ -199,6 +210,38 @@ class SettingsViewModel @Inject constructor(
                         it.copy(
                             isClearingTopicCache = false,
                             topicCacheClearResult = TopicCacheClearResult.Failure,
+                        )
+                    }
+                }
+        }
+    }
+
+    private fun clearImageCache() {
+        // Mirror of clearTopicCache(): close the dialog upfront so the user can't
+        // double-confirm, then gate the button on `isClearingImageCache` while Coil
+        // wipes the memory + disk caches.
+        _state.update {
+            it.copy(
+                showClearImageCacheConfirm = false,
+                isClearingImageCache = true,
+                imageCacheClearResult = null,
+            )
+        }
+        viewModelScope.launch {
+            runCatching { imageCacheMaintenance.clearImageCache() }
+                .onSuccess {
+                    _state.update {
+                        it.copy(
+                            isClearingImageCache = false,
+                            imageCacheClearResult = ImageCacheClearResult.Success,
+                        )
+                    }
+                }
+                .onFailure {
+                    _state.update {
+                        it.copy(
+                            isClearingImageCache = false,
+                            imageCacheClearResult = ImageCacheClearResult.Failure,
                         )
                     }
                 }

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -34,7 +34,6 @@
     <string name="settings_future_mp_write">Composer un nouveau message privé</string>
     <string name="settings_future_mp_notifications">Notifications et badge de MP non lus</string>
     <string name="settings_future_data_saver">Mode économie de données</string>
-    <string name="settings_future_clear_image_cache">Vider le cache des images</string>
     <string name="settings_future_hfr_profile">Avatars, signatures, messages par page</string>
     <string name="settings_future_notifications">Relève configurable, filtres, mode Ne pas déranger</string>
     <string name="settings_future_timezone">Fuseau horaire d’affichage</string>
@@ -67,6 +66,20 @@
     <string name="settings_clear_topic_cache_in_progress">Vidage du cache des topics…</string>
     <string name="settings_clear_topic_cache_success">Cache des topics vidé. Les prochains topics ouverts seront retéléchargés.</string>
     <string name="settings_clear_topic_cache_failure">Impossible de vider le cache des topics. Réessayez depuis cette page.</string>
+
+    <!-- #314 — action de maintenance « Vider le cache des images ». Vide les caches Coil
+         (mémoire + disque) : avatars, smileys perso, images [img]. Les images sont simplement
+         retéléchargées à leur prochain affichage ; ne touche ni à l'authentification, ni aux
+         drapeaux, ni aux pages de topics en cache, ni aux préférences. -->
+    <string name="settings_clear_image_cache_intro">Supprime les images téléchargées (avatars, smileys, images des messages) stockées en mémoire et sur le disque. Elles seront retéléchargées à leur prochain affichage. Les topics en cache, les drapeaux et l\'authentification ne sont pas affectés.</string>
+    <string name="settings_clear_image_cache_button">Vider le cache des images</string>
+    <string name="settings_clear_image_cache_confirm_title">Vider le cache des images ?</string>
+    <string name="settings_clear_image_cache_confirm_body">Cette action ne déconnecte pas et ne supprime aucun message. Les images seront retéléchargées à leur prochain affichage.</string>
+    <string name="settings_clear_image_cache_confirm_action">Vider</string>
+    <string name="settings_clear_image_cache_confirm_cancel">Annuler</string>
+    <string name="settings_clear_image_cache_in_progress">Vidage du cache des images…</string>
+    <string name="settings_clear_image_cache_success">Cache des images vidé. Les images seront retéléchargées à leur prochain affichage.</string>
+    <string name="settings_clear_image_cache_failure">Impossible de vider le cache des images. Réessayez depuis cette page.</string>
 
     <!-- Phase 2 finish — alpha toggle "Ignorer le cache topic". Bypasses the topic Room cache
          read path and turns the anonymous topic prefetch into a no-op, so a parser/renderer

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.feature.settings
 
+import fr.forumhfr.redface2.core.domain.cache.ImageCacheMaintenance
 import fr.forumhfr.redface2.core.domain.cache.TopicCacheMaintenance
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
@@ -30,6 +31,7 @@ class SettingsViewModelTest {
 
     private val repository = FakeUserPreferencesRepository()
     private val topicCacheMaintenance = FakeTopicCacheMaintenance()
+    private val imageCacheMaintenance = FakeImageCacheMaintenance()
 
     @Before
     fun setUp() {
@@ -210,6 +212,129 @@ class SettingsViewModelTest {
         // pending operation.
         assertTrue(viewModel.state.value.showClearTopicCacheConfirm)
         assertNull(viewModel.state.value.topicCacheClearResult)
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Image cache maintenance — "Vider le cache des images" action (#314)
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `ClearImageCacheClicked opens the confirmation dialog without touching the cache`() = runTest {
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.ClearImageCacheClicked)
+
+        assertTrue(viewModel.state.value.showClearImageCacheConfirm)
+        assertEquals(
+            "clear() must NOT run until the user confirms",
+            0,
+            imageCacheMaintenance.clearCalls,
+        )
+    }
+
+    @Test
+    fun `ClearImageCacheDismissed closes the dialog without calling clear`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.submit(SettingsIntent.ClearImageCacheClicked)
+
+        viewModel.submit(SettingsIntent.ClearImageCacheDismissed)
+
+        assertFalse(viewModel.state.value.showClearImageCacheConfirm)
+        assertEquals(0, imageCacheMaintenance.clearCalls)
+        assertNull(viewModel.state.value.imageCacheClearResult)
+    }
+
+    @Test
+    fun `ClearImageCacheConfirmed runs clear and surfaces Success`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.submit(SettingsIntent.ClearImageCacheClicked)
+
+        viewModel.submit(SettingsIntent.ClearImageCacheConfirmed)
+
+        val state = viewModel.state.value
+        assertEquals(1, imageCacheMaintenance.clearCalls)
+        assertFalse("dialog must close at confirm time", state.showClearImageCacheConfirm)
+        assertFalse("isClearing must flip back to false after success", state.isClearingImageCache)
+        assertEquals(ImageCacheClearResult.Success, state.imageCacheClearResult)
+    }
+
+    @Test
+    fun `ClearImageCacheConfirmed exposes in-progress state while clear is running`() = runTest {
+        imageCacheMaintenance.blockUntil = CompletableDeferred()
+        val viewModel = newViewModel()
+        viewModel.submit(SettingsIntent.ClearImageCacheClicked)
+
+        viewModel.submit(SettingsIntent.ClearImageCacheConfirmed)
+
+        assertTrue(viewModel.state.value.isClearingImageCache)
+        assertFalse(viewModel.state.value.canClearImageCache)
+
+        imageCacheMaintenance.blockUntil?.complete(Unit)
+        yield()
+
+        assertFalse(viewModel.state.value.isClearingImageCache)
+        assertEquals(ImageCacheClearResult.Success, viewModel.state.value.imageCacheClearResult)
+    }
+
+    @Test
+    fun `ClearImageCacheConfirmed surfaces Failure when the maintenance call throws`() = runTest {
+        imageCacheMaintenance.failOnClear = true
+        val viewModel = newViewModel()
+        viewModel.submit(SettingsIntent.ClearImageCacheClicked)
+
+        viewModel.submit(SettingsIntent.ClearImageCacheConfirmed)
+
+        val state = viewModel.state.value
+        assertEquals(1, imageCacheMaintenance.clearCalls)
+        assertFalse(state.isClearingImageCache)
+        assertEquals(ImageCacheClearResult.Failure, state.imageCacheClearResult)
+        // Proxy state stays untouched — the two domains must not bleed.
+        assertNull(state.error)
+        assertFalse(state.saved)
+    }
+
+    @Test
+    fun `re-clicking the image clear after a previous result resets the inline message`() = runTest {
+        imageCacheMaintenance.failOnClear = true
+        val viewModel = newViewModel()
+        viewModel.submit(SettingsIntent.ClearImageCacheClicked)
+        viewModel.submit(SettingsIntent.ClearImageCacheConfirmed)
+        assertEquals(ImageCacheClearResult.Failure, viewModel.state.value.imageCacheClearResult)
+
+        // Second pass — user retries.
+        viewModel.submit(SettingsIntent.ClearImageCacheClicked)
+
+        assertTrue(viewModel.state.value.showClearImageCacheConfirm)
+        assertNull(viewModel.state.value.imageCacheClearResult)
+    }
+
+    @Test
+    fun `image and topic clear flows stay independent`() = runTest {
+        // The two Maintenance entries live side by side in the same card — dedicated state
+        // fields must guarantee a click on one never opens/repaints the other (#314 design
+        // note: no shared topicCacheClearResult/isClearingTopicCache).
+        imageCacheMaintenance.failOnClear = true
+        val viewModel = newViewModel()
+        viewModel.submit(SettingsIntent.ClearTopicCacheClicked)
+        viewModel.submit(SettingsIntent.ClearTopicCacheConfirmed)
+        assertEquals(TopicCacheClearResult.Success, viewModel.state.value.topicCacheClearResult)
+
+        viewModel.submit(SettingsIntent.ClearImageCacheClicked)
+        assertFalse(
+            "the image dialog must not be mirrored on the topic flag",
+            viewModel.state.value.showClearTopicCacheConfirm,
+        )
+        viewModel.submit(SettingsIntent.ClearImageCacheConfirmed)
+
+        val state = viewModel.state.value
+        assertEquals(ImageCacheClearResult.Failure, state.imageCacheClearResult)
+        assertEquals(
+            "the image failure must not erase the topic success feedback",
+            TopicCacheClearResult.Success,
+            state.topicCacheClearResult,
+        )
+        assertEquals(1, topicCacheMaintenance.clearCalls)
+        assertEquals(1, imageCacheMaintenance.clearCalls)
     }
 
     // ──────────────────────────────────────────────────────────────────────
@@ -650,7 +775,7 @@ class SettingsViewModelTest {
         }
 
     private fun newViewModel(): SettingsViewModel =
-        SettingsViewModel(repository, topicCacheMaintenance)
+        SettingsViewModel(repository, topicCacheMaintenance, imageCacheMaintenance)
 
     private class FakeUserPreferencesRepository : UserPreferencesRepository {
         private val config = MutableStateFlow(ProxyConfig())
@@ -844,6 +969,19 @@ class SettingsViewModelTest {
         var blockUntil: CompletableDeferred<Unit>? = null
 
         override suspend fun clearTopicCache() {
+            clearCalls += 1
+            blockUntil?.await()
+            check(!failOnClear) { "boom" }
+        }
+    }
+
+    private class FakeImageCacheMaintenance : ImageCacheMaintenance {
+        var clearCalls: Int = 0
+            private set
+        var failOnClear: Boolean = false
+        var blockUntil: CompletableDeferred<Unit>? = null
+
+        override suspend fun clearImageCache() {
             clearCalls += 1
             blockUntil?.await()
             check(!failOnClear) { "boom" }

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -259,6 +259,24 @@ class SettingsViewModelTest {
     }
 
     @Test
+    fun `ClearImageCacheConfirmed ignores a re-entrant confirm while a clear is running`() = runTest {
+        // Codex final-review finding (#314): the dialog's confirm button is not gated by
+        // state — a double-tap before recomposition must not start two concurrent clears.
+        val gate = CompletableDeferred<Unit>()
+        imageCacheMaintenance.blockUntil = gate
+        val viewModel = newViewModel()
+        viewModel.submit(SettingsIntent.ClearImageCacheClicked)
+
+        viewModel.submit(SettingsIntent.ClearImageCacheConfirmed)
+        viewModel.submit(SettingsIntent.ClearImageCacheConfirmed)
+
+        assertEquals(1, imageCacheMaintenance.clearCalls)
+        gate.complete(Unit)
+        assertEquals(ImageCacheClearResult.Success, viewModel.state.value.imageCacheClearResult)
+        assertFalse(viewModel.state.value.isClearingImageCache)
+    }
+
+    @Test
     fun `ClearImageCacheConfirmed exposes in-progress state while clear is running`() = runTest {
         imageCacheMaintenance.blockUntil = CompletableDeferred()
         val viewModel = newViewModel()


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaaT)

Closes #314

## Vider le cache des images (Coil)

Miroir exact du pattern « Vider le cache des topics » :
- `ImageCacheMaintenance` (`:core:domain`) + `DefaultImageCacheMaintenance` (`:core:data`) : `SingletonImageLoader.get(@ApplicationContext)` résolu paresseusement, `memoryCache?.clear()` + `diskCache?.clear()` sous `withContext(ioDispatcher)`, module Hilt `@Binds @Singleton` (+ dépendance `libs.coil.core`).
- Carte Maintenance Settings : entrée active avec dialog de confirmation + résultat inline, **états/intents/résultats dédiés** (aucune collision avec le flux topics), **guard de réentrance** sur les confirms (finding Codex final — appliqué aussi au miroir topics, défaut latent identique).
- Vitrine #288 : ligne `#314` retirée du catalogue grisé, 9 strings dédiées.
- API Coil 3.4.0 vérifiée **par inspection du bytecode des jars** (pas de supposition).

## Tests

12 tests : chemins nominaux sur **vrais caches Coil** (seed → clear → vide, via `setUnsafe`/`reset`), chemins sans-cache/erreur via stubs, preuve du dispatch `ioDispatcher` (RecordingDispatcher), non-réentrance (fake bloquant, 1 seul appel).

## Validation

- Part 1 (`detektAll test testDebugUnitTest :app:assembleProdDebug --rerun-tasks`) : **BUILD SUCCESSFUL in 3m 11s** (revalidation post-fix Codex ; 1re passe verte 4m 10s, un échec intermédiaire prouvé OOM-kill kernel — flakiness infra, pas le code)
- Part 2 (`lintDebug :app:lintProdDebug`) : **BUILD SUCCESSFUL in 39s**
- Review multi-agent 4 saveurs (reprise en resume après le reset quota) : **0 finding ≥ 60** (13 mineurs < 40)
- Review Codex finale : 1 bloquant (réentrance du confirm) → **corrigé + testé**, reste « clean à mon niveau »

## Mono-maintainer

Merge `--squash --admin` prévu après CI verte (convention AGENTS.md, pas de reviewer sûr disponible).
