### PR TITLE
Éditeurs : curseur visible sous le clavier — champ en scroll externe (#275, #410)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextField.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextField.kt
@@ -1,11 +1,17 @@
 package fr.forumhfr.redface2.core.ui.editor
 
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.TextFieldValue
 
@@ -15,7 +21,32 @@ import androidx.compose.ui.text.input.TextFieldValue
  * The field is intentionally minimal — it exposes the `TextFieldValue` (text + selection)
  * directly so the toolbar above can apply formatting via [applyBbcodeAction] without
  * losing the caret position.
+ *
+ * ## [fillViewport] — keep the cursor visible under the IME (#275/#410)
+ *
+ * The editors used to give the field a bounded height (`weight(1f)`) and let the TEXT scroll
+ * INSIDE it. Compose's keep-the-cursor-visible machinery lives in **ancestor scrollables**
+ * (`Modifier.verticalScroll`/`scrollable` re-anchor the focused area when their viewport
+ * shrinks, and cursor bring-into-view requests propagate to them) — the text field's internal
+ * scroller has none of it. Net effect on device, across keyboards (#275 Gboard/SwiftKey/
+ * HeliBoard): the IME resize compressed the field and the cursor line stayed hidden below the
+ * fold, both while typing and on refocus after the preview (#410).
+ *
+ * `fillViewport = true` switches to the standard Compose text-input pattern: the field grows
+ * with its content (no internal scroll) inside this composable's own scrollable column, sized
+ * by the caller's bounded box (`weight(1f)` in the three full-screen editors). Typing,
+ * tap-to-place-cursor and toolbar insertions all route the cursor bring-into-view through OUR
+ * scrollable, and an IME resize re-anchors the focused area like in any scrollable form.
+ * `heightIn(min = viewport)` keeps the v108 dogfooding contract: with little text the outlined
+ * box still fills every free pixel, so tapping anywhere in the area focuses the field.
+ *
+ * Contract: `fillViewport = true` REQUIRES a bounded-height caller (a weighted/fixed box). Do
+ * not enable it inside an outer `verticalScroll` — nested same-direction scrollables with
+ * unbounded height are a Compose error; `TopicFormScreen` (outer scroll layout) keeps the
+ * default and relies on its own column, which is the same machinery.
  */
+@Suppress("LongParameterList") // Compose component API: optional defaulted params (modifier,
+// placeholder, fillViewport) are the idiomatic surface — a config holder would hurt call-sites.
 @Composable
 fun BbcodeTextField(
     value: TextFieldValue,
@@ -23,11 +54,53 @@ fun BbcodeTextField(
     label: String,
     modifier: Modifier = Modifier,
     placeholder: String? = null,
+    fillViewport: Boolean = false,
+) {
+    if (fillViewport) {
+        BoxWithConstraints(modifier = modifier) {
+            val viewportMinHeight = maxHeight
+            Column(
+                modifier = Modifier
+                    .verticalScroll(rememberScrollState())
+                    .testTag(BBCODE_FIELD_VIEWPORT_TAG),
+            ) {
+                BbcodeFieldImpl(
+                    value = value,
+                    onValueChange = onValueChange,
+                    label = label,
+                    placeholder = placeholder,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = viewportMinHeight),
+                )
+            }
+        }
+    } else {
+        BbcodeFieldImpl(
+            value = value,
+            onValueChange = onValueChange,
+            label = label,
+            placeholder = placeholder,
+            modifier = modifier.fillMaxWidth(),
+        )
+    }
+}
+
+/** Test tag of the #275/#410 scrollable viewport wrapping the grown field. */
+const val BBCODE_FIELD_VIEWPORT_TAG = "bbcode_field_viewport"
+
+@Composable
+private fun BbcodeFieldImpl(
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    label: String,
+    placeholder: String?,
+    modifier: Modifier,
 ) {
     OutlinedTextField(
         value = value,
         onValueChange = onValueChange,
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier,
         label = { Text(label) },
         placeholder = placeholder?.let { hint -> { Text(hint) } },
         minLines = 5,

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextField.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextField.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.isFinite
 
 /**
  * Controlled Material 3 BBCode text field used by the Phase 2B editor.
@@ -25,12 +26,13 @@ import androidx.compose.ui.text.input.TextFieldValue
  * ## [fillViewport] — keep the cursor visible under the IME (#275/#410)
  *
  * The editors used to give the field a bounded height (`weight(1f)`) and let the TEXT scroll
- * INSIDE it. Compose's keep-the-cursor-visible machinery lives in **ancestor scrollables**
+ * INSIDE it. Compose's keep-the-cursor-visible machinery works through **ancestor scrollables**
  * (`Modifier.verticalScroll`/`scrollable` re-anchor the focused area when their viewport
  * shrinks, and cursor bring-into-view requests propagate to them) — the text field's internal
- * scroller has none of it. Net effect on device, across keyboards (#275 Gboard/SwiftKey/
- * HeliBoard): the IME resize compressed the field and the cursor line stayed hidden below the
- * fold, both while typing and on refocus after the preview (#410).
+ * scroller does take part in bring-into-view, but it does not re-anchor the cursor line when
+ * an IME resize shrinks the field around it. Net effect on device, across keyboards (#275
+ * Gboard/SwiftKey/HeliBoard): the IME resize compressed the field and the cursor line stayed
+ * hidden below the fold, both while typing and on refocus after the preview (#410).
  *
  * `fillViewport = true` switches to the standard Compose text-input pattern: the field grows
  * with its content (no internal scroll) inside this composable's own scrollable column, sized
@@ -40,7 +42,8 @@ import androidx.compose.ui.text.input.TextFieldValue
  * `heightIn(min = viewport)` keeps the v108 dogfooding contract: with little text the outlined
  * box still fills every free pixel, so tapping anywhere in the area focuses the field.
  *
- * Contract: `fillViewport = true` REQUIRES a bounded-height caller (a weighted/fixed box). Do
+ * Contract: `fillViewport = true` REQUIRES a bounded-height caller (a weighted/fixed box) —
+ * enforced by a `require` at composition. Do
  * not enable it inside an outer `verticalScroll` — nested same-direction scrollables with
  * unbounded height are a Compose error; `TopicFormScreen` (outer scroll layout) keeps the
  * default and relies on its own column, which is the same machinery.
@@ -58,6 +61,11 @@ fun BbcodeTextField(
 ) {
     if (fillViewport) {
         BoxWithConstraints(modifier = modifier) {
+            require(maxHeight.isFinite) {
+                "BbcodeTextField(fillViewport = true) requires a bounded-height host " +
+                    "(weighted/fixed box) — an unbounded host would nest two unbounded " +
+                    "same-direction scrollables and break the heightIn(min) contract."
+            }
             val viewportMinHeight = maxHeight
             Column(
                 modifier = Modifier

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextFieldViewportTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextFieldViewportTest.kt
@@ -1,0 +1,116 @@
+package fr.forumhfr.redface2.core.ui.editor
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * #275/#410 — layout contract of the `fillViewport` mode of [BbcodeTextField]:
+ *
+ * - with content SHORTER than the bounded viewport, the field still fills it (v108 dogfooding:
+ *   no blank under the field, tapping anywhere in the area focuses) and the wrapping column has
+ *   nothing to scroll;
+ * - with content TALLER than the viewport, the field GROWS (no internal text scroll) and the
+ *   wrapping column becomes the scrollable — the ancestor-scrollable machinery that keeps the
+ *   cursor visible under the IME only exists on that path.
+ *
+ * The IME interaction itself (resize re-anchoring, bring-into-view on refocus) is platform
+ * behaviour that Robolectric cannot exercise — device dogfooding covers it; these tests pin the
+ * structure that behaviour depends on.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class BbcodeTextFieldViewportTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `short content - the field fills the viewport and nothing scrolls`() {
+        setFieldContent(text = "court")
+
+        val viewport = composeTestRule.onNodeWithTag(BBCODE_FIELD_VIEWPORT_TAG)
+            .fetchSemanticsNode()
+        val scrollRange = viewport.config[SemanticsProperties.VerticalScrollAxisRange]
+        assertTrue("nothing to scroll when the field fits", scrollRange.maxValue() == 0f)
+
+        val field = composeTestRule.onNode(hasSetTextAction()).fetchSemanticsNode()
+        assertTrue(
+            "the field stretches to the whole bounded viewport (got ${field.size.height} " +
+                "vs viewport ${viewport.size.height})",
+            field.size.height >= viewport.size.height,
+        )
+    }
+
+    @Test
+    fun `long content - the field grows and the wrapping column scrolls`() {
+        setFieldContent(text = (1..200).joinToString("\n") { "ligne $it" })
+
+        val viewport = composeTestRule.onNodeWithTag(BBCODE_FIELD_VIEWPORT_TAG)
+            .fetchSemanticsNode()
+        val scrollRange = viewport.config[SemanticsProperties.VerticalScrollAxisRange]
+        assertTrue("the wrapping column owns the scroll", scrollRange.maxValue() > 0f)
+
+        val field = composeTestRule.onNode(hasSetTextAction()).fetchSemanticsNode()
+        assertTrue(
+            "the field grows with its content instead of scrolling internally",
+            field.size.height > viewport.size.height,
+        )
+    }
+
+    @Test
+    fun `default mode keeps the plain bounded field`() {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                Surface(color = MaterialTheme.colorScheme.surface) {
+                    Box(Modifier.size(320.dp, 400.dp)) {
+                        BbcodeTextField(
+                            value = TextFieldValue("court"),
+                            onValueChange = {},
+                            label = "Message",
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    }
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithTag(BBCODE_FIELD_VIEWPORT_TAG).assertDoesNotExist()
+    }
+
+    private fun setFieldContent(text: String) {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                Surface(color = MaterialTheme.colorScheme.surface) {
+                    Box(Modifier.size(320.dp, 400.dp)) {
+                        BbcodeTextField(
+                            value = TextFieldValue(text),
+                            onValueChange = {},
+                            label = "Message",
+                            modifier = Modifier.fillMaxSize(),
+                            fillViewport = true,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextFieldViewportTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextFieldViewportTest.kt
@@ -28,8 +28,9 @@ import org.robolectric.annotation.GraphicsMode
  *   no blank under the field, tapping anywhere in the area focuses) and the wrapping column has
  *   nothing to scroll;
  * - with content TALLER than the viewport, the field GROWS (no internal text scroll) and the
- *   wrapping column becomes the scrollable — the ancestor-scrollable machinery that keeps the
- *   cursor visible under the IME only exists on that path.
+ *   wrapping column becomes the scrollable — the ancestor-scrollable path is the one that
+ *   reliably re-anchors the cursor under the IME (the field's internal scroller takes part in
+ *   bring-into-view but does not re-anchor on IME shrink).
  *
  * The IME interaction itself (resize re-anchoring, bring-into-view on refocus) is platform
  * behaviour that Robolectric cannot exercise — device dogfooding covers it; these tests pin the

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -128,6 +128,9 @@ private fun PostEditorContent(
                     label = stringResource(R.string.editor_field_label),
                     placeholder = stringResource(R.string.editor_field_placeholder),
                     modifier = Modifier.weight(1f),
+                    // #275/#410 — grow-with-content field in its own scrollable viewport so the
+                    // cursor stays visible under the IME (typing AND refocus after the preview).
+                    fillViewport = true,
                 )
 
                 Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -99,11 +99,12 @@ private fun PostEditorContent(
         Column(modifier = Modifier.fillMaxSize().statusBarsPadding()) {
             // No outer scroll : the draft field is weighted so it stretches to fill every
             // free pixel down to the bottom bar (dogfooding v108 — the column used to leave
-            // a large blank under « Afficher l'aperçu »). Long content scrolls INSIDE the
-            // field (and inside the preview pane), which is also why weight() is usable at
-            // all — it needs the bounded height an outer verticalScroll would destroy.
-            // Keyboard handling is unchanged : the bar's IME inset grows, this column
-            // shrinks by the same amount (weight absorbs), the field compresses.
+            // a large blank under « Afficher l'aperçu »). Long content scrolls in the field's
+            // own fillViewport column (#275/#410) and inside the preview pane, which is also
+            // why weight() is usable at all — it needs the bounded height an outer
+            // verticalScroll would destroy. Keyboard handling : the bar's IME inset grows,
+            // this column shrinks by the same amount (weight absorbs), and the field's
+            // viewport re-anchors the cursor line.
             Column(
                 modifier = Modifier
                     .weight(1f)

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeScreen.kt
@@ -165,7 +165,8 @@ private fun ComposeEditorBody(
     modifier: Modifier = Modifier,
 ) {
     // Same extensible-field design as the reply editor : no outer scroll, the draft stretches to
-    // the bar, long content scrolls INSIDE the field / the preview pane.
+    // the bar, long content scrolls in the field's own fillViewport column (#275/#410) / the
+    // preview pane.
     Column(
         modifier = modifier
             .fillMaxWidth()

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeScreen.kt
@@ -208,6 +208,9 @@ private fun ComposeEditorBody(
             label = stringResource(R.string.messages_reply_field_label),
             placeholder = stringResource(R.string.messages_reply_field_placeholder),
             modifier = Modifier.weight(1f),
+            // #275/#410 — grow-with-content field in its own scrollable viewport so the
+            // cursor stays visible under the IME (typing AND refocus after the preview).
+            fillViewport = true,
         )
 
         Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
@@ -168,6 +168,9 @@ private fun ReplyEditorBody(
             label = stringResource(R.string.messages_reply_field_label),
             placeholder = stringResource(R.string.messages_reply_field_placeholder),
             modifier = Modifier.weight(1f),
+            // #275/#410 — grow-with-content field in its own scrollable viewport so the
+            // cursor stays visible under the IME (typing AND refocus after the preview).
+            fillViewport = true,
         )
 
         Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
@@ -152,8 +152,8 @@ private fun ReplyEditorBody(
     modifier: Modifier = Modifier,
 ) {
     // No outer scroll : the draft field is weighted so it stretches down to the bar (same
-    // extensible-field design as the post editor) ; long content scrolls INSIDE the field
-    // and inside the preview pane.
+    // extensible-field design as the post editor) ; long content scrolls in the field's own
+    // fillViewport column (#275/#410) and inside the preview pane.
     Column(
         modifier = modifier
             .fillMaxWidth()


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Chantier B du mandat A+B+D. Mots-clés cassés (`refs-#N`) : fermeture à la promotion dev→main.

## Diagnostic (refs-#275, refs-#410)

Les trois éditeurs plein-écran (réponse/édition de post, réponse MP, nouveau MP) donnaient au champ une hauteur bornée (`weight(1f)`) avec **scroll interne** du texte. Or la machinerie Compose qui garde le curseur visible vit dans les **scrollables ancêtres** : les bring-into-view du curseur (frappe, tap-pour-placer, insertions toolbar) se propagent à eux, et le scrollable ré-ancre la zone focusée quand son viewport rétrécit sous l'IME (`ContentInViewNode`). Le scroller interne du champ n'a rien de tout ça — d'où, sur les 3 claviers rapportés (#275 Gboard/SwiftKey/HeliBoard) : la ligne du curseur cachée sous le pli pendant la frappe (#275) et au refocus après l'aperçu (#410). `TopicFormScreen` (layout à scroll externe) était déjà sur le bon pattern — cohérent avec le fait qu'aucun rapport ne vise la création de sujet.

## Fix

`BbcodeTextField` (`:core:ui`, partagé) gagne un mode `fillViewport` : le champ **grandit avec son contenu** (plus de scroll interne) dans sa propre colonne scrollable dimensionnée par la boîte bornée de l'appelant, avec `heightIn(min = viewport)` qui préserve le contrat v108 (la zone outlined remplit tout l'espace libre, tap n'importe où = focus). Les 3 éditeurs l'activent ; contrat documenté : jamais dans un scroll externe (scrollables imbriqués non bornés).

## Tests et limites

- `BbcodeTextFieldViewportTest` (Robolectric, 3 tests verts) : contenu court → champ remplit le viewport et rien ne scrolle ; contenu long → le champ grandit et la colonne possède le scroll ; mode par défaut inchangé.
- **L'interaction IME elle-même n'est pas exerçable sous Robolectric** : le ré-ancrage au resize et le bring-into-view au refocus reposent sur la machinerie plateforme du pattern standard « text field dans une colonne scrollable » — c'est précisément le pari du fix (passer du chemin custom cassé au chemin éprouvé par l'écosystème). **Dogfooding device requis** sur la prochaine release dev (Gboard + un clavier alternatif), scénarios : taper 30+ lignes clavier ouvert ; fermer le clavier, scroller l'aperçu, re-taper dans le champ ; insertion smiley/BBCode curseur en bas.

## Validation

- Part 1 : `detektAll test :app:assembleProdDebug` — **BUILD SUCCESSFUL** (Docker, pipefail)
- Part 2 : `:app:lintProdDebug` — **BUILD SUCCESSFUL**

🤖 Generated with [Claude Code](https://claude.com/claude-code)