### PR TITLE
fix(editor): libellé « Confirmer ? » + champ de rédaction extensible

### DIFF
--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -304,13 +304,19 @@ internal fun EditorSubmitBar(
                 // expressive press-morphing `shapes` overload does NOT exist on material3
                 // 1.4.0 (no ButtonShapes in the artifact, verified at the bytecode) — revisit
                 // when the BOM bumps material3.
-                FilledTonalButton(onClick = actions.onOpenOptions) {
-                    Text(text = stringResource(R.string.editor_actions_options))
-                }
-                actions.onOpenSmileys?.let { openSmileys ->
-                    Spacer(modifier = Modifier.width(8.dp))
-                    FilledTonalButton(onClick = openSmileys) {
-                        Text(text = stringResource(R.string.editor_smiley_open))
+                // While the confirmation is armed the secondary triggers step aside : they
+                // are not actionable mid-confirmation anyway, and the freed width guarantees
+                // the armed label never wraps (the tonal pills ate the Row slack and
+                // line-broke « Confirmer ? » — dogfooding v108).
+                if (!state.confirmArmed) {
+                    FilledTonalButton(onClick = actions.onOpenOptions) {
+                        Text(text = stringResource(R.string.editor_actions_options))
+                    }
+                    actions.onOpenSmileys?.let { openSmileys ->
+                        Spacer(modifier = Modifier.width(8.dp))
+                        FilledTonalButton(onClick = openSmileys) {
+                            Text(text = stringResource(R.string.editor_smiley_open))
+                        }
                     }
                 }
                 Spacer(modifier = Modifier.weight(1f))
@@ -343,6 +349,7 @@ internal fun EditorSubmitBar(
                             text = stringResource(
                                 if (armed) R.string.editor_submit_confirm else R.string.editor_submit,
                             ),
+                            maxLines = 1,
                         )
                     }
                 }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -96,11 +96,17 @@ private fun PostEditorContent(
         color = MaterialTheme.colorScheme.surface,
     ) {
         Column(modifier = Modifier.fillMaxSize().statusBarsPadding()) {
+            // No outer scroll : the draft field is weighted so it stretches to fill every
+            // free pixel down to the bottom bar (dogfooding v108 — the column used to leave
+            // a large blank under « Afficher l'aperçu »). Long content scrolls INSIDE the
+            // field (and inside the preview pane), which is also why weight() is usable at
+            // all — it needs the bounded height an outer verticalScroll would destroy.
+            // Keyboard handling is unchanged : the bar's IME inset grows, this column
+            // shrinks by the same amount (weight absorbs), the field compresses.
             Column(
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth()
-                    .verticalScroll(rememberScrollState())
                     .padding(horizontal = 16.dp, vertical = 12.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
@@ -120,6 +126,7 @@ private fun PostEditorContent(
                     onValueChange = { value -> onIntent(PostEditorIntent.ContentChanged(value)) },
                     label = stringResource(R.string.editor_field_label),
                     placeholder = stringResource(R.string.editor_field_placeholder),
+                    modifier = Modifier.weight(1f),
                 )
 
                 Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
@@ -138,7 +145,15 @@ private fun PostEditorContent(
 
                 if (state.isPreviewVisible) {
                     HorizontalDivider()
-                    BbcodePreview(content = state.preview)
+                    // The preview shares the stretch with the field (50/50) and scrolls
+                    // internally — long rendered content must not push the bar off-screen.
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                            .verticalScroll(rememberScrollState()),
+                    ) {
+                        BbcodePreview(content = state.preview)
+                    }
                 }
 
                 state.submitError?.let { error ->

--- a/feature/editor/src/main/res/values/strings.xml
+++ b/feature/editor/src/main/res/values/strings.xml
@@ -31,7 +31,7 @@
     <string name="editor_new_topic_created">Sujet créé. Rafraîchis la liste si besoin pour le retrouver.</string>
     <string name="editor_smiley_open">Smileys</string>
     <string name="editor_actions_options">Options</string>
-    <string name="editor_submit_confirm">Confirmer ?</string>
+    <string name="editor_submit_confirm">Confirmer&#160;?</string>
     <string name="editor_smiley_title">Smileys</string>
     <string name="editor_smiley_tab_standard">Standard</string>
     <string name="editor_smiley_tab_wiki">Wiki</string>

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
@@ -322,9 +322,12 @@ private fun ReplySubmitBar(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 // Tonal container for the secondary trigger, filled for « Envoyer » — same M3
-                // emphasis pair as the post editor's bar.
-                FilledTonalButton(onClick = onOpenOptions) {
-                    Text(text = stringResource(R.string.messages_reply_actions_options))
+                // emphasis pair as the post editor's bar. Hidden while the confirmation is
+                // armed so the armed label never wraps (same fix as the editor bar).
+                if (!confirmArmed) {
+                    FilledTonalButton(onClick = onOpenOptions) {
+                        Text(text = stringResource(R.string.messages_reply_actions_options))
+                    }
                 }
                 Spacer(modifier = Modifier.weight(1f))
                 if (isSubmitting) {
@@ -353,6 +356,7 @@ private fun ReplySubmitBar(
                                 R.string.messages_reply_submit
                             },
                         ),
+                        maxLines = 1,
                     )
                 }
             }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
@@ -227,10 +227,12 @@ private fun ReplyEditorBody(
     onErrorDismissed: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // No outer scroll : the draft field is weighted so it stretches down to the bar (same
+    // extensible-field design as the post editor) ; long content scrolls INSIDE the field
+    // and inside the preview pane.
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .verticalScroll(rememberScrollState())
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
@@ -241,6 +243,7 @@ private fun ReplyEditorBody(
             onValueChange = onContentChanged,
             label = stringResource(R.string.messages_reply_field_label),
             placeholder = stringResource(R.string.messages_reply_field_placeholder),
+            modifier = Modifier.weight(1f),
         )
 
         Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
@@ -259,7 +262,14 @@ private fun ReplyEditorBody(
 
         if (state.isPreviewVisible) {
             HorizontalDivider()
-            BbcodePreview(content = state.preview)
+            // Shares the stretch with the field (50/50) and scrolls internally.
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                BbcodePreview(content = state.preview)
+            }
         }
 
         state.submitError?.let { error ->

--- a/feature/messages/src/main/res/values/strings.xml
+++ b/feature/messages/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="messages_reply_preview_show">Aperçu</string>
     <string name="messages_reply_preview_hide">Masquer l\'aperçu</string>
     <string name="messages_reply_submit">Envoyer</string>
-    <string name="messages_reply_submit_confirm">Confirmer ?</string>
+    <string name="messages_reply_submit_confirm">Confirmer&#160;?</string>
     <string name="messages_reply_actions_options">Options</string>
     <string name="messages_reply_options_title">Options</string>
     <string name="messages_reply_option_signature">Activer la signature</string>


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi (2 commits, retours dogfooding v108)

### 1. Bugfix — « Confirmer ? » cassé sur deux lignes

Les pilules tonales (#390) mangent le mou de la Row : le libellé armé passait à la ligne (« Confirme / r ? »). Fix : pendant que la confirmation est armée, les déclencheurs secondaires s'effacent (ils ne sont pas actionnables à ce moment-là) → toute la largeur pour le bouton ; ceinture et bretelles : `maxLines = 1` + espace insécable avant « ? ».

### 2. Champ de rédaction extensible (choix XaTriX parmi 4 options)

L'éditeur de post et la réponse MP laissaient un grand vide entre « Afficher l'aperçu » et la barre du bas. Le scroll global de la colonne disparaît au profit d'un champ **weighté** qui s'étire jusqu'à la barre — le contenu long scrolle *dans* le champ. Aperçu ouvert : partage 50/50 avec scroll interne (le rendu ne peut jamais pousser la barre hors écran). Clavier : inchangé — l'inset IME de la barre grandit, la colonne weightée se compresse d'autant.

**`TopicFormScreen` garde volontairement son scroll** : son chrome (sujet + sous-catégorie + toolbar) remplit déjà les petits écrans et a besoin de l'échappatoire scroll quand l'IME est ouvert.

## Validation

Locale 2 parts verte : `detektAll test testDebugUnitTest :app:assembleProdDebug` puis `lintDebug :app:lintProdDebug` (Docker, `--max-workers=2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
