### PR TITLE
feat(messages,app): badge de MP non lus sur l'onglet Messages + réglage (refs-#313)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/MpUnreadBadgeViewModel.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/MpUnreadBadgeViewModel.kt
@@ -1,0 +1,59 @@
+package fr.forumhfr.redface2.navigation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.messages.MessagesRepository
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * #313 — unread-MP badge on the « Messages » destination of the navigation bar.
+ *
+ * [unreadCount] is `null` whenever the badge must NOT show : anonymous session, fetch failure,
+ * count not resolved yet, or the preference turned off. `0` is mapped to `null` too — an « empty »
+ * badge would only add noise. The count itself comes from `MessagesRepository.observeUnreadMpCount`
+ * (page-1 inbox proxy, cf. its KDoc) and refreshes via three channels : the auth flip (built-in),
+ * the page-1 inbox piggyback (free, fires when the user opens the Messages tab or comes back from
+ * a conversation), and the explicit [onAppForegrounded] tick below.
+ *
+ * `WhileSubscribed` (not Eagerly) : the only consumer is the navigation bar — when nothing shows
+ * it, nothing should hold the upstream fetch chain alive.
+ */
+@HiltViewModel
+class MpUnreadBadgeViewModel @Inject constructor(
+    private val messagesRepository: MessagesRepository,
+    userPreferencesRepository: UserPreferencesRepository,
+) : ViewModel() {
+
+    val unreadCount: StateFlow<Int?> =
+        combine(
+            userPreferencesRepository.observeMpUnreadBadge(),
+            messagesRepository.observeUnreadMpCount(),
+        ) { enabled, count ->
+            count?.takeIf { enabled && it > 0 }
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), null)
+
+    /**
+     * `ON_START` hook (app brought back to the foreground) : MPs received while backgrounded
+     * must surface without waiting for a tab visit. The FIRST start is skipped — the cold-start
+     * fetch already runs when the auth state resolves, a tick there would only double the call.
+     */
+    fun onAppForegrounded() {
+        if (firstStart) {
+            firstStart = false
+            return
+        }
+        messagesRepository.requestUnreadRefresh()
+    }
+
+    private var firstStart = true
+
+    private companion object {
+        const val STOP_TIMEOUT_MS = 5_000L
+    }
+}

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -39,7 +39,11 @@ import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffo
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.core.net.toUri
 import androidx.core.view.WindowCompat
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavBackStack
@@ -302,6 +306,39 @@ internal enum class TopLevelDestination(
     Messages(R.string.nav_messages, MessagesRoute),
 }
 
+/** #313 — badge cap : beyond this the badge shows « 9+ » (page-1 proxy, cf. MpUnreadBadgeViewModel). */
+private const val MAX_BADGE_COUNT = 9
+
+/**
+ * #313 — navigation item icon : the text glyph, plus the unread-MP count badge on the
+ * « Messages » destination only, and only when the ViewModel resolved a positive count
+ * ([mpUnreadCount] is null for 0/disabled/anonymous/failure). Capped at « 9+ » : page 1
+ * of the inbox is the source, an exact two-digit count carries no extra signal at badge size.
+ */
+@Composable
+private fun TopLevelDestinationIcon(destination: TopLevelDestination, mpUnreadCount: Int?) {
+    val glyph = stringResource(destination.labelRes).first().toString()
+    if (destination != TopLevelDestination.Messages || mpUnreadCount == null) {
+        Text(text = glyph)
+        return
+    }
+    BadgedBox(
+        badge = {
+            Badge {
+                Text(
+                    text = if (mpUnreadCount > MAX_BADGE_COUNT) {
+                        stringResource(R.string.nav_messages_badge_overflow)
+                    } else {
+                        mpUnreadCount.toString()
+                    },
+                )
+            }
+        },
+    ) {
+        Text(text = glyph)
+    }
+}
+
 internal data class ParsedDeepLink(
     val destination: TopLevelDestination,
     val route: RedfaceNavKey,
@@ -425,6 +462,15 @@ fun RedfaceApp(intent: Intent?) {
         // every tab (Hilt hands back the same scoped instance for an identical owner).
         val accountViewModel: AppAccountViewModel = hiltViewModel()
         val authState by accountViewModel.authState.collectAsStateWithLifecycle()
+        // #313 — unread-MP badge on the « Messages » nav item. Same shared-instance logic as the
+        // account ViewModel above. The ON_START hook refreshes the count when the app comes back
+        // to the foreground (MPs received while backgrounded) ; the first start is skipped by the
+        // ViewModel (the auth-flip fetch covers the cold start).
+        val mpBadgeViewModel: MpUnreadBadgeViewModel = hiltViewModel()
+        val mpUnreadCount by mpBadgeViewModel.unreadCount.collectAsStateWithLifecycle()
+        LifecycleEventEffect(Lifecycle.Event.ON_START) {
+            mpBadgeViewModel.onAppForegrounded()
+        }
         val reportEmailSubject = stringResource(fr.forumhfr.redface2.core.ui.R.string.account_menu_report_email_subject)
         val reportNoEmailClient = stringResource(fr.forumhfr.redface2.core.ui.R.string.account_menu_no_email_client)
         val context = LocalContext.current
@@ -506,7 +552,12 @@ fun RedfaceApp(intent: Intent?) {
                     item(
                         selected = currentDestination == destination,
                         onClick = { currentDestination = destination },
-                        icon = { Text(text = stringResource(destination.labelRes).first().toString()) },
+                        icon = {
+                            TopLevelDestinationIcon(
+                                destination = destination,
+                                mpUnreadCount = mpUnreadCount,
+                            )
+                        },
                         label = { Text(text = stringResource(destination.labelRes)) },
                     )
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,6 @@
     <string name="nav_forum">Forum</string>
     <string name="nav_search">Recherche</string>
     <string name="nav_messages">Messages</string>
+    <!-- #313 — badge MP non lus sur l'item Messages ; au-delà de 9 le badge plafonne. -->
+    <string name="nav_messages_badge_overflow">9+</string>
 </resources>

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/MpUnreadBadgeViewModelTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/MpUnreadBadgeViewModelTest.kt
@@ -1,0 +1,116 @@
+package fr.forumhfr.redface2.navigation
+
+import app.cash.turbine.test
+import fr.forumhfr.redface2.core.domain.messages.MessagesRepository
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * #313 — the badge contract: `unreadCount` is non-null ONLY when (preference on) AND (count
+ * resolved) AND (count > 0). Everything else — anonymous/null, zero, disabled — renders nothing.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class MpUnreadBadgeViewModelTest {
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun viewModel(
+        counts: Flow<Int?>,
+        badgeEnabled: Flow<Boolean> = flowOf(true),
+        messagesRepository: MessagesRepository = mockk(relaxed = true) {
+            every { observeUnreadMpCount() } returns counts
+        },
+    ): MpUnreadBadgeViewModel = MpUnreadBadgeViewModel(
+        messagesRepository = messagesRepository,
+        userPreferencesRepository = mockk {
+            every { observeMpUnreadBadge() } returns badgeEnabled
+        },
+    )
+
+    // NB : StateFlow + UnconfinedTestDispatcher → l'amont est déjà résolu à la souscription et
+    // l'état initial `null` est conflaté ; les tests lisent donc l'état COURANT
+    // (expectMostRecentItem) au lieu de présumer la séquence null → valeur.
+
+    @Test
+    fun `a positive count flows through when the preference is on`() = runTest {
+        viewModel(counts = flowOf(3)).unreadCount.test {
+            assertEquals(3, expectMostRecentItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `zero and null counts hide the badge`() = runTest {
+        viewModel(counts = flowOf(0)).unreadCount.test {
+            assertNull(expectMostRecentItem())
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+        viewModel(counts = flowOf(null)).unreadCount.test {
+            assertNull(expectMostRecentItem())
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `the preference turned off hides a positive count`() = runTest {
+        viewModel(counts = flowOf(7), badgeEnabled = flowOf(false)).unreadCount.test {
+            assertNull(expectMostRecentItem())
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `flipping the preference off live removes the badge`() = runTest {
+        val enabled = MutableStateFlow(true)
+        viewModel(counts = flowOf(4), badgeEnabled = enabled).unreadCount.test {
+            assertEquals(4, expectMostRecentItem())
+
+            enabled.value = false
+
+            assertNull(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onAppForegrounded skips the first start then ticks the repository`() = runTest {
+        val repository = mockk<MessagesRepository>(relaxed = true) {
+            every { observeUnreadMpCount() } returns flowOf(1)
+        }
+        val vm = viewModel(counts = flowOf(1), messagesRepository = repository)
+
+        vm.onAppForegrounded() // cold start — covered by the auth-flip fetch
+        verify(exactly = 0) { repository.requestUnreadRefresh() }
+
+        vm.onAppForegrounded() // back from background — must tick
+        vm.onAppForegrounded()
+        verify(exactly = 2) { repository.requestUnreadRefresh() }
+    }
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepository.kt
@@ -15,7 +15,11 @@ import javax.inject.Singleton
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.withContext
@@ -43,15 +47,36 @@ class DefaultMessagesRepository @Inject constructor(
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : MessagesRepository {
 
+    // #313 — two refresh channels beyond the auth flip. `unreadRefreshTicks` is the explicit
+    // request (app-foreground) ; `inboxDerivedUnread` is the free piggyback : every page-1 inbox
+    // fetch already carries the per-conversation dots, so the badge updates the moment the user
+    // opens the Messages tab or comes back from a conversation, without a second network call.
+    // tryEmit + extraBufferCapacity=1 : ticks may fire with no collector (badge disabled) — they
+    // must never suspend or throw, and one pending tick is enough (they coalesce).
+    private val unreadRefreshTicks = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    private val inboxDerivedUnread = MutableSharedFlow<Int>(extraBufferCapacity = 1)
+
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun observeUnreadMpCount(): Flow<Int?> = authRepository.observeAuthState()
         .transformLatest { state ->
             when (state) {
                 AuthState.Anonymous -> emit(null)
-                is AuthState.Authenticated -> emit(fetchUnreadCount())
+                is AuthState.Authenticated -> {
+                    emit(fetchUnreadCount())
+                    emitAll(
+                        merge(
+                            unreadRefreshTicks.map { fetchUnreadCount() },
+                            inboxDerivedUnread,
+                        ),
+                    )
+                }
             }
         }
         .flowOn(ioDispatcher)
+
+    override fun requestUnreadRefresh() {
+        unreadRefreshTicks.tryEmit(Unit)
+    }
 
     private suspend fun fetchUnreadCount(): Int? = withContext(ioDispatcher) {
         try {
@@ -78,7 +103,14 @@ class DefaultMessagesRepository @Inject constructor(
     // call per the repository contract (cf. NetworkOnMainThreadException regression, PR #162).
     override suspend fun getPrivateMessageList(page: Int): PrivateMessageListPage =
         withContext(ioDispatcher) {
-            parser.parseList(hfrClient.getPrivateMessageListPage(page = page))
+            val result = parser.parseList(hfrClient.getPrivateMessageListPage(page = page))
+            if (page == FIRST_PAGE) {
+                // #313 — page 1 is the same proxy fetchUnreadCount uses (newest-first, unread
+                // float to the top), so its dots refresh the badge for free. Deeper pages are
+                // NOT representative (their count would clobber a real one with a partial view).
+                inboxDerivedUnread.tryEmit(result.items.count { it.hasUnread })
+            }
+            result
         }
 
     override suspend fun getPrivateMessageThread(
@@ -94,5 +126,6 @@ class DefaultMessagesRepository @Inject constructor(
 
     private companion object {
         const val LOG_TAG = "MessagesRepository"
+        const val FIRST_PAGE = 1
     }
 }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepository.kt
@@ -17,8 +17,10 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -53,8 +55,12 @@ class DefaultMessagesRepository @Inject constructor(
     // opens the Messages tab or comes back from a conversation, without a second network call.
     // tryEmit + extraBufferCapacity=1 : ticks may fire with no collector (badge disabled) — they
     // must never suspend or throw, and one pending tick is enough (they coalesce).
+    // Piggyback emissions are SEALED to the session that started the fetch (pseudo snapshotted
+    // at call-time) : the repository is a singleton, so a page-1 fetch started under account A
+    // that lands after a logout/login to B must not feed B's badge with A's private metadata
+    // (Codex review, PR #439). The collector filters on the pseudo of ITS auth session.
     private val unreadRefreshTicks = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
-    private val inboxDerivedUnread = MutableSharedFlow<Int>(extraBufferCapacity = 1)
+    private val inboxDerivedUnread = MutableSharedFlow<Pair<String, Int>>(extraBufferCapacity = 1)
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun observeUnreadMpCount(): Flow<Int?> = authRepository.observeAuthState()
@@ -66,7 +72,11 @@ class DefaultMessagesRepository @Inject constructor(
                     emitAll(
                         merge(
                             unreadRefreshTicks.map { fetchUnreadCount() },
-                            inboxDerivedUnread,
+                            inboxDerivedUnread.mapNotNull { (pseudo, count) ->
+                                // Drop emissions sealed for another session (account switch
+                                // while the page-1 fetch was in flight).
+                                if (pseudo == state.pseudo) count else null
+                            },
                         ),
                     )
                 }
@@ -103,15 +113,22 @@ class DefaultMessagesRepository @Inject constructor(
     // call per the repository contract (cf. NetworkOnMainThreadException regression, PR #162).
     override suspend fun getPrivateMessageList(page: Int): PrivateMessageListPage =
         withContext(ioDispatcher) {
+            // Session snapshot at call-time, BEFORE the network call (same pattern as the flags
+            // generation counter of #431) : tagging after the fetch could stamp account B's
+            // pseudo on a response served under account A's cookies.
+            val sessionPseudo = if (page == FIRST_PAGE) currentPseudo() else null
             val result = parser.parseList(hfrClient.getPrivateMessageListPage(page = page))
-            if (page == FIRST_PAGE) {
+            if (page == FIRST_PAGE && sessionPseudo != null) {
                 // #313 — page 1 is the same proxy fetchUnreadCount uses (newest-first, unread
                 // float to the top), so its dots refresh the badge for free. Deeper pages are
                 // NOT representative (their count would clobber a real one with a partial view).
-                inboxDerivedUnread.tryEmit(result.items.count { it.hasUnread })
+                inboxDerivedUnread.tryEmit(sessionPseudo to result.items.count { it.hasUnread })
             }
             result
         }
+
+    private suspend fun currentPseudo(): String? =
+        (authRepository.observeAuthState().first() as? AuthState.Authenticated)?.pseudo
 
     override suspend fun getPrivateMessageThread(
         threadId: Int,

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -272,6 +272,21 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeMpUnreadBadge(): Flow<Boolean> =
+        dataStore.data
+            // Default `true` (#313): the badge is the feature; opting OUT is the preference.
+            .map { prefs -> prefs[KEY_MP_UNREAD_BADGE] ?: true }
+            .distinctUntilChanged()
+            .catch { emit(true) }
+
+    override suspend fun setMpUnreadBadge(enabled: Boolean) {
+        withContext(ioDispatcher) {
+            dataStore.edit { prefs ->
+                prefs[KEY_MP_UNREAD_BADGE] = enabled
+            }
+        }
+    }
+
     /**
      * Reads [KEY_THEME_MODE] defensively: an unknown / corrupt stored value (older build with a
      * renamed enum, manual edit) falls back to [ThemeMode.SYSTEM] instead of crashing on
@@ -370,5 +385,6 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         // #378 — auto-refresh of the flags lists on landing (default ON; Settings opt-out).
         val KEY_FLAGS_AUTO_REFRESH = booleanPreferencesKey("flags_auto_refresh")
         val KEY_TOPIC_PAGE_FABS = booleanPreferencesKey("topic_page_fabs")
+        val KEY_MP_UNREAD_BADGE = booleanPreferencesKey("mp_unread_badge")
     }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepositoryTest.kt
@@ -6,6 +6,7 @@ import fr.forumhfr.redface2.core.domain.auth.LoginError
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.messages.PrivateMessageListPage
+import fr.forumhfr.redface2.core.model.messages.PrivateMessageSummary
 import fr.forumhfr.redface2.core.model.messages.PrivateMessageThread
 import fr.forumhfr.redface2.core.network.HfrClient
 import fr.forumhfr.redface2.core.parser.messages.PrivateMessageListParser
@@ -14,6 +15,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import java.io.IOException
+import java.time.Instant
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -143,6 +145,80 @@ class DefaultMessagesRepositoryTest {
     }
 
     @Test
+    fun `a page-1 inbox fetch refreshes the observed unread count for free (piggyback #313)`() = runTest {
+        val hfrClient = mockk<HfrClient>()
+        coEvery { hfrClient.getPrivateMessageListPage(page = 1) } returns FAKE_HTML
+        val parser = mockk<PrivateMessageListParser>()
+        coEvery { parser.countUnread(FAKE_HTML) } returns 2
+        coEvery { parser.parseList(FAKE_HTML) } returns PrivateMessageListPage(
+            page = 1,
+            totalPages = 1,
+            items = listOf(summary(threadId = 1, hasUnread = true), summary(threadId = 2, hasUnread = false)),
+        )
+
+        val (repo, authStates) = buildRepository(hfrClient = hfrClient, parser = parser)
+
+        repo.observeUnreadMpCount().test {
+            authStates.emit(AuthState.Authenticated("xaat"))
+            assertEquals(2, awaitItem())
+
+            repo.getPrivateMessageList(page = 1)
+
+            assertEquals(
+                "the page-1 dots must refresh the badge without a second fetch",
+                1,
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `a deeper inbox page does NOT touch the observed count (partial view, #313)`() = runTest {
+        val hfrClient = mockk<HfrClient>()
+        coEvery { hfrClient.getPrivateMessageListPage(page = any()) } returns FAKE_HTML
+        val parser = mockk<PrivateMessageListParser>()
+        coEvery { parser.countUnread(FAKE_HTML) } returns 2
+        coEvery { parser.parseList(FAKE_HTML) } returns PrivateMessageListPage(
+            page = 2,
+            totalPages = 2,
+            items = listOf(summary(threadId = 9, hasUnread = true)),
+        )
+
+        val (repo, authStates) = buildRepository(hfrClient = hfrClient, parser = parser)
+
+        repo.observeUnreadMpCount().test {
+            authStates.emit(AuthState.Authenticated("xaat"))
+            assertEquals(2, awaitItem())
+
+            repo.getPrivateMessageList(page = 2)
+
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `requestUnreadRefresh re-fetches the count (#313)`() = runTest {
+        val hfrClient = mockk<HfrClient>()
+        coEvery { hfrClient.getPrivateMessageListPage(page = 1) } returns FAKE_HTML
+        val parser = mockk<PrivateMessageListParser>()
+        coEvery { parser.countUnread(FAKE_HTML) } returnsMany listOf(2, 5)
+
+        val (repo, authStates) = buildRepository(hfrClient = hfrClient, parser = parser)
+
+        repo.observeUnreadMpCount().test {
+            authStates.emit(AuthState.Authenticated("xaat"))
+            assertEquals(2, awaitItem())
+
+            repo.requestUnreadRefresh()
+
+            assertEquals(5, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `getPrivateMessageList fetches the requested page and returns the parsed inbox`() = runTest {
         val hfrClient = mockk<HfrClient>()
         coEvery { hfrClient.getPrivateMessageListPage(page = 2) } returns FAKE_HTML
@@ -183,6 +259,14 @@ class DefaultMessagesRepositoryTest {
         assertEquals(parsed, result)
         coVerify(exactly = 1) { threadParser.parse(FAKE_HTML, "Correspondant") }
     }
+
+    private fun summary(threadId: Int, hasUnread: Boolean) = PrivateMessageSummary(
+        threadId = threadId,
+        correspondent = "Correspondant",
+        subject = "Sujet",
+        date = Instant.EPOCH,
+        hasUnread = hasUnread,
+    )
 
     private fun buildRepository(
         hfrClient: HfrClient = mockk(relaxed = true),

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepositoryTest.kt
@@ -199,6 +199,43 @@ class DefaultMessagesRepositoryTest {
     }
 
     @Test
+    fun `a page-1 fetch in flight across an account switch cannot feed the new badge (#439)`() = runTest {
+        val hfrClient = mockk<HfrClient>()
+        coEvery { hfrClient.getPrivateMessageListPage(page = 1) } returns FAKE_HTML
+        val parser = mockk<PrivateMessageListParser>()
+        coEvery { parser.countUnread(FAKE_HTML) } returnsMany listOf(2, 3)
+        lateinit var authStates: MutableSharedFlow<AuthState>
+        coEvery { parser.parseList(FAKE_HTML) } coAnswers {
+            // The account switch lands while the page-1 fetch is in flight : the session pseudo
+            // was snapshotted at call-time (A), but by the time the response is parsed the
+            // collector is already running under B. parseList is only on the
+            // getPrivateMessageList path, so the badge's own countUnread fetches run free.
+            authStates.emit(AuthState.Authenticated("B"))
+            PrivateMessageListPage(
+                page = 1,
+                totalPages = 1,
+                items = listOf(summary(threadId = 1, hasUnread = true)),
+            )
+        }
+
+        val (repo, states) = buildRepository(hfrClient = hfrClient, parser = parser)
+        authStates = states
+
+        repo.observeUnreadMpCount().test {
+            authStates.emit(AuthState.Authenticated("A"))
+            assertEquals(2, awaitItem())
+
+            // Starts under A (snapshot), completes under B (the coAnswers above switched).
+            repo.getPrivateMessageList(page = 1)
+
+            assertEquals("B's own initial fetch", 3, awaitItem())
+            // The late piggyback (sealed for A) must NOT feed B's badge.
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `requestUnreadRefresh re-fetches the count (#313)`() = runTest {
         val hfrClient = mockk<HfrClient>()
         coEvery { hfrClient.getPrivateMessageListPage(page = 1) } returns FAKE_HTML
@@ -273,7 +310,9 @@ class DefaultMessagesRepositoryTest {
         parser: PrivateMessageListParser = mockk(relaxed = true),
         threadParser: PrivateMessageThreadParser = mockk(relaxed = true),
     ): Pair<DefaultMessagesRepository, MutableSharedFlow<AuthState>> {
-        val authStates = MutableSharedFlow<AuthState>(replay = 0)
+        // replay=1 mirrors production (the current auth state is readable at any time) : the
+        // repository snapshots the session pseudo via `first()` at fetch call-time (#439).
+        val authStates = MutableSharedFlow<AuthState>(replay = 1)
         val authRepository = object : AuthRepository {
             override fun observeAuthState(): Flow<AuthState> = authStates
 

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -559,5 +559,9 @@ class TopicRepositoryImplTest {
         override fun observeTopicPageFabs(): Flow<Boolean> = MutableStateFlow(true)
 
         override suspend fun setTopicPageFabs(enabled: Boolean) = Unit
+
+        override fun observeMpUnreadBadge(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setMpUnreadBadge(enabled: Boolean) = Unit
     }
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/messages/MessagesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/messages/MessagesRepository.kt
@@ -23,6 +23,18 @@ interface MessagesRepository {
     fun observeUnreadMpCount(): Flow<Int?>
 
     /**
+     * #313 — asks for a re-fetch of the unread count on the NEXT occasion (fire-and-forget,
+     * non-suspending : safe from a lifecycle callback). No-op while the user is anonymous or
+     * nobody collects [observeUnreadMpCount]. Caller : app-foreground (`ON_START`) so the
+     * badge catches MPs received while the app was backgrounded.
+     *
+     * The count also refreshes for free whenever page 1 of the inbox is fetched through
+     * [getPrivateMessageList] (the badge piggybacks on the Messages tab's own loads — no
+     * second network call).
+     */
+    fun requestUnreadRefresh()
+
+    /**
      * Fetches one page of the private-message inbox (`forum1.php?cat=prive`). Throws on
      * network / session errors (e.g. [fr.forumhfr.redface2.core.domain.auth.SessionExpiredException]);
      * the caller maps the failure to its UI state.

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -185,4 +185,15 @@ interface UserPreferencesRepository {
 
     /** Persists [observeTopicPageFabs]. Default `true` until the first call. */
     suspend fun setTopicPageFabs(enabled: Boolean)
+
+    /**
+     * #313 — unread-MP badge on the « Messages » destination of the navigation bar. When
+     * `true` (default) the badge shows the count of unread conversations for the authenticated
+     * session ; `false` hides it entirely (no fetch is saved — the underlying count flow is
+     * shared with other consumers). Observed by `:app`, toggled in Settings.
+     */
+    fun observeMpUnreadBadge(): Flow<Boolean>
+
+    /** Persists [observeMpUnreadBadge]. Default `true` until the first call. */
+    suspend fun setMpUnreadBadge(enabled: Boolean)
 }

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -1406,6 +1406,10 @@ class PostEditorViewModelTest {
         override fun observeTopicPageFabs(): Flow<Boolean> = MutableStateFlow(true)
 
         override suspend fun setTopicPageFabs(enabled: Boolean) = Unit
+
+        override fun observeMpUnreadBadge(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setMpUnreadBadge(enabled: Boolean) = Unit
     }
 
     private companion object {

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1259,6 +1259,10 @@ class TopicFormViewModelTest {
         override fun observeTopicPageFabs(): Flow<Boolean> = MutableStateFlow(true)
 
         override suspend fun setTopicPageFabs(enabled: Boolean) = Unit
+
+        override fun observeMpUnreadBadge(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setMpUnreadBadge(enabled: Boolean) = Unit
     }
 
     private companion object {

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1593,6 +1593,10 @@ class FlagsViewModelTest {
 
         override suspend fun setTopicPageFabs(enabled: Boolean) = Unit
 
+        override fun observeMpUnreadBadge(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setMpUnreadBadge(enabled: Boolean) = Unit
+
         // #312 — confirm-before-posting is irrelevant to FlagsViewModel; stubbed at its default.
         override fun observeConfirmBeforePosting(): Flow<Boolean> = MutableStateFlow(false)
 

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -257,6 +257,10 @@ internal fun SettingsContent(
             )
 
             SettingsSectionHeader(stringResource(R.string.settings_section_mp))
+            MessagesPreferencesCard(
+                state = state,
+                onIntent = onIntent,
+            )
             FutureSettingsCard(
                 items = listOf(
                     R.string.settings_future_mp_notifications to issueTag(313),
@@ -585,6 +589,35 @@ private fun TopicPreferencesCard(
  * first shows a confirmation dialog. Persisted via DataStore and observed live by the editor
  * ViewModels, so a flip here applies without reopening an editor.
  */
+@Composable
+private fun MessagesPreferencesCard(
+    state: SettingsState,
+    onIntent: (SettingsIntent) -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_mp_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            PreferenceSwitchRow(
+                title = stringResource(R.string.settings_mp_unread_badge_title),
+                description = stringResource(R.string.settings_mp_unread_badge_description),
+                checked = state.mpUnreadBadge,
+                enabled = state.canToggleMpUnreadBadge,
+                onCheckedChange = { onIntent(SettingsIntent.MpUnreadBadgeChanged(it)) },
+            )
+            if (state.mpUnreadBadgeError) {
+                PreferencePersistError(R.string.settings_mp_unread_badge_persist_failed)
+            }
+        }
+    }
+}
+
 @Composable
 private fun EditingPreferencesCard(
     state: SettingsState,

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -84,6 +84,11 @@ data class SettingsState(
     val isUpdatingTopicPageFabs: Boolean = false,
     val topicPageFabsError: Boolean = false,
     val topicPageFabsTouchedLocally: Boolean = false,
+    // #313 — badge MP non lus sur l'item Messages de la barre de navigation.
+    val mpUnreadBadge: Boolean = true,
+    val isUpdatingMpUnreadBadge: Boolean = false,
+    val mpUnreadBadgeError: Boolean = false,
+    val mpUnreadBadgeTouchedLocally: Boolean = false,
     // Publishing preferences (#312). Same optimistic-flip + startup-race-guard machinery:
     // `confirmBeforePosting` is the displayed value, `isUpdating*` gates the switch while DataStore
     // writes, `*Error` surfaces a persist failure, `*TouchedLocally` forbids a late `init` hydration
@@ -143,6 +148,9 @@ data class SettingsState(
     // #383 — the page-FABs toggle is gated only by its own write.
     val canToggleTopicPageFabs: Boolean
         get() = !isUpdatingTopicPageFabs
+
+    val canToggleMpUnreadBadge: Boolean
+        get() = !isUpdatingMpUnreadBadge
 
     // #312 — the confirm-before-posting toggle is gated only by its own write.
     val canToggleConfirmBeforePosting: Boolean
@@ -230,6 +238,9 @@ sealed interface SettingsIntent {
     // #383 — topic floating ‹/› page FABs toggle. Optimistic-flip contract, like the flags
     // toggles: the boolean is the desired post-flip state.
     data class TopicPageFabsChanged(val enabled: Boolean) : SettingsIntent
+
+    /** #313 — badge MP non lus (barre de navigation). */
+    data class MpUnreadBadgeChanged(val enabled: Boolean) : SettingsIntent
 
     // #312 — confirm-before-posting toggle. Optimistic-flip contract, like the flags toggles:
     // the boolean is the desired post-flip state.

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -121,6 +121,16 @@ class SettingsViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
+            val mpBadge = userPreferencesRepository.observeMpUnreadBadge().first()
+            _state.update { current ->
+                if (current.mpUnreadBadgeTouchedLocally || current.isUpdatingMpUnreadBadge) {
+                    current
+                } else {
+                    current.copy(mpUnreadBadge = mpBadge)
+                }
+            }
+        }
+        viewModelScope.launch {
             val confirm = userPreferencesRepository.observeConfirmBeforePosting().first()
             _state.update { current ->
                 if (current.confirmBeforePostingTouchedLocally || current.isUpdatingConfirmBeforePosting) {
@@ -193,6 +203,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.AmoledEnabledChanged -> updateAmoled(intent.enabled)
             is SettingsIntent.TopicTopBarAutoHideChanged -> updateTopicTopBarAutoHide(intent.enabled)
             is SettingsIntent.TopicPageFabsChanged -> updateTopicPageFabs(intent.enabled)
+            is SettingsIntent.MpUnreadBadgeChanged -> updateMpUnreadBadge(intent.enabled)
             is SettingsIntent.ShowDtSectionChanged -> updateShowDtSection(intent.enabled)
             is SettingsIntent.ConfirmBeforePostingChanged -> updateConfirmBeforePosting(intent.enabled)
             is SettingsIntent.FlagsAutoRefreshChanged -> updateFlagsAutoRefresh(intent.enabled)
@@ -523,6 +534,33 @@ class SettingsViewModel @Inject constructor(
                 }
             },
             persist = userPreferencesRepository::setTopicPageFabs,
+        )
+    }
+
+    private fun updateMpUnreadBadge(desired: Boolean) {
+        val previous = _state.value.mpUnreadBadge
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    mpUnreadBadge = desired,
+                    isUpdatingMpUnreadBadge = true,
+                    mpUnreadBadgeError = false,
+                    mpUnreadBadgeTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(mpUnreadBadge = desired, isUpdatingMpUnreadBadge = false)
+                } else {
+                    state.copy(
+                        mpUnreadBadge = previous,
+                        isUpdatingMpUnreadBadge = false,
+                        mpUnreadBadgeError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setMpUnreadBadge,
         )
     }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -9,6 +9,11 @@
     <string name="settings_section_topic">Sujet et lecture</string>
     <string name="settings_section_editing">Édition et publication</string>
     <string name="settings_section_mp">Messages privés</string>
+    <!-- #313 — carte « Messages privés » : badge MP non lus. -->
+    <string name="settings_mp_title">Notifications</string>
+    <string name="settings_mp_unread_badge_title">Badge de MP non lus</string>
+    <string name="settings_mp_unread_badge_description">Affiche le nombre de conversations non lues sur l\'onglet Messages. Actualisé à l\'ouverture de l\'app et à chaque visite de la liste.</string>
+    <string name="settings_mp_unread_badge_persist_failed">Impossible d\'enregistrer ce réglage pour le moment.</string>
     <string name="settings_section_hfr_account">Compte HFR</string>
     <string name="settings_section_notifications">Notifications</string>
     <string name="settings_section_accessibility">Accessibilité</string>

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -821,6 +821,45 @@ class SettingsViewModelTest {
     }
 
     // ──────────────────────────────────────────────────────────────────────
+    // Badge MP non lus (#313)
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `init hydrates mpUnreadBadge from a persisted false`() = runTest {
+        // Default is true — only a persisted opt-out exercises the hydration path.
+        repository.emitMpUnreadBadge(false)
+
+        val viewModel = newViewModel()
+
+        assertFalse(viewModel.state.value.mpUnreadBadge)
+        assertFalse(viewModel.state.value.mpUnreadBadgeError)
+    }
+
+    @Test
+    fun `MpUnreadBadgeChanged persists the flip`() = runTest {
+        val viewModel = newViewModel()
+        assertTrue("badge is on by default", viewModel.state.value.mpUnreadBadge)
+
+        viewModel.submit(SettingsIntent.MpUnreadBadgeChanged(false))
+
+        assertFalse(viewModel.state.value.mpUnreadBadge)
+        assertFalse(viewModel.state.value.isUpdatingMpUnreadBadge)
+        assertEquals(1, repository.mpUnreadBadgeSetCalls)
+    }
+
+    @Test
+    fun `MpUnreadBadgeChanged reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnMpUnreadBadgeSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.MpUnreadBadgeChanged(false))
+
+        assertTrue("failed persist must revert to the previous value", viewModel.state.value.mpUnreadBadge)
+        assertFalse(viewModel.state.value.isUpdatingMpUnreadBadge)
+        assertTrue(viewModel.state.value.mpUnreadBadgeError)
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
     // Confirm before posting (#312)
     // ──────────────────────────────────────────────────────────────────────
 
@@ -1058,6 +1097,24 @@ class SettingsViewModelTest {
 
         fun emitTopicPageFabs(value: Boolean) {
             topicPageFabs.value = value
+        }
+
+        // #313 — badge MP non lus. Même seam optimistic-flip que topicPageFabs.
+        private val mpUnreadBadge = MutableStateFlow(true)
+        var mpUnreadBadgeSetCalls: Int = 0
+            private set
+        var failOnMpUnreadBadgeSet: Boolean = false
+
+        override fun observeMpUnreadBadge(): Flow<Boolean> = mpUnreadBadge
+
+        override suspend fun setMpUnreadBadge(enabled: Boolean) {
+            mpUnreadBadgeSetCalls += 1
+            check(!failOnMpUnreadBadgeSet) { "boom" }
+            mpUnreadBadge.value = enabled
+        }
+
+        fun emitMpUnreadBadge(value: Boolean) {
+            mpUnreadBadge.value = value
         }
 
         // #312 — confirm-before-posting. Same optimistic-flip seam as the topic top-bar toggle.

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -1347,4 +1347,8 @@ private class FakeUserPreferencesRepository(
     override fun observeTopicPageFabs(): Flow<Boolean> = MutableStateFlow(topicPageFabs)
 
     override suspend fun setTopicPageFabs(enabled: Boolean) = Unit
+
+    override fun observeMpUnreadBadge(): Flow<Boolean> = MutableStateFlow(true)
+
+    override suspend fun setMpUnreadBadge(enabled: Boolean) = Unit
 }


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi

Badge M3 de MP non lus sur l'onglet Messages (volet « badge in-app » de #313). Design économe en requêtes :

- **Tick au foreground** : `MessagesRepository.requestUnreadRefresh()` déclenché sur `ON_START` (le premier start est sauté, le fetch initial du flow s'en charge)
- **Piggyback** : chaque fetch de la **page 1** de la liste MP réinjecte `count { hasUnread }` dans le flow (zéro requête supplémentaire ; pages > 1 inertes car vue partielle)
- `observeUnreadMpCount()` (dormant Phase 1B.1) réécrit en `transformLatest(authState)` + `merge(ticks, inboxDerived)`
- `MpUnreadBadgeViewModel` : `combine(pref, count)`, n'expose que `count > 0` si le réglage est actif, cap **« 9+ »**
- **Réglage on/off** dans Réglages, carte « Notifications » (défaut activé, pattern optimistic-flip + revert)

## Validation

- detektAll + tests + assembleProdDebug + lintProdDebug verts (Docker, 2 parts)
- 11 tests (3 repo piggyback/page2-inerte/tick, 5 badge VM, 3 settings) ; 6 fakes `UserPreferencesRepository` complétés
- **Vérifié émulateur** : badge « 3 » dès le login = exactement les 3 conversations à pastille rouge de la page 1

refs-#313 (le badge in-app ; les notifications système = issue séparée à venir, étage 2). Fermeture à la promotion dev→main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)