### PR TITLE
Quick wins D1 : palette smileys complète (#415), fallback smiley cassé (#416), Supprimer dans le menu (#418), page précédente atterrit en bas (#412)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -197,15 +197,6 @@ data class TopicRoute(
      * back stacks deserialise without the field.
      */
     val postSubmitOverflowLanding: Boolean = false,
-    /**
-     * #412 — `true` when this route comes from a « page précédente » navigation (chevron, FAB,
-     * swipe right — `onOpenPage` compares the target to the departing page). Reading a thread
-     * backwards means the last posts of the previous page come first: when the page has no saved
-     * anchor (#307), the screen lands at the BOTTOM instead of the top. A saved anchor still wins —
-     * the flag only replaces the `StartAtTop` fallback (cf. `resolveTopicScrollRestoration`).
-     * Default `false` keeps forward/jump navigation and older serialised back stacks unchanged.
-     */
-    val previousPageLanding: Boolean = false,
 ) : RedfaceNavKey
 
 @Serializable
@@ -455,6 +446,10 @@ fun RedfaceApp(intent: Intent?) {
         // on departure; the next landing on the same page restores it (unless the route carries a
         // scrollTo / submitSignal, cf. resolveTopicScrollRestoration). RAM/session only, like titles.
         var topicScrollAnchorCache by remember { mutableStateOf(emptyMap<TopicScrollKey, TopicScrollAnchor>()) }
+        // #412 — transient « land at the bottom » marker, lifecycle-matched to the anchor cache
+        // above (plain remember: lost on activity/process recreation, which falls back to the
+        // pre-#412 top landing instead of replaying a stale bottom scroll).
+        var topicPendingBottomLanding by remember { mutableStateOf<TopicScrollKey?>(null) }
 
         LaunchedEffect(authState) {
             when (authState) {
@@ -546,6 +541,8 @@ fun RedfaceApp(intent: Intent?) {
                                 anchor,
                             )
                         },
+                        pendingBottomLanding = topicPendingBottomLanding,
+                        onPendingBottomLanding = { topicPendingBottomLanding = it },
                     ),
                     onOpenProfile = { userId, pseudo, avatarUrl ->
                         // Review feedback I3: capture the **origin** tab so that
@@ -679,10 +676,19 @@ private data class TopicTitleNavState(
  *
  * @property anchors last saved read position per visited topic page.
  * @property onAnchorSaved records a page's read position when its screen is disposed.
+ * @property pendingBottomLanding #412 — the one page currently owed a bottom landing (armed by
+ *   `onOpenPage` on a strict « page - 1 » step, cleared on any other page change and consumed by
+ *   the screen after its first `Loaded`). Deliberately transient nav state, NOT a `TopicRoute`
+ *   field: a serialized route would replay the bottom landing on process/configuration restore and
+ *   could override the user's restored position (Codex review on PR #420). Losing it with the
+ *   composition just falls back to the pre-#412 top landing.
+ * @property onPendingBottomLanding rewrites the pending key (null clears it).
  */
 private data class TopicScrollNavState(
     val anchors: Map<TopicScrollKey, TopicScrollAnchor>,
     val onAnchorSaved: (cat: Int, post: Int, page: Int, anchor: TopicScrollAnchor) -> Unit,
+    val pendingBottomLanding: TopicScrollKey? = null,
+    val onPendingBottomLanding: (TopicScrollKey?) -> Unit = {},
 )
 
 /**
@@ -1030,7 +1036,11 @@ private fun RedfaceNavHost(
                     submitSignal = route.submitSignal,
                     savedAnchor = topicScrollNavState
                         .anchors[TopicScrollKey(route.cat, route.post, route.page)],
-                    previousPageLanding = route.previousPageLanding,
+                    // #412 — armed by onOpenPage on a strict « page - 1 » step; transient nav
+                    // state rather than a route field (Codex review on PR #420: a serialized
+                    // flag would replay the bottom landing on process/config restore).
+                    previousPageLanding = topicScrollNavState.pendingBottomLanding ==
+                        TopicScrollKey(route.cat, route.post, route.page),
                 )
                 TopicScreen(
                     request = TopicRequest(
@@ -1049,6 +1059,11 @@ private fun RedfaceNavHost(
                     restoreScrollAnchor =
                         (scrollRestoration as? TopicScrollRestoration.RestoreSaved)?.anchor,
                     startAtBottom = scrollRestoration is TopicScrollRestoration.StartAtBottom,
+                    onStartAtBottomConsumed = {
+                        // One-shot: once the screen has executed (or skipped) the bottom landing
+                        // for this page, drop the marker so it can never replay.
+                        topicScrollNavState.onPendingBottomLanding(null)
+                    },
                     onScrollAnchorSaved = { anchor ->
                         topicScrollNavState.onAnchorSaved(route.cat, route.post, route.page, anchor)
                     },
@@ -1116,6 +1131,14 @@ private fun RedfaceNavHost(
                         )
                     },
                     onOpenPage = { targetPage ->
+                        // #412 — a one-page step backwards lands at the bottom of the target page
+                        // (reading direction) unless that page has a saved anchor. Strict
+                        // « page - 1 » so pager jumps further back keep the top landing; any other
+                        // page change clears a stale marker.
+                        topicScrollNavState.onPendingBottomLanding(
+                            TopicScrollKey(route.cat, route.post, targetPage)
+                                .takeIf { targetPage == route.page - 1 },
+                        )
                         // #282 — replace the top entry IN PLACE rather than removeAt + add. The two-step
                         // version briefly leaves the parent on top (size-1), an observable intermediate
                         // state NavDisplay can start transitioning toward; an indexed set is a single
@@ -1125,10 +1148,6 @@ private fun RedfaceNavHost(
                             post = route.post,
                             page = targetPage,
                             scrollTo = null,
-                            // #412 — a one-page step backwards lands at the bottom of the target page
-                            // (reading direction) unless that page has a saved anchor. Strict
-                            // « page - 1 » so pager jumps further back keep the top landing.
-                            previousPageLanding = targetPage == route.page - 1,
                         )
                     },
                     onBack = {

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -197,6 +197,15 @@ data class TopicRoute(
      * back stacks deserialise without the field.
      */
     val postSubmitOverflowLanding: Boolean = false,
+    /**
+     * #412 — `true` when this route comes from a « page précédente » navigation (chevron, FAB,
+     * swipe right — `onOpenPage` compares the target to the departing page). Reading a thread
+     * backwards means the last posts of the previous page come first: when the page has no saved
+     * anchor (#307), the screen lands at the BOTTOM instead of the top. A saved anchor still wins —
+     * the flag only replaces the `StartAtTop` fallback (cf. `resolveTopicScrollRestoration`).
+     * Default `false` keeps forward/jump navigation and older serialised back stacks unchanged.
+     */
+    val previousPageLanding: Boolean = false,
 ) : RedfaceNavKey
 
 @Serializable
@@ -1021,6 +1030,7 @@ private fun RedfaceNavHost(
                     submitSignal = route.submitSignal,
                     savedAnchor = topicScrollNavState
                         .anchors[TopicScrollKey(route.cat, route.post, route.page)],
+                    previousPageLanding = route.previousPageLanding,
                 )
                 TopicScreen(
                     request = TopicRequest(
@@ -1038,6 +1048,7 @@ private fun RedfaceNavHost(
                     },
                     restoreScrollAnchor =
                         (scrollRestoration as? TopicScrollRestoration.RestoreSaved)?.anchor,
+                    startAtBottom = scrollRestoration is TopicScrollRestoration.StartAtBottom,
                     onScrollAnchorSaved = { anchor ->
                         topicScrollNavState.onAnchorSaved(route.cat, route.post, route.page, anchor)
                     },
@@ -1114,6 +1125,10 @@ private fun RedfaceNavHost(
                             post = route.post,
                             page = targetPage,
                             scrollTo = null,
+                            // #412 — a one-page step backwards lands at the bottom of the target page
+                            // (reading direction) unless that page has a saved anchor. Strict
+                            // « page - 1 » so pager jumps further back keep the top landing.
+                            previousPageLanding = targetPage == route.page - 1,
                         )
                     },
                     onBack = {

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/TopicScrollRestore.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/TopicScrollRestore.kt
@@ -64,6 +64,14 @@ internal sealed interface TopicScrollRestoration {
     /** A position was saved for this exact `(cat, post, page)` — restore it once loaded. */
     data class RestoreSaved(val anchor: TopicScrollAnchor) : TopicScrollRestoration
 
+    /**
+     * #412 — « page précédente » navigation onto a page with no saved anchor: land at the BOTTOM.
+     * Reading a thread backwards, the posts that chronologically follow what the user just read
+     * are the LAST ones of the previous page (same landing HFR's own `#bas` anchor gives on the
+     * web). A saved anchor still wins — this only replaces the [StartAtTop] fallback.
+     */
+    data object StartAtBottom : TopicScrollRestoration
+
     /** Never-visited page (or evicted anchor): keep the default top-of-page landing. */
     data object StartAtTop : TopicScrollRestoration
 }
@@ -76,17 +84,21 @@ internal sealed interface TopicScrollRestoration {
  *  2. post-submit route (`submitSignal != null`, covers the #344 `ScrollToEndOfPage` path and the
  *     #226 overflow landing) → [TopicScrollRestoration.FollowSubmitLanding] ;
  *  3. saved anchor for the page → [TopicScrollRestoration.RestoreSaved] ;
- *  4. nothing → [TopicScrollRestoration.StartAtTop].
+ *  4. « page précédente » navigation (#412, `previousPageLanding`) →
+ *     [TopicScrollRestoration.StartAtBottom] ;
+ *  5. nothing → [TopicScrollRestoration.StartAtTop].
  *
- * Pure so the four levels are unit-testable without Compose/nav3 (cf. `TopicScrollRestorationTest`).
+ * Pure so the five levels are unit-testable without Compose/nav3 (cf. `TopicScrollRestorationTest`).
  */
 internal fun resolveTopicScrollRestoration(
     scrollTo: Int?,
     submitSignal: Long?,
     savedAnchor: TopicScrollAnchor?,
+    previousPageLanding: Boolean = false,
 ): TopicScrollRestoration = when {
     scrollTo != null -> TopicScrollRestoration.FollowScrollTo
     submitSignal != null -> TopicScrollRestoration.FollowSubmitLanding
     savedAnchor != null -> TopicScrollRestoration.RestoreSaved(savedAnchor)
+    previousPageLanding -> TopicScrollRestoration.StartAtBottom
     else -> TopicScrollRestoration.StartAtTop
 }

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/TopicScrollRestorationTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/TopicScrollRestorationTest.kt
@@ -5,8 +5,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
- * Covers the pure priority resolver for the initial scroll of a topic page landing (#307):
- * route `scrollTo` > post-submit landing (`submitSignal`, #344) > saved anchor > top.
+ * Covers the pure priority resolver for the initial scroll of a topic page landing (#307, #412):
+ * route `scrollTo` > post-submit landing (`submitSignal`, #344) > saved anchor >
+ * previous-page bottom (#412) > top.
  */
 class TopicScrollRestorationTest {
 
@@ -75,7 +76,58 @@ class TopicScrollRestorationTest {
     }
 
     @Test
-    fun `level 4 - a never-visited page lands at the top`() {
+    fun `level 3 - a saved anchor beats the previous-page bottom landing`() {
+        // #412 — the issue is explicit: « page précédente SANS position retenue ». A retained
+        // position is what the user wants back, whatever direction brought them here.
+        val restoration = resolveTopicScrollRestoration(
+            scrollTo = null,
+            submitSignal = null,
+            savedAnchor = savedAnchor,
+            previousPageLanding = true,
+        )
+
+        assertEquals(TopicScrollRestoration.RestoreSaved(savedAnchor), restoration)
+    }
+
+    @Test
+    fun `level 4 - previous-page navigation without a saved anchor lands at the bottom`() {
+        // #412 — reading backwards: the next posts to read are the last of the previous page.
+        val restoration = resolveTopicScrollRestoration(
+            scrollTo = null,
+            submitSignal = null,
+            savedAnchor = null,
+            previousPageLanding = true,
+        )
+
+        assertEquals(TopicScrollRestoration.StartAtBottom, restoration)
+    }
+
+    @Test
+    fun `level 1 and 2 - scrollTo and submit landings ignore the previous-page flag`() {
+        // A quote/edit submit pops back onto « page - 1 » in some flows — the scroll effects own
+        // those landings, the #412 bottom fallback must never compete with them.
+        assertEquals(
+            TopicScrollRestoration.FollowScrollTo,
+            resolveTopicScrollRestoration(
+                scrollTo = 4242,
+                submitSignal = null,
+                savedAnchor = null,
+                previousPageLanding = true,
+            ),
+        )
+        assertEquals(
+            TopicScrollRestoration.FollowSubmitLanding,
+            resolveTopicScrollRestoration(
+                scrollTo = null,
+                submitSignal = 1_000L,
+                savedAnchor = null,
+                previousPageLanding = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `level 5 - a never-visited page lands at the top`() {
         val restoration = resolveTopicScrollRestoration(
             scrollTo = null,
             submitSignal = null,

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/BuiltinSmileys.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/BuiltinSmileys.kt
@@ -1,24 +1,24 @@
 package fr.forumhfr.redface2.core.model
 
 /**
- * Phase 2F-B (#11 partial) — canonical HFR built-in smiley set.
+ * Phase 2F-B (#11 partial), completed by #415 — canonical HFR built-in smiley set.
  *
- * Codes and image URLs come from the live HFR form fixture
- * `core/parser/src/test/resources/fixtures/write_reply_form_open_topic.html` (Phase 2A capture,
- * cf. `<img … onclick="putSmiley(...)">` block). The list is kept as a Kotlin constant rather
- * than parsed from the form at runtime because :
+ * Canonical source : HFR's own help page `smilies.php` (58 typed codes, live fixture
+ * `core/parser/src/test/resources/fixtures/smilies_help_page.html`, captured 2026-06-11).
+ * The first 25 entries keep the composer-toolbar order (fixture
+ * `write_reply_form_open_topic.html`, historical popularity ranking — the picker renders in
+ * order) ; the remaining 33 follow in `smilies.php` order. The toolbar only SHOWS a popular
+ * subset of what the server interprets, which is how `:sweat:` went missing (#415, beta
+ * report by DjullClint).
+ *
+ * Kept as a Kotlin constant rather than parsed at runtime because :
  *  - the built-in set rarely changes (one drift in the last 10 years observed) ;
- *  - exposing it as a constant means the picker can render the Standard tab without waiting
- *    for the editor's form GET to land ;
- *  - the list is verified against a real fixture, so it is not « invented codes » in the sense
- *    `AGENTS.md` forbids (cf. CLAUDE.md § « Smileys HFR »).
+ *  - the picker can render the Standard tab without waiting for any GET ;
+ *  - every code is verified against a real fixture, so nothing here is an « invented code »
+ *    in the sense `AGENTS.md` forbids (cf. CLAUDE.md § « Smileys HFR »).
  *
- * If HFR ever adds or renames a built-in, the regression surfaces at the next dogfood pass on
- * the picker — at which point we can either bump this constant or move to a runtime extraction
- * from the form HTML (`<img class="smileys">` selector). Phase 2F-B does not need either path.
- *
- * Order matches the order HFR serves the smileys in its toolbar, which itself follows the
- * historical popularity ranking. The picker renders the list in order — no resorting needed.
+ * `BuiltinSmileysSymmetryTest` (`:core:parser`) re-parses the `smilies.php` fixture and fails
+ * if this constant ever drifts from it (missing code, wrong URL).
  */
 @Suppress("MaxLineLength") // URL + token + source on one line per smiley keeps the table readable.
 val BUILTIN_HFR_SMILEYS: List<EditorSmiley> = listOf(
@@ -47,4 +47,39 @@ val BUILTIN_HFR_SMILEYS: List<EditorSmiley> = listOf(
     EditorSmiley(":whistle:", "https://forum-images.hardware.fr/icones/smilies/whistle.gif", EditorSmileySource.BUILTIN),
     EditorSmiley(":sol:", "https://forum-images.hardware.fr/icones/smilies/sol.gif", EditorSmileySource.BUILTIN),
     EditorSmiley(":pt1cable:", "https://forum-images.hardware.fr/icones/smilies/pt1cable.gif", EditorSmileySource.BUILTIN),
+    // Below : the 33 built-ins the server interprets but the composer toolbar does not show
+    // (#415) — smilies.php order.
+    EditorSmiley(":'(", "https://forum-images.hardware.fr/icones/ohill.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":eek:", "https://forum-images.hardware.fr/icones/smilies/eek.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":hap:", "https://forum-images.hardware.fr/icones/smilies/hap.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":dtc:", "https://forum-images.hardware.fr/icones/smilies/dtc.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":gun:", "https://forum-images.hardware.fr/icones/smilies/gun.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":miam:", "https://forum-images.hardware.fr/icones/smilies/miam.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":bic:", "https://forum-images.hardware.fr/icones/smilies/bic.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":hebe:", "https://forum-images.hardware.fr/icones/smilies/hebe.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":gratgrat:", "https://forum-images.hardware.fr/icones/smilies/gratgrat.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":hello:", "https://forum-images.hardware.fr/icones/smilies/hello.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":mmmfff:", "https://forum-images.hardware.fr/icones/smilies/mmmfff.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":mouais:", "https://forum-images.hardware.fr/icones/smilies/mouais.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":benetton:", "https://forum-images.hardware.fr/icones/smilies/benetton.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":eek2:", "https://forum-images.hardware.fr/icones/smilies/eek2.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":int:", "https://forum-images.hardware.fr/icones/smilies/int.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":evil:", "https://forum-images.hardware.fr/icones/smilies/evil.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":spamafote:", "https://forum-images.hardware.fr/icones/smilies/spamafote.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":calimero:", "https://forum-images.hardware.fr/icones/smilies/calimero.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":fuck:", "https://forum-images.hardware.fr/icones/smilies/fuck.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":sum:", "https://forum-images.hardware.fr/icones/smilies/sum.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":ouimaitre:", "https://forum-images.hardware.fr/icones/smilies/ouimaitre.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":foudtag:", "https://forum-images.hardware.fr/icones/smilies/foudtag.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":sweat:", "https://forum-images.hardware.fr/icones/smilies/sweat.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":mad:", "https://forum-images.hardware.fr/icones/smilies/mad.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":hot:", "https://forum-images.hardware.fr/icones/smilies/hot.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":bug:", "https://forum-images.hardware.fr/icones/smilies/bug.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":spookie:", "https://forum-images.hardware.fr/icones/smilies/spookie.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":fouyaya:", "https://forum-images.hardware.fr/icones/smilies/fouyaya.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":sleep:", "https://forum-images.hardware.fr/icones/smilies/sleep.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":vomi:", "https://forum-images.hardware.fr/icones/smilies/vomi.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":pouah:", "https://forum-images.hardware.fr/icones/smilies/pouah.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":24:", "https://forum-images.hardware.fr/icones/smilies/24.gif", EditorSmileySource.BUILTIN),
+    EditorSmiley(":crazy:", "https://forum-images.hardware.fr/icones/smilies/crazy.gif", EditorSmileySource.BUILTIN),
 )

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/smiley/BuiltinSmileysSymmetryTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/smiley/BuiltinSmileysSymmetryTest.kt
@@ -1,0 +1,70 @@
+package fr.forumhfr.redface2.core.parser.smiley
+
+import fr.forumhfr.redface2.core.model.BUILTIN_HFR_SMILEYS
+import org.jsoup.Jsoup
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #415 — symmetry between [BUILTIN_HFR_SMILEYS] and HFR's own help page `smilies.php`
+ * (fixture `smilies_help_page.html`, the canonical list of typed codes the server
+ * interprets). The composer toolbar only shows a popular subset, which is how `:sweat:`
+ * went missing from the picker. This test re-derives the (code → image URL) pairs from the
+ * fixture and fails on any drift : missing code, extra code, or wrong URL.
+ */
+class BuiltinSmileysSymmetryTest {
+
+    /**
+     * The help page lists one row per smiley : `<tr><th>:code:</th><th><img src=...></th></tr>`
+     * (code cell `cBackTab2`, image cell `cBackTab1`).
+     */
+    private fun fixturePairs(): Map<String, String> {
+        val stream = requireNotNull(
+            BuiltinSmileysSymmetryTest::class.java.classLoader
+                ?.getResourceAsStream("fixtures/smilies_help_page.html"),
+        ) { "Fixture not found: fixtures/smilies_help_page.html" }
+        val html = stream.bufferedReader().use { it.readText() }
+        val document = Jsoup.parse(html)
+        val pairs = mutableMapOf<String, String>()
+        document.select("tr").forEach { row ->
+            val code = row.selectFirst("th.cBackTab2")?.text()?.trim()?.takeIf {
+                it.startsWith(":") || it.startsWith(";")
+            } ?: return@forEach
+            val src = row.selectFirst("th.cBackTab1 img[src*=forum-images.hardware.fr/icones/]")
+                ?.attr("src")
+                ?.takeIf { it.endsWith(".gif") }
+                ?: return@forEach
+            pairs[code] = src
+        }
+        return pairs
+    }
+
+    @Test
+    fun `the constant matches smilies-php exactly — every code, every URL`() {
+        val expected = fixturePairs()
+        assertTrue("fixture should yield a substantial list, got ${expected.size}", expected.size >= 50)
+
+        val actual = BUILTIN_HFR_SMILEYS.associate { it.token to it.imageUrl }
+
+        assertEquals(
+            "codes present in smilies.php but missing from BUILTIN_HFR_SMILEYS",
+            emptySet<String>(),
+            expected.keys - actual.keys,
+        )
+        assertEquals(
+            "codes present in BUILTIN_HFR_SMILEYS but absent from smilies.php",
+            emptySet<String>(),
+            actual.keys - expected.keys,
+        )
+        expected.forEach { (code, url) ->
+            assertEquals("image URL drift for $code", url, actual[code])
+        }
+    }
+
+    @Test
+    fun `the beta-reported missing smiley is back`() {
+        // DjullClint, topic principal t2787127 — the report that triggered #415.
+        assertTrue(BUILTIN_HFR_SMILEYS.any { it.token == ":sweat:" })
+    }
+}

--- a/core/parser/src/test/resources/fixtures/smilies_help_page.html
+++ b/core/parser/src/test/resources/fixtures/smilies_help_page.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr" lang="fr">
+<head>
+<title>FORUM HardWare.fr</title>
+<link type="text/css" rel="stylesheet" href="/include/the_style1.php?color_key=FFFFFF/DEDFDF/000080/C2C3F4/001932/FFFFFF/FFFFFF/000000/000080/000000/000080/F7F7F7/DEDFDF/F7F7F7/DEDFDF/C0C0C0/C0C0C0/FFFFFF/000000/000000/0000FF/EEEEFF/DDDDEE/000000/FFEEEE/000000/FFFFFF/FF0000/FFFFFF/0/1/https%3A%40%40forum-images.hardware.fr/NULL/&amp;abs_img_path=%40data%40sites%40forum%40www%40static%40&amp;hide_bg_onglet=0&amp;v=11102781422" />
+<link type="text/css" rel="stylesheet" href="https://forum-images.hardware.fr/compressed/the_style.css?v=11102781422" /><script language="Javascript" type="text/javascript" src="https://forum-images.hardware.fr/compressed/common.js?v=11102781422"></script><style type="text/css">
+<!--
+.fastsearchMain{ width: 330px; }
+.fastsearchInput{ width: 70px; border: 1px solid black; }
+.fastsearchSubmit{ background-color: ; border: 0px;}
+.header2 { background-image: url(/img/forum3_1.gif);background-repeat: repeat-x; }
+.menuExt { font-family: Arial, Helvetica, sans-serif; font-size: 10px; color:#000; }
+.menuExt a { color:#000;text-decoration:none; }
+.menuExt a:hover { color:#000;text-decoration:underline; }
+form { display: inline; }
+.header { background-image: url(//forum-images.hardware.fr/img/header-bg.gif); background-repeat: repeat-x; }
+.tdmenu { width: 1px;height: 1px;color: #000000; }
+.hfrheadmenu { font-family: Arial, Helvetica, sans-serif;font-size:13px;font-weight:bold; }
+.hfrheadmenu span {color:;}
+.hfrheadmenu a { color:;text-decoration: none; }
+.hfrheadmenu a:hover { color:;text-decoration: underline; }
+.concours { font-family: Arial, Helvetica, sans-serif;color:;font-size: 16px;text-decoration: none;font-weight: bold;}
+.concours:hover { font-family: Arial, Helvetica, sans-serif;color:;font-size: 16px;text-decoration: underline;font-weight: bold; }
+.searchmenu { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: none;font-weight: bold; }
+.fastsearch { display: none; }
+.fastsearchHeader { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: none;font-weight: bold; }
+.fastsearchHeader:hover { font-family: Arial, Helvetica, sans-serif;color:;font-size: 13px;text-decoration: underline;font-weight: bold; }
+-->
+</style>
+<script async='async' src='https://www.googletagservices.com/tag/js/gpt.js'></script>
+<script>
+  var googletag = googletag || {};
+  googletag.cmd = googletag.cmd || [];
+</script>
+
+<script>
+  googletag.cmd.push(function() {
+    googletag.defineSlot('/2172442/forum_accueil_banniere', [728, 90], 'div-gpt-ad-1511901001563-0').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_achats_ventes_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-1').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_achats_ventes_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-2').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_achats_ventes_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-3').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_achats_ventes_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-4').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_apple_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-5').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_apple_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-6').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_apple_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-7').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_apple_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-8').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_banniere_jpdc', [728, 90], 'div-gpt-ad-1511901001563-9').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-10').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-11').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-12').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_discussions_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-13').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_emploi_etude_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-14').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_emploi_etude_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-15').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_emploi_etude_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-16').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_emploi_etude_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-17').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_graphisme_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-18').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_graphisme_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-19').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_graphisme_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-20').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_graphisme_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-21').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_banniere', [728, 90], 'div-gpt-ad-1511901001563-22').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-23').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-24').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-25').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-26').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_peripheriques_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-27').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_peripheriques_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-28').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_peripheriques_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-29').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_hardware_peripheriques_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-30').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_jeux_video_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-31').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_jeux_video_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-32').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_jeux_video_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-33').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_jeux_video_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-34').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_ordinateurs_portables_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-35').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_ordinateurs_portables_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-36').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_ordinateurs_portables_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-37').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_ordinateurs_portables_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-38').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_os_alternatif_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-39').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_os_alternatif_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-40').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_os_alternatif_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-41').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_os_alternatif_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-42').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_overclocking_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-43').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_overclocking_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-44').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_overclocking_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-45').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_overclocking_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-46').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_photo_numerique_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-47').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_photo_numerique_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-48').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_photo_numerique_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-49').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_photo_numerique_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-50').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_programmation_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-51').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_programmation_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-52').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_programmation_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-53').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_programmation_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-54').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_reseaux_grand_public_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-55').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_reseaux_grand_public_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-56').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_reseaux_grand_public_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-57').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_reseaux_grand_public_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-58').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_seti_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-59').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_seti_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-60').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_seti_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-61').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_seti_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-62').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_systemes_reseaux_pro_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-63').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_systemes_reseaux_pro_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-64').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_systemes_reseaux_pro_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-65').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_systemes_reseaux_pro_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-66').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_technologies_mobiles_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-67').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_technologies_mobiles_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-68').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_technologies_mobiles_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-69').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_technologies_mobiles_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-70').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_video_son_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-71').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_video_son_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-72').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_video_son_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-73').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_video_son_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-74').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_windows_software_banniere_haut', [728, 90], 'div-gpt-ad-1511901001563-75').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_windows_software_carre_bas', [336, 280], 'div-gpt-ad-1511901001563-76').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_windows_software_carre_haut', [336, 280], 'div-gpt-ad-1511901001563-77').addService(googletag.pubads());
+    googletag.defineSlot('/2172442/forum_windows_software_carre_milieu', [336, 280], 'div-gpt-ad-1511901001563-78').addService(googletag.pubads());
+    googletag.pubads().enableSingleRequest();
+    googletag.enableServices();
+  });
+</script>
+<script type='text/javascript'>
+     (function(){
+       var loc = window.location.href;
+       var dd = document.createElement('script');
+       dd.type = 'text/javascript'; dd.src = '//static.digidip.net/hardware.js?loc=' + loc;
+       var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(dd, s);
+     })();
+</script><meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+<meta http-equiv="Pragma" content="no-cache" />
+<meta http-equiv="Cache-Control" content="no-cache, must-revalidate" />
+<meta http-equiv="Expires" content="0" />
+<meta http-equiv="Imagetoolbar" content="no" />
+<meta name="Robots" content="index, follow" />
+</head>
+
+<body >
+		<script language="JavaScript" type="text/javascript" src="/js/cookiechoices.js"></script>
+<script language="javascript" type="text/javascript" src="/js/jquery-1.11.1.min.js"></script>
+<script language="JavaScript" type="text/javascript" src="/js/cnil.js"></script>
+<script>
+ document.addEventListener('DOMContentLoaded', function(event) {
+    cookieChoices.showCookieConsentBar('HardWare.fr utilise des cookies pour une navigation optimale et des cookies tiers pour l\'analyse du trafic et la publicité',
+      'Fermer', 'En savoir plus', 'https://www.hardware.fr/html/donnees_personnelles/');
+  });
+</script>
+<style>
+#cookieChoiceInfo span
+,#cookieChoiceDismiss
+,#PlusCookieChoice{
+	font-family:Tahoma,Arial,Helvetica,sans-serif;
+}
+#cookieChoiceDismiss
+,#PlusCookieChoice
+{
+	color:black;
+	text-decoration:none;
+}
+#cookieChoiceDismiss:hover
+,#PlusCookieChoice:hover
+{
+	color:#cc6908;
+}
+</style>
+ <table cellspacing="0" cellpadding="0" width="98%" bgcolor="#000000" border="0" align="center" class="hfrheadmenu" style="border:1px solid #000;border-top:0;">
+        <tr>
+          <td style="vertical-align: top">
+            <table cellspacing="0" cellpadding="0" width="100%" border="0">
+              <tr>
+                <td style="width: 100%" align="left" valign="middle" colspan="2" class="header2"><span class="md_cryptlink45CBCBC0C22D1F1FCCCCCC19454AC14BCC4AC1431944C1"><img src="/img/forum_logo.gif" width="900" height="71" border="0" alt="" /></span></td>
+              </tr>
+              <tr>
+                <td style="background-color:#001932">
+                  <table cellspacing="0" cellpadding="2" width="100%" border="0">
+                    <tr>
+                      <td>&nbsp;<a class="cHeader" href="/">Forum</a>&nbsp;|&nbsp;
+<a class="cHeader" href="https://www.hardware.fr/">HardWare.fr</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/html/news/">News</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/html/articles/">Articles</a>&nbsp;|&nbsp;<a class="cHeader" href="https://www.hardware.fr/articles/786-1/guide-pc-hardware-fr.html">PC</a>&nbsp;|&nbsp;<span class="md_cryptlink1F484F4C464919C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">S'identifier</span>&nbsp;|&nbsp;<span class="md_cryptlink1F4649C242C146C0CB464F4919C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">S'inscrire</span>&nbsp;|&nbsp;<a class="cHeader" href="https://shop.hardware.fr/" target="_blank" style="position: relative; padding: 0 21px 0 0;display: inline-block;">Shop <img src="/img/shop.png" style="height: 17px; display: inline; position: absolute; right: 0; top: -2px; "></a></td>
+<td align="right"><a class="cHeader" href="/search.php?config=hardwarefr.inc&cat=&subcat=0">Recherche <img src="//forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif"></a></td>
+                    </tr>
+                    </table></td></tr></table>
+</td></tr></table><div style="width: 99%" align="right">
+<span class="s2Ext menuExt"><span class="md_cryptlink1F4F494846494319C045C02F424F4944464C2E454AC14BCC4AC14344C119464942">7563 connect&eacute;s&nbsp;</span></span></div><br /><div class="container">
+<div class="mesdiscussions700" id="mesdiscussions">
+			
+	<div class="arbo">
+<span  id="md_arbo_tree_1" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;<a href="/" class="Ext">FORUM HardWare.fr</a></span>
+<br />
+<h1  id="md_arbo_tree_2" ><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/tline.gif" alt="" /><img src="https://forum-images.hardware.fr/themes_static/images_forum/1/open.gif" alt="" />&nbsp;&nbsp;Liste des smileys</h1>
+</div><div class="s1Ext"></div><br />	<div class="rightbutton fastsearch"><table class="main fastsearchMain" cellspacing="0" cellpadding="2"><tr class="cBackHeader fondForumDescription"><th><form method="post" id="fastsearch" action="/forum1.php"><input type="hidden" name="hash_check" value="" /><label for="fastsearchinputid"><a rel="nofollow" href="/search.php?config=hfr.inc&amp;cat=&amp;subcat=0" class="cHeader fastsearchHeader">Recherche :</a>&nbsp;<input type="text" name="search" id="fastsearchinputid" value="" class="fastsearchInput" alt="Search string" /></label><input type="hidden" name="recherches" value="1" /><input type="hidden" name="searchtype" value="1" /><input type="hidden" name="titre" value="3" /><input type="hidden" name="resSearch" value="200" /><input type="hidden" name="orderSearch" value="1" /><input type="hidden" name="config" value="hfr.inc" />&nbsp;<input type="image" src="https://forum-images.hardware.fr/themes_static/images_forum/1/ongletsearch.gif" class="fastsearchSubmit" title="Lancer une recherche" alt="Lancer une recherche" /></form></th></tr></table></div>	<div class="spacer">&nbsp;</div>
+	<br />	<div class="spacer">&nbsp;</div>
+
+<div class="s2Ext" style="text-align: left">Les smilies sont des images qui permettent d'indiquer l'humeur de vos phrases.
+	<br />n'hésitez pas à les utiliser !
+	<br />Voici la liste de smilies que vous pouvez insérer très facilement dans vos message en utilisant les raccourcis suivants :</div>
+<br />
+<div class="center" style="width:250px">
+<table class="main" cellspacing="0" cellpadding="4">
+	<tr class="cBackHeader">
+		<th>Ce que vous allez taper</th>
+		<th>Le smilie qui va apparaitre</th>
+	</tr>
+	<tr class="s2Topic"><th class="cBackTab2">:)</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smile.gif" alt="" /></th></tr>
+	<tr class="s2Topic"><th class="cBackTab2">:(</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/frown.gif" alt="" /></th></tr>
+	<tr class="s2Topic"><th class="cBackTab2">:o</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/redface.gif" alt="" /></th></tr>
+	<tr class="s2Topic"><th class="cBackTab2">:D</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/biggrin.gif" alt="" /></th></tr>
+	<tr class="s2Topic"><th class="cBackTab2">;)</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/wink.gif" alt="" /></th></tr>
+	<tr class="s2Topic"><th class="cBackTab2">:p</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/tongue.gif" alt="" /></th></tr>
+	<tr class="s2Topic"><th class="cBackTab2">:'(</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/ohill.gif" alt="" /></th></tr>
+	<tr class="s2Topic"><th class="cBackTab2">:??:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/confused.gif" alt="" /></th></tr>
+			<tr class="s2Topic"><th class="cBackTab2">:eek:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/eek.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:hap:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/hap.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:dtc:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/dtc.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:gun:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/gun.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:miam:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/miam.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:ouch:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/ouch.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:bic:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/bic.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:wahoo:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/wahoo.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:hebe:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/hebe.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:fou:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/fou.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:cry:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/cry.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:gratgrat:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/gratgrat.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:na:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/na.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:bounce:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/bounce.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:hello:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/hello.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:mmmfff:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/mmmfff.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:mouais:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/mouais.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:benetton:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/benetton.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:sol:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/sol.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:eek2:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/eek2.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:sarcastic:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/sarcastic.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:kaola:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/kaola.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:int:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/int.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:ange:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/ange.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:evil:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/evil.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:spamafote:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/spamafote.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:calimero:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/calimero.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:lol:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/lol.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:fuck:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/fuck.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:pt1cable:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/pt1cable.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:sum:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/sum.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:ouimaitre:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/ouimaitre.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:foudtag:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/foudtag.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:sweat:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/sweat.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:whistle:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/whistle.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:mad:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/mad.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:love:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/love.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:hot:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/hot.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:heink:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/heink.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:bug:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/bug.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:pfff:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/pfff.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:spookie:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/spookie.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:fouyaya:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/fouyaya.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:sleep:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/sleep.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:vomi:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/vomi.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:non:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/non.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:pouah:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/pouah.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:24:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/24.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:crazy:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/crazy.gif" alt="" /></th></tr>
+				<tr class="s2Topic"><th class="cBackTab2">:jap:</th><th class="cBackTab1"><img src="https://forum-images.hardware.fr/icones/smilies/jap.gif" alt="" /></th></tr>
+			</table>
+</div>
+<br /><br />
+
+	<div class="copyright">
+		<a href="http://www.mesdiscussions.net" target="_blank" class="copyright">Forum MesDiscussions.Net</a>, Version 2010.2 <br />(c) 2000-2011 Doctissimo<br />	</div>
+</div>
+</div>
+<center><font color="#000000" size="1" face="Arial, Helvetica, sans-serif"><br />Copyright © 1997-2025 Groupe <a href="https://www.ldlc.com" title="Achat de materiel Informatique">LDLC</a> (<a href="https://www.hardware.fr/html/donnees_personnelles/">Signaler un contenu illicite / Données personnelles</a>)</font></center>
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://tracking.groupe-ldlc.com/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '26']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<noscript><p><img src="https://tracking.groupe-ldlc.com/matomo.php?idsite=26&rec=1" style="border:0;" alt="" /></p></noscript>
+<!-- End Matomo Code --><script type="text/javascript">
+md_forum_decryptlink.init();
+</script>
+<script type="text/javascript">
+md_forum_decryptlink.init();
+</script>
+</body>
+</html>

--- a/core/parser/src/test/resources/fixtures/smilies_help_page.source.txt
+++ b/core/parser/src/test/resources/fixtures/smilies_help_page.source.txt
@@ -1,0 +1,7 @@
+Source: https://forum.hardware.fr/smilies.php
+Captured: 2026-06-11
+Auth: logged-out
+Sanitization: verified logged-out capture; static help page, no forms, no hash_check, no session data
+Purpose: #415 — canonical list of the 58 built-in smileys the server interprets (typed code
+precedes each <img>). BUILTIN_HFR_SMILEYS used to be derived from the composer toolbar palette
+(write_reply_form_open_topic.html), which only SHOWS 25 of them.

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Dp
@@ -1092,11 +1093,23 @@ internal fun smileyInlineContent(smiley: PostInline.Smiley, box: InlineMediaBox)
             placeholderVerticalAlign = PlaceholderVerticalAlign.TextBottom,
         ),
     ) {
-        AsyncImage(
+        SubcomposeAsyncImage(
             model = smiley.imageUrl,
             contentDescription = description,
             contentScale = PostMediaDisplayPolicy.smileyContentScale,
             modifier = Modifier.fillMaxSize(),
+            success = { SubcomposeAsyncImageContent() },
+            error = {
+                // #416 — a dead smiley sprite (deleted perso, stale URL) used to render as
+                // BLANK where web/RF1 fall back to the typed code. Show the token, ellipsised
+                // to the sprite box ; semantics carry the full token via contentDescription.
+                Text(
+                    text = description,
+                    fontSize = 10.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            },
         )
     }
 }

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/SmileyErrorFallbackTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/SmileyErrorFallbackTest.kt
@@ -1,0 +1,89 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import coil3.ColorImage
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.test.FakeImageLoaderEngine
+import fr.forumhfr.redface2.core.model.PostBlock
+import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.model.PostInline
+import fr.forumhfr.redface2.core.model.SmileyKind
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * #416 — a smiley sprite that fails to load (deleted perso, stale URL) must fall back to its
+ * typed token, never render as blank. Web and RF1 both show the code in that case ; before the
+ * fix, `smileyInlineContent` used a slot-less `AsyncImage` and the inline box stayed empty.
+ *
+ * The fake engine only intercepts [aliveUrl] — any other URL (the dead smiley) resolves to a
+ * Coil error result, which is exactly the production failure mode.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@OptIn(ExperimentalTestApi::class)
+class SmileyErrorFallbackTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val aliveUrl = "https://forum-images.hardware.fr/images/perso/1/alive.gif"
+    private val deadUrl = "https://forum-images.hardware.fr/images/perso/1/deleted-long-ago.gif"
+
+    @OptIn(coil3.annotation.DelicateCoilApi::class)
+    @Before
+    fun installFakeImageLoader() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val engine = FakeImageLoaderEngine.Builder()
+            .intercept(aliveUrl, ColorImage(0xFF2E7D32.toInt(), width = 40, height = 40))
+            // deadUrl intentionally NOT intercepted → Coil error result.
+            .build()
+        SingletonImageLoader.setUnsafe(ImageLoader.Builder(context).components { add(engine) }.build())
+    }
+
+    @Test
+    fun `a dead smiley falls back to its typed token instead of blank`() {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                Surface(color = MaterialTheme.colorScheme.surface) {
+                    PostRenderer(
+                        content = PostContent(
+                            blocks = listOf(
+                                PostBlock.Paragraph(
+                                    inlines = listOf(
+                                        PostInline.Text("avant "),
+                                        PostInline.Smiley(
+                                            kind = SmileyKind.Perso("deleted-long-ago"),
+                                            imageUrl = deadUrl,
+                                        ),
+                                        PostInline.Text(" après"),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    )
+                }
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodes(
+                androidx.compose.ui.test.hasText("[:deleted-long-ago]"),
+            ).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("[:deleted-long-ago]").assertExists()
+    }
+}

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostMenuSheet.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostMenuSheet.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -70,6 +71,14 @@ internal fun PostMenuSheet(
     permalink: String,
     citedCount: Int,
     onDismiss: () -> Unit,
+    /**
+     * #418 — « Supprimer ce message », moved here from the post card's action row (beta
+     * feedback by nicko : a destructive one-tap button under every own post invites
+     * accidental taps). Null hides the entry — same #292 gates as before (own editable
+     * post, postable topic, never the first post, no deletion in flight). The existing
+     * #292 confirmation dialog still guards the actual POST.
+     */
+    onDelete: (() -> Unit)? = null,
 ) {
     val sheetState = rememberModalBottomSheetState()
     val coroutineScope = rememberCoroutineScope()
@@ -154,6 +163,24 @@ internal fun PostMenuSheet(
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(stringResource(R.string.topic_post_menu_report_soon))
+            }
+
+            if (onDelete != null) {
+                Spacer(Modifier.height(8.dp))
+                // #418 — destructive action LAST (M3 idiom), error-tinted. The tap closes the
+                // sheet and hands over to the #292 confirmation dialog owned by TopicScreen.
+                OutlinedButton(
+                    onClick = {
+                        onDelete()
+                        hideThenDismiss(coroutineScope, sheetState, onDismiss)
+                    },
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error,
+                    ),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(stringResource(R.string.topic_post_menu_delete))
+                }
             }
 
             Spacer(Modifier.height(8.dp))

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -181,6 +181,13 @@ fun TopicScreen(
      */
     startAtBottom: Boolean = false,
     /**
+     * #412 — invoked once the bottom landing for this page has been executed (or skipped on an
+     * empty page), right after the first `Loaded` emission. `:app` uses it to clear the transient
+     * « page précédente » marker so the landing can never replay on a later visit to the same page
+     * (the marker is nav state, not a route field — cf. Codex review on PR #420).
+     */
+    onStartAtBottomConsumed: () -> Unit = {},
+    /**
      * #307 — reports the read position when the screen leaves the composition, so `:app` can cache
      * it per `(cat, post, page)` (twin of [onTitleLoaded] / the title cache). Fired from a single
      * `DisposableEffect` — the unique save point covering EVERY departure (swipe, FAB, header pager,
@@ -227,6 +234,7 @@ fun TopicScreen(
         request = request,
         restoreScrollAnchor = restoreScrollAnchor,
         startAtBottom = startAtBottom,
+        onStartAtBottomConsumed = onStartAtBottomConsumed,
         onScrollAnchorSaved = onScrollAnchorSaved,
     )
 
@@ -446,6 +454,7 @@ private fun TopicScrollRestorationEffects(
     request: TopicRequest,
     restoreScrollAnchor: TopicScrollAnchor?,
     startAtBottom: Boolean,
+    onStartAtBottomConsumed: () -> Unit,
     onScrollAnchorSaved: (TopicScrollAnchor) -> Unit,
 ) {
     var scrollAnchorSettled by remember { mutableStateOf(false) }
@@ -460,6 +469,11 @@ private fun TopicScrollRestorationEffects(
             // header card at index 0 makes the last post index == posts.size.
             startAtBottom && loadedMode.topic.posts.isNotEmpty() ->
                 lazyListState.scrollToItem(loadedMode.topic.posts.size)
+        }
+        if (startAtBottom) {
+            // Consume even when the empty-page guard skipped the scroll: the landing decision for
+            // this page is spent either way.
+            onStartAtBottomConsumed()
         }
         scrollAnchorSettled = true
     }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -164,13 +164,22 @@ fun TopicScreen(
     /**
      * #307 — saved read position to restore for THIS `(cat, post, page)` landing, or `null` when
      * nothing should be restored. `:app` resolves the full priority chain
-     * (`resolveTopicScrollRestoration`: route `scrollTo` > post-submit landing > saved anchor > top)
-     * BEFORE threading the value here, so a non-null anchor already means « the saved position won »
+     * (`resolveTopicScrollRestoration`: route `scrollTo` > post-submit landing > saved anchor >
+     * previous-page bottom (#412) > top) BEFORE threading the value here, so a non-null anchor
+     * already means « the saved position won »
      * — the screen applies it once the first `Loaded` emission lands, exactly once per landing, and
      * it can never compete with the `ScrollToPost` / `ScrollToEndOfPage` effects (their routes
      * resolve to `null` here).
      */
     restoreScrollAnchor: TopicScrollAnchor? = null,
+    /**
+     * #412 — `true` when this landing is a « page précédente » navigation with no saved anchor
+     * (resolved by `:app`, mutually exclusive with a non-null [restoreScrollAnchor]): once the
+     * first `Loaded` emission lands, scroll to the LAST item of the page — reading backwards,
+     * the next posts to read are at the bottom (HFR web's `#bas` landing). One-shot, same
+     * contract as the anchor restore.
+     */
+    startAtBottom: Boolean = false,
     /**
      * #307 — reports the read position when the screen leaves the composition, so `:app` can cache
      * it per `(cat, post, page)` (twin of [onTitleLoaded] / the title cache). Fired from a single
@@ -217,6 +226,7 @@ fun TopicScreen(
         lazyListState = lazyListState,
         request = request,
         restoreScrollAnchor = restoreScrollAnchor,
+        startAtBottom = startAtBottom,
         onScrollAnchorSaved = onScrollAnchorSaved,
     )
 
@@ -415,10 +425,11 @@ private suspend fun LazyListState.reanchorWhileMediaSettles(target: Int) {
  *
  * RESTORE: waits for the FIRST `Loaded` emission (same timing as the `ScrollToPost` effect, and read
  * from the [state] flow — not a recomposition-captured snapshot — for the same race-free reason),
- * then applies the anchor exactly once per route landing. Subsequent `Loaded` emissions
- * (cache→network refresh of the stale path, manual pull-to-refresh, post-delete reload) never
- * re-scroll: the effect has already completed, mirroring the one-shot contract of the scroll
- * effects. The priority chain was resolved by `:app` — see `restoreScrollAnchor` on [TopicScreen].
+ * then applies the anchor — or the #412 bottom landing when `startAtBottom` won the resolution —
+ * exactly once per route landing. Subsequent `Loaded` emissions (cache→network refresh of the stale
+ * path, manual pull-to-refresh, post-delete reload) never re-scroll: the effect has already
+ * completed, mirroring the one-shot contract of the scroll effects. The priority chain was resolved
+ * by `:app` — see `restoreScrollAnchor` / `startAtBottom` on [TopicScreen].
  *
  * SAVE: `onDispose` is the ONE save point. `onOpenPage` is shared by swipe, header, pager and
  * FAB, so saving per trigger would multiply call sites (and race); disposal of this composition
@@ -426,19 +437,29 @@ private suspend fun LazyListState.reanchorWhileMediaSettles(target: Int) {
  * `scrollAnchorSettled` gates the save: a page abandoned while still Loading reads (0, 0) from
  * a list that never rendered, and must not clobber the real position saved by an earlier visit.
  */
+@Suppress("LongParameterList") // Private effect holder: the params are TopicScreen's own
+// restoration inputs threaded as-is; grouping them into a holder type would only add indirection.
 @Composable
 private fun TopicScrollRestorationEffects(
     state: StateFlow<TopicUiState>,
     lazyListState: LazyListState,
     request: TopicRequest,
     restoreScrollAnchor: TopicScrollAnchor?,
+    startAtBottom: Boolean,
     onScrollAnchorSaved: (TopicScrollAnchor) -> Unit,
 ) {
     var scrollAnchorSettled by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) {
-        state.first { it.mode is TopicUiState.Mode.Loaded }
-        restoreScrollAnchor?.let { anchor ->
-            lazyListState.scrollToItem(anchor.index, anchor.offset)
+        val loadedMode = state.first { it.mode is TopicUiState.Mode.Loaded }.mode
+                as TopicUiState.Mode.Loaded
+        when {
+            restoreScrollAnchor != null ->
+                lazyListState.scrollToItem(restoreScrollAnchor.index, restoreScrollAnchor.offset)
+            // #412 — « page précédente » without a saved anchor: land on the last item (reading
+            // direction). Same `posts.size` target as the ScrollToEndOfPage handler — the +1
+            // header card at index 0 makes the last post index == posts.size.
+            startAtBottom && loadedMode.topic.posts.isNotEmpty() ->
+                lazyListState.scrollToItem(loadedMode.topic.posts.size)
         }
         scrollAnchorSettled = true
     }
@@ -883,22 +904,6 @@ private fun TopicLoadedContent(
             } else {
                 null
             }
-            // #292 — « Supprimer » uses the same gate as « Modifier » (HFR allows deletion via the
-            // edit form), EXCEPT it is never offered on the topic's first post: deleting that would
-            // remove the entire topic, an out-of-scope destructive path for this MVP. The first post
-            // is `topic.posts.first()` on page 1.
-            // Disable every delete affordance while a deletion is in flight (state.deletingNumreponse
-            // != null) so a second tap can't queue another POST mid-request (the ViewModel also
-            // guards, but hiding the button is the honest UI signal).
-            val deleteAction: (() -> Unit)? = if (
-                state.deletingNumreponse == null &&
-                !isFirstPostOfTopic(topic, post) &&
-                shouldShowDeleteAction(topic, post, state.isAuthenticated)
-            ) {
-                { onDeleteRequest(post.numreponse) }
-            } else {
-                null
-            }
             // Phase 2 finish (#208) — profile tap is enabled only when HFR exposed
             // a profile link for this post (Post.profileId != null). Posts without a
             // profile link (Publicité rows, anonymous reads) keep the tap hidden.
@@ -911,7 +916,6 @@ private fun TopicLoadedContent(
                 citedCount = citationCounts[post.numreponse] ?: 0,
                 onQuote = quoteAction,
                 onEdit = editAction,
-                onDelete = deleteAction,
                 onOpenProfile = profileAction,
                 onOpenMenu = { menuPost = post },
             )
@@ -921,6 +925,20 @@ private fun TopicLoadedContent(
     // (cat, post, page) — not the request — so it always reflects the page HFR actually
     // served (HFR clamps out-of-range pages). citedCount reuses the page-scoped #239 index.
     menuPost?.let { post ->
+        // #292 → #418 — « Supprimer » lives in the contextual menu now (anti accidental tap,
+        // beta feedback by nicko). Same gates as before : « Modifier »'s gate (HFR allows
+        // deletion via the edit form), never the topic's first post (deleting it would remove
+        // the whole topic — out-of-scope destructive path), and no delete affordance while a
+        // deletion is in flight (the ViewModel also guards ; hiding is the honest UI signal).
+        val menuDeleteAction: (() -> Unit)? = if (
+            state.deletingNumreponse == null &&
+            !isFirstPostOfTopic(topic, post) &&
+            shouldShowDeleteAction(topic, post, state.isAuthenticated)
+        ) {
+            { onDeleteRequest(post.numreponse) }
+        } else {
+            null
+        }
         PostMenuSheet(
             post = post,
             permalink = buildPostPermalink(
@@ -931,6 +949,7 @@ private fun TopicLoadedContent(
             ),
             citedCount = citationCounts[post.numreponse] ?: 0,
             onDismiss = { menuPost = null },
+            onDelete = menuDeleteAction,
         )
     }
 }
@@ -1184,11 +1203,6 @@ private fun TopicPostCard(
     onQuote: (() -> Unit)?,
     onEdit: (() -> Unit)?,
     /**
-     * #292 — « Supprimer » this post. Null hides the button (not the user's own post, locked topic,
-     * logged out, or the topic's first post — which is excluded to avoid whole-topic deletion).
-     */
-    onDelete: (() -> Unit)? = null,
-    /**
      * Phase 2 finish (#208) — tapping the avatar or author opens the profile bottom sheet.
      * Null when [Post.profileId] is null (Publicité rows, anonymous reads).
      */
@@ -1367,30 +1381,18 @@ private fun TopicPostCard(
         ) {
             // #281 — topic posts are selectable/copyable (opt-in; default is OFF in PostRenderer).
             PostRenderer(content = post.content, selectable = true)
-            if (onQuote != null || onEdit != null || onDelete != null) {
+            if (onQuote != null || onEdit != null) {
                 // Actions row at the bottom of the post card, sober TextButtons
                 // so they stay subordinate to the post content. « Modifier »
-                // (Phase 2D, #147) and « Supprimer » (#292) appear only on the
-                // user's own editable posts when the topic is still postable
-                // (« Supprimer » additionally excludes the first post). « Citer »
-                // (Phase 2C, #146) appears whenever the topic is postable, even
-                // when the per-post `quoteRef` link was obfuscated and parsed as
-                // null (#227). Any can be absent — we render the row only if at
-                // least one action is provided.
+                // (Phase 2D, #147) appears only on the user's own editable posts
+                // when the topic is still postable. « Citer » (Phase 2C, #146)
+                // appears whenever the topic is postable, even when the per-post
+                // `quoteRef` link was obfuscated and parsed as null (#227).
+                // « Supprimer » (#292) moved to the contextual menu (#418).
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.End,
                 ) {
-                    if (onDelete != null) {
-                        TextButton(
-                            onClick = onDelete,
-                            colors = ButtonDefaults.textButtonColors(
-                                contentColor = MaterialTheme.colorScheme.error,
-                            ),
-                        ) {
-                            Text(text = stringResource(R.string.topic_post_delete))
-                        }
-                    }
                     if (onEdit != null) {
                         TextButton(onClick = onEdit) {
                             Text(text = stringResource(R.string.topic_post_edit))

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -51,8 +51,10 @@
     <string name="topic_refresh_failed">Le rafraîchissement a échoué. Réessayez.</string>
     <string name="topic_open_profile_action">Voir le profil</string>
 
-    <!-- #292 — suppression d'un de ses propres posts (post normal). -->
+    <!-- #292 — suppression d'un de ses propres posts (post normal). #418 : l'action vit dans
+         le menu contextuel du post (anti appui intempestif), plus dans la rangée d'actions. -->
     <string name="topic_post_delete">Supprimer</string>
+    <string name="topic_post_menu_delete">Supprimer ce message</string>
     <string name="topic_post_delete_confirm_title">Effacer ce message ?</string>
     <string name="topic_post_delete_confirm_message">Cette action est irréversible.</string>
     <string name="topic_post_delete_confirm_action">Supprimer</string>


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Première vague des quick wins issus des retours bêta (chantier D du mandat « A+B+D puis D »). Quatre fixes indépendants, un commit chacun. Mots-clés de fermeture volontairement cassés (`refs-#N`) : les issues ferment à la promotion dev→main.

## #415 — Palette smileys builtin complète (refs-#415)

La palette du composer ne connaissait que 25 codes builtin ; la page d'aide canonique de HFR (`smilies.php`) en liste **58**. Les 33 manquants (`:sweat:`, `:hap:`, `:dtc:`, …) s'envoyaient bien mais restaient en texte brut dans l'aperçu local.

- `BuiltinSmileys` aligné sur `smilies.php` (58 entrées, URLs sprites incluses), KDoc réécrite avec la source canonique.
- Fixture capturée du HFR réel (`smilies_help_page.html`, anonyme, scrubée — `hash_check` vide) + `BuiltinSmileysSymmetryTest` qui asserte la symétrie exacte codes+URLs entre la palette et la fixture (toute divergence future casse le test).

## #416 — Smiley mort : fallback sur le token tapé (refs-#416)

Un sprite perso qui 404 (smiley supprimé, URL périmée) rendait une boîte inline **vide** : `smileyInlineContent` utilisait un `AsyncImage` sans slot d'erreur. Désormais `SubcomposeAsyncImage` rend le token tapé (`[:name]` / `:code:`) en texte ellipsé dans le slot `error` — même fallback que le web et RF1. Test Robolectric avec `FakeImageLoaderEngine` n'interceptant que l'URL vivante (toute autre URL = résultat erreur Coil, le mode de panne réel).

## #418 — « Supprimer » déplacé dans le menu contextuel (refs-#418)

Retour bêta (nicko) : un bouton destructif one-tap sous chaque post à soi invite à l'appui accidentel. L'action vit maintenant dans le menu contextuel du post (dernière entrée, teinte error, idiome M3 destructif), derrière les **mêmes gates #292** (post éditable à soi, topic postable, jamais le premier post, pas de suppression en vol) et le **même dialog de confirmation**. La rangée d'actions garde Citer/Modifier seulement.

## #412 — Page précédente sans position retenue → atterrir en bas (refs-#412)

Suggestion bêta (styx42) : en remontant un fil, « page précédente » sur une page **sans ancre sauvegardée** doit atterrir **en bas** (les posts qui suivent ce qu'on vient de lire), comme l'ancre `#bas` du web. La navigation avant/saut garde l'atterrissage en haut.

- `TopicRoute.previousPageLanding`, posé par `onOpenPage` quand la cible est exactement `page - 1` (chevron, FAB, swipe).
- `resolveTopicScrollRestoration` gagne un 5ᵉ niveau : `scrollTo` > submit landing > ancre sauvegardée > **bas de page précédente** > haut. Une ancre sauvegardée gagne toujours (l'issue est explicite : « sans position retenue »).
- `TopicScreen` scrolle au dernier item à la première émission `Loaded` (même contrat one-shot et même offset header +1 que le handler `ScrollToEndOfPage` #200).
- 4 cas ajoutés à `TopicScrollRestorationTest` (ancre > bas ; bas sans ancre ; scrollTo/submit ignorent le flag ; top inchangé).

## Validation

- Part 1 : `detektAll test :app:assembleProdDebug` — **BUILD SUCCESSFUL** (Docker, pipefail)
- Part 2 : `:app:lintProdDebug` — **BUILD SUCCESSFUL**
- Tests ciblés verts : `BuiltinSmileysSymmetryTest`, `SmileyErrorFallbackTest`, `TopicScrollRestorationTest` (9 tests)
- Limite : #418 et le rendu visuel #412 non vérifiés sur device dans cette session (pas d'émulateur disponible) — dogfooding attendu sur la release dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)