### PR TITLE
fix(flags): auto-refresh non throttlé au retour d'un sujet ouvert depuis la liste (refs-#378)

### DIFF
--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -224,7 +224,13 @@ fun FlagsRoute(
                             ),
                             actions = AuthenticatedActions(
                                 onSelectTab = viewModel::selectTab,
-                                onOpenFlag = onOpenFlag,
+                                // #378 follow-up — record the read BEFORE navigating: returning
+                                // from this topic must bypass the auto-refresh throttle (the flag
+                                // state just changed), cf. FlagsViewModel.onFlagOpened.
+                                onOpenFlag = { flag ->
+                                    viewModel.onFlagOpened()
+                                    onOpenFlag(flag)
+                                },
                                 onRefresh = viewModel::refresh,
                                 onLoginRequested = onLoginRequested,
                                 onRequestRemoveFlag = viewModel::requestRemoveFlag,

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -65,12 +65,16 @@ class FlagsViewModel @Inject constructor(
     private var lastAutoRefreshAt: Instant? = null
 
     /**
-     * #378 follow-up — armed by [onFlagOpened] (a topic was opened from this list), consumed by
-     * the next refresh ([maybeAutoRefresh] bypassing the throttle, or a manual [refresh] that
-     * captures the same post-reading state). Same ViewModel scoping rationale as
+     * #378 follow-up — generation counter incremented by [onFlagOpened] (a topic was opened from
+     * this list). A refresh CONSUMES the generations it can see at its **call time** by advancing
+     * [flagOpenedGenerationConsumed]; [maybeAutoRefresh] bypasses the throttle while un-consumed
+     * generations remain. A counter (not a boolean) so a read armed WHILE a landing refresh is
+     * suspended on its pref/auth gates is never swallowed by that refresh — it could not have
+     * captured that reading yet (Codex review on this PR). Same ViewModel scoping rationale as
      * [lastAutoRefreshAt].
      */
-    private var flagOpenedSinceLastAutoRefresh = false
+    private var flagOpenedGeneration = 0L
+    private var flagOpenedGenerationConsumed = 0L
 
     private val _selectedTab = MutableStateFlow<FlagTab>(FlagTab.Cyan)
     val selectedTab: StateFlow<FlagTab> = _selectedTab.asStateFlow()
@@ -511,9 +515,9 @@ class FlagsViewModel @Inject constructor(
     fun refresh() {
         // Super is a placeholder with no backing FlagType — pull-to-refresh is a no-op there.
         val type = _selectedTab.value.flagType ?: return
-        // A manual refresh captures the post-reading state too, so a pending "topic was opened"
-        // bypass would only duplicate the fan-out on the next landing — consume it (#378 follow-up).
-        flagOpenedSinceLastAutoRefresh = false
+        // A manual refresh captures the post-reading state too, so the generations visible at this
+        // call would only duplicate the fan-out on the next landing — consume them (#378 follow-up).
+        flagOpenedGenerationConsumed = flagOpenedGeneration
         viewModelScope.launch {
             _isRefreshing.value = true
             try {
@@ -534,7 +538,7 @@ class FlagsViewModel @Inject constructor(
      * is what it was for — the REST fan-out is one GET per public category.
      */
     fun onFlagOpened() {
-        flagOpenedSinceLastAutoRefresh = true
+        flagOpenedGeneration++
     }
 
     /**
@@ -557,23 +561,29 @@ class FlagsViewModel @Inject constructor(
         // no-op on a placeholder while still arming the throttle (Codex review on PR #421).
         val type = _selectedTab.value.flagType ?: return
         if (_isRefreshing.value) return
+        // Snapshot at CALL time (same rationale as the tab snapshot above): a read armed AFTER
+        // this landing's call belongs to the NEXT landing. The launch suspends on the pref/auth
+        // gates below — reading the generation there would let this refresh consume a reading it
+        // cannot have captured yet, losing the bypass for the actual return (Codex review).
+        val openedGenerationAtCall = flagOpenedGeneration
         viewModelScope.launch {
             if (!userPreferencesRepository.observeFlagsAutoRefresh().first()) return@launch
             if (authRepository.observeAuthState().first() !is AuthState.Authenticated) return@launch
             val now = clock.instant()
             val last = lastAutoRefreshAt
-            // Throttle SKIPPED when a topic was opened since the last refresh (see [onFlagOpened]):
-            // that landing is a return from a read, the state most worth refreshing.
-            val returningFromTopic = flagOpenedSinceLastAutoRefresh
+            // Throttle SKIPPED when a topic was opened since the last consuming refresh (see
+            // [onFlagOpened]): that landing is a return from a read, the state most worth
+            // refreshing.
+            val returningFromTopic = openedGenerationAtCall > flagOpenedGenerationConsumed
             if (!returningFromTopic && last != null && Duration.between(last, now) < AUTO_REFRESH_THROTTLE) {
                 return@launch
             }
             // Re-check after the suspensions: a manual pull-to-refresh may have started while
             // the pref/auth reads were in flight — don't double the REST fan-out.
             if (_isRefreshing.value) return@launch
-            // Consumed by the refresh this very landing triggers — the NEXT landing without a
-            // new read falls back to the plain throttle window.
-            flagOpenedSinceLastAutoRefresh = false
+            // Consume ONLY the generations visible at call time — a read armed during the
+            // suspensions above stays pending for the next landing.
+            flagOpenedGenerationConsumed = maxOf(flagOpenedGenerationConsumed, openedGenerationAtCall)
             lastAutoRefreshAt = now
             _isRefreshing.value = true
             try {

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -64,6 +64,14 @@ class FlagsViewModel @Inject constructor(
      */
     private var lastAutoRefreshAt: Instant? = null
 
+    /**
+     * #378 follow-up — armed by [onFlagOpened] (a topic was opened from this list), consumed by
+     * the next refresh ([maybeAutoRefresh] bypassing the throttle, or a manual [refresh] that
+     * captures the same post-reading state). Same ViewModel scoping rationale as
+     * [lastAutoRefreshAt].
+     */
+    private var flagOpenedSinceLastAutoRefresh = false
+
     private val _selectedTab = MutableStateFlow<FlagTab>(FlagTab.Cyan)
     val selectedTab: StateFlow<FlagTab> = _selectedTab.asStateFlow()
 
@@ -503,6 +511,9 @@ class FlagsViewModel @Inject constructor(
     fun refresh() {
         // Super is a placeholder with no backing FlagType — pull-to-refresh is a no-op there.
         val type = _selectedTab.value.flagType ?: return
+        // A manual refresh captures the post-reading state too, so a pending "topic was opened"
+        // bypass would only duplicate the fan-out on the next landing — consume it (#378 follow-up).
+        flagOpenedSinceLastAutoRefresh = false
         viewModelScope.launch {
             _isRefreshing.value = true
             try {
@@ -511,6 +522,19 @@ class FlagsViewModel @Inject constructor(
                 _isRefreshing.value = false
             }
         }
+    }
+
+    /**
+     * #378 follow-up (retours dev v118) — the screen calls this when the user opens a topic from
+     * the list. The next [maybeAutoRefresh] then BYPASSES the throttle window: coming back from a
+     * just-read topic is precisely when the flag state changed (the read topic should drop out of
+     * an unread-only view), and the 15 s window was eating exactly that case for fast readers
+     * ("je lis vite fait le dernier message → retour → pas de refresh"). The throttle keeps
+     * protecting the no-read round-trips (bottom-tab switches, immediate back-and-forth), which
+     * is what it was for — the REST fan-out is one GET per public category.
+     */
+    fun onFlagOpened() {
+        flagOpenedSinceLastAutoRefresh = true
     }
 
     /**
@@ -538,10 +562,18 @@ class FlagsViewModel @Inject constructor(
             if (authRepository.observeAuthState().first() !is AuthState.Authenticated) return@launch
             val now = clock.instant()
             val last = lastAutoRefreshAt
-            if (last != null && Duration.between(last, now) < AUTO_REFRESH_THROTTLE) return@launch
+            // Throttle SKIPPED when a topic was opened since the last refresh (see [onFlagOpened]):
+            // that landing is a return from a read, the state most worth refreshing.
+            val returningFromTopic = flagOpenedSinceLastAutoRefresh
+            if (!returningFromTopic && last != null && Duration.between(last, now) < AUTO_REFRESH_THROTTLE) {
+                return@launch
+            }
             // Re-check after the suspensions: a manual pull-to-refresh may have started while
             // the pref/auth reads were in flight — don't double the REST fan-out.
             if (_isRefreshing.value) return@launch
+            // Consumed by the refresh this very landing triggers — the NEXT landing without a
+            // new read falls back to the plain throttle window.
+            flagOpenedSinceLastAutoRefresh = false
             lastAutoRefreshAt = now
             _isRefreshing.value = true
             try {

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -34,6 +34,8 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.onSubscription
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -1233,6 +1235,29 @@ class FlagsViewModelTest {
         vm.maybeAutoRefresh() // bypass consumed here
         vm.maybeAutoRefresh() // plain re-landing without a new read — throttled again
 
+        assertEquals(2, flags.refreshCalls.size)
+    }
+
+    @Test
+    fun `a read armed while the landing refresh is suspended stays pending for the return`() = runTest {
+        // Codex review — maybeAutoRefresh snapshots the opened-generation at CALL time: a topic
+        // opened while the landing refresh is still queued/suspended on its pref/auth gates must
+        // NOT be consumed by that refresh (it cannot have captured the reading yet), so the
+        // actual return from the topic still bypasses the throttle.
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)
+        val clock = SteppingClock(Instant.parse("2026-06-11T12:00:00Z"))
+        val vm = FlagsViewModel(auth, flags, FakeForumRepository(), FakeUserPreferencesRepository(), clock)
+        advanceUntilIdle() // settle the init collectors
+
+        vm.maybeAutoRefresh() // landing — generation snapshot taken now, body not yet run
+        vm.onFlagOpened() // user opens a topic before the landing refresh resumed
+        advanceUntilIdle() // landing refresh runs: throttle armed, the read is NOT consumed
+        assertEquals(1, flags.refreshCalls.size)
+
+        vm.maybeAutoRefresh() // back from the topic, inside the 15 s window — still bypasses
+        advanceUntilIdle()
         assertEquals(2, flags.refreshCalls.size)
     }
 

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1206,6 +1206,54 @@ class FlagsViewModelTest {
     }
 
     @Test
+    fun `maybeAutoRefresh bypasses the throttle when a topic was opened since the last refresh`() = runTest {
+        // #378 follow-up (retours dev v118, Dintr-un lemn + bitubo) — coming back from a
+        // just-read topic must refresh even inside the 15 s window: the read changed the state.
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)
+        val clock = SteppingClock(Instant.parse("2026-06-11T12:00:00Z"))
+        val vm = FlagsViewModel(auth, flags, FakeForumRepository(), FakeUserPreferencesRepository(), clock)
+
+        vm.maybeAutoRefresh() // landing refresh, arms the throttle
+        vm.onFlagOpened() // user opens a topic from the list…
+        vm.maybeAutoRefresh() // …and comes right back (< 15 s)
+
+        assertEquals(2, flags.refreshCalls.size)
+    }
+
+    @Test
+    fun `the topic-opened bypass is consumed by the refresh it triggers`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)
+        val clock = SteppingClock(Instant.parse("2026-06-11T12:00:00Z"))
+        val vm = FlagsViewModel(auth, flags, FakeForumRepository(), FakeUserPreferencesRepository(), clock)
+
+        vm.maybeAutoRefresh()
+        vm.onFlagOpened()
+        vm.maybeAutoRefresh() // bypass consumed here
+        vm.maybeAutoRefresh() // plain re-landing without a new read — throttled again
+
+        assertEquals(2, flags.refreshCalls.size)
+    }
+
+    @Test
+    fun `a manual refresh consumes the pending topic-opened bypass`() = runTest {
+        // The pull captured the post-reading state already; the next landing inside the window
+        // must not duplicate the REST fan-out.
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)
+        val clock = SteppingClock(Instant.parse("2026-06-11T12:00:00Z"))
+        val vm = FlagsViewModel(auth, flags, FakeForumRepository(), FakeUserPreferencesRepository(), clock)
+
+        vm.maybeAutoRefresh() // arms the throttle
+        vm.onFlagOpened()
+        vm.refresh() // manual pull right after coming back
+        vm.maybeAutoRefresh() // landing inside the window, no new read since the pull
+
+        assertEquals(2, flags.refreshCalls.size)
+    }
+
+    @Test
     fun `manual refresh is never throttled by a preceding auto-refresh`() = runTest {
         val flags = FakeFlagRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Fix du retour testeurs dev v118 sur l'auto-refresh des drapeaux (refs-#378) :

- **Dintr-un lemn** ([#2787231](https://forum.hardware.fr/forum2.php?config=hfr.inc&cat=23&subcat=550&post=35421&page=8#t2787231)) : « le refresh auto ne fonctionne pas lorsqu'on ouvre le dernier topic non lu d'une catégorie ».
- **bitubo** ([#2787232](https://forum.hardware.fr/forum2.php?config=hfr.inc&cat=23&subcat=550&post=35421&page=8#t2787232)) : « il marche quand on reste un certain temps dans le topic ; si on lit vite fait le dernier message, au retour le refresh ne se fait pas ».

## Diagnostic (confirmé dans le code)

Signature exacte du **throttle 15 s** (`AUTO_REFRESH_THROTTLE`, `FlagsViewModel.maybeAutoRefresh`) : l'atterrissage sur la liste arme la fenêtre, et un aller-retour topic plus rapide que 15 s est throttlé — précisément le cas où l'état vient de changer (le sujet lu devrait sortir d'une vue « non-lus »). Le « ça marche chez moi » de @XaTriX ([#2787222](https://forum.hardware.fr/forum2.php?config=hfr.inc&cat=23&subcat=550&post=35421&page=8#t2787222)) colle : au-delà de 15 s dans le topic, le retour repasse.

## Fix

`FlagsRoute` marque l'ouverture d'un topic depuis la liste (`FlagsViewModel.onFlagOpened()`, appelé dans le callback `onOpenFlag` avant la navigation). Le `maybeAutoRefresh` suivant **bypasse le throttle** et consomme le marqueur ; un refresh manuel le consomme aussi (il capture le même état post-lecture). Les allers-retours **sans** lecture (switch d'onglets bottom nav, re-landing immédiat) restent throttlés — la protection du fan-out REST (~1 GET par catégorie) garde sa raison d'être.

3 tests VM ajoutés (bypass, consommation par le refresh déclenché, consommation par un pull manuel) — 51/51 verts.

## Validation

Locale verte (2 parts) : `detektAll` + tests `:feature:flags` + `:app:assembleProdDebug` puis `:app:lintProdDebug`. Mot-clé volontairement cassé (`refs-#378`) : l'issue ferme à la promotion dev→main.
