### PR TITLE
fix(ui): retours dogfooding v102 — menu de post, ligne drapeaux, en-têtes

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
@@ -43,6 +43,12 @@ import fr.forumhfr.redface2.core.model.FlagType
  * `weight(1f)` so the action stays pinned to the right and the text ellipsises instead of
  * overlapping it. When absent (default), the column fills the row as before.
  *
+ * [metadataEnd] is an optional end-aligned segment of the footer line (#325 follow-up:
+ * the last-reply timestamp). It is NEVER truncated — the start segment ([metadata]) takes
+ * the remaining width and ellipsises instead, so on narrow screens the date survives and
+ * the author/pagination clip first (dogfooding feedback on v102: the timestamp, placed
+ * last in a single string, was the part being cut off).
+ *
  * Note (#99): the « Retirer le drapeau » affordance is no longer an inline `trailingAction`
  * button — `:feature:flags` now wraps this row in a Material 3 `SwipeToDismissBox`
  * (swipe-to-remove + confirmation dialog). The slot is kept for future inline actions.
@@ -53,6 +59,7 @@ fun FlagItem(
     metadata: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    metadataEnd: String = "",
     trailingAction: (@Composable RowScope.() -> Unit)? = null,
 ) {
     Row(
@@ -75,16 +82,32 @@ fun FlagItem(
                 fontWeight = if (flag.hasUnread) FontWeight.SemiBold else FontWeight.Normal,
                 maxLines = 2,
             )
-            if (metadata.isNotEmpty()) {
-                Text(
-                    text = metadata,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    // #325 — the line can exceed narrow screens now that it carries the
-                    // last-reply timestamp: signal the truncation instead of hard-clipping.
-                    overflow = TextOverflow.Ellipsis,
-                )
+            if (metadata.isNotEmpty() || metadataEnd.isNotEmpty()) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = metadata,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        // #325 — only the START segment may truncate; the end-aligned
+                        // timestamp keeps its intrinsic width (weight measures this text
+                        // in the remaining space).
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f),
+                    )
+                    if (metadataEnd.isNotEmpty()) {
+                        Text(
+                            text = metadataEnd,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            modifier = Modifier.padding(start = 8.dp),
+                        )
+                    }
+                }
             }
         }
         trailingAction?.invoke(this)

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
@@ -26,6 +26,14 @@ import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
 
 /**
+ * Footer line of a [FlagItem] row, split in two segments (#325 follow-up). [start] is the
+ * only segment allowed to truncate (ellipsis); [end] — typically the last-reply
+ * timestamp — keeps its intrinsic width, pinned to the row's end. Either side may be
+ * empty. Bundled as one value so callers stay under the detekt parameter-count threshold.
+ */
+data class FlagMetadata(val start: String = "", val end: String = "")
+
+/**
  * Renders one row of the user's drapeaux list.
  *
  * Visual hierarchy mirrors what HFR users have spent ~20 years training their eyes on:
@@ -43,8 +51,8 @@ import fr.forumhfr.redface2.core.model.FlagType
  * `weight(1f)` so the action stays pinned to the right and the text ellipsises instead of
  * overlapping it. When absent (default), the column fills the row as before.
  *
- * [metadataEnd] is an optional end-aligned segment of the footer line (#325 follow-up:
- * the last-reply timestamp). It is NEVER truncated — the start segment ([metadata]) takes
+ * [FlagMetadata.end] is an optional end-aligned segment of the footer line (#325
+ * follow-up: the last-reply timestamp). It is NEVER truncated — the start segment takes
  * the remaining width and ellipsises instead, so on narrow screens the date survives and
  * the author/pagination clip first (dogfooding feedback on v102: the timestamp, placed
  * last in a single string, was the part being cut off).
@@ -56,10 +64,9 @@ import fr.forumhfr.redface2.core.model.FlagType
 @Composable
 fun FlagItem(
     flag: Flag,
-    metadata: String,
+    metadata: FlagMetadata,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    metadataEnd: String = "",
     trailingAction: (@Composable RowScope.() -> Unit)? = null,
 ) {
     Row(
@@ -82,13 +89,13 @@ fun FlagItem(
                 fontWeight = if (flag.hasUnread) FontWeight.SemiBold else FontWeight.Normal,
                 maxLines = 2,
             )
-            if (metadata.isNotEmpty() || metadataEnd.isNotEmpty()) {
+            if (metadata.start.isNotEmpty() || metadata.end.isNotEmpty()) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
-                        text = metadata,
+                        text = metadata.start,
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         maxLines = 1,
@@ -98,9 +105,9 @@ fun FlagItem(
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier.weight(1f),
                     )
-                    if (metadataEnd.isNotEmpty()) {
+                    if (metadata.end.isNotEmpty()) {
                         Text(
-                            text = metadataEnd,
+                            text = metadata.end,
                             style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             maxLines = 1,

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
@@ -26,14 +26,6 @@ import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
 
 /**
- * Footer line of a [FlagItem] row, split in two segments (#325 follow-up). [start] is the
- * only segment allowed to truncate (ellipsis); [end] — typically the last-reply
- * timestamp — keeps its intrinsic width, pinned to the row's end. Either side may be
- * empty. Bundled as one value so callers stay under the detekt parameter-count threshold.
- */
-data class FlagMetadata(val start: String = "", val end: String = "")
-
-/**
  * Renders one row of the user's drapeaux list.
  *
  * Visual hierarchy mirrors what HFR users have spent ~20 years training their eyes on:

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagMetadata.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagMetadata.kt
@@ -1,0 +1,9 @@
+package fr.forumhfr.redface2.core.ui
+
+/**
+ * Footer line of a [FlagItem] row, split in two segments (#325 follow-up). [start] is the
+ * only segment allowed to truncate (ellipsis); [end] — typically the last-reply
+ * timestamp — keeps its intrinsic width, pinned to the row's end. Either side may be
+ * empty. Bundled as one value so callers stay under the detekt parameter-count threshold.
+ */
+data class FlagMetadata(val start: String = "", val end: String = "")

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -686,8 +686,7 @@ private fun CategorySectionedFlagList(
                     // Confirming phase and the ViewModel rejects re-entry.
                     SwipeableFlagItem(
                         flag = flag,
-                        metadata = flagMetadata(flag),
-                        metadataEnd = flagMetadataEnd(flag),
+                        metadata = flagRowMetadata(flag),
                         removalInFlight = removalInFlight,
                         onClick = { actions.onOpenFlag(flag) },
                         onRequestRemove = { actions.onRequestRemoveFlag(flag) },
@@ -765,8 +764,7 @@ private fun FlatFlagList(
             ) { flag ->
                 SwipeableFlagItem(
                     flag = flag,
-                    metadata = flagMetadata(flag),
-                    metadataEnd = flagMetadataEnd(flag),
+                    metadata = flagRowMetadata(flag),
                     removalInFlight = removalInFlight,
                     onClick = { actions.onOpenFlag(flag) },
                     onRequestRemove = { actions.onRequestRemoveFlag(flag) },
@@ -819,8 +817,7 @@ private fun flatEmptyLabel(tab: FlagTab): Int = when (tab) {
 @Composable
 private fun SwipeableFlagItem(
     flag: Flag,
-    metadata: String,
-    metadataEnd: String,
+    metadata: FlagRowMetadata,
     removalInFlight: Boolean,
     onClick: () -> Unit,
     onRequestRemove: () -> Unit,
@@ -846,8 +843,8 @@ private fun SwipeableFlagItem(
     ) {
         FlagItem(
             flag = flag,
-            metadata = metadata,
-            metadataEnd = metadataEnd,
+            metadata = metadata.start,
+            metadataEnd = metadata.end,
             onClick = onClick,
             // Opaque background so the destructive backdrop never bleeds through the row while
             // it is animating back to settled. Swipe is the only removal affordance now, so we
@@ -952,32 +949,34 @@ private data class FlagsViewSettingsActions(
 )
 
 /**
- * Start segment of a drapeau row's footer: `author · p.X/Y`. Dogfooding feedback on v102:
- * the single-string footer (`author · N rép. · p.X/Y · timestamp`) truncated its tail —
- * the #325 timestamp — on narrow screens. The reply count is dropped entirely (redundant
- * with the page count for a quick scan, and the web listing survives without it on
- * mobile) and the timestamp moves to [flagMetadataEnd], rendered end-aligned and never
- * truncated by [FlagItem].
+ * Both segments of a drapeau row's footer, bundled so [SwipeableFlagItem] stays under the
+ * detekt parameter-count threshold (same idiom as [FlagsViewSettingsActions]).
+ *
+ * Dogfooding feedback on v102: the single-string footer (`author · N rép. · p.X/Y ·
+ * timestamp`) truncated its tail — the #325 timestamp — on narrow screens. [start] is
+ * `author · p.X/Y` (the only segment allowed to ellipsise; the reply count is dropped,
+ * redundant with the page count for a quick scan) and [end] is the last-reply timestamp,
+ * formatted web-style (`01-05-2026 à 17:07`) by [formatLastReplyTimestamp] from the raw
+ * REST string — rendered end-aligned and never truncated by [FlagItem]. Blank when REST
+ * omits it.
  */
-@Composable
-private fun flagMetadata(flag: Flag): String = if (flag.lastReplyAuthor.isNotBlank()) {
-    stringResource(
-        R.string.flags_item_metadata_with_author,
-        flag.lastReplyAuthor,
-        flag.lastReadPage,
-        flag.totalPages,
-    )
-} else {
-    stringResource(
-        R.string.flags_item_metadata_no_author,
-        flag.lastReadPage,
-        flag.totalPages,
-    )
-}
+private data class FlagRowMetadata(val start: String, val end: String)
 
-/**
- * End-aligned segment of the footer: the last-reply timestamp (#325), formatted web-style
- * (`01-05-2026 à 17:07`) by [formatLastReplyTimestamp] from the raw REST string. Blank when
- * REST omits it — [FlagItem] then renders the start segment alone.
- */
-private fun flagMetadataEnd(flag: Flag): String = formatLastReplyTimestamp(flag.lastReplyAt)
+@Composable
+private fun flagRowMetadata(flag: Flag): FlagRowMetadata {
+    val start = if (flag.lastReplyAuthor.isNotBlank()) {
+        stringResource(
+            R.string.flags_item_metadata_with_author,
+            flag.lastReplyAuthor,
+            flag.lastReadPage,
+            flag.totalPages,
+        )
+    } else {
+        stringResource(
+            R.string.flags_item_metadata_no_author,
+            flag.lastReadPage,
+            flag.totalPages,
+        )
+    }
+    return FlagRowMetadata(start = start, end = formatLastReplyTimestamp(flag.lastReplyAt))
+}

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
@@ -48,6 +49,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
@@ -62,6 +64,7 @@ import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.ui.FlagItem
 import fr.forumhfr.redface2.core.ui.FlagItemDivider
+import fr.forumhfr.redface2.core.ui.FlagMetadata
 import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.formatLastReplyTimestamp
 import kotlinx.coroutines.launch
@@ -291,15 +294,26 @@ private fun FlagsHeader(
             color = MaterialTheme.colorScheme.onSurface,
         )
         // Refresh moved to a PullToRefreshBox (swipe down) on the list — the header now carries the
-        // display-settings trigger (#309, text-only: the icons-extended dependency is not on this
-        // module's classpath) and the global account menu slot.
+        // display-settings trigger (#309) and the global account menu slot.
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             onOpenViewSettings?.let { open ->
-                TextButton(onClick = open) {
-                    Text(stringResource(R.string.flags_view_settings_action))
+                // Gear glyph instead of the « Affichage » text label (dogfooding v102: the word
+                // crowded the header). Text glyph because ForbiddenImport bans material icons
+                // (cf. the Text("←") precedent); U+FE0E pins the monochrome text rendition over
+                // the emoji one. The wording survives as the TalkBack label.
+                val viewSettingsLabel = stringResource(R.string.flags_view_settings_action)
+                IconButton(
+                    onClick = open,
+                    modifier = Modifier.semantics { contentDescription = viewSettingsLabel },
+                ) {
+                    Text(
+                        text = "\u2699\uFE0E",
+                        style = MaterialTheme.typography.titleLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                 }
             }
             topBarActions?.invoke()
@@ -817,7 +831,7 @@ private fun flatEmptyLabel(tab: FlagTab): Int = when (tab) {
 @Composable
 private fun SwipeableFlagItem(
     flag: Flag,
-    metadata: FlagRowMetadata,
+    metadata: FlagMetadata,
     removalInFlight: Boolean,
     onClick: () -> Unit,
     onRequestRemove: () -> Unit,
@@ -843,8 +857,7 @@ private fun SwipeableFlagItem(
     ) {
         FlagItem(
             flag = flag,
-            metadata = metadata.start,
-            metadataEnd = metadata.end,
+            metadata = metadata,
             onClick = onClick,
             // Opaque background so the destructive backdrop never bleeds through the row while
             // it is animating back to settled. Swipe is the only removal affordance now, so we
@@ -949,21 +962,16 @@ private data class FlagsViewSettingsActions(
 )
 
 /**
- * Both segments of a drapeau row's footer, bundled so [SwipeableFlagItem] stays under the
- * detekt parameter-count threshold (same idiom as [FlagsViewSettingsActions]).
- *
- * Dogfooding feedback on v102: the single-string footer (`author · N rép. · p.X/Y ·
- * timestamp`) truncated its tail — the #325 timestamp — on narrow screens. [start] is
- * `author · p.X/Y` (the only segment allowed to ellipsise; the reply count is dropped,
- * redundant with the page count for a quick scan) and [end] is the last-reply timestamp,
- * formatted web-style (`01-05-2026 à 17:07`) by [formatLastReplyTimestamp] from the raw
- * REST string — rendered end-aligned and never truncated by [FlagItem]. Blank when REST
- * omits it.
+ * Builds the two-segment footer of a drapeau row ([FlagMetadata]). Dogfooding feedback on
+ * v102: the single-string footer (`author · N rép. · p.X/Y · timestamp`) truncated its
+ * tail — the #325 timestamp — on narrow screens. `start` is `author · p.X/Y` (the only
+ * segment allowed to ellipsise; the reply count is dropped, redundant with the page count
+ * for a quick scan) and `end` is the last-reply timestamp, formatted web-style
+ * (`01-05-2026 à 17:07`) by [formatLastReplyTimestamp] from the raw REST string — rendered
+ * end-aligned and never truncated by [FlagItem]. Blank when REST omits it.
  */
-private data class FlagRowMetadata(val start: String, val end: String)
-
 @Composable
-private fun flagRowMetadata(flag: Flag): FlagRowMetadata {
+private fun flagRowMetadata(flag: Flag): FlagMetadata {
     val start = if (flag.lastReplyAuthor.isNotBlank()) {
         stringResource(
             R.string.flags_item_metadata_with_author,
@@ -978,5 +986,5 @@ private fun flagRowMetadata(flag: Flag): FlagRowMetadata {
             flag.totalPages,
         )
     }
-    return FlagRowMetadata(start = start, end = formatLastReplyTimestamp(flag.lastReplyAt))
+    return FlagMetadata(start = start, end = formatLastReplyTimestamp(flag.lastReplyAt))
 }

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -687,6 +687,7 @@ private fun CategorySectionedFlagList(
                     SwipeableFlagItem(
                         flag = flag,
                         metadata = flagMetadata(flag),
+                        metadataEnd = flagMetadataEnd(flag),
                         removalInFlight = removalInFlight,
                         onClick = { actions.onOpenFlag(flag) },
                         onRequestRemove = { actions.onRequestRemoveFlag(flag) },
@@ -765,6 +766,7 @@ private fun FlatFlagList(
                 SwipeableFlagItem(
                     flag = flag,
                     metadata = flagMetadata(flag),
+                    metadataEnd = flagMetadataEnd(flag),
                     removalInFlight = removalInFlight,
                     onClick = { actions.onOpenFlag(flag) },
                     onRequestRemove = { actions.onRequestRemoveFlag(flag) },
@@ -818,6 +820,7 @@ private fun flatEmptyLabel(tab: FlagTab): Int = when (tab) {
 private fun SwipeableFlagItem(
     flag: Flag,
     metadata: String,
+    metadataEnd: String,
     removalInFlight: Boolean,
     onClick: () -> Unit,
     onRequestRemove: () -> Unit,
@@ -844,6 +847,7 @@ private fun SwipeableFlagItem(
         FlagItem(
             flag = flag,
             metadata = metadata,
+            metadataEnd = metadataEnd,
             onClick = onClick,
             // Opaque background so the destructive backdrop never bleeds through the row while
             // it is animating back to settled. Swipe is the only removal affordance now, so we
@@ -948,43 +952,32 @@ private data class FlagsViewSettingsActions(
 )
 
 /**
- * Footer line of a drapeau row. #325 adds the last-reply timestamp, formatted web-style
- * (`01-05-2026 à 17:07`) by [formatLastReplyTimestamp] from the raw REST string. Both the
- * author and the timestamp are optional on the wire (blank when REST omits them), so each
- * combination maps to its own template — never a dangling `·` separator.
+ * Start segment of a drapeau row's footer: `author · p.X/Y`. Dogfooding feedback on v102:
+ * the single-string footer (`author · N rép. · p.X/Y · timestamp`) truncated its tail —
+ * the #325 timestamp — on narrow screens. The reply count is dropped entirely (redundant
+ * with the page count for a quick scan, and the web listing survives without it on
+ * mobile) and the timestamp moves to [flagMetadataEnd], rendered end-aligned and never
+ * truncated by [FlagItem].
  */
 @Composable
-private fun flagMetadata(flag: Flag): String {
-    val lastReplyAt = formatLastReplyTimestamp(flag.lastReplyAt)
-    val hasAuthor = flag.lastReplyAuthor.isNotBlank()
-    return when {
-        hasAuthor && lastReplyAt.isNotBlank() -> stringResource(
-            R.string.flags_item_metadata_with_author_at,
-            flag.lastReplyAuthor,
-            lastReplyAt,
-            flag.replyCount,
-            flag.lastReadPage,
-            flag.totalPages,
-        )
-        hasAuthor -> stringResource(
-            R.string.flags_item_metadata_with_author,
-            flag.lastReplyAuthor,
-            flag.replyCount,
-            flag.lastReadPage,
-            flag.totalPages,
-        )
-        lastReplyAt.isNotBlank() -> stringResource(
-            R.string.flags_item_metadata_no_author_at,
-            lastReplyAt,
-            flag.replyCount,
-            flag.lastReadPage,
-            flag.totalPages,
-        )
-        else -> stringResource(
-            R.string.flags_item_metadata_no_author,
-            flag.replyCount,
-            flag.lastReadPage,
-            flag.totalPages,
-        )
-    }
+private fun flagMetadata(flag: Flag): String = if (flag.lastReplyAuthor.isNotBlank()) {
+    stringResource(
+        R.string.flags_item_metadata_with_author,
+        flag.lastReplyAuthor,
+        flag.lastReadPage,
+        flag.totalPages,
+    )
+} else {
+    stringResource(
+        R.string.flags_item_metadata_no_author,
+        flag.lastReadPage,
+        flag.totalPages,
+    )
 }
+
+/**
+ * End-aligned segment of the footer: the last-reply timestamp (#325), formatted web-style
+ * (`01-05-2026 à 17:07`) by [formatLastReplyTimestamp] from the raw REST string. Blank when
+ * REST omits it — [FlagItem] then renders the start segment alone.
+ */
+private fun flagMetadataEnd(flag: Flag): String = formatLastReplyTimestamp(flag.lastReplyAt)

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -49,10 +49,8 @@
          "Shaad · 69017 rép. · p.1725/1726 · 01-05-2026 à 17:07". The timestamp-less variants
          remain as fallbacks when REST omits `last_post_date`. Without author (HFR returns no
          last replier on brand new topics): "69017 rép. · p.1/1". -->
-    <string name="flags_item_metadata_with_author_at">%1$s · %3$d rép. · p.%4$d/%5$d · %2$s</string>
-    <string name="flags_item_metadata_no_author_at">%2$d rép. · p.%3$d/%4$d · %1$s</string>
-    <string name="flags_item_metadata_with_author">%1$s · %2$d rép. · p.%3$d/%4$d</string>
-    <string name="flags_item_metadata_no_author">%1$d rép. · p.%2$d/%3$d</string>
+    <string name="flags_item_metadata_with_author">%1$s · p.%2$d/%3$d</string>
+    <string name="flags_item_metadata_no_author">p.%1$d/%2$d</string>
 
     <!-- #309 — Menu d'affichage des drapeaux (bottom sheet M3 ouvert depuis l'en-tête). Reflète et
          modifie les réglages d'affichage de l'onglet courant (ou globaux selon « par onglet »). -->

--- a/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchScreen.kt
@@ -110,12 +110,16 @@ internal fun SearchContent(
             modifier = Modifier
                 .fillMaxSize()
                 .statusBarsPadding()
-                .navigationBarsPadding()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+                .navigationBarsPadding(),
         ) {
+            // Header padding matches the other three main screens (24/12, headlineMedium) —
+            // dogfooding feedback on v102: Recherche inherited the content's tighter 16dp
+            // gutter, so its title and the account avatar sat visibly offset from
+            // Drapeaux / Forum / Messages.
             Row(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 12.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
@@ -126,35 +130,42 @@ internal fun SearchContent(
                 )
                 topBarActions?.invoke()
             }
-            SearchField(
-                query = state.query,
-                isSubmitEnabled = !state.isLoading && state.query.isNotBlank(),
-                onQueryChange = { onIntent(SearchIntent.QueryChanged(it)) },
-                onSubmit = { onIntent(SearchIntent.Submit) },
-            )
-            SearchOptions(
-                textScope = state.textScope,
-                onTextScopeSelected = { onIntent(SearchIntent.TextScopeSelected(it)) },
-            )
-            if (state.pivotCategories.isNotEmpty()) {
-                PivotChips(
-                    pivot = state.pivotCategories,
-                    selected = state.selectedCategory,
-                    onSelect = { onIntent(SearchIntent.CategorySelected(it)) },
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(start = 16.dp, end = 16.dp, bottom = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                SearchField(
+                    query = state.query,
+                    isSubmitEnabled = !state.isLoading && state.query.isNotBlank(),
+                    onQueryChange = { onIntent(SearchIntent.QueryChanged(it)) },
+                    onSubmit = { onIntent(SearchIntent.Submit) },
+                )
+                SearchOptions(
+                    textScope = state.textScope,
+                    onTextScopeSelected = { onIntent(SearchIntent.TextScopeSelected(it)) },
+                )
+                if (state.pivotCategories.isNotEmpty()) {
+                    PivotChips(
+                        pivot = state.pivotCategories,
+                        selected = state.selectedCategory,
+                        onSelect = { onIntent(SearchIntent.CategorySelected(it)) },
+                    )
+                }
+                HorizontalDivider()
+                // `Modifier.weight(1f)` is required so the inner `LazyColumn` (in
+                // `ResultsList`) gets a bounded vertical constraint. Without it, the
+                // child `LazyColumn` measures with `Constraints.Infinity` and Compose
+                // throws `IllegalStateException: Vertically scrollable component was
+                // measured with an infinite max constraints`.
+                SearchBody(
+                    state = state,
+                    onRetry = { onIntent(SearchIntent.Retry) },
+                    onOpenTopic = onOpenTopic,
+                    modifier = Modifier.weight(1f),
                 )
             }
-            HorizontalDivider()
-            // `Modifier.weight(1f)` is required so the inner `LazyColumn` (in
-            // `ResultsList`) gets a bounded vertical constraint. Without it, the
-            // child `LazyColumn` measures with `Constraints.Infinity` and Compose
-            // throws `IllegalStateException: Vertically scrollable component was
-            // measured with an infinite max constraints`.
-            SearchBody(
-                state = state,
-                onRetry = { onIntent(SearchIntent.Retry) },
-                onOpenTopic = onOpenTopic,
-                modifier = Modifier.weight(1f),
-            )
         }
     }
 }

--- a/feature/topic/build.gradle.kts
+++ b/feature/topic/build.gradle.kts
@@ -23,6 +23,9 @@ dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:extension"))
 
+    // androidx.core.net.toUri for the post-menu « Ouvrir dans le navigateur » action (#362
+    // follow-up) — same ktx idiom as the mailto: intent in :app.
+    implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.runtime.compose)

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostMenuSheet.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostMenuSheet.kt
@@ -1,50 +1,63 @@
 package fr.forumhfr.redface2.feature.topic
 
+import android.content.ActivityNotFoundException
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.content.Intent
 import android.os.Build
 import android.widget.Toast
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import fr.forumhfr.redface2.core.model.Post
+import fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 /**
  * #362 — per-post contextual menu, opened from the `⋯` trigger in the post header
- * ([TopicPostCard]). Carries:
+ * ([TopicPostCard]). Layout mirrors `ProfilePreviewSheet` (dogfooding feedback on v102:
+ * the original plain-text sheet read as unfinished next to the profile one):
  *
- * - an identity header: author + « Post n°{numreponse} » (the post number moved here
- *   from the header bar) + post date;
- * - the « Copier le lien de ce post » action — copies the canonical permalink
- *   ([buildPostPermalink]) and closes the sheet. Feedback follows the Diagnostics
- *   clipboard pattern: Android 13+ shows the system clipboard overlay natively, older
- *   devices get a Toast;
- * - an « Édité le … » info line when [Post.editedAt] is non-null;
- * - a « Cité N fois sur cette page » info line when [citedCount] > 0 (hidden at 0 —
- *   same page-scoped #239 count as the badge, which stays on the card).
+ * - a hero row: avatar + author, with « Post n°{numreponse} » (the post number moved
+ *   here from the header bar) and the post date underneath;
+ * - optional info lines: « Édité le … » when [Post.editedAt] is non-null, and
+ *   « Cité N fois sur cette page » when [citedCount] > 0 (hidden at 0 — same
+ *   page-scoped #239 count as the badge, which stays on the card);
+ * - stacked full-width actions, profile-sheet style: a filled « Copier le lien de ce
+ *   post » (primary), an outlined « Ouvrir dans le navigateur » (debug-friendly: the
+ *   canonical permalink opens in the default browser), and a DISABLED « Alerter »
+ *   placeholder — the report flow is not implemented yet, the greyed button shows the
+ *   roadmap like the Settings « menu vitrine » (#288).
+ *
+ * Clipboard feedback follows the Diagnostics pattern: Android 13+ shows the system
+ * overlay natively, older devices get a Toast. Both real actions play the sheet's hide
+ * animation before releasing the state (cf. `hideThenDismiss`).
  *
  * Lives in `:feature:topic` (local UI state in `TopicScreen`, no ViewModel): unlike
  * `ProfilePreviewSheet`, hoisted in `:app` only because it needs a Hilt ViewModel,
@@ -61,9 +74,9 @@ internal fun PostMenuSheet(
     val sheetState = rememberModalBottomSheetState()
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
-    // Resolved at composition time — the copy callback runs outside composition.
+    // Resolved at composition time — the action callbacks run outside composition.
     val copiedFeedback = stringResource(R.string.topic_post_menu_link_copied)
-    val copyLabel = stringResource(R.string.topic_post_menu_copy_link)
+    val browserFailedFeedback = stringResource(R.string.topic_post_menu_no_browser)
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -75,6 +88,97 @@ internal fun PostMenuSheet(
                 .padding(horizontal = 16.dp, vertical = 8.dp)
                 .navigationBarsPadding(),
         ) {
+            PostMenuHero(post = post)
+
+            if (post.editedAt != null || citedCount > 0) {
+                Spacer(Modifier.height(12.dp))
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                Spacer(Modifier.height(8.dp))
+                post.editedAt?.let { editedAt ->
+                    Text(
+                        text = stringResource(
+                            R.string.topic_post_menu_edited,
+                            editedAt.asTopicDate(),
+                        ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(vertical = 2.dp),
+                    )
+                }
+                if (citedCount > 0) {
+                    Text(
+                        text = pluralStringResource(
+                            R.plurals.topic_post_menu_cited_on_page,
+                            citedCount,
+                            citedCount,
+                        ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(vertical = 2.dp),
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            Button(
+                onClick = {
+                    copyPermalinkToClipboard(context, permalink, copiedFeedback)
+                    hideThenDismiss(coroutineScope, sheetState, onDismiss)
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.topic_post_menu_copy_link))
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            OutlinedButton(
+                onClick = {
+                    openPermalinkInBrowser(context, permalink, browserFailedFeedback)
+                    hideThenDismiss(coroutineScope, sheetState, onDismiss)
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.topic_post_menu_open_in_browser))
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            // Report flow not implemented yet — greyed « menu vitrine » placeholder (#288
+            // pattern): the affordance is visible, the « (à venir) » suffix explains why it
+            // is disabled.
+            OutlinedButton(
+                onClick = {},
+                enabled = false,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.topic_post_menu_report_soon))
+            }
+
+            Spacer(Modifier.height(8.dp))
+        }
+    }
+}
+
+/**
+ * Hero row of the sheet — avatar + author with the post identity (number, date)
+ * underneath, mirroring `ProfilePreviewHero`. [RedfaceUserAvatar] handles the
+ * `avatarUrl == null` / load-error placeholder on its own.
+ */
+@Composable
+private fun PostMenuHero(post: Post) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        RedfaceUserAvatar(
+            avatarUrl = post.avatarUrl,
+            author = post.author,
+            size = 56.dp,
+        )
+        Column {
             Text(
                 text = post.author,
                 style = MaterialTheme.typography.titleMedium,
@@ -90,51 +194,6 @@ internal fun PostMenuSheet(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-
-            Spacer(Modifier.height(8.dp))
-            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-
-            Text(
-                text = copyLabel,
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable(
-                        // Copy immediately, then play the hide animation before releasing the
-                        // state (cf. ProfilePreviewSheet's hideThenNavigate) — « au plus
-                        // simple »: the clipboard write has no reason to wait for the sheet.
-                        onClick = {
-                            copyPermalinkToClipboard(context, permalink, copiedFeedback)
-                            hideThenDismiss(coroutineScope, sheetState, onDismiss)
-                        },
-                        role = Role.Button,
-                        onClickLabel = copyLabel,
-                    )
-                    .padding(vertical = 14.dp),
-            )
-
-            post.editedAt?.let { editedAt ->
-                Text(
-                    text = stringResource(R.string.topic_post_menu_edited, editedAt.asTopicDate()),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(vertical = 4.dp),
-                )
-            }
-            if (citedCount > 0) {
-                Text(
-                    text = pluralStringResource(
-                        R.plurals.topic_post_menu_cited_on_page,
-                        citedCount,
-                        citedCount,
-                    ),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(vertical = 4.dp),
-                )
-            }
-
-            Spacer(Modifier.height(8.dp))
         }
     }
 }
@@ -149,6 +208,19 @@ private fun copyPermalinkToClipboard(context: Context, permalink: String, feedba
     clipboard.setPrimaryClip(ClipData.newPlainText("redface2 post link", permalink))
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
         Toast.makeText(context, feedback, Toast.LENGTH_SHORT).show()
+    }
+}
+
+/**
+ * Fires an `ACTION_VIEW` on the canonical permalink — lands in the default browser (or
+ * the user's link-handling app). A device without any handler is vanishingly rare but
+ * cheap to survive: the failure surfaces as a Toast instead of a crash.
+ */
+private fun openPermalinkInBrowser(context: Context, permalink: String, failureFeedback: String) {
+    try {
+        context.startActivity(Intent(Intent.ACTION_VIEW, permalink.toUri()))
+    } catch (ignored: ActivityNotFoundException) {
+        Toast.makeText(context, failureFeedback, Toast.LENGTH_SHORT).show()
     }
 }
 

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -19,6 +19,9 @@
     <string name="topic_post_menu_number">Post n°%1$d</string>
     <string name="topic_post_menu_copy_link">Copier le lien de ce post</string>
     <string name="topic_post_menu_link_copied">Lien copié</string>
+    <string name="topic_post_menu_open_in_browser">Ouvrir dans le navigateur</string>
+    <string name="topic_post_menu_no_browser">Aucun navigateur disponible</string>
+    <string name="topic_post_menu_report_soon">Alerter (à venir)</string>
     <string name="topic_post_menu_edited">Édité le %1$s</string>
     <plurals name="topic_post_menu_cited_on_page">
         <item quantity="one">Cité %1$d fois sur cette page</item>


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Retours dogfooding v102 (refs #362, #325 — livrées sur dev, fermeront à la promotion).

## Quoi

- **Menu de post réorganisé façon `ProfilePreviewSheet`** : hero avatar + pseudo avec n° de post et date en dessous, lignes « Édité le … » / « Cité N fois » sous séparateur, puis actions en boutons pleine largeur — « Copier le lien de ce post » (filled), **« Ouvrir dans le navigateur »** (outlined, `ACTION_VIEW` sur le permalien, utile en debug) et **« Alerter (à venir) » grisé** (placeholder vitrine du flux de signalement non implémenté, pattern #288). `:feature:topic` gagne `androidx core-ktx` (`toUri`, idiome `:app`).
- **Ligne drapeaux non tronquée** : pied scindé en deux segments (`FlagMetadata` dans `:core:ui`) — gauche `auteur · p.X/Y`, seul autorisé à s'ellipsiser ; droite l'horodatage #325 à largeur intrinsèque, jamais coupé. Compteur de réponses retiré (redondant avec la pagination).
- **Icône engrenage** à la place du libellé « Affichage » dans l'en-tête Drapeaux (glyphe texte `U+2699 U+FE0E`, ForbiddenImport bannit les material-icons ; libellé conservé en contentDescription TalkBack).
- **En-tête Recherche réaligné** sur Drapeaux/Forum/Messages (24/12) : la gouttière de contenu 16 dp s'appliquait à tout l'écran, titre et avatar de compte étaient décalés.

## Validation

Locale ×2 : `detektAll test testDebugUnitTest :app:assembleProdDebug --rerun-tasks` (2m59) puis `lintDebug :app:lintProdDebug` (1m31) — vertes. Reviews multi-agent sautées sur consigne (« fais pas de 4 flavors review, d'abord go sur dev »).

## Merge

Squash `--admin` mono-maintainer (cf. AGENTS.md § Review en mono-maintainer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)