### PR TITLE
fix(messages): saisie du nouveau MP visible clavier ouvert — body scrollable (refs-#275, refs-#410)

### DIFF
--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
@@ -164,12 +165,18 @@ private fun ComposeEditorBody(
     onErrorDismissed: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    // Same extensible-field design as the reply editor : no outer scroll, the draft stretches to
-    // the bar, long content scrolls in the field's own fillViewport column (#275/#410) / the
-    // preview pane.
+    // #275/#410 follow-up (dev v118 feedback, screen 520813) — compose is the ONE editor whose
+    // fixed header (recipients + subject + toolbar, ~300dp) could squeeze the weighted draft
+    // field to ~zero once the IME opened, with no outer scroll to bring it back into view: the
+    // reply editor's « no outer scroll, fillViewport field » design assumes the field owns most
+    // of the body. Header-heavy editors use the OTHER documented branch of the BbcodeTextField
+    // contract (cf. TopicFormScreen): the WHOLE body scrolls and the field keeps the default
+    // grow-with-content mode — cursor bring-into-view and IME re-anchoring route through this
+    // outer column (fillViewport here would nest two unbounded same-direction scrollables).
     Column(
         modifier = modifier
             .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
@@ -208,10 +215,11 @@ private fun ComposeEditorBody(
             onValueChange = onContentChanged,
             label = stringResource(R.string.messages_reply_field_label),
             placeholder = stringResource(R.string.messages_reply_field_placeholder),
-            modifier = Modifier.weight(1f),
-            // #275/#410 — grow-with-content field in its own scrollable viewport so the
-            // cursor stays visible under the IME (typing AND refocus after the preview).
-            fillViewport = true,
+            // Default grow-with-content mode inside the outer scroll (see the column comment):
+            // a min height keeps a real tap-target/typing area even with an empty draft.
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = COMPOSE_DRAFT_MIN_HEIGHT),
         )
 
         Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
@@ -230,13 +238,9 @@ private fun ComposeEditorBody(
 
         if (state.isPreviewVisible) {
             HorizontalDivider()
-            Column(
-                modifier = Modifier
-                    .weight(1f)
-                    .verticalScroll(rememberScrollState()),
-            ) {
-                BbcodePreview(content = state.preview)
-            }
+            // Plain block inside the outer scroll (a nested same-direction verticalScroll is a
+            // Compose error) — same shape as TopicFormScreen's preview.
+            BbcodePreview(content = state.preview, modifier = Modifier.fillMaxWidth())
         }
 
         state.submitError?.let { error ->
@@ -260,3 +264,7 @@ private fun ComposeEditorBody(
         }
     }
 }
+
+// #275/#410 follow-up — minimum draft area inside the scrollable compose body: with an empty
+// draft the outlined field still offers a real tap/typing target under the header fields.
+private val COMPOSE_DRAFT_MIN_HEIGHT = 160.dp


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Fix du retour dev v118 de @XaTriX ([#2787221](https://forum.hardware.fr/forum2.php?config=hfr.inc&cat=23&subcat=550&post=35421&page=8#t2787221), screen [520813](https://rehost.diberie.com/Picture/Get/r/520813)) : sur l'éditeur **« Nouveau message » (MP)**, clavier ouvert, **la zone de saisie du message disparaît** — destinataire + sujet + barre BBCode + barre « Envoyer » consomment l'écran et le champ est écrasé à ~0, sans aucun scroll pour le ramener en vue.

## Cause

`ComposeEditorBody` copiait le design de l'éditeur de réponse (« pas de scroll externe, le champ en `weight(1f)` + `fillViewport` s'étire jusqu'à la barre ») — un design qui suppose que le champ possède l'essentiel du body. Compose-MP est le seul éditeur avec ~300 dp de champs fixes au-dessus : à l'ouverture du clavier, le `weight(1f)` du champ se fait écraser et, sans scroll externe, rien ne peut le ramener en vue (refs-#275/refs-#410, même famille de symptômes).

## Fix — la branche « éditeur à en-tête haut » du contrat existant

`TopicFormScreen` (l'autre éditeur à en-tête haut : titre + sous-catégorie) utilise déjà la branche documentée du contrat `BbcodeTextField` pour ce cas : **le body entier scrolle** (`verticalScroll`) **et le champ reste en mode défaut grow-with-content** — le bring-into-view du curseur et le ré-ancrage au resize IME passent par le scrollable ancêtre (c'est la machinerie même décrite dans la KDoc de `BbcodeTextField` ; `fillViewport` y est explicitement interdit sous un scroll externe : deux scrollables imbriqués même direction non bornés).

- `ComposeEditorBody` → colonne `verticalScroll`, champ `heightIn(min = 160.dp)` (vraie zone de frappe même draft vide), aperçu en bloc simple dans le scroll (le scroll imbriqué de l'ancien aperçu disparaît).
- La barre « Envoyer » reste épinglée hors scroll (inchangée) ; l'éditeur de **réponse** MP garde `fillViewport` (pas d'en-tête → pas le bug).

## Validation

Locale verte (2 parts) : `detektAll` + tests `:feature:messages` + `:app:assembleProdDebug` puis `:app:lintProdDebug`. Vérif device souhaitée sur le scénario du screen (clavier ouvert, taper destinataire → sujet → message, aperçu ouvert/fermé). Mots-clés volontairement cassés (refs-#275/refs-#410) : fermeture à la promotion dev→main.
