### PR TITLE
feat(topic): posts plus larges, bande d'identité, bouton Confirmer à rebours

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/ArmedSubmitButton.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/ArmedSubmitButton.kt
@@ -1,0 +1,125 @@
+package fr.forumhfr.redface2.core.ui.editor
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.unit.dp
+
+/** Display state of [ArmedSubmitButton]. [showProgress] swaps the label for a spinner. */
+data class ArmedSubmitState(
+    val armed: Boolean,
+    val enabled: Boolean,
+    val showProgress: Boolean = false,
+)
+
+/** Bare resolved strings — callers own their string resources. */
+data class ArmedSubmitLabels(
+    val submit: String,
+    val confirm: String,
+)
+
+/** [onDisarm] fires when the countdown elapses without the confirming tap. */
+data class ArmedSubmitActions(
+    val onSubmit: () -> Unit,
+    val onConfirmSubmit: () -> Unit,
+    val onDisarm: () -> Unit,
+)
+
+/** How long the armed state survives without the confirming second tap (#312 v2). */
+const val CONFIRM_DISARM_DELAY_MS = 4_000L
+
+/**
+ * M3 state layers use the content colour at low alpha to mark a state on top of a
+ * container — we reuse that exact idiom for the elapsed part of the countdown, so the
+ * label keeps full contrast on both the « live » and the « elapsed » halves.
+ */
+private const val ELAPSED_SCRIM_ALPHA = 0.16f
+
+/**
+ * Submit button with the « confirmation avant publication » (#312 v2) armed behaviour,
+ * shared by the post/topic editor bar and the MP reply bar.
+ *
+ * First tap arms the button (label flips to [ArmedSubmitLabels.confirm], tertiary
+ * colors) ; the second tap performs the real submit. While armed, the background
+ * visibly drains left-to-right over [CONFIRM_DISARM_DELAY_MS] — a state-layer scrim
+ * sweeps the elapsed portion — then [ArmedSubmitActions.onDisarm] restores the normal
+ * state. Material 3 has no built-in timed button, so the countdown is drawn here.
+ */
+@Composable
+fun ArmedSubmitButton(
+    state: ArmedSubmitState,
+    labels: ArmedSubmitLabels,
+    actions: ArmedSubmitActions,
+) {
+    // remaining fraction of the countdown : 1f (just armed) → 0f (expired). The single
+    // Animatable both paces the scrim and times the disarm, so they can never drift.
+    val remaining = remember { Animatable(1f) }
+    LaunchedEffect(state.armed) {
+        if (state.armed) {
+            remaining.snapTo(1f)
+            remaining.animateTo(
+                targetValue = 0f,
+                animationSpec = tween(
+                    durationMillis = CONFIRM_DISARM_DELAY_MS.toInt(),
+                    easing = LinearEasing,
+                ),
+            )
+            actions.onDisarm()
+        }
+    }
+    val scrim = MaterialTheme.colorScheme.onTertiary.copy(alpha = ELAPSED_SCRIM_ALPHA)
+    val shape = ButtonDefaults.shape
+    Button(
+        enabled = state.enabled,
+        onClick = if (state.armed) actions.onConfirmSubmit else actions.onSubmit,
+        colors = if (state.armed) {
+            // Distinct (but not destructive) palette : the second tap is a deliberate
+            // confirmation, not a warning.
+            ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.tertiary,
+                contentColor = MaterialTheme.colorScheme.onTertiary,
+            )
+        } else {
+            ButtonDefaults.buttonColors()
+        },
+        modifier = Modifier
+            .clip(shape)
+            .drawWithContent {
+                drawContent()
+                if (state.armed) {
+                    val liveWidth = size.width * remaining.value
+                    drawRect(
+                        color = scrim,
+                        topLeft = Offset(liveWidth, 0f),
+                        size = Size(size.width - liveWidth, size.height),
+                    )
+                }
+            },
+    ) {
+        if (state.showProgress) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(18.dp),
+                color = MaterialTheme.colorScheme.onPrimary,
+            )
+        } else {
+            Text(
+                text = if (state.armed) labels.confirm else labels.submit,
+                maxLines = 1,
+            )
+        }
+    }
+}

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -20,8 +20,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
@@ -43,11 +41,14 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
+import fr.forumhfr.redface2.core.ui.editor.ArmedSubmitActions
+import fr.forumhfr.redface2.core.ui.editor.ArmedSubmitButton
+import fr.forumhfr.redface2.core.ui.editor.ArmedSubmitLabels
+import fr.forumhfr.redface2.core.ui.editor.ArmedSubmitState
 import fr.forumhfr.redface2.core.ui.editor.BbcodePreview
 import fr.forumhfr.redface2.core.ui.editor.BbcodeTextField
 import fr.forumhfr.redface2.core.ui.editor.BbcodeToolbar
 import fr.forumhfr.redface2.core.ui.editor.EditorOptionsSheet
-import kotlinx.coroutines.delay
 
 /**
  * Post-level editor screen. Phase 2C (#145) adds a Submit button that posts the
@@ -268,30 +269,20 @@ internal data class EditorSubmitActions(
     val onOpenSmileys: (() -> Unit)? = null,
 )
 
-/** How long the armed « Confirmer ? » state survives without a second tap (#312 v2). */
-private const val CONFIRM_DISARM_DELAY_MS = 4_000L
-
 /**
  * Bottom action bar of an editor screen, pinned above the IME so the user never has to
  * dismiss the keyboard to reach « Envoyer ». Shared by [PostEditorContent] and
  * `TopicFormContent`. Besides submit, it now carries the « Options » trigger (per-post
  * toggles moved into [EditorOptionsSheet]) and the « Smileys » trigger — reclaiming the
- * vertical space both used to take around the draft field (dogfooding feedback).
+ * vertical space both used to take around the draft field (dogfooding feedback). The
+ * armed-confirmation behaviour (#312 v2, countdown drain included) lives in the shared
+ * [ArmedSubmitButton].
  */
 @Composable
 internal fun EditorSubmitBar(
     state: EditorSubmitState,
     actions: EditorSubmitActions,
 ) {
-    // #312 v2 — auto-disarm : an armed confirmation that is not confirmed within the
-    // delay silently falls back to the normal « Envoyer » state (same ViewModel intent
-    // as dismissing the old dialog). Keyed on the flag so any re-arm restarts the clock.
-    LaunchedEffect(state.confirmArmed) {
-        if (state.confirmArmed) {
-            delay(CONFIRM_DISARM_DELAY_MS)
-            actions.onDisarmConfirm()
-        }
-    }
     Surface(
         color = MaterialTheme.colorScheme.surfaceContainer,
         tonalElevation = 3.dp,
@@ -339,35 +330,22 @@ internal fun EditorSubmitBar(
                     CircularProgressIndicator(modifier = Modifier.size(20.dp))
                     Spacer(modifier = Modifier.width(12.dp))
                 }
-                val armed = state.confirmArmed
-                Button(
-                    enabled = state.canSubmit,
-                    onClick = if (armed) actions.onConfirmSubmit else actions.onSubmit,
-                    colors = if (armed) {
-                        // Distinct (but not destructive) palette : the second tap is a
-                        // deliberate confirmation, not a warning.
-                        ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.tertiary,
-                            contentColor = MaterialTheme.colorScheme.onTertiary,
-                        )
-                    } else {
-                        ButtonDefaults.buttonColors()
-                    },
-                ) {
-                    if (state.isSubmitting) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(18.dp),
-                            color = MaterialTheme.colorScheme.onPrimary,
-                        )
-                    } else {
-                        Text(
-                            text = stringResource(
-                                if (armed) R.string.editor_submit_confirm else R.string.editor_submit,
-                            ),
-                            maxLines = 1,
-                        )
-                    }
-                }
+                ArmedSubmitButton(
+                    state = ArmedSubmitState(
+                        armed = state.confirmArmed,
+                        enabled = state.canSubmit,
+                        showProgress = state.isSubmitting,
+                    ),
+                    labels = ArmedSubmitLabels(
+                        submit = stringResource(R.string.editor_submit),
+                        confirm = stringResource(R.string.editor_submit_confirm),
+                    ),
+                    actions = ArmedSubmitActions(
+                        onSubmit = actions.onSubmit,
+                        onConfirmSubmit = actions.onConfirmSubmit,
+                        onDisarm = actions.onDisarmConfirm,
+                    ),
+                )
             }
         }
     }

--- a/feature/editor/src/main/res/values/strings.xml
+++ b/feature/editor/src/main/res/values/strings.xml
@@ -31,7 +31,7 @@
     <string name="editor_new_topic_created">Sujet créé. Rafraîchis la liste si besoin pour le retrouver.</string>
     <string name="editor_smiley_open">Smileys</string>
     <string name="editor_actions_options">Options</string>
-    <string name="editor_submit_confirm">Confirmer&#160;?</string>
+    <string name="editor_submit_confirm">Confirmer</string>
     <string name="editor_smiley_title">Smileys</string>
     <string name="editor_smiley_tab_standard">Standard</string>
     <string name="editor_smiley_tab_wiki">Wiki</string>

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
@@ -48,12 +47,15 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.ui.editor.ArmedSubmitActions
+import fr.forumhfr.redface2.core.ui.editor.ArmedSubmitButton
+import fr.forumhfr.redface2.core.ui.editor.ArmedSubmitLabels
+import fr.forumhfr.redface2.core.ui.editor.ArmedSubmitState
 import fr.forumhfr.redface2.core.ui.editor.BbcodeAction
 import fr.forumhfr.redface2.core.ui.editor.BbcodePreview
 import fr.forumhfr.redface2.core.ui.editor.BbcodeTextField
 import fr.forumhfr.redface2.core.ui.editor.BbcodeToolbar
 import fr.forumhfr.redface2.core.ui.editor.EditorOptionsSheet
-import kotlinx.coroutines.delay
 
 /**
  * Reply editor for a private-message conversation (#301). Reuses the shared `:core:ui` BBCode
@@ -285,15 +287,12 @@ private fun ReplyEditorBody(
     }
 }
 
-/** How long the armed « Confirmer ? » state survives without a second tap (#312 v2). */
-private const val CONFIRM_DISARM_DELAY_MS = 4_000L
-
 /**
  * Send button pinned to the bottom, lifted above the IME so the user never dismisses the keyboard to
  * reach « Envoyer ». Mirrors the post editor's submit bar (the editor's `EditorSubmitBar` is module-
  * private, so the window-insets pattern is replicated here). Requires `windowSoftInputMode=adjustNothing`.
- * #312 v2 : the confirmation preference arms the button (« Confirmer ? », tertiary colors) instead of
- * raising the old modal dialog — the SECOND tap sends, and the armed state auto-disarms after a delay.
+ * The armed-confirmation behaviour (#312 v2, countdown drain included) lives in the shared
+ * [ArmedSubmitButton].
  */
 @Composable
 @Suppress("LongParameterList") // Mirrors the editor bar's state + actions.
@@ -306,15 +305,6 @@ private fun ReplySubmitBar(
     onDisarmConfirm: () -> Unit,
     onOpenOptions: () -> Unit,
 ) {
-    // Auto-disarm : an armed confirmation that is not confirmed within the delay silently
-    // falls back to « Envoyer » (same ViewModel intent as dismissing the old dialog).
-    // Keyed on the flag so any re-arm restarts the clock.
-    LaunchedEffect(confirmArmed) {
-        if (confirmArmed) {
-            delay(CONFIRM_DISARM_DELAY_MS)
-            onDisarmConfirm()
-        }
-    }
     Surface(color = MaterialTheme.colorScheme.surfaceContainer, tonalElevation = 3.dp) {
         Column(modifier = Modifier.fillMaxWidth()) {
             HorizontalDivider()
@@ -344,31 +334,18 @@ private fun ReplySubmitBar(
                     CircularProgressIndicator(modifier = Modifier.size(20.dp))
                     Spacer(modifier = Modifier.width(12.dp))
                 }
-                Button(
-                    enabled = canSubmit,
-                    onClick = if (confirmArmed) onConfirmSubmit else onSubmit,
-                    colors = if (confirmArmed) {
-                        // Distinct (but not destructive) palette : the second tap is a
-                        // deliberate confirmation, not a warning.
-                        ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.tertiary,
-                            contentColor = MaterialTheme.colorScheme.onTertiary,
-                        )
-                    } else {
-                        ButtonDefaults.buttonColors()
-                    },
-                ) {
-                    Text(
-                        text = stringResource(
-                            if (confirmArmed) {
-                                R.string.messages_reply_submit_confirm
-                            } else {
-                                R.string.messages_reply_submit
-                            },
-                        ),
-                        maxLines = 1,
-                    )
-                }
+                ArmedSubmitButton(
+                    state = ArmedSubmitState(armed = confirmArmed, enabled = canSubmit),
+                    labels = ArmedSubmitLabels(
+                        submit = stringResource(R.string.messages_reply_submit),
+                        confirm = stringResource(R.string.messages_reply_submit_confirm),
+                    ),
+                    actions = ArmedSubmitActions(
+                        onSubmit = onSubmit,
+                        onConfirmSubmit = onConfirmSubmit,
+                        onDisarm = onDisarmConfirm,
+                    ),
+                )
             }
         }
     }

--- a/feature/messages/src/main/res/values/strings.xml
+++ b/feature/messages/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="messages_reply_preview_show">Aperçu</string>
     <string name="messages_reply_preview_hide">Masquer l\'aperçu</string>
     <string name="messages_reply_submit">Envoyer</string>
-    <string name="messages_reply_submit_confirm">Confirmer&#160;?</string>
+    <string name="messages_reply_submit_confirm">Confirmer</string>
     <string name="messages_reply_actions_options">Options</string>
     <string name="messages_reply_options_title">Options</string>
     <string name="messages_reply_option_signature">Activer la signature</string>

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -800,7 +800,9 @@ private fun TopicLoadedContent(
         // #283 — extra bottom padding so the last post's right-aligned actions clear the floating
         // bottom-action cluster (the Scaffold FAB slot floats over the content). Harmless extra
         // breathing room when the cluster is absent (anon + single page).
-        contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 88.dp),
+        // 8 dp gutters (was 16) — posts are the app's main reading surface, every horizontal
+        // pixel counts on a phone ; the cards keep their own inner padding for breathing room.
+        contentPadding = PaddingValues(start = 8.dp, top = 16.dp, end = 8.dp, bottom = 88.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         item {
@@ -1183,11 +1185,18 @@ private fun TopicPostCard(
             },
         ),
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+        // Identity band — the avatar/pseudo/date header gets its own tinted strip across the
+        // full card width (forum idiom, dogfooding v109) : secondaryContainer over the neutral
+        // card, tertiaryContainer when the card itself is highlighted secondaryContainer so the
+        // band stays distinct. The Surface also sets LocalContentColor to the matching
+        // on-container colour for the pseudo. The Card clips the strip to its rounded corners.
+        Surface(
+            color = if (highlighted) {
+                MaterialTheme.colorScheme.tertiaryContainer
+            } else {
+                MaterialTheme.colorScheme.secondaryContainer
+            },
+            modifier = Modifier.fillMaxWidth(),
         ) {
             // #201 — avatar + author header in a Row so the visual identity of the poster
             // is immediately visible. Falls back to a placeholder square (cf.
@@ -1232,7 +1241,9 @@ private fun TopicPostCard(
                 Modifier
             }
             Row(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 6.dp),
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 // Centre the avatar against the name+date block so the identity line reads as one
                 // tidy unit (the previous Top alignment + the inflated pseudo made the pseudo look
@@ -1281,8 +1292,10 @@ private fun TopicPostCard(
                     if (citedCount > 0) {
                         // #239 — sober pill: how many posts of THIS page cite this one. Page-scoped
                         // (cf. citationCountsByNumreponse); jumping to the citing posts is a follow-up.
+                        // `surface` container : the pill now lives on the secondaryContainer identity
+                        // band, where a secondaryContainer pill would be invisible.
                         Surface(
-                            color = MaterialTheme.colorScheme.secondaryContainer,
+                            color = MaterialTheme.colorScheme.surface,
                             shape = MaterialTheme.shapes.small,
                         ) {
                             Text(
@@ -1292,7 +1305,7 @@ private fun TopicPostCard(
                                     citedCount,
                                 ),
                                 style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
                             )
                         }
@@ -1320,6 +1333,15 @@ private fun TopicPostCard(
                         .semantics { contentDescription = menuLabel },
                 )
             }
+        }
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                // 12 dp inner gutters (was 16) — combined with the list's 8 dp this buys the
+                // post body ~24 dp of extra reading width per line on a phone.
+                .padding(start = 12.dp, top = 10.dp, end = 12.dp, bottom = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
             // #281 — topic posts are selectable/copyable (opt-in; default is OFF in PostRenderer).
             PostRenderer(content = post.content, selectable = true)
             if (onQuote != null || onEdit != null || onDelete != null) {


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi (dogfooding v109, trois fronts)

### 1. Largeur de lecture
Gouttières de la liste 16→8 dp + padding interne du corps 16→12 dp = **~24 dp de largeur en plus par ligne** sur téléphone.

### 2. Bande d'identité
L'en-tête avatar/pseudo/date devient une **bande teintée sur toute la largeur de la carte** (idiome forum) : `secondaryContainer` sur carte `surfaceContainer` neutre — l'accent marque l'identité au lieu d'inonder le post ; post surligné (ancre) → bande `tertiaryContainer`. Pastille « cité N fois » sur fond `surface` pour rester visible sur la bande. Tout dérive du thème (sombre/AMOLED suivis).

### 3. `ArmedSubmitButton` (:core:ui, partagé éditeur + MP — dédoublonne les deux barres)
M3 n'a pas de bouton à compte à rebours natif : pendant l'armement, un **voile state-layer (`onTertiary` 16 %) balaie le fond de gauche à droite sur les 4 s** — le texte reste lisible des deux côtés. Une seule `Animatable` pilote le voile ET le désarmement (zéro dérive). Libellé simplifié « Confirmer ? » → **« Confirmer »** (le drain dit l'urgence).

## Validation
Locale 2 parts verte : `detektAll test testDebugUnitTest :app:assembleProdDebug` puis `lintDebug :app:lintProdDebug`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)