### PR TITLE
feat(errors): distinguer panne HFR (5xx) de coupure réseau (#324)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/search/DefaultSearchRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/search/DefaultSearchRepository.kt
@@ -3,6 +3,7 @@ package fr.forumhfr.redface2.core.data.search
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
 import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
+import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.domain.search.SearchRepository
 import fr.forumhfr.redface2.core.model.search.SearchCategoryScope
 import fr.forumhfr.redface2.core.model.search.SearchRequest
@@ -46,6 +47,11 @@ class DefaultSearchRepository @Inject constructor(
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : SearchRepository {
 
+    // ThrowsCount: the three rethrow branches are the same redaction contract applied per
+    // exception TYPE (#324 — SessionExpired / HfrServer / generic IOException); folding them
+    // into one branch would either lose the type the downstream classifier needs or leak the
+    // query-bearing URL. Suppressed locally rather than relaxing the project rule.
+    @Suppress("ThrowsCount")
     override suspend fun search(request: SearchRequest): SearchResultPage {
         val catId = (request.category as? SearchCategoryScope.Category)?.id
         diagnostics.record(
@@ -79,8 +85,16 @@ class DefaultSearchRepository @Inject constructor(
                 // generic branch too if we let it through) ; its message embeds the final
                 // URL via "final URL was <url>" — which carries `search=<query>` — and the
                 // generic `substringBefore(" for ")` strip wouldn't catch this prefix.
-                // Handle it explicitly so neither variant leaks the query.
-                throw IOException("HFR search request failed: session expired")
+                // Handle it explicitly so neither variant leaks the query. #324: re-throw
+                // the SAME type (with a redacted URL) instead of a generic IOException so
+                // the shared error classifier downstream still sees the session expiry.
+                throw SessionExpiredException(REDACTED_URL)
+            } catch (error: HfrServerException) {
+                // #324 — keep the TYPE and status code (the ViewModel classifies a 5xx as
+                // « HFR est en panne », not as a network cut) while rebuilding the message
+                // so the URL — which carries `search=<query>` — never leaks, matching the
+                // redaction contract of the sibling branches.
+                throw HfrServerException(error.code, REDACTED_URL)
             } catch (error: IOException) {
                 throw IOException("HFR search request failed: ${error.message?.substringBefore(" for ")}")
             }
@@ -118,5 +132,12 @@ class DefaultSearchRepository @Inject constructor(
 
     private companion object {
         private const val LOG_TAG = "SearchRepository"
+
+        /**
+         * Placeholder substituted for the search URL when re-throwing typed exceptions
+         * (#324) : the original URL embeds `search=<query>` and must never survive into a
+         * message that can land in a diagnostics screenshot.
+         */
+        private const val REDACTED_URL = "<redacted>"
     }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/search/DefaultSearchRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/search/DefaultSearchRepositoryTest.kt
@@ -2,6 +2,7 @@ package fr.forumhfr.redface2.core.data.search
 
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
+import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.model.search.SearchCategoryScope
 import fr.forumhfr.redface2.core.model.search.SearchRequest
 import fr.forumhfr.redface2.core.model.search.SearchTextScope
@@ -224,6 +225,41 @@ class DefaultSearchRepositoryTest {
         assertTrue(
             "expected the message to mention « session expired », got <${thrown.message}>",
             thrown.message!!.contains("session expired"),
+        )
+        // #324 — the TYPE must survive the redaction so downstream classification
+        // (classifyHfrError → Other, never Network) still sees the session expiry.
+        assertTrue(
+            "expected the SessionExpiredException type to be preserved, got ${thrown::class.simpleName}",
+            thrown is SessionExpiredException,
+        )
+    }
+
+    @Test
+    fun `HfrServerException traverses with its code preserved and its URL redacted`() = runTest {
+        // #324 — without the dedicated catch branch, the generic IOException re-wrap would
+        // strip the type and a 5xx HFR outage would be classified as a network cut by
+        // SearchViewModel. The URL still must not survive (it carries `search=<query>`).
+        val hfrClient = mockk<HfrClient>()
+        coEvery {
+            hfrClient.searchTopics(any(), any(), any(), any(), any())
+        } throws HfrServerException(
+            code = 500,
+            url = "https://forum.hardware.fr/forum1.php?recherches=1&cat=&search=secret_term&...",
+        )
+
+        val repo = buildRepository(hfrClient = hfrClient)
+        val thrown = assertThrows(HfrServerException::class.java) {
+            kotlinx.coroutines.runBlocking { repo.search(SearchRequest(query = "secret_term")) }
+        }
+
+        assertEquals(500, thrown.code)
+        assertFalse(
+            "expected the URL portion to be redacted, got <${thrown.message}>",
+            thrown.message!!.contains("forum1.php"),
+        )
+        assertFalse(
+            "expected the user query to NOT survive the redaction, got <${thrown.message}>",
+            thrown.message!!.contains("secret_term"),
         )
     }
 

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -6,4 +6,6 @@ dependencies {
     api(project(":core:model"))
     api(libs.javax.inject)
     api(libs.kotlinx.coroutines.core)
+
+    testImplementation(libs.junit4)
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/error/HfrErrorKind.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/error/HfrErrorKind.kt
@@ -1,0 +1,47 @@
+package fr.forumhfr.redface2.core.domain.error
+
+import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import java.io.IOException
+
+/**
+ * Coarse classification of a read-path failure (#324), shared by every reading screen
+ * (topic, forum/catégories, drapeaux, recherche, MP, profil) so an HFR outage and a local
+ * connectivity cut are rendered consistently. The matching user-facing strings live in
+ * `:core:ui` (`error_hfr_server_down` / `error_no_connection`); [Other] keeps each
+ * screen's existing generic message.
+ */
+enum class HfrErrorKind {
+    /** HFR itself answered with a 5xx — the site is reachable but failing server-side. */
+    ServerDown,
+
+    /** No usable HTTP response came back: connectivity, DNS, timeout, TLS failure. */
+    Network,
+
+    /** Anything else: 4xx rejections, session expiry, parse errors, programming errors. */
+    Other,
+}
+
+/**
+ * Pure classifier mapping a read-path [Throwable] to its [HfrErrorKind]. The branch order
+ * is load-bearing (every listed type extends [IOException]):
+ *
+ * 1. [SessionExpiredException] → [HfrErrorKind.Other]. Screens with a dedicated session
+ *    treatment (e.g. the drapeaux reconnect CTA) branch on the exception type BEFORE
+ *    consulting this classifier and keep their behaviour; screens without one must not
+ *    present an expired session as a network cut.
+ * 2. [HfrServerException] with a 5xx code → [HfrErrorKind.ServerDown]; any other code
+ *    (4xx) → [HfrErrorKind.Other] (the request was wrong, not the server).
+ * 3. Any other [IOException] → [HfrErrorKind.Network] — the transport failures OkHttp
+ *    raises when no HTTP response came back.
+ * 4. Everything else → [HfrErrorKind.Other].
+ */
+fun classifyHfrError(error: Throwable): HfrErrorKind = when (error) {
+    is SessionExpiredException -> HfrErrorKind.Other
+    is HfrServerException ->
+        if (error.code >= HTTP_SERVER_ERROR_MIN) HfrErrorKind.ServerDown else HfrErrorKind.Other
+    is IOException -> HfrErrorKind.Network
+    else -> HfrErrorKind.Other
+}
+
+/** Lower bound of the HTTP 5xx server-error class. */
+private const val HTTP_SERVER_ERROR_MIN = 500

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/error/HfrErrorKind.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/error/HfrErrorKind.kt
@@ -7,7 +7,8 @@ import java.io.IOException
  * Coarse classification of a read-path failure (#324), shared by every reading screen
  * (topic, forum/catégories, drapeaux, recherche, MP, profil) so an HFR outage and a local
  * connectivity cut are rendered consistently. The matching user-facing strings live in
- * `:core:ui` (`error_hfr_server_down` / `error_no_connection`); [Other] keeps each
+ * `:core:ui` (`error_hfr_server_down` / `error_no_connection`, resolved through the
+ * shared `sharedLabelResOrNull()` mapper in `core.ui.error`); [Other] keeps each
  * screen's existing generic message.
  */
 enum class HfrErrorKind {

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/error/HfrServerException.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/error/HfrServerException.kt
@@ -1,0 +1,32 @@
+package fr.forumhfr.redface2.core.domain.error
+
+import java.io.IOException
+
+/**
+ * HFR answered the HTTP exchange with a non-2xx status (#324): the server was reached —
+ * DNS, TCP and TLS all succeeded — but it refused or failed to serve the resource. [code]
+ * lets consumers tell an HFR outage (5xx → [HfrErrorKind.ServerDown]) apart from a
+ * client-side rejection (4xx → [HfrErrorKind.Other]); see [classifyHfrError].
+ *
+ * Genuine connectivity failures (airplane mode, DNS resolution, timeouts) keep surfacing
+ * as the plain [IOException] subclasses OkHttp throws — this type is raised ONLY when an
+ * HTTP response actually came back. It extends [IOException] so every existing
+ * `catch (e: IOException)` site keeps treating it as a transport-level failure.
+ *
+ * Lives in `:core:domain` (not `:core:network`) so feature modules can type-check it
+ * without importing the network layer, which the Konsist architecture test forbids — same
+ * precedent as [fr.forumhfr.redface2.core.domain.auth.SessionExpiredException].
+ *
+ * @param code the HTTP status HFR answered with.
+ * @param url the requested URL, embedded in the default message for diagnostics. Callers
+ * sitting on a privacy boundary may pass a redacted placeholder (cf. the search
+ * repository, whose URLs carry the user's query).
+ * @param detailMessage optional richer diagnostic line (e.g. the REST client's body
+ * excerpt) preserved verbatim as the exception message; `null` keeps the canonical
+ * `"HFR returned <code> for <url>"` shape.
+ */
+class HfrServerException(
+    val code: Int,
+    url: String,
+    detailMessage: String? = null,
+) : IOException(detailMessage ?: "HFR returned $code for $url")

--- a/core/domain/src/test/kotlin/fr/forumhfr/redface2/core/domain/error/HfrErrorClassifierTest.kt
+++ b/core/domain/src/test/kotlin/fr/forumhfr/redface2/core/domain/error/HfrErrorClassifierTest.kt
@@ -1,0 +1,101 @@
+package fr.forumhfr.redface2.core.domain.error
+
+import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #324 — full truth table of [classifyHfrError]. The classification drives which shared
+ * string every reading screen renders, so each row pins one contract:
+ * 5xx → ServerDown, transport failures → Network, everything else (including the
+ * session-expiry special case and 4xx) → Other.
+ */
+class HfrErrorClassifierTest {
+
+    @Test
+    fun `HfrServerException 500 classifies as ServerDown`() {
+        assertEquals(
+            HfrErrorKind.ServerDown,
+            classifyHfrError(HfrServerException(code = 500, url = "https://forum.hardware.fr/forum2.php")),
+        )
+    }
+
+    @Test
+    fun `HfrServerException 503 classifies as ServerDown`() {
+        assertEquals(
+            HfrErrorKind.ServerDown,
+            classifyHfrError(HfrServerException(code = 503, url = "https://forum.hardware.fr/forum2.php")),
+        )
+    }
+
+    @Test
+    fun `HfrServerException 404 classifies as Other not ServerDown`() {
+        // A 4xx means the request was wrong (dead topic id, bad cat) — HFR itself is fine,
+        // so the screen must keep its generic message rather than claim an outage.
+        assertEquals(
+            HfrErrorKind.Other,
+            classifyHfrError(HfrServerException(code = 404, url = "https://forum.hardware.fr/forum2.php")),
+        )
+    }
+
+    @Test
+    fun `HfrServerException with a custom detail message keeps classifying on the code`() {
+        // The REST client (HfrApiClient) passes its richer body-excerpt message — the
+        // classification must come from the typed code, never from message parsing.
+        assertEquals(
+            HfrErrorKind.ServerDown,
+            classifyHfrError(
+                HfrServerException(
+                    code = 502,
+                    url = "https://forum.hardware.fr/webservices/rest_api.php",
+                    detailMessage = "HFR REST returned 502 for … — body[0..9]: bad gw",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `SessionExpiredException classifies as Other even though it is an IOException`() {
+        // Non-régression du CTA session expirée (FlagsRoute) : la branche session des écrans
+        // passe AVANT le classifieur, et une session expirée n'est jamais une coupure réseau.
+        assertEquals(
+            HfrErrorKind.Other,
+            classifyHfrError(SessionExpiredException("https://forum.hardware.fr/login.php")),
+        )
+    }
+
+    @Test
+    fun `UnknownHostException classifies as Network`() {
+        assertEquals(
+            HfrErrorKind.Network,
+            classifyHfrError(UnknownHostException("forum.hardware.fr")),
+        )
+    }
+
+    @Test
+    fun `SocketTimeoutException classifies as Network`() {
+        assertEquals(
+            HfrErrorKind.Network,
+            classifyHfrError(SocketTimeoutException("timeout")),
+        )
+    }
+
+    @Test
+    fun `plain IOException classifies as Network`() {
+        assertEquals(
+            HfrErrorKind.Network,
+            classifyHfrError(IOException("unexpected end of stream")),
+        )
+    }
+
+    @Test
+    fun `IllegalStateException classifies as Other`() {
+        assertEquals(
+            HfrErrorKind.Other,
+            classifyHfrError(IllegalStateException("parser invariant broken")),
+        )
+    }
+}

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrApiClient.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrApiClient.kt
@@ -1,10 +1,10 @@
 package fr.forumhfr.redface2.core.network
 
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.network.qualifiers.AnonymousClient
 import fr.forumhfr.redface2.core.network.qualifiers.AuthenticatedClient
 import fr.forumhfr.redface2.core.network.qualifiers.HfrBaseUrl
-import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 import okhttp3.Call
@@ -26,7 +26,9 @@ import okhttp3.Request
  *
  * The client returns raw JSON [String]. Parsing lives in `:core:data` next to its
  * consuming repositories (per ADR-003, "Frontières de modules"). On non-2xx the call
- * raises [IOException] with the URL, status and a short body excerpt for diagnostics.
+ * raises [HfrServerException] (#324 — typed status code so the screens can tell a 5xx
+ * outage from a network cut) with the URL, status and a short body excerpt for
+ * diagnostics.
  *
  * Authenticated calls run through [executeAuthenticatedJson] which surfaces a
  * [SessionExpiredException] when HFR redirects to login or returns the login HTML
@@ -182,7 +184,12 @@ class HfrApiClient @Inject constructor(
         } else {
             client.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
-                    throw IOException(failureMessage(response.code, url, response.body.string()))
+                    // #324 — typed (status code) while keeping the richer REST diagnostic line.
+                    throw HfrServerException(
+                        code = response.code,
+                        url = url.toString(),
+                        detailMessage = failureMessage(response.code, url, response.body.string()),
+                    )
                 }
                 response.body.string()
             }
@@ -192,7 +199,12 @@ class HfrApiClient @Inject constructor(
     private fun Call.executeAuthenticatedJson(): String = execute().use { response ->
         val body = response.body.string()
         if (!response.isSuccessful) {
-            throw IOException(failureMessage(response.code, response.request.url, body))
+            // #324 — typed (status code) while keeping the richer REST diagnostic line.
+            throw HfrServerException(
+                code = response.code,
+                url = response.request.url.toString(),
+                detailMessage = failureMessage(response.code, response.request.url, body),
+            )
         }
         val finalUrl = response.request.url
         if (finalUrl.isLoginUrl() || body.looksLikeLoginPage()) {

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
@@ -3,6 +3,7 @@ package fr.forumhfr.redface2.core.network
 import androidx.tracing.trace
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
+import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.search.SearchTextScope
 import fr.forumhfr.redface2.core.network.qualifiers.AnonymousClient
@@ -63,7 +64,9 @@ class HfrClient @Inject constructor(
                     anonymous.newCall(request).execute()
                 }.use { response ->
                     if (!response.isSuccessful) {
-                        throw IOException("HFR returned ${response.code} for $url")
+                        // #324 — typed so the read screens can tell a 5xx outage from a
+                        // local network cut (cf. core.domain.error.classifyHfrError).
+                        throw HfrServerException(response.code, url.toString())
                     }
                     trace("$TOPIC_TRACE_PREFIX.body_read") { response.body.string() }
                 }
@@ -463,7 +466,9 @@ class HfrClient @Inject constructor(
         return withContext(ioDispatcher) {
             anonymous.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
-                    throw java.io.IOException("HFR returned ${response.code} for $url")
+                    // #324 — typed so the profile sheet/page can tell a 5xx outage from a
+                    // local network cut (cf. core.domain.error.classifyHfrError).
+                    throw HfrServerException(response.code, url.toString())
                 }
                 response.body.string()
             }
@@ -565,7 +570,9 @@ class HfrClient @Inject constructor(
             }
             response.use {
                 if (!response.isSuccessful) {
-                    throw IOException("HFR returned ${response.code} for ${response.request.url}")
+                    // #324 — typed so the read screens can tell a 5xx outage from a local
+                    // network cut (cf. core.domain.error.classifyHfrError).
+                    throw HfrServerException(response.code, response.request.url.toString())
                 }
                 val html = if (tracePrefix != null) {
                     // Session-expiry detection (login redirect / login form sniff) runs after the

--- a/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/HfrApiClientTest.kt
+++ b/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/HfrApiClientTest.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.core.network
 
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import kotlinx.coroutines.test.runTest
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -145,15 +146,36 @@ class HfrApiClientTest {
     }
 
     @Test
-    fun `HTTP 500 surfaces an IOException carrying the URL and a body excerpt`() = runTest {
+    fun `HTTP 500 surfaces an HfrServerException carrying the code, URL and a body excerpt`() = runTest {
+        // #324 — the anonymous REST path must raise the TYPED exception (it feeds
+        // forum/catégories), keeping the pre-existing diagnostic message intact.
         server.enqueue(MockResponse().setResponseCode(500).setBody("internal explode"))
 
         val error = runCatching { client.getCategories() }.exceptionOrNull()
 
-        assertTrue("expected IOException, got $error", error is java.io.IOException)
-        val message = requireNotNull(error).message.orEmpty()
+        val typed = error as? HfrServerException
+            ?: throw AssertionError("expected HfrServerException, got $error")
+        assertEquals(500, typed.code)
+        val message = typed.message.orEmpty()
         assertTrue("missing status: $message", "500" in message)
         assertTrue("missing body excerpt: $message", "internal explode" in message)
+    }
+
+    @Test
+    fun `authenticated HTTP 502 surfaces an HfrServerException carrying the code`() = runTest {
+        // #324 — the authenticated REST path (executeAuthenticatedJson) feeds the topic
+        // listings and the drapeaux; a REST 5xx must be typed too or an HFR outage would
+        // be classified as a network cut.
+        server.enqueue(MockResponse().setResponseCode(502).setBody("bad gateway"))
+
+        val error = runCatching {
+            client.getTopicList(cat = 13, subcat = null, page = 1, useAuth = true)
+        }.exceptionOrNull()
+
+        val typed = error as? HfrServerException
+            ?: throw AssertionError("expected HfrServerException, got $error")
+        assertEquals(502, typed.code)
+        assertTrue("missing body excerpt: ${typed.message}", "bad gateway" in typed.message.orEmpty())
     }
 
     @Test

--- a/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/HfrClientTest.kt
+++ b/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/HfrClientTest.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.core.network
 
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.search.SearchTextScope
 import java.time.LocalDate
@@ -269,6 +270,47 @@ class HfrClientTest {
         server.shutdown()
 
         assertNull(client.resolveTopicPageUrl(cat = 23, post = 35421, numreponse = 2786758))
+    }
+
+    @Test
+    fun `getTopicPage anonymous surfaces a 500 as HfrServerException carrying the code`() = runTest {
+        // #324 — a non-2xx answered by HFR must be typed (HfrServerException) so the read
+        // screens can tell « HFR est en panne » (5xx) from a local network cut.
+        server.enqueue(MockResponse().setResponseCode(500).setBody("<html>boom</html>"))
+
+        val error = runCatching {
+            client.getTopicPage(cat = 23, post = 35395, page = 1, useAuth = false)
+        }.exceptionOrNull()
+
+        val typed = error as? HfrServerException
+            ?: throw AssertionError("expected HfrServerException, got $error")
+        assertEquals(500, typed.code)
+        assertTrue("missing status in message: ${typed.message}", "500" in typed.message.orEmpty())
+    }
+
+    @Test
+    fun `getTopicPage authenticated surfaces a 503 as HfrServerException carrying the code`() = runTest {
+        // Covers the shared executeAuthenticatedHtml() path (topic auth, MP list/thread, …).
+        server.enqueue(MockResponse().setResponseCode(503).setBody("<html>maintenance</html>"))
+
+        val error = runCatching {
+            client.getTopicPage(cat = 23, post = 35395, page = 1, useAuth = true)
+        }.exceptionOrNull()
+
+        val typed = error as? HfrServerException
+            ?: throw AssertionError("expected HfrServerException, got $error")
+        assertEquals(503, typed.code)
+    }
+
+    @Test
+    fun `getProfile surfaces a 500 as HfrServerException carrying the code`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(500).setBody("<html>boom</html>"))
+
+        val error = runCatching { client.getProfile(userId = 12345) }.exceptionOrNull()
+
+        val typed = error as? HfrServerException
+            ?: throw AssertionError("expected HfrServerException, got $error")
+        assertEquals(500, typed.code)
     }
 
     private fun taggedClient(tag: String): OkHttpClient =

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -40,6 +40,10 @@ android {
 }
 
 dependencies {
+    // #324 — `error/HfrErrorLabels.kt` maps the domain `HfrErrorKind` classification to the
+    // shared `error_hfr_server_down` / `error_no_connection` string resources. No cycle:
+    // :core:domain only depends on :core:model.
+    implementation(project(":core:domain"))
     implementation(project(":core:model"))
 
     api(platform(libs.androidx.compose.bom))

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/error/HfrErrorLabels.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/error/HfrErrorLabels.kt
@@ -1,0 +1,27 @@
+package fr.forumhfr.redface2.core.ui.error
+
+import androidx.annotation.StringRes
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
+import fr.forumhfr.redface2.core.ui.R
+
+/**
+ * #324 — single mapping between the domain failure classification ([HfrErrorKind]) and the
+ * user-facing labels shared by every reading screen (topic, forum/catégories, drapeaux,
+ * recherche, MP, profil).
+ *
+ * Contract:
+ * - [HfrErrorKind.ServerDown] → [R.string.error_hfr_server_down] (« HFR est en panne ») ;
+ * - [HfrErrorKind.Network] → [R.string.error_no_connection] (« Pas de connexion ») ;
+ * - [HfrErrorKind.Other] → `null` — there is intentionally NO shared fallback: each screen
+ *   keeps its own generic message (or raw diagnostic detail), e.g.
+ *   `kind.sharedLabelResOrNull() ?: R.string.flags_error`.
+ *
+ * Pure function (no Compose dependency) so screens can resolve the id in any context and
+ * tests can assert the mapping on the JVM without resources.
+ */
+@StringRes
+fun HfrErrorKind.sharedLabelResOrNull(): Int? = when (this) {
+    HfrErrorKind.ServerDown -> R.string.error_hfr_server_down
+    HfrErrorKind.Network -> R.string.error_no_connection
+    HfrErrorKind.Other -> null
+}

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -61,4 +61,11 @@
          instead of leaking the raw image / placeholder. #207 round-3 closes the a11y gap when the
          avatar is rendered as a standalone placeholder (no SubcomposeAsyncImage parent). -->
     <string name="avatar_content_description">Avatar de %1$s</string>
+
+    <!-- #324 — panne HFR (5xx) vs coupure réseau : libellés partagés par tous les écrans de
+         lecture (topic, forum/catégories, drapeaux, recherche, MP, profil). Mappés depuis
+         `core.domain.error.HfrErrorKind` (ServerDown / Network) ; le cas Other garde le message
+         générique propre à chaque écran. -->
+    <string name="error_hfr_server_down">HFR est en panne (erreur serveur)</string>
+    <string name="error_no_connection">Pas de connexion</string>
 </resources>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -63,9 +63,10 @@
     <string name="avatar_content_description">Avatar de %1$s</string>
 
     <!-- #324 — panne HFR (5xx) vs coupure réseau : libellés partagés par tous les écrans de
-         lecture (topic, forum/catégories, drapeaux, recherche, MP, profil). Mappés depuis
-         `core.domain.error.HfrErrorKind` (ServerDown / Network) ; le cas Other garde le message
-         générique propre à chaque écran. -->
+         lecture (topic, forum/catégories, drapeaux, recherche, MP, profil). Résolus depuis
+         `core.domain.error.HfrErrorKind` via `error/HfrErrorLabels.sharedLabelResOrNull()`
+         (ServerDown / Network) ; le cas Other garde le message générique propre à chaque
+         écran. -->
     <string name="error_hfr_server_down">HFR est en panne (erreur serveur)</string>
     <string name="error_no_connection">Pas de connexion</string>
 </resources>

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/error/HfrErrorLabelsTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/error/HfrErrorLabelsTest.kt
@@ -1,0 +1,37 @@
+package fr.forumhfr.redface2.core.ui.error
+
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
+import fr.forumhfr.redface2.core.ui.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #324 — locks the [sharedLabelResOrNull] contract: ServerDown / Network resolve to the
+ * shared `:core:ui` labels, Other resolves to nothing so each screen keeps its own
+ * generic fallback. Pure JVM test — only R-class constants are compared, no resource
+ * resolution is needed.
+ */
+class HfrErrorLabelsTest {
+
+    @Test
+    fun `ServerDown maps to the shared HFR outage label`() {
+        assertEquals(
+            R.string.error_hfr_server_down,
+            HfrErrorKind.ServerDown.sharedLabelResOrNull(),
+        )
+    }
+
+    @Test
+    fun `Network maps to the shared no-connection label`() {
+        assertEquals(
+            R.string.error_no_connection,
+            HfrErrorKind.Network.sharedLabelResOrNull(),
+        )
+    }
+
+    @Test
+    fun `Other maps to null so each screen keeps its local fallback`() {
+        assertNull(HfrErrorKind.Other.sharedLabelResOrNull())
+    }
+}

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -98,6 +98,7 @@ graph TB
     CDOM --> CM[":core:model"]
     CEXT --> CM
     CU --> CM
+    CU --> CDOM
 
     CDATA --> CDOM
     CDATA --> CN[":core:network"]
@@ -129,7 +130,7 @@ graph TB
 | `:core:network` | Deux clients : `HfrClient` (HTML brut sur `forum*.php`, login, MPs, mutations) et `HfrApiClient` (JSON REST sur `/webservices/rest_api.php`, browsing). Encapsulent OkHttp. Aucun type domaine exposé — du `String` brut ou des erreurs typées. Le helper de rewrite HATEOAS `HfrApiClient.rewriteHateoasHref(href)` vit ici. Cf. [ADR-003]({{ site.baseurl }}/adr/003-api-rest-hfr-hybride). | rien |
 | `:core:parser` | `HfrParser` : transforme le HTML HFR et, à partir de l'éditeur Phase 2, le BBCode HFR en modèles domaine, dont l'AST `PostContent`. Pas de parser JSON REST ici — les DTO REST vivent dans `:core:data`. | `:core:model` |
 | `:core:database` | Room DB, DAOs, entities, mappers entity↔model. Cache locale + cache MPStorage. | `:core:model` |
-| `:core:ui` | Thème Material 3 (`theme/`) et `PostRenderer` (`post/`, `PostContent` → Compose). D'autres sous-packages (`components/`, `adaptive/`, `semantics/`, `util/`, `extensions/`) sont prévus mais n'apparaîtront qu'au fur et à mesure de l'arrivée des features qui les justifient — pas de module vide en avance. Seul module autorisé à instancier `ColorScheme`, `Typography`, `Shapes`. | `:core:model` |
+| `:core:ui` | Thème Material 3 (`theme/`), `PostRenderer` (`post/`, `PostContent` → Compose) et libellés d'erreur partagés (`error/`, mapping `HfrErrorKind` → string resource, #324). D'autres sous-packages (`components/`, `adaptive/`, `semantics/`, `util/`, `extensions/`) sont prévus mais n'apparaîtront qu'au fur et à mesure de l'arrivée des features qui les justifient — pas de module vide en avance. Seul module autorisé à instancier `ColorScheme`, `Typography`, `Shapes`. | `:core:model`, `:core:domain` (#324 : résolution des libellés partagés depuis `HfrErrorKind`) |
 | `:core:extension` | Interfaces d'extension : `PostDecorator`, `TopicToolbarContributor`, `EditorToolbarContributor`. | `:core:model` |
 
 ### Modules feature (base)

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -105,6 +105,8 @@ graph TB
     CDATA --> CP[":core:parser"]
     CDATA --> CD[":core:database"]
 
+    CN --> CDOM
+
     CP --> CM
     CD --> CM
 
@@ -127,7 +129,7 @@ graph TB
 | `:core:model` | Modèles domaine purs (`Topic`, `Post`, `PostContent`, `Category`, `Flag`, `MP`). Aucune dépendance Android. | rien |
 | `:core:domain` | Interfaces de repositories (`TopicRepository`, `FlagRepository`, `AuthRepository`...) et règles métier partagées. Aucune dépendance framework. | `:core:model` |
 | `:core:data` | Implémentations des repositories. Orchestre réseau (HTML + REST JSON), parser HTML et cache. Porte les DTO `@Serializable` REST et leurs mappers vers `:core:model`. Fournit les bindings Hilt. | `:core:domain`, `:core:network`, `:core:parser`, `:core:database` |
-| `:core:network` | Deux clients : `HfrClient` (HTML brut sur `forum*.php`, login, MPs, mutations) et `HfrApiClient` (JSON REST sur `/webservices/rest_api.php`, browsing). Encapsulent OkHttp. Aucun type domaine exposé — du `String` brut ou des erreurs typées. Le helper de rewrite HATEOAS `HfrApiClient.rewriteHateoasHref(href)` vit ici. Cf. [ADR-003]({{ site.baseurl }}/adr/003-api-rest-hfr-hybride). | rien |
+| `:core:network` | Deux clients : `HfrClient` (HTML brut sur `forum*.php`, login, MPs, mutations) et `HfrApiClient` (JSON REST sur `/webservices/rest_api.php`, browsing). Encapsulent OkHttp. Aucun type domaine exposé — du `String` brut ou des erreurs typées. Le helper de rewrite HATEOAS `HfrApiClient.rewriteHateoasHref(href)` vit ici. Cf. [ADR-003]({{ site.baseurl }}/adr/003-api-rest-hfr-hybride). | `:core:domain` (erreurs typées levées par les clients : `SessionExpiredException`, `HfrServerException` #324) |
 | `:core:parser` | `HfrParser` : transforme le HTML HFR et, à partir de l'éditeur Phase 2, le BBCode HFR en modèles domaine, dont l'AST `PostContent`. Pas de parser JSON REST ici — les DTO REST vivent dans `:core:data`. | `:core:model` |
 | `:core:database` | Room DB, DAOs, entities, mappers entity↔model. Cache locale + cache MPStorage. | `:core:model` |
 | `:core:ui` | Thème Material 3 (`theme/`), `PostRenderer` (`post/`, `PostContent` → Compose) et libellés d'erreur partagés (`error/`, mapping `HfrErrorKind` → string resource, #324). D'autres sous-packages (`components/`, `adaptive/`, `semantics/`, `util/`, `extensions/`) sont prévus mais n'apparaîtront qu'au fur et à mesure de l'arrivée des features qui les justifient — pas de module vide en avance. Seul module autorisé à instancier `ColorScheme`, `Typography`, `Shapes`. | `:core:model`, `:core:domain` (#324 : résolution des libellés partagés depuis `HfrErrorKind`) |

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -55,6 +55,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
+import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.Flag
@@ -556,7 +558,19 @@ private fun ColumnScope.AuthenticatedBody(
                 val sessionExpired = current.cause is SessionExpiredException
                 Text(
                     text = stringResource(
-                        if (sessionExpired) R.string.flags_session_expired else R.string.flags_error,
+                        // The dedicated session branch stays FIRST — the #324 classifier
+                        // only refines the remaining failures (5xx outage vs network cut
+                        // vs generic), so the reconnect CTA below never regresses.
+                        when {
+                            sessionExpired -> R.string.flags_session_expired
+                            else -> when (classifyHfrError(current.cause)) {
+                                HfrErrorKind.ServerDown ->
+                                    fr.forumhfr.redface2.core.ui.R.string.error_hfr_server_down
+                                HfrErrorKind.Network ->
+                                    fr.forumhfr.redface2.core.ui.R.string.error_no_connection
+                                HfrErrorKind.Other -> R.string.flags_error
+                            }
+                        },
                     ),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.error,

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -55,7 +55,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
-import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.model.AuthState
@@ -63,6 +62,7 @@ import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.ui.FlagItem
 import fr.forumhfr.redface2.core.ui.FlagItemDivider
+import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.formatLastReplyTimestamp
 import kotlinx.coroutines.launch
 
@@ -559,17 +559,14 @@ private fun ColumnScope.AuthenticatedBody(
                 Text(
                     text = stringResource(
                         // The dedicated session branch stays FIRST — the #324 classifier
-                        // only refines the remaining failures (5xx outage vs network cut
-                        // vs generic), so the reconnect CTA below never regresses.
-                        when {
-                            sessionExpired -> R.string.flags_session_expired
-                            else -> when (classifyHfrError(current.cause)) {
-                                HfrErrorKind.ServerDown ->
-                                    fr.forumhfr.redface2.core.ui.R.string.error_hfr_server_down
-                                HfrErrorKind.Network ->
-                                    fr.forumhfr.redface2.core.ui.R.string.error_no_connection
-                                HfrErrorKind.Other -> R.string.flags_error
-                            }
+                        // only refines the remaining failures (shared ServerDown/Network
+                        // labels vs the generic flags_error), so the reconnect CTA below
+                        // never regresses.
+                        if (sessionExpired) {
+                            R.string.flags_session_expired
+                        } else {
+                            classifyHfrError(current.cause).sharedLabelResOrNull()
+                                ?: R.string.flags_error
                         },
                     ),
                     style = MaterialTheme.typography.bodyMedium,

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -4,6 +4,9 @@ import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.auth.LoginError
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
+import fr.forumhfr.redface2.core.domain.error.HfrServerException
+import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.flags.FlagRepository
 import fr.forumhfr.redface2.core.domain.flags.FlagsResult
 import fr.forumhfr.redface2.core.domain.forum.ForumRepository
@@ -312,6 +315,29 @@ class FlagsViewModelTest {
                 "expected SessionExpiredException to traverse the stack — got ${failure.cause::class.simpleName}",
                 failure.cause is SessionExpiredException,
             )
+            // #324 non-régression CTA : la session expirée doit rester classée Other (jamais
+            // Network/ServerDown) pour que la branche session de FlagsRoute garde la priorité.
+            assertEquals(HfrErrorKind.Other, classifyHfrError(failure.cause))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `flagsState propagates an HfrServerException cause so the route can render the outage`() = runTest {
+        // #324 — the drapeaux REST fetch (HfrApiClient) raises HfrServerException on a 5xx.
+        // FlagsRoute classifies `Failure.cause` at render time, so the typed exception must
+        // traverse repository → ViewModel → exposed state un-wrapped, like SessionExpired.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val vm = viewModel(auth, flags, forum)
+        val outage = HfrServerException(code = 500, url = "https://forum.hardware.fr/webservices/rest_api.php")
+
+        vm.flagsState.test {
+            awaitItem() // initial null
+            flags.emit(FlagType.CYAN, FlagsResult.Failure(outage))
+            val failure = awaitItem() as FlagsListUiState.Failure
+            assertEquals(HfrErrorKind.ServerDown, classifyHfrError(failure.cause))
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModel.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModel.kt
@@ -7,6 +7,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
+import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.forum.ForumRepository
 import fr.forumhfr.redface2.core.domain.forum.ForumResult
 import fr.forumhfr.redface2.core.model.AuthState
@@ -273,13 +274,15 @@ class CategoryViewModel @AssistedInject constructor(
     private fun ForumResult<List<SubCategory>>.toSubcategoriesUiState(): SubcategoriesUiState = when (this) {
         ForumResult.Loading -> SubcategoriesUiState.Loading
         is ForumResult.Success -> SubcategoriesUiState.Content(value)
-        is ForumResult.Failure -> SubcategoriesUiState.Error(cause.message)
+        // #324 — kind derives from the exception TYPE (5xx outage vs network cut vs other).
+        is ForumResult.Failure -> SubcategoriesUiState.Error(cause.message, classifyHfrError(cause))
     }
 
     private fun ForumResult<TopicListPage>.toTopicsUiState(): TopicsUiState = when (this) {
         ForumResult.Loading -> TopicsUiState.Loading
         is ForumResult.Success -> TopicsUiState.Content(value)
-        is ForumResult.Failure -> TopicsUiState.Error(cause.message)
+        // #324 — kind derives from the exception TYPE (5xx outage vs network cut vs other).
+        is ForumResult.Failure -> TopicsUiState.Error(cause.message, classifyHfrError(cause))
     }
 
     private fun ForumResult<List<Category>>.toCategoryName(cat: Int): String? = when (this) {

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.SubCategory
 import fr.forumhfr.redface2.core.model.TopicSummary
@@ -182,7 +183,16 @@ private fun SubcategoryChips(
 
         is SubcategoriesUiState.Error -> {
             Text(
-                text = state.message ?: stringResource(R.string.category_subcategories_error),
+                // #324 — ServerDown / Network render the shared :core:ui label; Other
+                // keeps the pre-existing rendering (raw message, generic fallback).
+                text = when (state.kind) {
+                    HfrErrorKind.ServerDown ->
+                        stringResource(fr.forumhfr.redface2.core.ui.R.string.error_hfr_server_down)
+                    HfrErrorKind.Network ->
+                        stringResource(fr.forumhfr.redface2.core.ui.R.string.error_no_connection)
+                    HfrErrorKind.Other ->
+                        state.message ?: stringResource(R.string.category_subcategories_error)
+                },
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.error,
                 modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
@@ -256,9 +266,18 @@ private fun TopicsBody(
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.error,
             )
-            if (!state.message.isNullOrBlank()) {
+            // #324 — ServerDown / Network swap the raw exception message for the shared
+            // :core:ui label; Other keeps the pre-existing rendering (raw message if any).
+            val detail = when (state.kind) {
+                HfrErrorKind.ServerDown ->
+                    stringResource(fr.forumhfr.redface2.core.ui.R.string.error_hfr_server_down)
+                HfrErrorKind.Network ->
+                    stringResource(fr.forumhfr.redface2.core.ui.R.string.error_no_connection)
+                HfrErrorKind.Other -> state.message
+            }
+            if (!detail.isNullOrBlank()) {
                 Text(
-                    text = state.message,
+                    text = detail,
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
@@ -44,10 +44,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.SubCategory
 import fr.forumhfr.redface2.core.model.TopicSummary
+import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.formatLastReplyTimestamp
 import fr.forumhfr.redface2.core.ui.theme.FlagPalette
 
@@ -185,14 +185,9 @@ private fun SubcategoryChips(
             Text(
                 // #324 — ServerDown / Network render the shared :core:ui label; Other
                 // keeps the pre-existing rendering (raw message, generic fallback).
-                text = when (state.kind) {
-                    HfrErrorKind.ServerDown ->
-                        stringResource(fr.forumhfr.redface2.core.ui.R.string.error_hfr_server_down)
-                    HfrErrorKind.Network ->
-                        stringResource(fr.forumhfr.redface2.core.ui.R.string.error_no_connection)
-                    HfrErrorKind.Other ->
-                        state.message ?: stringResource(R.string.category_subcategories_error)
-                },
+                text = state.kind.sharedLabelResOrNull()?.let { stringResource(it) }
+                    ?: state.message
+                    ?: stringResource(R.string.category_subcategories_error),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.error,
                 modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
@@ -268,13 +263,8 @@ private fun TopicsBody(
             )
             // #324 — ServerDown / Network swap the raw exception message for the shared
             // :core:ui label; Other keeps the pre-existing rendering (raw message if any).
-            val detail = when (state.kind) {
-                HfrErrorKind.ServerDown ->
-                    stringResource(fr.forumhfr.redface2.core.ui.R.string.error_hfr_server_down)
-                HfrErrorKind.Network ->
-                    stringResource(fr.forumhfr.redface2.core.ui.R.string.error_no_connection)
-                HfrErrorKind.Other -> state.message
-            }
+            val detail = state.kind.sharedLabelResOrNull()?.let { stringResource(it) }
+                ?: state.message
             if (!detail.isNullOrBlank()) {
                 Text(
                     text = detail,

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumScreen.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumScreen.kt
@@ -34,6 +34,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.model.Category
+import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 
 /**
  * Forum home tab. Lists the 19 public HFR categories from the REST API. Tapping a row
@@ -126,13 +127,7 @@ private fun ForumError(
 ) {
     // #324 — ServerDown / Network swap the raw exception message for the shared
     // :core:ui label; Other keeps the pre-existing rendering (raw message if any).
-    val detail = when (kind) {
-        HfrErrorKind.ServerDown ->
-            stringResource(fr.forumhfr.redface2.core.ui.R.string.error_hfr_server_down)
-        HfrErrorKind.Network ->
-            stringResource(fr.forumhfr.redface2.core.ui.R.string.error_no_connection)
-        HfrErrorKind.Other -> message
-    }
+    val detail = kind.sharedLabelResOrNull()?.let { stringResource(it) } ?: message
     Column(
         modifier = modifier
             .fillMaxSize()

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumScreen.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.model.Category
 
 /**
@@ -89,6 +90,7 @@ fun ForumScreen(
                     ForumUiState.Loading -> ForumLoading()
                     is ForumUiState.Error -> ForumError(
                         message = current.message,
+                        kind = current.kind,
                         onRetry = viewModel::refresh,
                     )
 
@@ -118,9 +120,19 @@ private fun ForumLoading(modifier: Modifier = Modifier) {
 @Composable
 private fun ForumError(
     message: String?,
+    kind: HfrErrorKind,
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // #324 — ServerDown / Network swap the raw exception message for the shared
+    // :core:ui label; Other keeps the pre-existing rendering (raw message if any).
+    val detail = when (kind) {
+        HfrErrorKind.ServerDown ->
+            stringResource(fr.forumhfr.redface2.core.ui.R.string.error_hfr_server_down)
+        HfrErrorKind.Network ->
+            stringResource(fr.forumhfr.redface2.core.ui.R.string.error_no_connection)
+        HfrErrorKind.Other -> message
+    }
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -132,9 +144,9 @@ private fun ForumError(
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.error,
         )
-        if (!message.isNullOrBlank()) {
+        if (!detail.isNullOrBlank()) {
             Text(
-                text = message,
+                text = detail,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumUiState.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumUiState.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.feature.forum
 
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.model.Category
 import fr.forumhfr.redface2.core.model.SubCategory
 import fr.forumhfr.redface2.core.model.TopicListPage
@@ -16,7 +17,16 @@ import java.text.Normalizer
 sealed interface ForumUiState {
     data object Loading : ForumUiState
     data class Content(val categories: List<Category>) : ForumUiState
-    data class Error(val message: String?) : ForumUiState
+
+    /**
+     * [kind] (#324) is the type-derived classification: ServerDown / Network make the
+     * screen render the shared `:core:ui` label instead of the raw [message]; Other keeps
+     * the pre-existing rendering ([message] when non-blank).
+     */
+    data class Error(
+        val message: String?,
+        val kind: HfrErrorKind = HfrErrorKind.Other,
+    ) : ForumUiState
 }
 
 /**
@@ -157,11 +167,21 @@ internal fun listingPageCount(totalTopics: Int, resultsPerPage: Int): Int {
 sealed interface SubcategoriesUiState {
     data object Loading : SubcategoriesUiState
     data class Content(val subcategories: List<SubCategory>) : SubcategoriesUiState
-    data class Error(val message: String?) : SubcategoriesUiState
+
+    /** [kind] (#324): same contract as [ForumUiState.Error.kind]. */
+    data class Error(
+        val message: String?,
+        val kind: HfrErrorKind = HfrErrorKind.Other,
+    ) : SubcategoriesUiState
 }
 
 sealed interface TopicsUiState {
     data object Loading : TopicsUiState
     data class Content(val page: TopicListPage) : TopicsUiState
-    data class Error(val message: String?) : TopicsUiState
+
+    /** [kind] (#324): same contract as [ForumUiState.Error.kind]. */
+    data class Error(
+        val message: String?,
+        val kind: HfrErrorKind = HfrErrorKind.Other,
+    ) : TopicsUiState
 }

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumViewModel.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumViewModel.kt
@@ -3,6 +3,7 @@ package fr.forumhfr.redface2.feature.forum
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.forum.ForumRepository
 import fr.forumhfr.redface2.core.domain.forum.ForumResult
 import fr.forumhfr.redface2.core.model.Category
@@ -58,7 +59,9 @@ class ForumViewModel @Inject constructor(
         when (this) {
             ForumResult.Loading -> ForumUiState.Loading
             is ForumResult.Success -> ForumUiState.Content(value)
-            is ForumResult.Failure -> ForumUiState.Error(cause.message)
+            // #324 — kind derives from the exception TYPE so the screen can tell an HFR
+            // 5xx outage from a local network cut.
+            is ForumResult.Failure -> ForumUiState.Error(cause.message, classifyHfrError(cause))
         }
 
     private companion object {

--- a/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/ForumViewModelTest.kt
+++ b/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/ForumViewModelTest.kt
@@ -1,11 +1,14 @@
 package fr.forumhfr.redface2.feature.forum
 
 import app.cash.turbine.test
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
+import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.domain.forum.ForumRepository
 import fr.forumhfr.redface2.core.domain.forum.ForumResult
 import fr.forumhfr.redface2.core.model.Category
 import fr.forumhfr.redface2.core.model.SubCategory
 import fr.forumhfr.redface2.core.model.TopicListPage
+import java.net.UnknownHostException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -57,6 +60,40 @@ class ForumViewModelTest {
             assertEquals(ForumUiState.Loading, awaitItem())
             repo.emitCategories(ForumResult.Failure(IllegalStateException("HFR down")))
             assertEquals(ForumUiState.Error("HFR down"), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `uiState classifies an HFR 5xx Failure on the REST path as ServerDown`() = runTest {
+        // #324 — the categories fetch goes through HfrApiClient (REST); a 500 there must
+        // be presented as « HFR est en panne », not as a connectivity problem.
+        val repo = FakeForumRepository()
+        val vm = ForumViewModel(repo)
+
+        vm.uiState.test {
+            assertEquals(ForumUiState.Loading, awaitItem())
+            repo.emitCategories(
+                ForumResult.Failure(
+                    HfrServerException(code = 500, url = "https://forum.hardware.fr/webservices/rest_api.php"),
+                ),
+            )
+            val error = awaitItem() as ForumUiState.Error
+            assertEquals(HfrErrorKind.ServerDown, error.kind)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `uiState classifies a transport failure as Network`() = runTest {
+        val repo = FakeForumRepository()
+        val vm = ForumViewModel(repo)
+
+        vm.uiState.test {
+            assertEquals(ForumUiState.Loading, awaitItem())
+            repo.emitCategories(ForumResult.Failure(UnknownHostException("forum.hardware.fr")))
+            val error = awaitItem() as ForumUiState.Error
+            assertEquals(HfrErrorKind.Network, error.kind)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessagesScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessagesScreen.kt
@@ -39,9 +39,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.model.messages.PrivateMessageSummary
 import fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar
+import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -129,13 +129,7 @@ fun MessagesScreen(
                                 // ServerDown / Network render the shared :core:ui label, Other
                                 // keeps the generic message.
                                 text = stringResource(
-                                    when (mode.kind) {
-                                        HfrErrorKind.ServerDown ->
-                                            fr.forumhfr.redface2.core.ui.R.string.error_hfr_server_down
-                                        HfrErrorKind.Network ->
-                                            fr.forumhfr.redface2.core.ui.R.string.error_no_connection
-                                        HfrErrorKind.Other -> R.string.messages_error_load
-                                    },
+                                    mode.kind.sharedLabelResOrNull() ?: R.string.messages_error_load,
                                 ),
                                 style = MaterialTheme.typography.bodyLarge,
                                 color = MaterialTheme.colorScheme.error,

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessagesScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessagesScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.model.messages.PrivateMessageSummary
 import fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar
 import java.time.Instant
@@ -124,12 +125,23 @@ fun MessagesScreen(
                             modifier = Modifier.padding(horizontal = 24.dp),
                         ) {
                             Text(
-                                text = stringResource(R.string.messages_error_load),
+                                // #324 — the kind is a type-derived closed enum (safe per #316);
+                                // ServerDown / Network render the shared :core:ui label, Other
+                                // keeps the generic message.
+                                text = stringResource(
+                                    when (mode.kind) {
+                                        HfrErrorKind.ServerDown ->
+                                            fr.forumhfr.redface2.core.ui.R.string.error_hfr_server_down
+                                        HfrErrorKind.Network ->
+                                            fr.forumhfr.redface2.core.ui.R.string.error_no_connection
+                                        HfrErrorKind.Other -> R.string.messages_error_load
+                                    },
+                                ),
                                 style = MaterialTheme.typography.bodyLarge,
                                 color = MaterialTheme.colorScheme.error,
                             )
                             // No raw error detail on screen (#316): it can embed the private
-                            // conversation URL. Generic message + retry only.
+                            // conversation URL. Kind-resolved message + retry only.
                             Button(onClick = viewModel::retry) {
                                 Text(text = stringResource(R.string.messages_retry))
                             }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessagesUiState.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessagesUiState.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.feature.messages
 
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.model.messages.PrivateMessageSummary
 
 /**
@@ -29,7 +30,11 @@ data class MessagesUiState(
          * auth error can embed the private `forum2.php?cat=prive&post=<id>` URL, which would leak the
          * conversation id on screen. The UI shows a generic message + retry; the raw message must
          * reach neither the screen nor the exportable DiagnosticsLog.
+         *
+         * [kind] (#324) is SAFE by construction: a closed enum derived from the exception TYPE
+         * only (`classifyHfrError`), never from its message — it lets the screen tell an HFR 5xx
+         * outage from a network cut without weakening the #316 guarantee.
          */
-        data object Error : Mode
+        data class Error(val kind: HfrErrorKind = HfrErrorKind.Other) : Mode
     }
 }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessagesViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessagesViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
+import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.messages.MessagesRepository
 import fr.forumhfr.redface2.core.model.AuthState
 import javax.inject.Inject
@@ -103,11 +104,12 @@ class MessagesViewModel @Inject constructor(
             } catch (cancellation: CancellationException) {
                 throw cancellation
             } catch (
-                // SwallowedException: the throwable message is intentionally NOT propagated to the
-                // UI state — it can embed the private forum2.php?cat=prive&post=<id> URL (#316).
-                // It must not reach the screen, nor the exportable DiagnosticsLog. The Error state
-                // carries no detail; the user gets a generic message + retry.
-                @Suppress("TooGenericExceptionCaught", "SwallowedException") error: Exception,
+                // The throwable MESSAGE is intentionally NOT propagated to the UI state — it can
+                // embed the private forum2.php?cat=prive&post=<id> URL (#316). It must not reach
+                // the screen, nor the exportable DiagnosticsLog. The Error state only carries the
+                // #324 kind, a closed enum derived from the exception TYPE (classifyHfrError) so
+                // the screen can tell an HFR 5xx outage from a network cut.
+                @Suppress("TooGenericExceptionCaught") error: Exception,
             ) {
                 _state.update { current ->
                     // A failed pull-to-refresh must not wipe the conversations already shown:
@@ -117,7 +119,7 @@ class MessagesViewModel @Inject constructor(
                         current.copy(isRefreshing = false)
                     } else {
                         current.copy(
-                            mode = MessagesUiState.Mode.Error,
+                            mode = MessagesUiState.Mode.Error(classifyHfrError(error)),
                             isRefreshing = false,
                         )
                     }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
@@ -38,9 +38,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.model.Post
 import fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar
+import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.post.PostRenderer
 import java.time.Instant
 import java.time.ZoneId
@@ -180,13 +180,7 @@ fun PrivateMessageThreadScreen(
                         // ServerDown / Network render the shared :core:ui label, Other keeps
                         // the generic message.
                         text = stringResource(
-                            when (mode.kind) {
-                                HfrErrorKind.ServerDown ->
-                                    fr.forumhfr.redface2.core.ui.R.string.error_hfr_server_down
-                                HfrErrorKind.Network ->
-                                    fr.forumhfr.redface2.core.ui.R.string.error_no_connection
-                                HfrErrorKind.Other -> R.string.messages_thread_error_load
-                            },
+                            mode.kind.sharedLabelResOrNull() ?: R.string.messages_thread_error_load,
                         ),
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.error,

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.model.Post
 import fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar
 import fr.forumhfr.redface2.core.ui.post.PostRenderer
@@ -175,12 +176,23 @@ fun PrivateMessageThreadScreen(
                     modifier = Modifier.padding(horizontal = 24.dp),
                 ) {
                     Text(
-                        text = stringResource(R.string.messages_thread_error_load),
+                        // #324 — the kind is a type-derived closed enum (safe per #316);
+                        // ServerDown / Network render the shared :core:ui label, Other keeps
+                        // the generic message.
+                        text = stringResource(
+                            when (mode.kind) {
+                                HfrErrorKind.ServerDown ->
+                                    fr.forumhfr.redface2.core.ui.R.string.error_hfr_server_down
+                                HfrErrorKind.Network ->
+                                    fr.forumhfr.redface2.core.ui.R.string.error_no_connection
+                                HfrErrorKind.Other -> R.string.messages_thread_error_load
+                            },
+                        ),
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.error,
                     )
                     // No raw error detail on screen (#316): it can embed the private conversation
-                    // URL. Generic message + retry only.
+                    // URL. Kind-resolved message + retry only.
                     Button(onClick = viewModel::retry) {
                         Text(text = stringResource(R.string.messages_retry))
                     }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadUiState.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadUiState.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.feature.messages
 
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.model.messages.PrivateMessageThread
 
 /**
@@ -24,8 +25,12 @@ data class PrivateMessageThreadUiState(
          * A load failure. Carries NO raw throwable message on purpose (#316): a network or auth
          * error can embed the private `forum2.php?cat=prive&post=<id>` URL, which would leak the
          * conversation id on screen. The UI shows a generic message + retry.
+         *
+         * [kind] (#324) is SAFE by construction: a closed enum derived from the exception TYPE
+         * only (`classifyHfrError`), never from its message — it lets the screen tell an HFR 5xx
+         * outage from a network cut without weakening the #316 guarantee.
          */
-        data object Error : Mode
+        data class Error(val kind: HfrErrorKind = HfrErrorKind.Other) : Mode
     }
 
     companion object {

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModel.kt
@@ -7,6 +7,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
+import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.messages.MessagesRepository
 import fr.forumhfr.redface2.core.model.AuthState
 import kotlinx.coroutines.CancellationException
@@ -95,12 +96,16 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
             } catch (cancellation: CancellationException) {
                 throw cancellation
             } catch (
-                // SwallowedException: the throwable message is intentionally NOT propagated to the
-                // UI state — it can embed the private forum2.php?cat=prive&post=<id> URL (#316), so
-                // it must reach neither the screen nor the exportable DiagnosticsLog. Generic Error.
-                @Suppress("TooGenericExceptionCaught", "SwallowedException") error: Exception,
+                // The throwable MESSAGE is intentionally NOT propagated to the UI state — it can
+                // embed the private forum2.php?cat=prive&post=<id> URL (#316), so it must reach
+                // neither the screen nor the exportable DiagnosticsLog. The Error state only
+                // carries the #324 kind, a closed enum derived from the exception TYPE
+                // (classifyHfrError) so the screen can tell an HFR 5xx outage from a network cut.
+                @Suppress("TooGenericExceptionCaught") error: Exception,
             ) {
-                _state.update { it.copy(mode = PrivateMessageThreadUiState.Mode.Error) }
+                _state.update {
+                    it.copy(mode = PrivateMessageThreadUiState.Mode.Error(classifyHfrError(error)))
+                }
             }
         }
     }

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/MessagesViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/MessagesViewModelTest.kt
@@ -1,6 +1,8 @@
 package fr.forumhfr.redface2.feature.messages
 
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
+import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.domain.messages.MessagesRepository
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.messages.PrivateMessageListPage
@@ -76,8 +78,25 @@ class MessagesViewModelTest {
         val viewModel = MessagesViewModel(repository, FakeAuthRepository())
 
         // #316: the Error mode carries NO raw throwable message (privacy — it can embed the private
-        // conversation URL). We only assert the generic Error state is reached, not its detail.
-        assertTrue(viewModel.state.value.mode is MessagesUiState.Mode.Error)
+        // conversation URL). The only detail is the #324 type-derived kind (safe closed enum).
+        val mode = viewModel.state.value.mode
+        assertTrue(mode is MessagesUiState.Mode.Error)
+        assertEquals(HfrErrorKind.Network, (mode as MessagesUiState.Mode.Error).kind)
+    }
+
+    @Test
+    fun `surfaces an HFR 5xx load failure with the ServerDown kind`() = runTest {
+        // #324 — an HFR outage must be distinguishable from a network cut on the inbox,
+        // still without any raw message (the kind is derived from the exception TYPE only).
+        val repository = mockk<MessagesRepository>()
+        coEvery { repository.getPrivateMessageList(page = 1) } throws
+            HfrServerException(code = 503, url = "https://forum.hardware.fr/forum1.php")
+
+        val viewModel = MessagesViewModel(repository, FakeAuthRepository())
+
+        val mode = viewModel.state.value.mode
+        assertTrue(mode is MessagesUiState.Mode.Error)
+        assertEquals(HfrErrorKind.ServerDown, (mode as MessagesUiState.Mode.Error).kind)
     }
 
     @Test

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModelTest.kt
@@ -1,6 +1,8 @@
 package fr.forumhfr.redface2.feature.messages
 
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
+import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.domain.messages.MessagesRepository
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.messages.PrivateMessageThread
@@ -88,8 +90,27 @@ class PrivateMessageThreadViewModelTest {
         val viewModel = PrivateMessageThreadViewModel(request, repository, FakeAuthRepository())
 
         // #316: the Error mode carries NO raw throwable message (privacy — it can embed the private
-        // conversation URL). We only assert the generic Error state is reached, not its detail.
-        assertTrue(viewModel.state.value.mode is PrivateMessageThreadUiState.Mode.Error)
+        // conversation URL). The only detail is the #324 type-derived kind (safe closed enum).
+        val mode = viewModel.state.value.mode
+        assertTrue(mode is PrivateMessageThreadUiState.Mode.Error)
+        assertEquals(HfrErrorKind.Network, (mode as PrivateMessageThreadUiState.Mode.Error).kind)
+    }
+
+    @Test
+    fun `surfaces an HFR 5xx load failure with the ServerDown kind`() = runTest {
+        // #324 — an HFR outage must be distinguishable from a network cut on a conversation,
+        // still without any raw message (the kind is derived from the exception TYPE only —
+        // never from a string that could embed forum2.php?cat=prive&post=<id>).
+        val repository = mockk<MessagesRepository>()
+        coEvery {
+            repository.getPrivateMessageThread(threadId = 42, page = 1, fallbackCorrespondent = null)
+        } throws HfrServerException(code = 500, url = "https://forum.hardware.fr/forum2.php")
+
+        val viewModel = PrivateMessageThreadViewModel(request, repository, FakeAuthRepository())
+
+        val mode = viewModel.state.value.mode
+        assertTrue(mode is PrivateMessageThreadUiState.Mode.Error)
+        assertEquals(HfrErrorKind.ServerDown, (mode as PrivateMessageThreadUiState.Mode.Error).kind)
     }
 
     @Test

--- a/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfilePreviewSheet.kt
+++ b/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfilePreviewSheet.kt
@@ -29,18 +29,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.model.UserProfile
 import fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar
+import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import kotlinx.coroutines.launch
-
-/**
- * #324 — maps a profile [ProfileUiState.ErrorKind] to its message resource: the shared
- * `:core:ui` labels for ServerDown / Network, the feature's generic string otherwise.
- * Shared by the bottom sheet and the full-page screen.
- */
-internal fun profileErrorMessageRes(kind: ProfileUiState.ErrorKind): Int = when (kind) {
-    ProfileUiState.ErrorKind.ServerDown -> fr.forumhfr.redface2.core.ui.R.string.error_hfr_server_down
-    ProfileUiState.ErrorKind.Network -> fr.forumhfr.redface2.core.ui.R.string.error_no_connection
-    ProfileUiState.ErrorKind.Unknown -> R.string.profile_error_load_failed
-}
 
 /**
  * Phase 2 finish (#208) — ModalBottomSheet summary of a user's profile.
@@ -177,9 +167,11 @@ private fun ProfilePreviewContent(
                 Spacer(Modifier.height(8.dp))
                 Text(
                     // Review feedback I7: localised via stringResource ; the ViewModel
-                    // surfaces an ErrorKind enum, not a String. #324 — ServerDown /
-                    // Network resolve to the shared :core:ui labels.
-                    text = stringResource(profileErrorMessageRes(mode.kind)),
+                    // surfaces an error kind, not a String. #324 — ServerDown / Network
+                    // resolve to the shared :core:ui labels, Other keeps the generic one.
+                    text = stringResource(
+                        mode.kind.sharedLabelResOrNull() ?: R.string.profile_error_load_failed,
+                    ),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.error,
                 )

--- a/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfilePreviewSheet.kt
+++ b/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfilePreviewSheet.kt
@@ -32,6 +32,17 @@ import fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar
 import kotlinx.coroutines.launch
 
 /**
+ * #324 — maps a profile [ProfileUiState.ErrorKind] to its message resource: the shared
+ * `:core:ui` labels for ServerDown / Network, the feature's generic string otherwise.
+ * Shared by the bottom sheet and the full-page screen.
+ */
+internal fun profileErrorMessageRes(kind: ProfileUiState.ErrorKind): Int = when (kind) {
+    ProfileUiState.ErrorKind.ServerDown -> fr.forumhfr.redface2.core.ui.R.string.error_hfr_server_down
+    ProfileUiState.ErrorKind.Network -> fr.forumhfr.redface2.core.ui.R.string.error_no_connection
+    ProfileUiState.ErrorKind.Unknown -> R.string.profile_error_load_failed
+}
+
+/**
  * Phase 2 finish (#208) — ModalBottomSheet summary of a user's profile.
  *
  * Opened from `TopicScreen` via `onOpenProfile(userId, pseudo, avatarUrl)`, hoisted in
@@ -166,8 +177,9 @@ private fun ProfilePreviewContent(
                 Spacer(Modifier.height(8.dp))
                 Text(
                     // Review feedback I7: localised via stringResource ; the ViewModel
-                    // surfaces an ErrorKind enum, not a String.
-                    text = stringResource(R.string.profile_error_load_failed),
+                    // surfaces an ErrorKind enum, not a String. #324 — ServerDown /
+                    // Network resolve to the shared :core:ui labels.
+                    text = stringResource(profileErrorMessageRes(mode.kind)),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.error,
                 )

--- a/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileScreen.kt
@@ -151,9 +151,10 @@ internal fun ProfileScreen(
                     )
                     Spacer(Modifier.height(16.dp))
                     // Review feedback I7: the ViewModel surfaces an ErrorKind enum,
-                    // not a String — the UI maps it to the localised resource.
+                    // not a String — the UI maps it to the localised resource. #324 —
+                    // ServerDown / Network resolve to the shared :core:ui labels.
                     Text(
-                        text = stringResource(R.string.profile_error_load_failed),
+                        text = stringResource(profileErrorMessageRes(mode.kind)),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.error,
                     )

--- a/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileScreen.kt
@@ -34,6 +34,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.model.UserProfile
 import fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar
+import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 
 /**
  * Phase 2 finish (#208) — full profile screen.
@@ -150,11 +151,14 @@ internal fun ProfileScreen(
                         avatarUrl = state.avatarUrlHint,
                     )
                     Spacer(Modifier.height(16.dp))
-                    // Review feedback I7: the ViewModel surfaces an ErrorKind enum,
+                    // Review feedback I7: the ViewModel surfaces an error kind,
                     // not a String — the UI maps it to the localised resource. #324 —
-                    // ServerDown / Network resolve to the shared :core:ui labels.
+                    // ServerDown / Network resolve to the shared :core:ui labels,
+                    // Other keeps the feature's generic message.
                     Text(
-                        text = stringResource(profileErrorMessageRes(mode.kind)),
+                        text = stringResource(
+                            mode.kind.sharedLabelResOrNull() ?: R.string.profile_error_load_failed,
+                        ),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.error,
                     )

--- a/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileUiState.kt
+++ b/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileUiState.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.feature.profile
 
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.model.UserProfile
 
 /**
@@ -32,26 +33,16 @@ data class ProfileUiState(
 
         /**
          * Review feedback I7: the ViewModel must not own the user-visible string.
-         * It surfaces an [ErrorKind] (and optionally the originating [Throwable] for
-         * diagnostics) and the UI maps it to a localised `stringResource(...)`. This
-         * keeps `:feature:profile` layer-clean and i18n-ready.
+         * It surfaces the classified [HfrErrorKind] (and optionally the originating
+         * [Throwable] for diagnostics) and the UI maps it to a localised
+         * `stringResource(...)` — the shared `:core:ui` labels for ServerDown /
+         * Network (#324), the feature's generic string for Other. This keeps
+         * `:feature:profile` layer-clean and i18n-ready.
          */
         data class Error(
-            val kind: ErrorKind,
+            val kind: HfrErrorKind,
             val cause: Throwable? = null,
         ) : Mode
-    }
-
-    /** Classification of profile-load failures surfaced by the ViewModel to the UI. */
-    enum class ErrorKind {
-        /** #324 — HFR answered with a 5xx: outage, UI shows the shared « panne » string. */
-        ServerDown,
-
-        /** #324 — no HTTP response came back: connectivity cut, UI shows « pas de connexion ». */
-        Network,
-
-        /** Generic / unknown failure — UI shows the « load failed » string. */
-        Unknown,
     }
 
     companion object {

--- a/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileUiState.kt
+++ b/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileUiState.kt
@@ -44,6 +44,12 @@ data class ProfileUiState(
 
     /** Classification of profile-load failures surfaced by the ViewModel to the UI. */
     enum class ErrorKind {
+        /** #324 — HFR answered with a 5xx: outage, UI shows the shared « panne » string. */
+        ServerDown,
+
+        /** #324 — no HTTP response came back: connectivity cut, UI shows « pas de connexion ». */
+        Network,
+
         /** Generic / unknown failure — UI shows the « load failed » string. */
         Unknown,
     }

--- a/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileViewModel.kt
+++ b/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileViewModel.kt
@@ -6,7 +6,6 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
-import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.profile.ProfileRepository
 import kotlinx.coroutines.Job
@@ -29,7 +28,7 @@ import kotlinx.coroutines.launch
  * = { factory -> factory.create(...) })`), while [profileRepository] is injected by
  * Hilt's usual component binding.
  *
- * Review feedback I7/I8: error states surface an [ProfileUiState.ErrorKind] (the UI
+ * Review feedback I7/I8: error states surface the classified `HfrErrorKind` (the UI
  * resolves the user-visible string via `stringResource`) and a [loadJob] is held so
  * concurrent Retry taps cancel the previous in-flight load.
  */
@@ -77,17 +76,12 @@ class ProfileViewModel @AssistedInject constructor(
                 onFailure = { error ->
                     // Review feedback I7: ViewModel must not carry a localised String. It
                     // surfaces the kind + cause ; the UI resolves the message via
-                    // `stringResource(...)`. #324 — the kind now derives from the shared
-                    // classifier so a 5xx outage and a network cut render distinctly.
-                    val kind = when (classifyHfrError(error)) {
-                        HfrErrorKind.ServerDown -> ProfileUiState.ErrorKind.ServerDown
-                        HfrErrorKind.Network -> ProfileUiState.ErrorKind.Network
-                        HfrErrorKind.Other -> ProfileUiState.ErrorKind.Unknown
-                    }
+                    // `stringResource(...)`. #324 — the kind is the shared classifier's
+                    // verdict so a 5xx outage and a network cut render distinctly.
                     _state.update {
                         it.copy(
                             mode = ProfileUiState.Mode.Error(
-                                kind = kind,
+                                kind = classifyHfrError(error),
                                 cause = error,
                             ),
                         )

--- a/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileViewModel.kt
+++ b/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileViewModel.kt
@@ -6,6 +6,8 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
+import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.profile.ProfileRepository
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -75,11 +77,17 @@ class ProfileViewModel @AssistedInject constructor(
                 onFailure = { error ->
                     // Review feedback I7: ViewModel must not carry a localised String. It
                     // surfaces the kind + cause ; the UI resolves the message via
-                    // `stringResource(R.string.profile_error_load_failed)`.
+                    // `stringResource(...)`. #324 — the kind now derives from the shared
+                    // classifier so a 5xx outage and a network cut render distinctly.
+                    val kind = when (classifyHfrError(error)) {
+                        HfrErrorKind.ServerDown -> ProfileUiState.ErrorKind.ServerDown
+                        HfrErrorKind.Network -> ProfileUiState.ErrorKind.Network
+                        HfrErrorKind.Other -> ProfileUiState.ErrorKind.Unknown
+                    }
                     _state.update {
                         it.copy(
                             mode = ProfileUiState.Mode.Error(
-                                kind = ProfileUiState.ErrorKind.Unknown,
+                                kind = kind,
                                 cause = error,
                             ),
                         )

--- a/feature/profile/src/test/kotlin/fr/forumhfr/redface2/feature/profile/ProfileViewModelTest.kt
+++ b/feature/profile/src/test/kotlin/fr/forumhfr/redface2/feature/profile/ProfileViewModelTest.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.feature.profile
 
 import app.cash.turbine.test
+import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.domain.profile.ProfileRepository
 import fr.forumhfr.redface2.core.model.UserProfile
 import io.mockk.coEvery
@@ -104,10 +105,11 @@ class ProfileViewModelTest {
     }
 
     @Test
-    fun `network error exposes Error state with ErrorKind Unknown and original cause`() = runTest {
+    fun `network error exposes Error state with ErrorKind Network and original cause`() = runTest {
         // Review feedback I7: the ViewModel must surface an ErrorKind enum (not a String
         // message) so the UI resolves the localised text via stringResource. The original
-        // Throwable is preserved on `cause` for diagnostics / future per-error-type messages.
+        // Throwable is preserved on `cause` for diagnostics. #324 — a transport IOException
+        // now classifies as Network (« Pas de connexion »), no longer as Unknown.
         val cause = IOException("network error")
         coEvery { repository.getProfile(54596) } returns Result.failure(cause)
 
@@ -117,8 +119,39 @@ class ProfileViewModelTest {
             val state = awaitItem()
             assertTrue("Mode should be Error on failure", state.mode is ProfileUiState.Mode.Error)
             val error = state.mode as ProfileUiState.Mode.Error
-            assertEquals(ProfileUiState.ErrorKind.Unknown, error.kind)
+            assertEquals(ProfileUiState.ErrorKind.Network, error.kind)
             assertEquals(cause, error.cause)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `HFR 5xx error exposes Error state with ErrorKind ServerDown`() = runTest {
+        // #324 — getProfile raises a typed HfrServerException on a non-2xx; a 5xx must be
+        // presented as « HFR est en panne » on both the sheet and the full page.
+        val cause = HfrServerException(code = 500, url = "https://forum.hardware.fr/hfr/profil-54596.htm")
+        coEvery { repository.getProfile(54596) } returns Result.failure(cause)
+
+        val vm = createViewModel()
+
+        vm.state.test {
+            val error = awaitItem().mode as ProfileUiState.Mode.Error
+            assertEquals(ProfileUiState.ErrorKind.ServerDown, error.kind)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `non-IO error keeps ErrorKind Unknown`() = runTest {
+        // #324 — parse failures and other programming errors keep the generic message.
+        coEvery { repository.getProfile(54596) } returns
+            Result.failure(IllegalStateException("parser invariant broken"))
+
+        val vm = createViewModel()
+
+        vm.state.test {
+            val error = awaitItem().mode as ProfileUiState.Mode.Error
+            assertEquals(ProfileUiState.ErrorKind.Unknown, error.kind)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/feature/profile/src/test/kotlin/fr/forumhfr/redface2/feature/profile/ProfileViewModelTest.kt
+++ b/feature/profile/src/test/kotlin/fr/forumhfr/redface2/feature/profile/ProfileViewModelTest.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.feature.profile
 
 import app.cash.turbine.test
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.domain.profile.ProfileRepository
 import fr.forumhfr.redface2.core.model.UserProfile
@@ -105,11 +106,11 @@ class ProfileViewModelTest {
     }
 
     @Test
-    fun `network error exposes Error state with ErrorKind Network and original cause`() = runTest {
-        // Review feedback I7: the ViewModel must surface an ErrorKind enum (not a String
+    fun `network error exposes Error state with kind Network and original cause`() = runTest {
+        // Review feedback I7: the ViewModel must surface an error-kind enum (not a String
         // message) so the UI resolves the localised text via stringResource. The original
         // Throwable is preserved on `cause` for diagnostics. #324 — a transport IOException
-        // now classifies as Network (« Pas de connexion »), no longer as Unknown.
+        // now classifies as Network (« Pas de connexion »), no longer as Other.
         val cause = IOException("network error")
         coEvery { repository.getProfile(54596) } returns Result.failure(cause)
 
@@ -119,14 +120,14 @@ class ProfileViewModelTest {
             val state = awaitItem()
             assertTrue("Mode should be Error on failure", state.mode is ProfileUiState.Mode.Error)
             val error = state.mode as ProfileUiState.Mode.Error
-            assertEquals(ProfileUiState.ErrorKind.Network, error.kind)
+            assertEquals(HfrErrorKind.Network, error.kind)
             assertEquals(cause, error.cause)
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `HFR 5xx error exposes Error state with ErrorKind ServerDown`() = runTest {
+    fun `HFR 5xx error exposes Error state with kind ServerDown`() = runTest {
         // #324 — getProfile raises a typed HfrServerException on a non-2xx; a 5xx must be
         // presented as « HFR est en panne » on both the sheet and the full page.
         val cause = HfrServerException(code = 500, url = "https://forum.hardware.fr/hfr/profil-54596.htm")
@@ -136,13 +137,13 @@ class ProfileViewModelTest {
 
         vm.state.test {
             val error = awaitItem().mode as ProfileUiState.Mode.Error
-            assertEquals(ProfileUiState.ErrorKind.ServerDown, error.kind)
+            assertEquals(HfrErrorKind.ServerDown, error.kind)
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `non-IO error keeps ErrorKind Unknown`() = runTest {
+    fun `non-IO error keeps kind Other`() = runTest {
         // #324 — parse failures and other programming errors keep the generic message.
         coEvery { repository.getProfile(54596) } returns
             Result.failure(IllegalStateException("parser invariant broken"))
@@ -151,7 +152,7 @@ class ProfileViewModelTest {
 
         vm.state.test {
             val error = awaitItem().mode as ProfileUiState.Mode.Error
-            assertEquals(ProfileUiState.ErrorKind.Unknown, error.kind)
+            assertEquals(HfrErrorKind.Other, error.kind)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchScreen.kt
@@ -332,6 +332,8 @@ private fun EmptyState(modifier: Modifier = Modifier) {
 @Composable
 private fun ErrorState(kind: SearchErrorKind, onRetry: () -> Unit, modifier: Modifier = Modifier) {
     val messageResId = when (kind) {
+        // #324 — shared :core:ui label for an HFR 5xx outage.
+        SearchErrorKind.ServerDown -> fr.forumhfr.redface2.core.ui.R.string.error_hfr_server_down
         SearchErrorKind.Network -> R.string.search_error_network
         SearchErrorKind.Unknown -> R.string.search_error_unknown
     }

--- a/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchScreen.kt
@@ -45,9 +45,11 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.model.search.SearchPivotCategory
 import fr.forumhfr.redface2.core.model.search.SearchTextScope
 import fr.forumhfr.redface2.core.model.search.SearchTopicResult
+import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.formatLastReplyTimestamp
 
 /**
@@ -330,13 +332,10 @@ private fun EmptyState(modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun ErrorState(kind: SearchErrorKind, onRetry: () -> Unit, modifier: Modifier = Modifier) {
-    val messageResId = when (kind) {
-        // #324 — shared :core:ui label for an HFR 5xx outage.
-        SearchErrorKind.ServerDown -> fr.forumhfr.redface2.core.ui.R.string.error_hfr_server_down
-        SearchErrorKind.Network -> R.string.search_error_network
-        SearchErrorKind.Unknown -> R.string.search_error_unknown
-    }
+private fun ErrorState(kind: HfrErrorKind, onRetry: () -> Unit, modifier: Modifier = Modifier) {
+    // #324 — shared :core:ui labels for an HFR 5xx outage / a connectivity cut;
+    // Other keeps the feature's generic message.
+    val messageResId = kind.sharedLabelResOrNull() ?: R.string.search_error_unknown
     Column(verticalArrangement = Arrangement.spacedBy(8.dp), modifier = modifier) {
         Text(
             text = stringResource(messageResId),

--- a/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchUiState.kt
+++ b/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchUiState.kt
@@ -32,6 +32,11 @@ data class SearchUiState(
  * exception messages to the user.
  */
 sealed interface SearchErrorKind {
+    /**
+     * #324 — HFR answered with a 5xx: the site itself is down, retrying immediately is
+     * unlikely to help. Distinct from [Network] (local connectivity cut).
+     */
+    data object ServerDown : SearchErrorKind
     data object Network : SearchErrorKind
     data object Unknown : SearchErrorKind
 }

--- a/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchUiState.kt
+++ b/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchUiState.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.feature.search
 
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.model.search.SearchPivotCategory
 import fr.forumhfr.redface2.core.model.search.SearchTextScope
 import fr.forumhfr.redface2.core.model.search.SearchTopicResult
@@ -11,8 +12,10 @@ import fr.forumhfr.redface2.core.model.search.SearchTopicResult
  * distinguish the « initial idle state » from a no-result outcome. Without it the
  * « Aucun résultat » empty state would flash before the user has even searched.
  *
- * `errorMessage` is a localized string already resolved by the ViewModel ; the
- * screen surfaces it verbatim with a retry button.
+ * `errorMessage` is the #324 [HfrErrorKind] classification of the last failure
+ * (`null` = no error) ; the screen resolves it to the shared ServerDown / Network
+ * labels, or to the feature's generic message for Other, with a retry button —
+ * no technical exception message ever reaches the UI.
  */
 data class SearchUiState(
     val query: String = "",
@@ -21,25 +24,9 @@ data class SearchUiState(
     val pivotCategories: List<SearchPivotCategory> = emptyList(),
     val results: List<SearchTopicResult> = emptyList(),
     val isLoading: Boolean = false,
-    val errorMessage: SearchErrorKind? = null,
+    val errorMessage: HfrErrorKind? = null,
     val hasSearched: Boolean = false,
 )
-
-/**
- * Localized failure kinds the screen can render. Kept as a discrete sum so the
- * Compose layer can pick the right string resource (network vs unexpected
- * response vs « no cat context » parser error) without leaking technical
- * exception messages to the user.
- */
-sealed interface SearchErrorKind {
-    /**
-     * #324 — HFR answered with a 5xx: the site itself is down, retrying immediately is
-     * unlikely to help. Distinct from [Network] (local connectivity cut).
-     */
-    data object ServerDown : SearchErrorKind
-    data object Network : SearchErrorKind
-    data object Unknown : SearchErrorKind
-}
 
 /**
  * Intents emitted by [SearchScreen]. `Retry` reuses the last submitted query

--- a/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchViewModel.kt
+++ b/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchViewModel.kt
@@ -3,13 +3,14 @@ package fr.forumhfr.redface2.feature.search
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
+import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.search.SearchRepository
 import fr.forumhfr.redface2.core.model.search.SearchCategoryScope
 import fr.forumhfr.redface2.core.model.search.SearchPivotCategory
 import fr.forumhfr.redface2.core.model.search.SearchRequest
 import fr.forumhfr.redface2.core.model.search.SearchTextScope
 import fr.forumhfr.redface2.core.model.search.SearchTopicResult
-import java.io.IOException
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
@@ -250,9 +251,15 @@ class SearchViewModel @Inject constructor(
                     }
                 },
                 onFailure = { error ->
-                    val kind = when (error) {
-                        is IOException -> SearchErrorKind.Network
-                        else -> SearchErrorKind.Unknown
+                    // #324 — shared type-derived classification. The repository lets
+                    // HfrServerException traverse (URL redacted) so a 5xx maps to
+                    // ServerDown instead of being mistaken for a network cut; a redacted
+                    // SessionExpiredException lands in Other → Unknown (search has no
+                    // dedicated session treatment).
+                    val kind = when (classifyHfrError(error)) {
+                        HfrErrorKind.ServerDown -> SearchErrorKind.ServerDown
+                        HfrErrorKind.Network -> SearchErrorKind.Network
+                        HfrErrorKind.Other -> SearchErrorKind.Unknown
                     }
                     _state.update {
                         it.copy(

--- a/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchViewModel.kt
+++ b/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchViewModel.kt
@@ -34,8 +34,8 @@ import kotlinx.coroutines.launch
  *  1. Clear any prior error, flip `isLoading=true`.
  *  2. Call [SearchRepository.search] with the user's query + scope.
  *  3. On success, populate `results`/`pivotCategories`/`selectedCategory`.
- *  4. On failure, map the exception kind to [SearchErrorKind] and surface
- *     a retry button.
+ *  4. On failure, classify the exception into an [HfrErrorKind] (#324) and
+ *     surface a retry button.
  *
  * The repository already redacts the query from `IOException` messages, so
  * nothing in this layer logs it either — we map error kinds purely on the
@@ -254,17 +254,12 @@ class SearchViewModel @Inject constructor(
                     // #324 — shared type-derived classification. The repository lets
                     // HfrServerException traverse (URL redacted) so a 5xx maps to
                     // ServerDown instead of being mistaken for a network cut; a redacted
-                    // SessionExpiredException lands in Other → Unknown (search has no
-                    // dedicated session treatment).
-                    val kind = when (classifyHfrError(error)) {
-                        HfrErrorKind.ServerDown -> SearchErrorKind.ServerDown
-                        HfrErrorKind.Network -> SearchErrorKind.Network
-                        HfrErrorKind.Other -> SearchErrorKind.Unknown
-                    }
+                    // SessionExpiredException lands in Other (search has no dedicated
+                    // session treatment).
                     _state.update {
                         it.copy(
                             isLoading = false,
-                            errorMessage = kind,
+                            errorMessage = classifyHfrError(error),
                             // Keep the previous results untouched on retry-friendly errors —
                             // wiping the list on a transient network blip is more disruptive
                             // than helpful.

--- a/feature/search/src/main/res/values/strings.xml
+++ b/feature/search/src/main/res/values/strings.xml
@@ -7,7 +7,8 @@
     <string name="search_idle_hint">Saisissez un mot-clé pour chercher dans les titres et messages HFR. Quand HFR fournit un extrait, le résultat ouvre le message correspondant ; sinon il ouvre le topic.</string>
     <string name="search_loading">Recherche en cours…</string>
     <string name="search_empty">Aucun résultat pour cette recherche.</string>
-    <string name="search_error_network">Erreur réseau. Vérifiez votre connexion puis réessayez.</string>
+    <!-- #324 — les cas ServerDown / Network rendent les libellés partagés de :core:ui
+         (error_hfr_server_down / error_no_connection) ; seul le fallback générique reste local. -->
     <string name="search_error_unknown">HFR a renvoyé une réponse inattendue. Réessayez.</string>
     <string name="search_scope_label">Champ de recherche</string>
     <string name="search_scope_titles_and_posts">Titres + messages</string>

--- a/feature/search/src/test/kotlin/fr/forumhfr/redface2/feature/search/SearchViewModelTest.kt
+++ b/feature/search/src/test/kotlin/fr/forumhfr/redface2/feature/search/SearchViewModelTest.kt
@@ -2,6 +2,7 @@ package fr.forumhfr.redface2.feature.search
 
 import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.domain.search.SearchRepository
 import fr.forumhfr.redface2.core.model.search.SearchCategoryScope
@@ -109,7 +110,7 @@ class SearchViewModelTest {
         vm.submit(SearchIntent.Submit)
 
         val final = vm.state.value
-        assertEquals(SearchErrorKind.Network, final.errorMessage)
+        assertEquals(HfrErrorKind.Network, final.errorMessage)
         assertEquals("kotlin", final.query)
         assertFalse(final.isLoading)
     }
@@ -124,20 +125,20 @@ class SearchViewModelTest {
         vm.submit(SearchIntent.Submit)
 
         val final = vm.state.value
-        assertEquals(SearchErrorKind.ServerDown, final.errorMessage)
+        assertEquals(HfrErrorKind.ServerDown, final.errorMessage)
         assertFalse(final.isLoading)
     }
 
     @Test
-    fun `repository SessionExpiredException sets the Unknown error kind not Network`() = runTest {
+    fun `repository SessionExpiredException sets the Other error kind not Network`() = runTest {
         // #324 — search has no dedicated session treatment; an expired session must not be
-        // presented as a connectivity cut (classifyHfrError → Other → Unknown).
+        // presented as a connectivity cut (classifyHfrError → Other).
         coEvery { repo.search(any()) } throws SessionExpiredException("<redacted>")
         val vm = SearchViewModel(repo)
         vm.submit(SearchIntent.QueryChanged("kotlin"))
         vm.submit(SearchIntent.Submit)
 
-        assertEquals(SearchErrorKind.Unknown, vm.state.value.errorMessage)
+        assertEquals(HfrErrorKind.Other, vm.state.value.errorMessage)
     }
 
     @Test
@@ -151,7 +152,7 @@ class SearchViewModelTest {
         val vm = SearchViewModel(repo)
         vm.submit(SearchIntent.QueryChanged("kotlin"))
         vm.submit(SearchIntent.Submit) // first attempt throws
-        assertEquals(SearchErrorKind.Network, vm.state.value.errorMessage)
+        assertEquals(HfrErrorKind.Network, vm.state.value.errorMessage)
 
         // User types a NEW value in the field but does NOT submit — Retry must
         // still re-use the previously submitted query, not the current field value.

--- a/feature/search/src/test/kotlin/fr/forumhfr/redface2/feature/search/SearchViewModelTest.kt
+++ b/feature/search/src/test/kotlin/fr/forumhfr/redface2/feature/search/SearchViewModelTest.kt
@@ -1,6 +1,8 @@
 package fr.forumhfr.redface2.feature.search
 
 import app.cash.turbine.test
+import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.domain.search.SearchRepository
 import fr.forumhfr.redface2.core.model.search.SearchCategoryScope
 import fr.forumhfr.redface2.core.model.search.SearchPivotCategory
@@ -110,6 +112,32 @@ class SearchViewModelTest {
         assertEquals(SearchErrorKind.Network, final.errorMessage)
         assertEquals("kotlin", final.query)
         assertFalse(final.isLoading)
+    }
+
+    @Test
+    fun `repository HfrServerException sets the ServerDown error kind`() = runTest {
+        // #324 — DefaultSearchRepository lets the typed exception traverse (URL redacted);
+        // a 5xx must surface as « HFR est en panne », not as a network problem.
+        coEvery { repo.search(any()) } throws HfrServerException(code = 500, url = "<redacted>")
+        val vm = SearchViewModel(repo)
+        vm.submit(SearchIntent.QueryChanged("kotlin"))
+        vm.submit(SearchIntent.Submit)
+
+        val final = vm.state.value
+        assertEquals(SearchErrorKind.ServerDown, final.errorMessage)
+        assertFalse(final.isLoading)
+    }
+
+    @Test
+    fun `repository SessionExpiredException sets the Unknown error kind not Network`() = runTest {
+        // #324 — search has no dedicated session treatment; an expired session must not be
+        // presented as a connectivity cut (classifyHfrError → Other → Unknown).
+        coEvery { repo.search(any()) } throws SessionExpiredException("<redacted>")
+        val vm = SearchViewModel(repo)
+        vm.submit(SearchIntent.QueryChanged("kotlin"))
+        vm.submit(SearchIntent.Submit)
+
+        assertEquals(SearchErrorKind.Unknown, vm.state.value.errorMessage)
     }
 
     @Test

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -68,12 +68,12 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.model.Poll
 import fr.forumhfr.redface2.core.model.Post
 import fr.forumhfr.redface2.core.model.Topic
 import fr.forumhfr.redface2.core.ui.RedfacePlaceholderScreen
 import fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar
+import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.post.PostRenderer
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -571,13 +571,10 @@ internal fun TopicContent(
                 is TopicUiState.Mode.Error -> {
                     // #324 — ServerDown / Network swap the raw exception message for the
                     // shared :core:ui label; Other keeps the existing diagnostic detail.
-                    val detail = when (mode.kind) {
-                        HfrErrorKind.ServerDown ->
-                            stringResource(fr.forumhfr.redface2.core.ui.R.string.error_hfr_server_down)
-                        HfrErrorKind.Network ->
-                            stringResource(fr.forumhfr.redface2.core.ui.R.string.error_no_connection)
-                        HfrErrorKind.Other -> mode.message
-                    }
+                    // (`if` rather than `?.let {} ?:` keeps TopicContent under detekt's
+                    // cyclomatic-complexity threshold.)
+                    val sharedLabelRes = mode.kind.sharedLabelResOrNull()
+                    val detail = if (sharedLabelRes != null) stringResource(sharedLabelRes) else mode.message
                     RedfacePlaceholderScreen(
                         title = stringResource(R.string.topic_error_title),
                         body = stringResource(R.string.topic_error_body, state.request.page, detail),

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -68,6 +68,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.model.Poll
 import fr.forumhfr.redface2.core.model.Post
 import fr.forumhfr.redface2.core.model.Topic
@@ -568,9 +569,18 @@ internal fun TopicContent(
                 }
 
                 is TopicUiState.Mode.Error -> {
+                    // #324 — ServerDown / Network swap the raw exception message for the
+                    // shared :core:ui label; Other keeps the existing diagnostic detail.
+                    val detail = when (mode.kind) {
+                        HfrErrorKind.ServerDown ->
+                            stringResource(fr.forumhfr.redface2.core.ui.R.string.error_hfr_server_down)
+                        HfrErrorKind.Network ->
+                            stringResource(fr.forumhfr.redface2.core.ui.R.string.error_no_connection)
+                        HfrErrorKind.Other -> mode.message
+                    }
                     RedfacePlaceholderScreen(
                         title = stringResource(R.string.topic_error_title),
-                        body = stringResource(R.string.topic_error_body, state.request.page, mode.message),
+                        body = stringResource(R.string.topic_error_body, state.request.page, detail),
                     ) {
                         TopicPageNavigation(
                             currentPage = state.request.page,

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.feature.topic
 
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.model.Topic
 
 data class TopicUiState(
@@ -61,6 +62,13 @@ data class TopicUiState(
 
         data class Error(
             val message: String,
+            /**
+             * #324 — coarse classification (HFR 5xx / coupure réseau / autre) derived from
+             * the exception TYPE by `classifyHfrError`. The screen swaps the raw [message]
+             * for the shared `:core:ui` string on [HfrErrorKind.ServerDown] /
+             * [HfrErrorKind.Network]; [HfrErrorKind.Other] keeps rendering [message].
+             */
+            val kind: HfrErrorKind = HfrErrorKind.Other,
         ) : Mode
     }
 

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -8,6 +8,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
+import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.topic.TopicRepository
 import fr.forumhfr.redface2.core.domain.write.DeletePostRepository
@@ -202,8 +203,18 @@ class TopicViewModel @AssistedInject constructor(
                     // the network blip after the cache emission. A surface for that error
                     // (Snackbar / banner) is deferred to Phase 1D.
                     _state.update { current ->
-                        if (current.mode is TopicUiState.Mode.Loaded) current
-                        else current.copy(mode = TopicUiState.Mode.Error(error.message ?: "Unknown error"))
+                        if (current.mode is TopicUiState.Mode.Loaded) {
+                            current
+                        } else {
+                            current.copy(
+                                mode = TopicUiState.Mode.Error(
+                                    message = error.message ?: "Unknown error",
+                                    // #324 — type-derived kind so the screen can tell an HFR
+                                    // 5xx outage from a local network cut.
+                                    kind = classifyHfrError(error),
+                                ),
+                            )
+                        }
                     }
                     // Close the async trace section even on the error path so the trace
                     // still draws a bounded sliver from intent to terminal state.

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -2,6 +2,8 @@ package fr.forumhfr.redface2.feature.topic
 
 import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
+import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
+import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
@@ -17,6 +19,7 @@ import fr.forumhfr.redface2.core.model.Post
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.Topic
 import java.io.IOException
+import java.net.UnknownHostException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -190,6 +193,42 @@ class TopicViewModelTest {
 
         val mode = assertMode<TopicUiState.Mode.Error>(viewModel.state.value)
         assertEquals("network", mode.message)
+    }
+
+    @Test
+    fun `flow failing with an HFR 5xx exposes the ServerDown error kind`() = runTest {
+        // #324 — an HFR outage (HfrServerException 5xx) must be distinguishable from a
+        // local network cut by the screen, via the type-derived kind on the Error mode.
+        val repository = FakeTopicRepository(
+            flowsToReturn = listOf(
+                flow { throw HfrServerException(code = 500, url = "https://forum.hardware.fr/forum2.php") },
+            ),
+        )
+
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+
+        val mode = assertMode<TopicUiState.Mode.Error>(viewModel.state.value)
+        assertEquals(HfrErrorKind.ServerDown, mode.kind)
+    }
+
+    @Test
+    fun `flow failing with a transport IOException exposes the Network error kind`() = runTest {
+        val repository = FakeTopicRepository(
+            flowsToReturn = listOf(flow { throw UnknownHostException("forum.hardware.fr") }),
+        )
+
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+
+        val mode = assertMode<TopicUiState.Mode.Error>(viewModel.state.value)
+        assertEquals(HfrErrorKind.Network, mode.kind)
     }
 
     @Test


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaaT)

Closes #324

## Quoi

- `HfrServerException(code, url)` dans `:core:domain` — levée sur réponse HTTP 5xx aux 5 sites réseau (3 dans `HfrClient`, 2 dans `HfrApiClient` REST).
- Classifieur `HfrErrorKind` : `SessionExpired → Other` testé **avant** `IOException → Network` (HfrServerException est une IOException ; l'ordre est porteur de sens).
- Fix ré-enveloppement `DefaultSearchRepository` : préserve `SessionExpiredException`/`HfrServerException` après redaction au lieu de les écraser en `IOException` générique.
- Centralisation `core/ui/error/HfrErrorLabels.kt` : `HfrErrorKind.sharedLabelResOrNull()` partagé par 9 sites ; enums locales `ProfileUiState.ErrorKind`/`SearchErrorKind` supprimées ; nouvelle arête `:core:ui → :core:domain` documentée dans `architecture.md` (+ alignement de l'arête préexistante `:core:network → :core:domain`, note Codex).
- 7 écrans de lecture affichent désormais « HFR est en panne » distinct de « pas de réseau ».

## Validation

- Locale ×2 : `detektAll test testDebugUnitTest :app:assembleProdDebug --rerun-tasks` (2m56) puis `lintDebug :app:lintProdDebug` (1m43) — vertes.
- Review multi-agent 4 saveurs : 0 finding ≥ 60 restant (3 mineurs résolus par la centralisation).
- Review Codex finale : **SHIP**, zéro bloquant.

## Merge

Squash `--admin` mono-maintainer : pas de second compte « sûr » disponible pour approuver sans créer un lien d'identité non voulu (cf. AGENTS.md § Review en mono-maintainer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)