### PR TITLE
feat(topic,editor): citation multiple — multi-quote (refs-#291)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -230,6 +230,14 @@ data class PostEditorRoute(
      * absent quote link ; quote still works from `quotedNumreponse` alone.
      */
     val quoteRef: Int? = null,
+    /**
+     * #291 multi-quote — `numreponse`s of the ADDITIONAL posts to quote after
+     * [quotedNumreponse], in selection order. The editor replays the #146 quote
+     * form fetch once per entry and concatenates the `[quotemsg]` prefills —
+     * client-side only, no new HFR contract. Empty for single quote / plain
+     * reply ; defaulted so older serialised back stacks deserialise.
+     */
+    val extraQuoteNumreponses: List<Int> = emptyList(),
 ) : RedfaceNavKey
 
 @Serializable
@@ -450,6 +458,12 @@ fun RedfaceApp(intent: Intent?) {
         // above (plain remember: lost on activity/process recreation, which falls back to the
         // pre-#412 top landing instead of replaying a stale bottom scroll).
         var topicPendingBottomLanding by remember { mutableStateOf<TopicScrollKey?>(null) }
+        // #291 — multi-quote basket: numreponses selected for quoting, in tap order, keyed by
+        // (cat, post) so a page change (which destroys the topic nav entry, cf. titles above)
+        // keeps the cross-page selection while a different topic never sees it. One basket at a
+        // time (selecting in another topic resets it — quoting is a single-topic act). Plain
+        // remember: losing it on process death just means re-selecting, like the markers above.
+        var multiQuoteBasket by remember { mutableStateOf<MultiQuoteBasket?>(null) }
 
         LaunchedEffect(authState) {
             when (authState) {
@@ -543,6 +557,13 @@ fun RedfaceApp(intent: Intent?) {
                         },
                         pendingBottomLanding = topicPendingBottomLanding,
                         onPendingBottomLanding = { topicPendingBottomLanding = it },
+                    ),
+                    multiQuoteNavState = MultiQuoteNavState(
+                        basket = multiQuoteBasket,
+                        onToggle = { cat, post, numreponse ->
+                            multiQuoteBasket = multiQuoteBasket.toggled(cat, post, numreponse)
+                        },
+                        onClear = { multiQuoteBasket = null },
                     ),
                     onOpenProfile = { userId, pseudo, avatarUrl ->
                         // Review feedback I3: capture the **origin** tab so that
@@ -692,6 +713,46 @@ private data class TopicScrollNavState(
 )
 
 /**
+ * #291 — multi-quote nav bundle threaded into [RedfaceNavHost], same shape as the other
+ * hoisted-state bundles ([TopicScrollNavState], `TopicTitleNavState`).
+ */
+private data class MultiQuoteNavState(
+    val basket: MultiQuoteBasket?,
+    val onToggle: (cat: Int, post: Int, numreponse: Int) -> Unit,
+    val onClear: () -> Unit,
+)
+
+/**
+ * #291 — multi-quote selection, hoisted to RedfaceApp (same survival rationale as
+ * [TopicScrollNavState]: a page change replaces the TopicRoute entry, so any state owned by the
+ * topic screen dies with it). [numreponses] keeps SELECTION ORDER — the quotes are concatenated
+ * in the order the user tapped them, not post order.
+ */
+internal data class MultiQuoteBasket(
+    val cat: Int,
+    val post: Int,
+    val numreponses: List<Int>,
+) {
+    fun matches(cat: Int, post: Int): Boolean = this.cat == cat && this.post == post
+}
+
+/**
+ * Toggles [numreponse] in the basket for topic ([cat], [post]). Selecting in a DIFFERENT topic
+ * replaces the basket (one quoting act at a time); removing the last entry clears it to null so
+ * the « Citer N » affordance disappears instead of advertising an empty selection.
+ */
+internal fun MultiQuoteBasket?.toggled(cat: Int, post: Int, numreponse: Int): MultiQuoteBasket? {
+    val current = this?.takeIf { it.matches(cat, post) }
+        ?: return MultiQuoteBasket(cat, post, listOf(numreponse))
+    val next = if (numreponse in current.numreponses) {
+        current.numreponses - numreponse
+    } else {
+        current.numreponses + numreponse
+    }
+    return if (next.isEmpty()) null else current.copy(numreponses = next)
+}
+
+/**
  * Composite cache key for [TopicTitleNavState]. A topic id (`post`) is unique only **per HFR
  * category**, not globally — two categories can theoretically expose the same id (cf. the same
  * `(cat, topicId)` composite key in `SearchScreen`), so keying by `post` alone could flash the
@@ -737,6 +798,8 @@ private fun RedfaceNavHost(
     topicTitleNavState: TopicTitleNavState,
     // #307 — per-page scroll-anchor cache, same hoisting rationale as topicTitleNavState.
     topicScrollNavState: TopicScrollNavState,
+    // #291 — multi-quote basket, same hoisting rationale (survives the per-page entry swap).
+    multiQuoteNavState: MultiQuoteNavState,
     onOpenProfile: (userId: Int, pseudo: String, avatarUrl: String?) -> Unit = { _, _, _ -> },
 ) {
     NavDisplay(
@@ -1096,6 +1159,40 @@ private fun RedfaceNavHost(
                             ),
                         )
                     },
+                    // #291 — selection of THIS topic's basket (another topic's selection must
+                    // never leak into the menu checkmarks or the « Citer N » FAB).
+                    multiQuoteSelection = multiQuoteNavState.basket
+                        ?.takeIf { it.matches(route.cat, route.post) }
+                        ?.numreponses
+                        .orEmpty(),
+                    onToggleMultiQuote = { numreponse ->
+                        multiQuoteNavState.onToggle(route.cat, route.post, numreponse)
+                    },
+                    onMultiQuote = { subcat, page ->
+                        // #291 — quote flavour of reply with the EXTRA numreponses riding the
+                        // route; the editor replays the #146 fetch per entry. The basket is
+                        // cleared on launch: the selection's intent is consumed, and backing
+                        // out of the editor should not re-arm a stale « Citer N ».
+                        val selection = multiQuoteNavState.basket
+                            ?.takeIf { it.matches(route.cat, route.post) }
+                            ?.numreponses
+                            .orEmpty()
+                        if (selection.isNotEmpty()) {
+                            backStack.add(
+                                PostEditorRoute(
+                                    mode = PostEditorMode.Reply,
+                                    cat = route.cat,
+                                    topicId = route.post,
+                                    page = page,
+                                    subcat = subcat,
+                                    quotedNumreponse = selection.first(),
+                                    quoteRef = null,
+                                    extraQuoteNumreponses = selection.drop(1),
+                                ),
+                            )
+                            multiQuoteNavState.onClear()
+                        }
+                    },
                     onEdit = { subcat, page, numreponse ->
                         // Phase 2D (#147) — `PostEditorMode.Edit` triggers the
                         // `bdd.php` flow inside the editor. `numreponse` identifies
@@ -1191,6 +1288,7 @@ private fun RedfaceNavHost(
                         subcat = route.subcat,
                         quotedNumreponse = route.quotedNumreponse,
                         quoteRef = route.quoteRef,
+                        extraQuoteNumreponses = route.extraQuoteNumreponses,
                     ),
                     onSubmitSucceeded = { targetPage, scrollTo ->
                         // Pop the editor and refresh the topic page. `targetPage` is parsed

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -472,12 +472,16 @@ fun RedfaceApp(intent: Intent?) {
                     readPrivateMessageThreadIds = emptySet()
                     multiRecipientThreadIds = emptySet()
                     privateMessageSentSignal = null
+                    // #291 — a write intention armed under another session must not survive the
+                    // transition (Codex review: stale « Citer N » after logout/login).
+                    multiQuoteBasket = null
                     resetStack(messagesBackStack, MessagesRoute, MessagesRoute)
                 }
                 is AuthState.Authenticated -> {
                     readPrivateMessageThreadIds = emptySet()
                     multiRecipientThreadIds = emptySet()
                     privateMessageSentSignal = null
+                    multiQuoteBasket = null
                     resetStack(messagesBackStack, MessagesRoute, MessagesRoute)
                 }
             }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorRequest.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorRequest.kt
@@ -32,4 +32,12 @@ data class PostEditorRequest(
      * or absent quote link — HFR still quotes from [quotedNumreponse] alone.
      */
     val quoteRef: Int? = null,
+    /**
+     * #291 multi-quote — `numreponse`s of the ADDITIONAL posts to quote after
+     * [quotedNumreponse], in selection order. The ViewModel replays the quote form
+     * fetch once per entry (same #146 contract, `quotedNumreponse` swapped) and
+     * concatenates the `[quotemsg]` prefills into the initial draft. Empty for a
+     * single quote or a plain reply.
+     */
+    val extraQuoteNumreponses: List<Int> = emptyList(),
 )

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -356,8 +356,15 @@ class PostEditorViewModel @AssistedInject constructor(
             }
         }
         val merged = prefills
-            .map { it.trimEnd() }
-            .filter { it.isNotBlank() }
+            .map { prefill ->
+                prefill.trimEnd().also { trimmed ->
+                    // Codex review — a 200-OK form whose prefill came back BLANK would silently
+                    // drop a quote the user explicitly selected (the exact failure mode the
+                    // sequential design refuses). Fail the whole fetch instead; the mapped
+                    // SubmitError keeps the editor on its retryable error path.
+                    check(trimmed.isNotBlank()) { "multi-quote prefill came back blank" }
+                }
+            }
             .joinToString(separator = "\n\n", postfix = "\n\n")
         return form.copy(initialContent = merged)
     }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -325,7 +325,41 @@ class PostEditorViewModel @AssistedInject constructor(
             _state.update { it.copy(submitError = SubmitError.MissingSubcat) }
             return
         }
-        launchFormFetch { replyRepository.fetchReplyForm(context) }
+        launchFormFetch { fetchReplyFormWithExtraQuotes(context) }
+    }
+
+    /**
+     * #291 multi-quote — the quote form fetch (#146) returns ONE `[quotemsg]` prefill per
+     * `numrep`, so additional quoted posts are fetched by replaying the same contract with
+     * `quotedNumreponse` swapped, then concatenated into the first form's [ReplyForm.initialContent]
+     * in selection order. Client-side only: HFR never sees a multi-numrep request, and the
+     * submit still rides the FIRST form's `hash_check`/hidden fields (per-session, not
+     * per-post — the single-quote and plain-reply paths already share them).
+     *
+     * Sequential on purpose: N is tiny (a handful of posts), order must be deterministic, and
+     * a failed extra fails the whole fetch — silently dropping a quote the user explicitly
+     * selected would be worse than the retryable form-fetch error.
+     */
+    private suspend fun fetchReplyFormWithExtraQuotes(context: ReplyContext): ReplyForm {
+        val form = replyRepository.fetchReplyForm(context)
+        val extras = request.extraQuoteNumreponses
+        if (extras.isEmpty() || !context.isQuote) return form
+        val prefills = buildList {
+            add(form.initialContent)
+            extras.forEach { numreponse ->
+                // quoteRef is positional/cosmetic and belongs to the FIRST post only.
+                add(
+                    replyRepository
+                        .fetchReplyForm(context.copy(quotedNumreponse = numreponse, quoteRef = null))
+                        .initialContent,
+                )
+            }
+        }
+        val merged = prefills
+            .map { it.trimEnd() }
+            .filter { it.isNotBlank() }
+            .joinToString(separator = "\n\n", postfix = "\n\n")
+        return form.copy(initialContent = merged)
     }
 
     private fun loadEditFormIfPossible() {

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -418,6 +418,31 @@ class PostEditorViewModelTest {
     }
 
     @Test
+    fun `multi-quote VM fails the whole fetch when a prefill comes back blank (#291)`() = runTest {
+        // A 200-OK form whose textarea prefill is EMPTY would otherwise silently drop a quote
+        // the user explicitly selected — same contract as a failed extra: fail globally.
+        replyRepository.formResultsByNumrep = mapOf(
+            101 to Result.success(authenticatedForm(initialContent = "[quotemsg=101,1,9]a[/quotemsg]\n\n")),
+            303 to Result.success(authenticatedForm(initialContent = "")),
+        )
+
+        val viewModel = newReplyViewModel(
+            quotedNumreponse = 101,
+            quoteRef = null,
+            extraQuoteNumreponses = listOf(303),
+        )
+        testScheduler.advanceUntilIdle()
+
+        viewModel.state.test {
+            val settled = expectMostRecentItem()
+            assertFalse(settled.isLoadingForm)
+            assertEquals("draft must not hydrate from a partial multi-quote", "", settled.draft.text)
+            assertEquals(SubmitError.Hfr(ReplyFailureReason.Unknown), settled.submitError)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `quote VM does not overwrite a draft the user already typed`() = runTest {
         // User-typed content lands on the VM before the form fetch completes —
         // we gate the fetch with a CompletableDeferred so we can interleave them

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -354,6 +354,70 @@ class PostEditorViewModelTest {
     }
 
     @Test
+    fun `multi-quote VM concatenates the prefills in selection order (#291)`() = runTest {
+        // One #146 form fetch per quoted post — the FIRST carries the session form (hash_check),
+        // the extras only contribute their prefill. HFR prefills end with a trailing blank line;
+        // the merge must keep ONE blank line between quotes and one after the last.
+        replyRepository.formResultsByNumrep = mapOf(
+            101 to Result.success(authenticatedForm(initialContent = "[quotemsg=101,1,9]a[/quotemsg]\n\n")),
+            303 to Result.success(authenticatedForm(initialContent = "[quotemsg=303,3,9]c[/quotemsg]\n\n")),
+            202 to Result.success(authenticatedForm(initialContent = "[quotemsg=202,2,9]b[/quotemsg]\n\n")),
+        )
+
+        // Selection order 101 → 303 → 202 is deliberately NOT post order.
+        val viewModel = newReplyViewModel(
+            quotedNumreponse = 101,
+            quoteRef = 0,
+            extraQuoteNumreponses = listOf(303, 202),
+        )
+        testScheduler.advanceUntilIdle()
+
+        assertEquals("one fetch per quoted post", 3, replyRepository.formFetches)
+        assertEquals(
+            "extras must replay the quote contract with the numreponse swapped (no stale quoteRef)",
+            listOf(101 to 0, 303 to null, 202 to null),
+            replyRepository.fetchedContexts.map { it.quotedNumreponse to it.quoteRef },
+        )
+        viewModel.state.test {
+            val settled = expectMostRecentItem()
+            assertFalse("Form must be fully loaded", settled.isLoadingForm)
+            assertEquals(
+                "prefills concatenated in SELECTION order, single blank line between quotes",
+                "[quotemsg=101,1,9]a[/quotemsg]\n\n" +
+                    "[quotemsg=303,3,9]c[/quotemsg]\n\n" +
+                    "[quotemsg=202,2,9]b[/quotemsg]\n\n",
+                settled.draft.text,
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `multi-quote VM fails the whole fetch when one extra quote fails (#291)`() = runTest {
+        // Silently dropping a quote the user explicitly selected would be worse than the
+        // retryable form-fetch error, so a failed extra fails the load.
+        replyRepository.formResultsByNumrep = mapOf(
+            101 to Result.success(authenticatedForm(initialContent = "[quotemsg=101,1,9]a[/quotemsg]\n\n")),
+            303 to Result.failure(java.io.IOException("boom")),
+        )
+
+        val viewModel = newReplyViewModel(
+            quotedNumreponse = 101,
+            quoteRef = null,
+            extraQuoteNumreponses = listOf(303),
+        )
+        testScheduler.advanceUntilIdle()
+
+        viewModel.state.test {
+            val settled = expectMostRecentItem()
+            assertFalse(settled.isLoadingForm)
+            assertEquals("draft must not hydrate from a partial multi-quote", "", settled.draft.text)
+            assertEquals(SubmitError.Network, settled.submitError)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `quote VM does not overwrite a draft the user already typed`() = runTest {
         // User-typed content lands on the VM before the form fetch completes —
         // we gate the fetch with a CompletableDeferred so we can interleave them
@@ -666,10 +730,12 @@ class PostEditorViewModelTest {
         }
     }
 
+    @Suppress("LongParameterList") // test helper: every param is an optional, defaulted scenario knob.
     private fun newReplyViewModel(
         subcat: Int? = SAMPLE_SUBCAT,
         quotedNumreponse: Int? = null,
         quoteRef: Int? = null,
+        extraQuoteNumreponses: List<Int> = emptyList(),
         diagnostics: DiagnosticsLog = DiagnosticsLog(),
         userPreferencesRepository: UserPreferencesRepository = FakeUserPreferencesRepository(),
     ): PostEditorViewModel =
@@ -683,6 +749,7 @@ class PostEditorViewModelTest {
                 subcat = subcat,
                 quotedNumreponse = quotedNumreponse,
                 quoteRef = quoteRef,
+                extraQuoteNumreponses = extraQuoteNumreponses,
             ),
             previewParser = previewParser,
             replyRepository = replyRepository,
@@ -1130,12 +1197,19 @@ class PostEditorViewModelTest {
         var lastSubmittedBbcode: String? = null
             private set
 
+        // #291 — per-numrep responses for the multi-quote pipeline; falls back to [formResult]
+        // when the quoted numreponse has no dedicated entry (single-quote / plain-reply tests).
+        var formResultsByNumrep: Map<Int, Result<ReplyForm>> = emptyMap()
+        val fetchedContexts: MutableList<ReplyContext> = mutableListOf()
+
         override suspend fun fetchReplyForm(context: ReplyContext): ReplyForm {
             formFetches += 1
             lastFetchedContext = context
+            fetchedContexts += context
             formGate?.await()
             formException?.let { throw it }
-            return formResult.getOrThrow()
+            val dedicated = context.quotedNumreponse?.let(formResultsByNumrep::get)
+            return (dedicated ?: formResult).getOrThrow()
         }
 
         var lastSubmittedOptions: fr.forumhfr.redface2.core.model.write.ReplyFormOptions? = null

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostMenuSheet.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostMenuSheet.kt
@@ -90,6 +90,16 @@ internal fun PostMenuSheet(
      * hide animation first so the profile sheet never stacks over this one.
      */
     onOpenProfile: (() -> Unit)? = null,
+    /**
+     * #291 — whether this post already sits in the multi-quote basket; flips the entry's
+     * label between « Ajouter à » and « Retirer de » la citation multiple.
+     */
+    multiQuoteSelected: Boolean = false,
+    /**
+     * #291 — toggles this post in the multi-quote basket. Null hides the entry — same gate
+     * as « Citer » (`shouldShowQuoteAction`): locked topic or anonymous session.
+     */
+    onToggleMultiQuote: (() -> Unit)? = null,
 ) {
     val sheetState = rememberModalBottomSheetState()
     val coroutineScope = rememberCoroutineScope()
@@ -173,6 +183,29 @@ internal fun PostMenuSheet(
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(stringResource(R.string.topic_post_menu_open_in_browser))
+            }
+
+            if (onToggleMultiQuote != null) {
+                Spacer(Modifier.height(8.dp))
+                // #291 — adds/removes this post in the multi-quote basket. The sheet closes on
+                // tap so the « Citer N » FAB count is immediately visible as feedback.
+                OutlinedButton(
+                    onClick = {
+                        onToggleMultiQuote()
+                        hideThenDismiss(coroutineScope, sheetState, onDismiss)
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        stringResource(
+                            if (multiQuoteSelected) {
+                                R.string.topic_post_menu_multi_quote_remove
+                            } else {
+                                R.string.topic_post_menu_multi_quote_add
+                            },
+                        ),
+                    )
+                }
             }
 
             Spacer(Modifier.height(8.dp))

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -196,6 +196,23 @@ fun TopicScreen(
      * still `Loading` never clobbers a previously saved position with `(0, 0)`.
      */
     onScrollAnchorSaved: (TopicScrollAnchor) -> Unit = {},
+    /**
+     * #291 — numreponses currently selected for multi-quote in THIS topic, in selection order.
+     * Owned by `:app` (the basket must survive the per-page entry swap, like the title cache);
+     * the screen only renders the count and the per-post toggle state.
+     */
+    multiQuoteSelection: List<Int> = emptyList(),
+    /**
+     * #291 — toggles a post in the multi-quote basket. Only invoked under the same gate as
+     * [onQuote] (`shouldShowQuoteAction`): a topic the user cannot reply to has nothing to quote.
+     */
+    onToggleMultiQuote: (numreponse: Int) -> Unit = {},
+    /**
+     * #291 — opens the editor pre-filled with every selected quote (same destination as
+     * [onQuote]; `:app` rides the selection on the route and clears the basket). Receives the
+     * topic's `(subcat, page)` like [onReply].
+     */
+    onMultiQuote: (subcat: Int, page: Int) -> Unit = { _, _ -> },
 ) {
     val viewModel = hiltViewModel<TopicViewModel, TopicViewModel.Factory>(
         creationCallback = { factory -> factory.create(request) },
@@ -347,6 +364,9 @@ fun TopicScreen(
         onOpenPage = onOpenPage,
         onOpenProfile = onOpenProfile,
         onDeleteRequest = { numreponse -> deleteCandidate = numreponse },
+        multiQuoteSelection = multiQuoteSelection,
+        onToggleMultiQuote = onToggleMultiQuote,
+        onMultiQuote = onMultiQuote,
     )
 
     // #292 — confirmation before the (irreversible, no-undo) deletion. Only « Supprimer » sends the
@@ -571,6 +591,11 @@ internal fun TopicContent(
     // #292 — a per-post « Supprimer » tap; the screen owns the confirmation dialog, so this only
     // requests it (carrying the post's numreponse). Never invoked for the first post (excluded).
     onDeleteRequest: (numreponse: Int) -> Unit = {},
+    // #291 — multi-quote selection (owned by :app) + its two actions, threaded to the post menu
+    // (toggle) and the floating cluster (« Citer N »).
+    multiQuoteSelection: List<Int> = emptyList(),
+    onToggleMultiQuote: (numreponse: Int) -> Unit = {},
+    onMultiQuote: (subcat: Int, page: Int) -> Unit = { _, _ -> },
 ) {
     // #285 — the topic title and #284 — the page counter live in a persistent top app bar so they
     // stay visible while the user scrolls (the in-card title/caption scrolls away). When the page
@@ -654,6 +679,12 @@ internal fun TopicContent(
                     showPageFabs = state.showPageFabs,
                     canGoPrevious = state.canGoPrevious,
                     canGoNext = state.canGoNext,
+                    // #291 — the « Citer N » FAB shares the reply gate: quoting IS replying.
+                    multiQuoteCount = effectiveMultiQuoteCount(
+                        current.topic,
+                        state.isAuthenticated,
+                        multiQuoteSelection,
+                    ),
                     // Clamp to [1, totalPages]: `canGoPrevious/Next` are derived from `request.page`
                     // while the target is computed from the parsed `topic.page`; if those ever desync
                     // (HFR clamps an out-of-range page to the last one), the clamp keeps navigation in
@@ -661,6 +692,7 @@ internal fun TopicContent(
                     onPreviousPage = { onOpenPage((current.topic.page - 1).coerceAtLeast(1)) },
                     onNextPage = { onOpenPage((current.topic.page + 1).coerceAtMost(current.topic.totalPages)) },
                     onReply = { onReply(current.topic.subcat, current.topic.page) },
+                    onMultiQuote = { onMultiQuote(current.topic.subcat, current.topic.page) },
                 )
             }
         },
@@ -738,6 +770,8 @@ internal fun TopicContent(
                                 onDeleteRequest = onDeleteRequest,
                                 onDoubleTapRefresh = { onIntent(TopicIntent.Refresh) },
                                 listState = listState,
+                                multiQuoteSelection = multiQuoteSelection,
+                                onToggleMultiQuote = onToggleMultiQuote,
                             )
                             TopicScrollbar(
                                 listState = listState,
@@ -766,6 +800,9 @@ private fun TopicLoadedContent(
     /** #382 — double-tap anywhere on the list refreshes the current page (RF1 parity). */
     onDoubleTapRefresh: () -> Unit = {},
     listState: LazyListState,
+    // #291 — selection state + toggle for the post menu's multi-quote entry.
+    multiQuoteSelection: List<Int> = emptyList(),
+    onToggleMultiQuote: (numreponse: Int) -> Unit = {},
 ) {
     val highlight = state.request.scrollTo
     // #239 — how many posts of THIS page cite each post, computed once per loaded post list. Drives
@@ -983,6 +1020,14 @@ private fun TopicLoadedContent(
             // anonymous reads expose no profile link, the hero stays inert.
             onOpenProfile = post.profileId?.let { profileId ->
                 { onOpenProfile(profileId, post.author, post.avatarUrl) }
+            },
+            // #291 — multi-quote toggle, same gate as « Citer » (quoting is a flavour of
+            // replying; a locked topic or an anonymous session has nothing to quote).
+            multiQuoteSelected = post.numreponse in multiQuoteSelection,
+            onToggleMultiQuote = if (shouldShowQuoteAction(topic, state.isAuthenticated)) {
+                { onToggleMultiQuote(post.numreponse) }
+            } else {
+                null
             },
         )
     }
@@ -1526,16 +1571,23 @@ private fun TopicBottomActions(
     showPageFabs: Boolean,
     canGoPrevious: Boolean,
     canGoNext: Boolean,
+    multiQuoteCount: Int,
     onPreviousPage: () -> Unit,
     onNextPage: () -> Unit,
     onReply: () -> Unit,
+    onMultiQuote: () -> Unit,
 ) {
     val previousLabel = stringResource(R.string.topic_fab_previous_page)
     val nextLabel = stringResource(R.string.topic_fab_next_page)
     // #383 — the preference only governs the ‹/› page FABs; « Répondre » keeps its own gate.
     val showPrevious = showPageFabs && canGoPrevious
     val showNext = showPageFabs && canGoNext
-    if (showReply || showPrevious || showNext) {
+    // #291 — appears as soon as the basket holds one post of this topic (call-site zeroes the
+    // count when quoting is unavailable). NOT governed by the #383 page-FABs preference: it is
+    // a write affordance the user explicitly armed, not page navigation.
+    val showMultiQuote = multiQuoteCount > 0
+    val showAnyAction = showReply || showPrevious || showNext || showMultiQuote
+    if (showAnyAction) {
         Row(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -1546,10 +1598,27 @@ private fun TopicBottomActions(
             if (showNext) {
                 PageFab(description = nextLabel, glyph = "›", onClick = onNextPage)
             }
+            if (showMultiQuote) {
+                MultiQuoteFab(count = multiQuoteCount, onClick = onMultiQuote)
+            }
             if (showReply) {
                 ReplyFab(onClick = onReply)
             }
         }
+    }
+}
+
+@Composable
+private fun MultiQuoteFab(count: Int, onClick: () -> Unit) {
+    // #291 — same SmallFloatingActionButton footprint as PageFab/ReplyFab; the glyph is a
+    // decorative « ❝N » (no Material icons — detekt ForbiddenImport blocks
+    // androidx.compose.material.*) and the real label rides on contentDescription for TalkBack.
+    val label = pluralStringResource(R.plurals.topic_fab_multi_quote, count, count)
+    SmallFloatingActionButton(
+        onClick = onClick,
+        modifier = Modifier.semantics { contentDescription = label },
+    ) {
+        Text("❝$count")
     }
 }
 
@@ -1591,6 +1660,12 @@ private fun ReplyFab(onClick: () -> Unit) {
 // (CategoryViewModel.canCreateTopic).
 internal fun shouldEnableReply(topic: Topic, isAuthenticated: Boolean): Boolean =
     topic.canReply && isAuthenticated
+
+// #291 — the « Citer N » FAB count, zeroed when quoting is unavailable (locked topic, anonymous
+// session): the basket may still hold posts, but advertising an unusable action would be a lie.
+// Extracted from TopicContent for the detekt cyclomatic-complexity budget.
+internal fun effectiveMultiQuoteCount(topic: Topic, isAuthenticated: Boolean, selection: List<Int>): Int =
+    if (shouldShowQuoteAction(topic, isAuthenticated)) selection.size else 0
 
 internal fun shouldShowQuoteAction(topic: Topic, isAuthenticated: Boolean): Boolean =
     topic.canReply && isAuthenticated

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -5,6 +5,14 @@
     <string name="topic_fab_reply">Répondre</string>
     <string name="topic_fab_previous_page">Page précédente</string>
     <string name="topic_fab_next_page">Page suivante</string>
+    <!-- #291 — FAB « Citer N » : ouvre l'éditeur pré-rempli avec les citations sélectionnées. -->
+    <plurals name="topic_fab_multi_quote">
+        <item quantity="one">Citer %1$d message sélectionné</item>
+        <item quantity="other">Citer %1$d messages sélectionnés</item>
+    </plurals>
+    <!-- #291 — entrée du menu contextuel : ajoute/retire le post du panier de citation multiple. -->
+    <string name="topic_post_menu_multi_quote_add">Ajouter à la citation multiple</string>
+    <string name="topic_post_menu_multi_quote_remove">Retirer de la citation multiple</string>
     <string name="topic_loading">Chargement…</string>
     <!-- #379 — marqueur explicite de fin de sujet, rendu après le dernier post de la DERNIÈRE page. -->
     <string name="topic_end_of_topic">Dernier message du sujet</string>


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi

refs-#291 — citer plusieurs messages d'un coup, comme le web HFR. Dans la liste de travail post-bêta.

## Design : MVP 100 % client, zéro nouveau contrat serveur

Le fetch de formulaire de citation #146 (`message.php?numrep=N` → textarea pré-rempli `[quotemsg]`) est **rejoué une fois par post sélectionné** et les prefills sont concaténés dans l'ordre de sélection. Le POST final ride le `hash_check` du PREMIER formulaire (par session, pas par post — déjà partagé par reply simple et quote). HFR ne voit jamais de requête multi-numrep.

## Flux utilisateur

1. Menu « ⋯ » d'un post → **« Ajouter à la citation multiple »** (toggle, même gate que « Citer ») ;
2. un FAB **« ❝N »** apparaît dans le cluster flottant (non gouverné par la pref #383 : affordance d'écriture explicitement armée, pas de la navigation) ;
3. tap → éditeur pré-rempli avec les N citations, panier vidé.

## Détails

- Panier hoisté dans `:app`, keyé `(cat, post)` — survit aux changements de page (l'entry TopicRoute est remplacée par page) ; sélectionner dans un autre topic le remplace ; retirer le dernier post le vide ;
- `PostEditorRoute.extraQuoteNumreponses: List<Int>` (défaut vide — les back stacks sérialisés existants désérialisent) ;
- extras fetchés séquentiellement avec `quotedNumreponse` swappé et `quoteRef = null` (positionnel, propre au premier post) ;
- **échec d'un extra = échec global** (retryable) — perdre silencieusement une citation explicitement sélectionnée serait pire ;
- sélection à 1 post = dégénère exactement en quote simple ;
- compteur FAB mis à zéro quand `shouldShowQuoteAction` est faux (topic verrouillé, session anonyme) — le panier n'annonce jamais une action inutilisable.

## Tests

- concat dans l'ordre de SÉLECTION (pas l'ordre des posts) + contrat des extras (`numreponse` swappé, `quoteRef` null) ;
- échec d'un extra → `SubmitError.Network`, draft non hydraté ;
- fake `ReplyRepository` étendu (`formResultsByNumrep`, `fetchedContexts`).

## Validation

2 parts locales : `detektAll test :app:assembleProdDebug` puis `:app:lintProdDebug` — BUILD SUCCESSFUL ×2.

Note : mot-clé de fermeture volontairement cassé (`refs-#291`) — fermeture à la promotion dev→main.