### PR TITLE
fix(ui): smiley inexistant rendu en token texte lisible (refs-#416)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
@@ -120,6 +120,28 @@ internal object PostMediaDisplayPolicy {
         is SmileyKind.Builtin -> builtinSmiley
         is SmileyKind.Perso -> persoSmiley
     }
+
+    /**
+     * #416 — box for a DEAD smiley sprite (recorded as a fresh measurement failure). HFR's BBCode
+     * engine turns ANY `:word:` into an `<img>` without checking existence, so an unknown code is
+     * served as a 404 gif : web/RF1 then show the typed token at text size. The token replaces the
+     * sprite in the inline content, so its placeholder must fit body-sized text, not a 16-px
+     * sprite — width scales with the token length, clamped to the same relative cap as sprites
+     * (the token of a long perso name must not overflow a narrow quote).
+     */
+    fun deadSmileyTokenBox(token: String, maxWidthSp: Int): InlineMediaBox {
+        val width = (token.length * DEAD_SMILEY_TOKEN_CHAR_SP).coerceAtMost(maxWidthSp)
+        return InlineMediaBox(width.sp, DEAD_SMILEY_TOKEN_HEIGHT_SP.sp)
+    }
+
+    /**
+     * Generous bodyMedium average glyph advance (the token is mostly lowercase + `:`/`[]`) — a
+     * slightly wide box only adds whitespace, a narrow one clips the token (the #416 symptom).
+     */
+    internal const val DEAD_SMILEY_TOKEN_CHAR_SP = 8
+
+    /** One bodyMedium line (14 sp glyphs + breathing room), matching the surrounding text. */
+    internal const val DEAD_SMILEY_TOKEN_HEIGHT_SP = 20
 }
 
 internal data class InlineMediaBox(

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -223,6 +223,17 @@ private fun ParagraphBlock(inlines: List<PostInline>) {
     }
     val measuredSizes: Map<String, IntSize?> = measurableUrls.associateWith { sizeCache.get(it) }
 
+    // #416 — a smiley URL with a FRESH FAILURE on record is DEAD (HFR's BBCode engine turns any
+    // unknown `:code:` into an <img> that 404s) : its token replaces the sprite as body-sized text.
+    // Failures land from two writers — the #175 measurement effect below (perso smileys) and the
+    // render-time error slot of smileyInlineContent (builtins, which are deliberately not measured).
+    // isFailureFresh reads the same SnapshotStateMap as the sizes, so a failure landing recomposes
+    // this block ; the AnnotatedString stays invariant (#175 pivot), only the inline-content map
+    // and the placeholder box change.
+    val allSmileyUrls = remember(inlines) { collectSmileyUrls(inlines) }
+    val deadSmileyUrls: Set<String> =
+        allSmileyUrls.filterTo(HashSet()) { sizeCache.isFailureFresh(it, System.currentTimeMillis()) }
+
     // Measure the not-yet-known URLs. Coil's execute() is a main-safe suspend call (it dispatches its
     // own I/O), and reuses the shared SingletonImageLoader caches the rendering AsyncImage hits — so no
     // double network fetch. A dead URL is recorded as a failure (TTL) so it is not re-fetched.
@@ -275,11 +286,21 @@ private fun ParagraphBlock(inlines: List<PostInline>) {
         val maxMediaWidthSp = with(LocalDensity.current) {
             (maxWidth.toSp().value * SMILEY_RELATIVE_MAX_WIDTH_FRACTION).roundToInt()
         }
-        val inlineContent = remember(inlines, measuredSizes, maxMediaWidthSp) {
+        val inlineContent = remember(inlines, measuredSizes, deadSmileyUrls, maxMediaWidthSp) {
             collectInlineMedia(
                 inlines,
-                smileyBox = { smiley -> smileyDisplayBox(smiley, measuredSizes, maxMediaWidthSp) },
+                smileyBox = { smiley ->
+                    val url = smiley.imageUrl
+                    if (url != null && url in deadSmileyUrls) {
+                        // #416 — the box must fit the body-sized token BEFORE the placeholder is
+                        // laid out, otherwise the text is clipped to the sprite footprint.
+                        PostMediaDisplayPolicy.deadSmileyTokenBox(smiley.kind.token(), maxMediaWidthSp)
+                    } else {
+                        smileyDisplayBox(smiley, measuredSizes, maxMediaWidthSp)
+                    }
+                },
                 imageBox = { image -> imageDisplayBox(image, measuredSizes, maxMediaWidthSp) },
+                deadSmileyUrls = deadSmileyUrls,
             )
         }
         Text(
@@ -793,19 +814,22 @@ internal fun collectInlineMedia(
     inlines: List<PostInline>,
     smileyBox: (PostInline.Smiley) -> InlineMediaBox = { PostMediaDisplayPolicy.smileyBox(it) },
     imageBox: (PostInline.InlineImage) -> InlineMediaBox = { PostMediaDisplayPolicy.inlineImage },
+    deadSmileyUrls: Set<String> = emptySet(),
 ): Map<String, InlineTextContent> {
     val out = mutableMapOf<String, InlineTextContent>()
     val media = MediaCounter()
-    walkInlinesForMedia(inlines, out, media, smileyBox, imageBox)
+    walkInlinesForMedia(inlines, out, media, smileyBox, imageBox, deadSmileyUrls)
     return out
 }
 
+@Suppress("LongParameterList") // Recursive walker — every param is the same threaded context.
 private fun walkInlinesForMedia(
     inlines: List<PostInline>,
     out: MutableMap<String, InlineTextContent>,
     media: MediaCounter,
     smileyBox: (PostInline.Smiley) -> InlineMediaBox,
     imageBox: (PostInline.InlineImage) -> InlineMediaBox,
+    deadSmileyUrls: Set<String>,
 ) {
     inlines.forEach { inline ->
         when (inline) {
@@ -813,16 +837,23 @@ private fun walkInlinesForMedia(
                 out += media.nextImage() to imageInlineContent(inline, imageBox(inline))
 
             is PostInline.Smiley -> {
-                if (inline.imageUrl == null) return@forEach
-                out += media.nextSmiley() to smileyInlineContent(inline, smileyBox(inline))
+                val url = inline.imageUrl ?: return@forEach
+                out += media.nextSmiley() to
+                    smileyInlineContent(inline, smileyBox(inline), dead = url in deadSmileyUrls)
             }
 
-            is PostInline.Strong -> walkInlinesForMedia(inline.children, out, media, smileyBox, imageBox)
-            is PostInline.Emphasis -> walkInlinesForMedia(inline.children, out, media, smileyBox, imageBox)
-            is PostInline.Underline -> walkInlinesForMedia(inline.children, out, media, smileyBox, imageBox)
-            is PostInline.Strike -> walkInlinesForMedia(inline.children, out, media, smileyBox, imageBox)
-            is PostInline.Color -> walkInlinesForMedia(inline.children, out, media, smileyBox, imageBox)
-            is PostInline.Link -> walkInlinesForMedia(inline.children, out, media, smileyBox, imageBox)
+            is PostInline.Strong ->
+                walkInlinesForMedia(inline.children, out, media, smileyBox, imageBox, deadSmileyUrls)
+            is PostInline.Emphasis ->
+                walkInlinesForMedia(inline.children, out, media, smileyBox, imageBox, deadSmileyUrls)
+            is PostInline.Underline ->
+                walkInlinesForMedia(inline.children, out, media, smileyBox, imageBox, deadSmileyUrls)
+            is PostInline.Strike ->
+                walkInlinesForMedia(inline.children, out, media, smileyBox, imageBox, deadSmileyUrls)
+            is PostInline.Color ->
+                walkInlinesForMedia(inline.children, out, media, smileyBox, imageBox, deadSmileyUrls)
+            is PostInline.Link ->
+                walkInlinesForMedia(inline.children, out, media, smileyBox, imageBox, deadSmileyUrls)
             else -> Unit
         }
     }
@@ -843,6 +874,33 @@ internal fun collectMeasurableSmileyUrls(inlines: List<PostInline>): Set<String>
 
 private fun collectMeasurableSmileyUrlsInto(inlines: List<PostInline>, urls: MutableSet<String>) {
     inlines.forEach { inline -> collectMeasurableSmileyUrl(inline, urls) }
+}
+
+/**
+ * #416 — collects EVERY smiley image URL (builtins included), unlike [collectMeasurableSmileyUrls]
+ * which deliberately skips builtins for the measurement pre-seed contract. The dead-sprite check
+ * needs the full set : an unknown `:code:` is served by HFR as a 404 builtin-style sprite, and its
+ * failure is recorded at render time (error slot), not by the measurement effect.
+ */
+internal fun collectSmileyUrls(inlines: List<PostInline>): Set<String> {
+    val urls = LinkedHashSet<String>()
+    collectSmileyUrlsInto(inlines, urls)
+    return urls
+}
+
+private fun collectSmileyUrlsInto(inlines: List<PostInline>, urls: MutableSet<String>) {
+    inlines.forEach { inline ->
+        when (inline) {
+            is PostInline.Smiley -> inline.imageUrl?.let { urls += it }
+            is PostInline.Strong -> collectSmileyUrlsInto(inline.children, urls)
+            is PostInline.Emphasis -> collectSmileyUrlsInto(inline.children, urls)
+            is PostInline.Underline -> collectSmileyUrlsInto(inline.children, urls)
+            is PostInline.Strike -> collectSmileyUrlsInto(inline.children, urls)
+            is PostInline.Color -> collectSmileyUrlsInto(inline.children, urls)
+            is PostInline.Link -> collectSmileyUrlsInto(inline.children, urls)
+            else -> Unit
+        }
+    }
 }
 
 private fun collectMeasurableSmileyUrl(inline: PostInline, urls: MutableSet<String>) {
@@ -1079,7 +1137,11 @@ internal fun imageInlineContent(image: PostInline.InlineImage, box: InlineMediaB
     }
 }
 
-internal fun smileyInlineContent(smiley: PostInline.Smiley, box: InlineMediaBox): InlineTextContent {
+internal fun smileyInlineContent(
+    smiley: PostInline.Smiley,
+    box: InlineMediaBox,
+    dead: Boolean = false,
+): InlineTextContent {
     val description = smiley.kind.token()
     return InlineTextContent(
         placeholder = Placeholder(
@@ -1093,6 +1155,19 @@ internal fun smileyInlineContent(smiley: PostInline.Smiley, box: InlineMediaBox)
             placeholderVerticalAlign = PlaceholderVerticalAlign.TextBottom,
         ),
     ) {
+        if (dead) {
+            // #416 (round 2, retour dev v118) — the sprite is KNOWN dead (fresh failure on record :
+            // HFR 404s any unknown `:code:`) and the box was sized for the token by deadSmileyTokenBox,
+            // so render the token at body size — no image attempt, no ellipsis budget needed (Clip is
+            // a guard for extreme fontScale).
+            Text(
+                text = description,
+                fontSize = DEAD_SMILEY_TOKEN_FONT_SP.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Clip,
+            )
+            return@InlineTextContent
+        }
         SubcomposeAsyncImage(
             model = smiley.imageUrl,
             contentDescription = description,
@@ -1100,9 +1175,20 @@ internal fun smileyInlineContent(smiley: PostInline.Smiley, box: InlineMediaBox)
             modifier = Modifier.fillMaxSize(),
             success = { SubcomposeAsyncImageContent() },
             error = {
-                // #416 — a dead smiley sprite (deleted perso, stale URL) used to render as
-                // BLANK where web/RF1 fall back to the typed code. Show the token, ellipsised
-                // to the sprite box ; semantics carry the full token via contentDescription.
+                // #416 — first failure of a sprite that was NOT known dead when this content was
+                // built (builtins are never measured ; a perso can die between measure and render).
+                // Record the failure so the paragraph recomposes onto the dead-token path above
+                // (readable, body-sized) ; the tiny ellipsised token below is only the transient
+                // frame between this error and that recomposition.
+                val cache = LocalIntrinsicMediaSizeCache.current
+                val url = smiley.imageUrl
+                if (url != null) {
+                    LaunchedEffect(url) {
+                        if (!cache.isFailureFresh(url, System.currentTimeMillis())) {
+                            cache.putFailure(url, System.currentTimeMillis())
+                        }
+                    }
+                }
                 Text(
                     text = description,
                     fontSize = 10.sp,
@@ -1113,6 +1199,9 @@ internal fun smileyInlineContent(smiley: PostInline.Smiley, box: InlineMediaBox)
         )
     }
 }
+
+/** #416 — body-sized token for a dead sprite (bodyMedium is 14 sp ; keep in sync with the box). */
+private const val DEAD_SMILEY_TOKEN_FONT_SP = 14
 
 private fun SmileyKind.token(): String = when (this) {
     is SmileyKind.Builtin -> code

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/CollectSmileyUrlsTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/CollectSmileyUrlsTest.kt
@@ -1,0 +1,46 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import fr.forumhfr.redface2.core.model.PostInline
+import fr.forumhfr.redface2.core.model.SmileyKind
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #416 — [collectSmileyUrls] feeds the dead-sprite check, so unlike [collectMeasurableSmileyUrls]
+ * (perso-only, measurement pre-seed contract) it must see EVERY smiley URL : HFR serves an unknown
+ * `:code:` as a builtin-style sprite that 404s, and that failure is recorded at render time.
+ */
+class CollectSmileyUrlsTest {
+
+    private val builtin = PostInline.Smiley(
+        kind = SmileyKind.Builtin(":zorglub:"),
+        imageUrl = "https://forum-images.hardware.fr/icones/smilies/zorglub.gif",
+    )
+    private val perso = PostInline.Smiley(
+        kind = SmileyKind.Perso("rofl"),
+        imageUrl = "https://forum-images.hardware.fr/images/perso/rofl.gif",
+    )
+    private val urlLess = PostInline.Smiley(kind = SmileyKind.Builtin(":)"), imageUrl = null)
+
+    @Test
+    fun `collects builtins AND persos, skips url-less smileys`() {
+        val urls = collectSmileyUrls(listOf(PostInline.Text("yo "), builtin, perso, urlLess))
+        assertEquals(setOf(builtin.imageUrl, perso.imageUrl), urls)
+    }
+
+    @Test
+    fun `recurses into inline containers like the media walk`() {
+        val nested = listOf(
+            PostInline.Strong(children = listOf(builtin)),
+            PostInline.Link(url = "https://example.org", children = listOf(perso)),
+        )
+        val urls = collectSmileyUrls(nested)
+        assertEquals(setOf(builtin.imageUrl, perso.imageUrl), urls)
+    }
+
+    @Test
+    fun `measurable collector still skips builtins — contract unchanged`() {
+        val measurable = collectMeasurableSmileyUrls(listOf(builtin, perso))
+        assertEquals(setOf(perso.imageUrl), measurable)
+    }
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicyTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicyTest.kt
@@ -160,4 +160,29 @@ class PostMediaDisplayPolicyTest {
         assertEquals(70, wideStrip.width)
         assertTrue("wide strip must keep height ≥ 1", wideStrip.height >= 1)
     }
+
+    // #416 — dead-sprite token box : the placeholder must fit the body-sized token, not the sprite.
+
+    @Test
+    fun `deadSmileyTokenBox width scales with the token length`() {
+        val short = PostMediaDisplayPolicy.deadSmileyTokenBox(":o", maxWidthSp = 400)
+        val long = PostMediaDisplayPolicy.deadSmileyTokenBox(":zorglub:", maxWidthSp = 400)
+        assertEquals((2 * PostMediaDisplayPolicy.DEAD_SMILEY_TOKEN_CHAR_SP).sp, short.placeholderWidth)
+        assertEquals((9 * PostMediaDisplayPolicy.DEAD_SMILEY_TOKEN_CHAR_SP).sp, long.placeholderWidth)
+        assertTrue(long.placeholderWidth.value > short.placeholderWidth.value)
+    }
+
+    @Test
+    fun `deadSmileyTokenBox clamps to the relative cap like sprites`() {
+        // A long perso token ([:longcustomsmileyname]) inside a deep quote must not overflow the
+        // narrow container — same `img { max-width }` philosophy as smileyDisplayBox.
+        val box = PostMediaDisplayPolicy.deadSmileyTokenBox("[:averyverylongpersoname]", maxWidthSp = 60)
+        assertEquals(60.sp, box.placeholderWidth)
+    }
+
+    @Test
+    fun `deadSmileyTokenBox height is one body line`() {
+        val box = PostMediaDisplayPolicy.deadSmileyTokenBox(":zorglub:", maxWidthSp = 400)
+        assertEquals(PostMediaDisplayPolicy.DEAD_SMILEY_TOKEN_HEIGHT_SP.sp, box.placeholderHeight)
+    }
 }


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi

Un code smiley inexistant (`:zorglub:`) s'affichait en caractère ellipsé minuscule : HFR convertit n'importe quel `:mot:` en `<img>` vers un GIF 404 (vérifié curl), et le fallback s'ellipsait dans la boîte sprite 21×18.

- `deadSmileyTokenBox(token, maxWidthSp)` : placeholder dimensionné au token (8 sp/caractère clampé, hauteur 20 sp)
- Le slot `error` du rendu enregistre l'échec via `putFailure` (TTL, mécanique #175) → recomposition → le token est rendu en texte 14 sp lisible
- `collectSmileyUrls` (builtins inclus — jamais pré-seedés donc passent par ce chemin) + `isFailureFresh` keyent l'`inlineContent`

## Validation

- detektAll + tests + assembleProdDebug + lintProdDebug verts (Docker, 2 parts)
- 6 tests (CollectSmileyUrlsTest ×3, PostMediaDisplayPolicyTest ×3)
- **Vérifié émulateur** : `:zorglub:` et `:tuvoispaslebug:` lisibles pleine taille sur le topic DEV p.8 (build d'intégration night/2026-06-12-integration)

refs-#416 (2e volet ; le 1er volet — fallback smiley perso cassé — était dans #420). Fermeture à la promotion dev→main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)