### PR TITLE
feat(ui): horodatage du dernier post dans les listes catégorie, recherche et drapeaux (#325)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
@@ -80,6 +81,9 @@ fun FlagItem(
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
+                    // #325 — the line can exceed narrow screens now that it carries the
+                    // last-reply timestamp: signal the truncation instead of hard-clipping.
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
         }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/LastReplyFormatting.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/LastReplyFormatting.kt
@@ -1,0 +1,38 @@
+package fr.forumhfr.redface2.core.ui
+
+/**
+ * REST listing timestamp shape, as printed by HFR's REST API (`last_post_date`):
+ * `YYYY-MM-DD HH:mm` — no seconds, no timezone. Proven by the live fixtures
+ * (`rest_cat23_participated.json`, `rest_topics_cat23_subcat550_p1.json`) and the
+ * mapper tests (`RestForumMappersTest`, `RestFlagMappersTest`).
+ */
+private val REST_TIMESTAMP = Regex("""(\d{4})-(\d{2})-(\d{2}) (\d{2}:\d{2})""")
+
+/**
+ * Formats a raw "last reply" timestamp for list rows so the app matches what the HFR
+ * website prints in its listings: the absolute compact form `DD-MM-YYYY à HH:mm`
+ * (year always shown, even for the current year — exactly like the web).
+ *
+ * Observed source formats (#325):
+ * - **REST mappers** (`TopicSummary.lastReplyAt`, `Flag.lastReplyAt`, both fed from the
+ *   REST `last_post_date` field): `YYYY-MM-DD HH:mm`, e.g. `2026-05-01 17:07`. This is
+ *   the shape this function rewrites, to `01-05-2026 à 17:07`.
+ * - **Search HTML parser** (`SearchTopicResult.lastReplyAt` via
+ *   `SearchResultParser.parseLastReply`): already the web form `DD-MM-YYYY à HH:mm`
+ *   (NBSP normalised to plain spaces upstream), e.g. `24-09-2025 à 06:48`. It does not
+ *   match the REST shape and therefore passes through unchanged — which is the desired
+ *   display.
+ *
+ * Strict fallback rule: any input that does not match the REST shape **in its
+ * entirety** is returned as-is. This function never throws and never turns a non-empty
+ * input into an empty one; it is a mechanical reorder, not a date parser (it does not
+ * validate that day/month values are calendar-plausible).
+ */
+fun formatLastReplyTimestamp(raw: String): String {
+    val match = REST_TIMESTAMP.matchEntire(raw) ?: return raw
+    val year = match.groupValues[1]
+    val month = match.groupValues[2]
+    val day = match.groupValues[3]
+    val time = match.groupValues[4]
+    return "$day-$month-$year à $time"
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/LastReplyFormattingTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/LastReplyFormattingTest.kt
@@ -1,0 +1,43 @@
+package fr.forumhfr.redface2.core.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure-JVM tests for [formatLastReplyTimestamp] (#325). One case per real source format
+ * (REST listing vs search HTML), plus the strict passthrough fallback contract.
+ */
+class LastReplyFormattingTest {
+
+    @Test
+    fun `rest timestamp is reordered to the web form`() {
+        // Format proven by rest_cat23_participated.json / RestFlagMappersTest.
+        assertEquals("01-05-2026 à 17:07", formatLastReplyTimestamp("2026-05-01 17:07"))
+    }
+
+    @Test
+    fun `rest timestamp keeps zero-padded fields verbatim`() {
+        assertEquals("09-02-2026 à 16:26", formatLastReplyTimestamp("2026-02-09 16:26"))
+    }
+
+    @Test
+    fun `search timestamp already in web form is returned unchanged`() {
+        // Format produced by SearchResultParser.parseLastReply (NBSP already stripped).
+        assertEquals("24-09-2025 à 06:48", formatLastReplyTimestamp("24-09-2025 à 06:48"))
+    }
+
+    @Test
+    fun `unknown formats pass through untouched`() {
+        assertEquals("hier à 06:48", formatLastReplyTimestamp("hier à 06:48"))
+        // Date-only and seconds-bearing variants are NOT the proven REST shape: no guessing.
+        assertEquals("2026-05-01", formatLastReplyTimestamp("2026-05-01"))
+        assertEquals("2026-05-01 17:07:33", formatLastReplyTimestamp("2026-05-01 17:07:33"))
+        // Partial match inside a longer string must not be rewritten either.
+        assertEquals("le 2026-05-01 17:07", formatLastReplyTimestamp("le 2026-05-01 17:07"))
+    }
+
+    @Test
+    fun `empty string passes through`() {
+        assertEquals("", formatLastReplyTimestamp(""))
+    }
+}

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -61,6 +61,7 @@ import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.ui.FlagItem
 import fr.forumhfr.redface2.core.ui.FlagItemDivider
+import fr.forumhfr.redface2.core.ui.formatLastReplyTimestamp
 import kotlinx.coroutines.launch
 
 /**
@@ -935,21 +936,44 @@ private data class FlagsViewSettingsActions(
     val onDismiss: () -> Unit,
 )
 
+/**
+ * Footer line of a drapeau row. #325 adds the last-reply timestamp, formatted web-style
+ * (`01-05-2026 à 17:07`) by [formatLastReplyTimestamp] from the raw REST string. Both the
+ * author and the timestamp are optional on the wire (blank when REST omits them), so each
+ * combination maps to its own template — never a dangling `·` separator.
+ */
 @Composable
-private fun flagMetadata(flag: Flag): String =
-    if (flag.lastReplyAuthor.isNotBlank()) {
-        stringResource(
+private fun flagMetadata(flag: Flag): String {
+    val lastReplyAt = formatLastReplyTimestamp(flag.lastReplyAt)
+    val hasAuthor = flag.lastReplyAuthor.isNotBlank()
+    return when {
+        hasAuthor && lastReplyAt.isNotBlank() -> stringResource(
+            R.string.flags_item_metadata_with_author_at,
+            flag.lastReplyAuthor,
+            lastReplyAt,
+            flag.replyCount,
+            flag.lastReadPage,
+            flag.totalPages,
+        )
+        hasAuthor -> stringResource(
             R.string.flags_item_metadata_with_author,
             flag.lastReplyAuthor,
             flag.replyCount,
             flag.lastReadPage,
             flag.totalPages,
         )
-    } else {
-        stringResource(
+        lastReplyAt.isNotBlank() -> stringResource(
+            R.string.flags_item_metadata_no_author_at,
+            lastReplyAt,
+            flag.replyCount,
+            flag.lastReadPage,
+            flag.totalPages,
+        )
+        else -> stringResource(
             R.string.flags_item_metadata_no_author,
             flag.replyCount,
             flag.lastReadPage,
             flag.totalPages,
         )
     }
+}

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -43,12 +43,14 @@
     <string name="flags_retry">Réessayer</string>
 
     <!-- Footer metadata formats. The `*_at` variants (#325) carry the last-reply timestamp
-         already formatted web-style by :core:ui (`01-05-2026 à 17:07`):
-         "Shaad · 01-05-2026 à 17:07 · 69017 rép. · p.1725/1726". The timestamp-less variants
+         already formatted web-style by :core:ui (`01-05-2026 à 17:07`), placed LAST so that
+         on narrow screens the ellipsis eats the added data first and never the pre-existing
+         read-progress « p.X/Y » (review #325):
+         "Shaad · 69017 rép. · p.1725/1726 · 01-05-2026 à 17:07". The timestamp-less variants
          remain as fallbacks when REST omits `last_post_date`. Without author (HFR returns no
          last replier on brand new topics): "69017 rép. · p.1/1". -->
-    <string name="flags_item_metadata_with_author_at">%1$s · %2$s · %3$d rép. · p.%4$d/%5$d</string>
-    <string name="flags_item_metadata_no_author_at">%1$s · %2$d rép. · p.%3$d/%4$d</string>
+    <string name="flags_item_metadata_with_author_at">%1$s · %3$d rép. · p.%4$d/%5$d · %2$s</string>
+    <string name="flags_item_metadata_no_author_at">%2$d rép. · p.%3$d/%4$d · %1$s</string>
     <string name="flags_item_metadata_with_author">%1$s · %2$d rép. · p.%3$d/%4$d</string>
     <string name="flags_item_metadata_no_author">%1$d rép. · p.%2$d/%3$d</string>
 

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -42,8 +42,13 @@
     <string name="flags_session_expired">Session HFR expirée. Reconnecte-toi pour recharger tes drapeaux.</string>
     <string name="flags_retry">Réessayer</string>
 
-    <!-- Footer metadata formats. With author: "Shaad · 69017 rép. · p.1725/1726". Without
-         author (HFR returns no last replier on brand new topics): "69017 rép. · p.1/1". -->
+    <!-- Footer metadata formats. The `*_at` variants (#325) carry the last-reply timestamp
+         already formatted web-style by :core:ui (`01-05-2026 à 17:07`):
+         "Shaad · 01-05-2026 à 17:07 · 69017 rép. · p.1725/1726". The timestamp-less variants
+         remain as fallbacks when REST omits `last_post_date`. Without author (HFR returns no
+         last replier on brand new topics): "69017 rép. · p.1/1". -->
+    <string name="flags_item_metadata_with_author_at">%1$s · %2$s · %3$d rép. · p.%4$d/%5$d</string>
+    <string name="flags_item_metadata_no_author_at">%1$s · %2$d rép. · p.%3$d/%4$d</string>
     <string name="flags_item_metadata_with_author">%1$s · %2$d rép. · p.%3$d/%4$d</string>
     <string name="flags_item_metadata_no_author">%1$d rép. · p.%2$d/%3$d</string>
 

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
@@ -47,6 +47,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.SubCategory
 import fr.forumhfr.redface2.core.model.TopicSummary
+import fr.forumhfr.redface2.core.ui.formatLastReplyTimestamp
 import fr.forumhfr.redface2.core.ui.theme.FlagPalette
 
 /**
@@ -376,7 +377,7 @@ private fun TopicRow(
                     R.string.category_topic_metadata,
                     topic.author,
                     topic.lastReplyAuthor,
-                    topic.lastReplyAt,
+                    formatLastReplyTimestamp(topic.lastReplyAt),
                     topic.replyCount,
                     topic.totalPages,
                 ),

--- a/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchScreen.kt
@@ -48,6 +48,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.model.search.SearchPivotCategory
 import fr.forumhfr.redface2.core.model.search.SearchTextScope
 import fr.forumhfr.redface2.core.model.search.SearchTopicResult
+import fr.forumhfr.redface2.core.ui.formatLastReplyTimestamp
 
 /**
  * Phase 2G-A/B (#150 partiel) — search tab screen.
@@ -421,7 +422,7 @@ private fun SearchResultCard(result: SearchTopicResult, onClick: () -> Unit) {
             Text(
                 text = stringResource(
                     R.string.search_result_last_reply,
-                    result.lastReplyAt,
+                    formatLastReplyTimestamp(result.lastReplyAt),
                     result.lastReplyAuthor,
                 ),
                 style = MaterialTheme.typography.bodySmall,


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaaT)

Closes #325

## Horodatage du dernier post lisible dans les 3 listes

- **Formateur pur partagé** `:core:ui` (`formatLastReplyTimestamp`) : la forme REST `YYYY-MM-DD HH:mm` (TopicSummary/Flag — prouvée par les fixtures REST `rest_cat23_participated.json`) devient la **parité web** `DD-MM-YYYY à HH:mm`. La recherche, déjà au format web (`parseLastReply`), passe inchangée. Règle de repli stricte : tout non-match ressort tel quel (jamais de crash, jamais de vide).
- Appliqué aux listes **catégorie** et **recherche**, et **ajouté** aux rows **Drapeaux** via `flagMetadata` (la donnée existait sur le modèle mais n'était pas affichée).
- **Post-review (finding sev. 60)** : l'horodatage est placé **en fin de ligne** (la donnée ajoutée clippe en premier — jamais le « p.X/Y » historique) + `TextOverflow.Ellipsis` sur la métadonnée. ⚠️ Choix produit à re-trancher par @XaaT si la cohérence visuelle avec la liste catégorie (timestamp en 2e position) prime sur la préservation du p.X/Y — facile à inverser (ordre des placeholders).
- Aucun modèle ni parser touché — pur affichage.

## Validation

- Part 1 : **BUILD SUCCESSFUL in 3m 11s** (revalidation post-fixes) — Part 2 : **BUILD SUCCESSFUL in 1m 18s**
- Review multi-agent 4 saveurs : 1 finding ≥ 60 (clip du p.X/Y) → **corrigé** ; 12 mineurs < 40
- Review Codex finale : **SHIP** (correspondance args Kotlin ↔ placeholders réordonnés vérifiée explicitement)

## Mono-maintainer

Merge `--squash --admin` prévu après CI verte (convention AGENTS.md).
