### PR TITLE
feat(topic): marquage visuel des posts ajoutés à la citation multiple (refs-#436)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.feature.topic
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
@@ -973,6 +974,8 @@ private fun TopicLoadedContent(
                 onEdit = editAction,
                 onOpenProfile = profileAction,
                 onOpenMenu = { menuPost = post },
+                // #436 — same membership source as the menu entry (PostMenuSheet).
+                multiQuoteSelected = post.numreponse in multiQuoteSelection,
             )
         }
         // #379 — explicit end-of-topic marker after the last post of the LAST page. The
@@ -1323,8 +1326,21 @@ private fun TopicPostCard(
      * of the header bar), permalink copy, edit marker, citation count.
      */
     onOpenMenu: () -> Unit = {},
+    /**
+     * #436 — true when this post sits in the multi-quote basket (#291). Marks the card with a
+     * primary border + an « Ajouté à la citation » pill in the identity band, so the selection
+     * is visible without opening the per-post menu (dev feedback by Dintr-un lemn). Orthogonal
+     * to [highlighted] (the scroll anchor) : both can be true at once, the border and the
+     * container tint compose without colliding.
+     */
+    multiQuoteSelected: Boolean = false,
 ) {
     Card(
+        border = if (multiQuoteSelected) {
+            BorderStroke(width = 2.dp, color = MaterialTheme.colorScheme.primary)
+        } else {
+            null
+        },
         colors = CardDefaults.cardColors(
             containerColor = if (highlighted) {
                 MaterialTheme.colorScheme.secondaryContainer
@@ -1454,6 +1470,23 @@ private fun TopicPostCard(
                                 ),
                                 style = MaterialTheme.typography.labelSmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+                            )
+                        }
+                    }
+                    if (multiQuoteSelected) {
+                        // #436 — basket-membership pill, same shape family as the #239 pill above.
+                        // primaryContainer : distinct from the band (secondaryContainer) AND from a
+                        // highlighted band (tertiaryContainer), and it echoes the primary border so
+                        // the two marks read as one signal.
+                        Surface(
+                            color = MaterialTheme.colorScheme.primaryContainer,
+                            shape = MaterialTheme.shapes.small,
+                        ) {
+                            Text(
+                                text = stringResource(R.string.topic_post_multiquote_selected),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer,
                                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
                             )
                         }

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -25,6 +25,8 @@
     <string name="topic_caption">post %1$d • page %2$d / %3$d</string>
     <string name="topic_post_index_prefix">#%1$d • </string>
     <!-- #362 — per-post contextual menu (post number, permalink copy, edit marker, citations). -->
+    <!-- #436 — pastille de la bande d'identité quand le post est au panier multi-quote (#291). -->
+    <string name="topic_post_multiquote_selected">Ajouté à la citation</string>
     <string name="topic_post_menu_action">Options du post</string>
     <string name="topic_post_menu_number">Post n°%1$d</string>
     <string name="topic_post_menu_copy_link">Copier le lien de ce post</string>


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi

Point 1 de #436 (multi-quote v2) : un post présent dans le panier multiquote est maintenant marqué :

- **Bordure 2 dp** `primary` sur la carte du post (`TopicPostCard` +`multiQuoteSelected`)
- **Pastille « Ajouté à la citation »** (`primaryContainer`, même famille visuelle que la pastille « cité N fois » de #239)

Les points 2–3 (panier au back, « Tout vider ») sont arbitrés (panier survivant + action sur le FAB) et seront traités dans un chantier séparé — commentaire d'arbitrage sur #436.

## Validation

- detektAll + tests + assembleProdDebug + lintProdDebug verts (Docker, 2 parts)
- **Vérifié émulateur** : bordure + pastille visibles après « Ajouter à la citation multiple », badge 1 sur le FAB panier

refs-#436 (point 1 seulement — l'issue reste ouverte pour les points 2–3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)