### PR TITLE
fix(theme): flash de thème clair au lancement — miroir synchrone du thème persisté

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/MainActivity.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/MainActivity.kt
@@ -1,6 +1,8 @@
 package fr.forumhfr.redface2
 
 import android.content.Intent
+import android.content.res.Configuration
+import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.enableEdgeToEdge
@@ -8,21 +10,62 @@ import androidx.activity.compose.setContent
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.toArgb
+import androidx.core.view.WindowCompat
 import dagger.hilt.android.AndroidEntryPoint
+import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrapStore
+import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
+import fr.forumhfr.redface2.core.ui.theme.RedfaceAmoledColorScheme
+import fr.forumhfr.redface2.core.ui.theme.RedfaceDarkColorScheme
+import fr.forumhfr.redface2.core.ui.theme.RedfaceLightColorScheme
 import fr.forumhfr.redface2.navigation.RedfaceApp
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    @Inject lateinit var themeBootstrapStore: ThemeBootstrapStore
+
     private var latestIntent by mutableStateOf<Intent?>(null)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+        applyBootstrapWindowBackground()
         latestIntent = intent
 
         setContent {
             RedfaceApp(intent = latestIntent)
         }
+    }
+
+    /**
+     * #386 — the manifest theme follows the OS uiMode, so between the first frame of the window
+     * and the first themed composition the user sees the OS background. When the persisted theme
+     * forces the opposite of the OS (e.g. dark app under a light system), that's a 1-2 s flash on
+     * a cold start. Seed the window background from the synchronous theme mirror ; AppThemeViewModel
+     * seeds the composition from the same mirror, so the first drawn frame already matches.
+     */
+    private fun applyBootstrapWindowBackground() {
+        val bootstrap = themeBootstrapStore.read()
+        val systemDark = (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
+            Configuration.UI_MODE_NIGHT_YES
+        val dark = when (bootstrap.themeMode) {
+            ThemeMode.DARK -> true
+            ThemeMode.LIGHT -> false
+            ThemeMode.SYSTEM -> systemDark
+        }
+        val background = when {
+            dark && bootstrap.amoledEnabled -> RedfaceAmoledColorScheme.background
+            dark -> RedfaceDarkColorScheme.background
+            else -> RedfaceLightColorScheme.background
+        }
+        window.setBackgroundDrawable(ColorDrawable(background.toArgb()))
+        // enableEdgeToEdge() derived the bar ICON contrast from the OS uiMode ; align it with the
+        // bootstrap background right away — the #286 SideEffect re-asserts it once composed.
+        val insets = WindowCompat.getInsetsController(window, window.decorView)
+        insets.isAppearanceLightStatusBars = !dark
+        insets.isAppearanceLightNavigationBars = !dark
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
@@ -3,6 +3,7 @@ package fr.forumhfr.redface2.navigation
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import javax.inject.Inject
@@ -15,23 +16,25 @@ import kotlinx.coroutines.flow.stateIn
  * [RedfaceApp] can compute the effective dark theme passed to `RedfaceTheme` (which previously
  * only read `isSystemInDarkTheme()`).
  *
- * [SharingStarted.Eagerly] so the first DataStore read starts as soon as the ViewModel is created,
- * keeping the initial-default window as short as possible. The default ([ThemeMode.SYSTEM] / amoled
- * off) is shown until that first read resolves — a brief flash (not a single frame) that only a user
- * who forced a non-SYSTEM mode differing from the OS can perceive on a cold start. Acceptable for the
- * default-SYSTEM majority; a dedicated `Loading` gate is the follow-up if that cold-start flash ever
- * becomes a complaint.
+ * [SharingStarted.Eagerly] so the first DataStore read starts as soon as the ViewModel is created.
+ * Until it resolves, the initial value comes from the SYNCHRONOUS [ThemeBootstrapStore] mirror —
+ * not a hard-coded SYSTEM default — so a user who forced a theme against the OS no longer sees
+ * the OS theme flash on a cold start (#386). MainActivity seeds the window background from the
+ * same mirror, covering the pre-first-frame window too.
  */
 @HiltViewModel
 class AppThemeViewModel @Inject constructor(
     userPreferencesRepository: UserPreferencesRepository,
+    themeBootstrapStore: ThemeBootstrapStore,
 ) : ViewModel() {
+
+    private val bootstrap = themeBootstrapStore.read()
 
     val themeMode: StateFlow<ThemeMode> =
         userPreferencesRepository.observeThemeMode()
-            .stateIn(viewModelScope, SharingStarted.Eagerly, ThemeMode.SYSTEM)
+            .stateIn(viewModelScope, SharingStarted.Eagerly, bootstrap.themeMode)
 
     val amoledEnabled: StateFlow<Boolean> =
         userPreferencesRepository.observeAmoledEnabled()
-            .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+            .stateIn(viewModelScope, SharingStarted.Eagerly, bootstrap.amoledEnabled)
 }

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModelTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModelTest.kt
@@ -1,0 +1,77 @@
+package fr.forumhfr.redface2.navigation
+
+import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrap
+import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrapStore
+import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * #386 — the cold-start contract : until DataStore's first emission lands, the exposed theme
+ * is the synchronous [ThemeBootstrapStore] mirror, NOT a hard-coded SYSTEM default. A user who
+ * forced DARK under a light OS must get DARK on the very first frame.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AppThemeViewModelTest {
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun bootstrapStore(bootstrap: ThemeBootstrap): ThemeBootstrapStore =
+        mockk { every { read() } returns bootstrap }
+
+    @Test
+    fun `before the first DataStore emission the mirror seeds the state`() = runTest {
+        val repository = mockk<UserPreferencesRepository> {
+            // A SharedFlow that never emits = DataStore still hydrating on a cold start.
+            every { observeThemeMode() } returns MutableSharedFlow()
+            every { observeAmoledEnabled() } returns MutableSharedFlow()
+        }
+
+        val vm = AppThemeViewModel(
+            userPreferencesRepository = repository,
+            themeBootstrapStore = bootstrapStore(ThemeBootstrap(ThemeMode.DARK, amoledEnabled = true)),
+        )
+
+        assertEquals(ThemeMode.DARK, vm.themeMode.value)
+        assertTrue(vm.amoledEnabled.value)
+    }
+
+    @Test
+    fun `the hydrated DataStore value wins over a divergent mirror`() = runTest {
+        // Partial restore / cleared mirror : DataStore stays the source of truth.
+        val repository = mockk<UserPreferencesRepository> {
+            every { observeThemeMode() } returns MutableStateFlow(ThemeMode.LIGHT)
+            every { observeAmoledEnabled() } returns MutableStateFlow(false)
+        }
+
+        val vm = AppThemeViewModel(
+            userPreferencesRepository = repository,
+            themeBootstrapStore = bootstrapStore(ThemeBootstrap(ThemeMode.DARK, amoledEnabled = true)),
+        )
+
+        assertEquals(ThemeMode.LIGHT, vm.themeMode.value)
+        assertEquals(false, vm.amoledEnabled.value)
+    }
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
+import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.model.FlagType
@@ -20,12 +21,14 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 
 @Singleton
 class DataStoreUserPreferencesRepository @Inject constructor(
     @param:UserPreferencesDataStore private val dataStore: DataStore<Preferences>,
+    private val themeBootstrapStore: ThemeBootstrapStore,
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : UserPreferencesRepository {
 
@@ -151,6 +154,13 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             // `dataStore.data` re-emits on ANY write; keep the theme flow quiet unless the mode
             // actually changes so RedfaceApp doesn't recompose the whole tree on unrelated edits.
             .distinctUntilChanged()
+            // #386 backfill : users who picked their theme BEFORE the mirror existed start with
+            // an empty mirror — converge it from the observed truth (idempotent, write-on-diff).
+            .onEach { mode ->
+                if (themeBootstrapStore.read().themeMode != mode) {
+                    themeBootstrapStore.writeThemeMode(mode)
+                }
+            }
             .catch { emit(ThemeMode.SYSTEM) }
 
     override suspend fun setThemeMode(mode: ThemeMode) {
@@ -158,6 +168,9 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             dataStore.edit { prefs ->
                 prefs[KEY_THEME_MODE] = mode.name
             }
+            // Mirror for the synchronous cold-start read (#386) — DataStore stays the source
+            // of truth, the mirror only seeds the first frame.
+            themeBootstrapStore.writeThemeMode(mode)
         }
     }
 
@@ -166,6 +179,11 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             // Default `false`: AMOLED is opt-in and only meaningful in dark (#286).
             .map { prefs -> prefs[KEY_AMOLED_ENABLED] ?: false }
             .distinctUntilChanged()
+            .onEach { enabled ->
+                if (themeBootstrapStore.read().amoledEnabled != enabled) {
+                    themeBootstrapStore.writeAmoledEnabled(enabled)
+                }
+            }
             .catch { emit(false) }
 
     override suspend fun setAmoledEnabled(enabled: Boolean) {
@@ -173,6 +191,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             dataStore.edit { prefs ->
                 prefs[KEY_AMOLED_ENABLED] = enabled
             }
+            themeBootstrapStore.writeAmoledEnabled(enabled)
         }
     }
 

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/SharedPreferencesThemeBootstrapStore.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/SharedPreferencesThemeBootstrapStore.kt
@@ -1,0 +1,48 @@
+package fr.forumhfr.redface2.core.data.preferences
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrap
+import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrapStore
+import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * [ThemeBootstrapStore] over a tiny dedicated `SharedPreferences` file (#386).
+ *
+ * SharedPreferences (not DataStore) on purpose : the whole point of the mirror is a
+ * synchronous read on the cold-start path, which DataStore cannot provide. The file holds
+ * two keys, so the one-off synchronous load is negligible. This does NOT reopen ADR-002
+ * (credentials stay in DataStore + Keystore) — nothing sensitive lives here.
+ */
+@Singleton
+class SharedPreferencesThemeBootstrapStore @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+) : ThemeBootstrapStore {
+
+    private val prefs by lazy { context.getSharedPreferences(FILE_NAME, Context.MODE_PRIVATE) }
+
+    override fun read(): ThemeBootstrap = ThemeBootstrap(
+        // Defensive read, same stance as the repository's DataStore read : an unknown stored
+        // value (downgrade, manual edit) falls back to SYSTEM instead of crashing.
+        themeMode = prefs.getString(KEY_THEME_MODE, null)
+            ?.let { stored -> ThemeMode.entries.firstOrNull { it.name == stored } }
+            ?: ThemeMode.SYSTEM,
+        amoledEnabled = prefs.getBoolean(KEY_AMOLED_ENABLED, false),
+    )
+
+    override fun writeThemeMode(mode: ThemeMode) {
+        prefs.edit().putString(KEY_THEME_MODE, mode.name).apply()
+    }
+
+    override fun writeAmoledEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_AMOLED_ENABLED, enabled).apply()
+    }
+
+    private companion object {
+        const val FILE_NAME = "theme_bootstrap"
+        const val KEY_THEME_MODE = "theme_mode"
+        const val KEY_AMOLED_ENABLED = "amoled_enabled"
+    }
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/UserPreferencesModule.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/UserPreferencesModule.kt
@@ -11,6 +11,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import javax.inject.Singleton
 
@@ -38,4 +39,10 @@ abstract class UserPreferencesBindingsModule {
     abstract fun bindUserPreferencesRepository(
         impl: DataStoreUserPreferencesRepository,
     ): UserPreferencesRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindThemeBootstrapStore(
+        impl: SharedPreferencesThemeBootstrapStore,
+    ): ThemeBootstrapStore
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -7,6 +7,8 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
+import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrap
+import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.model.FlagType
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -29,6 +31,18 @@ class DataStoreUserPreferencesRepositoryTest {
     private lateinit var repository: DataStoreUserPreferencesRepository
     private val dispatcher = UnconfinedTestDispatcher()
 
+    /** In-memory [ThemeBootstrapStore] — the SharedPreferences impl has its own Robolectric test. */
+    private val themeBootstrapStore = object : ThemeBootstrapStore {
+        var stored = ThemeBootstrap()
+        override fun read(): ThemeBootstrap = stored
+        override fun writeThemeMode(mode: ThemeMode) {
+            stored = stored.copy(themeMode = mode)
+        }
+        override fun writeAmoledEnabled(enabled: Boolean) {
+            stored = stored.copy(amoledEnabled = enabled)
+        }
+    }
+
     @Before
     fun setUp() {
         dataStore = PreferenceDataStoreFactory.create(
@@ -36,6 +50,7 @@ class DataStoreUserPreferencesRepositoryTest {
         )
         repository = DataStoreUserPreferencesRepository(
             dataStore = dataStore,
+            themeBootstrapStore = themeBootstrapStore,
             ioDispatcher = dispatcher,
         )
     }
@@ -334,6 +349,39 @@ class DataStoreUserPreferencesRepositoryTest {
             assertEquals(ThemeMode.SYSTEM, awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun `setThemeMode mirrors the value into the bootstrap store`() = runTest(dispatcher) {
+        // #386 — the synchronous cold-start mirror must follow every theme write.
+        repository.setThemeMode(ThemeMode.DARK)
+        assertEquals(ThemeMode.DARK, themeBootstrapStore.read().themeMode)
+
+        repository.setThemeMode(ThemeMode.LIGHT)
+        assertEquals(ThemeMode.LIGHT, themeBootstrapStore.read().themeMode)
+    }
+
+    @Test
+    fun `setAmoledEnabled mirrors the flag without clobbering the mirrored theme mode`() = runTest(dispatcher) {
+        repository.setThemeMode(ThemeMode.DARK)
+        repository.setAmoledEnabled(true)
+
+        assertEquals(ThemeBootstrap(ThemeMode.DARK, amoledEnabled = true), themeBootstrapStore.read())
+    }
+
+    @Test
+    fun `observing the theme backfills an empty mirror from the persisted value`() = runTest(dispatcher) {
+        // #386 (Codex review) — users who picked their theme BEFORE the mirror existed must
+        // converge on first observation, not keep flashing until they touch the setting again.
+        dataStore.edit { prefs -> prefs[stringPreferencesKey("theme_mode")] = ThemeMode.DARK.name }
+        assertEquals(ThemeMode.SYSTEM, themeBootstrapStore.read().themeMode)
+
+        repository.observeThemeMode().test {
+            assertEquals(ThemeMode.DARK, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        assertEquals(ThemeMode.DARK, themeBootstrapStore.read().themeMode)
     }
 
     @Test

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/SharedPreferencesThemeBootstrapStoreTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/SharedPreferencesThemeBootstrapStoreTest.kt
@@ -1,0 +1,53 @@
+package fr.forumhfr.redface2.core.data.preferences
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrap
+import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/** Synchronous theme mirror over SharedPreferences (#386). */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class SharedPreferencesThemeBootstrapStoreTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val store = SharedPreferencesThemeBootstrapStore(context)
+
+    @Test
+    fun `an empty mirror reads as the SYSTEM defaults`() {
+        assertEquals(ThemeBootstrap(ThemeMode.SYSTEM, amoledEnabled = false), store.read())
+    }
+
+    @Test
+    fun `per-key writes round-trip a forced dark AMOLED selection`() {
+        store.writeThemeMode(ThemeMode.DARK)
+        store.writeAmoledEnabled(true)
+
+        assertEquals(ThemeBootstrap(ThemeMode.DARK, amoledEnabled = true), store.read())
+    }
+
+    @Test
+    fun `writing one key never clobbers the other`() {
+        store.writeThemeMode(ThemeMode.DARK)
+        store.writeAmoledEnabled(true)
+        store.writeThemeMode(ThemeMode.LIGHT)
+
+        assertEquals(ThemeBootstrap(ThemeMode.LIGHT, amoledEnabled = true), store.read())
+    }
+
+    @Test
+    fun `an unknown stored mode degrades to SYSTEM instead of crashing`() {
+        // Same defensive stance as the repository's DataStore read (downgrade / manual edit).
+        context.getSharedPreferences("theme_bootstrap", Context.MODE_PRIVATE)
+            .edit()
+            .putString("theme_mode", "PURPLE")
+            .commit()
+
+        assertEquals(ThemeMode.SYSTEM, store.read().themeMode)
+    }
+}

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/ThemeBootstrap.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/ThemeBootstrap.kt
@@ -1,0 +1,32 @@
+package fr.forumhfr.redface2.core.domain.preferences
+
+/**
+ * Last persisted theme selection, readable SYNCHRONOUSLY during the cold-start window (#386).
+ *
+ * DataStore's first emission can take over a second on a cold start ; until it lands the app
+ * used to render with the [ThemeMode.SYSTEM] default, flashing the OS theme at any user who
+ * forced the opposite one (light flash on a forced-dark app under a light OS). The window
+ * background and the first composition both need the effective theme immediately, hence this
+ * mirror. Defaults (SYSTEM / amoled off) apply until the user changes the theme once.
+ */
+data class ThemeBootstrap(
+    val themeMode: ThemeMode = ThemeMode.SYSTEM,
+    val amoledEnabled: Boolean = false,
+)
+
+/**
+ * Synchronous mirror of the persisted theme preferences (#386). Written by the preferences
+ * repository on every theme change (and backfilled from the observed DataStore value, so
+ * users who picked their theme before the mirror existed converge on first launch) ; read
+ * on the cold-start path BEFORE the first DataStore emission. DataStore stays the source of
+ * truth — if the two ever diverge (partial restore, cleared mirror), the DataStore value
+ * wins as soon as it is hydrated.
+ *
+ * Writes are PER KEY on purpose : theme mode and AMOLED are persisted from independent
+ * coroutines, and a read-modify-write of the whole pair could lose the other field.
+ */
+interface ThemeBootstrapStore {
+    fun read(): ThemeBootstrap
+    fun writeThemeMode(mode: ThemeMode)
+    fun writeAmoledEnabled(enabled: Boolean)
+}


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Réf. closes-#386 (mot-clé volontairement cassé — fermeture à la promotion dev → main).

## Cause

Deux couches au flash rapporté par nicko (système clair + app forcée sombre → 1-2 s de blanc au lancement à froid) :

1. le thème de la fenêtre (`Theme.Redface2`, parent `Theme.DeviceDefault.NoActionBar`) suit l'uiMode **système** — la fenêtre démarre claire ;
2. la première émission DataStore peut prendre plus d'une seconde à froid, pendant laquelle `AppThemeViewModel` exposait le défaut `SYSTEM` → `RedfaceTheme` clair. La KDoc du VM (#286) documentait déjà ce flash et promettait un gate dédié « si ça devient une plainte » — c'est #386.

## Fix — miroir synchrone

Nouveau `ThemeBootstrapStore` (interface `:core:domain`, impl `SharedPreferences` dédiée 2 clés dans `:core:data`) :

- **écrit** par `DataStoreUserPreferencesRepository` à chaque `setThemeMode` / `setAmoledEnabled` ;
- **lu synchroniquement** au démarrage par `MainActivity` (fond de fenêtre posé depuis `RedfaceLight/Dark/AmoledColorScheme.background.toArgb()` — pas de duplication de couleur) et par `AppThemeViewModel` (valeur initiale du `stateIn` au lieu de `SYSTEM` en dur).

DataStore reste la source de vérité : en cas de divergence (restore partiel, miroir effacé), la valeur hydratée gagne dès qu'elle arrive. Ceci ne rouvre pas ADR-002 — rien de sensible dans le miroir.

## Tests

- `SharedPreferencesThemeBootstrapStoreTest` (Robolectric) : round-trip, défauts, valeur corrompue → SYSTEM.
- `DataStoreUserPreferencesRepositoryTest` : le miroir suit chaque écriture, AMOLED ne clobber pas le mode (fake in-memory, le test reste JVM pur).
- `AppThemeViewModelTest` : avant la première émission DataStore le miroir seed l'état ; la valeur hydratée gagne sur un miroir divergent.

## Limites

- Non vérifié sur device cette nuit (pas d'émulateur en run de nuit) — la repro #386 (système clair + app sombre, lancement à froid) est à confirmer au dogfooding.
- Le splash système (Android 12+) suit l'uiMode OS, hors de portée de l'app — hors scope.

Validation 2 parts Docker verte.
