### PR TITLE
feat(topic): marqueur « Dernier message du sujet » en fin de dernière page (refs-#379)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -939,8 +939,12 @@ private fun TopicLoadedContent(
         // « page X/Y » counter (#284) lets the reader deduce it; this says it. Reflects the
         // LOADED page (same contract as the counter): replies posted since the fetch surface
         // on the next refresh. Intermediate pages keep their natural « more below » flow.
+        // NO explicit key (Codex review): a stable key would make Lazy track the footer
+        // across an insertion — a reader parked on the marker would keep it in view while a
+        // freshly fetched post lands above the viewport, unseen. Positional identity is
+        // correct for a stateless sentinel.
         if (topic.page == topic.totalPages) {
-            item(key = "end-of-topic") {
+            item {
                 EndOfTopicFooter()
             }
         }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -934,6 +935,15 @@ private fun TopicLoadedContent(
                 onOpenMenu = { menuPost = post },
             )
         }
+        // #379 — explicit end-of-topic marker after the last post of the LAST page. The
+        // « page X/Y » counter (#284) lets the reader deduce it; this says it. Reflects the
+        // LOADED page (same contract as the counter): replies posted since the fetch surface
+        // on the next refresh. Intermediate pages keep their natural « more below » flow.
+        if (topic.page == topic.totalPages) {
+            item(key = "end-of-topic") {
+                EndOfTopicFooter()
+            }
+        }
     }
     // #362 — per-post contextual menu. The permalink is rebuilt from the LOADED topic's
     // (cat, post, page) — not the request — so it always reflects the page HFR actually
@@ -964,6 +974,36 @@ private fun TopicLoadedContent(
             citedCount = citationCounts[post.numreponse] ?: 0,
             onDismiss = { menuPost = null },
             onDelete = menuDeleteAction,
+        )
+    }
+}
+
+/**
+ * #379 — sober end-of-topic marker: a centred label between two hairlines, rendered as the
+ * LAST LazyColumn item of the topic's last page only. Pure presentation — the condition
+ * (`topic.page == topic.totalPages`) lives at the call site.
+ */
+@Composable
+private fun EndOfTopicFooter() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            color = MaterialTheme.colorScheme.outlineVariant,
+        )
+        Text(
+            text = stringResource(R.string.topic_end_of_topic),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            color = MaterialTheme.colorScheme.outlineVariant,
         )
     }
 }

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -6,6 +6,8 @@
     <string name="topic_fab_previous_page">Page précédente</string>
     <string name="topic_fab_next_page">Page suivante</string>
     <string name="topic_loading">Chargement…</string>
+    <!-- #379 — marqueur explicite de fin de sujet, rendu après le dernier post de la DERNIÈRE page. -->
+    <string name="topic_end_of_topic">Dernier message du sujet</string>
     <!-- #285 — top app bar : back affordance (content description) + fallback title shown while
          the topic page has not loaded yet (or errored), so the bar never reads blank. -->
     <string name="topic_back">Retour</string>


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi

refs-#379 — demandé par garath_ : le compteur « page X/Y » (#284) laisse déduire qu'on a atteint le dernier message, sans le dire. Un marqueur sobre « Dernier message du sujet » (label centré entre deux filets `outlineVariant`) est rendu comme dernier item de la liste, uniquement quand la page chargée est la dernière (`topic.page == topic.totalPages`).

## Comportement

- pages intermédiaires : aucun marqueur, le flux « il y a plus bas » reste naturel ;
- sujet d'une seule page : marqueur affiché (c'est bien la dernière page) ;
- le marqueur reflète la page CHARGÉE (même contrat que le compteur) : une réponse postée depuis le fetch apparaît au refresh suivant ;
- item SANS key explicite (review Codex) : une key stable ferait suivre le sentinel à travers une insertion — identité positionnelle correcte pour un footer sans état.

Pure présentation (condition au call-site, composable privé sans état) — pas de test ajouté, conforme à la couverture différenciée du repo.

## Validation

2 parts locales : `detektAll test :app:assembleProdDebug` puis `:app:lintProdDebug` — BUILD SUCCESSFUL ×2 (re-exécutée après la correction de review).

Note : mot-clé de fermeture volontairement cassé (`refs-#379`) — fermeture à la promotion dev→main.