### PR TITLE
feat: double-tap refresh (#382), section DT opt-in, grille 8 dp

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -206,6 +206,21 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeShowDtSection(): Flow<Boolean> =
+        dataStore.data
+            // Default `false`: the DT tab is a placeholder until the MPStorage sync (#6) — opt-in only.
+            .map { prefs -> prefs[KEY_FLAGS_SHOW_DT_SECTION] ?: false }
+            .distinctUntilChanged()
+            .catch { emit(false) }
+
+    override suspend fun setShowDtSection(enabled: Boolean) {
+        withContext(ioDispatcher) {
+            dataStore.edit { prefs ->
+                prefs[KEY_FLAGS_SHOW_DT_SECTION] = enabled
+            }
+        }
+    }
+
     /**
      * Reads [KEY_THEME_MODE] defensively: an unknown / corrupt stored value (older build with a
      * renamed enum, manual edit) falls back to [ThemeMode.SYSTEM] instead of crashing on
@@ -297,5 +312,8 @@ class DataStoreUserPreferencesRepository @Inject constructor(
 
         // #312 — confirmation dialog before any publish action (reply / edit / new topic / MP).
         val KEY_CONFIRM_BEFORE_POSTING = booleanPreferencesKey("confirm_before_posting")
+
+        // Opt-in « DT » placeholder tab on the Drapeaux screen (MPStorage sync lands later, #6).
+        val KEY_FLAGS_SHOW_DT_SECTION = booleanPreferencesKey("flags_show_dt_section")
     }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -547,5 +547,9 @@ class TopicRepositoryImplTest {
         override fun observeConfirmBeforePosting(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setConfirmBeforePosting(enabled: Boolean) = Unit
+
+        override fun observeShowDtSection(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setShowDtSection(enabled: Boolean) = Unit
     }
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -149,4 +149,15 @@ interface UserPreferencesRepository {
 
     /** Persists [observeConfirmBeforePosting]. Default `false` until the first call. */
     suspend fun setConfirmBeforePosting(enabled: Boolean)
+
+    /**
+     * Opt-in « DT » section on the Drapeaux screen: when `true`, a « DT » tab appears next
+     * to the flag-type tabs. Placeholder for now — the content (the followed-discussions
+     * list whose flags sync through the MPStorage document, #6) lands later. Default
+     * `false`. Observed by `:feature:flags`, toggled in Settings.
+     */
+    fun observeShowDtSection(): Flow<Boolean>
+
+    /** Persists [observeShowDtSection]. Default `false` until the first call. */
+    suspend fun setShowDtSection(enabled: Boolean)
 }

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -1295,6 +1295,10 @@ class PostEditorViewModelTest {
         override suspend fun setConfirmBeforePosting(enabled: Boolean) {
             confirmBeforePosting.value = enabled
         }
+
+        override fun observeShowDtSection(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setShowDtSection(enabled: Boolean) = Unit
     }
 
     private companion object {

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1247,6 +1247,10 @@ class TopicFormViewModelTest {
         override suspend fun setConfirmBeforePosting(enabled: Boolean) {
             confirmBeforePosting.value = enabled
         }
+
+        override fun observeShowDtSection(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setShowDtSection(enabled: Boolean) = Unit
     }
 
     private companion object {

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -118,6 +118,9 @@ fun FlagsRoute(
     // a cold start or a tab switch before DataStore re-resolves the selected tab (#317).
     val cyanShowsRead by viewModel.cyanShowsReadShortcut.collectAsStateWithLifecycle()
 
+    // Opt-in « DT » placeholder tab (Settings toggle ; MPStorage sync #6 lands later).
+    val showDtTab by viewModel.showDtTab.collectAsStateWithLifecycle()
+
     val snackbarHostState = remember { SnackbarHostState() }
 
     // #309 — display-settings bottom sheet. Opened from the header « Affichage » action; the trigger
@@ -132,6 +135,12 @@ fun FlagsRoute(
     LaunchedEffect(canConfigureView) {
         if (!canConfigureView) showViewSettingsSheet = false
     }
+
+    DtTabFallbackEffect(
+        showDtTab = showDtTab,
+        selectedTab = selectedTab,
+        onFallback = { viewModel.selectTab(FlagTab.Cyan) },
+    )
 
     // One-shot snackbar for the delflag outcome (#99). Keyed on the event instance so a
     // config change does not replay it ; consumed once shown so it never re-fires.
@@ -191,6 +200,7 @@ fun FlagsRoute(
                                 cyanShowsRead = cyanShowsRead,
                                 isRefreshing = isRefreshing,
                                 removeFlagState = removeFlagState,
+                                showDtTab = showDtTab,
                             ),
                             actions = AuthenticatedActions(
                                 onSelectTab = viewModel::selectTab,
@@ -473,6 +483,7 @@ private fun flagTabLabel(tab: FlagTab): Int = when (tab) {
     FlagTab.Red -> R.string.flags_type_read_only
     FlagTab.Favorite -> R.string.flags_tab_favorite
     FlagTab.Super -> R.string.flags_tab_super
+    FlagTab.Dt -> R.string.flags_tab_dt
 }
 
 @Composable
@@ -505,12 +516,15 @@ private fun ColumnScope.AuthenticatedBody(
 ) {
     val selectedTab = state.selectedTab
     val cyanShowsRead = state.cyanShowsRead
-    val tabs = listOf(
-        FlagTab.Cyan to stringResource(R.string.flags_tab_my_topics),
-        FlagTab.Red to stringResource(R.string.flags_tab_read_only),
-        FlagTab.Favorite to stringResource(R.string.flags_tab_favorite),
-        FlagTab.Super to stringResource(R.string.flags_tab_super),
-    )
+    val tabs = buildList {
+        add(FlagTab.Cyan to stringResource(R.string.flags_tab_my_topics))
+        add(FlagTab.Red to stringResource(R.string.flags_tab_read_only))
+        add(FlagTab.Favorite to stringResource(R.string.flags_tab_favorite))
+        // Opt-in placeholder (Settings toggle) — sits before Super : DT is closer to the
+        // real flag lists it will eventually join (MPStorage sync, #6).
+        if (state.showDtTab) add(FlagTab.Dt to stringResource(R.string.flags_tab_dt))
+        add(FlagTab.Super to stringResource(R.string.flags_tab_super))
+    }
     val selectedIndex = tabs.indexOfFirst { it.first == selectedTab }.coerceAtLeast(0)
     // Discreet « +lus » suffix on the Cyan label so the user knows read participated topics
     // are currently shown — re-tapping the (already selected) Cyan tab toggles it.
@@ -534,6 +548,11 @@ private fun ColumnScope.AuthenticatedBody(
     if (selectedTab == FlagTab.Super) {
         // Placeholder — no backend, no fetch, no pull-to-refresh (cf. FlagTab.Super KDoc).
         SuperPlaceholderBody()
+        return
+    }
+    if (selectedTab == FlagTab.Dt) {
+        // Placeholder — content arrives with the MPStorage sync (#6), cf. FlagTab.Dt KDoc.
+        DtPlaceholderBody()
         return
     }
 
@@ -927,6 +946,48 @@ private fun ColumnScope.SuperPlaceholderBody() {
 }
 
 /**
+ * If the Settings toggle hides the DT tab while it is selected, falls back to Cyan —
+ * otherwise the body would keep rendering a tab that no longer exists in the row.
+ * Extracted so the guard's branches don't count against [FlagsRoute]'s complexity budget.
+ */
+@Composable
+private fun DtTabFallbackEffect(
+    showDtTab: Boolean,
+    selectedTab: FlagTab,
+    onFallback: () -> Unit,
+) {
+    LaunchedEffect(showDtTab, selectedTab) {
+        if (!showDtTab && selectedTab == FlagTab.Dt) onFallback()
+    }
+}
+
+/**
+ * Sober M3 placeholder for the opt-in « DT » [FlagTab.Dt] tab. The content (followed
+ * discussions whose flags sync through the MPStorage document, #6) lands later.
+ */
+@Composable
+private fun ColumnScope.DtPlaceholderBody() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .weight(1f)
+            .padding(horizontal = 24.dp, vertical = 32.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.flags_dt_placeholder_title),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = stringResource(R.string.flags_dt_placeholder_body),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+/**
  * Read-only state bundle for [AuthenticatedBody], grouped so the composable stays under the
  * detekt parameter-count threshold and mirrors the [AuthenticatedActions] callback bundle.
  */
@@ -937,6 +998,8 @@ private data class FlagsBodyState(
     val cyanShowsRead: Boolean,
     val isRefreshing: Boolean,
     val removeFlagState: RemoveFlagState,
+    /** Whether the opt-in « DT » placeholder tab is shown (Settings toggle). */
+    val showDtTab: Boolean,
 )
 
 private data class AuthenticatedActions(

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -54,6 +54,18 @@ class FlagsViewModel @Inject constructor(
     private val _selectedTab = MutableStateFlow<FlagTab>(FlagTab.Cyan)
     val selectedTab: StateFlow<FlagTab> = _selectedTab.asStateFlow()
 
+    /**
+     * Whether the opt-in « DT » placeholder tab is shown (Settings toggle, default off).
+     * The content arrives with the MPStorage sync (#6) — until then the tab only renders
+     * a placeholder body, like [FlagTab.Super].
+     */
+    val showDtTab: StateFlow<Boolean> = userPreferencesRepository.observeShowDtSection()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = false,
+        )
+
     val authState: StateFlow<AuthState?> = authRepository.observeAuthState()
         .stateIn(
             scope = viewModelScope,
@@ -605,6 +617,15 @@ sealed interface FlagTab {
 
     /** Placeholder — future « super favoris ». No fetch, no backend. */
     data object Super : FlagTab {
+        override val flagType: FlagType? = null
+    }
+
+    /**
+     * Placeholder — future « discussions suivies » (DT) whose flags will sync through the
+     * MPStorage v0.1 document (#6, mpFlags DTCloud). No fetch, no backend yet ; the tab
+     * itself is opt-in behind the « section DT » Settings toggle.
+     */
+    data object Dt : FlagTab {
         override val flagType: FlagType? = null
     }
 }

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -21,6 +21,11 @@
     <string name="flags_super_placeholder_title">Super favoris — à venir</string>
     <string name="flags_super_placeholder_body">Les « super favoris » permettront d\'épingler les sujets les plus importants. Cette vue arrivera dans une prochaine version.</string>
 
+    <!-- Onglet « DT » opt-in (toggle Réglages) : placeholder en attendant la synchro MPStorage (#6). -->
+    <string name="flags_tab_dt">DT</string>
+    <string name="flags_dt_placeholder_title">Discussions suivies — à venir</string>
+    <string name="flags_dt_placeholder_body">Cette section listera vos DT avec des drapeaux synchronisés entre appareils via MPStorage. Le contenu arrivera dans une prochaine version.</string>
+
     <!-- #179 — Vue drapeaux groupée par catégorie (parité vue web par défaut). -->
     <!-- Cyan (« Mes sujets ») : section de catégorie sans nouveau message non lu. Wording parité web. -->
     <string name="flags_category_empty_cyan">Aucun nouveau message</string>

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1422,6 +1422,10 @@ class FlagsViewModelTest {
 
         override suspend fun setConfirmBeforePosting(enabled: Boolean) = Unit
 
+        override fun observeShowDtSection(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setShowDtSection(enabled: Boolean) = Unit
+
         fun setGroupBy(value: Boolean) {
             groupBy.value = value
         }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -505,6 +505,16 @@ private fun FlagsPreferencesCard(
             if (state.flagsPerTabOverrideError) {
                 PreferencePersistError(R.string.settings_flags_per_tab_override_persist_failed)
             }
+            PreferenceSwitchRow(
+                title = stringResource(R.string.settings_flags_show_dt_section_title),
+                description = stringResource(R.string.settings_flags_show_dt_section_description),
+                checked = state.showDtSection,
+                enabled = state.canToggleShowDtSection,
+                onCheckedChange = { onIntent(SettingsIntent.ShowDtSectionChanged(it)) },
+            )
+            if (state.showDtSectionError) {
+                PreferencePersistError(R.string.settings_flags_show_dt_section_persist_failed)
+            }
         }
     }
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -86,6 +86,12 @@ data class SettingsState(
     val isUpdatingConfirmBeforePosting: Boolean = false,
     val confirmBeforePostingError: Boolean = false,
     val confirmBeforePostingTouchedLocally: Boolean = false,
+    // Drapeaux — opt-in « DT » placeholder tab (MPStorage sync #6 lands later). Same
+    // optimistic-flip + startup-race-guard machinery. Default false (tab hidden).
+    val showDtSection: Boolean = false,
+    val isUpdatingShowDtSection: Boolean = false,
+    val showDtSectionError: Boolean = false,
+    val showDtSectionTouchedLocally: Boolean = false,
 ) {
     val canSave: Boolean
         get() = !isSaving
@@ -125,6 +131,10 @@ data class SettingsState(
     // #312 — the confirm-before-posting toggle is gated only by its own write.
     val canToggleConfirmBeforePosting: Boolean
         get() = !isUpdatingConfirmBeforePosting
+
+    // DT tab — gated only by its own write.
+    val canToggleShowDtSection: Boolean
+        get() = !isUpdatingShowDtSection
 }
 
 sealed interface SettingsError {
@@ -200,4 +210,8 @@ sealed interface SettingsIntent {
     // #312 — confirm-before-posting toggle. Optimistic-flip contract, like the flags toggles:
     // the boolean is the desired post-flip state.
     data class ConfirmBeforePostingChanged(val enabled: Boolean) : SettingsIntent
+
+    // Drapeaux — opt-in « DT » placeholder tab (MPStorage sync #6 lands later). Optimistic-flip
+    // contract, like the flags toggles: the boolean is the desired post-flip state.
+    data class ShowDtSectionChanged(val enabled: Boolean) : SettingsIntent
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -120,6 +120,16 @@ class SettingsViewModel @Inject constructor(
                 }
             }
         }
+        viewModelScope.launch {
+            val showDt = userPreferencesRepository.observeShowDtSection().first()
+            _state.update { current ->
+                if (current.showDtSectionTouchedLocally || current.isUpdatingShowDtSection) {
+                    current
+                } else {
+                    current.copy(showDtSection = showDt)
+                }
+            }
+        }
     }
 
     @Suppress("CyclomaticComplexMethod") // MVI when-dispatch over the SettingsIntent variants ; flat by design.
@@ -162,6 +172,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.ThemeModeChanged -> updateThemeMode(intent.mode)
             is SettingsIntent.AmoledEnabledChanged -> updateAmoled(intent.enabled)
             is SettingsIntent.TopicTopBarAutoHideChanged -> updateTopicTopBarAutoHide(intent.enabled)
+            is SettingsIntent.ShowDtSectionChanged -> updateShowDtSection(intent.enabled)
             is SettingsIntent.ConfirmBeforePostingChanged -> updateConfirmBeforePosting(intent.enabled)
         }
     }
@@ -463,6 +474,33 @@ class SettingsViewModel @Inject constructor(
                 }
             },
             persist = userPreferencesRepository::setTopicTopBarAutoHide,
+        )
+    }
+
+    private fun updateShowDtSection(desired: Boolean) {
+        val previous = _state.value.showDtSection
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    showDtSection = desired,
+                    isUpdatingShowDtSection = true,
+                    showDtSectionError = false,
+                    showDtSectionTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(showDtSection = desired, isUpdatingShowDtSection = false)
+                } else {
+                    state.copy(
+                        showDtSection = previous,
+                        isUpdatingShowDtSection = false,
+                        showDtSectionError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setShowDtSection,
         )
     }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -105,6 +105,11 @@
     <string name="settings_flags_per_tab_override_description">Chaque onglet (Mes sujets, Lu, Favoris) garde son propre affichage. Les réglages ci-dessus deviennent les valeurs par défaut ; ajustez chaque onglet depuis le menu d\'affichage de l\'écran Drapeaux.</string>
     <string name="settings_flags_per_tab_override_persist_failed">Impossible de mémoriser le réglage par onglet. Réessayez.</string>
 
+    <!-- Onglet « DT » opt-in dans l'écran Drapeaux (placeholder, synchro MPStorage à venir, #6). -->
+    <string name="settings_flags_show_dt_section_title">Section DT</string>
+    <string name="settings_flags_show_dt_section_description">Affiche un onglet « DT » dans l\'écran Drapeaux. Le contenu (discussions suivies avec drapeaux synchronisés via MPStorage) arrivera dans une prochaine version.</string>
+    <string name="settings_flags_show_dt_section_persist_failed">Impossible de mémoriser la section DT. Réessayez.</string>
+
     <!-- #286 — Thème. Sélecteur Clair/Système/Sombre (Système = suit l'OS) + thème AMOLED (vrai
          noir), persistés en DataStore et appliqués à toute l'app en direct. -->
     <string name="settings_theme_title">Thème</string>

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -989,6 +989,14 @@ class SettingsViewModelTest {
             confirmBeforePosting.value = enabled
         }
 
+        private val showDtSection = MutableStateFlow(false)
+
+        override fun observeShowDtSection(): Flow<Boolean> = showDtSection
+
+        override suspend fun setShowDtSection(enabled: Boolean) {
+            showDtSection.value = enabled
+        }
+
         fun emitConfirmBeforePosting(value: Boolean) {
             confirmBeforePosting.value = value
         }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.feature.topic
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -53,7 +54,9 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
@@ -696,6 +699,7 @@ internal fun TopicContent(
                                 onOpenPage = onOpenPage,
                                 onOpenProfile = onOpenProfile,
                                 onDeleteRequest = onDeleteRequest,
+                                onDoubleTapRefresh = { onIntent(TopicIntent.Refresh) },
                                 listState = listState,
                             )
                             TopicScrollbar(
@@ -722,6 +726,8 @@ private fun TopicLoadedContent(
     onOpenPage: (Int) -> Unit,
     onOpenProfile: (userId: Int, pseudo: String, avatarUrl: String?) -> Unit = { _, _, _ -> },
     onDeleteRequest: (numreponse: Int) -> Unit = {},
+    /** #382 — double-tap anywhere on the list refreshes the current page (RF1 parity). */
+    onDoubleTapRefresh: () -> Unit = {},
     listState: LazyListState,
 ) {
     val highlight = state.request.scrollTo
@@ -795,7 +801,21 @@ private fun TopicLoadedContent(
                     onOpenPage = onOpenPage,
                     enabled = swipeEnabled,
                 ),
-            ),
+            )
+            // #382 — double-tap anywhere on the list to refresh the page (RF1 parity). Child
+            // clickables (links, buttons, avatar) consume their own up events, so taps on them
+            // never count toward this detector; drags past slop cancel it, so scrolling and the
+            // #282 page swipe are untouched. The PullToRefreshBox spinner gives the feedback
+            // (isRefreshing is already shared with the pull gesture); the haptic tick confirms
+            // the trigger under the finger.
+            .pointerInput(Unit) {
+                detectTapGestures(
+                    onDoubleTap = {
+                        haptics.performHapticFeedback(HapticFeedbackType.Confirm)
+                        onDoubleTapRefresh()
+                    },
+                )
+            },
         state = listState,
         // #283 — extra bottom padding so the last post's right-aligned actions clear the floating
         // bottom-action cluster (the Scaffold FAB slot floats over the content). Harmless extra
@@ -803,7 +823,9 @@ private fun TopicLoadedContent(
         // 8 dp gutters (was 16) — posts are the app's main reading surface, every horizontal
         // pixel counts on a phone ; the cards keep their own inner padding for breathing room.
         contentPadding = PaddingValues(start = 8.dp, top = 16.dp, end = 8.dp, bottom = 88.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
+        // 8 dp vertical rhythm, matching the 8 dp side gutters above — a uniform grid (and a
+        // denser feed, cf. the #287 density feedback) instead of the previous 12/8 mismatch.
+        verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         item {
             // Phase 2D #148 — the « Modifier le premier message » action is

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -1315,4 +1315,8 @@ private class FakeUserPreferencesRepository(
     override fun observeConfirmBeforePosting(): Flow<Boolean> = MutableStateFlow(false)
 
     override suspend fun setConfirmBeforePosting(enabled: Boolean) = Unit
+
+    override fun observeShowDtSection(): Flow<Boolean> = MutableStateFlow(false)
+
+    override suspend fun setShowDtSection(enabled: Boolean) = Unit
 }


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi (lot dogfooding v110)

### 1. Double-tap pour rafraîchir la page de lecture (#382, parité RF1)
Double-tap n'importe où dans la liste des posts → re-fetch réseau de la page courante, via le même `TopicIntent.Refresh` que le pull-to-refresh #335 (le spinner du `PullToRefreshBox` sert de feedback partagé) + tic haptique. Les clickables enfants (liens, boutons, avatars) consomment leurs propres taps ; le swipe de page #282 et le scroll sont intacts.

`Closes-#382` volontairement cassé ici — fermeture portée par la PR de promotion dev→main.

### 2. « Section DT » opt-in (préparation MPStorage #6)
Toggle « Section DT » dans Réglages (carte Drapeaux, défaut off, machinerie optimistic-flip standard) → onglet « DT » entre Favoris et Super dans l'écran Drapeaux. Moule `FlagTab.Super` : placeholder sobre, aucun fetch, aucun backend — le contenu (discussions suivies avec drapeaux synchronisés via MPStorage) arrivera avec #6. Si le toggle masque l'onglet sélectionné, retour automatique sur Mes sujets (`DtTabFallbackEffect`, extrait pour rester sous le budget de complexité detekt).

### 3. Grille uniforme 8 dp
Rythme vertical de la liste des posts 12 → 8 dp, aligné sur les gouttières latérales de 8 dp (v110) : grille uniforme et fil plus dense (retour #287). Décision : harmoniser vers le bas plutôt que remonter les côtés à 12, pour conserver la largeur de lecture gagnée.

## Validation

Locale 2 parts verte : `detektAll test testDebugUnitTest :app:assembleProdDebug` puis `lintDebug :app:lintProdDebug` (Docker, `--max-workers=2`). Fakes `UserPreferencesRepository` des 6 suites de tests étendus avec la nouvelle préférence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
