### PR TITLE
feat(editor): confirmation optionnelle avant publication (#312)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -191,6 +191,21 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeConfirmBeforePosting(): Flow<Boolean> =
+        dataStore.data
+            // Default `false`: publishing stays one-tap unless the user opts into the #312 guard.
+            .map { prefs -> prefs[KEY_CONFIRM_BEFORE_POSTING] ?: false }
+            .distinctUntilChanged()
+            .catch { emit(false) }
+
+    override suspend fun setConfirmBeforePosting(enabled: Boolean) {
+        withContext(ioDispatcher) {
+            dataStore.edit { prefs ->
+                prefs[KEY_CONFIRM_BEFORE_POSTING] = enabled
+            }
+        }
+    }
+
     /**
      * Reads [KEY_THEME_MODE] defensively: an unknown / corrupt stored value (older build with a
      * renamed enum, manual edit) falls back to [ThemeMode.SYSTEM] instead of crashing on
@@ -279,5 +294,8 @@ class DataStoreUserPreferencesRepository @Inject constructor(
 
         // build 89 follow-up — topic top app bar auto-hide on scroll.
         val KEY_TOPIC_TOPBAR_AUTO_HIDE = booleanPreferencesKey("topic_topbar_auto_hide")
+
+        // #312 — confirmation dialog before any publish action (reply / edit / new topic / MP).
+        val KEY_CONFIRM_BEFORE_POSTING = booleanPreferencesKey("confirm_before_posting")
     }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -371,6 +371,27 @@ class DataStoreUserPreferencesRepositoryTest {
     }
 
     @Test
+    fun `observeConfirmBeforePosting defaults to false then persists true and false`() = runTest(dispatcher) {
+        // #312 — publishing stays one-tap by default; the guard is strictly opt-in.
+        repository.observeConfirmBeforePosting().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setConfirmBeforePosting(true)
+        repository.observeConfirmBeforePosting().test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setConfirmBeforePosting(false)
+        repository.observeConfirmBeforePosting().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `saving disabled proxy removes optional fields from effective config`() = runTest(dispatcher) {
         repository.saveProxyConfig(
             ProxyConfig(

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -508,5 +508,10 @@ class TopicRepositoryImplTest {
         override fun observeTopicTopBarAutoHide(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setTopicTopBarAutoHide(enabled: Boolean) = Unit
+
+        // #312 — confirm-before-posting is irrelevant to TopicRepositoryImpl; stubbed at its default.
+        override fun observeConfirmBeforePosting(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setConfirmBeforePosting(enabled: Boolean) = Unit
     }
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -137,4 +137,16 @@ interface UserPreferencesRepository {
 
     /** Persists [observeTopicTopBarAutoHide]. Default `false` until the first call. */
     suspend fun setTopicTopBarAutoHide(enabled: Boolean)
+
+    /**
+     * Confirmation before posting (#312): when `true`, every publish action (topic reply / post
+     * edit, new topic / first-post edit, private-message reply) first shows a confirmation dialog
+     * before the real submission is executed. Default `false` — submission stays one-tap unless the
+     * user opts in. Observed by the editor ViewModels (`:feature:editor`, `:feature:messages`),
+     * toggled in Settings.
+     */
+    fun observeConfirmBeforePosting(): Flow<Boolean>
+
+    /** Persists [observeConfirmBeforePosting]. Default `false` until the first call. */
+    suspend fun setConfirmBeforePosting(enabled: Boolean)
 }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/ConfirmSubmitDialog.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/ConfirmSubmitDialog.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.core.ui.editor
 
+import androidx.annotation.StringRes
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -19,14 +20,19 @@ import fr.forumhfr.redface2.core.ui.R
 fun ConfirmSubmitDialog(
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
+    // Forum wording by default; `:feature:messages` overrides the three texts because a
+    // private reply is NOT « envoyé sur le forum » and the established MP verb is « Envoyer ».
+    @StringRes title: Int = R.string.confirm_submit_title,
+    @StringRes body: Int = R.string.confirm_submit_body,
+    @StringRes confirmLabel: Int = R.string.confirm_submit_action,
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text(text = stringResource(R.string.confirm_submit_title)) },
-        text = { Text(text = stringResource(R.string.confirm_submit_body)) },
+        title = { Text(text = stringResource(title)) },
+        text = { Text(text = stringResource(body)) },
         confirmButton = {
             TextButton(onClick = onConfirm) {
-                Text(text = stringResource(R.string.confirm_submit_action))
+                Text(text = stringResource(confirmLabel))
             }
         },
         dismissButton = {

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/ConfirmSubmitDialog.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/ConfirmSubmitDialog.kt
@@ -1,0 +1,38 @@
+package fr.forumhfr.redface2.core.ui.editor
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import fr.forumhfr.redface2.core.ui.R
+
+/**
+ * #312 — confirmation dialog shown before a publish action when the « Confirmation avant
+ * publication » preference is on. Stateless on purpose: visibility is owned by the calling
+ * ViewModel (`showSubmitConfirmation` in its state) and both buttons route back through
+ * intents / callbacks, so the dialog can be shared by the three editors (`:feature:editor`
+ * post + topic forms, `:feature:messages` private reply) without dragging any ViewModel
+ * dependency into `:core:ui`. Same M3 AlertDialog shape as `DeletePostConfirmDialog`.
+ */
+@Composable
+fun ConfirmSubmitDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(R.string.confirm_submit_title)) },
+        text = { Text(text = stringResource(R.string.confirm_submit_body)) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(text = stringResource(R.string.confirm_submit_action))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(R.string.confirm_submit_cancel))
+            }
+        },
+    )
+}

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -33,6 +33,13 @@
     <string name="bbcode_color_grey">Gris</string>
     <string name="bbcode_preview_empty">La prévisualisation s\'affiche ici dès que vous saisissez du texte.</string>
 
+    <!-- #312 — confirmation avant publication, partagée par les trois éditeurs (réponse/édition,
+         sujet, message privé) via ConfirmSubmitDialog. -->
+    <string name="confirm_submit_title">Publier ce message ?</string>
+    <string name="confirm_submit_body">Votre message va être envoyé sur le forum.</string>
+    <string name="confirm_submit_action">Publier</string>
+    <string name="confirm_submit_cancel">Annuler</string>
+
     <!-- #198 Menu compte global — shared by every main screen via RedfaceAccountMenu. -->
     <string name="account_menu_status_loading">Compte en cours de vérification…</string>
     <string name="account_menu_status_anonymous">Anonyme</string>

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorIntent.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorIntent.kt
@@ -15,6 +15,15 @@ sealed interface PostEditorIntent {
     /** User asked to send the reply to HFR (Phase 2C, [PostEditorMode.Reply] only). */
     data object SubmitClicked : PostEditorIntent
 
+    /**
+     * #312 — user confirmed the « Confirmation avant publication » dialog. Executes the real
+     * submission directly, BYPASSING the preference re-check (otherwise the dialog would loop).
+     */
+    data object SubmitConfirmed : PostEditorIntent
+
+    /** #312 — user dismissed the confirmation dialog. No submission happens; the draft stays. */
+    data object SubmitConfirmationDismissed : PostEditorIntent
+
     /** User dismissed an in-flight error banner. Clears [PostEditorState.submitError]. */
     data object ErrorDismissed : PostEditorIntent
 

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -46,6 +46,7 @@ import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
 import fr.forumhfr.redface2.core.ui.editor.BbcodePreview
 import fr.forumhfr.redface2.core.ui.editor.BbcodeTextField
 import fr.forumhfr.redface2.core.ui.editor.BbcodeToolbar
+import fr.forumhfr.redface2.core.ui.editor.ConfirmSubmitDialog
 
 /**
  * Post-level editor screen. Phase 2C (#145) adds a Submit button that posts the
@@ -221,6 +222,14 @@ private fun PostEditorContent(
             ImageUrlDialog(
                 onDismiss = { imageUrlDialogOpen = false },
                 onInsert = { url -> onIntent(PostEditorIntent.ImageUrlInserted(url)) },
+            )
+        }
+        // #312 — « Confirmation avant publication ». Visibility is owned by the ViewModel, which
+        // only raises the flag once the submit passed every validation gate and the preference is on.
+        if (state.showSubmitConfirmation) {
+            ConfirmSubmitDialog(
+                onConfirm = { onIntent(PostEditorIntent.SubmitConfirmed) },
+                onDismiss = { onIntent(PostEditorIntent.SubmitConfirmationDismissed) },
             )
         }
     }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
@@ -86,6 +86,13 @@ data class PostEditorState(
      * repository falls back to `user_id=0`.
      */
     val userId: Int? = null,
+    /**
+     * #312 — `true` while the « Confirmation avant publication » dialog is shown. Only ever set
+     * when the persisted preference is on AND the submit already passed every validation gate
+     * (we never ask to confirm a form that could not be submitted). Confirm / dismiss go through
+     * [PostEditorIntent.SubmitConfirmed] / [PostEditorIntent.SubmitConfirmationDismissed].
+     */
+    val showSubmitConfirmation: Boolean = false,
 ) {
     /**
      * Submission is allowed when : we know the routing context (page + subcat + topicId),

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -11,6 +11,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
 import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.smiley.SmileyRepository
 import fr.forumhfr.redface2.core.domain.write.EditPostRepository
 import fr.forumhfr.redface2.core.domain.write.ReplyRepository
@@ -54,12 +55,14 @@ import kotlinx.coroutines.launch
  * by the repository are surfaced via [SubmitError]; the draft is preserved.
  */
 @HiltViewModel(assistedFactory = PostEditorViewModel.Factory::class)
+@Suppress("LongParameterList") // Hilt constructor injection — one dependency per collaborator.
 class PostEditorViewModel @AssistedInject constructor(
     @Assisted private val request: PostEditorRequest,
     private val previewParser: BbcodePreviewParser,
     private val replyRepository: ReplyRepository,
     private val editPostRepository: EditPostRepository,
     private val smileyRepository: SmileyRepository,
+    private val userPreferencesRepository: UserPreferencesRepository,
     private val diagnostics: DiagnosticsLog,
 ) : ViewModel() {
 
@@ -90,19 +93,36 @@ class PostEditorViewModel @AssistedInject constructor(
     /** In-flight wiki smiley search ; cancelled on next query change / picker close. */
     private var smileySearchJob: Job? = null
 
+    /**
+     * #312 — mirror of the persisted « Confirmation avant publication » preference. Collected on
+     * init (same DataStore-consumption shape as `TopicViewModel.observeTopicTopBarAutoHide`) and
+     * read synchronously at submit time. Kept off [PostEditorState] because the UI never renders
+     * the preference itself — only the dialog visibility flag it gates.
+     */
+    private var confirmBeforePosting: Boolean = false
+
     init {
+        viewModelScope.launch {
+            userPreferencesRepository.observeConfirmBeforePosting().collect { enabled ->
+                confirmBeforePosting = enabled
+            }
+        }
         when (request.mode) {
             PostEditorMode.Reply -> loadReplyFormIfPossible()
             PostEditorMode.Edit -> loadEditFormIfPossible()
         }
     }
 
+    @Suppress("CyclomaticComplexMethod") // MVI when-dispatch over the PostEditorIntent variants ; flat by design.
     fun submit(intent: PostEditorIntent) {
         when (intent) {
             is PostEditorIntent.ContentChanged -> onContentChanged(intent.value)
             is PostEditorIntent.ToolbarActionClicked -> onToolbarActionClicked(intent.action)
             PostEditorIntent.TogglePreview -> onTogglePreview()
             PostEditorIntent.SubmitClicked -> onSubmitClicked()
+            PostEditorIntent.SubmitConfirmed -> onSubmitConfirmed()
+            PostEditorIntent.SubmitConfirmationDismissed ->
+                _state.update { it.copy(showSubmitConfirmation = false) }
             PostEditorIntent.ErrorDismissed -> _state.update { it.copy(submitError = null) }
             is PostEditorIntent.ToggleSignature ->
                 _state.update { it.copy(signatureEnabled = intent.enabled) }
@@ -453,8 +473,19 @@ class PostEditorViewModel @AssistedInject constructor(
         _state.update { it.copy(isLoadingForm = false, submitError = mapped) }
     }
 
+    /**
+     * #312 — confirm path. Closes the dialog and re-runs the submit pipeline with
+     * `bypassConfirmation = true` so the real submission executes directly (re-checking the
+     * preference here would loop « confirmation → confirmation » forever). The validation
+     * guards run again on the latest snapshot, which is safe because the dialog is modal.
+     */
+    private fun onSubmitConfirmed() {
+        _state.update { it.copy(showSubmitConfirmation = false) }
+        onSubmitClicked(bypassConfirmation = true)
+    }
+
     @Suppress("ReturnCount") // guard clauses are the natural shape of the dispatcher
-    private fun onSubmitClicked() {
+    private fun onSubmitClicked(bypassConfirmation: Boolean = false) {
         val snapshot = _state.value
         if (!snapshot.canSubmit) return
         val form = loadedForm ?: run {
@@ -470,6 +501,13 @@ class PostEditorViewModel @AssistedInject constructor(
             return
         }
         if (submitJob?.isActive == true) return
+        // #312 — AFTER every validation gate (we never confirm an unsendable form), BEFORE the
+        // real POST: when the preference is on, park the submit behind the confirmation dialog.
+        // [onSubmitConfirmed] re-enters with `bypassConfirmation = true`.
+        if (!bypassConfirmation && confirmBeforePosting) {
+            _state.update { it.copy(showSubmitConfirmation = true) }
+            return
+        }
 
         val options = ReplyFormOptions(
             signatureEnabled = snapshot.signatureEnabled,

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormScreen.kt
@@ -43,6 +43,7 @@ import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
 import fr.forumhfr.redface2.core.ui.editor.BbcodePreview
 import fr.forumhfr.redface2.core.ui.editor.BbcodeTextField
 import fr.forumhfr.redface2.core.ui.editor.BbcodeToolbar
+import fr.forumhfr.redface2.core.ui.editor.ConfirmSubmitDialog
 
 /**
  * Topic-level form screen. Live for [TopicFormMode.EditFirstPost] (Phase 2D
@@ -246,6 +247,14 @@ internal fun TopicFormContent(
         ImageUrlDialog(
             onDismiss = { imageUrlDialogOpen = false },
             onInsert = { url -> onIntent(TopicFormIntent.ImageUrlInserted(url)) },
+        )
+    }
+    // #312 — « Confirmation avant publication ». Visibility is owned by the ViewModel, which only
+    // raises the flag once the submit passed the canSubmit gate and the preference is on.
+    if (state.showSubmitConfirmation) {
+        ConfirmSubmitDialog(
+            onConfirm = { onIntent(TopicFormIntent.SubmitConfirmed) },
+            onDismiss = { onIntent(TopicFormIntent.SubmitConfirmationDismissed) },
         )
     }
 }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormState.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormState.kt
@@ -80,6 +80,12 @@ data class TopicFormState(
      * fields : a silent `InvalidHashCheck` refetch must never erase a previously known id.
      */
     val userId: Int? = null,
+    /**
+     * #312 — `true` while the « Confirmation avant publication » dialog is shown. Mirrors
+     * [PostEditorState.showSubmitConfirmation]: only raised when the preference is on AND
+     * [canSubmit] already validated the form (we never confirm an unsendable form).
+     */
+    val showSubmitConfirmation: Boolean = false,
 ) {
     /**
      * Submit is allowed when the mode-specific routing context is complete,
@@ -145,6 +151,16 @@ sealed interface TopicFormIntent {
     data class ToolbarActionClicked(val action: BbcodeAction) : TopicFormIntent
     data object TogglePreview : TopicFormIntent
     data object SubmitClicked : TopicFormIntent
+
+    /**
+     * #312 — user confirmed the « Confirmation avant publication » dialog. Executes the real
+     * submission directly, BYPASSING the preference re-check (otherwise the dialog would loop).
+     */
+    data object SubmitConfirmed : TopicFormIntent
+
+    /** #312 — user dismissed the confirmation dialog. No submission happens; the draft stays. */
+    data object SubmitConfirmationDismissed : TopicFormIntent
+
     data object ErrorDismissed : TopicFormIntent
     data class SubcatSelected(val id: Int) : TopicFormIntent
     data class ToggleSignature(val enabled: Boolean) : TopicFormIntent

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModel.kt
@@ -11,6 +11,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
 import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.smiley.SmileyRepository
 import fr.forumhfr.redface2.core.domain.write.TopicFormRepository
 import fr.forumhfr.redface2.core.model.PostContent
@@ -59,6 +60,7 @@ class TopicFormViewModel @AssistedInject constructor(
     private val previewParser: BbcodePreviewParser,
     private val topicFormRepository: TopicFormRepository,
     private val smileyRepository: SmileyRepository,
+    private val userPreferencesRepository: UserPreferencesRepository,
     private val diagnostics: DiagnosticsLog,
 ) : ViewModel() {
 
@@ -90,14 +92,26 @@ class TopicFormViewModel @AssistedInject constructor(
     /** In-flight wiki smiley search ; cancelled on next query change / picker close / selection. */
     private var smileySearchJob: Job? = null
 
+    /**
+     * #312 — mirror of the persisted « Confirmation avant publication » preference. Collected on
+     * init (same DataStore-consumption shape as `TopicViewModel.observeTopicTopBarAutoHide`) and
+     * read synchronously at submit time, identical to `PostEditorViewModel`.
+     */
+    private var confirmBeforePosting: Boolean = false
+
     init {
+        viewModelScope.launch {
+            userPreferencesRepository.observeConfirmBeforePosting().collect { enabled ->
+                confirmBeforePosting = enabled
+            }
+        }
         when (request.mode) {
             TopicFormMode.EditFirstPost -> loadEditFirstPostFormIfPossible()
             TopicFormMode.New -> loadNewTopicFormIfPossible()
         }
     }
 
-    @Suppress("CyclomaticComplexMethod") // MVI when-dispatch over 14 intent variants ; flat by design.
+    @Suppress("CyclomaticComplexMethod") // MVI when-dispatch over 16 intent variants ; flat by design.
     fun submit(intent: TopicFormIntent) {
         when (intent) {
             is TopicFormIntent.SubjectChanged -> onSubjectChanged(intent.value)
@@ -105,6 +119,9 @@ class TopicFormViewModel @AssistedInject constructor(
             is TopicFormIntent.ToolbarActionClicked -> onToolbarActionClicked(intent.action)
             TopicFormIntent.TogglePreview -> onTogglePreview()
             TopicFormIntent.SubmitClicked -> onSubmitClicked()
+            TopicFormIntent.SubmitConfirmed -> onSubmitConfirmed()
+            TopicFormIntent.SubmitConfirmationDismissed ->
+                _state.update { it.copy(showSubmitConfirmation = false) }
             TopicFormIntent.ErrorDismissed -> _state.update { it.copy(submitError = null) }
             is TopicFormIntent.SubcatSelected ->
                 _state.update { it.copy(selectedSubcat = intent.id) }
@@ -349,7 +366,27 @@ class TopicFormViewModel @AssistedInject constructor(
         _state.update { it.copy(isLoadingForm = false, submitError = mapped) }
     }
 
-    private fun onSubmitClicked() {
+    /**
+     * #312 — confirm path. Closes the dialog and re-runs the submit dispatch with
+     * `bypassConfirmation = true` so the real submission executes directly (re-checking the
+     * preference here would loop « confirmation → confirmation » forever). The mode-specific
+     * guards run again on the latest snapshot, which is safe because the dialog is modal.
+     */
+    private fun onSubmitConfirmed() {
+        _state.update { it.copy(showSubmitConfirmation = false) }
+        onSubmitClicked(bypassConfirmation = true)
+    }
+
+    private fun onSubmitClicked(bypassConfirmation: Boolean = false) {
+        // #312 — single interception point covering BOTH submit paths (New + EditFirstPost).
+        // The `canSubmit` gate runs first so we never confirm an invalid form; the deeper
+        // per-mode guards (form not loaded, anonymous, in-flight job) are re-checked after the
+        // confirmation by the dispatched handler, exactly as on the direct path.
+        if (!_state.value.canSubmit) return
+        if (!bypassConfirmation && confirmBeforePosting) {
+            _state.update { it.copy(showSubmitConfirmation = true) }
+            return
+        }
         when (_state.value.mode) {
             TopicFormMode.EditFirstPost -> onSubmitEditFirstPostClicked()
             TopicFormMode.New -> onSubmitNewTopicClicked()

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModel.kt
@@ -377,12 +377,17 @@ class TopicFormViewModel @AssistedInject constructor(
         onSubmitClicked(bypassConfirmation = true)
     }
 
+    @Suppress("ReturnCount") // Guard clauses
     private fun onSubmitClicked(bypassConfirmation: Boolean = false) {
         // #312 — single interception point covering BOTH submit paths (New + EditFirstPost).
         // The `canSubmit` gate runs first so we never confirm an invalid form; the deeper
         // per-mode guards (form not loaded, anonymous, in-flight job) are re-checked after the
         // confirmation by the dispatched handler, exactly as on the direct path.
         if (!_state.value.canSubmit) return
+        // Same guard order as PostEditorViewModel / PrivateMessageReplyViewModel: never show
+        // the confirmation dialog over an in-flight submit. Redundant with canSubmit's
+        // !isSubmitting today, but keeps the three VMs symmetric if canSubmit is relaxed.
+        if (submitJob?.isActive == true) return
         if (!bypassConfirmation && confirmBeforePosting) {
             _state.update { it.copy(showSubmitConfirmation = true) }
             return

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -6,7 +6,12 @@ import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
 import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
 import fr.forumhfr.redface2.core.domain.editor.BbcodeValidation
+import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
+import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
+import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.write.ReplyRepository
+import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.PostBlock
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.PostInline
@@ -20,6 +25,8 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -664,6 +671,7 @@ class PostEditorViewModelTest {
         quotedNumreponse: Int? = null,
         quoteRef: Int? = null,
         diagnostics: DiagnosticsLog = DiagnosticsLog(),
+        userPreferencesRepository: UserPreferencesRepository = FakeUserPreferencesRepository(),
     ): PostEditorViewModel =
         PostEditorViewModel(
             request = PostEditorRequest(
@@ -680,6 +688,7 @@ class PostEditorViewModelTest {
             replyRepository = replyRepository,
             editPostRepository = editPostRepository,
             smileyRepository = smileyRepository,
+            userPreferencesRepository = userPreferencesRepository,
             diagnostics = diagnostics,
         )
 
@@ -882,6 +891,7 @@ class PostEditorViewModelTest {
         subcat: Int? = SAMPLE_SUBCAT,
         numreponse: Int? = SAMPLE_EDITED_NUMREPONSE,
         diagnostics: DiagnosticsLog = DiagnosticsLog(),
+        userPreferencesRepository: UserPreferencesRepository = FakeUserPreferencesRepository(),
     ): PostEditorViewModel =
         PostEditorViewModel(
             request = PostEditorRequest(
@@ -896,8 +906,127 @@ class PostEditorViewModelTest {
             replyRepository = replyRepository,
             editPostRepository = editPostRepository,
             smileyRepository = smileyRepository,
+            userPreferencesRepository = userPreferencesRepository,
             diagnostics = diagnostics,
         )
+
+    // ----- #312 : confirmation avant publication ------------------------------
+
+    @Test
+    fun `confirm-before-posting OFF keeps the one-tap reply submit unchanged`() = runTest {
+        replyRepository.formResult = Result.success(authenticatedForm())
+        replyRepository.submitResult = ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
+        val viewModel = newReplyViewModel() // default fake → preference OFF
+        testScheduler.advanceUntilIdle()
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("Hello!", TextRange(6))))
+
+        viewModel.submit(PostEditorIntent.SubmitClicked)
+
+        assertEquals("OFF must POST directly, no dialog detour", 1, replyRepository.submitCalls)
+        assertFalse(viewModel.state.value.showSubmitConfirmation)
+    }
+
+    @Test
+    fun `confirm-before-posting ON parks the reply submit behind the confirmation dialog`() = runTest {
+        replyRepository.formResult = Result.success(authenticatedForm())
+        replyRepository.submitResult = ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
+        val viewModel = newReplyViewModel(
+            userPreferencesRepository = FakeUserPreferencesRepository(confirmBeforePosting = true),
+        )
+        testScheduler.advanceUntilIdle()
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("Hello!", TextRange(6))))
+
+        viewModel.submit(PostEditorIntent.SubmitClicked)
+
+        assertTrue("the confirmation dialog must be armed", viewModel.state.value.showSubmitConfirmation)
+        assertEquals("no POST before the user confirms", 0, replyRepository.submitCalls)
+        assertFalse("nothing is in flight while the dialog is up", viewModel.state.value.isSubmitting)
+    }
+
+    @Test
+    fun `confirm-before-posting ON SubmitConfirmed executes the real submission without re-confirming`() = runTest {
+        replyRepository.formResult = Result.success(authenticatedForm())
+        replyRepository.submitResult = ReplySubmitResult.Success(
+            refreshUrl = "/hfr/.../sujet_X_20.htm#bas",
+            targetPage = 20,
+        )
+        val viewModel = newReplyViewModel(
+            userPreferencesRepository = FakeUserPreferencesRepository(confirmBeforePosting = true),
+        )
+        testScheduler.advanceUntilIdle()
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("Hello!", TextRange(6))))
+        viewModel.submit(PostEditorIntent.SubmitClicked)
+        assertEquals(0, replyRepository.submitCalls)
+
+        viewModel.effects.test {
+            viewModel.submit(PostEditorIntent.SubmitConfirmed)
+            val effect = awaitItem()
+            assertEquals(PostEditorEffect.SubmitSucceeded(targetPage = 20), effect)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals("confirm must bypass the preference and POST exactly once", 1, replyRepository.submitCalls)
+        assertFalse(
+            "the dialog must close on confirm — no « confirmation → confirmation » loop",
+            viewModel.state.value.showSubmitConfirmation,
+        )
+    }
+
+    @Test
+    fun `confirm-before-posting ON dismissing the dialog sends nothing and keeps the draft`() = runTest {
+        replyRepository.formResult = Result.success(authenticatedForm())
+        val viewModel = newReplyViewModel(
+            userPreferencesRepository = FakeUserPreferencesRepository(confirmBeforePosting = true),
+        )
+        testScheduler.advanceUntilIdle()
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("Hello!", TextRange(6))))
+        viewModel.submit(PostEditorIntent.SubmitClicked)
+
+        viewModel.submit(PostEditorIntent.SubmitConfirmationDismissed)
+
+        assertFalse(viewModel.state.value.showSubmitConfirmation)
+        assertEquals("dismiss must not POST anything", 0, replyRepository.submitCalls)
+        assertEquals("the draft survives the dismissal", "Hello!", viewModel.state.value.draft.text)
+        assertNull(viewModel.state.value.submitError)
+    }
+
+    @Test
+    fun `confirm-before-posting ON never confirms an invalid form`() = runTest {
+        // The confirmation slots in AFTER validation : a blank draft fails `canSubmit`, so no
+        // dialog may appear (confirming an unsendable form would be a lie).
+        replyRepository.formResult = Result.success(authenticatedForm())
+        val viewModel = newReplyViewModel(
+            userPreferencesRepository = FakeUserPreferencesRepository(confirmBeforePosting = true),
+        )
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(PostEditorIntent.SubmitClicked)
+
+        assertFalse("invalid form must not raise the dialog", viewModel.state.value.showSubmitConfirmation)
+        assertEquals(0, replyRepository.submitCalls)
+    }
+
+    @Test
+    fun `confirm-before-posting ON also guards the Edit submit`() = runTest {
+        editPostRepository.submitResult = ReplySubmitResult.Success(
+            refreshUrl = "/hfr/foo/bar-sujet_35395_20.htm#t100",
+            targetPage = 20,
+        )
+        val viewModel = newEditViewModel(
+            userPreferencesRepository = FakeUserPreferencesRepository(confirmBeforePosting = true),
+        )
+        testScheduler.advanceUntilIdle()
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("rewritten body")))
+
+        viewModel.submit(PostEditorIntent.SubmitClicked)
+        assertTrue(viewModel.state.value.showSubmitConfirmation)
+        assertEquals("no edit POST before the user confirms", 0, editPostRepository.submitCalls)
+
+        viewModel.submit(PostEditorIntent.SubmitConfirmed)
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(1, editPostRepository.submitCalls)
+        assertFalse(viewModel.state.value.showSubmitConfirmation)
+    }
 
     private fun authenticatedForm(initialContent: String = ""): ReplyForm = ReplyForm(
         hashCheck = "FAKE_HASH",
@@ -1080,6 +1209,44 @@ class PostEditorViewModelTest {
         fun failNext(error: Throwable) {
             requireNotNull(pending) { "no pending searchWiki to fail" }.completeExceptionally(error)
             pending = null
+        }
+    }
+
+    /**
+     * #312 — fake preferences repository. Only `observeConfirmBeforePosting` matters to the
+     * editor; every other member is stubbed at its default (same shape as the
+     * `FakeUserPreferencesRepository` in `TopicViewModelTest`).
+     */
+    private class FakeUserPreferencesRepository(
+        confirmBeforePosting: Boolean = false,
+    ) : UserPreferencesRepository {
+        private val confirmBeforePosting = MutableStateFlow(confirmBeforePosting)
+
+        override fun observeProxyConfig(): Flow<ProxyConfig> = MutableStateFlow(ProxyConfig())
+        override suspend fun saveProxyConfig(config: ProxyConfig) = Unit
+        override fun readProxyConfigForNetworkBootstrap(): ProxyConfig = ProxyConfig()
+        override fun observeIgnoreTopicCache(): Flow<Boolean> = MutableStateFlow(false)
+        override suspend fun setIgnoreTopicCache(enabled: Boolean) = Unit
+        override fun observeFlagsGroupByCategory(): Flow<Boolean> = MutableStateFlow(true)
+        override suspend fun setFlagsGroupByCategory(enabled: Boolean) = Unit
+        override fun observeFlagsHideReadCategories(): Flow<Boolean> = MutableStateFlow(false)
+        override suspend fun setFlagsHideReadCategories(enabled: Boolean) = Unit
+        override fun observeFlagsPerTabOverride(): Flow<Boolean> = MutableStateFlow(false)
+        override suspend fun setFlagsPerTabOverride(enabled: Boolean) = Unit
+        override fun observeFlagsViewSettings(type: FlagType): Flow<FlagsViewSettings> =
+            MutableStateFlow(FlagsViewSettings())
+        override suspend fun setFlagsGroupByCategoryForType(type: FlagType, enabled: Boolean) = Unit
+        override suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean) = Unit
+        override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) = Unit
+        override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
+        override suspend fun setThemeMode(mode: ThemeMode) = Unit
+        override fun observeAmoledEnabled(): Flow<Boolean> = MutableStateFlow(false)
+        override suspend fun setAmoledEnabled(enabled: Boolean) = Unit
+        override fun observeTopicTopBarAutoHide(): Flow<Boolean> = MutableStateFlow(false)
+        override suspend fun setTopicTopBarAutoHide(enabled: Boolean) = Unit
+        override fun observeConfirmBeforePosting(): Flow<Boolean> = confirmBeforePosting
+        override suspend fun setConfirmBeforePosting(enabled: Boolean) {
+            confirmBeforePosting.value = enabled
         }
     }
 

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -1028,6 +1028,53 @@ class PostEditorViewModelTest {
         assertFalse(viewModel.state.value.showSubmitConfirmation)
     }
 
+    @Test
+    fun `confirm-before-posting ON re-clicking submit keeps the dialog armed without posting`() = runTest {
+        replyRepository.formResult = Result.success(authenticatedForm())
+        val viewModel = newReplyViewModel(
+            userPreferencesRepository = FakeUserPreferencesRepository(confirmBeforePosting = true),
+        )
+        testScheduler.advanceUntilIdle()
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("Hello!", TextRange(6))))
+        viewModel.submit(PostEditorIntent.SubmitClicked)
+        assertTrue("the confirmation dialog must be armed", viewModel.state.value.showSubmitConfirmation)
+
+        // Second tap while the dialog is up (double-tap race) : idempotent — re-raising
+        // `showSubmitConfirmation = true` is a no-op, and no POST may slip through.
+        viewModel.submit(PostEditorIntent.SubmitClicked)
+
+        assertTrue("the dialog must stay armed", viewModel.state.value.showSubmitConfirmation)
+        assertFalse("nothing is in flight while the dialog is up", viewModel.state.value.isSubmitting)
+        assertEquals("no POST while the dialog is parked", 0, replyRepository.submitCalls)
+    }
+
+    @Test
+    fun `confirm-before-posting ON rapid double confirm posts exactly once`() = runTest {
+        replyRepository.formResult = Result.success(authenticatedForm())
+        // Hold the first confirmed submit in flight : with UnconfinedTestDispatcher a
+        // non-suspending fake would complete synchronously and the second confirm would
+        // legitimately re-fire. Same shape as `double submit only triggers one POST`.
+        val gate = CompletableDeferred<Unit>()
+        replyRepository.submitGate = gate
+        replyRepository.submitResult = ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
+        val viewModel = newReplyViewModel(
+            userPreferencesRepository = FakeUserPreferencesRepository(confirmBeforePosting = true),
+        )
+        testScheduler.advanceUntilIdle()
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("Hello!", TextRange(6))))
+        viewModel.submit(PostEditorIntent.SubmitClicked)
+        assertTrue("the confirmation dialog must be armed", viewModel.state.value.showSubmitConfirmation)
+
+        viewModel.submit(PostEditorIntent.SubmitConfirmed) // launches the POST ; suspends on gate
+        viewModel.submit(PostEditorIntent.SubmitConfirmed) // must be a no-op (canSubmit / submitJob guards)
+
+        gate.complete(Unit)
+
+        assertEquals("rapid double confirm must POST exactly once", 1, replyRepository.submitCalls)
+        assertFalse(viewModel.state.value.showSubmitConfirmation)
+        assertFalse(viewModel.state.value.isSubmitting)
+    }
+
     private fun authenticatedForm(initialContent: String = ""): ReplyForm = ReplyForm(
         hashCheck = "FAKE_HASH",
         sujet = "Fake Topic",

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -910,6 +910,71 @@ class TopicFormViewModelTest {
         assertEquals(0, topicFormRepository.newTopicSubmitCalls)
     }
 
+    @Test
+    fun `confirm-before-posting ON re-clicking submit keeps the New dialog armed without posting`() = runTest {
+        val viewModel = newTopicViewModel(
+            entrySubcat = SAMPLE_SUBCAT,
+            userPreferencesRepository = FakeUserPreferencesRepository(confirmBeforePosting = true),
+        )
+        viewModel.state.test {
+            expectMostRecentItem() // drain hydration
+            viewModel.submit(TopicFormIntent.SubjectChanged(TextFieldValue("Topic")))
+            viewModel.submit(TopicFormIntent.ContentChanged(TextFieldValue("Body", TextRange(4))))
+            viewModel.submit(TopicFormIntent.SubmitClicked)
+            val parked = expectMostRecentItem()
+            assertTrue("the confirmation dialog must be armed", parked.showSubmitConfirmation)
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        // Second tap while the dialog is up (double-tap race) : idempotent — re-raising
+        // `showSubmitConfirmation = true` is a no-op, and no POST may slip through.
+        viewModel.submit(TopicFormIntent.SubmitClicked)
+
+        assertTrue("the dialog must stay armed", viewModel.state.value.showSubmitConfirmation)
+        assertFalse("nothing is in flight while the dialog is up", viewModel.state.value.isSubmitting)
+        assertEquals("no POST while the dialog is parked", 0, topicFormRepository.newTopicSubmitCalls)
+    }
+
+    @Test
+    fun `confirm-before-posting ON rapid double confirm posts the New topic exactly once`() = runTest {
+        // Hold the first confirmed submit in flight : with UnconfinedTestDispatcher a
+        // non-suspending fake would complete synchronously and the second confirm would
+        // legitimately re-fire. Same shape as the `submitGate` double-submit test in
+        // `PostEditorViewModelTest`. EditFirstPost shares the same guards hoisted into
+        // `onSubmitClicked`, so New-mode coverage protects both submit paths.
+        val gate = CompletableDeferred<Unit>()
+        topicFormRepository.submitGate = gate
+        topicFormRepository.newTopicSubmitResult = NewTopicSubmitResult.Success(
+            newTopicId = null,
+            newNumreponse = null,
+            targetCat = SAMPLE_CAT,
+            targetSubcat = SAMPLE_SUBCAT,
+            refreshUrl = null,
+        )
+        val viewModel = newTopicViewModel(
+            entrySubcat = SAMPLE_SUBCAT,
+            userPreferencesRepository = FakeUserPreferencesRepository(confirmBeforePosting = true),
+        )
+        viewModel.state.test {
+            expectMostRecentItem() // drain hydration
+            viewModel.submit(TopicFormIntent.SubjectChanged(TextFieldValue("Topic")))
+            viewModel.submit(TopicFormIntent.ContentChanged(TextFieldValue("Body", TextRange(4))))
+            viewModel.submit(TopicFormIntent.SubmitClicked)
+            val parked = expectMostRecentItem()
+            assertTrue("the confirmation dialog must be armed", parked.showSubmitConfirmation)
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        viewModel.submit(TopicFormIntent.SubmitConfirmed) // launches the POST ; suspends on gate
+        viewModel.submit(TopicFormIntent.SubmitConfirmed) // must be a no-op (canSubmit / submitJob guards)
+
+        gate.complete(Unit)
+
+        assertEquals("rapid double confirm must POST exactly once", 1, topicFormRepository.newTopicSubmitCalls)
+        assertFalse(viewModel.state.value.showSubmitConfirmation)
+        assertFalse(viewModel.state.value.isSubmitting)
+    }
+
     private fun newTopicViewModel(
         entrySubcat: Int?,
         cat: Int = SAMPLE_CAT,
@@ -1027,6 +1092,9 @@ class TopicFormViewModelTest {
         )
 
         var formGate: CompletableDeferred<Unit>? = null
+        // #312 — holds an in-flight submit (both Edit FP and New) until the test releases it,
+        // mirroring `FakeReplyRepository.submitGate` in `PostEditorViewModelTest`.
+        var submitGate: CompletableDeferred<Unit>? = null
 
         var formFetches: Int = 0
             private set
@@ -1072,6 +1140,7 @@ class TopicFormViewModelTest {
             lastSubmittedBbcode = bbcodeContent
             lastSubmittedSubcat = selectedSubcat
             lastSubmittedOptions = options
+            submitGate?.await()
             return submitResult ?: error("submitResult not set")
         }
 
@@ -1096,6 +1165,7 @@ class TopicFormViewModelTest {
             lastSubmittedBbcode = bbcodeContent
             lastSubmittedSubcat = selectedSubcat
             lastSubmittedOptions = options
+            submitGate?.await()
             return newTopicSubmitResult ?: error("newTopicSubmitResult not set")
         }
     }

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -5,10 +5,15 @@ import androidx.compose.ui.text.input.TextFieldValue
 import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
 import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
+import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
+import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
+import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.smiley.SmileyRepository
 import fr.forumhfr.redface2.core.domain.write.TopicFormRepository
 import fr.forumhfr.redface2.core.model.EditorSmiley
 import fr.forumhfr.redface2.core.model.EditorSmileySource
+import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.PostBlock
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.PostInline
@@ -24,6 +29,8 @@ import fr.forumhfr.redface2.core.model.write.TopicPollForm
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -752,10 +759,162 @@ class TopicFormViewModelTest {
         assertEquals("image: ", viewModel.state.value.draft.text)
     }
 
+    // ----- #312 : confirmation avant publication ------------------------------
+
+    @Test
+    fun `confirm-before-posting OFF keeps the one-tap EditFirstPost submit unchanged`() = runTest {
+        topicFormRepository.submitResult = ReplySubmitResult.Success(targetPage = 1, refreshUrl = "/hfr/")
+        val viewModel = newViewModel() // default fake → preference OFF
+        viewModel.state.test {
+            awaitHydratedState()
+            viewModel.submit(TopicFormIntent.SubmitClicked)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals("OFF must POST directly, no dialog detour", 1, topicFormRepository.submitCalls)
+        assertFalse(viewModel.state.value.showSubmitConfirmation)
+    }
+
+    @Test
+    fun `confirm-before-posting ON parks the EditFirstPost submit behind the confirmation dialog`() = runTest {
+        topicFormRepository.submitResult = ReplySubmitResult.Success(targetPage = 1, refreshUrl = "/hfr/")
+        val viewModel = newViewModel(
+            userPreferencesRepository = FakeUserPreferencesRepository(confirmBeforePosting = true),
+        )
+        viewModel.state.test {
+            awaitHydratedState()
+            viewModel.submit(TopicFormIntent.SubmitClicked)
+            val parked = expectMostRecentItem()
+            assertTrue("the confirmation dialog must be armed", parked.showSubmitConfirmation)
+            assertFalse("nothing is in flight while the dialog is up", parked.isSubmitting)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals("no POST before the user confirms", 0, topicFormRepository.submitCalls)
+    }
+
+    @Test
+    fun `confirm-before-posting ON EditFirstPost confirm executes the real submission once`() = runTest {
+        topicFormRepository.submitResult = ReplySubmitResult.Success(targetPage = 1, refreshUrl = "/hfr/")
+        val viewModel = newViewModel(
+            userPreferencesRepository = FakeUserPreferencesRepository(confirmBeforePosting = true),
+        )
+        viewModel.state.test {
+            awaitHydratedState()
+            cancelAndIgnoreRemainingEvents()
+        }
+        viewModel.submit(TopicFormIntent.SubmitClicked)
+        assertEquals(0, topicFormRepository.submitCalls)
+
+        viewModel.effects.test {
+            viewModel.submit(TopicFormIntent.SubmitConfirmed)
+            val effect = awaitItem() as TopicFormEffect.SubmitSucceeded
+            assertEquals(1, effect.targetPage)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals("confirm must bypass the preference and POST exactly once", 1, topicFormRepository.submitCalls)
+        assertFalse(
+            "the dialog must close on confirm — no « confirmation → confirmation » loop",
+            viewModel.state.value.showSubmitConfirmation,
+        )
+    }
+
+    @Test
+    fun `confirm-before-posting OFF keeps the one-tap New submit unchanged`() = runTest {
+        topicFormRepository.newTopicSubmitResult = NewTopicSubmitResult.Success(
+            newTopicId = null,
+            newNumreponse = null,
+            targetCat = SAMPLE_CAT,
+            targetSubcat = SAMPLE_SUBCAT,
+            refreshUrl = null,
+        )
+        val viewModel = newTopicViewModel(entrySubcat = SAMPLE_SUBCAT) // default fake → OFF
+        viewModel.state.test {
+            expectMostRecentItem() // drain hydration
+            viewModel.submit(TopicFormIntent.SubjectChanged(TextFieldValue("Topic")))
+            viewModel.submit(TopicFormIntent.ContentChanged(TextFieldValue("Body", TextRange(4))))
+            viewModel.submit(TopicFormIntent.SubmitClicked)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals("OFF must POST directly, no dialog detour", 1, topicFormRepository.newTopicSubmitCalls)
+        assertFalse(viewModel.state.value.showSubmitConfirmation)
+    }
+
+    @Test
+    fun `confirm-before-posting ON parks the New submit then confirm posts it`() = runTest {
+        topicFormRepository.newTopicSubmitResult = NewTopicSubmitResult.Success(
+            newTopicId = null,
+            newNumreponse = null,
+            targetCat = SAMPLE_CAT,
+            targetSubcat = SAMPLE_SUBCAT,
+            refreshUrl = null,
+        )
+        val viewModel = newTopicViewModel(
+            entrySubcat = SAMPLE_SUBCAT,
+            userPreferencesRepository = FakeUserPreferencesRepository(confirmBeforePosting = true),
+        )
+        viewModel.state.test {
+            expectMostRecentItem() // drain hydration
+            viewModel.submit(TopicFormIntent.SubjectChanged(TextFieldValue("Topic")))
+            viewModel.submit(TopicFormIntent.ContentChanged(TextFieldValue("Body", TextRange(4))))
+            viewModel.submit(TopicFormIntent.SubmitClicked)
+            val parked = expectMostRecentItem()
+            assertTrue("the confirmation dialog must be armed", parked.showSubmitConfirmation)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals("no POST before the user confirms", 0, topicFormRepository.newTopicSubmitCalls)
+
+        viewModel.submit(TopicFormIntent.SubmitConfirmed)
+
+        assertEquals(1, topicFormRepository.newTopicSubmitCalls)
+        assertFalse(viewModel.state.value.showSubmitConfirmation)
+    }
+
+    @Test
+    fun `confirm-before-posting ON dismissing the dialog sends nothing and keeps subject and draft`() = runTest {
+        val viewModel = newTopicViewModel(
+            entrySubcat = SAMPLE_SUBCAT,
+            userPreferencesRepository = FakeUserPreferencesRepository(confirmBeforePosting = true),
+        )
+        viewModel.state.test {
+            expectMostRecentItem() // drain hydration
+            viewModel.submit(TopicFormIntent.SubjectChanged(TextFieldValue("Topic")))
+            viewModel.submit(TopicFormIntent.ContentChanged(TextFieldValue("Body", TextRange(4))))
+            viewModel.submit(TopicFormIntent.SubmitClicked)
+            viewModel.submit(TopicFormIntent.SubmitConfirmationDismissed)
+            val finalState = expectMostRecentItem()
+            assertFalse(finalState.showSubmitConfirmation)
+            assertEquals("the subject survives the dismissal", "Topic", finalState.subject.text)
+            assertEquals("the draft survives the dismissal", "Body", finalState.draft.text)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals("dismiss must not POST anything", 0, topicFormRepository.newTopicSubmitCalls)
+        assertEquals(0, topicFormRepository.submitCalls)
+    }
+
+    @Test
+    fun `confirm-before-posting ON never confirms an invalid New form`() = runTest {
+        // The confirmation slots in AFTER the canSubmit gate : with no sub-category picked (cat
+        // WITH sub-categories, no entry chip), the form is invalid so no dialog may appear.
+        val viewModel = newTopicViewModel(
+            entrySubcat = null,
+            userPreferencesRepository = FakeUserPreferencesRepository(confirmBeforePosting = true),
+        )
+        viewModel.state.test {
+            expectMostRecentItem() // drain hydration
+            viewModel.submit(TopicFormIntent.SubjectChanged(TextFieldValue("Topic")))
+            viewModel.submit(TopicFormIntent.ContentChanged(TextFieldValue("Body", TextRange(4))))
+            viewModel.submit(TopicFormIntent.SubmitClicked)
+            val finalState = expectMostRecentItem()
+            assertFalse("invalid form must not raise the dialog", finalState.showSubmitConfirmation)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(0, topicFormRepository.newTopicSubmitCalls)
+    }
+
     private fun newTopicViewModel(
         entrySubcat: Int?,
         cat: Int = SAMPLE_CAT,
         diagnostics: DiagnosticsLog = DiagnosticsLog(),
+        userPreferencesRepository: UserPreferencesRepository = FakeUserPreferencesRepository(),
     ): TopicFormViewModel = TopicFormViewModel(
         request = TopicFormRequest(
             mode = TopicFormMode.New,
@@ -768,6 +927,7 @@ class TopicFormViewModelTest {
         previewParser = previewParser,
         topicFormRepository = topicFormRepository,
         smileyRepository = smileyRepository,
+        userPreferencesRepository = userPreferencesRepository,
         diagnostics = diagnostics,
     )
 
@@ -784,6 +944,7 @@ class TopicFormViewModelTest {
 
     private fun newViewModel(
         diagnostics: DiagnosticsLog = DiagnosticsLog(),
+        userPreferencesRepository: UserPreferencesRepository = FakeUserPreferencesRepository(),
     ): TopicFormViewModel = TopicFormViewModel(
         request = TopicFormRequest(
             mode = TopicFormMode.EditFirstPost,
@@ -796,6 +957,7 @@ class TopicFormViewModelTest {
         previewParser = previewParser,
         topicFormRepository = topicFormRepository,
         smileyRepository = smileyRepository,
+        userPreferencesRepository = userPreferencesRepository,
         diagnostics = diagnostics,
     )
 
@@ -976,6 +1138,44 @@ class TopicFormViewModelTest {
         fun failNext(error: Throwable) {
             requireNotNull(pending) { "no pending searchWiki to fail" }.completeExceptionally(error)
             pending = null
+        }
+    }
+
+    /**
+     * #312 — fake preferences repository. Only `observeConfirmBeforePosting` matters to the
+     * topic form; every other member is stubbed at its default (same shape as the
+     * `FakeUserPreferencesRepository` in `PostEditorViewModelTest` / `TopicViewModelTest`).
+     */
+    private class FakeUserPreferencesRepository(
+        confirmBeforePosting: Boolean = false,
+    ) : UserPreferencesRepository {
+        private val confirmBeforePosting = MutableStateFlow(confirmBeforePosting)
+
+        override fun observeProxyConfig(): Flow<ProxyConfig> = MutableStateFlow(ProxyConfig())
+        override suspend fun saveProxyConfig(config: ProxyConfig) = Unit
+        override fun readProxyConfigForNetworkBootstrap(): ProxyConfig = ProxyConfig()
+        override fun observeIgnoreTopicCache(): Flow<Boolean> = MutableStateFlow(false)
+        override suspend fun setIgnoreTopicCache(enabled: Boolean) = Unit
+        override fun observeFlagsGroupByCategory(): Flow<Boolean> = MutableStateFlow(true)
+        override suspend fun setFlagsGroupByCategory(enabled: Boolean) = Unit
+        override fun observeFlagsHideReadCategories(): Flow<Boolean> = MutableStateFlow(false)
+        override suspend fun setFlagsHideReadCategories(enabled: Boolean) = Unit
+        override fun observeFlagsPerTabOverride(): Flow<Boolean> = MutableStateFlow(false)
+        override suspend fun setFlagsPerTabOverride(enabled: Boolean) = Unit
+        override fun observeFlagsViewSettings(type: FlagType): Flow<FlagsViewSettings> =
+            MutableStateFlow(FlagsViewSettings())
+        override suspend fun setFlagsGroupByCategoryForType(type: FlagType, enabled: Boolean) = Unit
+        override suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean) = Unit
+        override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) = Unit
+        override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
+        override suspend fun setThemeMode(mode: ThemeMode) = Unit
+        override fun observeAmoledEnabled(): Flow<Boolean> = MutableStateFlow(false)
+        override suspend fun setAmoledEnabled(enabled: Boolean) = Unit
+        override fun observeTopicTopBarAutoHide(): Flow<Boolean> = MutableStateFlow(false)
+        override suspend fun setTopicTopBarAutoHide(enabled: Boolean) = Unit
+        override fun observeConfirmBeforePosting(): Flow<Boolean> = confirmBeforePosting
+        override suspend fun setConfirmBeforePosting(enabled: Boolean) {
+            confirmBeforePosting.value = enabled
         }
     }
 

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1391,6 +1391,11 @@ class FlagsViewModelTest {
 
         override suspend fun setTopicTopBarAutoHide(enabled: Boolean) = Unit
 
+        // #312 — confirm-before-posting is irrelevant to FlagsViewModel; stubbed at its default.
+        override fun observeConfirmBeforePosting(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setConfirmBeforePosting(enabled: Boolean) = Unit
+
         fun setGroupBy(value: Boolean) {
             groupBy.value = value
         }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
@@ -47,6 +47,7 @@ import fr.forumhfr.redface2.core.ui.editor.BbcodeAction
 import fr.forumhfr.redface2.core.ui.editor.BbcodePreview
 import fr.forumhfr.redface2.core.ui.editor.BbcodeTextField
 import fr.forumhfr.redface2.core.ui.editor.BbcodeToolbar
+import fr.forumhfr.redface2.core.ui.editor.ConfirmSubmitDialog
 
 /**
  * Reply editor for a private-message conversation (#301). Reuses the shared `:core:ui` BBCode
@@ -88,6 +89,14 @@ fun PrivateMessageReplyScreen(
         onRetryFormLoad = viewModel::retryFormLoad,
         modifier = modifier,
     )
+    // #312 — « Confirmation avant publication ». Visibility is owned by the ViewModel, which only
+    // raises the flag once the submit passed every validation gate and the preference is on.
+    if (state.showSubmitConfirmation) {
+        ConfirmSubmitDialog(
+            onConfirm = viewModel::onSubmitConfirmed,
+            onDismiss = viewModel::onSubmitConfirmationDismissed,
+        )
+    }
 }
 
 @Composable

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
@@ -92,9 +92,14 @@ fun PrivateMessageReplyScreen(
     // #312 — « Confirmation avant publication ». Visibility is owned by the ViewModel, which only
     // raises the flag once the submit passed every validation gate and the preference is on.
     if (state.showSubmitConfirmation) {
+        // MP wording: a private reply is not « envoyé sur le forum », and the MP verb
+        // everywhere else is « Envoyer » — override the forum defaults of the shared dialog.
         ConfirmSubmitDialog(
             onConfirm = viewModel::onSubmitConfirmed,
             onDismiss = viewModel::onSubmitConfirmationDismissed,
+            title = R.string.messages_reply_confirm_title,
+            body = R.string.messages_reply_confirm_body,
+            confirmLabel = R.string.messages_reply_confirm_action,
         )
     }
 }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyUiState.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyUiState.kt
@@ -33,6 +33,13 @@ data class PrivateMessageReplyUiState(
     val optionsHydratedFromForm: Boolean = false,
     val isSubmitting: Boolean = false,
     val submitError: PrivateMessageReplyError? = null,
+    /**
+     * #312 — `true` while the « Confirmation avant publication » dialog is shown. Only raised when
+     * the persisted preference is on AND the submit already passed every validation gate (mirrors
+     * the post editor's `showSubmitConfirmation`). Confirm / dismiss go through
+     * [PrivateMessageReplyViewModel.onSubmitConfirmed] / [PrivateMessageReplyViewModel.onSubmitConfirmationDismissed].
+     */
+    val showSubmitConfirmation: Boolean = false,
 ) {
     val canSubmit: Boolean
         get() = formAvailable && !isLoadingForm && !isSubmitting && draft.text.isNotBlank()

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
@@ -10,6 +10,7 @@ import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.write.PrivateMessageWriteRepository
 import fr.forumhfr.redface2.core.model.write.PrivateMessageReplyContext
 import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
@@ -48,6 +49,7 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
     @Assisted private val request: PrivateMessageReplyRequest,
     private val repository: PrivateMessageWriteRepository,
     private val previewParser: BbcodePreviewParser,
+    private val userPreferencesRepository: UserPreferencesRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(PrivateMessageReplyUiState())
@@ -65,7 +67,19 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
     private var formJob: Job? = null
     private var submitJob: Job? = null
 
+    /**
+     * #312 — mirror of the persisted « Confirmation avant publication » preference. Collected on
+     * init (same DataStore-consumption shape as `TopicViewModel.observeTopicTopBarAutoHide`) and
+     * read synchronously at submit time, identical to the post editor.
+     */
+    private var confirmBeforePosting: Boolean = false
+
     init {
+        viewModelScope.launch {
+            userPreferencesRepository.observeConfirmBeforePosting().collect { enabled ->
+                confirmBeforePosting = enabled
+            }
+        }
         loadForm()
     }
 
@@ -170,8 +184,24 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
 
     fun onErrorDismissed() = _state.update { it.copy(submitError = null) }
 
+    /**
+     * #312 — confirm path. Closes the dialog and re-runs the submit pipeline with
+     * `bypassConfirmation = true` so the real submission executes directly (re-checking the
+     * preference here would loop « confirmation → confirmation » forever). The validation
+     * guards run again on the latest snapshot, which is safe because the dialog is modal.
+     */
+    fun onSubmitConfirmed() {
+        _state.update { it.copy(showSubmitConfirmation = false) }
+        onSubmit(bypassConfirmation = true)
+    }
+
+    /** #312 — dismiss path: close the dialog, send nothing, keep the draft. */
+    fun onSubmitConfirmationDismissed() = _state.update { it.copy(showSubmitConfirmation = false) }
+
+    fun onSubmit() = onSubmit(bypassConfirmation = false)
+
     @Suppress("ReturnCount") // Guard clauses are the natural shape of the submit dispatcher.
-    fun onSubmit() {
+    private fun onSubmit(bypassConfirmation: Boolean) {
         val snapshot = _state.value
         if (!snapshot.canSubmit) return
         val form = loadedForm ?: run {
@@ -183,6 +213,13 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
             return
         }
         if (submitJob?.isActive == true) return
+        // #312 — AFTER every validation gate (we never confirm an unsendable form), BEFORE the
+        // real POST: when the preference is on, park the submit behind the confirmation dialog.
+        // [onSubmitConfirmed] re-enters with `bypassConfirmation = true`.
+        if (!bypassConfirmation && confirmBeforePosting) {
+            _state.update { it.copy(showSubmitConfirmation = true) }
+            return
+        }
 
         val options = ReplyFormOptions(
             signatureEnabled = snapshot.signatureEnabled,

--- a/feature/messages/src/main/res/values/strings.xml
+++ b/feature/messages/src/main/res/values/strings.xml
@@ -37,4 +37,7 @@
     <string name="messages_reply_error_network">Problème de connexion. Vérifiez votre réseau puis réessayez.</string>
     <string name="messages_reply_error_session_expired">La session a expiré. Reconnectez-vous puis réessayez.</string>
     <string name="messages_reply_error_unexpected">Réponse inattendue de HFR. Votre message a peut-être été envoyé : vérifiez la conversation.</string>
+    <string name="messages_reply_confirm_title">Envoyer ce message privé ?</string>
+    <string name="messages_reply_confirm_body">Votre message privé va être envoyé à votre correspondant.</string>
+    <string name="messages_reply_confirm_action">Envoyer</string>
 </resources>

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
@@ -16,6 +16,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import java.io.IOException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -319,5 +320,62 @@ class PrivateMessageReplyViewModelTest {
 
         assertFalse("invalid form must not raise the dialog", viewModel.state.value.showSubmitConfirmation)
         coVerify(exactly = 0) { repository.submitReply(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `confirm-before-posting ON re-submitting while the dialog is up keeps it armed without posting`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form()
+
+        val viewModel = PrivateMessageReplyViewModel(
+            request,
+            repository,
+            previewParser,
+            userPreferences(confirmBeforePosting = true),
+        )
+        viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
+        viewModel.onSubmit()
+        assertTrue("the confirmation dialog must be armed", viewModel.state.value.showSubmitConfirmation)
+
+        // Second tap while the dialog is up (double-tap race) : idempotent — re-raising
+        // `showSubmitConfirmation = true` is a no-op, and no POST may slip through.
+        viewModel.onSubmit()
+
+        assertTrue("the dialog must stay armed", viewModel.state.value.showSubmitConfirmation)
+        assertFalse("nothing is in flight while the dialog is up", viewModel.state.value.isSubmitting)
+        coVerify(exactly = 0) { repository.submitReply(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `confirm-before-posting ON rapid double onSubmitConfirmed posts exactly once`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form()
+        // Hold the first confirmed submit in flight : with UnconfinedTestDispatcher a
+        // non-suspending mock would complete synchronously and the second confirm would
+        // legitimately re-fire. The gate keeps `submitJob` active across both confirms.
+        val gate = CompletableDeferred<Unit>()
+        coEvery { repository.submitReply(any(), any(), any(), any()) } coAnswers {
+            gate.await()
+            ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
+        }
+
+        val viewModel = PrivateMessageReplyViewModel(
+            request,
+            repository,
+            previewParser,
+            userPreferences(confirmBeforePosting = true),
+        )
+        viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
+        viewModel.onSubmit()
+        assertTrue("the confirmation dialog must be armed", viewModel.state.value.showSubmitConfirmation)
+
+        viewModel.onSubmitConfirmed() // launches the POST ; suspends on gate
+        viewModel.onSubmitConfirmed() // must be a no-op (canSubmit / submitJob guards)
+
+        gate.complete(Unit)
+
+        coVerify(exactly = 1) { repository.submitReply(any(), any(), any(), any()) }
+        assertFalse(viewModel.state.value.showSubmitConfirmation)
+        assertFalse(viewModel.state.value.isSubmitting)
     }
 }

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
@@ -3,6 +3,7 @@ package fr.forumhfr.redface2.feature.messages
 import androidx.compose.ui.text.input.TextFieldValue
 import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.write.PrivateMessageWriteRepository
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.write.PrivateMessageReplyContext
@@ -12,10 +13,12 @@ import fr.forumhfr.redface2.core.model.write.ReplyFormOptions
 import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import java.io.IOException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -45,6 +48,15 @@ class PrivateMessageReplyViewModelTest {
 
     private val previewParser = BbcodePreviewParser { PostContent(blocks = emptyList()) }
 
+    /**
+     * #312 — preferences mock. `observeConfirmBeforePosting` is the only member the reply
+     * ViewModel consumes; a hot [MutableStateFlow] mirrors the DataStore observe shape.
+     */
+    private fun userPreferences(confirmBeforePosting: Boolean = false): UserPreferencesRepository =
+        mockk {
+            every { observeConfirmBeforePosting() } returns MutableStateFlow(confirmBeforePosting)
+        }
+
     private fun form(
         hashCheck: String = "abc",
         hiddenFields: Map<String, String> = mapOf(
@@ -66,7 +78,7 @@ class PrivateMessageReplyViewModelTest {
         val repository = mockk<PrivateMessageWriteRepository>()
         coEvery { repository.fetchReplyForm(any()) } returns form()
 
-        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser, userPreferences())
 
         val state = viewModel.state.value
         assertFalse(state.isLoadingForm)
@@ -83,7 +95,7 @@ class PrivateMessageReplyViewModelTest {
         coEvery { repository.submitReply(any(), any(), any(), any()) } returns
             ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
 
-        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser, userPreferences())
         viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
 
         viewModel.effects.test {
@@ -105,7 +117,7 @@ class PrivateMessageReplyViewModelTest {
         coEvery { repository.submitReply(any(), any(), any(), any()) } returns
             ReplySubmitResult.Failure(ReplyFailureReason.EmptyMessage)
 
-        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser, userPreferences())
         viewModel.onContentChanged(TextFieldValue("non-blank"))
         viewModel.onSubmit()
 
@@ -122,7 +134,7 @@ class PrivateMessageReplyViewModelTest {
         coEvery { repository.submitReply(any(), any(), any(), any()) } returns
             ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)
 
-        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser, userPreferences())
         viewModel.onContentChanged(TextFieldValue("hello"))
         viewModel.onSubmit()
 
@@ -138,7 +150,7 @@ class PrivateMessageReplyViewModelTest {
         coEvery { repository.submitReply(any(), any(), any(), any()) } returns
             ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)
 
-        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser, userPreferences())
         // First load hydrates signature ON (hidden `signature=1`); the user turns it OFF.
         viewModel.onToggleSignature(false)
         viewModel.onContentChanged(TextFieldValue("hello"))
@@ -160,7 +172,7 @@ class PrivateMessageReplyViewModelTest {
         coEvery { repository.submitReply(any(), any(), any(), any()) } returns
             ReplySubmitResult.Failure(ReplyFailureReason.Unknown)
 
-        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser, userPreferences())
         viewModel.onContentChanged(TextFieldValue("hello"))
         viewModel.onSubmit()
 
@@ -175,7 +187,7 @@ class PrivateMessageReplyViewModelTest {
         val repository = mockk<PrivateMessageWriteRepository>()
         coEvery { repository.fetchReplyForm(any()) } throws IOException("network down")
 
-        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser, userPreferences())
 
         val state = viewModel.state.value
         assertTrue(state.formError)
@@ -188,7 +200,7 @@ class PrivateMessageReplyViewModelTest {
         val repository = mockk<PrivateMessageWriteRepository>()
         coEvery { repository.fetchReplyForm(any()) } returns form(isAnonymous = true)
 
-        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser)
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser, userPreferences())
 
         assertTrue(viewModel.state.value.formError)
         assertFalse(viewModel.state.value.formAvailable)
@@ -200,5 +212,112 @@ class PrivateMessageReplyViewModelTest {
         val context = PrivateMessageReplyContext(threadId = request.threadId, page = request.page)
         assertEquals(3195237, context.threadId)
         assertEquals(1, context.page)
+    }
+
+    // ----- #312 : confirmation avant publication ------------------------------
+
+    @Test
+    fun `confirm-before-posting OFF keeps the one-tap submit unchanged`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form()
+        coEvery { repository.submitReply(any(), any(), any(), any()) } returns
+            ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
+
+        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser, userPreferences())
+        viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
+        viewModel.onSubmit()
+
+        coVerify(exactly = 1) { repository.submitReply(any(), any(), any(), any()) }
+        assertFalse(viewModel.state.value.showSubmitConfirmation)
+    }
+
+    @Test
+    fun `confirm-before-posting ON parks the submit behind the confirmation dialog`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form()
+
+        val viewModel = PrivateMessageReplyViewModel(
+            request,
+            repository,
+            previewParser,
+            userPreferences(confirmBeforePosting = true),
+        )
+        viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
+        viewModel.onSubmit()
+
+        assertTrue("the confirmation dialog must be armed", viewModel.state.value.showSubmitConfirmation)
+        assertFalse("nothing is in flight while the dialog is up", viewModel.state.value.isSubmitting)
+        coVerify(exactly = 0) { repository.submitReply(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `confirm-before-posting ON onSubmitConfirmed executes the real submission without re-confirming`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form()
+        coEvery { repository.submitReply(any(), any(), any(), any()) } returns
+            ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
+
+        val viewModel = PrivateMessageReplyViewModel(
+            request,
+            repository,
+            previewParser,
+            userPreferences(confirmBeforePosting = true),
+        )
+        viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
+        viewModel.onSubmit()
+        coVerify(exactly = 0) { repository.submitReply(any(), any(), any(), any()) }
+
+        viewModel.effects.test {
+            viewModel.onSubmitConfirmed()
+            assertEquals(
+                PrivateMessageReplyEffect.SubmitSucceeded(threadId = 3195237, page = 1),
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+        // Confirm bypasses the preference re-check : exactly one POST, no dialog re-arm.
+        coVerify(exactly = 1) { repository.submitReply(any(), any(), any(), any()) }
+        assertFalse(viewModel.state.value.showSubmitConfirmation)
+    }
+
+    @Test
+    fun `confirm-before-posting ON dismissing the dialog sends nothing and keeps the draft`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form()
+
+        val viewModel = PrivateMessageReplyViewModel(
+            request,
+            repository,
+            previewParser,
+            userPreferences(confirmBeforePosting = true),
+        )
+        viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
+        viewModel.onSubmit()
+
+        viewModel.onSubmitConfirmationDismissed()
+
+        assertFalse(viewModel.state.value.showSubmitConfirmation)
+        assertEquals("the draft survives the dismissal", "Coucou en privé.", viewModel.state.value.draft.text)
+        assertNull(viewModel.state.value.submitError)
+        coVerify(exactly = 0) { repository.submitReply(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `confirm-before-posting ON never confirms an empty draft`() = runTest {
+        // The confirmation slots in AFTER validation : a blank draft fails `canSubmit`, so no
+        // dialog may appear (confirming an unsendable form would be a lie).
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form()
+
+        val viewModel = PrivateMessageReplyViewModel(
+            request,
+            repository,
+            previewParser,
+            userPreferences(confirmBeforePosting = true),
+        )
+        viewModel.onSubmit()
+
+        assertFalse("invalid form must not raise the dialog", viewModel.state.value.showSubmitConfirmation)
+        coVerify(exactly = 0) { repository.submitReply(any(), any(), any(), any()) }
     }
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -248,9 +248,12 @@ internal fun SettingsContent(
             )
 
             SettingsSectionHeader(stringResource(R.string.settings_section_editing))
+            EditingPreferencesCard(
+                state = state,
+                onIntent = onIntent,
+            )
             FutureSettingsCard(
                 items = listOf(
-                    R.string.settings_future_submit_confirm to issueTag(312),
                     R.string.settings_future_signature to stringResource(R.string.settings_phase_planned),
                 ),
             )
@@ -531,6 +534,41 @@ private fun TopicPreferencesCard(
             )
             if (state.topicTopBarAutoHideError) {
                 PreferencePersistError(R.string.settings_topic_topbar_auto_hide_persist_failed)
+            }
+        }
+    }
+}
+
+/**
+ * Publishing preferences (#312): the « Confirmation avant publication » toggle. When on, every
+ * publish action (topic reply / post edit, new topic / first-post edit, private-message reply)
+ * first shows a confirmation dialog. Persisted via DataStore and observed live by the editor
+ * ViewModels, so a flip here applies without reopening an editor.
+ */
+@Composable
+private fun EditingPreferencesCard(
+    state: SettingsState,
+    onIntent: (SettingsIntent) -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_editing_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            PreferenceSwitchRow(
+                title = stringResource(R.string.settings_confirm_before_posting_title),
+                description = stringResource(R.string.settings_confirm_before_posting_description),
+                checked = state.confirmBeforePosting,
+                enabled = state.canToggleConfirmBeforePosting,
+                onCheckedChange = { onIntent(SettingsIntent.ConfirmBeforePostingChanged(it)) },
+            )
+            if (state.confirmBeforePostingError) {
+                PreferencePersistError(R.string.settings_confirm_before_posting_persist_failed)
             }
         }
     }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -71,6 +71,14 @@ data class SettingsState(
     val isUpdatingTopicTopBarAutoHide: Boolean = false,
     val topicTopBarAutoHideError: Boolean = false,
     val topicTopBarAutoHideTouchedLocally: Boolean = false,
+    // Publishing preferences (#312). Same optimistic-flip + startup-race-guard machinery:
+    // `confirmBeforePosting` is the displayed value, `isUpdating*` gates the switch while DataStore
+    // writes, `*Error` surfaces a persist failure, `*TouchedLocally` forbids a late `init` hydration
+    // from clobbering a fast user flip. Default false (publishing stays one-tap).
+    val confirmBeforePosting: Boolean = false,
+    val isUpdatingConfirmBeforePosting: Boolean = false,
+    val confirmBeforePostingError: Boolean = false,
+    val confirmBeforePostingTouchedLocally: Boolean = false,
 ) {
     val canSave: Boolean
         get() = !isSaving
@@ -103,6 +111,10 @@ data class SettingsState(
     // Build 89 follow-up — the topic top-bar auto-hide toggle is gated only by its own write.
     val canToggleTopicTopBarAutoHide: Boolean
         get() = !isUpdatingTopicTopBarAutoHide
+
+    // #312 — the confirm-before-posting toggle is gated only by its own write.
+    val canToggleConfirmBeforePosting: Boolean
+        get() = !isUpdatingConfirmBeforePosting
 }
 
 sealed interface SettingsError {
@@ -157,4 +169,8 @@ sealed interface SettingsIntent {
     // Build 89 follow-up — topic top-bar auto-hide toggle. Optimistic-flip contract, like the
     // flags toggles: the boolean is the desired post-flip state.
     data class TopicTopBarAutoHideChanged(val enabled: Boolean) : SettingsIntent
+
+    // #312 — confirm-before-posting toggle. Optimistic-flip contract, like the flags toggles:
+    // the boolean is the desired post-flip state.
+    data class ConfirmBeforePostingChanged(val enabled: Boolean) : SettingsIntent
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -108,6 +108,16 @@ class SettingsViewModel @Inject constructor(
                 }
             }
         }
+        viewModelScope.launch {
+            val confirm = userPreferencesRepository.observeConfirmBeforePosting().first()
+            _state.update { current ->
+                if (current.confirmBeforePostingTouchedLocally || current.isUpdatingConfirmBeforePosting) {
+                    current
+                } else {
+                    current.copy(confirmBeforePosting = confirm)
+                }
+            }
+        }
     }
 
     @Suppress("CyclomaticComplexMethod") // MVI when-dispatch over the SettingsIntent variants ; flat by design.
@@ -141,6 +151,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.ThemeModeChanged -> updateThemeMode(intent.mode)
             is SettingsIntent.AmoledEnabledChanged -> updateAmoled(intent.enabled)
             is SettingsIntent.TopicTopBarAutoHideChanged -> updateTopicTopBarAutoHide(intent.enabled)
+            is SettingsIntent.ConfirmBeforePostingChanged -> updateConfirmBeforePosting(intent.enabled)
         }
     }
 
@@ -404,6 +415,33 @@ class SettingsViewModel @Inject constructor(
                 }
             },
             persist = userPreferencesRepository::setTopicTopBarAutoHide,
+        )
+    }
+
+    private fun updateConfirmBeforePosting(desired: Boolean) {
+        val previous = _state.value.confirmBeforePosting
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    confirmBeforePosting = desired,
+                    isUpdatingConfirmBeforePosting = true,
+                    confirmBeforePostingError = false,
+                    confirmBeforePostingTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(confirmBeforePosting = desired, isUpdatingConfirmBeforePosting = false)
+                } else {
+                    state.copy(
+                        confirmBeforePosting = previous,
+                        isUpdatingConfirmBeforePosting = false,
+                        confirmBeforePostingError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setConfirmBeforePosting,
         )
     }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -27,7 +27,6 @@
     <string name="settings_future_flags_on_listing">Poser les drapeaux en listant une catégorie</string>
     <string name="settings_future_scroll_memory">Retenir la position de lecture par page</string>
     <string name="settings_future_prefetch">Préchargement de la page suivante</string>
-    <string name="settings_future_submit_confirm">Confirmation avant publication</string>
     <string name="settings_future_signature">Signature automatique et notification e-mail</string>
     <!-- #301 — la réponse à une conversation existante est livrée ; reste « à venir » la
          composition d'un nouveau MP depuis zéro (new-MP), encore non observée côté HFR. -->
@@ -111,4 +110,13 @@
     <string name="settings_topic_topbar_auto_hide_title">Masquer la barre en défilant</string>
     <string name="settings_topic_topbar_auto_hide_description">La barre du haut (titre du sujet et numéro de page) disparaît quand vous faites défiler vers le bas et réapparaît dès que vous remontez.</string>
     <string name="settings_topic_topbar_auto_hide_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
+
+    <!-- #312 — Publication. Confirmation avant chaque envoi (réponse/édition de message, sujet,
+         message privé) ; persisté en DataStore et lu en direct par les éditeurs.
+         `settings_future_submit_confirm` (catalogue vitrine #288) renommé selon la convention des
+         toggles actifs. -->
+    <string name="settings_editing_title">Publication</string>
+    <string name="settings_confirm_before_posting_title">Confirmation avant publication</string>
+    <string name="settings_confirm_before_posting_description">Demande une confirmation avant d\'envoyer une réponse, un sujet ou un message privé.</string>
+    <string name="settings_confirm_before_posting_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
 </resources>

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -613,6 +613,44 @@ class SettingsViewModelTest {
         assertTrue(viewModel.state.value.topicTopBarAutoHideError)
     }
 
+    // ──────────────────────────────────────────────────────────────────────
+    // Confirm before posting (#312)
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `init hydrates confirmBeforePosting from the persisted preference`() = runTest {
+        repository.emitConfirmBeforePosting(true)
+
+        val viewModel = newViewModel()
+
+        assertTrue(viewModel.state.value.confirmBeforePosting)
+        assertFalse(viewModel.state.value.confirmBeforePostingError)
+    }
+
+    @Test
+    fun `ConfirmBeforePostingChanged persists the flip`() = runTest {
+        val viewModel = newViewModel()
+        assertFalse("confirm-before-posting is off by default", viewModel.state.value.confirmBeforePosting)
+
+        viewModel.submit(SettingsIntent.ConfirmBeforePostingChanged(true))
+
+        assertTrue(viewModel.state.value.confirmBeforePosting)
+        assertFalse(viewModel.state.value.isUpdatingConfirmBeforePosting)
+        assertEquals(1, repository.confirmBeforePostingSetCalls)
+    }
+
+    @Test
+    fun `ConfirmBeforePostingChanged reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnConfirmBeforePostingSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.ConfirmBeforePostingChanged(true))
+
+        assertFalse("must revert to the previous value on failure", viewModel.state.value.confirmBeforePosting)
+        assertFalse(viewModel.state.value.isUpdatingConfirmBeforePosting)
+        assertTrue(viewModel.state.value.confirmBeforePostingError)
+    }
+
     @Test
     fun `theme hydration race - a stale initial DataStore emission must not overwrite a local mode change`() =
         runTest {
@@ -792,6 +830,24 @@ class SettingsViewModelTest {
             topicTopBarAutoHideSetCalls += 1
             check(!failOnTopicTopBarAutoHideSet) { "boom" }
             topicTopBarAutoHide.value = enabled
+        }
+
+        // #312 — confirm-before-posting. Same optimistic-flip seam as the topic top-bar toggle.
+        private val confirmBeforePosting = MutableStateFlow(false)
+        var confirmBeforePostingSetCalls: Int = 0
+            private set
+        var failOnConfirmBeforePostingSet: Boolean = false
+
+        override fun observeConfirmBeforePosting(): Flow<Boolean> = confirmBeforePosting
+
+        override suspend fun setConfirmBeforePosting(enabled: Boolean) {
+            confirmBeforePostingSetCalls += 1
+            check(!failOnConfirmBeforePostingSet) { "boom" }
+            confirmBeforePosting.value = enabled
+        }
+
+        fun emitConfirmBeforePosting(value: Boolean) {
+            confirmBeforePosting.value = value
         }
 
         fun emitThemeMode(value: ThemeMode) {

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -1271,4 +1271,9 @@ private class FakeUserPreferencesRepository(
     override fun observeTopicTopBarAutoHide(): Flow<Boolean> = MutableStateFlow(topicTopBarAutoHide)
 
     override suspend fun setTopicTopBarAutoHide(enabled: Boolean) = Unit
+
+    // #312 — confirm-before-posting is irrelevant to TopicViewModel; stubbed at its default.
+    override fun observeConfirmBeforePosting(): Flow<Boolean> = MutableStateFlow(false)
+
+    override suspend fun setConfirmBeforePosting(enabled: Boolean) = Unit
 }


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaaT)

Closes #312

## Quoi

- Toggle Settings « Confirmer avant publication » (`confirm_before_posting`, défaut OFF — comportement actuel préservé à l'identique).
- Interception du submit dans les 3 surfaces d'écriture : `TopicFormViewModel` (réponse + création de topic), `PostEditorViewModel` (édition), `PrivateMessageReplyViewModel` (réponse MP).
- `ConfirmSubmitDialog` partagé dans `:core:ui`, paramétrable (`@StringRes title/body/confirmLabel`) ; wording dédié MP « Envoyer ce message privé ? ».
- Guard anti double-submit `submitJob?.isActive` remonté en tête de `TopicFormViewModel.onSubmitClicked` — l'interception de confirmation ne court-circuite plus la protection.
- 6 tests double-submit (submit suspendu, les 3 surfaces, toggle ON/OFF).

## Validation

- Locale ×2 : `detektAll test testDebugUnitTest :app:assembleProdDebug --rerun-tasks` (2m58) puis `lintDebug :app:lintProdDebug` — vertes.
- Review multi-agent 4 saveurs : findings ≥ 60 tous traités (guard double-submit, wording MP).
- Review Codex finale : **SHIP**, zéro finding (garde-fous `canSubmit` → `isActive` → confirmation → submit vérifiés sur les 3 flux, pas de fuite du contenu dans les logs).

## Merge

Squash `--admin` mono-maintainer : pas de second compte « sûr » disponible pour approuver sans créer un lien d'identité non voulu (cf. AGENTS.md § Review en mono-maintainer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)