### PR TITLE
chore(release): report du bump 0.9.0 + changelog v113 (statut open) sur dev

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -18,8 +18,8 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ## v113 — `0.9.0` — 2026-06-11
 
-**Statut** : `local` (candidat — promotion `promote/0.9.0` figée sur dev `bb3ee57b`, en attente de review Codex)
-**Commit** : candidat depuis dev `bb3ee57b` (build dev 112), versionCode anticipé 113 (ledger 112+1)
+**Statut** : `open` (track open testing) + F-Droid `.beta`
+**Commit** : merge de promotion `0313e8f4` (#400, candidat dev `bb3ee57b` + review Codex SHIP), tag `app-v113` (versionCode 113, ledger 112→113)
 **Fichier** : AAB `bundleProdRelease` (`fr.forumhfr.redface2`) → track open testing + tag pour F-Droid beta
 
 **Lot dogfooding du 2026-06-10 soir** : 7 PR mergées sur dev (#388–#392, #397, #399), dogfoodées en continu sur le canal dev (v106 → v112).

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -22,7 +22,7 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 **Commit** : candidat depuis dev `bb3ee57b` (build dev 112), versionCode anticipé 113 (ledger 112+1)
 **Fichier** : AAB `bundleProdRelease` (`fr.forumhfr.redface2`) → track open testing + tag pour F-Droid beta
 
-**Lot dogfooding du 2026-06-10 soir** : 8 PR mergées sur dev (#388–#392, #397, #399), dogfoodées en continu sur le canal dev (v106 → v112).
+**Lot dogfooding du 2026-06-10 soir** : 7 PR mergées sur dev (#388–#392, #397, #399), dogfoodées en continu sur le canal dev (v106 → v112).
 
 ### Added
 - **Barre d'actions de l'éditeur** — « Options | Smileys | Envoyer » épinglée au-dessus du clavier sur les trois éditeurs (post, sujet, MP) ; les toggles HFR (signature/smileys/notification) passent dans un bottom sheet ouvert par « Options » ; boutons secondaires en pilules tonales (#390).

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,32 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## v113 — `0.9.0` — 2026-06-11
+
+**Statut** : `local` (candidat — promotion `promote/0.9.0` figée sur dev `bb3ee57b`, en attente de review Codex)
+**Commit** : candidat depuis dev `bb3ee57b` (build dev 112), versionCode anticipé 113 (ledger 112+1)
+**Fichier** : AAB `bundleProdRelease` (`fr.forumhfr.redface2`) → track open testing + tag pour F-Droid beta
+
+**Lot dogfooding du 2026-06-10 soir** : 8 PR mergées sur dev (#388–#392, #397, #399), dogfoodées en continu sur le canal dev (v106 → v112).
+
+### Added
+- **Barre d'actions de l'éditeur** — « Options | Smileys | Envoyer » épinglée au-dessus du clavier sur les trois éditeurs (post, sujet, MP) ; les toggles HFR (signature/smileys/notification) passent dans un bottom sheet ouvert par « Options » ; boutons secondaires en pilules tonales (#390).
+- **Confirmation par double-bouton** (#312 v2) — le dialog modal disparaît : « Envoyer » s'arme (« Confirmer », couleurs tertiary), le fond se vide pendant les 4 s du compte à rebours (désarmement auto), le 2ᵉ appui envoie.
+- **Champ de rédaction extensible** — le champ BBCode s'étire jusqu'à la barre d'actions (éditeur de post et réponse MP) ; aperçu ouvert = partage 50/50 avec scroll interne.
+- **Double-tap pour rafraîchir** (#382) — double-tap n'importe où dans une page de sujet = re-fetch réseau (même retour visuel que le pull-to-refresh, tic haptique).
+- **Section DT (opt-in)** — toggle Réglages › Drapeaux faisant apparaître un onglet « DT » placeholder ; le contenu (drapeaux synchronisés via MPStorage, #6) arrivera plus tard.
+
+### Fixed
+- **Pastilles lu/non-lu de l'onglet Forum** (#329) — la pastille de drapeau d'une ligne lue est atténuée (même grammaire que l'onglet Drapeaux) ; l'état visuel n'avait jamais été implémenté.
+- **Libellé « Confirmer » cassé sur deux lignes** — les déclencheurs secondaires s'effacent pendant l'armement.
+- **Gouttières réelles des posts** — le NavHost ajoutait déjà 8 dp par côté (hérité du bootstrap) : la liste n'ajoute plus rien, les posts ont enfin 8 dp réels par côté (dette du padding global tracée en #398).
+
+### Changed
+- **Lecture des posts** — bande d'identité teintée (avatar/pseudo/date) sur toute la largeur de la carte ; ~24 dp de largeur de lecture en plus ; grille uniforme 8 dp (rythme vertical aligné sur les côtés).
+- **`versionName` 0.8.0 → 0.9.0**.
+
+---
+
 ## v104 — `0.8.0` — 2026-06-10
 
 **Statut** : `open` (track open testing) + F-Droid `.beta`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.8.0"
+        versionName = "0.9.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Report sur `dev` des commits de la branche de promotion `promote/0.9.0` (#400, mergée no-ff `0313e8f4` sur main) :

- cherry-pick `11935ae` — bump `versionName` 0.8.0 → 0.9.0 + entrée changelog v113
- cherry-pick `e8cc413` — fix lot v113 = 7 PR (finding mineur de la review Codex du candidat)
- statut v113 `local` → `open` : bêta shippée (run beta 27310478252 vert, Play open testing + F-Droid `.beta`, tag `app-v113`), annonces HFR postées (topic principal + topic DEV)

Même mécanique que #374 pour la 0.8.0.