### PR TITLE
feat(topic): pseudo cliquable vers le profil dans le menu de post (refs-#395)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostMenuSheet.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostMenuSheet.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.widget.Toast
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -31,6 +32,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -66,6 +68,8 @@ import kotlinx.coroutines.launch
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
+@Suppress("LongParameterList") // contextual-menu surface: each optional action (delete #418,
+// profile #395) is a defaulted nullable param — the idiomatic Compose API, same as TopicBottomActions.
 internal fun PostMenuSheet(
     post: Post,
     permalink: String,
@@ -79,6 +83,13 @@ internal fun PostMenuSheet(
      * #292 confirmation dialog still guards the actual POST.
      */
     onDelete: (() -> Unit)? = null,
+    /**
+     * #395 — opens the author's profile from the hero row (avatar + pseudo), parity with
+     * the #208 tap on the post card. Null keeps the hero inert — same gate as the card
+     * (`Post.profileId == null` : Publicité rows, anonymous reads). The sheet plays its
+     * hide animation first so the profile sheet never stacks over this one.
+     */
+    onOpenProfile: (() -> Unit)? = null,
 ) {
     val sheetState = rememberModalBottomSheetState()
     val coroutineScope = rememberCoroutineScope()
@@ -97,7 +108,19 @@ internal fun PostMenuSheet(
                 .padding(horizontal = 16.dp, vertical = 8.dp)
                 .navigationBarsPadding(),
         ) {
-            PostMenuHero(post = post)
+            PostMenuHero(
+                post = post,
+                onClick = onOpenProfile?.let { openProfile ->
+                    {
+                        // Hide first, then dismiss AND navigate — the profile bottom sheet
+                        // must not stack over a still-visible menu sheet.
+                        hideThenDismiss(coroutineScope, sheetState) {
+                            onDismiss()
+                            openProfile()
+                        }
+                    }
+                },
+            )
 
             if (post.editedAt != null || citedCount > 0) {
                 Spacer(Modifier.height(12.dp))
@@ -192,13 +215,29 @@ internal fun PostMenuSheet(
  * Hero row of the sheet — avatar + author with the post identity (number, date)
  * underneath, mirroring `ProfilePreviewHero`. [RedfaceUserAvatar] handles the
  * `avatarUrl == null` / load-error placeholder on its own.
+ *
+ * #395 — when [onClick] is non-null the WHOLE row is one « Voir le profil » tap target:
+ * in a menu sheet a row reads as one action (M3 list-item idiom), unlike the post card
+ * where the date had to stay inert (#208 review I6) because it sits in flowing content.
  */
 @Composable
-private fun PostMenuHero(post: Post) {
+private fun PostMenuHero(post: Post, onClick: (() -> Unit)?) {
+    val openProfileLabel = stringResource(R.string.topic_open_profile_action)
+    val clickModifier = if (onClick != null) {
+        Modifier.clickable(
+            onClick = onClick,
+            role = Role.Button,
+            onClickLabel = openProfileLabel,
+        )
+    } else {
+        Modifier
+    }
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .then(clickModifier),
     ) {
         RedfaceUserAvatar(
             avatarUrl = post.avatarUrl,

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -964,6 +964,11 @@ private fun TopicLoadedContent(
             citedCount = citationCounts[post.numreponse] ?: 0,
             onDismiss = { menuPost = null },
             onDelete = menuDeleteAction,
+            // #395 — same profileId gate as the post card (#208): Publicité rows and
+            // anonymous reads expose no profile link, the hero stays inert.
+            onOpenProfile = post.profileId?.let { profileId ->
+                { onOpenProfile(profileId, post.author, post.avatarUrl) }
+            },
         )
     }
 }


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi

refs-#395 — dans le menu contextuel de post (#362), l'en-tête avatar + pseudo + n° + date n'était pas actionnable (remonté par tinc, build 103). La row hero entière devient un tap « Voir le profil », parité avec le tap avatar/pseudo de la carte de post (#208).

## Comment

- `PostMenuSheet` : nouveau param `onOpenProfile: (() -> Unit)? = null` ; quand non-null, `PostMenuHero` est cliquable (`Role.Button` + `onClickLabel` « Voir le profil » pour TalkBack). La row ENTIÈRE est le tap target — idiome menu-row M3, documenté vs la carte où la date reste inerte (review I6 de #208) ;
- séquencement : le menu joue son animation de fermeture (`hideThenDismiss`) puis `onDismiss()` (relâche `menuPost`) **et seulement ensuite** ouvre le profil — les deux bottom sheets ne s'empilent jamais ;
- `TopicScreen` : gate `post.profileId?.let { ... }` identique à la carte — lignes Publicité et lectures anonymes gardent un hero inerte.

Pure présentation (aucun changement ViewModel/état) — pas de test ajouté, conforme à la couverture différenciée du repo (les sheets UI ne sont pas testés unitairement ; le contrat testable, le gate profileId, est partagé avec #208).

## Validation

2 parts locales : `detektAll test :app:assembleProdDebug` puis `:app:lintProdDebug` — BUILD SUCCESSFUL ×2.

Note : mot-clé de fermeture volontairement cassé (`refs-#395`) — fermeture à la promotion dev→main.