### PR TITLE
feat(topic): réglage pour masquer les boutons flottants de page (refs-#383)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -256,6 +256,22 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeTopicPageFabs(): Flow<Boolean> =
+        dataStore.data
+            // Default `true`: the ‹/› cluster (#283) predates the swipe (#282); hiding it is the
+            // #383 opt-out for readers who navigate by swipe only.
+            .map { prefs -> prefs[KEY_TOPIC_PAGE_FABS] ?: true }
+            .distinctUntilChanged()
+            .catch { emit(true) }
+
+    override suspend fun setTopicPageFabs(enabled: Boolean) {
+        withContext(ioDispatcher) {
+            dataStore.edit { prefs ->
+                prefs[KEY_TOPIC_PAGE_FABS] = enabled
+            }
+        }
+    }
+
     /**
      * Reads [KEY_THEME_MODE] defensively: an unknown / corrupt stored value (older build with a
      * renamed enum, manual edit) falls back to [ThemeMode.SYSTEM] instead of crashing on
@@ -353,5 +369,6 @@ class DataStoreUserPreferencesRepository @Inject constructor(
 
         // #378 — auto-refresh of the flags lists on landing (default ON; Settings opt-out).
         val KEY_FLAGS_AUTO_REFRESH = booleanPreferencesKey("flags_auto_refresh")
+        val KEY_TOPIC_PAGE_FABS = booleanPreferencesKey("topic_page_fabs")
     }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -419,6 +419,27 @@ class DataStoreUserPreferencesRepositoryTest {
     }
 
     @Test
+    fun `observeTopicPageFabs defaults to true then persists false and true`() = runTest(dispatcher) {
+        // #383 — the ‹/› cluster is the historical behaviour; hiding it is the opt-out.
+        repository.observeTopicPageFabs().test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setTopicPageFabs(false)
+        repository.observeTopicPageFabs().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setTopicPageFabs(true)
+        repository.observeTopicPageFabs().test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `observeConfirmBeforePosting defaults to false then persists true and false`() = runTest(dispatcher) {
         // #312 — publishing stays one-tap by default; the guard is strictly opt-in.
         repository.observeConfirmBeforePosting().test {

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -555,5 +555,9 @@ class TopicRepositoryImplTest {
         override fun observeFlagsAutoRefresh(): Flow<Boolean> = MutableStateFlow(true)
 
         override suspend fun setFlagsAutoRefresh(enabled: Boolean) = Unit
+
+        override fun observeTopicPageFabs(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setTopicPageFabs(enabled: Boolean) = Unit
     }
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -173,4 +173,16 @@ interface UserPreferencesRepository {
 
     /** Persists [observeFlagsAutoRefresh]. Default `true` until the first call. */
     suspend fun setFlagsAutoRefresh(enabled: Boolean)
+
+    /**
+     * Floating previous/next page buttons at the bottom of a topic (#283): when `false`, the
+     * ‹/› mini-FABs are hidden — the page swipe (#282) and the header pager already cover
+     * page-change, and some readers find the cluster intrusive (#383). The « Répondre » FAB
+     * is NOT governed by this preference and stays visible. Default `true` (historical
+     * behaviour). Observed by `:feature:topic`, toggled in Settings.
+     */
+    fun observeTopicPageFabs(): Flow<Boolean>
+
+    /** Persists [observeTopicPageFabs]. Default `true` until the first call. */
+    suspend fun setTopicPageFabs(enabled: Boolean)
 }

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -1303,6 +1303,10 @@ class PostEditorViewModelTest {
         override fun observeFlagsAutoRefresh(): Flow<Boolean> = MutableStateFlow(true)
 
         override suspend fun setFlagsAutoRefresh(enabled: Boolean) = Unit
+
+        override fun observeTopicPageFabs(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setTopicPageFabs(enabled: Boolean) = Unit
     }
 
     private companion object {

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1255,6 +1255,10 @@ class TopicFormViewModelTest {
         override fun observeFlagsAutoRefresh(): Flow<Boolean> = MutableStateFlow(true)
 
         override suspend fun setFlagsAutoRefresh(enabled: Boolean) = Unit
+
+        override fun observeTopicPageFabs(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setTopicPageFabs(enabled: Boolean) = Unit
     }
 
     private companion object {

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1516,6 +1516,10 @@ class FlagsViewModelTest {
 
         override suspend fun setTopicTopBarAutoHide(enabled: Boolean) = Unit
 
+        override fun observeTopicPageFabs(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setTopicPageFabs(enabled: Boolean) = Unit
+
         // #312 — confirm-before-posting is irrelevant to FlagsViewModel; stubbed at its default.
         override fun observeConfirmBeforePosting(): Flow<Boolean> = MutableStateFlow(false)
 

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -531,10 +531,16 @@ private fun FlagsPreferencesCard(
 }
 
 /**
- * Topic reading preferences (build 89 follow-up): the « masquer la barre du haut en défilant »
- * toggle. When on, the topic top app bar (title + page counter) collapses on scroll-down and snaps
- * back on the first scroll-up (Material3 `enterAlways`), freeing reading space. Persisted via
- * DataStore and observed live by the topic screen, so a flip here applies without reopening a topic.
+ * Topic reading preferences:
+ *
+ * - « masquer la barre du haut en défilant » (build 89 follow-up) — when on, the topic top app
+ *   bar (title + page counter) collapses on scroll-down and snaps back on the first scroll-up
+ *   (Material3 `enterAlways`), freeing reading space;
+ * - « boutons de changement de page » (#383) — when off, the floating ‹/› mini-FABs (#283) are
+ *   hidden for swipe-only readers; « Répondre » keeps its own gates and stays.
+ *
+ * Both persisted via DataStore and observed live by the topic screen, so a flip here applies
+ * without reopening a topic.
  */
 @Composable
 private fun TopicPreferencesCard(

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -561,6 +561,16 @@ private fun TopicPreferencesCard(
             if (state.topicTopBarAutoHideError) {
                 PreferencePersistError(R.string.settings_topic_topbar_auto_hide_persist_failed)
             }
+            PreferenceSwitchRow(
+                title = stringResource(R.string.settings_topic_page_fabs_title),
+                description = stringResource(R.string.settings_topic_page_fabs_description),
+                checked = state.topicPageFabs,
+                enabled = state.canToggleTopicPageFabs,
+                onCheckedChange = { onIntent(SettingsIntent.TopicPageFabsChanged(it)) },
+            )
+            if (state.topicPageFabsError) {
+                PreferencePersistError(R.string.settings_topic_page_fabs_persist_failed)
+            }
         }
     }
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -78,6 +78,12 @@ data class SettingsState(
     val isUpdatingTopicTopBarAutoHide: Boolean = false,
     val topicTopBarAutoHideError: Boolean = false,
     val topicTopBarAutoHideTouchedLocally: Boolean = false,
+    // Topic — #383 floating ‹/› page FABs (#283). Same machinery. Default TRUE (historical
+    // cluster); the toggle is the opt-out for swipe-only readers. « Répondre » is not governed.
+    val topicPageFabs: Boolean = true,
+    val isUpdatingTopicPageFabs: Boolean = false,
+    val topicPageFabsError: Boolean = false,
+    val topicPageFabsTouchedLocally: Boolean = false,
     // Publishing preferences (#312). Same optimistic-flip + startup-race-guard machinery:
     // `confirmBeforePosting` is the displayed value, `isUpdating*` gates the switch while DataStore
     // writes, `*Error` surfaces a persist failure, `*TouchedLocally` forbids a late `init` hydration
@@ -133,6 +139,10 @@ data class SettingsState(
     // Build 89 follow-up — the topic top-bar auto-hide toggle is gated only by its own write.
     val canToggleTopicTopBarAutoHide: Boolean
         get() = !isUpdatingTopicTopBarAutoHide
+
+    // #383 — the page-FABs toggle is gated only by its own write.
+    val canToggleTopicPageFabs: Boolean
+        get() = !isUpdatingTopicPageFabs
 
     // #312 — the confirm-before-posting toggle is gated only by its own write.
     val canToggleConfirmBeforePosting: Boolean
@@ -216,6 +226,10 @@ sealed interface SettingsIntent {
     // Build 89 follow-up — topic top-bar auto-hide toggle. Optimistic-flip contract, like the
     // flags toggles: the boolean is the desired post-flip state.
     data class TopicTopBarAutoHideChanged(val enabled: Boolean) : SettingsIntent
+
+    // #383 — topic floating ‹/› page FABs toggle. Optimistic-flip contract, like the flags
+    // toggles: the boolean is the desired post-flip state.
+    data class TopicPageFabsChanged(val enabled: Boolean) : SettingsIntent
 
     // #312 — confirm-before-posting toggle. Optimistic-flip contract, like the flags toggles:
     // the boolean is the desired post-flip state.

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -111,6 +111,16 @@ class SettingsViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
+            val pageFabs = userPreferencesRepository.observeTopicPageFabs().first()
+            _state.update { current ->
+                if (current.topicPageFabsTouchedLocally || current.isUpdatingTopicPageFabs) {
+                    current
+                } else {
+                    current.copy(topicPageFabs = pageFabs)
+                }
+            }
+        }
+        viewModelScope.launch {
             val confirm = userPreferencesRepository.observeConfirmBeforePosting().first()
             _state.update { current ->
                 if (current.confirmBeforePostingTouchedLocally || current.isUpdatingConfirmBeforePosting) {
@@ -182,6 +192,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.ThemeModeChanged -> updateThemeMode(intent.mode)
             is SettingsIntent.AmoledEnabledChanged -> updateAmoled(intent.enabled)
             is SettingsIntent.TopicTopBarAutoHideChanged -> updateTopicTopBarAutoHide(intent.enabled)
+            is SettingsIntent.TopicPageFabsChanged -> updateTopicPageFabs(intent.enabled)
             is SettingsIntent.ShowDtSectionChanged -> updateShowDtSection(intent.enabled)
             is SettingsIntent.ConfirmBeforePostingChanged -> updateConfirmBeforePosting(intent.enabled)
             is SettingsIntent.FlagsAutoRefreshChanged -> updateFlagsAutoRefresh(intent.enabled)
@@ -485,6 +496,33 @@ class SettingsViewModel @Inject constructor(
                 }
             },
             persist = userPreferencesRepository::setTopicTopBarAutoHide,
+        )
+    }
+
+    private fun updateTopicPageFabs(desired: Boolean) {
+        val previous = _state.value.topicPageFabs
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    topicPageFabs = desired,
+                    isUpdatingTopicPageFabs = true,
+                    topicPageFabsError = false,
+                    topicPageFabsTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(topicPageFabs = desired, isUpdatingTopicPageFabs = false)
+                } else {
+                    state.copy(
+                        topicPageFabs = previous,
+                        isUpdatingTopicPageFabs = false,
+                        topicPageFabsError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setTopicPageFabs,
         )
     }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -135,6 +135,12 @@
     <string name="settings_topic_topbar_auto_hide_description">La barre du haut (titre du sujet et numéro de page) disparaît quand vous faites défiler vers le bas et réapparaît dès que vous remontez.</string>
     <string name="settings_topic_topbar_auto_hide_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
 
+    <!-- #383 — Boutons flottants ‹/› de changement de page (#283). Le swipe (#282) couvre déjà le
+         changement de page ; ce réglage est l'opt-out demandé en bêta. « Répondre » reste affiché. -->
+    <string name="settings_topic_page_fabs_title">Boutons de changement de page</string>
+    <string name="settings_topic_page_fabs_description">Affiche les boutons flottants ‹ et › en bas du sujet. Désactivez-les si vous changez de page au glissement ; le bouton Répondre reste affiché.</string>
+    <string name="settings_topic_page_fabs_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
+
     <!-- #312 — Publication. Confirmation avant chaque envoi (réponse/édition de message, sujet,
          message privé) ; persisté en DataStore et lu en direct par les éditeurs.
          `settings_future_submit_confirm` (catalogue vitrine #288) renommé selon la convention des

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -757,6 +757,34 @@ class SettingsViewModelTest {
     }
 
     // ──────────────────────────────────────────────────────────────────────
+    // Topic page FABs (#383)
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `TopicPageFabsChanged persists the flip`() = runTest {
+        val viewModel = newViewModel()
+        assertTrue("page FABs are on by default", viewModel.state.value.topicPageFabs)
+
+        viewModel.submit(SettingsIntent.TopicPageFabsChanged(false))
+
+        assertFalse(viewModel.state.value.topicPageFabs)
+        assertFalse(viewModel.state.value.isUpdatingTopicPageFabs)
+        assertEquals(1, repository.topicPageFabsSetCalls)
+    }
+
+    @Test
+    fun `TopicPageFabsChanged reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnTopicPageFabsSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.TopicPageFabsChanged(false))
+
+        assertTrue("must revert to the previous value on failure", viewModel.state.value.topicPageFabs)
+        assertFalse(viewModel.state.value.isUpdatingTopicPageFabs)
+        assertTrue(viewModel.state.value.topicPageFabsError)
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
     // Confirm before posting (#312)
     // ──────────────────────────────────────────────────────────────────────
 
@@ -973,6 +1001,20 @@ class SettingsViewModelTest {
             topicTopBarAutoHideSetCalls += 1
             check(!failOnTopicTopBarAutoHideSet) { "boom" }
             topicTopBarAutoHide.value = enabled
+        }
+
+        // #383 — topic page FABs. Same optimistic-flip seam as the topic top-bar toggle.
+        private val topicPageFabs = MutableStateFlow(true)
+        var topicPageFabsSetCalls: Int = 0
+            private set
+        var failOnTopicPageFabsSet: Boolean = false
+
+        override fun observeTopicPageFabs(): Flow<Boolean> = topicPageFabs
+
+        override suspend fun setTopicPageFabs(enabled: Boolean) {
+            topicPageFabsSetCalls += 1
+            check(!failOnTopicPageFabsSet) { "boom" }
+            topicPageFabs.value = enabled
         }
 
         // #312 — confirm-before-posting. Same optimistic-flip seam as the topic top-bar toggle.

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -761,6 +761,42 @@ class SettingsViewModelTest {
     // ──────────────────────────────────────────────────────────────────────
 
     @Test
+    fun `init hydrates topicPageFabs from a persisted false`() = runTest {
+        // The default is true — only a persisted opt-out exercises the hydration path.
+        repository.emitTopicPageFabs(false)
+
+        val viewModel = newViewModel()
+
+        assertFalse(viewModel.state.value.topicPageFabs)
+        assertFalse(viewModel.state.value.topicPageFabsError)
+    }
+
+    @Test
+    fun `topicPageFabs hydration race - a stale emission must not overwrite a local flip`() = runTest {
+        // Same startup race as ignoreTopicCache: init suspends on .first() (the override
+        // emits nothing yet), the user opts out locally, then the stale `true` arrives —
+        // the TouchedLocally guard must skip the apply.
+        val initialHydrationFlow = MutableSharedFlow<Boolean>(replay = 0)
+        repository.topicPageFabsObserveOverride = initialHydrationFlow
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.TopicPageFabsChanged(false))
+        assertFalse(
+            "optimistic flip must reach the state synchronously",
+            viewModel.state.value.topicPageFabs,
+        )
+        assertTrue(viewModel.state.value.topicPageFabsTouchedLocally)
+
+        initialHydrationFlow.emit(true)
+
+        assertFalse(
+            "stale initial DataStore hydration must NOT overwrite the local opt-out",
+            viewModel.state.value.topicPageFabs,
+        )
+        assertEquals(1, repository.topicPageFabsSetCalls)
+    }
+
+    @Test
     fun `TopicPageFabsChanged persists the flip`() = runTest {
         val viewModel = newViewModel()
         assertTrue("page FABs are on by default", viewModel.state.value.topicPageFabs)
@@ -1003,18 +1039,25 @@ class SettingsViewModelTest {
             topicTopBarAutoHide.value = enabled
         }
 
-        // #383 — topic page FABs. Same optimistic-flip seam as the topic top-bar toggle.
+        // #383 — topic page FABs. Same optimistic-flip seam as the topic top-bar toggle,
+        // plus the observe-override seam of ignoreTopicCache for the hydration-race test.
         private val topicPageFabs = MutableStateFlow(true)
         var topicPageFabsSetCalls: Int = 0
             private set
         var failOnTopicPageFabsSet: Boolean = false
+        var topicPageFabsObserveOverride: Flow<Boolean>? = null
 
-        override fun observeTopicPageFabs(): Flow<Boolean> = topicPageFabs
+        override fun observeTopicPageFabs(): Flow<Boolean> =
+            topicPageFabsObserveOverride ?: topicPageFabs
 
         override suspend fun setTopicPageFabs(enabled: Boolean) {
             topicPageFabsSetCalls += 1
             check(!failOnTopicPageFabsSet) { "boom" }
             topicPageFabs.value = enabled
+        }
+
+        fun emitTopicPageFabs(value: Boolean) {
+            topicPageFabs.value = value
         }
 
         // #312 — confirm-before-posting. Same optimistic-flip seam as the topic top-bar toggle.

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -650,6 +650,7 @@ internal fun TopicContent(
             if (current != null) {
                 TopicBottomActions(
                     showReply = shouldEnableReply(current.topic, state.isAuthenticated),
+                    showPageFabs = state.showPageFabs,
                     canGoPrevious = state.canGoPrevious,
                     canGoNext = state.canGoNext,
                     // Clamp to [1, totalPages]: `canGoPrevious/Next` are derived from `request.page`
@@ -1473,6 +1474,7 @@ private fun DeletePostConfirmDialog(
 @Suppress("LongParameterList") // hoisted action cluster, mirrors other hoisted composables in this file
 private fun TopicBottomActions(
     showReply: Boolean,
+    showPageFabs: Boolean,
     canGoPrevious: Boolean,
     canGoNext: Boolean,
     onPreviousPage: () -> Unit,
@@ -1481,15 +1483,18 @@ private fun TopicBottomActions(
 ) {
     val previousLabel = stringResource(R.string.topic_fab_previous_page)
     val nextLabel = stringResource(R.string.topic_fab_next_page)
-    if (showReply || canGoPrevious || canGoNext) {
+    // #383 — the preference only governs the ‹/› page FABs; « Répondre » keeps its own gate.
+    val showPrevious = showPageFabs && canGoPrevious
+    val showNext = showPageFabs && canGoNext
+    if (showReply || showPrevious || showNext) {
         Row(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            if (canGoPrevious) {
+            if (showPrevious) {
                 PageFab(description = previousLabel, glyph = "‹", onClick = onPreviousPage)
             }
-            if (canGoNext) {
+            if (showNext) {
                 PageFab(description = nextLabel, glyph = "›", onClick = onNextPage)
             }
             if (showReply) {

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -33,6 +33,13 @@ data class TopicUiState(
      */
     val topBarAutoHide: Boolean = false,
     /**
+     * #383 — mirrors `UserPreferencesRepository.observeTopicPageFabs()`. When `false`, the
+     * floating ‹/› page mini-FABs (#283) are hidden — the page swipe (#282) and the header
+     * pager still cover page-change. The « Répondre » FAB is not governed by this flag.
+     * Default `true` keeps the historical cluster until the first preference emission.
+     */
+    val showPageFabs: Boolean = true,
+    /**
      * #335 — `true` while a manual pull-to-refresh of the current page is in flight. Drives the
      * Material3 `PullToRefreshBox` spinner. Set on the `Refresh` intent, cleared in the refresh
      * coroutine's `finally` (so a cancellation — e.g. a delete starting mid-refresh — never leaves

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -108,6 +108,13 @@ class TopicViewModel @AssistedInject constructor(
                 _state.update { it.copy(topBarAutoHide = autoHide) }
             }
             .launchIn(viewModelScope)
+        // #383 — mirror the page-FABs preference so the screen can hide the ‹/› cluster
+        // without a refetch, same pattern as the top-bar auto-hide above.
+        userPreferencesRepository.observeTopicPageFabs()
+            .onEach { enabled ->
+                _state.update { it.copy(showPageFabs = enabled) }
+            }
+            .launchIn(viewModelScope)
     }
 
     fun send(intent: TopicIntent) {

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -428,6 +428,25 @@ class TopicViewModelTest {
     }
 
     @Test
+    fun `state showPageFabs reflects the user preference (#383)`() = runTest {
+        val hidden = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            userPreferencesRepository = FakeUserPreferencesRepository(topicPageFabs = false),
+        )
+        assertEquals(false, hidden.state.value.showPageFabs)
+
+        val shown = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            userPreferencesRepository = FakeUserPreferencesRepository(topicPageFabs = true),
+        )
+        assertEquals(true, shown.state.value.showPageFabs)
+    }
+
+    @Test
     fun `DeletePost success emits PostDeleted and force-refreshes the current page (#292)`() = runTest {
         // Page 2 so the editable post 777 is NOT the first post (the FP lives on page 1 and is
         // excluded from deletion). Editable + authenticated + canReply → the VM gate lets it through.
@@ -1260,13 +1279,14 @@ private class FakeStreamingTopicRepository(
 }
 
 /**
- * No-op preferences fake for the topic ViewModel tests. Only [observeTopicTopBarAutoHide] is read by
- * [TopicViewModel] (build 89 follow-up) — everything else returns the DataStore default so the fake
- * stays a thin stand-in. The single relevant value is constructor-injectable for any future test that
- * wants to assert the auto-hide flag reaches state.
+ * No-op preferences fake for the topic ViewModel tests. Only [observeTopicTopBarAutoHide]
+ * (build 89 follow-up) and [observeTopicPageFabs] (#383) are read by [TopicViewModel] —
+ * everything else returns the DataStore default so the fake stays a thin stand-in. The two
+ * relevant values are constructor-injectable so tests can assert they reach state.
  */
 private class FakeUserPreferencesRepository(
     private val topicTopBarAutoHide: Boolean = false,
+    private val topicPageFabs: Boolean = true,
 ) : UserPreferencesRepository {
     override fun observeProxyConfig(): Flow<ProxyConfig> = MutableStateFlow(ProxyConfig())
 
@@ -1323,4 +1343,8 @@ private class FakeUserPreferencesRepository(
     override fun observeFlagsAutoRefresh(): Flow<Boolean> = MutableStateFlow(true)
 
     override suspend fun setFlagsAutoRefresh(enabled: Boolean) = Unit
+
+    override fun observeTopicPageFabs(): Flow<Boolean> = MutableStateFlow(topicPageFabs)
+
+    override suspend fun setTopicPageFabs(enabled: Boolean) = Unit
 }


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi

refs-#383 — les mini-FABs flottants ‹/› en bas de sujet (#283) font doublon avec le swipe de page (#282) pour les lecteurs qui naviguent au geste (demande de nicko en bêta). Nouveau réglage « Boutons de changement de page » dans **Réglages → Lecture des sujets**, activé par défaut (comportement historique). Le bouton « Répondre » garde ses propres gates et reste affiché.

## Comment

Réplication à l'identique du pattern du toggle « Masquer la barre en défilant » :

- `UserPreferencesRepository.observeTopicPageFabs()/setTopicPageFabs()` (défaut `true`, `catch → true`), clé DataStore `topic_page_fabs` ;
- miroir dans `TopicUiState.showPageFabs` via `TopicViewModel.init` — un flip s'applique en direct sans rouvrir le sujet ;
- gate dans `TopicBottomActions` : `showPrevious/showNext = pref && canGo*` ; la `TopicPageNavigation` de l'écran d'erreur n'est volontairement PAS gouvernée (c'est un repère de navigation, pas le cluster flottant) ;
- Settings : machinerie optimistic-flip + garde anti-course d'hydratation (`TouchedLocally`/`isUpdating`), revert + flag erreur si la persistance échoue.

## Tests

- `SettingsViewModelTest` : flip persisté ; revert + erreur sur échec de persistance ;
- `TopicViewModelTest` : `showPageFabs` reflète la préférence (true/false) ;
- fakes `UserPreferencesRepository` mis à jour (6 fichiers).

## Validation

2 parts locales : `detektAll test :app:assembleProdDebug` puis `:app:lintProdDebug` — BUILD SUCCESSFUL ×2.

Note : mot-clé de fermeture volontairement cassé (`refs-#383`) — fermeture à la promotion dev→main.