### PR TITLE
fix(parser): lignes vides préservées et interligne naturel (refs-#333, refs-#280)

### DIFF
--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
@@ -316,8 +316,9 @@ class PostContentParser {
 
     @Suppress("CyclomaticComplexMethod")
     private fun parseInlineElement(element: Element): List<PostInline> = when (element.tagName()) {
-        // Two granularities of vertical rhythm coexist:
-        //   - top-level <br> flushes the current paragraph (handled in parseBlocks).
+        // Every <br> is an intra-paragraph LineBreak (#333/#280):
+        //   - top-level <br> joins the running paragraph in parseBlocks (it used to FLUSH it,
+        //     which split each authored line into its own block — see the comment there).
         //   - <br> nested inside any inline parent (<strong>, <a>, <span>, <font>, …) keeps
         //     the author's intra-paragraph break as an explicit LineBreak so the renderer
         //     does not silently merge the two text runs.

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
@@ -41,7 +41,13 @@ class PostContentParser {
         val paragraph = mutableListOf<PostInline>()
 
         fun flushParagraph() {
+            // #333 — trim breaks and blank fragments at the paragraph EDGES only: breaks adjacent
+            // to a block boundary (quote, image, end of post) duplicate the renderer's inter-block
+            // spacing, but INTERIOR breaks are the author's literal line structure — including
+            // consecutive ones, i.e. deliberate empty lines — and must survive verbatim.
             val cleaned = collapseInlines(paragraph)
+                .dropWhile { it.isBlankOrBreak() }
+                .dropLastWhile { it.isBlankOrBreak() }
             if (cleaned.any { it.isNonBlank() }) {
                 blocks += PostBlock.Paragraph(cleaned)
             }
@@ -51,7 +57,13 @@ class PostContentParser {
         nodes.forEach { node ->
             when (classifyNode(node)) {
                 NodeKind.IGNORE -> Unit
-                NodeKind.LINE_BREAK -> flushParagraph()
+                // #333/#280 — a top-level <br> used to FLUSH the paragraph, so every authored
+                // line became its own Paragraph block: blank lines (the `<br><br>` HFR emits for
+                // an empty line) collapsed into a single dropped-empty-paragraph (#333) and the
+                // renderer's 8dp inter-block gap replaced the natural line height between every
+                // line (#280). A top-level break is now an inline LineBreak INSIDE the running
+                // paragraph — web parity: N consecutive breaks render N newlines.
+                NodeKind.LINE_BREAK -> paragraph += PostInline.LineBreak
 
                 NodeKind.QUOTE -> {
                     flushParagraph()
@@ -436,6 +448,13 @@ class PostContentParser {
     private fun PostInline.isNonBlank(): Boolean = when (this) {
         is PostInline.Text -> value.isNotBlank()
         else -> true
+    }
+
+    /** #333 — edge-trim predicate for [parseBlocks]: breaks and whitespace-only fragments. */
+    private fun PostInline.isBlankOrBreak(): Boolean = when (this) {
+        PostInline.LineBreak -> true
+        is PostInline.Text -> value.isBlank()
+        else -> false
     }
 
     private fun collectQuotedAuthors(content: PostContent): List<String> {

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
@@ -363,11 +363,15 @@ class PostContentParserTest {
             1,
             paragraphs.size,
         )
-        val kinds = paragraphs.single().inlines.map { it::class.simpleName }
         assertEquals(
             "the empty line must survive as two consecutive LineBreaks between the Text lines",
-            listOf("Text", "LineBreak", "LineBreak", "Text"),
-            kinds,
+            listOf(
+                PostInline.Text("ligne1"),
+                PostInline.LineBreak,
+                PostInline.LineBreak,
+                PostInline.Text("ligne2"),
+            ),
+            paragraphs.single().inlines,
         )
     }
 

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
@@ -342,6 +342,86 @@ class PostContentParserTest {
     }
 
     @Test
+    fun `deliberate empty line survives as two LineBreaks inside one paragraph`() {
+        // #333/#280 — an authored empty line is emitted by HFR as `<br /><br />` between the two
+        // text lines. The parser used to FLUSH the paragraph on every top-level <br>, so each
+        // line became its own Paragraph block: the empty line collapsed into a dropped empty
+        // paragraph (#333) and the renderer's inter-block gap replaced the natural line height
+        // between every line (#280).
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            """
+            <div id="para123"><p>ligne1<br /><br />ligne2</p></div>
+            """.trimIndent(),
+        )
+
+        val result = parser.parse(element)
+
+        val paragraphs = result.ast.blocks.filterIsInstance<PostBlock.Paragraph>()
+        assertEquals(
+            "both lines and the empty line belong to ONE paragraph, got=${result.ast.blocks}",
+            1,
+            paragraphs.size,
+        )
+        val kinds = paragraphs.single().inlines.map { it::class.simpleName }
+        assertEquals(
+            "the empty line must survive as two consecutive LineBreaks between the Text lines",
+            listOf("Text", "LineBreak", "LineBreak", "Text"),
+            kinds,
+        )
+    }
+
+    @Test
+    fun `single br keeps consecutive authored lines in the same paragraph`() {
+        // #280 — real fixture witness: the answer post on the single-page topic separates its
+        // sentences with single <br />s (`…comprendre le problème.<br />Je te propose…`). They
+        // must stay in ONE paragraph with LineBreaks, not become one block per line.
+        val topic = pageParser.parse(fixture("topic_page_single.html"))
+
+        val paragraph = topic.posts
+            .flatMap { it.content.allBlocks() }
+            .filterIsInstance<PostBlock.Paragraph>()
+            .firstOrNull { block ->
+                block.inlines.filterIsInstance<PostInline.Text>()
+                    .any { it.value.contains("comprendre le problème") }
+            }
+
+        assertNotNull("fixture should contain the multi-line answer paragraph", paragraph)
+        assertTrue(
+            "the next authored line stays in the SAME paragraph, got=${paragraph!!.inlines}",
+            paragraph.inlines.filterIsInstance<PostInline.Text>()
+                .any { it.value.contains("Je te propose") },
+        )
+        assertTrue(
+            "the authored line boundary survives as an inline LineBreak",
+            paragraph.inlines.any { it is PostInline.LineBreak },
+        )
+    }
+
+    @Test
+    fun `breaks adjacent to block boundaries never leak to paragraph edges`() {
+        // #333 — edge-trim invariant over real pages. The fixtures carry both directions:
+        // `a écrit :</a></b><br /><br /><p>…` (leading, quote header, topic_page_single) and
+        // `…:o" /><br /><br /></p>` (trailing, end of quoted content, topic_redface2_p24).
+        // Breaks at a paragraph edge would duplicate the renderer's inter-block spacing.
+        listOf("topic_page_single.html", "topic_redface2_p24.html").forEach { name ->
+            val topic = pageParser.parse(fixture(name))
+
+            topic.posts.flatMap { it.content.allBlocks() }
+                .filterIsInstance<PostBlock.Paragraph>()
+                .forEach { block ->
+                    val edges = listOfNotNull(block.inlines.firstOrNull(), block.inlines.lastOrNull())
+                    assertTrue(
+                        "$name: paragraph edges must not be breaks or blank text, got=${block.inlines}",
+                        edges.none {
+                            it is PostInline.LineBreak || (it is PostInline.Text && it.value.isBlank())
+                        },
+                    )
+                }
+        }
+    }
+
+    @Test
     fun `span class u is recognised as Underline`() {
         val topic = pageParser.parse(fixture("topic_khakha_page_1.html"))
 


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Problème

Deux bugs de rendu avec la même cause racine dans `parseBlocks` :

- **refs-#333** — une ligne vide délibérée (saut de ligne dans le message) est perdue à la publication : HFR l'émet comme `<br /><br />`, et chaque `<br>` top-level FLUSHAIT le paragraphe courant — la « ligne vide » devenait un paragraphe vide, jeté.
- **refs-#280** — chaque ligne devenait son propre bloc `Paragraph`, donc le renderer remplaçait la hauteur de ligne naturelle par son gap inter-blocs de 8dp (`Arrangement.spacedBy`) entre CHAQUE ligne : interligne anormalement aéré sur tout post multi-lignes.

## Fix

- Un `<br>` top-level devient un `PostInline.LineBreak` DANS le paragraphe courant (parité web : N breaks consécutifs = N retours à la ligne ; `PostRenderer` fait déjà `LineBreak -> append('\n')`).
- `flushParagraph` trimme breaks et fragments blancs aux BORDS du paragraphe uniquement : les breaks adjacents à une frontière de bloc (citation, image, fin de post) dupliqueraient l'espacement inter-blocs du renderer ; les breaks intérieurs sont la structure littérale voulue par l'auteur — y compris les doubles (lignes vides).

## Tests

3 tests de régression ancrés sur les patterns des fixtures réelles :
- ligne vide → UN `Paragraph` `[Text, LineBreak, LineBreak, Text]` (structure émise par HFR) ;
- `<br />` simple entre phrases (fixture `topic_page_single.html`, post multi-lignes réel) → même paragraphe, pas un bloc par ligne ;
- invariant de bord sur 2 fixtures réelles (en-tête de citation `</b><br /><br /><p>` et fin de contenu cité `<br /><br /></p>`) : aucun paragraphe ne commence/finit par un break ou un blanc.

La suite parser complète passe sans modification d'aucun test existant (33 tests `PostContentParserTest`, 246 au total sur le module).

## Validation

2 parts locales : `detektAll test :app:assembleProdDebug` puis `:app:lintProdDebug` — BUILD SUCCESSFUL ×2.

Note : mots-clés de fermeture volontairement cassés (`refs-#N`) — fermeture à la promotion dev→main.