### PR TITLE
feat(search): author filter (pseud=) + « Derniers messages » from the profile

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -94,6 +94,17 @@ data object ForumRoute : RedfaceNavKey
 @Serializable
 data object SearchRoute : RedfaceNavKey
 
+/**
+ * Author-only search pushed from the profile's « Derniers messages » button. A separate
+ * route (NOT a parameter on [SearchRoute]) so the search tab root stays a serializable
+ * `data object` — saved back stacks from previous app versions keep restoring — and so
+ * the pushed screen gets its own nav-entry ViewModelStore, leaving the tab's idle
+ * search state untouched. The entry pre-fills the author field and fires immediately
+ * (cf. `SearchViewModel.initialPseudo`).
+ */
+@Serializable
+data class SearchUserPostsRoute(val pseudo: String) : RedfaceNavKey
+
 @Serializable
 data object MessagesRoute : RedfaceNavKey
 
@@ -789,6 +800,30 @@ private fun RedfaceNavHost(
                     topBarActions = accountMenu,
                 )
             }
+            entry<SearchUserPostsRoute> { route ->
+                // Profile « Derniers messages » : same screen as the search tab, but
+                // pushed onto the current tab's stack with the author pre-filled and the
+                // search fired at construction. `onBack` gives the pushed entry its back
+                // affordance (the tab root never sets it).
+                SearchScreen(
+                    onOpenTopic = { cat, post, page, scrollTo ->
+                        backStack.add(
+                            TopicRoute(
+                                cat = cat,
+                                post = post,
+                                page = page,
+                                scrollTo = scrollTo,
+                            ),
+                        )
+                    },
+                    initialPseudo = route.pseudo,
+                    onBack = {
+                        if (backStack.size > 1) {
+                            backStack.removeAt(backStack.lastIndex)
+                        }
+                    },
+                )
+            }
             entry<MessagesRoute> {
                 MessagesScreen(
                     readThreadIds = privateMessageNavState.readThreadIds,
@@ -921,6 +956,9 @@ private fun RedfaceNavHost(
                         if (backStack.size > 1) {
                             backStack.removeAt(backStack.lastIndex)
                         }
+                    },
+                    onShowUserPosts = { pseudo ->
+                        backStack.add(SearchUserPostsRoute(pseudo = pseudo))
                     },
                 )
             }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/search/DefaultSearchRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/search/DefaultSearchRepository.kt
@@ -32,7 +32,8 @@ import kotlinx.coroutines.withContext
  *
  * Diagnostics never carry the [SearchRequest.query] verbatim — a search term can be free
  * user text, including content lifted from a message draft. We log only the length, the
- * cat presence flag, and the page index.
+ * cat presence flag, and the page index. The author filter ([SearchRequest.pseudo]) is a
+ * public username, but it rides the same URL as the query — same presence-flag treatment.
  *
  * On `IOException`, the catch site strips the URL (which contains `search=<query>`) from
  * the message before re-throwing, so the wrapped exception never leaks into a diagnostic
@@ -58,7 +59,8 @@ class DefaultSearchRepository @Inject constructor(
             DiagnosticsLog.Level.INFO,
             LOG_TAG,
             "GET forum1 search hasCat=${catId != null} scope=${request.textScope} " +
-                "queryLength=${request.query.length} page=${request.page}",
+                "queryLength=${request.query.length} hasPseudo=${!request.pseudo.isNullOrBlank()} " +
+                "page=${request.page}",
         )
         return withContext(ioDispatcher) {
             // HFR's form serialises today's date even when `daterange=2` makes it
@@ -79,6 +81,7 @@ class DefaultSearchRepository @Inject constructor(
                     page = request.page,
                     date = today,
                     textScope = request.textScope,
+                    pseudo = request.pseudo,
                 )
             } catch (error: SessionExpiredException) {
                 // `SessionExpiredException` extends `IOException` (so it's caught by the

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/search/DefaultSearchRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/search/DefaultSearchRepositoryTest.kt
@@ -166,6 +166,69 @@ class DefaultSearchRepositoryTest {
     }
 
     @Test
+    fun `author filter is forwarded to the HfrClient`() = runTest {
+        // #402 — author-only search : empty query, pseud filter riding through.
+        val hfrClient = mockk<HfrClient>()
+        coEvery {
+            hfrClient.searchTopics(
+                query = any(),
+                cat = any(),
+                page = any(),
+                date = any(),
+                textScope = any(),
+                pseudo = any(),
+            )
+        } returns NO_RESULTS_HTML
+
+        val repo = buildRepository(hfrClient = hfrClient)
+        repo.search(SearchRequest(query = "", pseudo = "Lt Ripley"))
+
+        coVerify(exactly = 1) {
+            hfrClient.searchTopics(
+                query = "",
+                cat = any(),
+                page = any(),
+                date = any(),
+                textScope = any(),
+                pseudo = "Lt Ripley",
+            )
+        }
+    }
+
+    @Test
+    fun `IOException message never carries the pseud parameter`() = runTest {
+        // #402 — the search URL now also embeds `pseud=<author>` ; the same strip that
+        // protects `search=` must keep the author out of the rebranded message.
+        val hfrClient = mockk<HfrClient>()
+        coEvery {
+            hfrClient.searchTopics(
+                query = any(),
+                cat = any(),
+                page = any(),
+                date = any(),
+                textScope = any(),
+                pseudo = any(),
+            )
+        } throws IOException(
+            "HFR returned 500 for https://forum.hardware.fr/forum1.php" +
+                "?recherches=1&cat=&pseud=Secret+Pseudo&search=&...",
+        )
+
+        val repo = buildRepository(hfrClient = hfrClient)
+        val thrown = assertThrows(IOException::class.java) {
+            kotlinx.coroutines.runBlocking {
+                repo.search(SearchRequest(query = "", pseudo = "Secret Pseudo"))
+            }
+        }
+
+        assertFalse(
+            "expected the pseud parameter to NOT appear in the rebranded exception, got <${thrown.message}>",
+            thrown.message!!.contains("Secret"),
+        )
+        assertTrue(thrown.message!!.contains("500"))
+    }
+
+    @Test
     fun `IOException from HfrClient is rebranded without leaking the query URL`() = runTest {
         val hfrClient = mockk<HfrClient>()
         // Mimic the exact message shape that `executeAuthenticatedHtml` produces.

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/search/Search.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/search/Search.kt
@@ -31,12 +31,23 @@ package fr.forumhfr.redface2.core.model.search
 /**
  * Caller-side description of a search. Built by the ViewModel from the user's
  * input and passed verbatim to [fr.forumhfr.redface2.core.domain.search.SearchRepository].
+ *
+ * [pseudo] maps to HFR's `pseud` form field — an author filter. HFR supports an
+ * author-only search (`search=` empty, `pseud=` set), verified live 2026-06-11 in
+ * all three shapes : explicit cat + `titre=1` (fixture
+ * `search_pseud_filter_lt_ripley.html`), explicit cat + `titre=3` (content rows
+ * with « Dernier message correspondant » snippets), and all-categories + `titre=3`
+ * (302 redirect onto the standard multi-cat pivot, which OkHttp follows). The
+ * result semantics are « topics where this user posted » — HFR does NOT
+ * distinguish authored vs participated. At least one of [query] / [pseudo] must
+ * be non-blank ; the ViewModel enforces this before building the request.
  */
 data class SearchRequest(
     val query: String,
     val category: SearchCategoryScope = SearchCategoryScope.All,
     val textScope: SearchTextScope = SearchTextScope.TitlesAndPosts,
     val page: Int = 1,
+    val pseudo: String? = null,
 )
 
 /**

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
@@ -341,6 +341,10 @@ class HfrClient @Inject constructor(
      *                 computes it from an injectable [java.time.Clock] so tests are
      *                 reproducible.
      * - [textScope] : HFR's `titre` field (`1` titles, `3` titles + posts, `0` posts).
+     * - [pseudo]    : HFR's `pseud` field — author filter. `null`/blank = no filter (encoded
+     *                 as the empty `pseud=` the form always carries). Author-only searches
+     *                 (empty [query]) are supported by HFR ; all-categories author searches
+     *                 answer a 302 onto the multi-cat pivot, which OkHttp follows.
      *
      * Uses the **anonymous** client : the search endpoint is public and we don't want the
      * user's session cookies attached to a request whose URL contains the search payload
@@ -354,6 +358,7 @@ class HfrClient @Inject constructor(
         page: Int,
         date: java.time.LocalDate,
         textScope: SearchTextScope,
+        pseudo: String? = null,
     ): String {
         val orderSearch = if (textScope == SearchTextScope.TitlesOnly) {
             ORDER_BY_LAST_TOPIC_REPLY
@@ -366,7 +371,7 @@ class HfrClient @Inject constructor(
             .addQueryParameter("cat", cat?.let { "$it*hfr.inc" } ?: "")
             .addQueryParameter("orderSearch", orderSearch)
             .addQueryParameter("config", "hfr.inc")
-            .addQueryParameter("pseud", "")
+            .addQueryParameter("pseud", pseudo.orEmpty())
             .addQueryParameter("search", query)
             .addQueryParameter("titre", textScope.hfrTitreValue.toString())
             .addQueryParameter("jour", date.dayOfMonth.toString())

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
@@ -352,6 +352,7 @@ class HfrClient @Inject constructor(
      * failures to typed errors and is responsible for stripping the `search=` parameter
      * before logging.
      */
+    @Suppress("LongParameterList") // HFR search form : one parameter per wire field.
     suspend fun searchTopics(
         query: String,
         cat: Int?,

--- a/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/HfrClientTest.kt
+++ b/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/HfrClientTest.kt
@@ -151,6 +151,29 @@ class HfrClientTest {
     }
 
     @Test
+    fun `searchTopics encodes the author filter on the anonymous client even with an empty query`() = runTest {
+        // #402 — author-only search (« Derniers messages » from the profile) : pseud= carries the
+        // pseudo (space and all, OkHttp-encoded), search= rides along empty.
+        server.enqueue(MockResponse().setResponseCode(200).setBody("<html><body>ok</body></html>"))
+
+        client.searchTopics(
+            query = "",
+            cat = null,
+            page = 1,
+            date = LocalDate.of(2026, 6, 11),
+            textScope = SearchTextScope.TitlesAndPosts,
+            pseudo = "Lt Ripley",
+        )
+
+        val request = server.takeRequest()
+        val url = requireNotNull(request.requestUrl)
+        assertEquals("anonymous", request.headers["X-RF2-Client"])
+        assertEquals("Lt Ripley", url.queryParameter("pseud"))
+        assertEquals("", url.queryParameter("search"))
+        assertNull("page=1 should use HFR's implicit first page", url.queryParameter("page"))
+    }
+
+    @Test
     fun `searchTopics encodes posts-only scope`() = runTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody("<html><body>ok</body></html>"))
 

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/search/SearchResultParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/search/SearchResultParserTest.kt
@@ -115,6 +115,47 @@ class SearchResultParserTest {
     }
 
     @Test
+    fun `author-only fixture (empty query, pseud filter) parses like a regular listing`() {
+        // #402 — the profile's « Derniers messages » flow : `pseud=Lt+Ripley` with an EMPTY
+        // `search=`. The filter lives entirely in the request layer ; the response listing
+        // must parse like any explicit-cat page (no pivot, plain rows).
+        val html = readFixture("search_pseud_filter_lt_ripley.html")
+        val page = parser.parse(
+            html,
+            query = "",
+            requestedCategory = SearchCategoryScope.Category(id = 10, name = "Programmation"),
+        )
+
+        assertEquals(emptyList<Any>(), page.pivotCategories)
+        assertNull(page.selectedCategory)
+        assertEquals(20, page.topics.size)
+        assertTrue("all rows should inherit the requested cat", page.topics.all { it.cat == 10 })
+        // The listing is « topics where this user posted » : rows whose AUTHOR is someone
+        // else are legitimate (Lt Ripley only participated) — the parser must keep them.
+        assertTrue(
+            "expected at least one row authored by the searched user",
+            page.topics.any { it.author == "Lt Ripley" },
+        )
+    }
+
+    @Test
+    fun `author-only all-categories fixture parses the followed pivot page`() {
+        // #402 — the EXACT wire shape of the profile's « Derniers messages » button :
+        // pseud + empty search + cat= (all). HFR 302-redirects onto the multi-cat pivot ;
+        // this fixture is the followed page, i.e. what OkHttp hands the parser.
+        val html = readFixture("search_pseud_all_categories_pivot.html")
+        val page = parser.parse(
+            html,
+            query = "",
+            requestedCategory = SearchCategoryScope.All,
+        )
+
+        assertEquals(20, page.topics.size)
+        assertTrue("the author search must surface the multi-cat pivot", page.pivotCategories.isNotEmpty())
+        assertNotNull("the first pivot category must come back selected", page.selectedCategory)
+    }
+
+    @Test
     fun `content-only fixture exposes matched post anchor and excerpt`() {
         val html = readFixture("search_content_kotlin_explicit_cat.html")
         val page = parser.parse(

--- a/core/parser/src/test/resources/fixtures/search_pseud_all_categories_pivot.html
+++ b/core/parser/src/test/resources/fixtures/search_pseud_all_categories_pivot.html
@@ -1,0 +1,271 @@
+
+	<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+	<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr" lang="fr">
+	<head><title>Lt Ripley - Hardware - FORUM HardWare.fr</title><link rel="stylesheet" type="text/css" href="/include/the_style1.php?color_key=FFFFFF/DEDFDF/000080/C2C3F4/001932/FFFFFF/FFFFFF/000000/000080/000000/000080/F7F7F7/DEDFDF/F7F7F7/DEDFDF/C0C0C0/C0C0C0/FFFFFF/000000/000000/0000FF/EEEEFF/DDDDEE/000000/FFEEEE/000000/FFFFFF/FF0000/FFFFFF/0/1/https%3A%40%40forum-images.hardware.fr/NULL/&amp;abs_img_path=%40data%40sites%40forum%40www%40static%40&amp;hide_bg_onglet=0&amp;v=11102781422" /><link type="text/css" rel="stylesheet" href="https://forum-images.hardware.fr/compressed/the_style.css?v=11102781422" /><link rel="alternate" href="/rss.php?config=hfr.inc&amp;cat=1&amp;subcat=0&amp;num=10" type="application/rss+xml" title="FORUM HardWare.fr - Hardware" /><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/tabs.js?v=11102781422"></script><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/forum1.js?v=11102781422"></script><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/common.js?v=11102781422"></script><style type="text/css">
+	.textareaOff {
+		font-size:8px;
+		border:1px solid #f00;
+		background-color:#ddd;
+	}
+	</style>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta http-equiv="Imagetoolbar" content="no" />
+	<meta name="Robots" content="noindex, follow" />
+	<style type="text/css">
+<!--
+.fastsearchMain{ width: 330px; }
+.fastsearchInput{ width: 70px; border: 1px solid black; }
+.fastsearchSubmit{ background-color: ; border: 0px;}
+.header2 { background-image: url(/img/forum3_1.gif);background-repeat: repeat-x; }
+.menuExt { font-family: Arial, Helvetica, sans-serif; font-size: 10px; color:#000; }
+.menuExt a { color:#000;text-decoration:none; }
+.menuExt a:hover { color:#000;text-decoration:underline; }
+form { display: inline; }
+.header { background-image: url(//forum-images.hardware.fr/img/header-bg.gif); background-repeat: repeat-x; }
+.tdmenu { width: 1px;height: 1px;color: #000000; }
+.hfrheadmenu { font-family: Arial, Helvetica, sans-serif;font-size:13px;font-weight:bold; }
+.hfrheadmenu span {color:;}
+.hfrheadmenu a { color:;text-decoration: none; }
+.hfrheadmenu a:hover { color:;text-decoration: underline; }
+.concours { font-family: Arial, Helvetica, sans-serif;color:;font-size: 16px;text-decoration: none;font-weight: bold;}
+.concours:hover { font-family: Arial, Helvetica, sans-serif;color:;font-size: 16px;text-decoration: underline;font-weight: bold; }
+.searchmenu { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: none;font-weight: bold; }
+.fastsearch { display: none; }
+.fastsearchHeader { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: none;font-weight: bold; }
+.fastsearchHeader:hover { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: underline;font-weight: bold; }
+-->
+</style>
+<script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+<script>
+  window.googletag = window.googletag || {cmd: []};
+  googletag.cmd.push(function() {
+    googletag.defineSlot('/2172442/forum_discussions_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-11').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-12').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-13').addService(googletag.pubads());
+    googletag.pubads().enableSingleRequest();
+    googletag.enableServices();
+  });
+</script>
+<script type='text/javascript'>
+     (function(){
+       var loc = window.location.href;
+       var dd = document.createElement('script');
+       dd.type = 'text/javascript'; dd.src = '//static.digidip.net/hardware.js?loc=' + loc;
+       var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(dd, s);
+     })();
+</script></head><body id="category__topics_listing__results_search"  ><script language="JavaScript" type="text/javascript" src="/js/cookiechoices.js"></script>
+<script language="javascript" type="text/javascript" src="/js/jquery-1.11.1.min.js"></script>
+<script language="JavaScript" type="text/javascript" src="/js/cnil.js"></script>
+<script>
+ document.addEventListener('DOMContentLoaded', function(event) {
+    cookieChoices.showCookieConsentBar('HardWare.fr utilise des cookies pour une navigation optimale et des cookies tiers pour l\'analyse du trafic et la publicité',
+      'Fermer', 'En savoir plus', 'https://www.hardware.fr/html/donnees_personnelles/');
+  });
+</script>
+<style>
+#cookieChoiceInfo span
+,#cookieChoiceDismiss
+,#PlusCookieChoice{
+	font-family:Tahoma,Arial,Helvetica,sans-serif;
+}
+#cookieChoiceDismiss
+,#PlusCookieChoice
+{
+	color:black;
+	text-decoration:none;
+}
+#cookieChoiceDismiss:hover
+,#PlusCookieChoice:hover
+{
+	color:#cc6908;
+}
+</style>
+ <table cellspacing="0" cellpadding="0" width="98%" bgcolor="#000000" border="0" align="center" class="hfrheadmenu" style="border:1px solid #000;border-top:0;">
+        <tr>
+          <td style="vertical-align: top">
+            <table cellspacing="0" cellpadding="0" width="100%" border="0">
+              <tr>
+                <td style="width: 100%" align="left" valign="middle" colspan="2" class="header2"><span class="md_cryptlink45CBCBC0C22D1F1FCCCCCC19454AC14BCC4AC1431944C1"><img src="/img/forum_logo.gif" width="900" height="71" border="0" alt="" /></span></td>
+              </tr>
+              <tr>
+                <td style="background-color:#001932">
+                  <table cellspacing="0" cellpadding="2" width="100%" border="0">
+                    <tr>
+                      <td>&nbsp;<a class="cHeader" href="/">Forum</a>&nbsp;|&nbsp;
+<a class="cHeader" href="https://www.hardware.fr/">HardWare.fr</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/html/news/">News</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/html/articles/">Articles</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/articles/786-1/guide-pc-hardware-fr.html">PC</a>&nbsp;|&nbsp;<span class="md_cryptlink1F484F4C464919C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">S'identifier</span>&nbsp;|&nbsp;<span class="md_cryptlink1F4649C242C146C0CB464F4919C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">S'inscrire</span>&nbsp;|&nbsp;<a class="cHeader" href="https://shop.hardware.fr/" target="_blank" style="position: relative; padding: 0 21px 0 0;display: inline-block;">Shop <img src="/img/shop.png" style="height: 17px; display: inline; position: absolute; right: 0; top: -2px; "></a></td>
+<td align="right"><a class="cHeader" href="/search.php?config=hardwarefr.inc&cat=1&subcat=0">Recherche <img src="//forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif"></a></td>
+                    </tr>
+                    </table></td></tr></table>
+</td></tr></table><div style="width: 99%" align="right">
+<span class="s2Ext menuExt"><span class="md_cryptlink1F4F494846494319C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">8920 connect&eacute;s&nbsp;</span></span></div><br /><div class="container"><div class="mesdiscussions" id="mesdiscussions"><div class="arbo">
+<span  id="md_arbo_tree_1" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/" class="Ext">FORUM HardWare.fr</a></span>
+<br />
+<h1  id="md_arbo_tree_2" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;Hardware</h1>
+</div><div class="rightbutton fastsearch"><table class="main fastsearchMain" cellspacing="0" cellpadding="2"><tr class="cBackHeader fondForumDescription"><th><form method="post" id="fastsearch" action="/forum1.php"><input type="hidden" name="hash_check" value="" /><label for="fastsearchinputid"><a rel="nofollow" href="/search.php?config=hfr.inc&amp;cat=1&amp;subcat=0" class="cHeader fastsearchHeader">Recherche :</a>&nbsp;<input type="text" name="search" id="fastsearchinputid" value="" class="fastsearchInput" alt="Search string" /></label><input type="hidden" name="recherches" value="1" /><input type="hidden" name="searchtype" value="1" /><input type="hidden" name="titre" value="3" /><input type="hidden" name="resSearch" value="200" /><input type="hidden" name="orderSearch" value="1" /><input type="hidden" name="config" value="hfr.inc" /><input type="hidden" name="cat" value="1" />&nbsp;<input type="image" src="https://forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif" class="fastsearchSubmit" title="Lancer une recherche" alt="Lancer une recherche" /></form></th></tr></table></div><div class="spacer fastsearch"></div><div class="rightbutton"><a rel="nofollow" href="/hfr/Hardware/nouveau_sondage.htm" id="md_btn_new_poll"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/newsondage.gif" title="Cliquer ici pour poster un sondage" alt="Cliquer ici pour poster un sondage" /></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a rel="nofollow" href="/hfr/Hardware/nouveau_sujet.htm" id="md_btn_new_topic"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/newsujet.gif" title="Créer un nouveau message" alt="Créer un nouveau message" /></a><br /><br /></div><div class="compactModoInterface spacer">&nbsp;</div><br /><div class="s1Ext"></div><br /><div class="search">
+		<form action="/forum1.php?config=hfr.inc" method="post"><input type="hidden" name="hash_check" value="" />
+			<b>Le moteur de recherche a trouvé des résultats dans les catégories suivantes :</b>
+			<br />
+			<br />
+			<input type="hidden" value="20" name="resSearch" />
+			<input type="hidden" value="11" name="jour" />
+			<input type="hidden" value="6" name="mois" />
+			<input type="hidden" value="2026" name="annee" />
+			<input type="hidden" value="3" name="titre" />
+			<input type="hidden" value="" name="search" />
+			<input type="hidden" value="Lt Ripley" name="pseud" />
+			<input type="hidden" value="2" name="daterange" />
+			<input type="hidden" value="1" name="searchtype" />
+			<input type="hidden" value="1" name="searchall" />
+			<input type="hidden" value="0" name="moderation" />
+			<input type="hidden" value="0" name="orderSearch" />
+			<input type="hidden" value="0" name="trash" />
+			<input type="hidden" value="0" name="trash_post" />
+			<input type="hidden" value="1" name="recherches" />
+			<select name="cat"><optgroup label="FORUM HardWare.fr"><option value="1*hfr.inc" selected="selected">Hardware</option><option value="16*hfr.inc" >Hardware - Périphériques</option><option value="15*hfr.inc" >Ordinateurs portables</option><option value="2*hfr.inc" >Overclocking, Cooling &amp; Modding</option><option value="30*hfr.inc" >Electronique, domotique, DIY</option><option value="23*hfr.inc" >Technologies Mobiles</option><option value="25*hfr.inc" >Apple</option><option value="3*hfr.inc" >Video &amp; Son</option><option value="14*hfr.inc" >Photo numérique</option><option value="5*hfr.inc" >Jeux Video</option><option value="4*hfr.inc" >Windows &amp; Software</option><option value="22*hfr.inc" >Réseaux grand public / SoHo</option><option value="11*hfr.inc" >Linux et OS Alternatifs</option><option value="10*hfr.inc" >Programmation</option><option value="32*hfr.inc" >Intelligence Artificielle</option><option value="6*hfr.inc" >Achats &amp; Ventes</option><option value="13*hfr.inc" >Discussions</option></optgroup></select><input type="hidden" value="|1*hfr|16*hfr|15*hfr|2*hfr|30*hfr|23*hfr|25*hfr|3*hfr|14*hfr|5*hfr|4*hfr|22*hfr|11*hfr|10*hfr|32*hfr|6*hfr|13*hfr|" name="post_cat_list"><input type="submit" value="Voir les résultats" alt="Voir les résultats" /></form></div><br /><table class="none" style="border:0px" cellspacing="0" cellpadding="0"><tr><td style="vertical-align:bottom"><div class="left"></div></td><td style="vertical-align:bottom"><div class="menu"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/annonce.gif" alt="" />&nbsp;&nbsp;<div class="cBackTab1" style="text-align: center; border: red solid 2px; padding: 3px;"><a class="cLink" style="font-weight: bold; font-size: 12pt;" href="/forum2.php3?post=425421&amp;cat=1">Règles de la catégorie Hardware</a><br /><a class="cLink" style="font-size: 10pt;" href="/forum2.php3?post=534284&amp;cat=1">Liste des topics uniques</a></div></div>&nbsp;</td></tr></table><table class="main" cellspacing="0" cellpadding="2"><tr class="cBackHeader fondForum1Subcat"><td class="padding" align="center" colspan="9"><a href="/hfr/Hardware/carte-mere/liste_sujet-1.htm" class="cHeader">Carte mère</a> | <a href="/hfr/Hardware/Memoire/liste_sujet-1.htm" class="cHeader">Mémoire</a> | <a href="/hfr/Hardware/Processeur/liste_sujet-1.htm" class="cHeader">Processeur</a> | <a href="/hfr/Hardware/2D-3D/liste_sujet-1.htm" class="cHeader">Carte graphique</a> | <a href="/hfr/Hardware/Boitier/liste_sujet-1.htm" class="cHeader">Boitier</a> | <a href="/hfr/Hardware/Alimentation/liste_sujet-1.htm" class="cHeader">Alimentation</a> | <a href="/hfr/Hardware/HDD/liste_sujet-1.htm" class="cHeader">Disque dur</a> | <a href="/hfr/Hardware/SSD/liste_sujet-1.htm" class="cHeader">Disque SSD</a> | <a href="/hfr/Hardware/lecteur-graveur/liste_sujet-1.htm" class="cHeader">CD/DVD/BD</a> | <a href="/hfr/Hardware/minipc/liste_sujet-1.htm" class="cHeader">Mini PC</a> | <a href="/hfr/Hardware/Benchs/liste_sujet-1.htm" class="cHeader">Bench</a> | <a href="/hfr/Hardware/Materiels-problemes-divers/liste_sujet-1.htm" class="cHeader">Matériels &amp; problèmes divers</a> | <a href="/hfr/Hardware/conseilsachats/liste_sujet-1.htm" class="cHeader">Conseil d'achat</a> | <a href="/hfr/Hardware/hfr/liste_sujet-1.htm" class="cHeader">HFR</a> | <a href="/hfr/Hardware/actualites/liste_sujet-1.htm" class="cHeader">Actus</a></td></tr><tr class="cBackHeader fondForum1PagesHaut"><td class="padding" colspan="9"><div class="left"><b>&nbsp;Page&nbsp;: </b>&nbsp;&nbsp;<b>1</b></div><div class="pagepresuiv">&nbsp;&nbsp;</div><div class="pagepresuiv"></div></td></tr><tr class="cBackHeader fondForum1Description"><th scope="col">&nbsp;&nbsp;&nbsp;</th><th scope="col">&nbsp;&nbsp;&nbsp;</th><th scope="col" style="width:50%; text-align:left;" align="left">Sujet</th>
+				<th scope="col" colspan="2">Dern. page</th><th scope="col">Auteur du sujet</th><th scope="col" style="width:10%; text-align:center" colspan="2">
+					<b>Nombre de</b>
+					<br />
+					<div class="plop"><span style='font-size: 8px'>Rép.</span></div>
+					<div class="plop"><span style='font-size: 8px'>Lues</span></div>
+				</th><th scope="col">Date du dernier message</th></tr><tr class="sujet ligne_booleen cBackCouleurTab1 " >
+					<td class="sujetCase1 cBackCouleurTab2 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" title="Nouveau message" alt="On" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td scope="row" class="sujetCase3" ondblclick="location.href='/hfr/Hardware/2D-3D/ventilo-declenche-rx6400-sujet_1061404_1.htm'"><a href="/hfr/Hardware/2D-3D/ventilo-declenche-rx6400-sujet_1061404_1.htm" class="cCatTopic" title="Sujet n°1061404">Ventilo qui se déclenche pour un rien RX6400</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab2 ">Lt Ripley</td>
+				  <td class="sujetCase7">8</td>
+				  <td class="sujetCase8">579</td>
+				  <td class="sujetCase9 cBackCouleurTab2 "><a href="/hfr/Hardware/2D-3D/ventilo-declenche-rx6400-sujet_1061404_1.htm#bas" class="Tableau">23-03-2023&nbsp;à&nbsp;16:29<br /><b>Lt Ripley</b></a></td></tr><tr class="sujet ligne_booleen cBackCouleurTab3 " >
+					<td class="sujetCase1 cBackCouleurTab4 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" title="Nouveau message" alt="On" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td scope="row" class="sujetCase3" ondblclick="location.href='/hfr/Hardware/Processeur/10700k-chauffe-sujet_1058097_1.htm'"><a href="/hfr/Hardware/Processeur/10700k-chauffe-sujet_1058097_1.htm" class="cCatTopic" title="Sujet n°1058097">10700k qui chauffe</a></td><td class="sujetCase4"><a href="/hfr/Hardware/Processeur/10700k-chauffe-sujet_1058097_2.htm" class="cCatTopic">2</a></td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab4 ">Lt Ripley</td>
+				  <td class="sujetCase7">54</td>
+				  <td class="sujetCase8">3380</td>
+				  <td class="sujetCase9 cBackCouleurTab4 "><a href="/hfr/Hardware/Processeur/10700k-chauffe-sujet_1058097_2.htm#bas" class="Tableau">28-04-2022&nbsp;à&nbsp;16:04<br /><b>Lt Ripley</b></a></td></tr><tr class="sujet ligne_booleen cBackCouleurTab1 " >
+					<td class="sujetCase1 cBackCouleurTab2 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" title="Nouveau message" alt="On" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td scope="row" class="sujetCase3" ondblclick="location.href='/hfr/Hardware/Materiels-problemes-divers/monter-carte-wifi-sujet_1058021_1.htm'"><a href="/hfr/Hardware/Materiels-problemes-divers/monter-carte-wifi-sujet_1058021_1.htm" class="cCatTopic" title="Sujet n°1058021">Monter une carte M.2 WiFi en USB</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab2 ">Lt Ripley</td>
+				  <td class="sujetCase7">2</td>
+				  <td class="sujetCase8">468</td>
+				  <td class="sujetCase9 cBackCouleurTab2 "><a href="/hfr/Hardware/Materiels-problemes-divers/monter-carte-wifi-sujet_1058021_1.htm#bas" class="Tableau">02-04-2022&nbsp;à&nbsp;15:50<br /><b>Lt Ripley</b></a></td></tr><tr class="sujet ligne_booleen cBackCouleurTab3 " >
+					<td class="sujetCase1 cBackCouleurTab4 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" title="Nouveau message" alt="On" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td scope="row" class="sujetCase3" ondblclick="location.href='/hfr/Hardware/Processeur/11700k-z490ud-gigabyte-sujet_1057086_1.htm'"><a href="/hfr/Hardware/Processeur/11700k-z490ud-gigabyte-sujet_1057086_1.htm" class="cCatTopic" title="Sujet n°1057086">Passer au 11700k sur une Z490UD Gigabyte ?</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab4 ">Lt Ripley</td>
+				  <td class="sujetCase7">10</td>
+				  <td class="sujetCase8">826</td>
+				  <td class="sujetCase9 cBackCouleurTab4 "><a href="/hfr/Hardware/Processeur/11700k-z490ud-gigabyte-sujet_1057086_1.htm#bas" class="Tableau">29-12-2021&nbsp;à&nbsp;15:21<br /><b>Lt Ripley</b></a></td></tr><tr class="sujet ligne_booleen cBackCouleurTab1 " >
+					<td class="sujetCase1 cBackCouleurTab2 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" title="Nouveau message" alt="On" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td scope="row" class="sujetCase3" ondblclick="location.href='/hfr/Hardware/carte-mere/recup-carte-fille-sujet_1053683_1.htm'"><a href="/hfr/Hardware/carte-mere/recup-carte-fille-sujet_1053683_1.htm" class="cCatTopic" title="Sujet n°1053683">Récup un HDMI ou DVI du CPU sur carte fille ?</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab2 ">Lt Ripley</td>
+				  <td class="sujetCase7">10</td>
+				  <td class="sujetCase8">492</td>
+				  <td class="sujetCase9 cBackCouleurTab2 "><a href="/hfr/Hardware/carte-mere/recup-carte-fille-sujet_1053683_1.htm#bas" class="Tableau">24-02-2021&nbsp;à&nbsp;11:42<br /><b>intercepte</b></a></td></tr><tr class="sujet ligne_booleen cBackCouleurTab3 " >
+					<td class="sujetCase1 cBackCouleurTab4 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" title="Nouveau message" alt="On" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td scope="row" class="sujetCase3" ondblclick="location.href='/hfr/Hardware/carte-mere/connecteurs-z490ud-gigabyte-sujet_1053120_1.htm'"><a href="/hfr/Hardware/carte-mere/connecteurs-z490ud-gigabyte-sujet_1053120_1.htm" class="cCatTopic" title="Sujet n°1053120">Connecteurs alim sur CM Z490UD gigabyte</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab4 ">Lt Ripley</td>
+				  <td class="sujetCase7">6</td>
+				  <td class="sujetCase8">347</td>
+				  <td class="sujetCase9 cBackCouleurTab4 "><a href="/hfr/Hardware/carte-mere/connecteurs-z490ud-gigabyte-sujet_1053120_1.htm#bas" class="Tableau">24-01-2021&nbsp;à&nbsp;17:42<br /><b>artouillas​sse</b></a></td></tr><tr class="sujet ligne_booleen cBackCouleurTab1 " >
+					<td class="sujetCase1 cBackCouleurTab2 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" title="Nouveau message" alt="On" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td scope="row" class="sujetCase3" ondblclick="location.href='/hfr/Hardware/Alimentation/alimentation-qualite-android-sujet_1042607_1.htm'"><a href="/hfr/Hardware/Alimentation/alimentation-qualite-android-sujet_1042607_1.htm" class="cCatTopic" title="Sujet n°1042607">Alimentation 5v 2A de qualité (pour box TV android)</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab2 ">Lt Ripley</td>
+				  <td class="sujetCase7">11</td>
+				  <td class="sujetCase8">407</td>
+				  <td class="sujetCase9 cBackCouleurTab2 "><a href="/hfr/Hardware/Alimentation/alimentation-qualite-android-sujet_1042607_1.htm#bas" class="Tableau">24-09-2019&nbsp;à&nbsp;16:34<br /><b>freetronic</b></a></td></tr><tr class="sujet ligne_booleen cBackCouleurTab3 " >
+					<td class="sujetCase1 cBackCouleurTab4 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" title="Nouveau message" alt="On" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td scope="row" class="sujetCase3" ondblclick="location.href='/hfr/Hardware/Alimentation/qualite-mini-resolu-sujet_1042281_1.htm'"><a href="/hfr/Hardware/Alimentation/qualite-mini-resolu-sujet_1042281_1.htm" class="cCatTopic" title="Sujet n°1042281">Quelle alim 12V - 5A de qualité ?  (mini PC)  [Resolu]</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab4 ">Lt Ripley</td>
+				  <td class="sujetCase7">3</td>
+				  <td class="sujetCase8">358</td>
+				  <td class="sujetCase9 cBackCouleurTab4 "><a href="/hfr/Hardware/Alimentation/qualite-mini-resolu-sujet_1042281_1.htm#bas" class="Tableau">05-09-2019&nbsp;à&nbsp;15:44<br /><b>Lt Ripley</b></a></td></tr><tr class="sujet ligne_booleen cBackCouleurTab1 " >
+					<td class="sujetCase1 cBackCouleurTab2 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" title="Nouveau message" alt="On" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td scope="row" class="sujetCase3" ondblclick="location.href='/hfr/Hardware/Processeur/connaitre-temperature-acceptable-sujet_1041931_1.htm'"><a href="/hfr/Hardware/Processeur/connaitre-temperature-acceptable-sujet_1041931_1.htm" class="cCatTopic" title="Sujet n°1041931">Connaitre la température max acceptable des CPU</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab2 ">Lt Ripley</td>
+				  <td class="sujetCase7">3</td>
+				  <td class="sujetCase8">606</td>
+				  <td class="sujetCase9 cBackCouleurTab2 "><a href="/hfr/Hardware/Processeur/connaitre-temperature-acceptable-sujet_1041931_1.htm#bas" class="Tableau">24-08-2019&nbsp;à&nbsp;16:09<br /><b>freetronic</b></a></td></tr><tr class="sujet ligne_booleen cBackCouleurTab3 " >
+					<td class="sujetCase1 cBackCouleurTab4 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" title="Nouveau message" alt="On" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td scope="row" class="sujetCase3" ondblclick="location.href='/hfr/Hardware/Materiels-problemes-divers/usb-booter-sujet_1041884_1.htm'"><a href="/hfr/Hardware/Materiels-problemes-divers/usb-booter-sujet_1041884_1.htm" class="cCatTopic" title="Sujet n°1041884">Quelle clé USB 3.0 pour booter ?</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab4 ">Lt Ripley</td>
+				  <td class="sujetCase7">1</td>
+				  <td class="sujetCase8">201</td>
+				  <td class="sujetCase9 cBackCouleurTab4 "><a href="/hfr/Hardware/Materiels-problemes-divers/usb-booter-sujet_1041884_1.htm#bas" class="Tableau">17-08-2019&nbsp;à&nbsp;13:24<br /><b>Lt Ripley</b></a></td></tr><tr class="sujet ligne_booleen cBackCouleurTab1 " >
+					<td class="sujetCase1 cBackCouleurTab2 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" title="Nouveau message" alt="On" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td scope="row" class="sujetCase3" ondblclick="location.href='/hfr/Hardware/HDD/seagate-barracuda-delirant-sujet_1040891_1.htm'"><a href="/hfr/Hardware/HDD/seagate-barracuda-delirant-sujet_1040891_1.htm" class="cCatTopic" title="Sujet n°1040891">Seagate Barracuda 2to neuf, bench HDTune délirant ?  [Resolu]</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab2 ">Lt Ripley</td>
+				  <td class="sujetCase7">11</td>
+				  <td class="sujetCase8">374</td>
+				  <td class="sujetCase9 cBackCouleurTab2 "><a href="/hfr/Hardware/HDD/seagate-barracuda-delirant-sujet_1040891_1.htm#bas" class="Tableau">03-07-2019&nbsp;à&nbsp;15:10<br /><b>seagate_su​rfer</b></a></td></tr><tr class="sujet ligne_booleen cBackCouleurTab3 " >
+					<td class="sujetCase1 cBackCouleurTab4 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" title="Nouveau message" alt="On" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td scope="row" class="sujetCase3" ondblclick="location.href='/hfr/Hardware/SSD/resultats-tres-crystal-sujet_1033249_1.htm'"><a href="/hfr/Hardware/SSD/resultats-tres-crystal-sujet_1033249_1.htm" class="cCatTopic" title="Sujet n°1033249">Résultats très bas Crystal D.M. et AS SSD</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab4 ">Lt Ripley</td>
+				  <td class="sujetCase7">19</td>
+				  <td class="sujetCase8">548</td>
+				  <td class="sujetCase9 cBackCouleurTab4 "><a href="/hfr/Hardware/SSD/resultats-tres-crystal-sujet_1033249_1.htm#bas" class="Tableau">25-09-2018&nbsp;à&nbsp;16:48<br /><b>Lt Ripley</b></a></td></tr><tr class="sujet ligne_booleen cBackCouleurTab1 " >
+					<td class="sujetCase1 cBackCouleurTab2 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" title="Nouveau message" alt="On" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td scope="row" class="sujetCase3" ondblclick="location.href='/hfr/Hardware/conseilsachats/monte-pc-sujet_1025738_1.htm'"><a href="/hfr/Hardware/conseilsachats/monte-pc-sujet_1025738_1.htm" class="cCatTopic" title="Sujet n°1025738">Je monte un PC pour une mémé [c'est fait]</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab2 ">Lt Ripley</td>
+				  <td class="sujetCase7">22</td>
+				  <td class="sujetCase8">630</td>
+				  <td class="sujetCase9 cBackCouleurTab2 "><a href="/hfr/Hardware/conseilsachats/monte-pc-sujet_1025738_1.htm#bas" class="Tableau">07-12-2017&nbsp;à&nbsp;23:26<br /><b>Captain_se​xxy</b></a></td></tr><tr class="sujet ligne_booleen cBackCouleurTab3 " >
+					<td class="sujetCase1 cBackCouleurTab4 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" title="Nouveau message" alt="On" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td scope="row" class="sujetCase3" ondblclick="location.href='/hfr/Hardware/HDD/boitier-externe-veille-sujet_1010785_1.htm'"><a href="/hfr/Hardware/HDD/boitier-externe-veille-sujet_1010785_1.htm" class="cCatTopic" title="Sujet n°1010785">HDD 4to dans boitier externe ne se met pas en veille</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab4 ">Lt Ripley</td>
+				  <td class="sujetCase7">5</td>
+				  <td class="sujetCase8">227</td>
+				  <td class="sujetCase9 cBackCouleurTab4 "><a href="/hfr/Hardware/HDD/boitier-externe-veille-sujet_1010785_1.htm#bas" class="Tableau">12-12-2016&nbsp;à&nbsp;16:51<br /><b>Lt Ripley</b></a></td></tr><tr class="sujet ligne_booleen cBackCouleurTab1 " >
+					<td class="sujetCase1 cBackCouleurTab2 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" title="Nouveau message" alt="On" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td scope="row" class="sujetCase3" ondblclick="location.href='/hfr/Hardware/Materiels-problemes-divers/garantie-kingston-hyperx-sujet_1006168_1.htm'"><a href="/hfr/Hardware/Materiels-problemes-divers/garantie-kingston-hyperx-sujet_1006168_1.htm" class="cCatTopic" title="Sujet n°1006168">Garantie clé usb Kingston HyperX 256go</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab2 ">Lt Ripley</td>
+				  <td class="sujetCase7">0</td>
+				  <td class="sujetCase8">51</td>
+				  <td class="sujetCase9 cBackCouleurTab2 "><a href="/hfr/Hardware/Materiels-problemes-divers/garantie-kingston-hyperx-sujet_1006168_1.htm#bas" class="Tableau">21-08-2016&nbsp;à&nbsp;15:30<br /><b>Lt Ripley</b></a></td></tr><tr class="sujet ligne_booleen cBackCouleurTab3 " >
+					<td class="sujetCase1 cBackCouleurTab4 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" title="Nouveau message" alt="On" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td scope="row" class="sujetCase3" ondblclick="location.href='/hfr/Hardware/HDD/donnees-secteurs-wd30ezrx-sujet_997966_1.htm'"><a href="/hfr/Hardware/HDD/donnees-secteurs-wd30ezrx-sujet_997966_1.htm" class="cCatTopic" title="Sujet n°997966">Données smart (secteurs def) sur WD Green 3To WD30EZRX</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab4 ">Lt Ripley</td>
+				  <td class="sujetCase7">30</td>
+				  <td class="sujetCase8">834</td>
+				  <td class="sujetCase9 cBackCouleurTab4 "><a href="/hfr/Hardware/HDD/donnees-secteurs-wd30ezrx-sujet_997966_1.htm#bas" class="Tableau">08-03-2016&nbsp;à&nbsp;18:48<br /><b>Lon3lydr3a​ms</b></a></td></tr><tr class="sujet ligne_booleen cBackCouleurTab1 " >
+					<td class="sujetCase1 cBackCouleurTab2 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" title="Nouveau message" alt="On" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td scope="row" class="sujetCase3" ondblclick="location.href='/hfr/Hardware/conseilsachats/moniteur-confort-yeux-sujet_984237_1.htm'"><a href="/hfr/Hardware/conseilsachats/moniteur-confort-yeux-sujet_984237_1.htm" class="cCatTopic" title="Sujet n°984237">Moniteur 4k pour le confort des yeux ?</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab2 ">Lt Ripley</td>
+				  <td class="sujetCase7">3</td>
+				  <td class="sujetCase8">138</td>
+				  <td class="sujetCase9 cBackCouleurTab2 "><a href="/hfr/Hardware/conseilsachats/moniteur-confort-yeux-sujet_984237_1.htm#bas" class="Tableau">31-07-2015&nbsp;à&nbsp;18:23<br /><b>michael777</b></a></td></tr><tr class="sujet ligne_booleen cBackCouleurTab3 " >
+					<td class="sujetCase1 cBackCouleurTab4 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" title="Nouveau message" alt="On" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td scope="row" class="sujetCase3" ondblclick="location.href='/hfr/Hardware/conseilsachats/config-polyvalente-900-sujet_977947_1.htm'"><a href="/hfr/Hardware/conseilsachats/config-polyvalente-900-sujet_977947_1.htm" class="cCatTopic" title="Sujet n°977947">Config polyvalente 900&euro;</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab4 ">Lt Ripley</td>
+				  <td class="sujetCase7">4</td>
+				  <td class="sujetCase8">181</td>
+				  <td class="sujetCase9 cBackCouleurTab4 "><a href="/hfr/Hardware/conseilsachats/config-polyvalente-900-sujet_977947_1.htm#bas" class="Tableau">04-04-2015&nbsp;à&nbsp;14:48<br /><b>Lt Ripley</b></a></td></tr><tr class="sujet ligne_booleen cBackCouleurTab1 " >
+					<td class="sujetCase1 cBackCouleurTab2 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" title="Nouveau message" alt="On" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td scope="row" class="sujetCase3" ondblclick="location.href='/hfr/Hardware/SSD/840-500-rendu-sujet_962698_1.htm'"><a href="/hfr/Hardware/SSD/840-500-rendu-sujet_962698_1.htm" class="cCatTopic" title="Sujet n°962698">840 de 500 go à rendu l'âme ?!!</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab2 ">Lt Ripley</td>
+				  <td class="sujetCase7">23</td>
+				  <td class="sujetCase8">753</td>
+				  <td class="sujetCase9 cBackCouleurTab2 "><a href="/hfr/Hardware/SSD/840-500-rendu-sujet_962698_1.htm#bas" class="Tableau">15-09-2014&nbsp;à&nbsp;18:47<br /><b>tinc</b></a></td></tr><tr class="sujet ligne_booleen cBackCouleurTab3 " >
+					<td class="sujetCase1 cBackCouleurTab4 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" title="Nouveau message" alt="On" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td scope="row" class="sujetCase3" ondblclick="location.href='/hfr/Hardware/conseilsachats/avis-config-polyvalente-sujet_960741_1.htm'"><a href="/hfr/Hardware/conseilsachats/avis-config-polyvalente-sujet_960741_1.htm" class="cCatTopic" title="Sujet n°960741">Avis config polyvalente</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab4 ">Lt Ripley</td>
+				  <td class="sujetCase7">7</td>
+				  <td class="sujetCase8">134</td>
+				  <td class="sujetCase9 cBackCouleurTab4 "><a href="/hfr/Hardware/conseilsachats/avis-config-polyvalente-sujet_960741_1.htm#bas" class="Tableau">03-07-2014&nbsp;à&nbsp;13:55<br /><b>Lt Ripley</b></a></td></tr><tr class="cBackHeader fondForum1PagesBas"><td class="padding" colspan="9"><div class="left"><b>&nbsp;Page&nbsp;: </b>&nbsp;&nbsp;<b>1</b></div><div class="pagepresuiv">&nbsp;&nbsp;</div><div class="pagepresuiv"></div></td></tr></table><input type="hidden" name="hash_check" value="" /><br /><form action="/forum1.php" method="get" id="goto"><input type="hidden" name="hash_check" value="" />
+		<div class="nombres">
+			<b>Aller à : </b>
+			<select name="cat" onchange="document.getElementById('goto').submit()"><option value="1" selected="selected">Hardware</option><option value="16" >Hardware - Périphériques</option><option value="15" >Ordinateurs portables</option><option value="2" >Overclocking, Cooling &amp; Modding</option><option value="30" >Electronique, domotique, DIY</option><option value="23" >Technologies Mobiles</option><option value="25" >Apple</option><option value="3" >Video &amp; Son</option><option value="14" >Photo numérique</option><option value="5" >Jeux Video</option><option value="4" >Windows &amp; Software</option><option value="22" >Réseaux grand public / SoHo</option><option value="21" >Systèmes &amp; Réseaux Pro</option><option value="11" >Linux et OS Alternatifs</option><option value="10" >Programmation</option><option value="32" >Intelligence Artificielle</option><option value="12" >Graphisme</option><option value="6" >Achats &amp; Ventes</option><option value="8" >Emploi &amp; Etudes</option><option value="13" >Discussions</option></select><input type="hidden" name="config" value="hfr.inc" /><input type="submit" value="Go" /><br />
+				<br /><a rel="nofollow" href="/hfr/Hardware/nouveau_sondage.htm" id="md_btn_new_poll_bottom"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/newsondage.gif" title="Cliquer ici pour poster un sondage" alt="Cliquer ici pour poster un sondage" /></a>
+					&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a rel="nofollow" href="/hfr/Hardware/nouveau_sujet.htm" id="md_btn_new_topic_bottom"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/newsujet.gif" title="Créer un nouveau message" alt="Créer un nouveau message" /></a></div></form>
+		<div class="legende">
+			<img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" alt="" />&nbsp;&nbsp;Nouveaux sujets
+			<br /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb.gif" alt="" />&nbsp;&nbsp;Nouveaux messages dans un ancien sujet
+			<br /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closed.gif" alt="" />&nbsp;&nbsp;Pas de nouveau message
+			<br /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/flag0.gif" alt="" />&nbsp;&nbsp;Allez au dernier message lu dans un sujet auquel vous n'avez pas participé
+			<br /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/flag1.gif" alt="" />&nbsp;&nbsp;Allez au dernier message lu dans un sujet auquel vous avez participé
+			<br /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/favoris.gif" alt="" />&nbsp;&nbsp;Allez au dernier message lu dans un favori
+		</div>
+		<div class="spacer">&nbsp;</div>
+		<br />
+		<div class="copyright"><a href="http://www.mesdiscussions.net" target="_blank" class="copyright">Forum MesDiscussions.Net</a>, Version 2010.2 <br />(c) 2000-2011 Doctissimo<br /><div class="gene">Page générée en  0.085 secondes</div></div>
+	</div>
+	</div><center><font color="#000000" size="1" face="Arial, Helvetica, sans-serif"><br />Copyright © 1997-2025 Groupe <a href="https://www.ldlc.com" title="Achat de materiel Informatique">LDLC</a> (<a href="https://www.hardware.fr/html/donnees_personnelles/">Signaler un contenu illicite / Données personnelles</a>)</font></center>
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://tracking.groupe-ldlc.com/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '26']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<noscript><p><img src="https://tracking.groupe-ldlc.com/matomo.php?idsite=26&rec=1" style="border:0;" alt="" /></p></noscript>
+<!-- End Matomo Code --><script type="text/javascript">
+md_forum_decryptlink.init();
+</script>
+<script type="text/javascript">
+md_forum_decryptlink.init();
+</script>
+</body>
+	</html>

--- a/core/parser/src/test/resources/fixtures/search_pseud_all_categories_pivot.source.txt
+++ b/core/parser/src/test/resources/fixtures/search_pseud_all_categories_pivot.source.txt
@@ -1,0 +1,15 @@
+Source : https://forum.hardware.fr/forum1.php?recherches=1&cat=&orderSearch=0&config=hfr.inc&pseud=Lt+Ripley&search=&titre=3&jour=11&mois=6&annee=2026&resSearch=20&daterange=2&subcat=0&searchtype=1&trash=0&trash_post=0&moderation=0
+
+Captured : 2026-06-11 via curl -L, anonymous (no session cookies).
+
+Query : `search=` (empty), `pseud=Lt+Ripley`, `cat=` (ALL categories), `titre=3` (titles + posts).
+
+Shape : « author-only, all categories » — the exact wire shape of the profile's « Derniers
+messages » button (#402). HFR answers the all-categories author search with a **302** onto the
+standard multi-cat pivot URL (`cat=1&post_cat_list=|1*hfr|16*hfr|…&searchall=1`) ; this file is
+the FOLLOWED page (curl -L), i.e. what OkHttp hands the parser after its automatic redirect.
+20 topic rows (resSearch=20) in the first pivot category, plus the pivot dropdown listing every
+category where Lt Ripley posted.
+
+Sanitization : none required — anonymous capture, `hash_check` empty, no cookies, no PII beyond
+the public username the filter explicitly required (same exposure as search_pseud_filter_lt_ripley).

--- a/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileScreen.kt
@@ -52,6 +52,9 @@ import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
  *  to keep this PR focused).
  *
  * @param onBack  Navigation callback — pops back to the previous screen.
+ * @param onShowUserPosts  Navigation callback for « Derniers messages » — pushes the
+ *   author-only search pre-filled with the profile's canonical pseudo. Hoisted to `:app`
+ *   like [onBack] so the feature module stays navigation-graph-free.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -60,6 +63,7 @@ fun ProfileRoute(
     pseudoHint: String,
     avatarUrlHint: String?,
     onBack: () -> Unit,
+    onShowUserPosts: (String) -> Unit,
 ) {
     // `key = "profile-$userId"` derives a distinct VM per profile in the nav entry's
     // ViewModelStore. Even though each `ProfileFullRoute` navigation creates its own back
@@ -81,6 +85,7 @@ fun ProfileRoute(
         state = state,
         onIntent = viewModel::onIntent,
         onBack = onBack,
+        onShowUserPosts = onShowUserPosts,
     )
 }
 
@@ -90,6 +95,7 @@ internal fun ProfileScreen(
     state: ProfileUiState,
     onIntent: (ProfileIntent) -> Unit,
     onBack: () -> Unit,
+    onShowUserPosts: (String) -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -170,7 +176,10 @@ internal fun ProfileScreen(
 
                 is ProfileUiState.Mode.Loaded -> {
                     Spacer(Modifier.height(16.dp))
-                    ProfileFullContent(profile = mode.profile)
+                    ProfileFullContent(
+                        profile = mode.profile,
+                        onShowUserPosts = onShowUserPosts,
+                    )
                 }
             }
         }
@@ -200,7 +209,10 @@ private fun ProfileLoadingHero(pseudo: String, avatarUrl: String?) {
  * Avatars are square/rounded as per brief constraint — [RedfaceUserAvatar] enforces this.
  */
 @Composable
-private fun ProfileFullContent(profile: UserProfile) {
+private fun ProfileFullContent(
+    profile: UserProfile,
+    onShowUserPosts: (String) -> Unit,
+) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -257,13 +269,14 @@ private fun ProfileFullContent(profile: UserProfile) {
 
     Spacer(Modifier.height(24.dp))
 
-    // « Derniers messages » is disabled — no stable route exists yet.
+    // Author-only search (« topics where this user posted ») pre-filled with the
+    // CANONICAL pseudo from the loaded profile — not the tap-site hint, whose casing
+    // can drift from the real account name.
     OutlinedButton(
-        onClick = {},
-        enabled = false,
+        onClick = { onShowUserPosts(profile.pseudo) },
         modifier = Modifier.fillMaxWidth(),
     ) {
-        Text(stringResource(R.string.profile_action_recent_posts_coming_soon))
+        Text(stringResource(R.string.profile_action_recent_posts))
     }
 
     Spacer(Modifier.height(16.dp))

--- a/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileScreen.kt
@@ -271,9 +271,13 @@ private fun ProfileFullContent(
 
     // Author-only search (« topics where this user posted ») pre-filled with the
     // CANONICAL pseudo from the loaded profile — not the tap-site hint, whose casing
-    // can drift from the real account name.
+    // can drift from the real account name. Disabled on ProfileParser's defensive
+    // sentinel ("?", served when even the page title gave no pseudo) — searching it
+    // would fire a pointless author query (Codex review of #403).
+    val hasUsablePseudo = profile.pseudo.isNotBlank() && profile.pseudo != "?"
     OutlinedButton(
         onClick = { onShowUserPosts(profile.pseudo) },
+        enabled = hasUsablePseudo,
         modifier = Modifier.fillMaxWidth(),
     ) {
         Text(stringResource(R.string.profile_action_recent_posts))

--- a/feature/profile/src/main/res/values/strings.xml
+++ b/feature/profile/src/main/res/values/strings.xml
@@ -23,7 +23,7 @@
     <!-- Actions -->
     <string name="profile_action_open_full">Voir le profil complet</string>
     <string name="profile_action_retry">Réessayer</string>
-    <string name="profile_action_recent_posts_coming_soon">Derniers messages (à venir)</string>
+    <string name="profile_action_recent_posts">Derniers messages</string>
 
     <!-- Error messages -->
     <string name="profile_error_load_failed">Impossible de charger le profil.</string>

--- a/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchScreen.kt
@@ -28,6 +28,8 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
@@ -38,7 +40,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
@@ -72,8 +77,15 @@ fun SearchScreen(
     onOpenTopic: (cat: Int, post: Int, page: Int, scrollTo: Int?) -> Unit,
     modifier: Modifier = Modifier,
     topBarActions: @Composable (() -> Unit)? = null,
-    viewModel: SearchViewModel = hiltViewModel(),
+    initialPseudo: String? = null,
+    onBack: (() -> Unit)? = null,
 ) {
+    // AssistedInject (same pattern as ProfileRoute) : `initialPseudo` is only known at
+    // construction time. The nav-entry-scoped ViewModelStore already gives the profile
+    // entry point its own instance, distinct from the search tab's idle one.
+    val viewModel = hiltViewModel<SearchViewModel, SearchViewModel.Factory>(
+        creationCallback = { factory -> factory.create(initialPseudo) },
+    )
     val state by viewModel.state.collectAsStateWithLifecycle()
     // Same one-shot collection pattern as TopicScreen : the Channel-backed flow
     // delivers each navigation effect exactly once.
@@ -91,9 +103,11 @@ fun SearchScreen(
         onOpenTopic = { result -> viewModel.submit(SearchIntent.OpenResult(result)) },
         modifier = modifier,
         topBarActions = topBarActions,
+        onBack = onBack,
     )
 }
 
+@Suppress("LongParameterList") // Screen surface : state + intent sink + 2 nav callbacks + chrome slots.
 @Composable
 internal fun SearchContent(
     state: SearchUiState,
@@ -101,6 +115,7 @@ internal fun SearchContent(
     onOpenTopic: (SearchTopicResult) -> Unit,
     modifier: Modifier = Modifier,
     topBarActions: @Composable (() -> Unit)? = null,
+    onBack: (() -> Unit)? = null,
 ) {
     Surface(
         modifier = modifier.fillMaxSize(),
@@ -123,11 +138,32 @@ internal fun SearchContent(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
-                Text(
-                    text = stringResource(R.string.search_title),
-                    style = MaterialTheme.typography.headlineMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    // Profile entry point (« Derniers messages ») : the screen is pushed
+                    // onto the current tab's back stack instead of living at the search
+                    // tab root, so it needs its own back affordance. Same dp-sized vector
+                    // as ProfileScreen (material-icons is detekt-banned).
+                    if (onBack != null) {
+                        val backLabel = stringResource(R.string.search_back)
+                        IconButton(
+                            onClick = onBack,
+                            modifier = Modifier.semantics { contentDescription = backLabel },
+                        ) {
+                            Icon(
+                                painter = painterResource(
+                                    fr.forumhfr.redface2.core.ui.R.drawable.ic_arrow_back,
+                                ),
+                                contentDescription = null,
+                                modifier = Modifier.size(24.dp),
+                            )
+                        }
+                    }
+                    Text(
+                        text = stringResource(R.string.search_title),
+                        style = MaterialTheme.typography.headlineMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
                 topBarActions?.invoke()
             }
             Column(
@@ -138,8 +174,12 @@ internal fun SearchContent(
             ) {
                 SearchField(
                     query = state.query,
-                    isSubmitEnabled = !state.isLoading && state.query.isNotBlank(),
+                    pseudo = state.pseudo,
+                    // HFR accepts query-only, author-only, and combined searches.
+                    isSubmitEnabled = !state.isLoading &&
+                        (state.query.isNotBlank() || state.pseudo.isNotBlank()),
                     onQueryChange = { onIntent(SearchIntent.QueryChanged(it)) },
+                    onPseudoChange = { onIntent(SearchIntent.PseudoChanged(it)) },
                     onSubmit = { onIntent(SearchIntent.Submit) },
                 )
                 SearchOptions(
@@ -207,11 +247,14 @@ private fun SearchOptions(
     }
 }
 
+@Suppress("LongParameterList") // Two text fields + their change callbacks + the shared submit pair.
 @Composable
 private fun SearchField(
     query: String,
+    pseudo: String,
     isSubmitEnabled: Boolean,
     onQueryChange: (String) -> Unit,
+    onPseudoChange: (String) -> Unit,
     onSubmit: () -> Unit,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -221,6 +264,16 @@ private fun SearchField(
             singleLine = true,
             label = { Text(stringResource(R.string.search_field_label)) },
             placeholder = { Text(stringResource(R.string.search_field_placeholder)) },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+            keyboardActions = KeyboardActions(onSearch = { if (isSubmitEnabled) onSubmit() }),
+            modifier = Modifier.fillMaxWidth(),
+        )
+        OutlinedTextField(
+            value = pseudo,
+            onValueChange = onPseudoChange,
+            singleLine = true,
+            label = { Text(stringResource(R.string.search_pseudo_label)) },
+            placeholder = { Text(stringResource(R.string.search_pseudo_placeholder)) },
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
             keyboardActions = KeyboardActions(onSearch = { if (isSubmitEnabled) onSubmit() }),
             modifier = Modifier.fillMaxWidth(),

--- a/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchUiState.kt
+++ b/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchUiState.kt
@@ -19,6 +19,12 @@ import fr.forumhfr.redface2.core.model.search.SearchTopicResult
  */
 data class SearchUiState(
     val query: String = "",
+    /**
+     * Author filter, forwarded as HFR's `pseud` field. A search is submittable when
+     * at least one of [query] / [pseudo] is non-blank — HFR supports author-only
+     * searches (« every topic where this user posted », cf. [SearchRequest.pseudo]).
+     */
+    val pseudo: String = "",
     val textScope: SearchTextScope = SearchTextScope.TitlesAndPosts,
     val selectedCategory: SearchPivotCategory? = null,
     val pivotCategories: List<SearchPivotCategory> = emptyList(),
@@ -38,6 +44,7 @@ data class SearchUiState(
  */
 sealed interface SearchIntent {
     data class QueryChanged(val query: String) : SearchIntent
+    data class PseudoChanged(val pseudo: String) : SearchIntent
     data class TextScopeSelected(val scope: SearchTextScope) : SearchIntent
     data object Submit : SearchIntent
     data object Retry : SearchIntent

--- a/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchViewModel.kt
+++ b/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchViewModel.kt
@@ -2,6 +2,9 @@ package fr.forumhfr.redface2.feature.search
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.domain.error.classifyHfrError
@@ -11,7 +14,6 @@ import fr.forumhfr.redface2.core.model.search.SearchPivotCategory
 import fr.forumhfr.redface2.core.model.search.SearchRequest
 import fr.forumhfr.redface2.core.model.search.SearchTextScope
 import fr.forumhfr.redface2.core.model.search.SearchTopicResult
-import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -45,13 +47,20 @@ import kotlinx.coroutines.launch
  * result's real topic page (HFR's search hrefs always carry `page=1`) and emits a
  * one-shot [SearchEffect.NavigateToTopic] through [effects] (Channel +
  * `receiveAsFlow`, same pattern as `TopicViewModel`).
+ *
+ * [initialPseudo] supports the profile's « Derniers messages » entry point : a
+ * non-blank value pre-fills the author field and fires the search immediately
+ * (author-only, all categories — cf. [SearchRequest.pseudo]). `@AssistedInject`
+ * (same pattern as `ProfileViewModel`) because the value comes from the nav
+ * route at construction time ; the search tab passes `null` and starts idle.
  */
-@HiltViewModel
-class SearchViewModel @Inject constructor(
+@HiltViewModel(assistedFactory = SearchViewModel.Factory::class)
+class SearchViewModel @AssistedInject constructor(
     private val searchRepository: SearchRepository,
+    @Assisted private val initialPseudo: String?,
 ) : ViewModel() {
 
-    private val _state = MutableStateFlow(SearchUiState())
+    private val _state = MutableStateFlow(SearchUiState(pseudo = initialPseudo.orEmpty().trim()))
     val state: StateFlow<SearchUiState> = _state.asStateFlow()
 
     private val _effects: Channel<SearchEffect> = Channel(capacity = Channel.BUFFERED)
@@ -65,6 +74,9 @@ class SearchViewModel @Inject constructor(
 
     /** The text scope that was last actually submitted, used by [retry] and pivot changes. */
     private var lastSubmittedTextScope: SearchTextScope = SearchTextScope.TitlesAndPosts
+
+    /** The author filter that was last actually submitted, used by [retry] and pivot changes. */
+    private var lastSubmittedPseudo: String? = null
 
     private var searchJob: Job? = null
 
@@ -82,9 +94,25 @@ class SearchViewModel @Inject constructor(
      */
     private var isOpeningResult = false
 
+    init {
+        // Profile entry point : land directly on the author's recent posts. The
+        // init-time submit mirrors what the user would do by hand (fill the author
+        // field, tap « Rechercher ») so retry/pivot/scope flows behave identically.
+        val prefilled = _state.value.pseudo
+        if (prefilled.isNotEmpty()) {
+            launchSearch(
+                query = "",
+                scope = SearchCategoryScope.All,
+                textScope = _state.value.textScope,
+                pseudo = prefilled,
+            )
+        }
+    }
+
     fun submit(intent: SearchIntent) {
         when (intent) {
             is SearchIntent.QueryChanged -> onQueryChanged(intent.query)
+            is SearchIntent.PseudoChanged -> onPseudoChanged(intent.pseudo)
             is SearchIntent.TextScopeSelected -> onTextScopeSelected(intent.scope)
             SearchIntent.Submit -> onSubmit()
             SearchIntent.Retry -> onRetry()
@@ -97,11 +125,20 @@ class SearchViewModel @Inject constructor(
         // A typed-but-not-submitted query invalidates the currently displayed
         // search. Keeping the old list under the new field value is misleading
         // and can let an in-flight response land as stale results.
+        invalidateDisplayedSearch { it.copy(query = query) }
+    }
+
+    private fun onPseudoChanged(pseudo: String) {
+        // Same invalidation contract as onQueryChanged : the author filter is part
+        // of the search identity, so editing it orphans the displayed results.
+        invalidateDisplayedSearch { it.copy(pseudo = pseudo) }
+    }
+
+    private inline fun invalidateDisplayedSearch(transform: (SearchUiState) -> SearchUiState) {
         searchGeneration += 1
         searchJob?.cancel()
         _state.update {
-            it.copy(
-                query = query,
+            transform(it).copy(
                 selectedCategory = null,
                 pivotCategories = emptyList(),
                 results = emptyList(),
@@ -113,9 +150,17 @@ class SearchViewModel @Inject constructor(
     }
 
     private fun onSubmit() {
-        val trimmed = _state.value.query.trim()
-        if (trimmed.isEmpty()) return
-        launchSearch(trimmed, SearchCategoryScope.All, _state.value.textScope)
+        val trimmedQuery = _state.value.query.trim()
+        val trimmedPseudo = _state.value.pseudo.trim()
+        // HFR accepts query-only, author-only, and combined searches — but at least
+        // one of the two must be set (cf. SearchRequest.pseudo).
+        if (trimmedQuery.isEmpty() && trimmedPseudo.isEmpty()) return
+        launchSearch(
+            query = trimmedQuery,
+            scope = SearchCategoryScope.All,
+            textScope = _state.value.textScope,
+            pseudo = trimmedPseudo.takeIf { it.isNotEmpty() },
+        )
     }
 
     private fun onTextScopeSelected(scope: SearchTextScope) {
@@ -123,22 +168,28 @@ class SearchViewModel @Inject constructor(
         if (current.textScope == scope) return
         _state.update { it.copy(textScope = scope) }
         val query = current.query.trim()
-        if (current.hasSearched && query.isNotEmpty()) {
-            launchSearch(query, lastSubmittedCategory, scope)
+        val pseudo = current.pseudo.trim()
+        if (current.hasSearched && (query.isNotEmpty() || pseudo.isNotEmpty())) {
+            launchSearch(query, lastSubmittedCategory, scope, pseudo.takeIf { it.isNotEmpty() })
         }
     }
 
     private fun onRetry() {
         val query = lastSubmittedQuery ?: return
-        launchSearch(query, lastSubmittedCategory, lastSubmittedTextScope)
+        launchSearch(query, lastSubmittedCategory, lastSubmittedTextScope, lastSubmittedPseudo)
     }
 
     private fun onCategorySelected(category: SearchPivotCategory) {
-        val query = lastSubmittedQuery ?: _state.value.query.trim().takeIf { it.isNotEmpty() } ?: return
+        // `lastSubmittedQuery` can legitimately be "" after an author-only search ;
+        // re-scope with whatever (query, pseudo) pair the listing on screen came from.
+        val query = lastSubmittedQuery ?: _state.value.query.trim()
+        val pseudo = lastSubmittedPseudo
+        if (query.isEmpty() && pseudo.isNullOrEmpty()) return
         launchSearch(
             query = query,
             scope = SearchCategoryScope.Category(id = category.id, name = category.label),
             textScope = lastSubmittedTextScope,
+            pseudo = pseudo,
         )
     }
 
@@ -212,7 +263,12 @@ class SearchViewModel @Inject constructor(
         }
     }
 
-    private fun launchSearch(query: String, scope: SearchCategoryScope, textScope: SearchTextScope) {
+    private fun launchSearch(
+        query: String,
+        scope: SearchCategoryScope,
+        textScope: SearchTextScope,
+        pseudo: String? = null,
+    ) {
         // Cancel any in-flight search ; a newer query must take precedence.
         searchJob?.cancel()
         val generation = searchGeneration + 1
@@ -220,9 +276,11 @@ class SearchViewModel @Inject constructor(
         lastSubmittedQuery = query
         lastSubmittedCategory = scope
         lastSubmittedTextScope = textScope
+        lastSubmittedPseudo = pseudo
         _state.update {
             it.copy(
                 query = query,
+                pseudo = pseudo.orEmpty(),
                 textScope = textScope,
                 isLoading = true,
                 errorMessage = null,
@@ -231,7 +289,9 @@ class SearchViewModel @Inject constructor(
         }
         searchJob = viewModelScope.launch {
             val outcome = runCatching {
-                searchRepository.search(SearchRequest(query = query, category = scope, textScope = textScope))
+                searchRepository.search(
+                    SearchRequest(query = query, category = scope, textScope = textScope, pseudo = pseudo),
+                )
             }
             val cancellation = outcome.exceptionOrNull() as? CancellationException
             if (cancellation != null) {
@@ -268,6 +328,11 @@ class SearchViewModel @Inject constructor(
                 },
             )
         }
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(initialPseudo: String?): SearchViewModel
     }
 
     private companion object {

--- a/feature/search/src/main/res/values/strings.xml
+++ b/feature/search/src/main/res/values/strings.xml
@@ -2,9 +2,12 @@
     <string name="search_title">Recherche</string>
     <string name="search_field_label">Mot-clé recherché</string>
     <string name="search_field_placeholder">Mot dans un titre ou un message…</string>
+    <string name="search_pseudo_label">Auteur (pseudo)</string>
+    <string name="search_pseudo_placeholder">Topics où ce membre a posté…</string>
+    <string name="search_back">Retour</string>
     <string name="search_submit">Rechercher</string>
     <string name="search_retry">Réessayer</string>
-    <string name="search_idle_hint">Saisissez un mot-clé pour chercher dans les titres et messages HFR. Quand HFR fournit un extrait, le résultat ouvre le message correspondant ; sinon il ouvre le topic.</string>
+    <string name="search_idle_hint">Saisissez un mot-clé et/ou un pseudo. Le pseudo seul liste les topics où ce membre a posté. Quand HFR fournit un extrait, le résultat ouvre le message correspondant ; sinon il ouvre le topic.</string>
     <string name="search_loading">Recherche en cours…</string>
     <string name="search_empty">Aucun résultat pour cette recherche.</string>
     <!-- #324 — les cas ServerDown / Network rendent les libellés partagés de :core:ui
@@ -14,7 +17,7 @@
     <string name="search_scope_titles_and_posts">Titres + messages</string>
     <string name="search_scope_titles_only">Titres seuls</string>
     <string name="search_scope_posts_only">Messages seuls</string>
-    <string name="search_future_filters_hint">Filtres auteur, date et pagination arrivent dans la suite de la recherche.</string>
+    <string name="search_future_filters_hint">Filtres date et pagination arrivent dans la suite de la recherche.</string>
     <string name="search_pivot_label">Catégories HFR avec résultats</string>
     <string name="search_pivot_hint">HFR affiche les topics d’une catégorie à la fois. Choisir une catégorie relance la même recherche dans ce périmètre.</string>
     <string name="search_result_location">dans %1$s</string>

--- a/feature/search/src/test/kotlin/fr/forumhfr/redface2/feature/search/SearchViewModelTest.kt
+++ b/feature/search/src/test/kotlin/fr/forumhfr/redface2/feature/search/SearchViewModelTest.kt
@@ -54,7 +54,7 @@ class SearchViewModelTest {
 
     @Test
     fun `QueryChanged updates the query in state`() = runTest {
-        val vm = SearchViewModel(repo)
+        val vm = SearchViewModel(repo, initialPseudo = null)
         vm.submit(SearchIntent.QueryChanged("kotlin"))
         assertEquals("kotlin", vm.state.value.query)
         assertFalse(vm.state.value.hasSearched)
@@ -62,7 +62,7 @@ class SearchViewModelTest {
 
     @Test
     fun `Submit with a blank query does not call the repository`() = runTest {
-        val vm = SearchViewModel(repo)
+        val vm = SearchViewModel(repo, initialPseudo = null)
         vm.submit(SearchIntent.QueryChanged("   "))
         vm.submit(SearchIntent.Submit)
         coVerify(exactly = 0) { repo.search(any()) }
@@ -76,7 +76,7 @@ class SearchViewModelTest {
             topics = listOf(fakeTopic(topicId = 1, title = "Hello kotlin")),
             pivot = listOf(SearchPivotCategory(id = 10, label = "Programmation", isSelected = true)),
         )
-        val vm = SearchViewModel(repo)
+        val vm = SearchViewModel(repo, initialPseudo = null)
         vm.submit(SearchIntent.QueryChanged("kotlin"))
         vm.submit(SearchIntent.Submit)
 
@@ -92,7 +92,7 @@ class SearchViewModelTest {
     @Test
     fun `Submit no-results leaves results empty without an error`() = runTest {
         coEvery { repo.search(any()) } returns fakePage(topics = emptyList(), pivot = emptyList())
-        val vm = SearchViewModel(repo)
+        val vm = SearchViewModel(repo, initialPseudo = null)
         vm.submit(SearchIntent.QueryChanged("xqzkbm9wj4abc"))
         vm.submit(SearchIntent.Submit)
 
@@ -105,7 +105,7 @@ class SearchViewModelTest {
     @Test
     fun `repository IOException sets the network error kind and preserves the query`() = runTest {
         coEvery { repo.search(any()) } throws IOException("HFR search request failed: HFR returned 500")
-        val vm = SearchViewModel(repo)
+        val vm = SearchViewModel(repo, initialPseudo = null)
         vm.submit(SearchIntent.QueryChanged("kotlin"))
         vm.submit(SearchIntent.Submit)
 
@@ -120,7 +120,7 @@ class SearchViewModelTest {
         // #324 — DefaultSearchRepository lets the typed exception traverse (URL redacted);
         // a 5xx must surface as « HFR est en panne », not as a network problem.
         coEvery { repo.search(any()) } throws HfrServerException(code = 500, url = "<redacted>")
-        val vm = SearchViewModel(repo)
+        val vm = SearchViewModel(repo, initialPseudo = null)
         vm.submit(SearchIntent.QueryChanged("kotlin"))
         vm.submit(SearchIntent.Submit)
 
@@ -134,7 +134,7 @@ class SearchViewModelTest {
         // #324 — search has no dedicated session treatment; an expired session must not be
         // presented as a connectivity cut (classifyHfrError → Other).
         coEvery { repo.search(any()) } throws SessionExpiredException("<redacted>")
-        val vm = SearchViewModel(repo)
+        val vm = SearchViewModel(repo, initialPseudo = null)
         vm.submit(SearchIntent.QueryChanged("kotlin"))
         vm.submit(SearchIntent.Submit)
 
@@ -149,7 +149,7 @@ class SearchViewModelTest {
             if (attempt == 1) throw IOException("offline")
             else fakePage(topics = listOf(fakeTopic(2, "Recovered")), pivot = emptyList())
         }
-        val vm = SearchViewModel(repo)
+        val vm = SearchViewModel(repo, initialPseudo = null)
         vm.submit(SearchIntent.QueryChanged("kotlin"))
         vm.submit(SearchIntent.Submit) // first attempt throws
         assertEquals(HfrErrorKind.Network, vm.state.value.errorMessage)
@@ -190,7 +190,7 @@ class SearchViewModelTest {
             ),
         )
 
-        val vm = SearchViewModel(repo)
+        val vm = SearchViewModel(repo, initialPseudo = null)
         vm.submit(SearchIntent.QueryChanged("android"))
         vm.submit(SearchIntent.Submit)
 
@@ -232,7 +232,7 @@ class SearchViewModelTest {
             pivot = emptyList(),
         )
 
-        val vm = SearchViewModel(repo)
+        val vm = SearchViewModel(repo, initialPseudo = null)
         vm.submit(SearchIntent.QueryChanged("android"))
         vm.submit(SearchIntent.Submit)
         vm.submit(SearchIntent.TextScopeSelected(SearchTextScope.TitlesOnly))
@@ -293,7 +293,7 @@ class SearchViewModelTest {
             pivot = emptyList(),
         )
 
-        val vm = SearchViewModel(repo)
+        val vm = SearchViewModel(repo, initialPseudo = null)
         vm.submit(SearchIntent.QueryChanged("android"))
         vm.submit(SearchIntent.Submit)
         vm.submit(
@@ -347,7 +347,7 @@ class SearchViewModelTest {
             pivot = emptyList(),
         )
 
-        val vm = SearchViewModel(repo)
+        val vm = SearchViewModel(repo, initialPseudo = null)
         vm.submit(SearchIntent.QueryChanged("android"))
         vm.submit(SearchIntent.TextScopeSelected(SearchTextScope.PostsOnly))
         vm.submit(SearchIntent.Submit)
@@ -372,7 +372,7 @@ class SearchViewModelTest {
         coEvery { repo.search(SearchRequest(query = "kotlin", category = SearchCategoryScope.All)) } returns
             fakePage(topics = listOf(fakeTopic(1, "kotlin hit")), pivot = emptyList())
 
-        val vm = SearchViewModel(repo)
+        val vm = SearchViewModel(repo, initialPseudo = null)
         vm.state.test {
             // initial idle state
             skipItems(1)
@@ -404,7 +404,7 @@ class SearchViewModelTest {
             gate.await()
         }
 
-        val vm = SearchViewModel(repo)
+        val vm = SearchViewModel(repo, initialPseudo = null)
         vm.submit(SearchIntent.QueryChanged("android"))
         vm.submit(SearchIntent.Submit)
         assertTrue(vm.state.value.isLoading)
@@ -432,7 +432,7 @@ class SearchViewModelTest {
     @Test
     fun `OpenResult with a matched numreponse emits the resolved page`() = runTest {
         coEvery { repo.resolveSearchResultPage(cat = 23, post = 35421, numreponse = 2786758) } returns 3
-        val vm = SearchViewModel(repo)
+        val vm = SearchViewModel(repo, initialPseudo = null)
         val result = fakeTopic(topicId = 35421, title = "Redface dev", cat = 23, page = 1, numreponse = 2786758)
 
         vm.effects.test {
@@ -448,7 +448,7 @@ class SearchViewModelTest {
     @Test
     fun `OpenResult falls back to the href page when resolution returns null`() = runTest {
         coEvery { repo.resolveSearchResultPage(any(), any(), any()) } returns null
-        val vm = SearchViewModel(repo)
+        val vm = SearchViewModel(repo, initialPseudo = null)
         val result = fakeTopic(topicId = 35421, title = "Redface dev", cat = 23, page = 2, numreponse = 2786758)
 
         vm.effects.test {
@@ -464,7 +464,7 @@ class SearchViewModelTest {
     @Test
     fun `OpenResult falls back to page 1 when resolution throws and the href has no page`() = runTest {
         coEvery { repo.resolveSearchResultPage(any(), any(), any()) } throws IOException("offline")
-        val vm = SearchViewModel(repo)
+        val vm = SearchViewModel(repo, initialPseudo = null)
         val result = fakeTopic(topicId = 35421, title = "Redface dev", cat = 23, page = null, numreponse = 2786758)
 
         vm.effects.test {
@@ -480,7 +480,7 @@ class SearchViewModelTest {
 
     @Test
     fun `OpenResult on a title-only row emits page 1 without calling the repository`() = runTest {
-        val vm = SearchViewModel(repo)
+        val vm = SearchViewModel(repo, initialPseudo = null)
         val result = fakeTopic(topicId = 777, title = "Title-only hit", cat = 10)
 
         vm.effects.test {
@@ -498,7 +498,7 @@ class SearchViewModelTest {
     fun `OpenResult ignores further taps while a resolution is in flight`() = runTest {
         val gate = CompletableDeferred<Int?>()
         coEvery { repo.resolveSearchResultPage(any(), any(), any()) } coAnswers { gate.await() }
-        val vm = SearchViewModel(repo)
+        val vm = SearchViewModel(repo, initialPseudo = null)
         val result = fakeTopic(topicId = 35421, title = "Redface dev", cat = 23, page = 1, numreponse = 2786758)
 
         vm.effects.test {
@@ -525,7 +525,7 @@ class SearchViewModelTest {
         coEvery { repo.resolveSearchResultPage(any(), any(), any()) } coAnswers {
             CompletableDeferred<Int?>().await()
         }
-        val vm = SearchViewModel(repo)
+        val vm = SearchViewModel(repo, initialPseudo = null)
         val result = fakeTopic(topicId = 35421, title = "Redface dev", cat = 23, page = 1, numreponse = 2786758)
 
         vm.effects.test {
@@ -541,7 +541,7 @@ class SearchViewModelTest {
     @Test
     fun `OpenResult guard resets after a completed resolution`() = runTest {
         coEvery { repo.resolveSearchResultPage(any(), any(), any()) } returns 3
-        val vm = SearchViewModel(repo)
+        val vm = SearchViewModel(repo, initialPseudo = null)
         val result = fakeTopic(topicId = 35421, title = "Redface dev", cat = 23, page = 1, numreponse = 2786758)
 
         vm.effects.test {
@@ -553,6 +553,134 @@ class SearchViewModelTest {
             cancelAndIgnoreRemainingEvents()
         }
         coVerify(exactly = 2) { repo.resolveSearchResultPage(any(), any(), any()) }
+    }
+
+    // Author filter (`pseud=`) — query-only, author-only, and combined searches are all
+    // legal ; at least one of the two must be non-blank.
+
+    @Test
+    fun `Submit with author only calls the repository with the pseudo and an empty query`() = runTest {
+        coEvery { repo.search(any()) } returns fakePage(
+            topics = listOf(fakeTopic(1, "participated topic")),
+            pivot = emptyList(),
+        )
+        val vm = SearchViewModel(repo, initialPseudo = null)
+        vm.submit(SearchIntent.PseudoChanged("Lt Ripley"))
+        vm.submit(SearchIntent.Submit)
+
+        coVerify(exactly = 1) {
+            repo.search(
+                SearchRequest(query = "", category = SearchCategoryScope.All, pseudo = "Lt Ripley"),
+            )
+        }
+        assertTrue(vm.state.value.hasSearched)
+        assertEquals(1, vm.state.value.results.size)
+    }
+
+    @Test
+    fun `Submit with blank query AND blank pseudo does not call the repository`() = runTest {
+        val vm = SearchViewModel(repo, initialPseudo = null)
+        vm.submit(SearchIntent.QueryChanged("   "))
+        vm.submit(SearchIntent.PseudoChanged("  "))
+        vm.submit(SearchIntent.Submit)
+        coVerify(exactly = 0) { repo.search(any()) }
+        assertFalse(vm.state.value.hasSearched)
+    }
+
+    @Test
+    fun `a non-blank initialPseudo fires the author-only search at construction`() = runTest {
+        coEvery { repo.search(any()) } returns fakePage(
+            topics = listOf(fakeTopic(1, "recent post topic")),
+            pivot = emptyList(),
+        )
+        val vm = SearchViewModel(repo, initialPseudo = "Lt Ripley")
+
+        coVerify(exactly = 1) {
+            repo.search(
+                SearchRequest(query = "", category = SearchCategoryScope.All, pseudo = "Lt Ripley"),
+            )
+        }
+        val state = vm.state.value
+        assertEquals("Lt Ripley", state.pseudo)
+        assertTrue(state.hasSearched)
+        assertEquals("recent post topic", state.results.first().title)
+    }
+
+    @Test
+    fun `a null initialPseudo starts idle without any repository call`() = runTest {
+        val vm = SearchViewModel(repo, initialPseudo = null)
+        coVerify(exactly = 0) { repo.search(any()) }
+        assertFalse(vm.state.value.hasSearched)
+    }
+
+    @Test
+    fun `PseudoChanged invalidates the displayed results like QueryChanged`() = runTest {
+        coEvery { repo.search(any()) } returns fakePage(
+            topics = listOf(fakeTopic(1, "hit")),
+            pivot = emptyList(),
+        )
+        val vm = SearchViewModel(repo, initialPseudo = null)
+        vm.submit(SearchIntent.QueryChanged("kotlin"))
+        vm.submit(SearchIntent.Submit)
+        assertEquals(1, vm.state.value.results.size)
+
+        vm.submit(SearchIntent.PseudoChanged("Lt Ripley"))
+
+        val typed = vm.state.value
+        assertEquals("Lt Ripley", typed.pseudo)
+        assertEquals("the un-submitted query stays in its field", "kotlin", typed.query)
+        assertFalse("editing the author filter orphans the displayed results", typed.hasSearched)
+        assertEquals(emptyList<SearchTopicResult>(), typed.results)
+    }
+
+    @Test
+    fun `Retry re-runs the last author-only search with its pseudo`() = runTest {
+        var attempt = 0
+        coEvery { repo.search(any()) } answers {
+            attempt += 1
+            if (attempt == 1) throw IOException("offline")
+            else fakePage(topics = listOf(fakeTopic(2, "Recovered")), pivot = emptyList())
+        }
+        val vm = SearchViewModel(repo, initialPseudo = null)
+        vm.submit(SearchIntent.PseudoChanged("Lt Ripley"))
+        vm.submit(SearchIntent.Submit)
+        assertEquals(HfrErrorKind.Network, vm.state.value.errorMessage)
+
+        vm.submit(SearchIntent.Retry)
+
+        coVerify(exactly = 2) {
+            repo.search(
+                SearchRequest(query = "", category = SearchCategoryScope.All, pseudo = "Lt Ripley"),
+            )
+        }
+        assertEquals("Recovered", vm.state.value.results.first().title)
+    }
+
+    @Test
+    fun `CategorySelected keeps the author filter of an author-only search`() = runTest {
+        coEvery { repo.search(any()) } returns fakePage(
+            topics = listOf(fakeTopic(1, "pivot hit")),
+            pivot = listOf(
+                SearchPivotCategory(id = 1, label = "Hardware", isSelected = true),
+                SearchPivotCategory(id = 10, label = "Programmation", isSelected = false),
+            ),
+        )
+        val vm = SearchViewModel(repo, initialPseudo = "Lt Ripley")
+        vm.submit(
+            SearchIntent.CategorySelected(
+                SearchPivotCategory(id = 10, label = "Programmation", isSelected = false),
+            ),
+        )
+
+        coVerify(exactly = 1) {
+            repo.search(
+                SearchRequest(
+                    query = "",
+                    category = SearchCategoryScope.Category(id = 10, name = "Programmation"),
+                    pseudo = "Lt Ripley",
+                ),
+            )
+        }
     }
 
     private fun fakeTopic(


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Référence #402 (`closes-#402` volontairement cassé — fermeture à la promotion dev→main).

## Quoi

- **`SearchRequest.pseudo`** → `HfrClient.searchTopics` envoie `pseud=` (était vide en dur) → `DefaultSearchRepository` forward + diagnostics en flag de présence (même contrat de redaction que la query).
- **Formulaire de recherche** : champ « Auteur (pseudo) » sous le mot-clé ; soumission légale si mot-clé OU pseudo non vide ; retry / re-scope pivot / changement de portée conservent le filtre auteur ; éditer l'un des deux champs invalide les résultats affichés (contrat `QueryChanged` partagé).
- **`SearchViewModel` → `@AssistedInject`** (pattern `ProfileViewModel`) : `initialPseudo` non vide = recherche auteur-seul tirée dans `init` (entrée profil).
- **`SearchUserPostsRoute(pseudo)`** : route séparée poussée sur la pile de l'onglet courant — `SearchRoute` racine reste un `data object` (sérialisation des back stacks préservée) et l'état de l'onglet Recherche n'est pas touché. Affordance retour dédiée dans l'en-tête.
- **Profil** : « Derniers messages » activé (était grisé « à venir ») — navigue avec le pseudo **canonique** du profil chargé.

## Contrat vérifié live (2026-06-11)

Recherche par auteur seul OK dans les trois shapes : cat explicite `titre=1` (fixture existante `search_pseud_filter_lt_ripley.html`), cat explicite `titre=3` (snippets + numreponse → navigation directe vers le post), toutes-cats `titre=3` (302 → pivot multi-cat, suivi par OkHttp, shape déjà parsé).

## Tests

- 7 nouveaux tests `SearchViewModelTest` (auteur seul, les deux vides, prefill init, invalidation `PseudoChanged`, retry avec pseudo, pivot avec pseudo, idle sans prefill) — exécutés.
- Validation 2 parts Docker : `detektAll test testDebugUnitTest :app:assembleProdDebug` puis `:app:lintProdDebug` — vertes.

Review Codex en cours, posté en commentaire à réception.