### PR TITLE
feat(mpstorage): lecture seule v0.1 de facto — ADR-014, parser tolérant, pipeline 3-GET

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepository.kt
@@ -1,0 +1,123 @@
+package fr.forumhfr.redface2.core.data.mpstorage
+
+import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
+import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
+import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageResult
+import fr.forumhfr.redface2.core.network.HfrClient
+import fr.forumhfr.redface2.core.parser.messages.PrivateMessageThreadParser
+import fr.forumhfr.redface2.core.parser.mpstorage.MpStorageDiscoveryParser
+import fr.forumhfr.redface2.core.parser.mpstorage.MpStorageParser
+import fr.forumhfr.redface2.core.parser.write.ReplyFormParser
+import java.time.Clock
+import java.time.LocalDate
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+
+/**
+ * Default [MpStorageRepository] (#6, ADR-014) — three authenticated GETs, zero writes :
+ *
+ *  1. subject search (`forum1.php?recherches=1&cat=prive&search=<hash>&titre=1`) →
+ *     [MpStorageDiscoveryParser] yields the storage conversation's thread id, or `null`
+ *     (no storage on this account → [MpStorageResult.NotFound], the nominal case) ;
+ *  2. conversation page 1 → the FIRST post's `numreponse` (the storage document lives in
+ *     the first post, per the de-facto contract) ;
+ *  3. edit form of that post → `content_form` (raw text) → [MpStorageParser].
+ *
+ * Diagnostics never log the document content (it aggregates private reading positions from
+ * every userscript) — only presence flags, sizes and failure classes, same #316 stance as
+ * the other private-message repositories.
+ */
+@Singleton
+@Suppress("LongParameterList") // One dep per pipeline stage (3 GETs, 3 parsers) + diagnostics, clock, dispatcher.
+class DefaultMpStorageRepository @Inject constructor(
+    private val hfrClient: HfrClient,
+    private val discoveryParser: MpStorageDiscoveryParser,
+    private val threadParser: PrivateMessageThreadParser,
+    private val replyFormParser: ReplyFormParser,
+    private val storageParser: MpStorageParser,
+    private val diagnostics: DiagnosticsLog,
+    private val clock: Clock,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) : MpStorageRepository {
+
+    override suspend fun fetchStorage(): MpStorageResult {
+        return try {
+            withContext(ioDispatcher) {
+                val searchHtml = hfrClient.searchPrivateMessagesBySubject(
+                    subject = MpStorageRepository.STORAGE_SUBJECT_HASH,
+                    date = LocalDate.now(clock),
+                )
+                val threadId = discoveryParser.parseFirstThreadId(searchHtml)
+                if (threadId == null) {
+                    diagnostics.record(DiagnosticsLog.Level.INFO, LOG_TAG, "discovery: no storage MP")
+                    return@withContext MpStorageResult.NotFound
+                }
+                diagnostics.record(DiagnosticsLog.Level.INFO, LOG_TAG, "discovery: storage MP found")
+
+                val thread = threadParser.parse(hfrClient.getPrivateMessageThreadPage(threadId, page = 1))
+                val firstNumreponse = thread.messages.firstOrNull()?.numreponse
+                if (firstNumreponse == null) {
+                    diagnostics.record(DiagnosticsLog.Level.WARN, LOG_TAG, "storage thread has no first post")
+                    return@withContext MpStorageResult.Unreadable
+                }
+
+                val form = replyFormParser
+                    .parse(hfrClient.getPrivateMessageEditForm(threadId, firstNumreponse))
+                    .getOrElse { error ->
+                        diagnostics.record(
+                            DiagnosticsLog.Level.WARN,
+                            LOG_TAG,
+                            "edit form parse FAILED: ${error::class.simpleName}",
+                        )
+                        return@withContext MpStorageResult.Unreadable
+                    }
+                if (form.isAnonymous) {
+                    // The session evaporated between the search and the edit form GET.
+                    throw SessionExpiredException("MPStorage edit form served anonymous composer")
+                }
+
+                storageParser.parse(form.initialContent).fold(
+                    onSuccess = { document ->
+                        diagnostics.record(
+                            DiagnosticsLog.Level.INFO,
+                            LOG_TAG,
+                            "storage parsed: flags=${document.mpFlags.size} " +
+                                "rawSize=${document.rawEnvelope.length}",
+                        )
+                        MpStorageResult.Found(document)
+                    },
+                    onFailure = { error ->
+                        // ADR-014 : an unreadable document is surfaced, NEVER repaired.
+                        diagnostics.record(
+                            DiagnosticsLog.Level.WARN,
+                            LOG_TAG,
+                            "storage document unreadable: ${error::class.simpleName}",
+                        )
+                        MpStorageResult.Unreadable
+                    },
+                )
+            }
+        } catch (cancel: CancellationException) {
+            throw cancel
+        } catch (error: SessionExpiredException) {
+            diagnostics.record(DiagnosticsLog.Level.WARN, LOG_TAG, "fetchStorage SessionExpired")
+            throw error
+        } catch (@Suppress("TooGenericExceptionCaught") error: Throwable) {
+            diagnostics.record(
+                DiagnosticsLog.Level.WARN,
+                LOG_TAG,
+                "fetchStorage FAILED: ${error::class.simpleName}",
+            )
+            throw error
+        }
+    }
+
+    private companion object {
+        private const val LOG_TAG = "MpStorageRepository"
+    }
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/MpStorageRepositoryModule.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/MpStorageRepositoryModule.kt
@@ -1,0 +1,36 @@
+package fr.forumhfr.redface2.core.data.mpstorage
+
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
+import fr.forumhfr.redface2.core.parser.mpstorage.MpStorageDiscoveryParser
+import fr.forumhfr.redface2.core.parser.mpstorage.MpStorageParser
+import javax.inject.Singleton
+
+/**
+ * MPStorage (#6, ADR-014) — Hilt wiring. Same pattern as [fr.forumhfr.redface2.core.data
+ * .search.SearchRepositoryModule] : `@Binds` for the interface, `@Provides` for the pure
+ * parsers (no `@Inject` constructors). `PrivateMessageThreadParser` / `ReplyFormParser`
+ * are already provided by `PlatformBindingsModule` / the write modules.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class MpStorageRepositoryModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindMpStorageRepository(impl: DefaultMpStorageRepository): MpStorageRepository
+
+    companion object {
+        @Provides
+        @Singleton
+        fun provideMpStorageParser(): MpStorageParser = MpStorageParser()
+
+        @Provides
+        @Singleton
+        fun provideMpStorageDiscoveryParser(): MpStorageDiscoveryParser = MpStorageDiscoveryParser()
+    }
+}

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepositoryTest.kt
@@ -1,0 +1,151 @@
+package fr.forumhfr.redface2.core.data.mpstorage
+
+import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageDocument
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageFlagEntry
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageResult
+import fr.forumhfr.redface2.core.network.HfrClient
+import fr.forumhfr.redface2.core.parser.messages.PrivateMessageThreadParser
+import fr.forumhfr.redface2.core.parser.mpstorage.MpStorageDiscoveryParser
+import fr.forumhfr.redface2.core.parser.mpstorage.MpStorageParser
+import fr.forumhfr.redface2.core.parser.write.ReplyFormParser
+import io.mockk.every
+import io.mockk.mockk
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * MPStorage read pipeline (#6, ADR-014) over a [MockWebServer], real fixtures only :
+ * the discovery listing fixtures were captured live 2026-06-11 ; the conversation page is
+ * the #298 fixture ; the edit form is the Phase 2D fixture (whose `content_form` is a real
+ * BBCode post, NOT JSON — which legitimately exercises the [MpStorageResult.Unreadable]
+ * arm of the pipeline). The Found arm is exercised with a stubbed storage parser over the
+ * same pipeline (plus the JSON-contract coverage in `MpStorageParserTest`) ; a live
+ * end-to-end Found fixture requires an account that owns a storage MP (ADR-014 lists this
+ * as a remaining verification gap).
+ */
+class DefaultMpStorageRepositoryTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var repository: DefaultMpStorageRepository
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().apply { start() }
+        repository = buildRepository()
+    }
+
+    private fun buildRepository(storageParser: MpStorageParser = MpStorageParser()): DefaultMpStorageRepository {
+        val okHttp = OkHttpClient.Builder().build()
+        val client = HfrClient(
+            authenticated = okHttp,
+            anonymous = okHttp,
+            baseUrl = server.url("/"),
+            ioDispatcher = Dispatchers.Unconfined,
+        )
+        return DefaultMpStorageRepository(
+            hfrClient = client,
+            discoveryParser = MpStorageDiscoveryParser(),
+            threadParser = PrivateMessageThreadParser(),
+            replyFormParser = ReplyFormParser(),
+            storageParser = storageParser,
+            diagnostics = DiagnosticsLog(),
+            clock = Clock.fixed(Instant.parse("2026-06-11T00:00:00Z"), ZoneOffset.UTC),
+            ioDispatcher = Dispatchers.Unconfined,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `no storage MP maps to NotFound after a single authenticated search GET`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("mp_storage_search_no_results.html")))
+
+        val result = repository.fetchStorage()
+
+        assertEquals(MpStorageResult.NotFound, result)
+        assertEquals(1, server.requestCount)
+        val url = requireNotNull(server.takeRequest().requestUrl)
+        assertEquals("forum1.php", url.pathSegments.first())
+        assertEquals("prive", url.queryParameter("cat"))
+        assertEquals("1", url.queryParameter("recherches"))
+        assertEquals("a2bcc09b796b8c6fab77058ff8446c34", url.queryParameter("search"))
+        assertEquals("1", url.queryParameter("titre"))
+    }
+
+    @Test
+    fun `discovery hit drives the 3-GET pipeline and a non-JSON document maps to Unreadable`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("mp_storage_search_hit.html")))
+        server.enqueue(MockResponse().setBody(fixture("private_message_thread.html")))
+        // Real edit-form fixture : its content_form is a plain BBCode post — per ADR-014 an
+        // unreadable document is surfaced, NEVER repaired (no further request, no write).
+        server.enqueue(MockResponse().setBody(fixture("write_edit_form_test_post.html")))
+
+        val result = repository.fetchStorage()
+
+        assertEquals(MpStorageResult.Unreadable, result)
+        assertEquals(3, server.requestCount)
+
+        val search = requireNotNull(server.takeRequest().requestUrl)
+        assertEquals("forum1.php", search.pathSegments.first())
+
+        // Thread page of the FIRST discovered conversation — the fixture's first listing row
+        // (HFR default sort : last-message date) was renumbered 9000003 during scrubbing.
+        val thread = requireNotNull(server.takeRequest().requestUrl)
+        assertEquals("forum2.php", thread.pathSegments.first())
+        assertEquals("prive", thread.queryParameter("cat"))
+        assertEquals("9000003", thread.queryParameter("post"))
+        assertEquals("1", thread.queryParameter("page"))
+
+        // Edit form of the conversation's FIRST post — the #298 thread fixture's first
+        // anchor is t1980664234, so that exact numreponse must be forwarded.
+        val edit = requireNotNull(server.takeRequest().requestUrl)
+        assertEquals("message.php", edit.pathSegments.first())
+        assertEquals("prive", edit.queryParameter("cat"))
+        assertEquals("9000003", edit.queryParameter("post"))
+        assertEquals("1980664234", edit.queryParameter("numreponse"))
+    }
+
+    @Test
+    fun `a parseable document rides the same pipeline and maps to Found`() = runTest {
+        // Codex review of #406 : no real account with a storage MP exists to capture a live
+        // JSON content_form (the ADR-014 verification gap), so the Found arm is exercised by
+        // stubbing ONLY the storage parser over the real 3-GET pipeline and real fixtures.
+        val document = MpStorageDocument(
+            sourceName = "DTCloud",
+            mpFlags = listOf(MpStorageFlagEntry(threadId = 12345, page = 3, numreponse = 42, uri = null)),
+            rawEnvelope = """{ "data": [] }""",
+        )
+        repository = buildRepository(
+            storageParser = mockk { every { parse(any()) } returns Result.success(document) },
+        )
+        server.enqueue(MockResponse().setBody(fixture("mp_storage_search_hit.html")))
+        server.enqueue(MockResponse().setBody(fixture("private_message_thread.html")))
+        server.enqueue(MockResponse().setBody(fixture("write_edit_form_test_post.html")))
+
+        val result = repository.fetchStorage()
+
+        assertEquals(MpStorageResult.Found(document), result)
+        assertEquals(3, server.requestCount)
+    }
+
+    private fun fixture(name: String): String {
+        val stream = requireNotNull(
+            DefaultMpStorageRepositoryTest::class.java.classLoader?.getResourceAsStream("fixtures/$name"),
+        ) { "Fixture not found: fixtures/$name" }
+        return stream.bufferedReader().use { it.readText() }
+    }
+}

--- a/core/data/src/test/resources/fixtures/mp_storage_search_hit.html
+++ b/core/data/src/test/resources/fixtures/mp_storage_search_hit.html
@@ -1,0 +1,228 @@
+
+	<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+	<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr" lang="fr">
+	<head><title>Messages privés - FORUM HardWare.fr</title><link rel="stylesheet" type="text/css" href="/include/the_style1.php?color_key=f2f3ef/DEDFDF/000080/C2C3F4/d5e6e1/000080/000080/000000/000080/000000/000080/f7f7f7/f0eee9/f7f7f7/f0eee9/C0C0C0/C0C0C0/FFFFFF/000000/000000/0000FF/EEEEFF/DDDDEE/000000/FFEEEE/000000/FFFFFF/FF0000/FFFFFF/0/1/https%3A%40%40forum-images.hardware.fr/NULL/&amp;abs_img_path=%40data%40sites%40forum%40www%40static%40&amp;hide_bg_onglet=0&amp;v=11102781422" /><link type="text/css" rel="stylesheet" href="https://forum-images.hardware.fr/compressed/the_style.css?v=11102781422" /><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/tabs.js?v=11102781422"></script><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/forum1.js?v=11102781422"></script><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/common.js?v=11102781422"></script><style type="text/css">
+	.textareaOff {
+		font-size:8px;
+		border:1px solid #f00;
+		background-color:#ddd;
+	}
+	</style>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta http-equiv="Imagetoolbar" content="no" />
+	<meta name="Robots" content="noindex, follow" />
+	<style type="text/css">
+<!--
+.fastsearchMain{ width: 330px; }
+.fastsearchInput{ width: 70px; border: 1px solid black; }
+.fastsearchSubmit{ background-color: ; border: 0px;}
+.header2 { background-image: url(/img/forum3_1.gif);background-repeat: repeat-x; }
+.menuExt { font-family: Arial, Helvetica, sans-serif; font-size: 10px; color:#000; }
+.menuExt a { color:#000;text-decoration:none; }
+.menuExt a:hover { color:#000;text-decoration:underline; }
+form { display: inline; }
+.header { background-image: url(//forum-images.hardware.fr/img/header-bg.gif); background-repeat: repeat-x; }
+.tdmenu { width: 1px;height: 1px;color: #000000; }
+.hfrheadmenu { font-family: Arial, Helvetica, sans-serif;font-size:13px;font-weight:bold; }
+.hfrheadmenu span {color:;}
+.hfrheadmenu a { color:;text-decoration: none; }
+.hfrheadmenu a:hover { color:;text-decoration: underline; }
+.concours { font-family: Arial, Helvetica, sans-serif;color:;font-size: 16px;text-decoration: none;font-weight: bold;}
+.concours:hover { font-family: Arial, Helvetica, sans-serif;color:;font-size: 16px;text-decoration: underline;font-weight: bold; }
+.searchmenu { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: none;font-weight: bold; }
+.fastsearch { display: none; }
+.fastsearchHeader { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: none;font-weight: bold; }
+.fastsearchHeader:hover { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: underline;font-weight: bold; }
+-->
+</style>
+<script async='async' src='https://www.googletagservices.com/tag/js/gpt.js'></script>
+<script>
+  var googletag = googletag || {};
+  googletag.cmd = googletag.cmd || [];
+</script>
+
+<script>
+  googletag.cmd.push(function() {
+    googletag.defineSlot('/2172442/forum_accueil_banniere', [728, 90], 'div-gpt-ad-1511901001563-0').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_achats_ventes_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-1').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_achats_ventes_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-2').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_achats_ventes_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-3').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_achats_ventes_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-4').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_apple_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-5').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_apple_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-6').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_apple_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-7').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_apple_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-8').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_banniere_jpdc', [728, 90], 'div-gpt-ad-1511901001563-9').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-10').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-11').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-12').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-13').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_emploi_etude_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-14').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_emploi_etude_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-15').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_emploi_etude_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-16').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_emploi_etude_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-17').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_graphisme_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-18').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_graphisme_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-19').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_graphisme_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-20').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_graphisme_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-21').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_banniere', [728, 90], 'div-gpt-ad-1511901001563-22').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-23').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-24').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-25').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-26').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_peripheriques_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-27').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_peripheriques_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-28').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_peripheriques_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-29').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_peripheriques_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-30').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_jeux_video_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-31').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_jeux_video_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-32').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_jeux_video_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-33').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_jeux_video_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-34').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_ordinateurs_portables_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-35').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_ordinateurs_portables_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-36').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_ordinateurs_portables_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-37').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_ordinateurs_portables_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-38').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_os_alternatif_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-39').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_os_alternatif_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-40').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_os_alternatif_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-41').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_os_alternatif_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-42').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_overclocking_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-43').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_overclocking_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-44').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_overclocking_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-45').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_overclocking_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-46').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_photo_numerique_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-47').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_photo_numerique_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-48').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_photo_numerique_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-49').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_photo_numerique_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-50').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_programmation_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-51').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_programmation_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-52').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_programmation_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-53').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_programmation_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-54').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_reseaux_grand_public_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-55').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_reseaux_grand_public_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-56').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_reseaux_grand_public_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-57').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_reseaux_grand_public_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-58').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_seti_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-59').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_seti_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-60').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_seti_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-61').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_seti_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-62').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_systemes_reseaux_pro_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-63').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_systemes_reseaux_pro_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-64').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_systemes_reseaux_pro_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-65').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_systemes_reseaux_pro_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-66').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_technologies_mobiles_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-67').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_technologies_mobiles_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-68').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_technologies_mobiles_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-69').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_technologies_mobiles_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-70').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_video_son_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-71').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_video_son_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-72').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_video_son_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-73').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_video_son_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-74').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_windows_software_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-75').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_windows_software_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-76').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_windows_software_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-77').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_windows_software_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-78').addService(googletag.pubads());
+    googletag.pubads().enableSingleRequest();
+    googletag.enableServices();
+  });
+</script>
+<script type='text/javascript'>
+     (function(){
+       var loc = window.location.href;
+       var dd = document.createElement('script');
+       dd.type = 'text/javascript'; dd.src = '//static.digidip.net/hardware.js?loc=' + loc;
+       var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(dd, s);
+     })();
+</script></head><body id="unique__topics_listing__results_search_private_thread"  > <table cellspacing="0" cellpadding="0" width="98%" bgcolor="#000000" border="0" align="center" class="hfrheadmenu" style="border:1px solid #000;border-top:0;">
+        <tr>
+          <td style="vertical-align: top">
+            <table cellspacing="0" cellpadding="0" width="100%" border="0">
+              <tr>
+                <td style="width: 100%" align="left" valign="middle" colspan="2" class="header2"><span class="md_cryptlink45CBCBC0C22D1F1FCCCCCC19454AC14BCC4AC1431944C1"><img src="/img/forum_logo.gif" width="900" height="71" border="0" alt="" /></span></td>
+              </tr>
+              <tr>
+                <td style="background-color:#d5e6e1">
+                  <table cellspacing="0" cellpadding="2" width="100%" border="0">
+                    <tr>
+                      <td>&nbsp;<a class="cHeader" href="/">Forum</a>&nbsp;|&nbsp;
+<a class="cHeader" href="https://www.hardware.fr/">HardWare.fr</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/html/news/">News</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/html/articles/">Articles</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/articles/786-1/guide-pc-hardware-fr.html">PC</a>&nbsp;|&nbsp;<span class="md_cryptlink1FC349484F4C19C045C02F424F4944464C2E454AC14BCC4AC14344C11946494214424F4B434543C52E2341434A21264B2A4A424B422625422B252122212C44204321442C2C2A2A2142">Se d&eacute;connecter</span>&nbsp;|&nbsp;<span class="md_cryptlink1FC3C243C11F434B46CBC0C14F44464819C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">Profil</span>&nbsp;|&nbsp;<a class="cHeader" href="https://shop.hardware.fr/" target="_blank" style="position: relative; padding: 0 21px 0 0;display: inline-block;">Shop <img src="/img/shop.png" style="height: 17px; display: inline; position: absolute; right: 0; top: -2px; "></a></td>
+<td align="right"><a class="cHeader" href="/search.php?config=hardwarefr.inc&cat=prive&subcat=0">Recherche <img src="//forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif"></a></td>
+                    </tr>
+                    </table></td></tr></table>
+</td></tr></table><div style="width: 99%" align="right">
+<span class="s2Ext menuExt"><span class="md_cryptlink1F4F494846494319C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">8209 connect&eacute;s&nbsp;</span></span></div><br /><div class="container"><div class="mesdiscussions" id="mesdiscussions"><div class="arbo">
+<span  id="md_arbo_tree_1" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/" class="Ext">FORUM HardWare.fr</a></span>
+<br />
+<h1  id="md_arbo_tree_2" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;Messages privés</h1>
+</div><div class="rightbutton fastsearch"><table class="main fastsearchMain" cellspacing="0" cellpadding="2"><tr class="cBackHeader fondForumDescription"><th><form method="post" id="fastsearch" action="/forum1.php"><input type="hidden" name="hash_check" value="SCRUBBED_HASH_CHECK" /><label for="fastsearchinputid"><a rel="nofollow" href="/search.php?config=hfr.inc&amp;cat=prive&amp;subcat=0" class="cHeader fastsearchHeader">Recherche :</a>&nbsp;<input type="text" name="search" id="fastsearchinputid" value="" class="fastsearchInput" alt="Search string" /></label><input type="hidden" name="recherches" value="1" /><input type="hidden" name="searchtype" value="1" /><input type="hidden" name="titre" value="3" /><input type="hidden" name="resSearch" value="200" /><input type="hidden" name="orderSearch" value="1" /><input type="hidden" name="config" value="hfr.inc" /><input type="hidden" name="cat" value="prive" />&nbsp;<input type="image" src="https://forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif" class="fastsearchSubmit" title="Lancer une recherche" alt="Lancer une recherche" /></form></th></tr></table></div><div class="spacer fastsearch"></div><div class="rightbutton"><a rel="nofollow" href="/message.php?config=hfr.inc&amp;cat=prive&amp;sond=0&amp;p=1&amp;subcat=0&amp;dest=&amp;subcatgroup=0" id="md_btn_new_topic"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/newsujet.gif" title="Créer un nouveau message" alt="Créer un nouveau message" /></a><br /><br /></div><div class="compactModoInterface spacer">&nbsp;</div><br /><div class="s1Ext"></div><br /><table class="none" style="border:0px" cellspacing="0" cellpadding="0"><tr><td style="vertical-align:bottom"></td><td style="vertical-align:bottom">&nbsp;</td></tr></table><table class="main" cellspacing="0" cellpadding="2"><tr class="cBackHeader fondForum1Subcat"><th class="padding" colspan="11"><form action="/user/ignore.php" method="get"><input type="hidden" name="hash_check" value="SCRUBBED_HASH_CHECK" /><div class="left">&nbsp;Mettre / Enlever de l'ignore list :
+							<input type="hidden" name="config" value="hfr.inc" />
+							<input type="text" name="auteur" value="" size="25" />
+							<input type="hidden" name="page" value="1" />
+							<input type="submit" value="Go" />
+						</div>
+					</form></th></tr><form name="form1" method="post" action="/modo/manageaction.php?config=hfr.inc&amp;cat=prive&amp;type_page=forum1&amp;moderation=0"><input type="hidden" name="hash_check" value="SCRUBBED_HASH_CHECK" /><tr class="cBackHeader fondForum1PagesHaut"><td class="padding" colspan="11"><div class="left"><b>&nbsp;Page&nbsp;: </b>&nbsp;&nbsp;<b>1</b></div><div class="pagepresuiv">&nbsp;&nbsp;</div><div class="pagepresuiv"></div></td></tr><tr class="cBackHeader fondForum1Description"><th scope="col">&nbsp;&nbsp;&nbsp;</th><th scope="col">&nbsp;&nbsp;&nbsp;</th><th scope="col">&nbsp;&nbsp;&nbsp;</th><th scope="col" style="width:50%; text-align:left;" align="left">Sujet</th>
+				<th scope="col" colspan="2">Dern. page</th><th scope="col">Interlocuteur</th><th scope="col" style="width:10%; text-align:center" colspan="2">
+					<b>Nombre de</b>
+					<br />
+					<div class="plop"><span style='font-size: 8px'>Rép.</span></div>
+					<div class="plop"><span style='font-size: 8px'>Lues</span></div>
+				</th><th scope="col">Date du dernier message</th><th scope="col"><a href="javascript:check_change('topic')" class="cHeader">---</a></th></tr><tr class="sujet ligne_booleen cBackCouleurTab1 "  onmouseover="md_process_roll_over(this,1)" onmouseout="md_process_roll_over(this,0)">
+					<td class="sujetCase1 cBackCouleurTab2 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedp.gif" title="Pas de nouveau message. Message privé pour TestUser" alt="Off" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td class="sujetCase2">&nbsp;</td><td scope="row" class="sujetCase3" ondblclick="location.href='/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=9000003&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=0&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0'"><span class="red" title="Ce message n'a pas été lu par : alien64, Bitman, bozoleclown, fire in the hole !!!, FRACTAL, KICKBACK, KillMe, Mistral_ winner, mitchb51, pharmajo, Raspa, sad-keitaro, Space, totoz, uxam, V, verdoux, vicenzo, Nowa, Fenston, Brad Pitt, Hermes le Messager, ze_snake, zcoold, toniocourc, gouleyance, Hansaplast, drake-, ph75, Pere Dodu, prokie, niku, tekel, -Patrick-, LorDjidane, viniw, racingman11, michel 1664, Kede, cyd125, Lobster, Apokrif, Foxus666, xxantoinexx, Scrypt, babyboy4, pojolfou, srfcboy, Baathor, andhar, jerome38, poutrella, boubougna, Dam468, orbis, htaeD, RoY_, patx3, boubagump ii, FRANCKBLB, ben80, Shinseiki, BlinkGT, koko707, Hodor, Amaniak, Nykhola, Slider14, M_D_C, tapiefan, StefSamy, weemanbe, Johnny_Marrocain, KingJames6323, _Makaveli_, canti75, Bobox, tourtour, Bakk, The North Face, sidela, doutrisor, toper_harley_, Mike Hoksbiger, super_pourri, voor0ck, croustx, verseb, Hazumaki, data, gracchus, Blaq, ozidivision, t_faz, matnissa, TrakT, Godyfou, el nino71, psykhi, dragages, ilyama, Yurk, shenron67, Twano, Critias, quiet now, Arkin, cisco1, vieilArthuro, Subarashi, freddy021, Donkey&#039;, Correspondant, Kirk_Lee_Hammett, _Pouvoir, rockbottom, fracture du tibia, GenyaB, genkidama-hfr, Van Winkle, The Smoking Man, IMGaia, roland-, dissou, Damze, el_nono_masquay, coco_killer, Brazeinstein, jeprendsmonpied, Bisounours58, arnyek, fazero, spacex, Azrail, Hubert Farnsworth, weeWEEx, Hauptimisateur, varlocke, le zombie, LeGuideDuBledard, Ass-Itch, Van Langenhove, saLutat1ons, Coyote a foie jaune, meta67, Bretzel Authentique, Proust4, Chapiiiiiiii, Gallagh, kronekenbc, jamesmoore, Nyymi, petite fraise, Kupfer, Bobinou90, tesser4ct, Trifon_Ivanov, NewChallenger, doublebeurre, orodreths, Smelly Jelly, teamfive94, filiptif, Nitescent, El Flasco, thoulisse_bernard, maitre morissard, Burracho, NEmergix, starsida, juan-natal la pagina, ge haussmann, valentinvtl, liliro, Dabeuliouu, raskoln, Jahaa_sv, shinketsushuu, Demodulateur, alain haque-barre, DjullClint, Mad Ratz, Francis_Llacer, Chutelibre, aktarus69, carbon based, LiamManziel, casey tatum, Rucous, Horizon rouge, sebmbalo, delphine donkey, SaucissonMasque, BarbaLurke, sillage276, Hornett, erik von hartmann, Cliff Barnes, MajoriteSilencieuse, - Erik Von Hartmann, Gwrach, 1000Trees, orvalon, LeAmAs, Princesse Ruspoli, jeanguylecointre, NarineDebouchee, Stilgar59, herrphilippvonmoritz, ironpanda, volog, ImpactShiny, mais bien-sur, MySong-Tong, sergebenhamou, mejoralo, Fiotte du Tertiaire, dona nobis pacem, la creatura, La_Salamandre, Administration, antoine grise mine, Roupillon, Serresjp, bonnefranquette, -jean5-, nicha, bobo le fou, arlette chabrot, christophe barbie, alexandre lacanette, martin2troie, choufarci, FrerTok, abdelatif mourousi, marie-laure aigrie, multimmy, Cizia zazi, Rick_C137, tarzan-la-banane, azymantiop, ddlabraguette, noel le grec, nut3l@, vanadix, carlos rey, grossbaf1, herpes le passager, Oreille Sale, professeur raoult, brawndo, Liberatore, jydi75, maajora, estunpanda, Jay_hacke, rcommueriez">[non lu]</span> <a href="/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=9000003&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=0&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0" class="cCatTopic" title="Sujet n°2975088">Sujet de test 1</a></td><td class="sujetCase4"><a href="/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=9000003&amp;page=683&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=0&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0" class="cCatTopic">Sujet de test 2</a></td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab2 "><span title="TestUser">Correspondant</span></td>
+				  <td class="sujetCase7">27298</td>
+				  <td class="sujetCase8">491579</td>
+				  <td class="sujetCase9 cBackCouleurTab2 "><a href="/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=9000003&amp;page=683&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=0&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0#bas" class="Tableau">10-06-2026&nbsp;à&nbsp;23:20<br /><b>Correspondant</b></a></td><td class="sujetCase10"><input type="checkbox" name="topic0"  value="2975088" /><input type="hidden" name="valuecat0" value="prive" /><input type="hidden" name="valueforum0" value="hardwarefr" /></td></tr><tr class="sujet ligne_booleen cBackCouleurTab3 "  onmouseover="md_process_roll_over(this,1)" onmouseout="md_process_roll_over(this,0)">
+					<td class="sujetCase1 cBackCouleurTab4 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedp.gif" title="Pas de nouveau message. Message privé pour Correspondant" alt="Off" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td class="sujetCase2"><a href="/user/ignore.php?config=hfr.inc&amp;auteur=Correspondant&amp;page=1"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/ignore0.gif" title="Mettre Correspondant en ignore list" alt="On" /></a></td><td scope="row" class="sujetCase3" ondblclick="location.href='/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=9000002&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=0&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0'"><a href="/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=9000002&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=0&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0" class="cCatTopic" title="Sujet n°2824282">Sujet de test 3</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab4 "><a rel="nofollow" href="/profilebdd.php?config=hfr.inc&amp;pseudo=Correspondant" class="Tableau">Correspondant</a></td>
+				  <td class="sujetCase7">23</td>
+				  <td class="sujetCase8">52</td>
+				  <td class="sujetCase9 cBackCouleurTab4 "><a href="/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=9000002&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=0&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0#bas" class="Tableau">19-10-2019&nbsp;à&nbsp;10:01<br /><b>TestUser</b></a></td><td class="sujetCase10"><input type="checkbox" name="topic1"  value="2824282" /><input type="hidden" name="valuecat1" value="prive" /><input type="hidden" name="valueforum1" value="hardwarefr" /></td></tr><tr class="sujet ligne_booleen cBackCouleurTab1 "  onmouseover="md_process_roll_over(this,1)" onmouseout="md_process_roll_over(this,0)">
+					<td class="sujetCase1 cBackCouleurTab2 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedp.gif" title="Pas de nouveau message. Message privé pour Correspondant" alt="Off" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td class="sujetCase2"><a href="/user/ignore.php?config=hfr.inc&amp;auteur=Correspondant&amp;page=1"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/ignore0.gif" title="Mettre Correspondant en ignore list" alt="On" /></a></td><td scope="row" class="sujetCase3" ondblclick="location.href='/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=9000001&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=0&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0'"><a href="/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=9000001&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=0&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0" class="cCatTopic" title="Sujet n°2668077">Sujet de test 4</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab2 "><a rel="nofollow" href="/profilebdd.php?config=hfr.inc&amp;pseudo=Correspondant" class="Tableau">Correspondant</a></td>
+				  <td class="sujetCase7">0</td>
+				  <td class="sujetCase8">2</td>
+				  <td class="sujetCase9 cBackCouleurTab2 "><a href="/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=9000001&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=0&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0#bas" class="Tableau">21-02-2018&nbsp;à&nbsp;09:07<br /><b>Correspondant</b></a></td><td class="sujetCase10"><input type="checkbox" name="topic2"  value="2668077" /><input type="hidden" name="valuecat2" value="prive" /><input type="hidden" name="valueforum2" value="hardwarefr" /></td></tr><tr class="cBackHeader fondForum1PagesBas"><td class="padding" colspan="11"><div class="left"><b>&nbsp;Page&nbsp;: </b>&nbsp;&nbsp;<b>1</b></div><div class="pagepresuiv">&nbsp;&nbsp;</div><div class="pagepresuiv"></div></td></tr></table><input type="hidden" name="hash_check" value="SCRUBBED_HASH_CHECK" /><input type="hidden" name="topic3" value="-1" /><input type="hidden" name="topic_statusno3" value="-1" /><select name="action_reaction"><option>Choisissez l'action à effectuer</option><option value="valid_eff_prive">Valider l'effacement</option></select>&nbsp;<input type="submit" value="Valider" /></form><form action="/forum1.php" method="get" id="goto"><input type="hidden" name="hash_check" value="SCRUBBED_HASH_CHECK" />
+		<div class="nombres">
+			<b>Aller à : </b>
+			<select name="cat" onchange="document.getElementById('goto').submit()"><option value="1" >Hardware</option><option value="16" >Hardware - Périphériques</option><option value="15" >Ordinateurs portables</option><option value="2" >Overclocking, Cooling &amp; Modding</option><option value="30" >Electronique, domotique, DIY</option><option value="23" >Technologies Mobiles</option><option value="25" >Apple</option><option value="3" >Video &amp; Son</option><option value="14" >Photo numérique</option><option value="5" >Jeux Video</option><option value="4" >Windows &amp; Software</option><option value="22" >Réseaux grand public / SoHo</option><option value="21" >Systèmes &amp; Réseaux Pro</option><option value="11" >Linux et OS Alternatifs</option><option value="10" >Programmation</option><option value="32" >Intelligence Artificielle</option><option value="12" >Graphisme</option><option value="6" >Achats &amp; Ventes</option><option value="8" >Emploi &amp; Etudes</option><option value="13" >Discussions</option><option value="24" >Blabla - Divers ( back to life )</option><option value="prive" selected="selected">Messages privés</option></select><input type="hidden" name="config" value="hfr.inc" /><input type="submit" value="Go" /><br />
+				<br /><a rel="nofollow" href="/message.php?config=hfr.inc&amp;cat=prive&amp;sond=0&amp;p=1&amp;subcat=0&amp;dest=&amp;subcatgroup=0" id="md_btn_new_topic_bottom"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/newsujet.gif" title="Créer un nouveau message" alt="Créer un nouveau message" /></a></div></form>
+		<div class="legende">
+			<img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" alt="" />&nbsp;&nbsp;Nouveaux sujets
+			<br /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb.gif" alt="" />&nbsp;&nbsp;Nouveaux messages dans un ancien sujet
+			<br /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closed.gif" alt="" />&nbsp;&nbsp;Pas de nouveau message
+			<br /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/flag0.gif" alt="" />&nbsp;&nbsp;Allez au dernier message lu dans un sujet auquel vous n'avez pas participé
+			<br /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/flag1.gif" alt="" />&nbsp;&nbsp;Allez au dernier message lu dans un sujet auquel vous avez participé
+			<br /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/favoris.gif" alt="" />&nbsp;&nbsp;Allez au dernier message lu dans un favori
+		</div>
+		<div class="spacer">&nbsp;</div>
+		<br />
+		<div class="copyright"><a href="http://www.mesdiscussions.net" target="_blank" class="copyright">Forum MesDiscussions.Net</a>, Version 2010.2 <br />(c) 2000-2011 Doctissimo<br /><div class="gene">Page générée en  0.126 secondes</div></div>
+	</div>
+	</div><center><font color="#000000" size="1" face="Arial, Helvetica, sans-serif"><br />Copyright © 1997-2025 Groupe <a href="https://www.ldlc.com" title="Achat de materiel Informatique">LDLC</a> (<a href="https://www.hardware.fr/html/donnees_personnelles/">Signaler un contenu illicite / Données personnelles</a>)</font></center>
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://tracking.groupe-ldlc.com/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '26']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<noscript><p><img src="https://tracking.groupe-ldlc.com/matomo.php?idsite=26&rec=1" style="border:0;" alt="" /></p></noscript>
+<!-- End Matomo Code --><script type="text/javascript">
+md_forum_decryptlink.init();
+</script>
+<script type="text/javascript">
+md_forum_decryptlink.init();
+</script>
+<script type="text/javascript">
+var md_url_img_shadow= 'https://forum-images.hardware.fr';
+var md_tabs_menu_shadow= 1;
+</script>
+</body>
+	</html>

--- a/core/data/src/test/resources/fixtures/mp_storage_search_hit.source.txt
+++ b/core/data/src/test/resources/fixtures/mp_storage_search_hit.source.txt
@@ -1,0 +1,11 @@
+Source: forum.hardware.fr (capture authentifiee live, compte XaTriX). 2026-06-11
+Captured page: forum1.php?recherches=1&cat=prive&config=hfr.inc&search=Trucs&titre=1&orderSearch=1&resSearch=50&daterange=2&searchtype=1&jour=11&mois=6&annee=2026&pseud=&subcat=0&trash=0&trash_post=0&moderation=0
+Methode: curl GET authentifie (login POST login_validation.php -> cookies), User-Agent navigateur. AUCUN POST emis.
+Notes: recherche par SUJET dans cat=prive avec resultats (3 conversations) — le shape « decouverte
+  reussie » du MP storage MPStorage v0.1 (#6) : la recherche du hash-sujet renverrait ce meme
+  listing avec 1 ligne. Les liens de resultats portent cat=prive&post=<threadId>. Le terme de
+  recherche reel etait un mot d'un sujet du compte (pas le hash : ce compte n'a pas de MP storage,
+  cf. mp_storage_search_no_results.html) ; la STRUCTURE est identique.
+Privacy: scrubbe. hash_check -> SCRUBBED_HASH_CHECK ; sujets -> « Sujet de test N » ; pseudo compte
+  -> TestUser ; correspondants (auteur + dernier posteur) -> Correspondant ; threadIds prives
+  renumerotes 9000001..9000003 (mapping consistant dans tous les href).

--- a/core/data/src/test/resources/fixtures/mp_storage_search_no_results.html
+++ b/core/data/src/test/resources/fixtures/mp_storage_search_no_results.html
@@ -1,0 +1,31 @@
+	<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+	<html>
+	<head>
+	<title>FORUM HardWare.fr</title>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta http-equiv="Pragma" content="no-cache" />
+	<meta http-equiv="Cache-Control" content="no-cache, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+	<meta http-equiv="Imagetoolbar" content="no" />
+	<meta name="Robots" content="noindex, follow" />
+	<link rel="stylesheet" type="text/css" href="/include/the_style1.php?color_key=f2f3ef/DEDFDF/000080/C2C3F4/d5e6e1/000080/000080/000000/000080/000000/000080/f7f7f7/f0eee9/f7f7f7/f0eee9/C0C0C0/C0C0C0/FFFFFF/000000/000000/0000FF/EEEEFF/DDDDEE/000000/FFEEEE/000000/FFFFFF/FF0000/FFFFFF/0/1/https%3A%40%40forum-images.hardware.fr/NULL/&amp;abs_img_path=%40data%40sites%40forum%40www%40static%40&amp;hide_bg_onglet=0&amp;v=11102781422" />
+	<link type="text/css" rel="stylesheet" href="https://forum-images.hardware.fr/compressed/the_style.css?v=11102781422" />	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+		<style type="text/css">
+	.hop{			background-color: #f7f7f7;
+			color: #000000;
+			margin:auto;
+			text-align: center;
+			width:50%;
+			border: 1px solid #C0C0C0;}
+	</style>
+	</head>
+
+	<body>
+			<div class="container">
+	<div class="mesdiscussions" id="mesdiscussions">
+	<br /><br />
+	<div class="hop">
+	Désolé, aucune réponse n'a été trouvée !	<br /><br /><a href="javascript:history.back(1)" class="Topic"><b>Retour à la page précédente</b></a>	</div>
+	</div>
+	</div>
+	</body></html>

--- a/core/data/src/test/resources/fixtures/mp_storage_search_no_results.source.txt
+++ b/core/data/src/test/resources/fixtures/mp_storage_search_no_results.source.txt
@@ -1,0 +1,10 @@
+Source: forum.hardware.fr (capture authentifiee live, compte XaTriX). 2026-06-11
+Captured page: forum1.php?recherches=1&cat=prive&config=hfr.inc&search=a2bcc09b796b8c6fab77058ff8446c34&titre=1&orderSearch=1&resSearch=50&daterange=2&searchtype=1&jour=11&mois=6&annee=2026&pseud=&subcat=0&trash=0&trash_post=0&moderation=0
+Methode: curl GET authentifie (login POST login_validation.php -> cookies md_user/md_passs/md_id), User-Agent navigateur.
+Notes: decouverte du MP storage MPStorage v0.1 (#6) — recherche par sujet (= le hash fixe
+  a2bcc09b796b8c6fab77058ff8446c34) dans cat=prive. Le compte n'a PAS de MP storage : HFR repond
+  la page minimale « Désolé, aucune réponse n'a été trouvée ! » (.hop), MEME shape que la recherche
+  publique sans resultat (fixture search_no_results.html). Verifie au passage : la recherche GET
+  cat=prive est ACCEPTEE en authentifie (la REST API la rejette, cf. reference cat-values).
+Privacy: scrubbe. hash_check -> SCRUBBED_HASH_CHECK. Aucun sujet/pseudo/correspondant dans la page
+  (zero resultat). AUCUN POST emis (GET only).

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/mpstorage/MpStorageRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/mpstorage/MpStorageRepository.kt
@@ -1,0 +1,32 @@
+package fr.forumhfr.redface2.core.domain.mpstorage
+
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageResult
+
+/**
+ * MPStorage read access (#6, ADR-014) — the cross-userscript storage document living in the
+ * first post of a dedicated HFR private message (subject = fixed hash, recipient = the
+ * third-party `MultiMP` account).
+ *
+ * READ-ONLY by design for Phase 3 : the write path (full-overwrite `bdd.php`, last-write-wins)
+ * is deferred to a dedicated opt-in follow-up (ADR-014 §4). Implementations must NEVER write
+ * anything — in particular never "repair" an unreadable document (the original library's
+ * destructive-reset trap).
+ *
+ * [fetchStorage] performs the full discovery + read pipeline (authenticated) :
+ * subject search → conversation first post → edit form → `content_form` JSON. The
+ * « account has no storage » outcome ([MpStorageResult.NotFound]) is the first-class
+ * nominal case, not an error. Transport / session failures are raised as exceptions.
+ *
+ * Reading marks the storage conversation itself as read server-side (a GET of any page of a
+ * `cat=prive` conversation clears its whole-conversation dot, cf. #361/ADR-013) — acceptable :
+ * the storage MP is machinery, not user correspondence ; DTCloud behaves identically.
+ */
+interface MpStorageRepository {
+
+    suspend fun fetchStorage(): MpStorageResult
+
+    companion object {
+        /** Fixed storage subject — the de-facto v0.1 contract's discriminator (#6). */
+        const val STORAGE_SUBJECT_HASH: String = "a2bcc09b796b8c6fab77058ff8446c34"
+    }
+}

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/mpstorage/MpStorage.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/mpstorage/MpStorage.kt
@@ -1,0 +1,60 @@
+package fr.forumhfr.redface2.core.model.mpstorage
+
+/**
+ * MPStorage (#6, ADR-014) — domain models for the cross-userscript storage document.
+ *
+ * The storage is the FIRST post of a dedicated HFR private message (subject = the fixed
+ * hash `a2bcc09b796b8c6fab77058ff8446c34`, recipient = the third-party `MultiMP` account).
+ * Its body is one JSON document shared by every tool (DTCloud's `mpFlags`, HFR4K's `hfr4k`,
+ * …) inside a weakly-namespaced v0.1 envelope :
+ * `{ data: [ { version: '0.1', <tool keys> } ], sourceName, lastUpdate }`.
+ *
+ * Redface 2 adopts the envelope AS-IS (ADR-014) : reads project only the keys it consumes,
+ * and keep the raw JSON intact for the future read-modify-write — writing is a full
+ * overwrite (last-write-wins, no lock), so third-party keys must survive any round-trip.
+ */
+
+/** Outcome of a storage lookup. The account having NO storage is the first-class case. */
+sealed interface MpStorageResult {
+    /** No dedicated MP found — the account never used a MPStorage-based userscript. */
+    data object NotFound : MpStorageResult
+
+    /** The dedicated MP exists and its first post parsed into a [MpStorageDocument]. */
+    data class Found(val document: MpStorageDocument) : MpStorageResult
+
+    /**
+     * The dedicated MP exists but its first post is NOT a readable v0.1 envelope.
+     * Surfaced explicitly (never "repaired" : ADR-014 forbids the original library's
+     * destructive reset-to-default on invalid content).
+     */
+    data object Unreadable : MpStorageResult
+}
+
+/**
+ * Projection of the storage document. [rawEnvelope] carries the verbatim JSON (the whole
+ * `content_form` body) so the future write path can re-emit unknown keys untouched.
+ */
+data class MpStorageDocument(
+    /** Last WRITING TOOL (`sourceName`), not a per-tool property. Null when absent. */
+    val sourceName: String?,
+    /** DTCloud's `mpFlags.list` section — empty when the section is absent. */
+    val mpFlags: List<MpStorageFlagEntry>,
+    /** The verbatim JSON document. Never rebuilt field-by-field. */
+    val rawEnvelope: String,
+)
+
+/**
+ * One DTCloud entry : the READING-RESUME POSITION of a DT conversation (≥ 3 pseudos).
+ * It is NOT a read/unread state (that is the server-side dot, cf. #361/ADR-013) and NOT
+ * a pinned marker.
+ */
+data class MpStorageFlagEntry(
+    /** HFR thread id of the conversation (`post` on the wire). */
+    val threadId: Int,
+    /** 1-based page the user last stood on. */
+    val page: Int,
+    /** Post anchor on that page (`href` = `"t<numreponse>"` on the wire). Null when absent/odd. */
+    val numreponse: Int?,
+    /** Desktop-format URI, relayed verbatim (DTCloud rebuilds its links from it). */
+    val uri: String?,
+)

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
@@ -150,6 +150,65 @@ class HfrClient @Inject constructor(
     }
 
     /**
+     * MPStorage discovery (#6, ADR-014) — authenticated subject search inside `cat=prive`.
+     * Same `recherches=1` wire as the public search, but scoped to the private inbox :
+     * verified live 2026-06-11 (fixtures `mp_storage_search_*`) — the GET variant is
+     * accepted while the REST API rejects `cat=prive`. `titre=1` (subjects only) because
+     * the storage MP is identified by its fixed hash SUBJECT.
+     *
+     * [date] mirrors [searchTopics] : HFR's form serialises today's date even though
+     * `daterange=2` makes it irrelevant — injectable for test determinism.
+     */
+    suspend fun searchPrivateMessagesBySubject(subject: String, date: java.time.LocalDate): String {
+        val url = baseUrl.newBuilder()
+            .addPathSegment("forum1.php")
+            .addQueryParameter("recherches", "1")
+            .addQueryParameter("cat", "prive")
+            .addQueryParameter("config", "hfr.inc")
+            .addQueryParameter("search", subject)
+            .addQueryParameter("titre", "1")
+            .addQueryParameter("orderSearch", "1")
+            .addQueryParameter("resSearch", "50")
+            .addQueryParameter("daterange", "2")
+            .addQueryParameter("searchtype", "1")
+            .addQueryParameter("jour", date.dayOfMonth.toString())
+            .addQueryParameter("mois", date.monthValue.toString())
+            .addQueryParameter("annee", date.year.toString())
+            .addQueryParameter("pseud", "")
+            .addQueryParameter("subcat", "0")
+            .addQueryParameter("trash", "0")
+            .addQueryParameter("trash_post", "0")
+            .addQueryParameter("moderation", "0")
+            .build()
+        val request = Request.Builder().url(url).get().build()
+        return authenticated.newCall(request).executeAuthenticatedHtml()
+    }
+
+    /**
+     * MPStorage read (#6, ADR-014) — GET the edit form of a private-message post the user
+     * owns. The textarea `content_form` carries the RAW storage document (not rendered
+     * HTML), exactly how `MPStorage.user.js` reads it. Same `message.php` family as
+     * [getEditForm], with `cat=prive` (a String — the typed public variant cannot carry it).
+     */
+    suspend fun getPrivateMessageEditForm(threadId: Int, numreponse: Int): String {
+        val url = baseUrl.newBuilder()
+            .addPathSegment("message.php")
+            .addQueryParameter("config", "hfr.inc")
+            .addQueryParameter("cat", "prive")
+            .addQueryParameter("post", threadId.toString())
+            .addQueryParameter("numreponse", numreponse.toString())
+            .addQueryParameter("page", "1")
+            .addQueryParameter("p", "1")
+            .addQueryParameter("subcat", "0")
+            .addQueryParameter("sondage", "0")
+            .addQueryParameter("owntopic", "0")
+            .addQueryParameter("new", "0")
+            .build()
+        val request = Request.Builder().url(url).get().build()
+        return authenticated.newCall(request).executeAuthenticatedHtml()
+    }
+
+    /**
      * Phase 2C — GET the HFR reply or quote form. The shape is the same in both
      * cases (`/message.php?cat=…&post=…&page=…&p=1&subcat=…&sondage=0&owntopic=0
      * &new=0`); a quote carries `numrep={quotedNumreponse}` and may additionally

--- a/core/parser/build.gradle.kts
+++ b/core/parser/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 dependencies {
     api(project(":core:model"))
     implementation(libs.jsoup)
+    // MPStorage (#6/ADR-014) : tolerant JsonElement-level parsing of the v0.1 envelope.
+    implementation(libs.kotlinx.serialization.json)
 
     testImplementation(libs.junit4)
 }

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/mpstorage/MpStorageDiscoveryParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/mpstorage/MpStorageDiscoveryParser.kt
@@ -1,0 +1,26 @@
+package fr.forumhfr.redface2.core.parser.mpstorage
+
+import org.jsoup.Jsoup
+
+/**
+ * MPStorage discovery (#6, ADR-014) — extracts the storage conversation's thread id from
+ * the authenticated `cat=prive` subject-search listing (fixtures `mp_storage_search_hit.html`
+ * / `mp_storage_search_no_results.html`, captured live 2026-06-11).
+ *
+ * The subject being a fixed 32-hex hash, a hit listing carries (at most) one relevant row ;
+ * we take the FIRST conversation link. The no-results page (« Désolé, aucune réponse n'a été
+ * trouvée ! », same shape as the public search) simply has no such link → `null`, which the
+ * repository maps to the first-class « no storage on this account » outcome.
+ */
+class MpStorageDiscoveryParser {
+
+    fun parseFirstThreadId(html: String): Int? {
+        val document = Jsoup.parse(html)
+        val link = document.selectFirst("a.cCatTopic[href*=cat=prive]") ?: return null
+        return POST_ID.find(link.attr("href"))?.groupValues?.get(1)?.toIntOrNull()
+    }
+
+    private companion object {
+        private val POST_ID = Regex("""post=(\d+)""")
+    }
+}

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/mpstorage/MpStorageParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/mpstorage/MpStorageParser.kt
@@ -1,0 +1,92 @@
+package fr.forumhfr.redface2.core.parser.mpstorage
+
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageDocument
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageFlagEntry
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * MPStorage (#6, ADR-014) — tolerant parser of the v0.1 envelope found in the first post of
+ * the dedicated storage MP (the raw `content_form` text, NOT rendered HTML).
+ *
+ * Tolerance contract :
+ *  - the envelope is written by JavaScript userscripts — numbers may arrive as strings and
+ *    vice versa, so every numeric field goes through [asIntOrNull] ;
+ *  - UNKNOWN KEYS ARE NEVER AN ERROR : other tools (HFR4K, …) freely add their own keys to
+ *    the shared v0.1 entry. The projection only reads what Redface 2 consumes ; the verbatim
+ *    text is kept in [MpStorageDocument.rawEnvelope] for the future read-modify-write ;
+ *  - a `data` array without any `version == "0.1"` entry is a VALID document with no
+ *    consumable section (a future v0.2 written by another tool must not read as corruption) ;
+ *  - anything that is not a JSON object with a `data` array is a failure. Per ADR-014 the
+ *    caller surfaces it explicitly and NEVER writes a "repaired" default over it (the
+ *    original library's destructive-reset trap).
+ *
+ * The sample shapes exercised in tests follow the published library contract
+ * (`MPStorage.user.js` + the Wiripse documentation page) — this is a third-party JSON
+ * contract, not scraped HFR HTML, hence no HTML fixture requirement.
+ */
+class MpStorageParser {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    @Suppress("ReturnCount") // Guard clauses (empty / not-JSON / not-object / no-data) + the success return.
+    fun parse(contentForm: String): Result<MpStorageDocument> {
+        if (contentForm.isBlank()) {
+            return Result.failure(IllegalArgumentException("MPStorage document is empty"))
+        }
+        val root = try {
+            json.parseToJsonElement(contentForm)
+        } catch (error: kotlinx.serialization.SerializationException) {
+            return Result.failure(IllegalArgumentException("MPStorage document is not JSON", error))
+        }
+        val envelope = root as? JsonObject
+            ?: return Result.failure(IllegalArgumentException("MPStorage envelope is not a JSON object"))
+        val dataArray = envelope["data"] as? JsonArray
+            ?: return Result.failure(IllegalArgumentException("MPStorage envelope has no data array"))
+
+        val v01Entry = dataArray
+            .filterIsInstance<JsonObject>()
+            .firstOrNull { (it["version"] as? JsonPrimitive)?.content == "0.1" }
+
+        return Result.success(
+            MpStorageDocument(
+                sourceName = (envelope["sourceName"] as? JsonPrimitive)?.content,
+                mpFlags = parseFlagEntries(v01Entry?.get("mpFlags")),
+                // VERBATIM, including surrounding whitespace — the future read-modify-write
+                // must round-trip exactly what the edit form served (ADR-014).
+                rawEnvelope = contentForm,
+            ),
+        )
+    }
+
+    /**
+     * DTCloud's `mpFlags.list[]`. Entries missing a usable `post` are skipped (not fatal —
+     * the rest of the list stays consumable) ; `page` falls back to 1 ; `href` is the
+     * `"t<numreponse>"` anchor and degrades to null on any unexpected shape.
+     */
+    private fun parseFlagEntries(mpFlags: JsonElement?): List<MpStorageFlagEntry> {
+        val list = (mpFlags as? JsonObject)?.get("list") as? JsonArray ?: return emptyList()
+        return list.mapNotNull { item ->
+            val entry = item as? JsonObject ?: return@mapNotNull null
+            val threadId = entry["post"].asIntOrNull() ?: return@mapNotNull null
+            MpStorageFlagEntry(
+                threadId = threadId,
+                page = entry["page"].asIntOrNull() ?: 1,
+                numreponse = (entry["href"] as? JsonPrimitive)?.content
+                    ?.removePrefix("t")
+                    ?.toIntOrNull(),
+                uri = (entry["uri"] as? JsonPrimitive)?.content,
+            )
+        }
+    }
+
+    /** JS userscripts serialise numbers loosely — accept both `42` and `"42"`. */
+    private fun JsonElement?.asIntOrNull(): Int? =
+        (this as? JsonPrimitive)?.content?.toIntOrNull()
+}

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/mpstorage/MpStorageDiscoveryParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/mpstorage/MpStorageDiscoveryParserTest.kt
@@ -1,0 +1,34 @@
+package fr.forumhfr.redface2.core.parser.mpstorage
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * MPStorage discovery (#6, ADR-014) — both fixtures captured live 2026-06-11 from the
+ * authenticated `cat=prive` subject search (cf. their `.source.txt`).
+ */
+class MpStorageDiscoveryParserTest {
+
+    private val parser = MpStorageDiscoveryParser()
+
+    @Test
+    fun `a hit listing yields the first conversation's thread id`() {
+        // First row of the listing (HFR default sort : last-message date) — renumbered 9000003.
+        val html = readFixture("mp_storage_search_hit.html")
+        assertEquals(9_000_003, parser.parseFirstThreadId(html))
+    }
+
+    @Test
+    fun `the no-results page yields null — the account has no storage MP`() {
+        val html = readFixture("mp_storage_search_no_results.html")
+        assertNull(parser.parseFirstThreadId(html))
+    }
+
+    private fun readFixture(name: String): String {
+        val stream = requireNotNull(
+            MpStorageDiscoveryParserTest::class.java.classLoader?.getResourceAsStream("fixtures/$name"),
+        ) { "Fixture not found: fixtures/$name" }
+        return stream.bufferedReader().use { it.readText() }
+    }
+}

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/mpstorage/MpStorageParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/mpstorage/MpStorageParserTest.kt
@@ -1,0 +1,139 @@
+package fr.forumhfr.redface2.core.parser.mpstorage
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * MPStorage (#6, ADR-014). The samples follow the published v0.1 contract
+ * (`MPStorage.user.js` + Wiripse doc) — a third-party JSON contract, not HFR HTML.
+ */
+class MpStorageParserTest {
+
+    private val parser = MpStorageParser()
+
+    @Test
+    fun `parses a DTCloud document and projects the mpFlags entries`() {
+        val document = """
+            {
+              "data": [
+                {
+                  "version": "0.1",
+                  "mpFlags": {
+                    "list": [
+                      { "uri": "/forum2.php?config=hfr.inc&cat=prive&post=12345&page=3#t1980000001",
+                        "post": 12345, "page": 3, "href": "t1980000001", "p": 2 },
+                      { "uri": "/forum2.php?config=hfr.inc&cat=prive&post=67890&page=1",
+                        "post": 67890, "page": 1, "href": "", "p": 1 }
+                    ]
+                  }
+                }
+              ],
+              "sourceName": "DTCloud",
+              "lastUpdate": 1718064000000
+            }
+        """.trimIndent()
+
+        val parsed = parser.parse(document).getOrThrow()
+
+        assertEquals("DTCloud", parsed.sourceName)
+        assertEquals(2, parsed.mpFlags.size)
+        val first = parsed.mpFlags.first()
+        assertEquals(12345, first.threadId)
+        assertEquals(3, first.page)
+        assertEquals(1_980_000_001, first.numreponse)
+        assertTrue(first.uri!!.contains("post=12345"))
+        // Empty href degrades to a null anchor, the entry stays consumable.
+        assertNull(parsed.mpFlags[1].numreponse)
+        // The verbatim text survives for the future read-modify-write.
+        assertEquals(document, parsed.rawEnvelope)
+    }
+
+    @Test
+    fun `tolerates string-typed numbers from JS serialisation`() {
+        val document = """
+            { "data": [ { "version": "0.1",
+                "mpFlags": { "list": [ { "post": "12345", "page": "2", "href": "t42" } ] } } ] }
+        """.trimIndent()
+
+        val parsed = parser.parse(document).getOrThrow()
+
+        assertEquals(12345, parsed.mpFlags.first().threadId)
+        assertEquals(2, parsed.mpFlags.first().page)
+        assertEquals(42, parsed.mpFlags.first().numreponse)
+    }
+
+    @Test
+    fun `unknown tool keys are not an error and survive in the raw envelope`() {
+        val document = """
+            { "data": [ { "version": "0.1",
+                "hfr4k": { "opaque": [1, 2, 3] },
+                "mpFlags": { "list": [] } } ],
+              "sourceName": "HFR4K" }
+        """.trimIndent()
+
+        val parsed = parser.parse(document).getOrThrow()
+
+        assertEquals(emptyList<Any>(), parsed.mpFlags)
+        assertTrue("third-party keys must survive verbatim", parsed.rawEnvelope.contains("hfr4k"))
+    }
+
+    @Test
+    fun `a data array without a v01 entry is a valid document with no consumable section`() {
+        // A future format written by another tool must NOT read as corruption (ADR-014 :
+        // corruption triggers an explicit failure, and failures must never be "repaired").
+        val document = """{ "data": [ { "version": "0.2", "somethingNew": true } ] }"""
+
+        val parsed = parser.parse(document).getOrThrow()
+
+        assertEquals(emptyList<Any>(), parsed.mpFlags)
+        assertNull(parsed.sourceName)
+    }
+
+    @Test
+    fun `entries without a usable post id are skipped not fatal`() {
+        val document = """
+            { "data": [ { "version": "0.1",
+                "mpFlags": { "list": [ { "page": 1 }, { "post": 777, "page": 4 } ] } } ] }
+        """.trimIndent()
+
+        val parsed = parser.parse(document).getOrThrow()
+
+        assertEquals(1, parsed.mpFlags.size)
+        assertEquals(777, parsed.mpFlags.first().threadId)
+    }
+
+    @Test
+    fun `page falls back to 1 when absent`() {
+        val document = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [ { "post": 5 } ] } } ] }"""
+
+        assertEquals(1, parser.parse(document).getOrThrow().mpFlags.first().page)
+    }
+
+    @Test
+    fun `rawEnvelope is verbatim — surrounding whitespace is preserved`() {
+        // Codex review of #406 : the future read-modify-write must round-trip exactly what
+        // the edit form served, including leading/trailing whitespace.
+        val document = "\n  { \"data\": [], \"sourceName\": \"DTCloud\" }  \n"
+
+        val parsed = parser.parse(document).getOrThrow()
+
+        assertEquals(document, parsed.rawEnvelope)
+    }
+
+    @Test
+    fun `non-JSON content fails explicitly`() {
+        assertTrue(parser.parse("Bonjour, ceci est un MP normal.").isFailure)
+    }
+
+    @Test
+    fun `a JSON object without a data array fails explicitly`() {
+        assertTrue(parser.parse("""{ "sourceName": "DTCloud" }""").isFailure)
+    }
+
+    @Test
+    fun `empty content fails explicitly`() {
+        assertTrue(parser.parse("   ").isFailure)
+    }
+}

--- a/core/parser/src/test/resources/fixtures/mp_storage_search_hit.html
+++ b/core/parser/src/test/resources/fixtures/mp_storage_search_hit.html
@@ -1,0 +1,228 @@
+
+	<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+	<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr" lang="fr">
+	<head><title>Messages privés - FORUM HardWare.fr</title><link rel="stylesheet" type="text/css" href="/include/the_style1.php?color_key=f2f3ef/DEDFDF/000080/C2C3F4/d5e6e1/000080/000080/000000/000080/000000/000080/f7f7f7/f0eee9/f7f7f7/f0eee9/C0C0C0/C0C0C0/FFFFFF/000000/000000/0000FF/EEEEFF/DDDDEE/000000/FFEEEE/000000/FFFFFF/FF0000/FFFFFF/0/1/https%3A%40%40forum-images.hardware.fr/NULL/&amp;abs_img_path=%40data%40sites%40forum%40www%40static%40&amp;hide_bg_onglet=0&amp;v=11102781422" /><link type="text/css" rel="stylesheet" href="https://forum-images.hardware.fr/compressed/the_style.css?v=11102781422" /><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/tabs.js?v=11102781422"></script><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/forum1.js?v=11102781422"></script><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/common.js?v=11102781422"></script><style type="text/css">
+	.textareaOff {
+		font-size:8px;
+		border:1px solid #f00;
+		background-color:#ddd;
+	}
+	</style>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta http-equiv="Imagetoolbar" content="no" />
+	<meta name="Robots" content="noindex, follow" />
+	<style type="text/css">
+<!--
+.fastsearchMain{ width: 330px; }
+.fastsearchInput{ width: 70px; border: 1px solid black; }
+.fastsearchSubmit{ background-color: ; border: 0px;}
+.header2 { background-image: url(/img/forum3_1.gif);background-repeat: repeat-x; }
+.menuExt { font-family: Arial, Helvetica, sans-serif; font-size: 10px; color:#000; }
+.menuExt a { color:#000;text-decoration:none; }
+.menuExt a:hover { color:#000;text-decoration:underline; }
+form { display: inline; }
+.header { background-image: url(//forum-images.hardware.fr/img/header-bg.gif); background-repeat: repeat-x; }
+.tdmenu { width: 1px;height: 1px;color: #000000; }
+.hfrheadmenu { font-family: Arial, Helvetica, sans-serif;font-size:13px;font-weight:bold; }
+.hfrheadmenu span {color:;}
+.hfrheadmenu a { color:;text-decoration: none; }
+.hfrheadmenu a:hover { color:;text-decoration: underline; }
+.concours { font-family: Arial, Helvetica, sans-serif;color:;font-size: 16px;text-decoration: none;font-weight: bold;}
+.concours:hover { font-family: Arial, Helvetica, sans-serif;color:;font-size: 16px;text-decoration: underline;font-weight: bold; }
+.searchmenu { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: none;font-weight: bold; }
+.fastsearch { display: none; }
+.fastsearchHeader { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: none;font-weight: bold; }
+.fastsearchHeader:hover { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: underline;font-weight: bold; }
+-->
+</style>
+<script async='async' src='https://www.googletagservices.com/tag/js/gpt.js'></script>
+<script>
+  var googletag = googletag || {};
+  googletag.cmd = googletag.cmd || [];
+</script>
+
+<script>
+  googletag.cmd.push(function() {
+    googletag.defineSlot('/2172442/forum_accueil_banniere', [728, 90], 'div-gpt-ad-1511901001563-0').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_achats_ventes_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-1').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_achats_ventes_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-2').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_achats_ventes_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-3').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_achats_ventes_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-4').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_apple_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-5').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_apple_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-6').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_apple_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-7').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_apple_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-8').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_banniere_jpdc', [728, 90], 'div-gpt-ad-1511901001563-9').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-10').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-11').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-12').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-13').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_emploi_etude_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-14').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_emploi_etude_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-15').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_emploi_etude_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-16').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_emploi_etude_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-17').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_graphisme_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-18').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_graphisme_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-19').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_graphisme_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-20').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_graphisme_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-21').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_banniere', [728, 90], 'div-gpt-ad-1511901001563-22').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-23').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-24').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-25').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-26').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_peripheriques_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-27').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_peripheriques_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-28').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_peripheriques_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-29').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_peripheriques_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-30').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_jeux_video_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-31').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_jeux_video_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-32').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_jeux_video_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-33').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_jeux_video_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-34').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_ordinateurs_portables_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-35').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_ordinateurs_portables_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-36').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_ordinateurs_portables_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-37').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_ordinateurs_portables_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-38').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_os_alternatif_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-39').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_os_alternatif_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-40').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_os_alternatif_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-41').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_os_alternatif_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-42').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_overclocking_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-43').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_overclocking_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-44').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_overclocking_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-45').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_overclocking_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-46').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_photo_numerique_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-47').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_photo_numerique_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-48').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_photo_numerique_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-49').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_photo_numerique_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-50').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_programmation_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-51').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_programmation_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-52').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_programmation_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-53').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_programmation_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-54').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_reseaux_grand_public_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-55').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_reseaux_grand_public_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-56').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_reseaux_grand_public_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-57').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_reseaux_grand_public_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-58').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_seti_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-59').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_seti_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-60').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_seti_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-61').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_seti_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-62').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_systemes_reseaux_pro_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-63').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_systemes_reseaux_pro_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-64').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_systemes_reseaux_pro_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-65').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_systemes_reseaux_pro_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-66').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_technologies_mobiles_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-67').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_technologies_mobiles_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-68').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_technologies_mobiles_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-69').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_technologies_mobiles_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-70').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_video_son_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-71').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_video_son_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-72').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_video_son_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-73').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_video_son_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-74').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_windows_software_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-75').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_windows_software_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-76').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_windows_software_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-77').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_windows_software_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-78').addService(googletag.pubads());
+    googletag.pubads().enableSingleRequest();
+    googletag.enableServices();
+  });
+</script>
+<script type='text/javascript'>
+     (function(){
+       var loc = window.location.href;
+       var dd = document.createElement('script');
+       dd.type = 'text/javascript'; dd.src = '//static.digidip.net/hardware.js?loc=' + loc;
+       var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(dd, s);
+     })();
+</script></head><body id="unique__topics_listing__results_search_private_thread"  > <table cellspacing="0" cellpadding="0" width="98%" bgcolor="#000000" border="0" align="center" class="hfrheadmenu" style="border:1px solid #000;border-top:0;">
+        <tr>
+          <td style="vertical-align: top">
+            <table cellspacing="0" cellpadding="0" width="100%" border="0">
+              <tr>
+                <td style="width: 100%" align="left" valign="middle" colspan="2" class="header2"><span class="md_cryptlink45CBCBC0C22D1F1FCCCCCC19454AC14BCC4AC1431944C1"><img src="/img/forum_logo.gif" width="900" height="71" border="0" alt="" /></span></td>
+              </tr>
+              <tr>
+                <td style="background-color:#d5e6e1">
+                  <table cellspacing="0" cellpadding="2" width="100%" border="0">
+                    <tr>
+                      <td>&nbsp;<a class="cHeader" href="/">Forum</a>&nbsp;|&nbsp;
+<a class="cHeader" href="https://www.hardware.fr/">HardWare.fr</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/html/news/">News</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/html/articles/">Articles</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/articles/786-1/guide-pc-hardware-fr.html">PC</a>&nbsp;|&nbsp;<span class="md_cryptlink1FC349484F4C19C045C02F424F4944464C2E454AC14BCC4AC14344C11946494214424F4B434543C52E2341434A21264B2A4A424B422625422B252122212C44204321442C2C2A2A2142">Se d&eacute;connecter</span>&nbsp;|&nbsp;<span class="md_cryptlink1FC3C243C11F434B46CBC0C14F44464819C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">Profil</span>&nbsp;|&nbsp;<a class="cHeader" href="https://shop.hardware.fr/" target="_blank" style="position: relative; padding: 0 21px 0 0;display: inline-block;">Shop <img src="/img/shop.png" style="height: 17px; display: inline; position: absolute; right: 0; top: -2px; "></a></td>
+<td align="right"><a class="cHeader" href="/search.php?config=hardwarefr.inc&cat=prive&subcat=0">Recherche <img src="//forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif"></a></td>
+                    </tr>
+                    </table></td></tr></table>
+</td></tr></table><div style="width: 99%" align="right">
+<span class="s2Ext menuExt"><span class="md_cryptlink1F4F494846494319C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">8209 connect&eacute;s&nbsp;</span></span></div><br /><div class="container"><div class="mesdiscussions" id="mesdiscussions"><div class="arbo">
+<span  id="md_arbo_tree_1" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/" class="Ext">FORUM HardWare.fr</a></span>
+<br />
+<h1  id="md_arbo_tree_2" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;Messages privés</h1>
+</div><div class="rightbutton fastsearch"><table class="main fastsearchMain" cellspacing="0" cellpadding="2"><tr class="cBackHeader fondForumDescription"><th><form method="post" id="fastsearch" action="/forum1.php"><input type="hidden" name="hash_check" value="SCRUBBED_HASH_CHECK" /><label for="fastsearchinputid"><a rel="nofollow" href="/search.php?config=hfr.inc&amp;cat=prive&amp;subcat=0" class="cHeader fastsearchHeader">Recherche :</a>&nbsp;<input type="text" name="search" id="fastsearchinputid" value="" class="fastsearchInput" alt="Search string" /></label><input type="hidden" name="recherches" value="1" /><input type="hidden" name="searchtype" value="1" /><input type="hidden" name="titre" value="3" /><input type="hidden" name="resSearch" value="200" /><input type="hidden" name="orderSearch" value="1" /><input type="hidden" name="config" value="hfr.inc" /><input type="hidden" name="cat" value="prive" />&nbsp;<input type="image" src="https://forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif" class="fastsearchSubmit" title="Lancer une recherche" alt="Lancer une recherche" /></form></th></tr></table></div><div class="spacer fastsearch"></div><div class="rightbutton"><a rel="nofollow" href="/message.php?config=hfr.inc&amp;cat=prive&amp;sond=0&amp;p=1&amp;subcat=0&amp;dest=&amp;subcatgroup=0" id="md_btn_new_topic"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/newsujet.gif" title="Créer un nouveau message" alt="Créer un nouveau message" /></a><br /><br /></div><div class="compactModoInterface spacer">&nbsp;</div><br /><div class="s1Ext"></div><br /><table class="none" style="border:0px" cellspacing="0" cellpadding="0"><tr><td style="vertical-align:bottom"></td><td style="vertical-align:bottom">&nbsp;</td></tr></table><table class="main" cellspacing="0" cellpadding="2"><tr class="cBackHeader fondForum1Subcat"><th class="padding" colspan="11"><form action="/user/ignore.php" method="get"><input type="hidden" name="hash_check" value="SCRUBBED_HASH_CHECK" /><div class="left">&nbsp;Mettre / Enlever de l'ignore list :
+							<input type="hidden" name="config" value="hfr.inc" />
+							<input type="text" name="auteur" value="" size="25" />
+							<input type="hidden" name="page" value="1" />
+							<input type="submit" value="Go" />
+						</div>
+					</form></th></tr><form name="form1" method="post" action="/modo/manageaction.php?config=hfr.inc&amp;cat=prive&amp;type_page=forum1&amp;moderation=0"><input type="hidden" name="hash_check" value="SCRUBBED_HASH_CHECK" /><tr class="cBackHeader fondForum1PagesHaut"><td class="padding" colspan="11"><div class="left"><b>&nbsp;Page&nbsp;: </b>&nbsp;&nbsp;<b>1</b></div><div class="pagepresuiv">&nbsp;&nbsp;</div><div class="pagepresuiv"></div></td></tr><tr class="cBackHeader fondForum1Description"><th scope="col">&nbsp;&nbsp;&nbsp;</th><th scope="col">&nbsp;&nbsp;&nbsp;</th><th scope="col">&nbsp;&nbsp;&nbsp;</th><th scope="col" style="width:50%; text-align:left;" align="left">Sujet</th>
+				<th scope="col" colspan="2">Dern. page</th><th scope="col">Interlocuteur</th><th scope="col" style="width:10%; text-align:center" colspan="2">
+					<b>Nombre de</b>
+					<br />
+					<div class="plop"><span style='font-size: 8px'>Rép.</span></div>
+					<div class="plop"><span style='font-size: 8px'>Lues</span></div>
+				</th><th scope="col">Date du dernier message</th><th scope="col"><a href="javascript:check_change('topic')" class="cHeader">---</a></th></tr><tr class="sujet ligne_booleen cBackCouleurTab1 "  onmouseover="md_process_roll_over(this,1)" onmouseout="md_process_roll_over(this,0)">
+					<td class="sujetCase1 cBackCouleurTab2 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedp.gif" title="Pas de nouveau message. Message privé pour TestUser" alt="Off" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td class="sujetCase2">&nbsp;</td><td scope="row" class="sujetCase3" ondblclick="location.href='/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=9000003&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=0&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0'"><span class="red" title="Ce message n'a pas été lu par : alien64, Bitman, bozoleclown, fire in the hole !!!, FRACTAL, KICKBACK, KillMe, Mistral_ winner, mitchb51, pharmajo, Raspa, sad-keitaro, Space, totoz, uxam, V, verdoux, vicenzo, Nowa, Fenston, Brad Pitt, Hermes le Messager, ze_snake, zcoold, toniocourc, gouleyance, Hansaplast, drake-, ph75, Pere Dodu, prokie, niku, tekel, -Patrick-, LorDjidane, viniw, racingman11, michel 1664, Kede, cyd125, Lobster, Apokrif, Foxus666, xxantoinexx, Scrypt, babyboy4, pojolfou, srfcboy, Baathor, andhar, jerome38, poutrella, boubougna, Dam468, orbis, htaeD, RoY_, patx3, boubagump ii, FRANCKBLB, ben80, Shinseiki, BlinkGT, koko707, Hodor, Amaniak, Nykhola, Slider14, M_D_C, tapiefan, StefSamy, weemanbe, Johnny_Marrocain, KingJames6323, _Makaveli_, canti75, Bobox, tourtour, Bakk, The North Face, sidela, doutrisor, toper_harley_, Mike Hoksbiger, super_pourri, voor0ck, croustx, verseb, Hazumaki, data, gracchus, Blaq, ozidivision, t_faz, matnissa, TrakT, Godyfou, el nino71, psykhi, dragages, ilyama, Yurk, shenron67, Twano, Critias, quiet now, Arkin, cisco1, vieilArthuro, Subarashi, freddy021, Donkey&#039;, Correspondant, Kirk_Lee_Hammett, _Pouvoir, rockbottom, fracture du tibia, GenyaB, genkidama-hfr, Van Winkle, The Smoking Man, IMGaia, roland-, dissou, Damze, el_nono_masquay, coco_killer, Brazeinstein, jeprendsmonpied, Bisounours58, arnyek, fazero, spacex, Azrail, Hubert Farnsworth, weeWEEx, Hauptimisateur, varlocke, le zombie, LeGuideDuBledard, Ass-Itch, Van Langenhove, saLutat1ons, Coyote a foie jaune, meta67, Bretzel Authentique, Proust4, Chapiiiiiiii, Gallagh, kronekenbc, jamesmoore, Nyymi, petite fraise, Kupfer, Bobinou90, tesser4ct, Trifon_Ivanov, NewChallenger, doublebeurre, orodreths, Smelly Jelly, teamfive94, filiptif, Nitescent, El Flasco, thoulisse_bernard, maitre morissard, Burracho, NEmergix, starsida, juan-natal la pagina, ge haussmann, valentinvtl, liliro, Dabeuliouu, raskoln, Jahaa_sv, shinketsushuu, Demodulateur, alain haque-barre, DjullClint, Mad Ratz, Francis_Llacer, Chutelibre, aktarus69, carbon based, LiamManziel, casey tatum, Rucous, Horizon rouge, sebmbalo, delphine donkey, SaucissonMasque, BarbaLurke, sillage276, Hornett, erik von hartmann, Cliff Barnes, MajoriteSilencieuse, - Erik Von Hartmann, Gwrach, 1000Trees, orvalon, LeAmAs, Princesse Ruspoli, jeanguylecointre, NarineDebouchee, Stilgar59, herrphilippvonmoritz, ironpanda, volog, ImpactShiny, mais bien-sur, MySong-Tong, sergebenhamou, mejoralo, Fiotte du Tertiaire, dona nobis pacem, la creatura, La_Salamandre, Administration, antoine grise mine, Roupillon, Serresjp, bonnefranquette, -jean5-, nicha, bobo le fou, arlette chabrot, christophe barbie, alexandre lacanette, martin2troie, choufarci, FrerTok, abdelatif mourousi, marie-laure aigrie, multimmy, Cizia zazi, Rick_C137, tarzan-la-banane, azymantiop, ddlabraguette, noel le grec, nut3l@, vanadix, carlos rey, grossbaf1, herpes le passager, Oreille Sale, professeur raoult, brawndo, Liberatore, jydi75, maajora, estunpanda, Jay_hacke, rcommueriez">[non lu]</span> <a href="/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=9000003&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=0&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0" class="cCatTopic" title="Sujet n°2975088">Sujet de test 1</a></td><td class="sujetCase4"><a href="/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=9000003&amp;page=683&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=0&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0" class="cCatTopic">Sujet de test 2</a></td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab2 "><span title="TestUser">Correspondant</span></td>
+				  <td class="sujetCase7">27298</td>
+				  <td class="sujetCase8">491579</td>
+				  <td class="sujetCase9 cBackCouleurTab2 "><a href="/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=9000003&amp;page=683&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=0&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0#bas" class="Tableau">10-06-2026&nbsp;à&nbsp;23:20<br /><b>Correspondant</b></a></td><td class="sujetCase10"><input type="checkbox" name="topic0"  value="2975088" /><input type="hidden" name="valuecat0" value="prive" /><input type="hidden" name="valueforum0" value="hardwarefr" /></td></tr><tr class="sujet ligne_booleen cBackCouleurTab3 "  onmouseover="md_process_roll_over(this,1)" onmouseout="md_process_roll_over(this,0)">
+					<td class="sujetCase1 cBackCouleurTab4 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedp.gif" title="Pas de nouveau message. Message privé pour Correspondant" alt="Off" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td class="sujetCase2"><a href="/user/ignore.php?config=hfr.inc&amp;auteur=Correspondant&amp;page=1"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/ignore0.gif" title="Mettre Correspondant en ignore list" alt="On" /></a></td><td scope="row" class="sujetCase3" ondblclick="location.href='/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=9000002&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=0&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0'"><a href="/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=9000002&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=0&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0" class="cCatTopic" title="Sujet n°2824282">Sujet de test 3</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab4 "><a rel="nofollow" href="/profilebdd.php?config=hfr.inc&amp;pseudo=Correspondant" class="Tableau">Correspondant</a></td>
+				  <td class="sujetCase7">23</td>
+				  <td class="sujetCase8">52</td>
+				  <td class="sujetCase9 cBackCouleurTab4 "><a href="/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=9000002&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=0&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0#bas" class="Tableau">19-10-2019&nbsp;à&nbsp;10:01<br /><b>TestUser</b></a></td><td class="sujetCase10"><input type="checkbox" name="topic1"  value="2824282" /><input type="hidden" name="valuecat1" value="prive" /><input type="hidden" name="valueforum1" value="hardwarefr" /></td></tr><tr class="sujet ligne_booleen cBackCouleurTab1 "  onmouseover="md_process_roll_over(this,1)" onmouseout="md_process_roll_over(this,0)">
+					<td class="sujetCase1 cBackCouleurTab2 "><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedp.gif" title="Pas de nouveau message. Message privé pour Correspondant" alt="Off" /></td>
+			<td class="sujetCase2"><img src="https://forum-images.hardware.fr/icones/message/icon1.gif" alt="" /></td><td class="sujetCase2"><a href="/user/ignore.php?config=hfr.inc&amp;auteur=Correspondant&amp;page=1"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/ignore0.gif" title="Mettre Correspondant en ignore list" alt="On" /></a></td><td scope="row" class="sujetCase3" ondblclick="location.href='/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=9000001&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=0&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0'"><a href="/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=9000001&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=0&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0" class="cCatTopic" title="Sujet n°2668077">Sujet de test 4</a></td><td class="sujetCase4">&nbsp;</td><td class="sujetCase5">&nbsp;</td><td class="sujetCase6 cBackCouleurTab2 "><a rel="nofollow" href="/profilebdd.php?config=hfr.inc&amp;pseudo=Correspondant" class="Tableau">Correspondant</a></td>
+				  <td class="sujetCase7">0</td>
+				  <td class="sujetCase8">2</td>
+				  <td class="sujetCase9 cBackCouleurTab2 "><a href="/forum2.php?config=hfr.inc&amp;cat=prive&amp;post=9000001&amp;page=1&amp;p=1&amp;sondage=0&amp;owntopic=0&amp;trash=0&amp;trash_post=0&amp;print=0&amp;numreponse=0&amp;quote_only=0&amp;new=0&amp;nojs=0#bas" class="Tableau">21-02-2018&nbsp;à&nbsp;09:07<br /><b>Correspondant</b></a></td><td class="sujetCase10"><input type="checkbox" name="topic2"  value="2668077" /><input type="hidden" name="valuecat2" value="prive" /><input type="hidden" name="valueforum2" value="hardwarefr" /></td></tr><tr class="cBackHeader fondForum1PagesBas"><td class="padding" colspan="11"><div class="left"><b>&nbsp;Page&nbsp;: </b>&nbsp;&nbsp;<b>1</b></div><div class="pagepresuiv">&nbsp;&nbsp;</div><div class="pagepresuiv"></div></td></tr></table><input type="hidden" name="hash_check" value="SCRUBBED_HASH_CHECK" /><input type="hidden" name="topic3" value="-1" /><input type="hidden" name="topic_statusno3" value="-1" /><select name="action_reaction"><option>Choisissez l'action à effectuer</option><option value="valid_eff_prive">Valider l'effacement</option></select>&nbsp;<input type="submit" value="Valider" /></form><form action="/forum1.php" method="get" id="goto"><input type="hidden" name="hash_check" value="SCRUBBED_HASH_CHECK" />
+		<div class="nombres">
+			<b>Aller à : </b>
+			<select name="cat" onchange="document.getElementById('goto').submit()"><option value="1" >Hardware</option><option value="16" >Hardware - Périphériques</option><option value="15" >Ordinateurs portables</option><option value="2" >Overclocking, Cooling &amp; Modding</option><option value="30" >Electronique, domotique, DIY</option><option value="23" >Technologies Mobiles</option><option value="25" >Apple</option><option value="3" >Video &amp; Son</option><option value="14" >Photo numérique</option><option value="5" >Jeux Video</option><option value="4" >Windows &amp; Software</option><option value="22" >Réseaux grand public / SoHo</option><option value="21" >Systèmes &amp; Réseaux Pro</option><option value="11" >Linux et OS Alternatifs</option><option value="10" >Programmation</option><option value="32" >Intelligence Artificielle</option><option value="12" >Graphisme</option><option value="6" >Achats &amp; Ventes</option><option value="8" >Emploi &amp; Etudes</option><option value="13" >Discussions</option><option value="24" >Blabla - Divers ( back to life )</option><option value="prive" selected="selected">Messages privés</option></select><input type="hidden" name="config" value="hfr.inc" /><input type="submit" value="Go" /><br />
+				<br /><a rel="nofollow" href="/message.php?config=hfr.inc&amp;cat=prive&amp;sond=0&amp;p=1&amp;subcat=0&amp;dest=&amp;subcatgroup=0" id="md_btn_new_topic_bottom"><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/newsujet.gif" title="Créer un nouveau message" alt="Créer un nouveau message" /></a></div></form>
+		<div class="legende">
+			<img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb_new.gif" alt="" />&nbsp;&nbsp;Nouveaux sujets
+			<br /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closedb.gif" alt="" />&nbsp;&nbsp;Nouveaux messages dans un ancien sujet
+			<br /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/closed.gif" alt="" />&nbsp;&nbsp;Pas de nouveau message
+			<br /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/flag0.gif" alt="" />&nbsp;&nbsp;Allez au dernier message lu dans un sujet auquel vous n'avez pas participé
+			<br /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/flag1.gif" alt="" />&nbsp;&nbsp;Allez au dernier message lu dans un sujet auquel vous avez participé
+			<br /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/favoris.gif" alt="" />&nbsp;&nbsp;Allez au dernier message lu dans un favori
+		</div>
+		<div class="spacer">&nbsp;</div>
+		<br />
+		<div class="copyright"><a href="http://www.mesdiscussions.net" target="_blank" class="copyright">Forum MesDiscussions.Net</a>, Version 2010.2 <br />(c) 2000-2011 Doctissimo<br /><div class="gene">Page générée en  0.126 secondes</div></div>
+	</div>
+	</div><center><font color="#000000" size="1" face="Arial, Helvetica, sans-serif"><br />Copyright © 1997-2025 Groupe <a href="https://www.ldlc.com" title="Achat de materiel Informatique">LDLC</a> (<a href="https://www.hardware.fr/html/donnees_personnelles/">Signaler un contenu illicite / Données personnelles</a>)</font></center>
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://tracking.groupe-ldlc.com/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '26']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<noscript><p><img src="https://tracking.groupe-ldlc.com/matomo.php?idsite=26&rec=1" style="border:0;" alt="" /></p></noscript>
+<!-- End Matomo Code --><script type="text/javascript">
+md_forum_decryptlink.init();
+</script>
+<script type="text/javascript">
+md_forum_decryptlink.init();
+</script>
+<script type="text/javascript">
+var md_url_img_shadow= 'https://forum-images.hardware.fr';
+var md_tabs_menu_shadow= 1;
+</script>
+</body>
+	</html>

--- a/core/parser/src/test/resources/fixtures/mp_storage_search_hit.source.txt
+++ b/core/parser/src/test/resources/fixtures/mp_storage_search_hit.source.txt
@@ -1,0 +1,11 @@
+Source: forum.hardware.fr (capture authentifiee live, compte XaTriX). 2026-06-11
+Captured page: forum1.php?recherches=1&cat=prive&config=hfr.inc&search=Trucs&titre=1&orderSearch=1&resSearch=50&daterange=2&searchtype=1&jour=11&mois=6&annee=2026&pseud=&subcat=0&trash=0&trash_post=0&moderation=0
+Methode: curl GET authentifie (login POST login_validation.php -> cookies), User-Agent navigateur. AUCUN POST emis.
+Notes: recherche par SUJET dans cat=prive avec resultats (3 conversations) — le shape « decouverte
+  reussie » du MP storage MPStorage v0.1 (#6) : la recherche du hash-sujet renverrait ce meme
+  listing avec 1 ligne. Les liens de resultats portent cat=prive&post=<threadId>. Le terme de
+  recherche reel etait un mot d'un sujet du compte (pas le hash : ce compte n'a pas de MP storage,
+  cf. mp_storage_search_no_results.html) ; la STRUCTURE est identique.
+Privacy: scrubbe. hash_check -> SCRUBBED_HASH_CHECK ; sujets -> « Sujet de test N » ; pseudo compte
+  -> TestUser ; correspondants (auteur + dernier posteur) -> Correspondant ; threadIds prives
+  renumerotes 9000001..9000003 (mapping consistant dans tous les href).

--- a/core/parser/src/test/resources/fixtures/mp_storage_search_no_results.html
+++ b/core/parser/src/test/resources/fixtures/mp_storage_search_no_results.html
@@ -1,0 +1,31 @@
+	<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+	<html>
+	<head>
+	<title>FORUM HardWare.fr</title>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta http-equiv="Pragma" content="no-cache" />
+	<meta http-equiv="Cache-Control" content="no-cache, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+	<meta http-equiv="Imagetoolbar" content="no" />
+	<meta name="Robots" content="noindex, follow" />
+	<link rel="stylesheet" type="text/css" href="/include/the_style1.php?color_key=f2f3ef/DEDFDF/000080/C2C3F4/d5e6e1/000080/000080/000000/000080/000000/000080/f7f7f7/f0eee9/f7f7f7/f0eee9/C0C0C0/C0C0C0/FFFFFF/000000/000000/0000FF/EEEEFF/DDDDEE/000000/FFEEEE/000000/FFFFFF/FF0000/FFFFFF/0/1/https%3A%40%40forum-images.hardware.fr/NULL/&amp;abs_img_path=%40data%40sites%40forum%40www%40static%40&amp;hide_bg_onglet=0&amp;v=11102781422" />
+	<link type="text/css" rel="stylesheet" href="https://forum-images.hardware.fr/compressed/the_style.css?v=11102781422" />	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+		<style type="text/css">
+	.hop{			background-color: #f7f7f7;
+			color: #000000;
+			margin:auto;
+			text-align: center;
+			width:50%;
+			border: 1px solid #C0C0C0;}
+	</style>
+	</head>
+
+	<body>
+			<div class="container">
+	<div class="mesdiscussions" id="mesdiscussions">
+	<br /><br />
+	<div class="hop">
+	Désolé, aucune réponse n'a été trouvée !	<br /><br /><a href="javascript:history.back(1)" class="Topic"><b>Retour à la page précédente</b></a>	</div>
+	</div>
+	</div>
+	</body></html>

--- a/core/parser/src/test/resources/fixtures/mp_storage_search_no_results.source.txt
+++ b/core/parser/src/test/resources/fixtures/mp_storage_search_no_results.source.txt
@@ -1,0 +1,10 @@
+Source: forum.hardware.fr (capture authentifiee live, compte XaTriX). 2026-06-11
+Captured page: forum1.php?recherches=1&cat=prive&config=hfr.inc&search=a2bcc09b796b8c6fab77058ff8446c34&titre=1&orderSearch=1&resSearch=50&daterange=2&searchtype=1&jour=11&mois=6&annee=2026&pseud=&subcat=0&trash=0&trash_post=0&moderation=0
+Methode: curl GET authentifie (login POST login_validation.php -> cookies md_user/md_passs/md_id), User-Agent navigateur.
+Notes: decouverte du MP storage MPStorage v0.1 (#6) — recherche par sujet (= le hash fixe
+  a2bcc09b796b8c6fab77058ff8446c34) dans cat=prive. Le compte n'a PAS de MP storage : HFR repond
+  la page minimale « Désolé, aucune réponse n'a été trouvée ! » (.hop), MEME shape que la recherche
+  publique sans resultat (fixture search_no_results.html). Verifie au passage : la recherche GET
+  cat=prive est ACCEPTEE en authentifie (la REST API la rejette, cf. reference cat-values).
+Privacy: scrubbe. hash_check -> SCRUBBED_HASH_CHECK. Aucun sujet/pseudo/correspondant dans la page
+  (zero resultat). AUCUN POST emis (GET only).

--- a/docs/adr/014-mpstorage-v01-de-facto.md
+++ b/docs/adr/014-mpstorage-v01-de-facto.md
@@ -1,0 +1,47 @@
+---
+title: ADR-014
+parent: ADRs
+grand_parent: Spécifications
+nav_order: 14
+permalink: /adr/014-mpstorage-v01-de-facto
+---
+
+# ADR-014 — MPStorage : adopter l'enveloppe v0.1 de facto (lecture d'abord, écriture différée)
+
+## Statut
+
+Proposé — 2026-06-11
+
+Cette ADR formalise les verdicts de l'[exploration du format MPStorage réel](https://github.com/ForumHFR/redface2/issues/6#issuecomment-4673324560) (2026-06-10 : confrontation `MPStorage.user.js` / `DTCloud.user.js` / `multimp.user.js` / doc Wiripse) et des vérifications live du 2026-06-11 (découverte par recherche `cat=prive`, fixtures `mp_storage_search_*`). Conformément à la règle « pas de décision implicite », **rien n'est acté tant que le statut n'est pas passé à « Accepté »** ; `models.md` § MPStorage porte la projection de cette proposition.
+
+## Contexte
+
+L'issue [#6](https://github.com/ForumHFR/redface2/issues/6) (MPStorage, sync cross-plateforme) attendait « MPStorage2 » dans `XaaT/hfr-redkit` — qui est **vide** : la seule spec déployée et interopérable est le format v0.1 de facto, en production depuis ~2019 dans les userscripts (DTCloud pour les drapeaux DT, HFR4K, …). Par ailleurs, `models.md` décrivait un modèle (`MPStorageData/MultiMPFlag(lastReadDate, pinned)`) **incompatible** avec ce format réel — l'implémenter aurait cassé la compatibilité additive avec les userscripts (exigence Q4 de #6, non négociable).
+
+Mécanique du format réel (détail complet dans [le rapport #6](https://github.com/ForumHFR/redface2/issues/6#issuecomment-4673324560)) :
+
+- stockage = premier post d'un MP dédié (sujet = hash fixe `a2bcc09b796b8c6fab77058ff8446c34`, destinataire = compte tiers `MultiMP`) ;
+- enveloppe JSON `{ data: [ { version: '0.1', <clés par outil> } ], sourceName, lastUpdate }` — namespacing faible, chaque outil pose ses clés dans l'entrée partagée ;
+- lecture = GET du formulaire d'édition du premier post (textarea `content_form`) ; écriture = POST `bdd.php` `cat=prive` en **remplacement intégral** (last-write-wins, pas de verrou) ;
+- piège connu de la bibliothèque d'origine : contenu invalide → **reset destructif au défaut** ;
+- `mpFlags.list[]` (DTCloud) = **position de reprise de lecture** par conversation DT (`{uri, post, page, href: "t<numreponse>", p}`), pas un lu/non-lu (cf. ADR-013/#361 : le lu/non-lu MP est le dot serveur binaire).
+
+Vérifications live 2026-06-11 (GET only, compte XaTriX) :
+
+- la **découverte par recherche authentifiée** marche : `forum1.php?recherches=1&cat=prive&search=<hash>&titre=1` répond le listing standard (fixture `mp_storage_search_hit.html`, capturée sur un sujet réel du compte) ou la page « aucune réponse » (fixture `mp_storage_search_no_results.html`) — alors que la REST API rejette `cat=prive` ;
+- le compte de test **n'a pas de MP storage** : « pas de storage » est donc le cas nominal premier du client, pas un cas d'erreur.
+
+## Décision
+
+1. **Geler le contrat sur l'enveloppe v0.1 de facto.** Pas de « MPStorage2 » côté Redface 2 : toute extension passe par de **nouvelles clés additives** dans l'entrée v0.1. Si un MPStorage2 émerge un jour dans `hfr-redkit`, il fera l'objet d'une nouvelle ADR (et le format v0.1 restera lu pour la migration).
+2. **Lecture d'abord.** Phase 3 livre un client **lecture seule** dans `:core:data` : découverte (recherche par sujet) → premier post (`numreponse` via la page de conversation) → formulaire d'édition → `content_form` → parsing **tolérant** (clés inconnues ignorées à la projection mais le JSON intégral est conservé dans `MpStorageDocument.rawEnvelope`).
+3. **Jamais de reset destructif.** Un document illisible = échec de lecture explicite surfacé à l'UI ; aucune écriture de « réparation ».
+4. **Écriture différée et opt-in** (hors scope de cette ADR au-delà du principe) : read-modify-write immédiatement avant le POST `bdd.php`, déclenchée à la sortie d'une conversation DT — pas une édition par page vue comme DTCloud ; les clés tierces du `rawEnvelope` survivent au round-trip.
+5. **Surface UI** : l'onglet « DT » opt-in (PR #397) consommera `mpFlags` (liste des conversations DT avec position de reprise) ; fusion avec le drapal local ADR-013 étage 1 (local prioritaire, MPStorage = seed + sync).
+
+## Conséquences
+
+- `models.md` § MPStorage remplace les modèles inventés par `MpStorageDocument` / `MpStorageFlagEntry` (cette PR).
+- Les ids découverts (mpId, numreponse du premier post) seront cachés en DataStore **par compte** et purgés au logout (même règle de vie privée que #316).
+- Risques assumés et documentés : lost-update inter-outils (full overwrite sans condition), taille max du post MP inconnue (la `list` DTCloud n'est jamais prunée — la vérification de taille devra précéder toute écriture), dépendance au compte tiers `MultiMP`.
+- Trous de vérification restants avant l'étape écriture : effet du GET du formulaire d'édition sur le dot du correspondant (non mesuré par #361), contrat `bdd.php cat=prive` (non capturé), round-trip JSON réel (le compte de test n'a pas encore de MP storage).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,3 +41,4 @@ Les numéros `004` à `007` sont volontairement laissés libres pour des décisi
 | [ADR-011]({{ site.baseurl }}/adr/011-postcontent-ast) | AST sémantique `PostContent` comme contrat de rendu |
 | [ADR-012]({{ site.baseurl }}/adr/012-credentials-proxy) | Credentials proxy : extension d'Option A |
 | [ADR-013]({{ site.baseurl }}/adr/013-mp-lecture-cache-prefetch) | Lecture MP : partage topic↔MP, cache à trois étages, prefetch borné (Proposé) |
+| [ADR-014]({{ site.baseurl }}/adr/014-mpstorage-v01-de-facto) | MPStorage : enveloppe v0.1 de facto, lecture d'abord, écriture différée (Proposé) |

--- a/docs/specs/models.md
+++ b/docs/specs/models.md
@@ -564,39 +564,58 @@ reply/quote MP, MultiMP et MPStorage restent dans la suite Phase 3.
 
 ## MPStorage
 
-MPStorage est une bibliothèque cross-plateforme qui utilise un **MP HFR dédié** comme backend de stockage. Les données (drapeaux MultiMP, bookmarks, préférences) sont sérialisées en JSON dans le corps de ce message privé. Cela permet la synchronisation entre appareils sans serveur tiers.
+MPStorage est une bibliothèque cross-plateforme (HFRGMTools/Wiripse, en production depuis ~2019) qui utilise un **MP HFR dédié** comme backend de stockage : sujet = hash fixe `a2bcc09b796b8c6fab77058ff8446c34`, destinataire = compte tiers `MultiMP`. Le **premier post** de ce MP contient un document JSON **partagé par tous les userscripts** (DTCloud pour les drapeaux DT, HFR4K, …). Redface 2 adopte **l'enveloppe v0.1 de facto telle quelle** (cf. exploration [#6](https://github.com/ForumHFR/redface2/issues/6)) : toute extension Redface 2 passe par de **nouvelles clés additives** dans l'entrée v0.1, jamais par un nouveau format — la compatibilité avec les userscripts existants est non négociable.
+
+Enveloppe réelle (source : `MPStorage.user.js` + doc Wiripse, confrontées le 2026-06-10) :
+
+```json
+{
+  "data": [
+    {
+      "version": "0.1",
+      "mpFlags": { "list": [ { "uri": "…", "post": 12345, "page": 3, "href": "t1980000001", "p": 2 } ] },
+      "hfr4k": { "…": "clés d'un autre outil, à préserver verbatim" }
+    }
+  ],
+  "sourceName": "DTCloud",
+  "lastUpdate": 1718064000000
+}
+```
+
+Modèles Kotlin (lecture seule, Phase 3) :
 
 ```kotlin
-// Données stockées dans le MP de stockage (format JSON)
-data class MPStorageData(
-    val multiMPFlags: Map<Int, MultiMPFlag>,  // clé = mpId
-    val bookmarks: List<Bookmark>,
-    val settings: MPStorageSettings,
+/**
+ * Document du premier post du MP storage. Parsing TOLÉRANT : seules les clés que
+ * Redface 2 consomme sont projetées ; le JSON intégral est conservé dans
+ * [rawEnvelope] pour le futur read-modify-write (écriture = full overwrite
+ * last-write-wins, les clés des autres outils doivent survivre au round-trip).
+ */
+data class MpStorageDocument(
+    val sourceName: String?,                 // dernier OUTIL écrivain (pas par-outil)
+    val mpFlags: List<MpStorageFlagEntry>,   // section DTCloud, vide si absente
+    val rawEnvelope: String,                 // JSON intégral, jamais reconstruit champ à champ
 )
 
-data class MultiMPFlag(
-    // mpId est la clé du Map, pas besoin de le dupliquer
-    val lastReadDate: Instant,
-    val pinned: Boolean,
-)
-
-data class MPStorageSettings(
-    val compactFlags: Boolean = false,
-    val defaultImageHost: String = "diberie",
-)
-
-data class Bookmark(
-    val cat: Int,
-    val post: Int,              // topic ID
-    val numreponse: Int,        // post ID
-    val topicTitle: String,
-    val author: String,
-    val preview: String,
-    val createdAt: Instant,
+/**
+ * Position de REPRISE DE LECTURE d'une conversation DT (≥ 3 pseudos) — ce n'est
+ * NI un lu/non-lu (le lu/non-lu MP est le dot serveur, cf. #361), NI un pinned.
+ */
+data class MpStorageFlagEntry(
+    val threadId: Int,      // `post` côté wire
+    val page: Int,
+    val numreponse: Int?,   // `href` = "t<numreponse>" côté wire
+    val uri: String?,       // format desktop exact, relayé verbatim
 )
 ```
 
-L'app synchronise ces données avec le MP de stockage HFR et les cache localement dans Room pour des accès rapides. Cela garantit la compatibilité avec les userscripts existants qui utilisent le même mécanisme.
+Règles non négociables (exploration #6) :
+
+- **Préserver les clés inconnues** : l'écriture MPStorage est un remplacement intégral sans verrou (last-write-wins) — perdre `hfr4k` ou toute clé tierce casserait les userscripts de l'utilisateur.
+- **Jamais de reset destructif** sur contenu invalide (le piège de la bibliothèque d'origine) : un document illisible = lecture en échec explicite, pas un écrasement par le défaut.
+- **Découverte** = recherche authentifiée par sujet : `forum1.php?recherches=1&cat=prive&search=<hash>&titre=1` (vérifié live 2026-06-11, fixtures `mp_storage_search_*`). L'absence de MP storage (compte n'ayant jamais utilisé DTCloud) est le **cas nominal premier**.
+- **Lecture** = GET du formulaire d'édition du premier post (`message.php?cat=prive&post=<mpId>&numreponse=<repId>`), textarea `content_form` (contenu brut, pas le HTML rendu).
+- **Écriture** (différée, opt-in) = POST `bdd.php` `cat=prive` en read-modify-write juste avant le POST, jamais une édition par page vue.
 
 ---
 


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Réf. #6 (mot-clé volontairement non utilisé : l'issue reste ouverte — l'UI n'est pas couverte ici).

## Quoi

Couche **lecture seule** de MPStorage v0.1 « de facto », conformément aux investigations postées sur [#6 (rapport)](https://github.com/ForumHFR/redface2/issues/6#issuecomment-4673324560) :

- **ADR-014** (`docs/adr/014-mpstorage-v01-de-facto.md`, statut **Proposé**) : adopter temporairement le format v0.1 réellement écrit par les userscripts (DTCloud en premier consommateur), au lieu du contrat v2 spéculatif ; la lecture v0.1 prépare la migration v1 → v2 de la donnée. **@XaTriX : relecture demandée avant toute UI** — c'est le point « je reste ouvert à modifier le contrat temporairement » de la consigne de nuit.
- `docs/specs/models.md` § MPStorage réaligné sur le format réel (`MpStorageDocument` / `MpStorageFlagEntry` ; les anciens types spéculatifs `MPStorageData`/`MultiMPFlag` sont retirés).
- **Découverte** : recherche authentifiée par sujet en `cat=prive` (hash `a2bcc09b…` du sujet du MP de stockage vers `MultiMP`) — mécanisme vérifié live (la REST API rejette `cat=prive`, la recherche HTML l'accepte).
- **Pipeline 3 GET read-only** (`DefaultMpStorageRepository`) : recherche → page 1 de la conversation → formulaire d'édition du premier post → `content_form` brut → `MpStorageParser`. **Zéro write**, zéro réparation : un document illisible est remonté `Unreadable`, jamais écrasé par un défaut (le piège du reset destructif de la lib d'origine est verrouillé par contrat).
- **Parser tolérant** : clés inconnues préservées (`rawEnvelope` verbatim pour le futur read-modify-write), nombres JS laxistes (`42`/`"42"`), entrée `version=="0.1"` sélectionnée, `data` sans entrée v0.1 = document valide vide.
- Diagnostics sans contenu (les positions de lecture privées ne sont jamais loguées — posture #316).

## Hors scope (différé)

- **UI (onglet DT)** : différée à une PR ultérieure, après relecture de l'ADR-014.
- Écriture / migration v0.1 → v2 : préparée par `rawEnvelope`, non implémentée.

## Tests

- `MpStorageParserTest` : 9 cas sur le contrat JSON (enveloppe, tolérance, échecs).
- `MpStorageDiscoveryParserTest` : 2 fixtures capturées live 2026-06-11 (hit + no-results), scrubées.
- `DefaultMpStorageRepositoryTest` : NotFound en 1 GET (URL vérifiée paramètre par paramètre) ; hit → pipeline 3-GET → `Unreadable` exercé via la fixture réelle d'edit form (son `content_form` est du BBCode, pas du JSON — bras légitime).
- Lacune connue (documentée dans l'ADR) : pas de fixture live « Found » end-to-end — le compte XaTriX n'a **pas** de MP de stockage (vérifié live : la recherche du hash ne retourne rien → NotFound est le cas nominal premier).

## Validation

Validation 2 parts Docker (detektAll + tests + assembleProdDebug, puis lintProdDebug) verte en local.
