### PR TITLE
fix(forum): pastilles de drapeau atténuées quand le topic est lu (#329)

### DIFF
--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
@@ -372,7 +372,7 @@ private fun TopicRow(
         modifier = rowModifier,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        FlagIndicator(flagType = topic.flagType)
+        FlagIndicator(flagType = topic.flagType, hasUnread = topic.hasUnread)
         Column(modifier = Modifier.fillMaxWidth()) {
             Text(
                 text = topic.title,
@@ -405,8 +405,11 @@ private fun TopicRow(
     }
 }
 
+/** Alpha of a read flag dot — same dimming contract as `FlagDot` (:core:ui FlagItem). */
+private const val READ_FLAG_DOT_ALPHA = 0.35f
+
 @Composable
-private fun FlagIndicator(flagType: FlagType?) {
+private fun FlagIndicator(flagType: FlagType?, hasUnread: Boolean?) {
     // Reserve the same gutter width on every row, flagged or not, so titles stay
     // left-aligned across rows in mixed (auth) listings. When flagType is null the
     // gutter is an empty Spacer; when it is non-null we paint the colored dot inside
@@ -419,7 +422,12 @@ private fun FlagIndicator(flagType: FlagType?) {
         Spacer(modifier = gutter)
         return
     }
-    val color = FlagPalette.colorFor(flagType)
+    // #329 — a read flag keeps its bucket colour but dims, so a vivid dot means
+    // « unread » : same visual grammar as the Drapeaux tab. `hasUnread` is tri-state ;
+    // null (state unknown, e.g. REST omitted the field) keeps the vivid dot rather
+    // than wrongly claiming the topic was read.
+    val base = FlagPalette.colorFor(flagType)
+    val color = if (hasUnread == false) base.copy(alpha = READ_FLAG_DOT_ALPHA) else base
     val description = stringResource(
         when (flagType) {
             FlagType.CYAN -> R.string.category_flag_cyan


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi

Dans les listings de l'onglet Forum, la pastille de drapeau d'une ligne lue est désormais **atténuée à 35 % d'alpha** — même grammaire visuelle que l'onglet Drapeaux (`FlagDot`, `:core:ui`) : pastille vive = non-lu.

## Cause racine (#329)

Ce n'était **pas** un problème de cache ou de refresh : la donnée (`TopicSummary.hasUnread`, issue du champ REST `is_read`) arrive bien et se rafraîchit au retour de lecture. C'est `FlagIndicator` (ForumCategoryScreen) qui peignait la pastille à pleine vivacité **sans jamais consulter `hasUnread`** — l'axe lu/non-lu n'était porté que par la graisse du titre. État visuel jamais implémenté, conforme au « c'est pas encore fait » de XaTriX (#2786485).

`hasUnread` est tri-état : `null` (champ absent côté REST) garde la pastille vive plutôt que de prétendre à tort que le topic est lu.

## Hors périmètre

Staleness résiduelle de quelques secondes si on revient d'un topic en moins de 5 s (fenêtre `WhileSubscribed` du ViewModel) — territoire de l'auto-refresh des listes (#335).

`Closes-#329` volontairement cassé ici : la fermeture sera portée par la PR de promotion dev→main.

## Validation

Locale 2 parts verte : `detektAll test testDebugUnitTest :app:assembleProdDebug` puis `lintDebug :app:lintProdDebug` (Docker, `--max-workers=2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
