### PR TITLE
feat(messages): swipe de pages sur la conversation MP — in-place (refs-#351, tranche b)

### DIFF
--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
@@ -30,11 +30,15 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -48,6 +52,7 @@ import fr.forumhfr.redface2.core.model.Post
 import fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar
 import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.list.LazyListScrollbar
+import fr.forumhfr.redface2.core.ui.pager.pageSwipeEdgeHint
 import fr.forumhfr.redface2.core.ui.post.PostRenderer
 import java.time.Instant
 import java.time.ZoneId
@@ -228,7 +233,8 @@ fun PrivateMessageThreadScreen(
                         modifier = Modifier.fillMaxSize(),
                     ) {
                         // #300/#351 — same overlay layout as the topic page: the shared scrollbar
-                        // rides the right edge of the message list.
+                        // rides the right edge of the message list, OUTSIDE the swiped element so
+                        // it stays put while the page follows the finger.
                         Box(modifier = Modifier.fillMaxSize()) {
                             ThreadMessages(
                                 messages = mode.thread.messages,
@@ -236,6 +242,14 @@ fun PrivateMessageThreadScreen(
                                 totalPages = state.totalPages,
                                 onSelectPage = viewModel::selectPage,
                                 listState = listState,
+                                // #351b — horizontal swipe changes page in place (same thresholds
+                                // and feel as the topic via the shared :core:ui geometry).
+                                swipeModifier = rememberThreadSwipeModifier(
+                                    renderedPage = mode.thread.page,
+                                    totalPages = state.totalPages,
+                                    isRefreshing = state.isRefreshing,
+                                    onSelectPage = viewModel::selectPage,
+                                ),
                             )
                             LazyListScrollbar(
                                 listState = listState,
@@ -270,17 +284,75 @@ private fun ScrollToTopOnPageChange(listState: LazyListState, renderedPage: Int)
     }
 }
 
+/**
+ * #351b — builds the swipe modifier chain for the message list: shared edge glow
+ * ([pageSwipeEdgeHint]) + in-place page-change gesture ([threadPageSwipe]).
+ *
+ * Every input the gesture needs later is wrapped in [rememberUpdatedState] and read through
+ * stable lambdas: [threadPageSwipe]'s `pointerInput` is keyed on `Unit` and NEVER re-keyed (the
+ * in-place pager changes pages under a live composition), so the lambdas captured by its initial
+ * block must keep reading live values for the whole life of the composition. The gesture is gated
+ * off while a load is in flight ([isRefreshing]) and re-arms when it settles.
+ */
 @Composable
+private fun rememberThreadSwipeModifier(
+    renderedPage: Int,
+    totalPages: Int,
+    isRefreshing: Boolean,
+    onSelectPage: (Int) -> Unit,
+): Modifier {
+    val dragOffset = remember { mutableFloatStateOf(0f) }
+    val haptics = LocalHapticFeedback.current
+    val currentPage = rememberUpdatedState(renderedPage)
+    val currentTotal = rememberUpdatedState(totalPages)
+    val swipeEnabled = rememberUpdatedState(!isRefreshing)
+    val currentOnSelectPage = rememberUpdatedState(onSelectPage)
+    // Same desaturated accent as the topic edge glow (#282): mostly neutral with a touch of primary.
+    val accent = lerp(
+        MaterialTheme.colorScheme.onSurfaceVariant,
+        MaterialTheme.colorScheme.primary,
+        ACCENT_PRIMARY_BLEND,
+    )
+    val handlers = remember(haptics) {
+        ThreadSwipeHandlers(
+            haptics = haptics,
+            onSelectPage = { page -> currentOnSelectPage.value(page) },
+            enabled = { swipeEnabled.value },
+        )
+    }
+    return Modifier
+        .pageSwipeEdgeHint(
+            currentPage = renderedPage,
+            totalPages = { currentTotal.value },
+            dragOffset = dragOffset,
+            accent = accent,
+            enabled = { swipeEnabled.value },
+        )
+        .threadPageSwipe(
+            currentPage = { currentPage.value },
+            totalPages = { currentTotal.value },
+            dragOffset = dragOffset,
+            handlers = handlers,
+        )
+}
+
+@Composable
+@Suppress("LongParameterList") // List host: pager triple + hoisted list state + swipe chain, all distinct.
 private fun ThreadMessages(
     messages: List<Post>,
     page: Int,
     totalPages: Int,
     onSelectPage: (Int) -> Unit,
     listState: LazyListState,
+    swipeModifier: Modifier = Modifier,
 ) {
     LazyColumn(
         state = listState,
-        modifier = Modifier.fillMaxSize(),
+        // #351b — the swipe chain (edge glow + gesture + graphicsLayer follow) applies to the list
+        // itself, like the topic's LazyColumn: the scrollbar overlay outside stays fixed on screen.
+        modifier = Modifier
+            .fillMaxSize()
+            .then(swipeModifier),
         contentPadding = PaddingValues(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
@@ -353,6 +425,9 @@ private fun MessageCard(message: Post) {
         }
     }
 }
+
+// #351b — same blend as the topic edge glow (#282): a full-primary glow read as an imposing panel.
+private const val ACCENT_PRIMARY_BLEND = 0.3f
 
 private val messageDateFormatter = DateTimeFormatter
     .ofPattern("dd/MM/yyyy HH:mm:ss", Locale.FRANCE)

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
@@ -241,6 +241,10 @@ fun PrivateMessageThreadScreen(
                                 page = state.page,
                                 totalPages = state.totalPages,
                                 onSelectPage = viewModel::selectPage,
+                                // Codex review — gate the pager buttons with the same condition as
+                                // the swipe: re-tapping during a keep-content load would only cancel
+                                // and restart the round-trip (supersede), never advance faster.
+                                pagerEnabled = !state.isRefreshing,
                                 listState = listState,
                                 // #351b — horizontal swipe changes page in place (same thresholds
                                 // and feel as the topic via the shared :core:ui geometry).
@@ -307,13 +311,26 @@ private fun rememberThreadSwipeModifier(
     val currentTotal = rememberUpdatedState(totalPages)
     val swipeEnabled = rememberUpdatedState(!isRefreshing)
     val currentOnSelectPage = rememberUpdatedState(onSelectPage)
+    // Codex review — dragOffset SURVIVES the in-place page change (no composition teardown, unlike
+    // the topic's route-driven model where the offset state dies with the screen). Drop any residual
+    // translation when a new page lands so the incoming content never inherits the old offset. An
+    // in-flight spring-back may stream a few frames after this reset; it converges to 0 by
+    // construction, so the transient is negligible. A drag still under the finger keeps following it
+    // (rare: the page swapped under an active drag) — coherent with the finger, assumed.
+    LaunchedEffect(renderedPage) {
+        dragOffset.floatValue = 0f
+    }
     // Same desaturated accent as the topic edge glow (#282): mostly neutral with a touch of primary.
     val accent = lerp(
         MaterialTheme.colorScheme.onSurfaceVariant,
         MaterialTheme.colorScheme.primary,
         ACCENT_PRIMARY_BLEND,
     )
-    val handlers = remember(haptics) {
+    // Captured ONCE by threadPageSwipe's pointerInput(Unit) block — deliberately remember-ed without
+    // keys so the code does not pretend a recreation would reach the gesture (it would not: the
+    // initial block keeps its first capture). The callback and the gate stay live through the
+    // rememberUpdatedState-backed lambdas; haptics (LocalHapticFeedback) is stable per Activity.
+    val handlers = remember {
         ThreadSwipeHandlers(
             haptics = haptics,
             onSelectPage = { page -> currentOnSelectPage.value(page) },
@@ -337,12 +354,13 @@ private fun rememberThreadSwipeModifier(
 }
 
 @Composable
-@Suppress("LongParameterList") // List host: pager triple + hoisted list state + swipe chain, all distinct.
+@Suppress("LongParameterList") // List host: pager state + hoisted list state + swipe chain, all distinct.
 private fun ThreadMessages(
     messages: List<Post>,
     page: Int,
     totalPages: Int,
     onSelectPage: (Int) -> Unit,
+    pagerEnabled: Boolean = true,
     listState: LazyListState,
     swipeModifier: Modifier = Modifier,
 ) {
@@ -368,14 +386,20 @@ private fun ThreadMessages(
                     horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    OutlinedButton(onClick = { onSelectPage(page - 1) }, enabled = page > 1) {
+                    OutlinedButton(
+                        onClick = { onSelectPage(page - 1) },
+                        enabled = pagerEnabled && page > 1,
+                    ) {
                         Text(text = stringResource(R.string.messages_pager_previous))
                     }
                     Text(
                         text = stringResource(R.string.messages_pager_position, page, totalPages),
                         style = MaterialTheme.typography.labelLarge,
                     )
-                    OutlinedButton(onClick = { onSelectPage(page + 1) }, enabled = page < totalPages) {
+                    OutlinedButton(
+                        onClick = { onSelectPage(page + 1) },
+                        enabled = pagerEnabled && page < totalPages,
+                    ) {
                         Text(text = stringResource(R.string.messages_pager_next))
                     }
                 }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/ThreadPageSwipe.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/ThreadPageSwipe.kt
@@ -1,0 +1,173 @@
+package fr.forumhfr.redface2.feature.messages
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitHorizontalTouchSlopOrCancellation
+import androidx.compose.foundation.gestures.horizontalDrag
+import androidx.compose.runtime.MutableFloatState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.input.pointer.util.VelocityTracker
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.ui.pager.FLING_VELOCITY_THRESHOLD
+import fr.forumhfr.redface2.core.ui.pager.MIN_COMMIT_DISTANCE
+import fr.forumhfr.redface2.core.ui.pager.swipeArmed
+import fr.forumhfr.redface2.core.ui.pager.swipeCommitDirection
+import fr.forumhfr.redface2.core.ui.pager.swipeCommitDistancePx
+import fr.forumhfr.redface2.core.ui.pager.swipeFollowOffset
+import fr.forumhfr.redface2.core.ui.pager.swipeTargetPage
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Horizontal swipe → change conversation page (#351b): the **in-place** counterpart of the topic's
+ * route-driven `topicPageSwipe` (#282). The *feel* is identical by construction — thresholds,
+ * drag-follow shaping and edge hint all come from the shared pure geometry in
+ * `:core:ui` (`core.ui.pager.PageSwipe`) — but the machinery differs on purpose (ADR-013):
+ *
+ * - **Commit → [ThreadSwipeHandlers.onSelectPage]**, the same in-place reload the pager buttons
+ *   use: the ViewModel keeps the displayed page on screen behind `isRefreshing` (keep-content load,
+ *   #351a) and swaps it when the new page lands. The composition SURVIVES the page change, so there
+ *   is **no slide-out**: a committed page springs back to rest and stays readable while the network
+ *   round-trip runs. The "network feel" is assumed — `cat=prive` is auth-only, so there is no
+ *   anonymous prefetch and (per ADR-013) no persisted cache to make the landing instant.
+ * - **No per-composition re-entrance latch**: the topic latch exists because its composition is
+ *   torn down by the route change; here the gesture is instead gated by
+ *   [ThreadSwipeHandlers.enabled] (wired to `!isRefreshing` at the call site), which re-arms
+ *   naturally when the load settles. The gate is read at `down`, so a swipe during an in-flight
+ *   load is inert (same UX as the disabled pager buttons would be). A commit that races the
+ *   `isRefreshing` state propagation can at worst re-issue `onSelectPage` for the same target
+ *   (currentPage has not changed yet); the ViewModel's load() supersedes the in-flight identical
+ *   request — benign by construction.
+ * - [currentPage] and [totalPages] are lambdas (backed by `rememberUpdatedState` at the call site):
+ *   the in-place model changes the page UNDER a live composition, so the gesture — keyed on `Unit`,
+ *   never re-keyed — must read both fresh on every frame.
+ *
+ * Coexistence mirrors the topic gesture: horizontal slop only (the vertical list scroll and the
+ * pull-to-refresh nested-scroll are never stolen), a child consuming the horizontal drag first
+ * cancels ours, edges are a damped no-op wall.
+ */
+internal fun Modifier.threadPageSwipe(
+    currentPage: () -> Int,
+    totalPages: () -> Int,
+    dragOffset: MutableFloatState,
+    handlers: ThreadSwipeHandlers,
+): Modifier = this
+    // `pointerInput` BEFORE `graphicsLayer`, same constraint as the topic gesture: deltas must be
+    // read in the untranslated coordinate space (inside the translated layer each frame's
+    // `positionChange()` would be Δfinger − Δtranslation → halved tracking, doubled commit
+    // distance). Keyed on Unit: nothing in here ever needs a restart — pages, counts and the gate
+    // are all read through live lambdas.
+    .pointerInput(Unit) {
+        val commitDistancePx = swipeCommitDistancePx(size.width.toFloat(), MIN_COMMIT_DISTANCE.toPx())
+        val flingThresholdPx = FLING_VELOCITY_THRESHOLD.toPx()
+        // Reserved for the spring-back release transition; the drag writes `dragOffset`
+        // synchronously per frame (no coroutine, no allocation), the Animatable streams back into
+        // the same state on release.
+        val release = Animatable(0f)
+        coroutineScope {
+            val animationScope = this
+            var releaseJob: Job? = null
+            awaitEachGesture {
+                val down = awaitFirstDown(requireUnconsumed = false)
+                // Gate at `down`: while a page load is in flight (isRefreshing) the swipe is inert,
+                // and it re-arms when the load settles — the in-place equivalent of the topic's
+                // "ignore until the route change tears this down".
+                if (!handlers.enabled()) return@awaitEachGesture
+                val velocityTracker = VelocityTracker()
+                velocityTracker.addPosition(down.uptimeMillis, down.position)
+                var overSlop = 0f
+                val drag = awaitHorizontalTouchSlopOrCancellation(down.id) { change, slop ->
+                    change.consume()
+                    overSlop = slop
+                } ?: return@awaitEachGesture
+                // Cancel a running spring-back deterministically at slop crossing (not at `down`,
+                // which would let a mere tap interrupt it). Synchronous Job.cancel(): no late
+                // fire-and-forget stop() racing a newer animation (same reasoning as #282).
+                releaseJob?.cancel()
+                var totalDx = overSlop
+                var armed = false
+                velocityTracker.addPosition(drag.uptimeMillis, drag.position)
+                dragOffset.floatValue =
+                    threadFollowOffset(totalDx, commitDistancePx, currentPage(), totalPages())
+                val completed = horizontalDrag(drag.id) { change ->
+                    totalDx += change.positionChange().x
+                    velocityTracker.addPosition(change.uptimeMillis, change.position)
+                    val offset =
+                        threadFollowOffset(totalDx, commitDistancePx, currentPage(), totalPages())
+                    dragOffset.floatValue = offset
+                    val nowArmed = swipeArmed(offset, commitDistancePx)
+                    if (nowArmed && !armed) {
+                        handlers.haptics.performHapticFeedback(
+                            HapticFeedbackType.GestureThresholdActivate,
+                        )
+                    }
+                    armed = nowArmed
+                    change.consume()
+                }
+                if (completed) {
+                    val velocityX = velocityTracker.calculateVelocity().x
+                    val forward =
+                        swipeCommitDirection(totalDx, velocityX, commitDistancePx, flingThresholdPx)
+                    val target = forward?.let { swipeTargetPage(currentPage(), totalPages(), it) }
+                    if (forward != null && target != null) {
+                        handlers.haptics.performHapticFeedback(HapticFeedbackType.Confirm)
+                        handlers.onSelectPage(target)
+                    }
+                }
+                // ALWAYS spring back — commit included: with no slide-out (the composition is kept),
+                // the page returns to rest and stays readable behind the refresh indicator until the
+                // new page lands (the screen then scrolls to top and resets the offset).
+                releaseJob = animationScope.launch {
+                    release.snapTo(dragOffset.floatValue)
+                    release.animateTo(0f, THREAD_SPRING_BACK) { dragOffset.floatValue = value }
+                }
+            }
+        }
+    }
+    // Draw-only translation + armed elevation lift, same draw-phase contract as the topic gesture
+    // (reads `dragOffset` without recomposition; the lift sells "release will turn the page").
+    .graphicsLayer {
+        val offset = dragOffset.floatValue
+        translationX = offset
+        val commitDistancePx = swipeCommitDistancePx(size.width, MIN_COMMIT_DISTANCE.toPx())
+        shadowElevation =
+            if (swipeArmed(offset, commitDistancePx)) THREAD_COMMIT_SHADOW_ELEVATION_DP.dp.toPx() else 0f
+    }
+
+/**
+ * Non-per-frame inputs of [threadPageSwipe], bundled (same shape as `TopicSwipeHandlers`) so the
+ * gesture's parameter list stays within the project's limit. [enabled] is read once per gesture at
+ * `down` and re-arms when the in-flight load settles; [onSelectPage] performs the in-place page
+ * change (keep-content load).
+ */
+internal class ThreadSwipeHandlers(
+    val haptics: HapticFeedback,
+    val onSelectPage: (Int) -> Unit,
+    val enabled: () -> Boolean,
+)
+
+private fun threadFollowOffset(
+    totalDx: Float,
+    commitDistancePx: Float,
+    currentPage: Int,
+    totalPages: Int,
+): Float {
+    val hasTarget = swipeTargetPage(currentPage, totalPages, forward = totalDx < 0f) != null
+    return swipeFollowOffset(totalDx, commitDistancePx, hasTarget)
+}
+
+private const val THREAD_COMMIT_SHADOW_ELEVATION_DP = 8f
+
+private val THREAD_SPRING_BACK = spring<Float>(
+    dampingRatio = Spring.DampingRatioNoBouncy,
+    stiffness = Spring.StiffnessMedium,
+)


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Tranche **b** de refs-#351 : **swipe horizontal de pages sur la conversation MP**, version **in-place** actée dans l'analyse de l'issue (« le portage minimal coûte peu → faisable, retenu »). S'appuie sur la tranche a (#428) : géométrie partagée `:core:ui` + chargements keep-content.

## Ce que fait le geste

- **Mêmes seuils, même ressenti que le topic par construction** : distance de commit, fling, drag-follow 1:1 + overpull tanh, mur amorti aux bords, edge-glow tardif + accent armé, haptique armement/commit — tout vient des fonctions pures partagées de `core.ui.pager` (#282). Le glow réutilise le modifier partagé `pageSwipeEdgeHint` avec le même accent désaturé.
- **Commit → `selectPage(target)`**, le même rechargement in-place que les boutons du pager : la page affichée **reste lisible** derrière l'indicateur de refresh pendant le round-trip (keep-content, tranche a), puis la nouvelle page atterrit en haut. **Pas de slide-out** — la composition survit au changement de page, contrairement au topic route-driven. Le « ressenti réseau » est assumé (cf. issue) : `cat=prive` est auth-only → pas de prefetch anonyme possible, et pas de cache persisté (ADR-013).
- **Pas de latch de réentrance par composition** (le mécanisme topic n'a pas de sens ici) : le geste est **gated sur `isRefreshing`** lu au `down` — inerte pendant un chargement, ré-armé naturellement quand il se pose. La micro-course commit ↔ propagation d'état peut au pire ré-émettre `selectPage` pour la même cible (supersede bénin dans le ViewModel).
- `pointerInput(Unit)` jamais re-keyé (le pager change de page sous une composition vivante) : page courante, total, gate et callback sont tous lus à travers des lambdas adossées à `rememberUpdatedState` — y compris dans `ThreadSwipeHandlers`, créé une fois et capturé par le bloc initial.
- Coexistence identique au topic : slop horizontal uniquement (le scroll vertical et le nested-scroll du pull-to-refresh ne sont jamais volés), un enfant qui consomme le drag annule le geste, bords = no-op amorti. Le swipe s'applique à la `LazyColumn` ; l'ascenseur overlay reste fixe à l'écran pendant le follow.

## Hors périmètre (assumé)

- **Restauration de la page après process death** (la route reste figée sur la page d'ouverture) : la solution actée par l'ADR-013 est la **position de lecture locale par conversation** (étage 1 du cache MP, format aligné MPStorage2 #6) — « mieux que SavedStateHandle ». Micro-issue dédiée ouverte : voir lien en commentaire.
- Convergence route-driven topic↔MP : suspendue au critère de l'ADR-013 ; si elle arrive, ce geste in-place est remplacé à coût nul (les fonctions pures partagées restent la base).

## Validation

- Locale verte (2 parts) : `detektAll test :app:assembleProdDebug` puis `:app:lintProdDebug`.
- La logique nouvelle testable (géométrie, keep-content) est déjà couverte par les tests de la tranche a ; la machinerie `pointerInput` n'a pas de test unitaire, comme son équivalent topic (`topicPageSwipe`).
- Mot-clé volontairement cassé (`refs-#351`) : fermeture à la promotion dev→main.
