### PR TITLE
feat(editor): boutons tonaux pour Options/Smileys dans la barre d'éditeur

### DIFF
--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -298,11 +299,17 @@ internal fun EditorSubmitBar(
                     .padding(horizontal = 16.dp, vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                TextButton(onClick = actions.onOpenOptions) {
+                // Tonal containers for the secondary triggers, filled for « Envoyer » — the
+                // canonical M3 emphasis pair (user choice over outlined / bare text). The
+                // expressive press-morphing `shapes` overload does NOT exist on material3
+                // 1.4.0 (no ButtonShapes in the artifact, verified at the bytecode) — revisit
+                // when the BOM bumps material3.
+                FilledTonalButton(onClick = actions.onOpenOptions) {
                     Text(text = stringResource(R.string.editor_actions_options))
                 }
                 actions.onOpenSmileys?.let { openSmileys ->
-                    TextButton(onClick = openSmileys) {
+                    Spacer(modifier = Modifier.width(8.dp))
+                    FilledTonalButton(onClick = openSmileys) {
                         Text(text = stringResource(R.string.editor_smiley_open))
                     }
                 }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -320,7 +321,9 @@ private fun ReplySubmitBar(
                     .padding(horizontal = 16.dp, vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                TextButton(onClick = onOpenOptions) {
+                // Tonal container for the secondary trigger, filled for « Envoyer » — same M3
+                // emphasis pair as the post editor's bar.
+                FilledTonalButton(onClick = onOpenOptions) {
                     Text(text = stringResource(R.string.messages_reply_actions_options))
                 }
                 Spacer(modifier = Modifier.weight(1f))


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi

Suite du retour dogfooding v106/v107 sur la barre d'éditeur : « Options » et « Smileys » passent de `TextButton` (texte nu) à **`FilledTonalButton`** (contenant teinté en pilule), avec un écart de 8 dp entre les deux. « Envoyer » reste le seul bouton plein — c'est la paire d'emphase canonique M3 (tonal = secondaire, filled = action principale). Les deux barres (éditeur post/sujet et réponse MP) sont alignées.

Choix fait avec XaTriX parmi 4 options (tonal / outlined / groupe connecté expressif / statu quo).

## Morphing expressif : différé

Le second choix (shape morphing à l'appui, `shapes = ButtonDefaults.shapes()`) a été tenté puis replié : **l'API n'existe pas dans material3 1.4.0** — ni `ButtonShapes`, ni `ButtonDefaults.shapes()`, ni l'overload `Button(shapes=)` (vérifié au bytecode de l'artifact du BOM 2026.05.01, qui est le dernier BOM publié ; l'API ne vit que dans les 1.5.0-alpha). À réactiver quand une 1.5.0 stable sortira.

## Validation

Locale 2 parts verte : `detektAll test testDebugUnitTest :app:assembleProdDebug` puis `lintDebug :app:lintProdDebug` (Docker, `--max-workers=2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
