### PR TITLE
Passe drapeaux : favoris perdus au retour d'onglet (#384), +lus masqués (#385), snackbar invisible (#417), auto-refresh (#378, #331)

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.Redface2" parent="@android:style/Theme.DeviceDefault.NoActionBar" />
+    <!-- #417 — forceDarkAllowed=false: OEM « dark mode for apps » (MIUI/HyperOS per-app force
+         dark) rewrites draw calls with per-surface heuristics. On the reporter's device it left
+         the M3 Snackbar's light `inverseSurface` container untouched but lightened its dark
+         `inverseOnSurface` text, rendering the « Drapeau retiré : … » feedback as light-on-light
+         (looks empty — see the zoomed capture on the issue). The app paints its own dark theme
+         (Compose, ThemeMode setting) so OS-level inversion is never wanted. minSdk 29 = the
+         attribute's API floor, no values-v29 split needed. -->
+    <style name="Theme.Redface2" parent="@android:style/Theme.DeviceDefault.NoActionBar">
+        <item name="android:forceDarkAllowed">false</item>
+    </style>
 </resources>

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/flags/DefaultFlagRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/flags/DefaultFlagRepository.kt
@@ -236,7 +236,7 @@ class DefaultFlagRepository @Inject constructor(
             // [FlagsResult.Failure] propagates with the original cause.
             coroutineScope {
                 cats.map { category ->
-                    async { fetchAllPages(cat = category.id, bucket = bucket, defaultType = type) }
+                    async { fetchAllPages(cat = category.id, bucket = bucket, type = type) }
                 }.awaitAll().flatten()
                     // Per-category fan-out concatenates results in cat-iteration order — without a
                     // global sort the screen would group by cat (Discussions block, then Tech block,
@@ -318,7 +318,7 @@ class DefaultFlagRepository @Inject constructor(
     private suspend fun fetchAllPages(
         cat: Int,
         bucket: HfrRestFlagBucket,
-        defaultType: FlagType,
+        type: FlagType,
     ): List<Flag> {
         val accumulated = mutableListOf<Flag>()
         var page = 1
@@ -334,7 +334,7 @@ class DefaultFlagRepository @Inject constructor(
             val envelope = json.decodeFromString<RestListEnvelope<RestTopic>>(body)
             val mapped = RestFlagMappers.toFlags(
                 envelope = envelope,
-                defaultType = defaultType,
+                type = type,
                 fallbackCat = cat,
             )
             accumulated += mapped

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/flags/RestFlagMappers.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/flags/RestFlagMappers.kt
@@ -23,9 +23,16 @@ import kotlin.math.max
  * without re-deriving the parsing.
  *
  * Mapping rules :
- * - `flag_owntopic` → [FlagType] (1=CYAN, 2=RED, 3=FAVORITE) ; unknown / null buckets
- *   fall back to the [defaultType] passed by the caller (the bucket the request was
- *   issued for) so a future server-side bucket addition does not crash the screen.
+ * - [Flag.type] is the **requested bucket** ([type]), never derived from `flag_owntopic`.
+ *   Live-verified 2026-06-11 (#384, fixture `rest_cat13_participated_favorites.json`) :
+ *   the `participated` bucket returns participated-AND-favorited topics with
+ *   `flag_owntopic = 3`, and the `read` bucket returns `flag_owntopic = 0` — the field
+ *   describes the strongest flag ON the topic (3 = favori/étoile), NOT which bucket the
+ *   row belongs to. Mapping it to [Flag.type] made `replaceForType(CYAN)` persist those
+ *   rows under FAVORITE in Room, so a Room-served « Mes sujets » list silently lost its
+ *   favorited topics (the #384 amputation) and a swipe-removal on such a row deleted the
+ *   favori instead of the cyan drapeau. A future « étoile » badge can surface
+ *   `flag_owntopic == 3` as a separate field if needed.
  * - `is_read == false` → `hasUnread = true`. When `is_read` is missing (defensive
  *   path, REST flag responses always carry it for an authenticated request) we
  *   default to `true` because surfacing a likely-stale "read" badge is a worse UX
@@ -60,15 +67,15 @@ internal object RestFlagMappers {
 
     fun toFlags(
         envelope: RestListEnvelope<RestTopic>,
-        defaultType: FlagType,
+        type: FlagType,
         fallbackCat: Int? = null,
     ): List<Flag> = envelope.resource.resources.mapNotNull { dto ->
-        toFlag(dto, defaultType, fallbackCat)
+        toFlag(dto, type, fallbackCat)
     }
 
     private fun toFlag(
         dto: RestTopic,
-        defaultType: FlagType,
+        type: FlagType,
         fallbackCat: Int?,
     ): Flag? {
         val cat = fallbackCat
@@ -100,7 +107,9 @@ internal object RestFlagMappers {
             title = dto.title.decodeHtmlEntities(),
             totalPages = totalPages,
             replyCount = replyCount,
-            type = toFlagType(dto.flagOwntopic) ?: defaultType,
+            // #384 — the requested bucket IS the type; `flag_owntopic` describes the strongest
+            // flag on the topic (3 = favori), not bucket membership. See the object KDoc.
+            type = type,
             hasUnread = dto.isRead?.let { !it } ?: true,
             lastReadPage = lastReadPage,
             lastPostReadId = dto.lastPostReadId,
@@ -108,13 +117,6 @@ internal object RestFlagMappers {
             lastReplyAuthor = dto.links.lastAuthor?.title.orEmpty(),
             lastReplyAt = dto.lastPostDate,
         )
-    }
-
-    private fun toFlagType(rawFlagOwntopic: Int?): FlagType? = when (rawFlagOwntopic) {
-        1 -> FlagType.CYAN
-        2 -> FlagType.RED
-        3 -> FlagType.FAVORITE
-        else -> null
     }
 
     private fun extractCatId(href: String): Int? =

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -240,6 +240,22 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeFlagsAutoRefresh(): Flow<Boolean> =
+        dataStore.data
+            // Default `true`: the lists going stale is the #378 complaint — the toggle is an
+            // opt-out for users who prefer pull-to-refresh only.
+            .map { prefs -> prefs[KEY_FLAGS_AUTO_REFRESH] ?: true }
+            .distinctUntilChanged()
+            .catch { emit(true) }
+
+    override suspend fun setFlagsAutoRefresh(enabled: Boolean) {
+        withContext(ioDispatcher) {
+            dataStore.edit { prefs ->
+                prefs[KEY_FLAGS_AUTO_REFRESH] = enabled
+            }
+        }
+    }
+
     /**
      * Reads [KEY_THEME_MODE] defensively: an unknown / corrupt stored value (older build with a
      * renamed enum, manual edit) falls back to [ThemeMode.SYSTEM] instead of crashing on
@@ -334,5 +350,8 @@ class DataStoreUserPreferencesRepository @Inject constructor(
 
         // Opt-in « DT » placeholder tab on the Drapeaux screen (MPStorage sync lands later, #6).
         val KEY_FLAGS_SHOW_DT_SECTION = booleanPreferencesKey("flags_show_dt_section")
+
+        // #378 — auto-refresh of the flags lists on landing (default ON; Settings opt-out).
+        val KEY_FLAGS_AUTO_REFRESH = booleanPreferencesKey("flags_auto_refresh")
     }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/flags/DefaultFlagRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/flags/DefaultFlagRepositoryTest.kt
@@ -93,6 +93,43 @@ class DefaultFlagRepositoryTest {
     }
 
     @Test
+    fun `a CYAN fetch persists favorited rows under CYAN - regression 384`() = runTest {
+        // Live-captured contract (rest_cat13_participated_favorites.json, 2026-06-11): the
+        // participated bucket returns participated-AND-favorited topics with flag_owntopic=3.
+        // Before the fix they were persisted under FAVORITE, so replaceForType(CYAN) never
+        // rewrote them and getFlags(CYAN) lost them on the next Room-served landing — the
+        // « liste amputée au retour de l'onglet Messages » of #384.
+        val (apiClient, forumRepository) = wireDeps {
+            stubFlagsCall(13, HfrRestFlagBucket.PARTICIPATED, fixture("rest_cat13_participated_favorites.json"))
+            stubFlagsCall(23, HfrRestFlagBucket.PARTICIPATED, EMPTY_PAGE)
+        }
+        val flagDao = stubFlagDao()
+        val repo = buildRepository(apiClient, forumRepository, flagDao = flagDao)
+
+        repo.observe(FlagType.CYAN).test {
+            assertEquals(FlagsResult.Loading, awaitItem())
+            val success = awaitItem() as FlagsResult.Success
+            assertEquals(3, success.flags.size)
+            assertTrue(
+                "in-memory list types every row with the requested bucket",
+                success.flags.all { it.type == FlagType.CYAN },
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        coVerify {
+            flagDao.replaceForType(
+                userId = "xat",
+                type = FlagType.CYAN,
+                rows = match { rows ->
+                    rows.size == 3 && rows.all { it.type == FlagType.CYAN } &&
+                        rows.map { it.topicId }.containsAll(listOf(26595, 55667, 121657))
+                },
+            )
+        }
+    }
+
+    @Test
     fun `observe emits Failure when the network throws`() = runTest {
         val apiClient = mockk<HfrApiClient>()
         coEvery {

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/flags/RestFlagMappersTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/flags/RestFlagMappersTest.kt
@@ -33,7 +33,7 @@ class RestFlagMappersTest {
 
         val flags = RestFlagMappers.toFlags(
             envelope = envelope,
-            defaultType = FlagType.CYAN,
+            type = FlagType.CYAN,
             fallbackCat = 23,
         )
 
@@ -95,7 +95,7 @@ class RestFlagMappersTest {
 
         val flags = RestFlagMappers.toFlags(
             envelope = envelope,
-            defaultType = FlagType.RED,
+            type = FlagType.RED,
             fallbackCat = null,
         )
 
@@ -133,13 +133,38 @@ class RestFlagMappersTest {
         """.trimIndent()
         val envelope = json.decodeFromString<RestListEnvelope<RestTopic>>(payload)
 
-        val flags = RestFlagMappers.toFlags(envelope, defaultType = FlagType.CYAN, fallbackCat = null)
+        val flags = RestFlagMappers.toFlags(envelope, type = FlagType.CYAN, fallbackCat = null)
 
         assertTrue("orphaned topic must be dropped", flags.isEmpty())
     }
 
     @Test
-    fun `unknown flag_owntopic falls back to defaultType not crash`() {
+    fun `participated bucket types favorited rows as the requested bucket - regression 384`() {
+        // Live-captured proof (2026-06-11): the participated bucket returns
+        // participated-AND-favorited topics with flag_owntopic=3. Typing them FAVORITE made
+        // replaceForType(CYAN) persist them under the wrong Room type, so a Room-served
+        // « Mes sujets » silently lost its favorited topics after a tab round-trip (#384).
+        val envelope = json.decodeFromString<RestListEnvelope<RestTopic>>(
+            fixture("rest_cat13_participated_favorites.json"),
+        )
+
+        val flags = RestFlagMappers.toFlags(
+            envelope = envelope,
+            type = FlagType.CYAN,
+            fallbackCat = 13,
+        )
+
+        assertEquals(3, flags.size)
+        val favorited = flags.filter { it.topicId == 26595 || it.topicId == 55667 }
+        assertEquals("the two flag_owntopic=3 rows must be present", 2, favorited.size)
+        assertTrue(
+            "every row of a CYAN fetch is typed CYAN, whatever flag_owntopic says",
+            flags.all { it.type == FlagType.CYAN },
+        )
+    }
+
+    @Test
+    fun `flag_owntopic never drives the type - the requested bucket does`() {
         val payload = """
             {
               "resource": {
@@ -163,7 +188,7 @@ class RestFlagMappersTest {
         """.trimIndent()
         val envelope = json.decodeFromString<RestListEnvelope<RestTopic>>(payload)
 
-        val flags = RestFlagMappers.toFlags(envelope, defaultType = FlagType.FAVORITE, fallbackCat = null)
+        val flags = RestFlagMappers.toFlags(envelope, type = FlagType.FAVORITE, fallbackCat = null)
 
         val flag = flags.single()
         assertEquals(FlagType.FAVORITE, flag.type)
@@ -194,7 +219,7 @@ class RestFlagMappersTest {
         """.trimIndent()
         val envelope = json.decodeFromString<RestListEnvelope<RestTopic>>(payload)
 
-        val flag = RestFlagMappers.toFlags(envelope, defaultType = FlagType.CYAN, fallbackCat = null).single()
+        val flag = RestFlagMappers.toFlags(envelope, type = FlagType.CYAN, fallbackCat = null).single()
         assertNull(flag.lastPostReadId)
         // hasUnread defensively false when REST tells us is_read=true
         assertFalse(flag.hasUnread)
@@ -224,7 +249,7 @@ class RestFlagMappersTest {
         """.trimIndent()
         val envelope = json.decodeFromString<RestListEnvelope<RestTopic>>(payload)
 
-        val flag = RestFlagMappers.toFlags(envelope, defaultType = FlagType.CYAN, fallbackCat = null).single()
+        val flag = RestFlagMappers.toFlags(envelope, type = FlagType.CYAN, fallbackCat = null).single()
         // ceil(81/20) = 5 — not ceil(81/40) = 3 — confirms the mapper trusts the href bucket.
         assertEquals(5, flag.totalPages)
     }
@@ -252,7 +277,7 @@ class RestFlagMappersTest {
         """.trimIndent()
         val envelope = json.decodeFromString<RestListEnvelope<RestTopic>>(payload)
 
-        val flag = RestFlagMappers.toFlags(envelope, defaultType = FlagType.CYAN, fallbackCat = null).single()
+        val flag = RestFlagMappers.toFlags(envelope, type = FlagType.CYAN, fallbackCat = null).single()
         assertNotNull(flag)
         assertEquals(FlagType.CYAN, flag.type)
         // Defensive: missing is_read → assume hasUnread (worse to claim "all read" than the inverse).

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -551,5 +551,9 @@ class TopicRepositoryImplTest {
         override fun observeShowDtSection(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setShowDtSection(enabled: Boolean) = Unit
+
+        override fun observeFlagsAutoRefresh(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setFlagsAutoRefresh(enabled: Boolean) = Unit
     }
 }

--- a/core/data/src/test/resources/fixtures/rest_cat13_participated_favorites.json
+++ b/core/data/src/test/resources/fixtures/rest_cat13_participated_favorites.json
@@ -1,0 +1,162 @@
+{
+ "resource": {
+  "page": 1,
+  "results_count": 3,
+  "results_per_page": 84,
+  "resources": [
+   {
+    "id": 121657,
+    "title": "Topic des SONDAGES",
+    "last_post_date": "2026-06-11 15:39",
+    "is_closed": false,
+    "is_sticky": false,
+    "links": {
+     "forum": {
+      "linked_type": "forum",
+      "type": "link",
+      "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+     },
+     "category": {
+      "linked_type": "forum_category",
+      "type": "link",
+      "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/"
+     },
+     "subcategory": {
+      "linked_type": "forum_subcategory",
+      "type": "link",
+      "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/432/"
+     },
+     "posts": {
+      "linked_type": "list",
+      "type": "link",
+      "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/432/topics/121657/posts/?page=1&results_per_page=40",
+      "count": 10
+     },
+     "last_author": {
+      "linked_type": "user",
+      "type": "link",
+      "href": null,
+      "title": "Pims_UTT",
+      "tns3": "mesdiscussions-1006347.png"
+     },
+     "author": {
+      "linked_type": "user",
+      "type": "link",
+      "href": null,
+      "title": "XaTriX",
+      "tns3": "mesdiscussions-54596.png"
+     }
+    },
+    "type": "topic",
+    "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/432/topics/121657/",
+    "is_read": false,
+    "flag_owntopic": 1,
+    "last_position": 4,
+    "last_post_read_id": 74800786
+   },
+   {
+    "id": 26595,
+    "title": "Topic Aviation",
+    "last_post_date": "2026-06-11 15:34",
+    "is_closed": false,
+    "is_sticky": false,
+    "links": {
+     "forum": {
+      "linked_type": "forum",
+      "type": "link",
+      "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+     },
+     "category": {
+      "linked_type": "forum_category",
+      "type": "link",
+      "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/"
+     },
+     "subcategory": {
+      "linked_type": "forum_subcategory",
+      "type": "link",
+      "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/422/"
+     },
+     "posts": {
+      "linked_type": "list",
+      "type": "link",
+      "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/422/topics/26595/posts/?page=4532&results_per_page=40",
+      "count": 181260
+     },
+     "last_author": {
+      "linked_type": "user",
+      "type": "link",
+      "href": null,
+      "title": "cd5",
+      "tns3": "mesdiscussions-684334.jpg"
+     },
+     "author": {
+      "linked_type": "user",
+      "type": "link",
+      "href": null,
+      "title": "floflow",
+      "tns3": "mesdiscussions-221567.jpg"
+     }
+    },
+    "type": "topic",
+    "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/422/topics/26595/",
+    "is_read": false,
+    "flag_owntopic": 3,
+    "last_position": 181258,
+    "last_post_read_id": 74797773
+   },
+   {
+    "id": 55667,
+    "title": "Le topic de toutes les Questions (AVFFUO)",
+    "last_post_date": "2026-06-11 15:11",
+    "is_closed": false,
+    "is_sticky": false,
+    "links": {
+     "forum": {
+      "linked_type": "forum",
+      "type": "link",
+      "href": "https://forum.hardware.fr/api/forums/hardwarefr/"
+     },
+     "category": {
+      "linked_type": "forum_category",
+      "type": "link",
+      "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/"
+     },
+     "subcategory": {
+      "linked_type": "forum_subcategory",
+      "type": "link",
+      "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/432/"
+     },
+     "posts": {
+      "linked_type": "list",
+      "type": "link",
+      "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/432/topics/55667/posts/?page=14898&results_per_page=40",
+      "count": 595908
+     },
+     "last_author": {
+      "linked_type": "user",
+      "type": "link",
+      "href": null,
+      "title": "XaTriX",
+      "tns3": "mesdiscussions-54596.png"
+     },
+     "author": {
+      "linked_type": "user",
+      "type": "link",
+      "href": null,
+      "title": "moonblood",
+      "tns3": "mesdiscussions-385923.jpg"
+     }
+    },
+    "type": "topic",
+    "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/subcategories/432/topics/55667/",
+    "is_read": true,
+    "flag_owntopic": 3,
+    "last_position": 595908,
+    "last_post_read_id": 74800762
+   }
+  ],
+  "list_type": "topic",
+  "type": "list",
+  "href": "https://forum.hardware.fr/api/forums/hardwarefr/categories/13/topics/participated/?page=1&results_per_page=84"
+ }
+}

--- a/core/data/src/test/resources/fixtures/rest_cat13_participated_favorites.source.txt
+++ b/core/data/src/test/resources/fixtures/rest_cat13_participated_favorites.source.txt
@@ -1,0 +1,29 @@
+Source: forum.hardware.fr — REST API (authentifié)
+Captured endpoint: GET /webservices/rest_api.php?uri=forums/hardwarefr/categories/13/topics/participated/&page=1&results_per_page=50
+Captured: 2026-06-11 avec cookies md_user/md_pass (compte du mainteneur)
+Type: topics participés (bucket `participated`) scopés cat=13 — capture de PREUVE pour le bug #384
+
+Scrub / réduction (documentés, cf. AGENTS.md § fixtures) :
+- Le payload complet listait 84 topics participés du compte ; seuls 3 topics grand public ont été
+  conservés (121657 « Topic des SONDAGES », 26595 « Topic Aviation », 55667 « AVFFUO ») pour ne pas
+  publier la liste de lecture personnelle du compte. `results_count`/`results_per_page` de
+  l'enveloppe ont été réalignés sur le subset (3) pour garder une enveloppe auto-cohérente.
+- Aucun champ supprimé à l'intérieur des lignes conservées : le shape par-ligne est verbatim.
+
+CE QUE CETTE FIXTURE PROUVE (vérifié live 2026-06-11) :
+- Le bucket `participated` renvoie AUSSI les topics participés-ET-favoris, avec
+  `flag_owntopic = 3` (26595 et 55667 ici) au lieu de 1. `flag_owntopic` indique la NATURE du
+  drapeau le plus fort posé sur le topic (3 = favori/étoile), PAS l'appartenance au bucket : le
+  bucket d'appartenance est celui de l'URL demandée.
+- Corollaire #384 : mapper `flag_owntopic` → `Flag.type` faisait persister ces lignes sous
+  FAVORITE dans Room pendant un fetch CYAN (`replaceForType(CYAN)` ne les revoit jamais),
+  d'où la liste « Mes sujets » amputée de ses favoris après un rechargement depuis Room
+  (retour de l'onglet Messages = ViewModel recréé = clearSessionCache → Room).
+- Observation connexe (non incluse dans la fixture) : le bucket `read` renvoie
+  `flag_owntopic = 0` (pas 2) pour les sujets suivis — le mapping 2=RED documenté n'a jamais été
+  observé live ; seul le fallback « type = bucket demandé » est correct.
+
+Conséquence pour Redface 2 :
+- `RestFlagMappers` type désormais chaque ligne avec le bucket demandé (paramètre `type`), sans
+  consulter `flag_owntopic`. Un futur badge « étoile » dans les listes pourra exposer
+  `flag_owntopic == 3` comme champ séparé si besoin.

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -160,4 +160,17 @@ interface UserPreferencesRepository {
 
     /** Persists [observeShowDtSection]. Default `false` until the first call. */
     suspend fun setShowDtSection(enabled: Boolean)
+
+    /**
+     * Auto-refresh of the Drapeaux lists (#378): when `true`, landing on the flags screen
+     * (app open, back from a topic, return from another tab) silently re-fetches the current
+     * tab — throttled by the ViewModel so rapid back-and-forth does not hammer the REST
+     * fan-out — with the pull-to-refresh indicator as the visual cue. Default `true` (the
+     * feature exists because the lists went stale without it); the toggle is the opt-OUT
+     * requested in the beta thread. Observed by `:feature:flags`, toggled in Settings.
+     */
+    fun observeFlagsAutoRefresh(): Flow<Boolean>
+
+    /** Persists [observeFlagsAutoRefresh]. Default `true` until the first call. */
+    suspend fun setFlagsAutoRefresh(enabled: Boolean)
 }

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/Flag.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/Flag.kt
@@ -3,12 +3,17 @@ package fr.forumhfr.redface2.core.model
 /**
  * One row of the user's HFR drapeaux page. Phase 1D-1 reads this from the REST API
  * (`forums/hardwarefr/topics/{participated,read,favorites}/`) per ADR-003 — `forum1f.php`
- * HTML scraping has been retired. HFR exposes three drapeau buckets, mapped 1:1 to the
- * REST `flag_owntopic` integer :
+ * HTML scraping has been retired. HFR exposes three drapeau buckets:
  *
- * - `flag_owntopic=1` → [FlagType.CYAN] — sujets participés
- * - `flag_owntopic=2` → [FlagType.RED] — lus uniquement
- * - `flag_owntopic=3` → [FlagType.FAVORITE] — favoris
+ * - `participated/` → [FlagType.CYAN] — sujets participés
+ * - `read/` → [FlagType.RED] — lus uniquement
+ * - `favorites/` → [FlagType.FAVORITE] — favoris
+ *
+ * [type] is the **bucket the row was fetched from**, NOT the REST `flag_owntopic` integer.
+ * Live-verified 2026-06-11 (#384, fixture `rest_cat13_participated_favorites.json`): the
+ * `participated` bucket returns participated-AND-favorited topics with `flag_owntopic=3`, and
+ * the `read` bucket returns `flag_owntopic=0` — the field describes the strongest flag ON the
+ * topic, not bucket membership. Mapping it to [type] corrupted the per-type Room cache.
  *
  * Differences with the legacy HTML model :
  * - `views` was sourced from a column on `forum1f.php`. The REST flag listings do not

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -1299,6 +1299,10 @@ class PostEditorViewModelTest {
         override fun observeShowDtSection(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setShowDtSection(enabled: Boolean) = Unit
+
+        override fun observeFlagsAutoRefresh(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setFlagsAutoRefresh(enabled: Boolean) = Unit
     }
 
     private companion object {

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1251,6 +1251,10 @@ class TopicFormViewModelTest {
         override fun observeShowDtSection(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setShowDtSection(enabled: Boolean) = Unit
+
+        override fun observeFlagsAutoRefresh(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setFlagsAutoRefresh(enabled: Boolean) = Unit
     }
 
     private companion object {

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -14,7 +14,9 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
@@ -123,6 +125,15 @@ fun FlagsRoute(
 
     val snackbarHostState = remember { SnackbarHostState() }
 
+    // #385 — hoisted list state + scroll-to-top when the unread filter flips (cf.
+    // FilterFlipScrollResetEffect).
+    val flagsListState = rememberLazyListState()
+    FilterFlipScrollResetEffect(
+        selectedTab = selectedTab,
+        unreadOnly = flagsViewSettings.unreadOnly,
+        listState = flagsListState,
+    )
+
     // #309 — display-settings bottom sheet. Opened from the header « Affichage » action; the trigger
     // is only offered when there is a real list to configure (authenticated AND a real FlagType tab,
     // i.e. not the Super placeholder).
@@ -141,6 +152,15 @@ fun FlagsRoute(
         selectedTab = selectedTab,
         onFallback = { viewModel.selectTab(FlagTab.Cyan) },
     )
+
+    // #378 — auto-refresh on landing. LaunchedEffect(Unit) re-fires every time this screen
+    // (re)enters the composition: app open, back from a topic, return from another bottom tab —
+    // exactly the two requested triggers plus the tab round-trip that motivated #384. The
+    // ViewModel gates it (preference opt-out, auth, real tab, in-flight refresh, 15 s throttle)
+    // and reuses the pull-to-refresh indicator as the visual cue.
+    LaunchedEffect(Unit) {
+        viewModel.maybeAutoRefresh()
+    }
 
     // One-shot snackbar for the delflag outcome (#99). Keyed on the event instance so a
     // config change does not replay it ; consumed once shown so it never re-fires.
@@ -209,6 +229,7 @@ fun FlagsRoute(
                                 onLoginRequested = onLoginRequested,
                                 onRequestRemoveFlag = viewModel::requestRemoveFlag,
                             ),
+                            listState = flagsListState,
                         )
                     }
                 }
@@ -513,6 +534,9 @@ private fun AnonymousBody(onLoginRequested: () -> Unit) {
 private fun ColumnScope.AuthenticatedBody(
     state: FlagsBodyState,
     actions: AuthenticatedActions,
+    // #385 — hoisted by FlagsRoute so the filter-flip effect can reset the scroll. One state
+    // shared by the grouped and flat lists (only one is composed at a time).
+    listState: LazyListState,
 ) {
     val selectedTab = state.selectedTab
     val cyanShowsRead = state.cyanShowsRead
@@ -622,6 +646,7 @@ private fun ColumnScope.AuthenticatedBody(
                     selectedTab = selectedTab,
                     removalInFlight = state.removeFlagState is RemoveFlagState.Removing,
                     actions = actions,
+                    listState = listState,
                 )
 
                 is FlagsContent.Flat -> FlatFlagList(
@@ -629,8 +654,35 @@ private fun ColumnScope.AuthenticatedBody(
                     selectedTab = selectedTab,
                     removalInFlight = state.removeFlagState is RemoveFlagState.Removing,
                     actions = actions,
+                    listState = listState,
                 )
             }
+        }
+    }
+}
+
+/**
+ * #385 — « +lus » left the first re-appearing topics hidden above the viewport: the list state
+ * anchors on the first VISIBLE item's key, so rows inserted above it (read topics re-shown)
+ * require a manual scroll up to be discovered. Reset the hoisted [listState] to the top when the
+ * « non-lus uniquement » filter flips ON THE SAME TAB — the user just asked for a different topic
+ * set, show it from the start. Tab switches keep the current behaviour (no reset): only a same-tab
+ * flip triggers, hence the (tab, unreadOnly) pair comparison instead of a plain key on
+ * [unreadOnly] (which changes on tab switches too — the per-tab #317 setting is what
+ * `flagsViewSettings` resolves).
+ */
+@Composable
+private fun FilterFlipScrollResetEffect(
+    selectedTab: FlagTab,
+    unreadOnly: Boolean,
+    listState: LazyListState,
+) {
+    var lastFilterByTab by remember { mutableStateOf<Pair<FlagTab, Boolean>?>(null) }
+    LaunchedEffect(selectedTab, unreadOnly) {
+        val previous = lastFilterByTab
+        lastFilterByTab = selectedTab to unreadOnly
+        if (previous != null && previous.first == selectedTab && previous.second != unreadOnly) {
+            listState.scrollToItem(0)
         }
     }
 }
@@ -666,8 +718,10 @@ private fun CategorySectionedFlagList(
     selectedTab: FlagTab,
     removalInFlight: Boolean,
     actions: AuthenticatedActions,
+    listState: LazyListState,
 ) {
     LazyColumn(
+        state = listState,
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.surface),
@@ -774,8 +828,10 @@ private fun FlatFlagList(
     selectedTab: FlagTab,
     removalInFlight: Boolean,
     actions: AuthenticatedActions,
+    listState: LazyListState,
 ) {
     LazyColumn(
+        state = listState,
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.surface),

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -128,9 +128,9 @@ fun FlagsRoute(
     // #385 — hoisted list state + scroll-to-top when the unread filter flips (cf.
     // FilterFlipScrollResetEffect).
     val flagsListState = rememberLazyListState()
+    val tabUnreadFilter by viewModel.tabUnreadFilter.collectAsStateWithLifecycle()
     FilterFlipScrollResetEffect(
-        selectedTab = selectedTab,
-        unreadOnly = flagsViewSettings.unreadOnly,
+        tabUnreadFilter = tabUnreadFilter,
         listState = flagsListState,
     )
 
@@ -666,22 +666,26 @@ private fun ColumnScope.AuthenticatedBody(
  * anchors on the first VISIBLE item's key, so rows inserted above it (read topics re-shown)
  * require a manual scroll up to be discovered. Reset the hoisted [listState] to the top when the
  * « non-lus uniquement » filter flips ON THE SAME TAB — the user just asked for a different topic
- * set, show it from the start. Tab switches keep the current behaviour (no reset): only a same-tab
- * flip triggers, hence the (tab, unreadOnly) pair comparison instead of a plain key on
- * [unreadOnly] (which changes on tab switches too — the per-tab #317 setting is what
- * `flagsViewSettings` resolves).
+ * set, show it from the start. Tab switches keep the current behaviour (no reset).
+ *
+ * [tabUnreadFilter] is the ViewModel's ATOMIC (tab, unreadOnly) pair — each filter value is
+ * pinned to the tab that produced it (`flatMapLatest`), so a tab switch can never be observed as
+ * « new tab + stale filter » then « new tab + real filter », which this effect would misread as a
+ * same-tab flip and reset the scroll on every switch (Codex review on PR #421).
  */
 @Composable
 private fun FilterFlipScrollResetEffect(
-    selectedTab: FlagTab,
-    unreadOnly: Boolean,
+    tabUnreadFilter: Pair<FlagTab, Boolean>,
     listState: LazyListState,
 ) {
     var lastFilterByTab by remember { mutableStateOf<Pair<FlagTab, Boolean>?>(null) }
-    LaunchedEffect(selectedTab, unreadOnly) {
+    LaunchedEffect(tabUnreadFilter) {
         val previous = lastFilterByTab
-        lastFilterByTab = selectedTab to unreadOnly
-        if (previous != null && previous.first == selectedTab && previous.second != unreadOnly) {
+        lastFilterByTab = tabUnreadFilter
+        if (previous != null &&
+            previous.first == tabUnreadFilter.first &&
+            previous.second != tabUnreadFilter.second
+        ) {
             listState.scrollToItem(0)
         }
     }

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -163,6 +163,31 @@ class FlagsViewModel @Inject constructor(
         )
 
     /**
+     * #385 — the selected tab and ITS resolved « non-lus uniquement » value as one atomic
+     * emission, for the screen's filter-flip scroll reset. The screen must never compare a new
+     * tab against the previous tab's filter value: collecting [selectedTab] and the resolved
+     * settings as two separate states lets Compose observe « new tab + stale filter » then
+     * « new tab + real filter » — a phantom same-tab flip that would reset the scroll on every
+     * tab switch (Codex review on PR #421). `flatMapLatest` pins each filter emission to the
+     * tab that produced it, so consecutive emissions with the same tab are real flips only.
+     * Placeholder tabs (Super/DT) emit `false` — they have no list, the value is inert.
+     */
+    val tabUnreadFilter: StateFlow<Pair<FlagTab, Boolean>> = selectedTab
+        .flatMapLatest { tab ->
+            when (val type = tab.flagType) {
+                null -> flowOf(tab to false)
+                else -> userPreferencesRepository.observeFlagsViewSettings(type)
+                    .map { tab to it.unreadOnly }
+            }
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            // Type-aware seed mirroring flagsViewSettings: CYAN defaults to unread-only.
+            initialValue = _selectedTab.value to (_selectedTab.value == FlagTab.Cyan),
+        )
+
+    /**
      * Optimistic shim for CYAN's « non-lus uniquement » value (#317), mirroring
      * [pendingPerTabOverride]. The « +lus » re-tap is the ONLY read-then-flip site, and it is always
      * CYAN — so the shim is deliberately CYAN-scoped (RED/FAVORITE writes never touch it, so a
@@ -503,7 +528,10 @@ class FlagsViewModel @Inject constructor(
      *   throttle (it goes straight through [refresh]).
      */
     fun maybeAutoRefresh() {
-        if (_selectedTab.value.flagType == null) return
+        // Snapshot the tab at CALL time (the landing being refreshed) — re-reading it after the
+        // suspension points below could refresh a different tab than the one that landed, or
+        // no-op on a placeholder while still arming the throttle (Codex review on PR #421).
+        val type = _selectedTab.value.flagType ?: return
         if (_isRefreshing.value) return
         viewModelScope.launch {
             if (!userPreferencesRepository.observeFlagsAutoRefresh().first()) return@launch
@@ -511,8 +539,16 @@ class FlagsViewModel @Inject constructor(
             val now = clock.instant()
             val last = lastAutoRefreshAt
             if (last != null && Duration.between(last, now) < AUTO_REFRESH_THROTTLE) return@launch
+            // Re-check after the suspensions: a manual pull-to-refresh may have started while
+            // the pref/auth reads were in flight — don't double the REST fan-out.
+            if (_isRefreshing.value) return@launch
             lastAutoRefreshAt = now
-            refresh()
+            _isRefreshing.value = true
+            try {
+                flagRepository.refresh(type)
+            } finally {
+                _isRefreshing.value = false
+            }
         }
     }
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -14,9 +14,13 @@ import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.Category
 import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
 import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -47,9 +51,18 @@ class FlagsViewModel @Inject constructor(
     private val flagRepository: FlagRepository,
     private val forumRepository: ForumRepository,
     private val userPreferencesRepository: UserPreferencesRepository,
+    private val clock: Clock,
 ) : ViewModel() {
 
     private var observedPseudo: String? = null
+
+    /**
+     * #378 — instant of the last refresh triggered through [maybeAutoRefresh], for the
+     * throttle. ViewModel-scoped on purpose: the ViewModel survives the screen leaving the
+     * composition (tab switch, topic push), so rapid back-and-forth shares one window, while
+     * a cold app start (fresh ViewModel) always allows the first auto-refresh.
+     */
+    private var lastAutoRefreshAt: Instant? = null
 
     private val _selectedTab = MutableStateFlow<FlagTab>(FlagTab.Cyan)
     val selectedTab: StateFlow<FlagTab> = _selectedTab.asStateFlow()
@@ -475,6 +488,34 @@ class FlagsViewModel @Inject constructor(
         }
     }
 
+    /**
+     * #378 — auto-refresh on landing. Invoked by the screen every time it (re)enters the
+     * composition: app open, back from a topic, return from another bottom tab. Delegates to
+     * [refresh] (same `isRefreshing` indicator — the requested visual cue) when ALL of:
+     *
+     * - the « auto-refresh » preference is on (default; the Settings toggle is the opt-out),
+     * - the user is authenticated (an anonymous landing has no flags to refresh),
+     * - the selected tab has a real [FlagType] (Super/DT placeholders have no backend),
+     * - no refresh is already in flight,
+     * - the last auto-refresh is older than [AUTO_REFRESH_THROTTLE] — the per-tab REST fan-out
+     *   is ~one GET per public category, so rapid back-and-forth between a topic and the list
+     *   must not multiply it. A manual pull-to-refresh is never throttled and does not arm the
+     *   throttle (it goes straight through [refresh]).
+     */
+    fun maybeAutoRefresh() {
+        if (_selectedTab.value.flagType == null) return
+        if (_isRefreshing.value) return
+        viewModelScope.launch {
+            if (!userPreferencesRepository.observeFlagsAutoRefresh().first()) return@launch
+            if (authRepository.observeAuthState().first() !is AuthState.Authenticated) return@launch
+            val now = clock.instant()
+            val last = lastAutoRefreshAt
+            if (last != null && Duration.between(last, now) < AUTO_REFRESH_THROTTLE) return@launch
+            lastAutoRefreshAt = now
+            refresh()
+        }
+    }
+
     // Round-2 review (PR #207): `logout()` was removed from this ViewModel — the global account
     // menu (#198) now drives the logout from `AppAccountViewModel.logout()`, which owns the
     // canonical `clearSessionCache → authRepository.logout` ordering. Keeping a second copy
@@ -672,6 +713,14 @@ sealed interface FlagsContent {
      */
     data class Flat(val flags: List<Flag>) : FlagsContent
 }
+
+/**
+ * #378 — minimum delay between two auto-refreshes ([FlagsViewModel.maybeAutoRefresh]). 15 s:
+ * shorter than any realistic topic-read round-trip (the « back from a topic » trigger stays
+ * effective) but long enough that bouncing between tabs or popping in and out of a topic does
+ * not re-run the per-category REST fan-out every time.
+ */
+private val AUTO_REFRESH_THROTTLE: Duration = Duration.ofSeconds(15)
 
 /**
  * State of the « Retirer le drapeau » interaction (#99). [Confirming] and [Removing] carry

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1188,6 +1188,24 @@ class FlagsViewModelTest {
     }
 
     @Test
+    fun `tabUnreadFilter pairs each filter value with the tab that produced it`() = runTest {
+        // #385/#421 — a tab switch must never be observable as « new tab + previous tab's
+        // filter »: each emission carries the tab its unreadOnly value was resolved FOR.
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)
+        val vm = viewModel(auth, flags, FakeForumRepository())
+
+        vm.tabUnreadFilter.test {
+            // Initial: Cyan with its type-aware default (unread-only ON).
+            assertEquals(FlagTab.Cyan to true, awaitItem())
+            vm.selectTab(FlagTab.Red)
+            // The RED emission carries RED's own resolved default (false) — atomically.
+            assertEquals(FlagTab.Red to false, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `manual refresh is never throttled by a preceding auto-refresh`() = runTest {
         val flags = FakeFlagRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -21,6 +21,10 @@ import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.SubCategory
 import fr.forumhfr.redface2.core.model.TopicListPage
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -44,6 +48,10 @@ import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class FlagsViewModelTest {
+
+    /** Frozen clock for every test that does not exercise the #378 throttle window. */
+    private val fixedClock: Clock =
+        Clock.fixed(Instant.parse("2026-06-11T12:00:00Z"), ZoneOffset.UTC)
 
     @Before
     fun setUp() {
@@ -249,7 +257,7 @@ class FlagsViewModelTest {
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository() // CYAN default unreadOnly = true
         prefs.blockUnreadOnlySetUntil = kotlinx.coroutines.CompletableDeferred()
-        val vm = FlagsViewModel(auth, flags, forum, prefs)
+        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
 
         vm.selectTab(FlagTab.Cyan) // re-tap: true → write(false) gated, pending = false
         vm.selectTab(FlagTab.Cyan) // re-tap: reads optimistic false → write(true) gated, pending = true
@@ -274,7 +282,7 @@ class FlagsViewModelTest {
         val prefs = FakeUserPreferencesRepository() // CYAN default unreadOnly = true
         prefs.blockUnreadOnlySetForType = FlagType.RED
         prefs.blockUnreadOnlySetUntil = kotlinx.coroutines.CompletableDeferred()
-        val vm = FlagsViewModel(auth, flags, forum, prefs)
+        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
 
         vm.selectTab(FlagTab.Red)
         vm.setFlagsUnreadOnly(false) // RED write goes in flight (gated), must not touch the CYAN shim
@@ -758,7 +766,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1, 13))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(groupByCategory = false)
-        val vm = FlagsViewModel(auth, flags, forum, prefs)
+        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -783,7 +791,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(groupByCategory = true)
-        val vm = FlagsViewModel(auth, flags, forum, prefs)
+        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -805,7 +813,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1, 10))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(hideReadCategories = true)
-        val vm = FlagsViewModel(auth, flags, forum, prefs)
+        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -833,7 +841,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1, 10))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(hideReadCategories = true)
-        val vm = FlagsViewModel(auth, flags, forum, prefs)
+        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -865,7 +873,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1, 10))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(hideReadCategories = true)
-        val vm = FlagsViewModel(auth, flags, forum, prefs)
+        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -894,7 +902,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1, 10))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(hideReadCategories = true)
-        val vm = FlagsViewModel(auth, flags, forum, prefs)
+        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -925,7 +933,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(groupByCategory = true, perTabOverride = true)
-        val vm = FlagsViewModel(auth, flags, forum, prefs)
+        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
         prefs.setFlagsGroupByCategoryForType(FlagType.CYAN, false)
 
         vm.flagsState.test {
@@ -954,7 +962,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(groupByCategory = true)
-        val vm = FlagsViewModel(auth, flags, forum, prefs)
+        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -985,7 +993,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(groupByCategory = true, perTabOverride = true)
-        val vm = FlagsViewModel(auth, flags, forum, prefs)
+        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -1016,7 +1024,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(groupByCategory = true, perTabOverride = true)
-        val vm = FlagsViewModel(auth, flags, forum, prefs)
+        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
         prefs.setFlagsGroupByCategoryForType(FlagType.RED, false)
 
         vm.flagsViewSettings.test {
@@ -1037,7 +1045,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository()
-        val vm = FlagsViewModel(auth, flags, forum, prefs)
+        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
 
         assertFalse(vm.flagsViewSettings.value.hideReadCategories)
         vm.setFlagsHideReadCategories(true)
@@ -1055,7 +1063,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(perTabOverride = true)
-        val vm = FlagsViewModel(auth, flags, forum, prefs)
+        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
 
         vm.setFlagsHideReadCategories(true) // CYAN selected
         assertTrue("CYAN per-type hide-read on", vm.flagsViewSettings.value.hideReadCategories)
@@ -1077,7 +1085,7 @@ class FlagsViewModelTest {
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository() // persisted override OFF
         prefs.blockPerTabOverrideSetUntil = kotlinx.coroutines.CompletableDeferred()
-        val vm = FlagsViewModel(auth, flags, forum, prefs)
+        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
 
         vm.setFlagsPerTabOverride(true) // optimistic ON; persisted write GATED (never commits here)
         vm.setFlagsGroupByCategory(false)
@@ -1097,7 +1105,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(groupByCategory = true) // override OFF initially
-        val vm = FlagsViewModel(auth, flags, forum, prefs)
+        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -1126,12 +1134,85 @@ class FlagsViewModelTest {
      * so the existing tests keep asserting on the grouped sections. Tests that exercise the flat
      * view or the hide-read filter pass an explicit [prefs].
      */
+    // #378 — auto-refresh on landing: pref gate, auth gate, throttle window.
+
+    @Test
+    fun `maybeAutoRefresh refreshes the current tab when authenticated`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)
+        val vm = viewModel(auth, flags, FakeForumRepository())
+
+        vm.maybeAutoRefresh()
+
+        assertEquals(listOf(FlagType.CYAN), flags.refreshCalls)
+    }
+
+    @Test
+    fun `maybeAutoRefresh honours the Settings opt-out`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)
+        val prefs = FakeUserPreferencesRepository()
+        prefs.flagsAutoRefresh.value = false
+        val vm = viewModel(auth, flags, FakeForumRepository(), prefs)
+
+        vm.maybeAutoRefresh()
+
+        assertEquals(emptyList<FlagType>(), flags.refreshCalls)
+    }
+
+    @Test
+    fun `maybeAutoRefresh is a no-op while anonymous`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Anonymous, flagRepository = flags)
+        val vm = viewModel(auth, flags, FakeForumRepository())
+
+        vm.maybeAutoRefresh()
+
+        assertEquals(emptyList<FlagType>(), flags.refreshCalls)
+    }
+
+    @Test
+    fun `maybeAutoRefresh throttles rapid landings then allows after the window`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)
+        val clock = SteppingClock(Instant.parse("2026-06-11T12:00:00Z"))
+        val vm = FlagsViewModel(auth, flags, FakeForumRepository(), FakeUserPreferencesRepository(), clock)
+
+        vm.maybeAutoRefresh()
+        vm.maybeAutoRefresh() // immediate re-landing (back-and-forth) — throttled
+        assertEquals(1, flags.refreshCalls.size)
+
+        clock.now = clock.now.plusSeconds(16) // past the 15 s window
+        vm.maybeAutoRefresh()
+        assertEquals(2, flags.refreshCalls.size)
+    }
+
+    @Test
+    fun `manual refresh is never throttled by a preceding auto-refresh`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)
+        val vm = viewModel(auth, flags, FakeForumRepository())
+
+        vm.maybeAutoRefresh()
+        vm.refresh() // user pull-to-refresh right after the auto pass
+
+        assertEquals(2, flags.refreshCalls.size)
+    }
+
+    /** Mutable [Clock] for the #378 throttle tests — `now` is advanced by hand. */
+    private class SteppingClock(start: Instant) : Clock() {
+        var now: Instant = start
+        override fun getZone(): ZoneId = ZoneOffset.UTC
+        override fun withZone(zone: ZoneId?): Clock = this
+        override fun instant(): Instant = now
+    }
+
     private fun viewModel(
         auth: FakeAuthRepository,
         flags: FakeFlagRepository,
         forum: FakeForumRepository,
         prefs: FakeUserPreferencesRepository = FakeUserPreferencesRepository(),
-    ): FlagsViewModel = FlagsViewModel(auth, flags, forum, prefs)
+    ): FlagsViewModel = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
 
     /** Flattens whatever content shape into the topics order for assertions on flag content. */
     private fun flatTopics(state: FlagsListUiState.Success): List<Flag> =
@@ -1425,6 +1506,15 @@ class FlagsViewModelTest {
         override fun observeShowDtSection(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setShowDtSection(enabled: Boolean) = Unit
+
+        // #378 — writable so the auto-refresh tests can flip the opt-out.
+        val flagsAutoRefresh = MutableStateFlow(true)
+
+        override fun observeFlagsAutoRefresh(): Flow<Boolean> = flagsAutoRefresh
+
+        override suspend fun setFlagsAutoRefresh(enabled: Boolean) {
+            flagsAutoRefresh.value = enabled
+        }
 
         fun setGroupBy(value: Boolean) {
             groupBy.value = value

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -515,6 +515,17 @@ private fun FlagsPreferencesCard(
             if (state.showDtSectionError) {
                 PreferencePersistError(R.string.settings_flags_show_dt_section_persist_failed)
             }
+            // #378 — auto-refresh on landing (app open / back from a topic). Opt-OUT: default on.
+            PreferenceSwitchRow(
+                title = stringResource(R.string.settings_flags_auto_refresh_title),
+                description = stringResource(R.string.settings_flags_auto_refresh_description),
+                checked = state.flagsAutoRefresh,
+                enabled = state.canToggleFlagsAutoRefresh,
+                onCheckedChange = { onIntent(SettingsIntent.FlagsAutoRefreshChanged(it)) },
+            )
+            if (state.flagsAutoRefreshError) {
+                PreferencePersistError(R.string.settings_flags_auto_refresh_persist_failed)
+            }
         }
     }
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -92,6 +92,12 @@ data class SettingsState(
     val isUpdatingShowDtSection: Boolean = false,
     val showDtSectionError: Boolean = false,
     val showDtSectionTouchedLocally: Boolean = false,
+    // Drapeaux — #378 auto-refresh on landing (app open / back from a topic). Same machinery.
+    // Default TRUE: the staleness was the complaint, the toggle is the opt-out.
+    val flagsAutoRefresh: Boolean = true,
+    val isUpdatingFlagsAutoRefresh: Boolean = false,
+    val flagsAutoRefreshError: Boolean = false,
+    val flagsAutoRefreshTouchedLocally: Boolean = false,
 ) {
     val canSave: Boolean
         get() = !isSaving
@@ -135,6 +141,10 @@ data class SettingsState(
     // DT tab — gated only by its own write.
     val canToggleShowDtSection: Boolean
         get() = !isUpdatingShowDtSection
+
+    // #378 — flags auto-refresh, gated only by its own write.
+    val canToggleFlagsAutoRefresh: Boolean
+        get() = !isUpdatingFlagsAutoRefresh
 }
 
 sealed interface SettingsError {
@@ -214,4 +224,8 @@ sealed interface SettingsIntent {
     // Drapeaux — opt-in « DT » placeholder tab (MPStorage sync #6 lands later). Optimistic-flip
     // contract, like the flags toggles: the boolean is the desired post-flip state.
     data class ShowDtSectionChanged(val enabled: Boolean) : SettingsIntent
+
+    // Drapeaux — #378 auto-refresh on landing. Optimistic-flip contract, like the flags
+    // toggles: the boolean is the desired post-flip state.
+    data class FlagsAutoRefreshChanged(val enabled: Boolean) : SettingsIntent
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -130,6 +130,16 @@ class SettingsViewModel @Inject constructor(
                 }
             }
         }
+        viewModelScope.launch {
+            val autoRefresh = userPreferencesRepository.observeFlagsAutoRefresh().first()
+            _state.update { current ->
+                if (current.flagsAutoRefreshTouchedLocally || current.isUpdatingFlagsAutoRefresh) {
+                    current
+                } else {
+                    current.copy(flagsAutoRefresh = autoRefresh)
+                }
+            }
+        }
     }
 
     @Suppress("CyclomaticComplexMethod") // MVI when-dispatch over the SettingsIntent variants ; flat by design.
@@ -174,6 +184,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.TopicTopBarAutoHideChanged -> updateTopicTopBarAutoHide(intent.enabled)
             is SettingsIntent.ShowDtSectionChanged -> updateShowDtSection(intent.enabled)
             is SettingsIntent.ConfirmBeforePostingChanged -> updateConfirmBeforePosting(intent.enabled)
+            is SettingsIntent.FlagsAutoRefreshChanged -> updateFlagsAutoRefresh(intent.enabled)
         }
     }
 
@@ -501,6 +512,33 @@ class SettingsViewModel @Inject constructor(
                 }
             },
             persist = userPreferencesRepository::setShowDtSection,
+        )
+    }
+
+    private fun updateFlagsAutoRefresh(desired: Boolean) {
+        val previous = _state.value.flagsAutoRefresh
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    flagsAutoRefresh = desired,
+                    isUpdatingFlagsAutoRefresh = true,
+                    flagsAutoRefreshError = false,
+                    flagsAutoRefreshTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(flagsAutoRefresh = desired, isUpdatingFlagsAutoRefresh = false)
+                } else {
+                    state.copy(
+                        flagsAutoRefresh = previous,
+                        isUpdatingFlagsAutoRefresh = false,
+                        flagsAutoRefreshError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setFlagsAutoRefresh,
         )
     }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -110,6 +110,12 @@
     <string name="settings_flags_show_dt_section_description">Affiche un onglet « DT » dans l\'écran Drapeaux. Le contenu (discussions suivies avec drapeaux synchronisés via MPStorage) arrivera dans une prochaine version.</string>
     <string name="settings_flags_show_dt_section_persist_failed">Impossible de mémoriser la section DT. Réessayez.</string>
 
+    <!-- #378 — auto-refresh des listes de drapeaux à l'arrivée sur l'écran (ouverture de l'app,
+         retour d'un sujet). Activé par défaut ; ce réglage est l'opt-out. -->
+    <string name="settings_flags_auto_refresh_title">Actualisation automatique</string>
+    <string name="settings_flags_auto_refresh_description">Rafraîchit la liste des drapeaux à l\'ouverture de l\'app et au retour d\'un sujet. L\'indicateur de rafraîchissement signale l\'actualisation en cours.</string>
+    <string name="settings_flags_auto_refresh_persist_failed">Impossible de mémoriser l\'actualisation automatique. Réessayez.</string>
+
     <!-- #286 — Thème. Sélecteur Clair/Système/Sombre (Système = suit l'OS) + thème AMOLED (vrai
          noir), persistés en DataStore et appliqués à toute l'app en direct. -->
     <string name="settings_theme_title">Thème</string>

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -997,6 +997,15 @@ class SettingsViewModelTest {
             showDtSection.value = enabled
         }
 
+        // #378 — flags auto-refresh opt-out, same writable seam as showDtSection.
+        private val flagsAutoRefresh = MutableStateFlow(true)
+
+        override fun observeFlagsAutoRefresh(): Flow<Boolean> = flagsAutoRefresh
+
+        override suspend fun setFlagsAutoRefresh(enabled: Boolean) {
+            flagsAutoRefresh.value = enabled
+        }
+
         fun emitConfirmBeforePosting(value: Boolean) {
             confirmBeforePosting.value = value
         }

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -1319,4 +1319,8 @@ private class FakeUserPreferencesRepository(
     override fun observeShowDtSection(): Flow<Boolean> = MutableStateFlow(false)
 
     override suspend fun setShowDtSection(enabled: Boolean) = Unit
+
+    override fun observeFlagsAutoRefresh(): Flow<Boolean> = MutableStateFlow(true)
+
+    override suspend fun setFlagsAutoRefresh(enabled: Boolean) = Unit
 }


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

La « passe drapeaux » du mandat A+B+D. Quatre commits atomiques. Mots-clés cassés (`refs-#N`) : fermeture à la promotion dev→main.

## #384 — Liste amputée au retour de l'onglet Messages (refs-#384)

**Cause racine prouvée live** (2026-06-11, fixture capturée `rest_cat13_participated_favorites.json`) : le bucket REST `participated` renvoie les sujets participés-ET-favoris avec `flag_owntopic=3` — le champ décrit le drapeau le plus fort posé SUR le topic (3 = favori/étoile), pas l'appartenance au bucket. Le mapper typait ces lignes `FAVORITE` → `replaceForType(CYAN)` les persistait sous le mauvais type Room → tout atterrissage servi par Room (retour de l'onglet Messages = ViewModel recréé = cache mémoire purgé) perdait les favoris de « Mes sujets » (l'écart « étoiles jaunes » décrit par Lt Ripley), restaurés par le fetch complet du pull-to-refresh. Bonus corrigé : le swipe-retrait sur une telle ligne supprimait le **favori** au lieu du drapeau cyan.

Fix : chaque ligne d'un fetch bucket est typée avec le **bucket demandé**. Observation connexe documentée dans la fixture : le bucket `read` renvoie `flag_owntopic=0` (le mapping 2=RED documenté n'a jamais été observé live). Tests de régression mapper (fixture) + repository (persistance Room).

## #385 — « +lus » : premiers topics masqués jusqu'à un scroll (refs-#385)

La lazy list ancre sur la clé du premier item visible : les topics lus réinsérés AU-DESSUS restaient hors viewport. L'état de liste est hoisté et remis en haut sur un basculement même-onglet du filtre « non-lus uniquement » (re-tap cyan ou toggle du sheet). Les changements d'onglet gardent leur comportement.

## #417 — « Message vide » après retrait d'un drapeau (refs-#417)

Le zoom de la capture du rapporteur montre que le snackbar n'est **pas vide** : « Drapeau retiré : [TOPIC …] » est rendu **clair-sur-clair**. Les 3 schemes in-app sont corrects (v88 comme aujourd'hui) — l'inversion vient de l'OS (force dark MIUI/HyperOS « mode sombre pour les apps » sur une fenêtre non déclarée dark-aware). Fix : `android:forceDarkAllowed=false` (API 29 = minSdk) — l'app peint son propre thème, y compris CLAIR forcé contre un OS sombre, l'inversion OS n'est jamais voulue. **À confirmer par le rapporteur sur device** (analyse postée sur l'issue).

## #378 — Auto-refresh des listes (refs-#378) + #331

Demandé par garath_ et bitubo : re-fetch silencieux de l'onglet courant quand l'écran (ré)entre en composition — ouverture de l'app, retour d'un sujet, retour d'un autre onglet — avec l'indicateur pull-to-refresh comme signal visuel. Gates : préférence « Actualisation automatique » (défaut ON, opt-out dans Réglages comme demandé), session authentifiée, onglet réel, pas de refresh en vol, throttle 15 s (le fan-out REST ≈ 1 GET/catégorie). Le pull-to-refresh manuel n'est jamais throttlé. 5 tests ViewModel (gates + fenêtre de throttle via clock pas-à-pas).

**#331 (dernier posteur incorrect)** : vérifié live — le `last_author` REST est correct pour les 2 topics RF2 (bitubo/XaTriX au moment du test). Le mauvais nom venait du cache mémoire jamais revalidé ; cet auto-refresh ferme la fenêtre de staleness. Commentaire à venir sur l'issue, à confirmer en dogfooding avant fermeture.

## Validation

- Part 1 : `detektAll test :app:assembleProdDebug` — **BUILD SUCCESSFUL** (Docker, pipefail)
- Part 2 : `:app:lintProdDebug` — **BUILD SUCCESSFUL**
- Tests ciblés verts : `RestFlagMappersTest`, `DefaultFlagRepositoryTest` (avant l'extraction detekt), suite complète via part 1
- Limites : #417 dépend d'une confirmation device (MIUI) ; le rendu #385/#378 non vérifié sur device cette session — dogfooding attendu sur la release dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)