### PR TITLE
fix(network): timeout réel du probe recherche + bump 0.8.0 (prép. bêta)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,33 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## v104 — `0.8.0` — 2026-06-10
+
+**Statut** : `local` (entrée écrite avant le dispatch ; passer à `open` + F-Droid `.beta` après le ship)
+**Commit** : merge de promotion `dev → main` (numéro v104 anticipé : registre de tags à 103 au moment du bump)
+**Fichier** : AAB `bundleProdRelease` (`fr.forumhfr.redface2`) → **track open testing** + tag pour F-Droid beta
+
+**Troisième batch** : night-run 2026-06-10 (8 items, dont 7 features/fixes code) + lot dogfooding même journée, dogfoodé sur le canal dev (v102 → v103).
+
+### Added
+- **Menu contextuel de post** (#362) — icône « ⋯ » dans la barre du post : pseudo + avatar, numéro du post (déplacé ici), « Copier le lien de ce post », « Ouvrir dans le navigateur », date d'édition, nombre de citations sur la page ; « Alerter (à venir) » grisé.
+- **Horodatage du dernier message** (#325) — dans les listes catégorie, recherche et drapeaux ; sur les drapeaux il est aligné à droite et jamais tronqué (le compteur de réponses, redondant avec p.X/Y, disparaît).
+- **Vider le cache des images** (#314) — Réglages › carte Maintenance (mémoire + disque Coil).
+- **Confirmation avant publication** (#312) — toggle Réglages (désactivé par défaut) ; couvre réponse, création de topic, édition de post et réponse MP, avec wording dédié MP.
+- **Panne HFR vs coupure réseau** (#324) — les écrans de lecture distinguent « HFR est en panne » (5xx serveur) de « pas de connexion » ; la session expirée garde son bouton de reconnexion.
+
+### Fixed
+- **Résultats de recherche** (#277) — ouvrir un résultat atterrit sur la bonne page et le bon post (résolution par redirection HFR côté serveur ; budget réseau 3 s appliqué par OkHttp avec repli page 1 — durci post-review Codex de promotion).
+- **Position de lecture par page** (#307) — revenir sur une page déjà visitée d'un sujet (swipe, pager, retour) reprend la position quittée au lieu du haut de page (cache session borné, priorité aux atterrissages deep-link/post-publication).
+- **En-tête Recherche** réaligné sur le gabarit des autres onglets (titre et avatar n'étaient pas aux mêmes marges).
+
+### Changed
+- **`versionName` 0.7.0 → 0.8.0**.
+- **En-tête Drapeaux** : icône engrenage à la place du libellé « Affichage » (libellé conservé pour TalkBack).
+- ADR-013 « Lecture MP : partage topic↔MP, cache 3 étages, prefetch borné » ajoutée (statut Proposé).
+
+---
+
 ## v101 — `0.7.0` — 2026-06-09
 
 **Statut** : `open` (track open testing) + F-Droid `.beta`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.7.0"
+        versionName = "0.8.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
@@ -532,9 +532,17 @@ class HfrClient @Inject constructor(
      * Anonymous client variant that does NOT follow redirects, for callers that consume
      * the `Location` header itself (cf. [resolveTopicPageUrl]). Derived once — sharing
      * the connection pool / dispatcher of [anonymous] — instead of being rebuilt per call.
+     *
+     * The tight [HfrConstants.ProbeCallTimeout] (3 s vs the 30 s default) is the REAL
+     * timeout of the probe : the caller's `withTimeoutOrNull` cannot interrupt a blocking
+     * `execute()`, so without it a degraded network would freeze the search tap (and its
+     * in-flight guard) for the full default call timeout (promotion review finding).
      */
     private val anonymousNoRedirect: OkHttpClient by lazy {
-        anonymous.newBuilder().followRedirects(false).build()
+        anonymous.newBuilder()
+            .followRedirects(false)
+            .callTimeout(HfrConstants.ProbeCallTimeout)
+            .build()
     }
 
     /**

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrConstants.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrConstants.kt
@@ -22,4 +22,13 @@ object HfrConstants {
     val ReadTimeout: Duration = Duration.ofSeconds(20)
     val WriteTimeout: Duration = Duration.ofSeconds(20)
     val CallTimeout: Duration = Duration.ofSeconds(30)
+
+    /**
+     * End-to-end budget of the search-result page probe (`resolveTopicPageUrl`, #277).
+     * MUST stay <= the ViewModel-side `RESOLVE_TIMEOUT_MS` (3 s) : coroutine cancellation
+     * cannot interrupt a blocking OkHttp `execute()`, so the enforcement lives HERE —
+     * OkHttp aborts the call itself and surfaces an IOException, which the probe already
+     * degrades to its page-1 fallback. The coroutine timeout is only a belt-and-braces.
+     */
+    val ProbeCallTimeout: Duration = Duration.ofSeconds(3)
 }

--- a/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/HfrClientTest.kt
+++ b/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/HfrClientTest.kt
@@ -5,6 +5,7 @@ import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.search.SearchTextScope
 import java.time.LocalDate
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
@@ -270,6 +271,32 @@ class HfrClientTest {
         server.shutdown()
 
         assertNull(client.resolveTopicPageUrl(cat = 23, post = 35421, numreponse = 2786758))
+    }
+
+    @Test
+    fun `resolveTopicPageUrl aborts a stalled probe after its dedicated call timeout`() = runTest {
+        // Promotion-review finding : coroutine cancellation cannot interrupt a blocking
+        // OkHttp execute(), so the 3 s probe budget MUST be enforced by OkHttp itself
+        // (ProbeCallTimeout on the derived no-redirect client). The server stalls the
+        // headers for 10 s ; without the dedicated timeout the call would only die at the
+        // 30 s default — and the late answer would then be a perfectly valid redirect,
+        // so the assertNull below would fail too (double signal).
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(301)
+                .addHeader("Location", "/hfr/cat/sujet_1_3.htm#t42")
+                .setHeadersDelay(10, TimeUnit.SECONDS),
+        )
+
+        val startedAtMs = System.currentTimeMillis()
+        val location = client.resolveTopicPageUrl(cat = 23, post = 35421, numreponse = 2786758)
+        val elapsedMs = System.currentTimeMillis() - startedAtMs
+
+        assertNull("a stalled probe must degrade to the page-1 fallback", location)
+        assertTrue(
+            "probe must be cut by its own call timeout, not the 30 s default (took ${"$"}{elapsedMs}ms)",
+            elapsedMs < 9_000,
+        )
     }
 
     @Test


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Dernière PR avant la promotion `dev → main` (bêta 0.8.0).

## Quoi

- **Fix du finding important de la review Codex de promotion** (seul finding sur les 9 PR du jour, zéro bloquant) : le `withTimeoutOrNull(3 s)` du `SearchViewModel` ne peut pas interrompre un `Call.execute()` OkHttp bloquant — en réseau dégradé, un tap sur résultat de recherche restait muet jusqu'au `callTimeout` par défaut (30 s), guard in-flight verrouillé. Le budget est désormais appliqué par OkHttp (`HfrConstants.ProbeCallTimeout` = 3 s sur le client dérivé no-redirect) ; l'`IOException` retombe sur le fallback page-1 existant. Test MockWebServer : headers retardés de 10 s → `null` en ~3 s (double signal : une réponse tardive serait un redirect valide).
- **Bump `versionName` 0.7.0 → 0.8.0** (guard CI : la bêta v101 est en 0.7.0) + entrée `app/CHANGELOG.md` v104.

## Validation

Locale ×2 verte (3m07 + 51s, fix probe ; le bump est doc + une ligne gradle).

## Merge

Squash `--admin` mono-maintainer (cf. AGENTS.md § Review en mono-maintainer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)