### PR TITLE
feat(messages,ui): picker de smileys dans les éditeurs MP — composant promu :core:ui (refs-#387)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerController.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerController.kt
@@ -1,0 +1,115 @@
+package fr.forumhfr.redface2.core.ui.editor
+
+import fr.forumhfr.redface2.core.model.EditorSmiley
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * #387 — self-contained state machine for the [SmileyPickerSheet], extracted from
+ * `PostEditorViewModel`'s embedded logic so ANY editor host (the MP reply/compose ViewModels
+ * today, the `:feature:editor` ViewModels as a follow-up migration) gets the picker without
+ * re-implementing the debounce and its race guards.
+ *
+ * The host owns insertion : a tap on a smiley hands the BBCode token back to the host
+ * (cf. `SmileyPickerSheet.onSmileyClicked`), which wraps it into its own draft via
+ * `insertBbcodeToken` and then calls [dismiss].
+ *
+ * Wiki search contract (mirrors HFR's web composer, `/compressed/message.js`) :
+ *  - queries of length ≤ 2 reset the wiki branch to Idle (the Standard tab stays usable) ;
+ *  - a 300 ms debounce coalesces a typing burst ; `Loading` flips only AFTER the debounce so
+ *    a one-burst « jap » never flashes a spinner ;
+ *  - job-identity + query-equality guards drop stale responses (cancelled jobs, retyped
+ *    queries) so an older network result can never overwrite a newer one.
+ *
+ * [searchWiki] is a lambda (not `SmileyRepository`) so `:core:ui` gains no dependency on
+ * `:core:domain` ; [userId] feeds HFR's wiki endpoint and falls back to 0 when the session
+ * has not resolved an id (proven harmless — same fallback as `PostEditorViewModel`).
+ */
+class SmileyPickerController(
+    private val scope: CoroutineScope,
+    private val searchWiki: suspend (userId: Int, query: String) -> List<EditorSmiley>,
+    private val userId: () -> Int? = { null },
+    private val onSearchFailed: (Throwable) -> Unit = {},
+) {
+
+    private val _state = MutableStateFlow<SmileyPickerState>(SmileyPickerState.Hidden)
+    val state: StateFlow<SmileyPickerState> = _state.asStateFlow()
+
+    private var searchJob: Job? = null
+
+    fun open() {
+        _state.update { current ->
+            if (current is SmileyPickerState.Open) current else SmileyPickerState.Open()
+        }
+    }
+
+    fun dismiss() {
+        searchJob?.cancel()
+        searchJob = null
+        _state.value = SmileyPickerState.Hidden
+    }
+
+    fun onQueryChanged(query: String) {
+        _state.update { current ->
+            val open = current as? SmileyPickerState.Open ?: return@update current
+            open.copy(query = query)
+        }
+        // Cancel in-flight searches so an older response can't overwrite a newer query.
+        searchJob?.cancel()
+        if (query.length < MIN_WIKI_QUERY_LENGTH) {
+            _state.update { current ->
+                val open = current as? SmileyPickerState.Open ?: return@update current
+                open.copy(wiki = WikiSearchState.Idle)
+            }
+            return
+        }
+        searchJob = scope.launch {
+            // A superseding query cancels this job AT this suspension point (cancel() above),
+            // so no explicit job-identity guard is needed : a job that survives the delay is
+            // the latest one, and the query-equality guards below drop any residual stale
+            // write (the only theoretical leak — the same query retyped inside the window —
+            // converges to the same result anyway).
+            delay(SEARCH_DEBOUNCE_MS)
+            _state.update { current ->
+                val open = current as? SmileyPickerState.Open ?: return@update current
+                if (open.query != query) return@update current
+                open.copy(wiki = WikiSearchState.Loading)
+            }
+            val outcome = runCatching { searchWiki(userId() ?: 0, query) }
+            outcome.fold(
+                onSuccess = { items ->
+                    updateWikiIfCurrent(query, WikiSearchState.Results(items))
+                },
+                onFailure = { error ->
+                    if (error is CancellationException) throw error
+                    onSearchFailed(error)
+                    updateWikiIfCurrent(query, WikiSearchState.Error)
+                },
+            )
+        }
+    }
+
+    /** Drops the result if the user closed the picker or typed a different query meanwhile. */
+    private fun updateWikiIfCurrent(query: String, wiki: WikiSearchState) {
+        _state.update { current ->
+            val open = current as? SmileyPickerState.Open ?: return@update current
+            if (open.query != query) return@update current
+            open.copy(wiki = wiki)
+        }
+    }
+
+    companion object {
+        /** HFR's web composer debounce (`find_smilies_timer`, /compressed/message.js). */
+        const val SEARCH_DEBOUNCE_MS = 300L
+
+        /** HFR's web composer threshold : the wiki search arms at 3 typed characters. */
+        const val MIN_WIKI_QUERY_LENGTH = 3
+    }
+}

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerController.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerController.kt
@@ -57,6 +57,10 @@ class SmileyPickerController(
     }
 
     fun onQueryChanged(query: String) {
+        // A late callback landing after dismiss() must not arm a search : Hidden means
+        // "no live work", and the debounce below would otherwise fire a network call whose
+        // result is only THEN dropped by the Open guards (Codex review, PR #440).
+        if (_state.value !is SmileyPickerState.Open) return
         _state.update { current ->
             val open = current as? SmileyPickerState.Open ?: return@update current
             open.copy(query = query)

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerSheet.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerSheet.kt
@@ -1,4 +1,6 @@
-package fr.forumhfr.redface2.feature.editor
+package fr.forumhfr.redface2.core.ui.editor
+
+import fr.forumhfr.redface2.core.ui.R
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -38,7 +40,8 @@ import fr.forumhfr.redface2.core.model.BUILTIN_HFR_SMILEYS
 import fr.forumhfr.redface2.core.model.EditorSmiley
 
 /**
- * Phase 2F-B (#11 partial) — bottom-sheet smiley picker.
+ * Phase 2F-B (#11 partial) — bottom-sheet smiley picker. Promoted from `:feature:editor`
+ * to `:core:ui` for the MP editors (#387) — same pattern as `EditorOptionsSheet` (#388).
  *
  * Two tabs :
  *  - **Standard** : the canonical `BUILTIN_HFR_SMILEYS` constant, ~25 entries, available
@@ -53,7 +56,7 @@ import fr.forumhfr.redface2.core.model.EditorSmiley
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-internal fun SmileyPickerSheet(
+fun SmileyPickerSheet(
     state: SmileyPickerState.Open,
     onDismiss: () -> Unit,
     onQueryChange: (String) -> Unit,

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerState.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerState.kt
@@ -1,0 +1,37 @@
+package fr.forumhfr.redface2.core.ui.editor
+
+import fr.forumhfr.redface2.core.model.EditorSmiley
+
+/**
+ * State of the [SmileyPickerSheet], promoted from `:feature:editor` with the sheet (#387) so any
+ * editor host (`:feature:editor` VMs, the MP editors, [SmileyPickerController]) shares one shape.
+ */
+/**
+ * Phase 2F-B (#11 partial) — visibility + content of the smiley bottom-sheet picker.
+ *
+ *  - [Hidden] : sheet collapsed, no live work.
+ *  - [Open] : sheet visible. `query` drives the wiki search ; `wiki` reflects the lifecycle
+ *    of the latest search. The Standard tab does not need its own status because the
+ *    [BUILTIN_HFR_SMILEYS][fr.forumhfr.redface2.core.model.BUILTIN_HFR_SMILEYS] constant is
+ *    available synchronously.
+ */
+sealed interface SmileyPickerState {
+    data object Hidden : SmileyPickerState
+    data class Open(
+        val query: String = "",
+        val wiki: WikiSearchState = WikiSearchState.Idle,
+    ) : SmileyPickerState
+}
+
+/**
+ * Lifecycle of the wiki smiley search call. `Idle` until the query crosses the
+ * `query.length > 2` threshold HFR enforces ; `Loading` during the round-trip ; `Results`
+ * on success ; `Error` on network or parse failure (the picker stays usable on the Standard
+ * tab regardless).
+ */
+sealed interface WikiSearchState {
+    data object Idle : WikiSearchState
+    data object Loading : WikiSearchState
+    data class Results(val items: List<EditorSmiley>) : WikiSearchState
+    data object Error : WikiSearchState
+}

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -62,4 +62,14 @@
          écran. -->
     <string name="error_hfr_server_down">HFR est en panne (erreur serveur)</string>
     <string name="error_no_connection">Pas de connexion</string>
+    <!-- #387 — smiley picker (promu depuis :feature:editor avec SmileyPickerSheet). -->
+    <string name="editor_smiley_title">Smileys</string>
+    <string name="editor_smiley_tab_standard">Standard</string>
+    <string name="editor_smiley_tab_wiki">Wiki</string>
+    <string name="editor_smiley_search_label">Rechercher un smiley perso</string>
+    <string name="editor_smiley_search_hint">Tape au moins 3 caractères pour interroger le wiki HFR.</string>
+    <string name="editor_smiley_search_loading">Recherche…</string>
+    <string name="editor_smiley_search_empty">Aucun smiley trouvé.</string>
+    <string name="editor_smiley_search_error">Erreur réseau. Réessaie dans un instant.</string>
+    <string name="editor_smiley_insert_description">Insérer %1$s</string>
 </resources>

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerControllerTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerControllerTest.kt
@@ -1,0 +1,143 @@
+package fr.forumhfr.redface2.core.ui.editor
+
+import fr.forumhfr.redface2.core.model.EditorSmiley
+import fr.forumhfr.redface2.core.model.EditorSmileySource
+import java.io.IOException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #387 — the picker state machine extracted from PostEditorViewModel : debounce, the ≤ 2-chars
+ * idle gate, stale-result guards, the userId 0 fallback. Pure JVM (virtual time).
+ *
+ * The controller takes the TestScope itself (NOT backgroundScope) : with coroutines 1.11
+ * the test scheduler does not advance backgroundScope children from advanceUntilIdle in
+ * this setup (probed empirically) ; every launched search either completes or is
+ * explicitly cancelled by dismiss(), so runTest never hangs on a leftover child.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SmileyPickerControllerTest {
+
+    private val smiley = EditorSmiley(
+        token = "[:rofl]",
+        imageUrl = "https://x/rofl.gif",
+        source = EditorSmileySource.WIKI,
+    )
+
+    @Test
+    fun `open is idempotent and dismiss resets to Hidden`() = runTest {
+        val controller = SmileyPickerController(this, { _, _ -> emptyList() })
+
+        controller.open()
+        controller.onQueryChanged("ja")
+        controller.open() // must NOT reset the typed query
+
+        val open = controller.state.value as SmileyPickerState.Open
+        assertEquals("ja", open.query)
+
+        controller.dismiss()
+        assertEquals(SmileyPickerState.Hidden, controller.state.value)
+    }
+
+    @Test
+    fun `queries of 2 chars or fewer keep the wiki branch Idle without searching`() = runTest {
+        var calls = 0
+        val controller = SmileyPickerController(this, { _, _ -> calls++; emptyList() })
+
+        controller.open()
+        controller.onQueryChanged("ja")
+        advanceUntilIdle()
+
+        val open = controller.state.value as SmileyPickerState.Open
+        assertEquals(WikiSearchState.Idle, open.wiki)
+        assertEquals(0, calls)
+    }
+
+    @Test
+    fun `a debounced query lands Results`() = runTest {
+        val controller = SmileyPickerController(this, { _, query ->
+            assertEquals("jap", query)
+            listOf(smiley)
+        })
+
+        controller.open()
+        controller.onQueryChanged("jap")
+        advanceUntilIdle()
+
+        val open = controller.state.value as SmileyPickerState.Open
+        assertEquals(WikiSearchState.Results(listOf(smiley)), open.wiki)
+    }
+
+    @Test
+    fun `typing within the debounce window coalesces to a single search`() = runTest {
+        val queries = mutableListOf<String>()
+        val controller = SmileyPickerController(this, { _, query ->
+            queries += query
+            emptyList()
+        })
+
+        controller.open()
+        controller.onQueryChanged("jap")
+        advanceTimeBy(SmileyPickerController.SEARCH_DEBOUNCE_MS / 2)
+        controller.onQueryChanged("japo")
+        advanceUntilIdle()
+
+        assertEquals(listOf("japo"), queries)
+    }
+
+    @Test
+    fun `a search failure lands Error and notifies the host`() = runTest {
+        var reported: Throwable? = null
+        val controller = SmileyPickerController(
+            scope = this,
+            searchWiki = { _, _ -> throw IOException("offline") },
+            onSearchFailed = { reported = it },
+        )
+
+        controller.open()
+        controller.onQueryChanged("jap")
+        advanceUntilIdle()
+
+        val open = controller.state.value as SmileyPickerState.Open
+        assertEquals(WikiSearchState.Error, open.wiki)
+        assertTrue(reported is IOException)
+    }
+
+    @Test
+    fun `a result arriving after dismiss is dropped`() = runTest {
+        val controller = SmileyPickerController(this, { _, _ -> listOf(smiley) })
+
+        controller.open()
+        controller.onQueryChanged("jap")
+        advanceTimeBy(SmileyPickerController.SEARCH_DEBOUNCE_MS / 2)
+        controller.dismiss()
+        advanceUntilIdle()
+
+        assertEquals(
+            "a dismissal mid-debounce must leave the picker Hidden, not resurrect an Open state",
+            SmileyPickerState.Hidden,
+            controller.state.value,
+        )
+    }
+
+    @Test
+    fun `a null user id falls back to 0 (PostEditorViewModel parity)`() = runTest {
+        var seenUserId: Int? = null
+        val controller = SmileyPickerController(
+            scope = this,
+            searchWiki = { userId, _ -> seenUserId = userId; emptyList() },
+            userId = { null },
+        )
+
+        controller.open()
+        controller.onQueryChanged("jap")
+        advanceUntilIdle()
+
+        assertEquals(0, seenUserId)
+    }
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerControllerTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerControllerTest.kt
@@ -126,6 +126,20 @@ class SmileyPickerControllerTest {
     }
 
     @Test
+    fun `a query change landing after dismiss is ignored — no search while Hidden`() = runTest {
+        var calls = 0
+        val controller = SmileyPickerController(this, { _, _ -> calls++; emptyList() })
+
+        controller.open()
+        controller.dismiss()
+        controller.onQueryChanged("jap") // late UI callback after the sheet closed
+        advanceUntilIdle()
+
+        assertEquals(SmileyPickerState.Hidden, controller.state.value)
+        assertEquals("Hidden means no live work — the debounce must not arm", 0, calls)
+    }
+
+    @Test
     fun `a null user id falls back to 0 (PostEditorViewModel parity)`() = runTest {
         var seenUserId: Int? = null
         val controller = SmileyPickerController(

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -1,5 +1,7 @@
 package fr.forumhfr.redface2.feature.editor
 
+import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
+import fr.forumhfr.redface2.core.ui.editor.SmileyPickerSheet
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.feature.editor
 
+import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 import androidx.compose.ui.text.input.TextFieldValue
 import fr.forumhfr.redface2.core.domain.editor.BbcodeValidation
 import fr.forumhfr.redface2.core.domain.editor.validateBbcodeDraft
@@ -138,35 +139,7 @@ sealed interface SubmitError {
     data object MissingSubcat : SubmitError
 }
 
-/**
- * Phase 2F-B (#11 partial) — visibility + content of the smiley bottom-sheet picker.
- *
- *  - [Hidden] : sheet collapsed, no live work.
- *  - [Open] : sheet visible. `query` drives the wiki search ; `wiki` reflects the lifecycle
- *    of the latest search. The Standard tab does not need its own status because the
- *    [BUILTIN_HFR_SMILEYS][fr.forumhfr.redface2.core.model.BUILTIN_HFR_SMILEYS] constant is
- *    available synchronously.
- */
-sealed interface SmileyPickerState {
-    data object Hidden : SmileyPickerState
-    data class Open(
-        val query: String = "",
-        val wiki: WikiSearchState = WikiSearchState.Idle,
-    ) : SmileyPickerState
-}
 
-/**
- * Lifecycle of the wiki smiley search call. `Idle` until the query crosses the
- * `query.length > 2` threshold HFR enforces ; `Loading` during the round-trip ; `Results`
- * on success ; `Error` on network or parse failure (the picker stays usable on the Standard
- * tab regardless).
- */
-sealed interface WikiSearchState {
-    data object Idle : WikiSearchState
-    data object Loading : WikiSearchState
-    data class Results(val items: List<EditorSmiley>) : WikiSearchState
-    data object Error : WikiSearchState
-}
 
 internal fun PostEditorState.withDraft(updated: TextFieldValue): PostEditorState =
     copy(

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -1,5 +1,7 @@
 package fr.forumhfr.redface2.feature.editor
 
+import fr.forumhfr.redface2.core.ui.editor.WikiSearchState
+import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormScreen.kt
@@ -1,5 +1,7 @@
 package fr.forumhfr.redface2.feature.editor
 
+import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
+import fr.forumhfr.redface2.core.ui.editor.SmileyPickerSheet
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormState.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormState.kt
@@ -1,5 +1,7 @@
 package fr.forumhfr.redface2.feature.editor
 
+import fr.forumhfr.redface2.core.ui.editor.WikiSearchState
+import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 import androidx.compose.ui.text.input.TextFieldValue
 import fr.forumhfr.redface2.core.domain.editor.BbcodeValidation
 import fr.forumhfr.redface2.core.domain.editor.validateBbcodeDraft

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModel.kt
@@ -1,5 +1,7 @@
 package fr.forumhfr.redface2.feature.editor
 
+import fr.forumhfr.redface2.core.ui.editor.WikiSearchState
+import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel

--- a/feature/editor/src/main/res/values/strings.xml
+++ b/feature/editor/src/main/res/values/strings.xml
@@ -29,22 +29,14 @@
     <string name="editor_topic_subcat_picker_placeholder">Choisir une sous-catégorie</string>
     <string name="editor_topic_poll_readonly_note">Ce sujet contient un sondage. Son édition n\'est pas encore disponible dans cette version ; vos réponses utilisateurs et options de vote restent inchangées.</string>
     <string name="editor_new_topic_created">Sujet créé. Rafraîchis la liste si besoin pour le retrouver.</string>
-    <string name="editor_smiley_open">Smileys</string>
     <string name="editor_actions_options">Options</string>
     <string name="editor_submit_confirm">Confirmer</string>
-    <string name="editor_smiley_title">Smileys</string>
-    <string name="editor_smiley_tab_standard">Standard</string>
-    <string name="editor_smiley_tab_wiki">Wiki</string>
-    <string name="editor_smiley_search_label">Rechercher un smiley perso</string>
-    <string name="editor_smiley_search_hint">Tape au moins 3 caractères pour interroger le wiki HFR.</string>
-    <string name="editor_smiley_search_loading">Recherche…</string>
-    <string name="editor_smiley_search_empty">Aucun smiley trouvé.</string>
-    <string name="editor_smiley_search_error">Erreur réseau. Réessaie dans un instant.</string>
-    <string name="editor_smiley_insert_description">Insérer %1$s</string>
     <string name="editor_image_url_title">Insérer une image</string>
     <string name="editor_image_url_label">URL de l’image</string>
     <string name="editor_image_url_help">URL http:// ou https:// uniquement.</string>
     <string name="editor_image_url_error">Seules les URL http:// et https:// sont acceptées.</string>
     <string name="editor_image_url_insert">Insérer</string>
     <string name="editor_image_url_cancel">Annuler</string>
+    <!-- Label du bouton « Smileys » de la barre éditeur (le sheet vit dans :core:ui, #387). -->
+    <string name="editor_smiley_open">Smileys</string>
 </resources>

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -1,5 +1,7 @@
 package fr.forumhfr.redface2.feature.editor
 
+import fr.forumhfr.redface2.core.ui.editor.WikiSearchState
+import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import app.cash.turbine.test

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1,5 +1,7 @@
 package fr.forumhfr.redface2.feature.editor
 
+import fr.forumhfr.redface2.core.ui.editor.WikiSearchState
+import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import app.cash.turbine.test

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessageEditorComponents.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessageEditorComponents.kt
@@ -121,6 +121,7 @@ internal fun MessageSubmitBar(
     onConfirmSubmit: () -> Unit,
     onDisarmConfirm: () -> Unit,
     onOpenOptions: () -> Unit,
+    onOpenSmileys: () -> Unit,
 ) {
     Surface(color = MaterialTheme.colorScheme.surfaceContainer, tonalElevation = 3.dp) {
         Column(modifier = Modifier.fillMaxWidth()) {
@@ -144,6 +145,11 @@ internal fun MessageSubmitBar(
                 if (!confirmArmed) {
                     FilledTonalButton(onClick = onOpenOptions) {
                         Text(text = stringResource(R.string.messages_reply_actions_options))
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    // #387 — same Options/Smileys/Envoyer trio as the post editor's bar (#388).
+                    FilledTonalButton(onClick = onOpenSmileys) {
+                        Text(text = stringResource(R.string.messages_reply_actions_smileys))
                     }
                 }
                 Spacer(modifier = Modifier.weight(1f))

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeScreen.kt
@@ -34,6 +34,9 @@ import fr.forumhfr.redface2.core.ui.editor.BbcodePreview
 import fr.forumhfr.redface2.core.ui.editor.BbcodeTextField
 import fr.forumhfr.redface2.core.ui.editor.BbcodeToolbar
 import fr.forumhfr.redface2.core.ui.editor.EditorOptionsSheet
+import fr.forumhfr.redface2.core.ui.editor.SmileyPickerController
+import fr.forumhfr.redface2.core.ui.editor.SmileyPickerSheet
+import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 
 /**
  * New-conversation composer (#301 follow-up). Same chrome as the reply editor — shared header,
@@ -77,6 +80,8 @@ fun PrivateMessageComposeScreen(
         onSubmitConfirmed = viewModel::onSubmitConfirmed,
         onSubmitConfirmationDismissed = viewModel::onSubmitConfirmationDismissed,
         onRetryFormLoad = viewModel::retryFormLoad,
+        smileyPicker = viewModel.smileyPicker,
+        onSmileySelected = viewModel::onSmileySelected,
         modifier = modifier,
     )
 }
@@ -99,6 +104,8 @@ private fun PrivateMessageComposeContent(
     onSubmitConfirmed: () -> Unit,
     onSubmitConfirmationDismissed: () -> Unit,
     onRetryFormLoad: () -> Unit,
+    smileyPicker: SmileyPickerController,
+    onSmileySelected: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var optionsSheetOpen by remember { mutableStateOf(false) }
@@ -133,6 +140,7 @@ private fun PrivateMessageComposeContent(
                         onConfirmSubmit = onSubmitConfirmed,
                         onDisarmConfirm = onSubmitConfirmationDismissed,
                         onOpenOptions = { optionsSheetOpen = true },
+                        onOpenSmileys = smileyPicker::open,
                     )
                 }
             }
@@ -149,6 +157,16 @@ private fun PrivateMessageComposeContent(
                     onEmailNotificationChanged = onToggleEmailNotification,
                 )
             }
+        }
+        // #387 — smiley picker sheet (Standard + Wiki), same component as the post editors.
+        val pickerState by smileyPicker.state.collectAsStateWithLifecycle()
+        (pickerState as? SmileyPickerState.Open)?.let { open ->
+            SmileyPickerSheet(
+                state = open,
+                onDismiss = smileyPicker::dismiss,
+                onQueryChange = smileyPicker::onQueryChanged,
+                onSmileyClicked = onSmileySelected,
+            )
         }
     }
 }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModel.kt
@@ -171,12 +171,15 @@ class PrivateMessageComposeViewModel @AssistedInject constructor(
     /**
      * #387 — smiley picker (Standard + Wiki), same sheet as the post editors. The controller owns
      * the picker state machine (debounce, race guards) ; this ViewModel only handles insertion.
-     * userId stays at the controller's 0 fallback : the MP write flow never resolves a numeric
-     * user id, and the wiki endpoint accepts 0 (same fallback as PostEditorViewModel).
+     * userId comes from the loaded compose form ([ReplyForm.userId], HFR's `find_smilies_timer`
+     * second argument) so the wiki search prioritizes the user's own smileys exactly like the
+     * post editors do ; the controller falls back to 0 while the form is still loading
+     * (Codex review, PR #440).
      */
     val smileyPicker = SmileyPickerController(
         scope = viewModelScope,
         searchWiki = smileyRepository::searchWiki,
+        userId = { loadedForm?.userId },
     )
 
     fun onSmileySelected(token: String) {

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModel.kt
@@ -17,7 +17,10 @@ import fr.forumhfr.redface2.core.model.write.ReplyForm
 import fr.forumhfr.redface2.core.model.write.ReplyFormOptions
 import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
 import fr.forumhfr.redface2.core.ui.editor.BbcodeAction
+import fr.forumhfr.redface2.core.domain.smiley.SmileyRepository
+import fr.forumhfr.redface2.core.ui.editor.SmileyPickerController
 import fr.forumhfr.redface2.core.ui.editor.applyBbcodeAction
+import fr.forumhfr.redface2.core.ui.editor.insertBbcodeToken
 import java.io.IOException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
@@ -50,6 +53,7 @@ class PrivateMessageComposeViewModel @AssistedInject constructor(
     private val repository: PrivateMessageWriteRepository,
     private val previewParser: BbcodePreviewParser,
     private val userPreferencesRepository: UserPreferencesRepository,
+    smileyRepository: SmileyRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(
@@ -162,6 +166,35 @@ class PrivateMessageComposeViewModel @AssistedInject constructor(
                 ),
             )
         }
+    }
+
+    /**
+     * #387 — smiley picker (Standard + Wiki), same sheet as the post editors. The controller owns
+     * the picker state machine (debounce, race guards) ; this ViewModel only handles insertion.
+     * userId stays at the controller's 0 fallback : the MP write flow never resolves a numeric
+     * user id, and the wiki endpoint accepts 0 (same fallback as PostEditorViewModel).
+     */
+    val smileyPicker = SmileyPickerController(
+        scope = viewModelScope,
+        searchWiki = smileyRepository::searchWiki,
+    )
+
+    fun onSmileySelected(token: String) {
+        _state.update { current ->
+            val outcome = insertBbcodeToken(
+                token = token,
+                text = current.draft.text,
+                selectionStart = current.draft.selection.start,
+                selectionEnd = current.draft.selection.end,
+            )
+            current.withDraftPreview(
+                TextFieldValue(
+                    text = outcome.text,
+                    selection = TextRange(outcome.selectionStart, outcome.selectionEnd),
+                ),
+            )
+        }
+        smileyPicker.dismiss()
     }
 
     fun onTogglePreview() {

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
@@ -32,6 +32,9 @@ import fr.forumhfr.redface2.core.ui.editor.BbcodePreview
 import fr.forumhfr.redface2.core.ui.editor.BbcodeTextField
 import fr.forumhfr.redface2.core.ui.editor.BbcodeToolbar
 import fr.forumhfr.redface2.core.ui.editor.EditorOptionsSheet
+import fr.forumhfr.redface2.core.ui.editor.SmileyPickerController
+import fr.forumhfr.redface2.core.ui.editor.SmileyPickerSheet
+import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 
 /**
  * Reply editor for a private-message conversation (#301). Reuses the shared `:core:ui` BBCode
@@ -73,6 +76,8 @@ fun PrivateMessageReplyScreen(
         onSubmitConfirmed = viewModel::onSubmitConfirmed,
         onSubmitConfirmationDismissed = viewModel::onSubmitConfirmationDismissed,
         onRetryFormLoad = viewModel::retryFormLoad,
+        smileyPicker = viewModel.smileyPicker,
+        onSmileySelected = viewModel::onSmileySelected,
         modifier = modifier,
     )
 }
@@ -93,6 +98,8 @@ private fun PrivateMessageReplyContent(
     onSubmitConfirmed: () -> Unit,
     onSubmitConfirmationDismissed: () -> Unit,
     onRetryFormLoad: () -> Unit,
+    smileyPicker: SmileyPickerController,
+    onSmileySelected: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var optionsSheetOpen by remember { mutableStateOf(false) }
@@ -119,6 +126,7 @@ private fun PrivateMessageReplyContent(
                         onConfirmSubmit = onSubmitConfirmed,
                         onDisarmConfirm = onSubmitConfirmationDismissed,
                         onOpenOptions = { optionsSheetOpen = true },
+                        onOpenSmileys = smileyPicker::open,
                     )
                 }
             }
@@ -137,6 +145,16 @@ private fun PrivateMessageReplyContent(
                     onEmailNotificationChanged = onToggleEmailNotification,
                 )
             }
+        }
+        // #387 — smiley picker sheet (Standard + Wiki), same component as the post editors.
+        val pickerState by smileyPicker.state.collectAsStateWithLifecycle()
+        (pickerState as? SmileyPickerState.Open)?.let { open ->
+            SmileyPickerSheet(
+                state = open,
+                onDismiss = smileyPicker::dismiss,
+                onQueryChange = smileyPicker::onQueryChanged,
+                onSmileyClicked = onSmileySelected,
+            )
         }
     }
 }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
@@ -172,12 +172,15 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
     /**
      * #387 — smiley picker (Standard + Wiki), same sheet as the post editors. The controller owns
      * the picker state machine (debounce, race guards) ; this ViewModel only handles insertion.
-     * userId stays at the controller's 0 fallback : the MP write flow never resolves a numeric
-     * user id, and the wiki endpoint accepts 0 (same fallback as PostEditorViewModel).
+     * userId comes from the loaded reply form ([ReplyForm.userId], HFR's `find_smilies_timer`
+     * second argument) so the wiki search prioritizes the user's own smileys exactly like the
+     * post editors do ; the controller falls back to 0 while the form is still loading
+     * (Codex review, PR #440).
      */
     val smileyPicker = SmileyPickerController(
         scope = viewModelScope,
         searchWiki = smileyRepository::searchWiki,
+        userId = { loadedForm?.userId },
     )
 
     fun onSmileySelected(token: String) {

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
@@ -18,7 +18,10 @@ import fr.forumhfr.redface2.core.model.write.ReplyForm
 import fr.forumhfr.redface2.core.model.write.ReplyFormOptions
 import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
 import fr.forumhfr.redface2.core.ui.editor.BbcodeAction
+import fr.forumhfr.redface2.core.domain.smiley.SmileyRepository
+import fr.forumhfr.redface2.core.ui.editor.SmileyPickerController
 import fr.forumhfr.redface2.core.ui.editor.applyBbcodeAction
+import fr.forumhfr.redface2.core.ui.editor.insertBbcodeToken
 import java.io.IOException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
@@ -50,6 +53,7 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
     private val repository: PrivateMessageWriteRepository,
     private val previewParser: BbcodePreviewParser,
     private val userPreferencesRepository: UserPreferencesRepository,
+    smileyRepository: SmileyRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(PrivateMessageReplyUiState())
@@ -163,6 +167,35 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
                 ),
             )
         }
+    }
+
+    /**
+     * #387 — smiley picker (Standard + Wiki), same sheet as the post editors. The controller owns
+     * the picker state machine (debounce, race guards) ; this ViewModel only handles insertion.
+     * userId stays at the controller's 0 fallback : the MP write flow never resolves a numeric
+     * user id, and the wiki endpoint accepts 0 (same fallback as PostEditorViewModel).
+     */
+    val smileyPicker = SmileyPickerController(
+        scope = viewModelScope,
+        searchWiki = smileyRepository::searchWiki,
+    )
+
+    fun onSmileySelected(token: String) {
+        _state.update { current ->
+            val outcome = insertBbcodeToken(
+                token = token,
+                text = current.draft.text,
+                selectionStart = current.draft.selection.start,
+                selectionEnd = current.draft.selection.end,
+            )
+            current.withDraftPreview(
+                TextFieldValue(
+                    text = outcome.text,
+                    selection = TextRange(outcome.selectionStart, outcome.selectionEnd),
+                ),
+            )
+        }
+        smileyPicker.dismiss()
     }
 
     fun onTogglePreview() {

--- a/feature/messages/src/main/res/values/strings.xml
+++ b/feature/messages/src/main/res/values/strings.xml
@@ -35,6 +35,8 @@
     <string name="messages_reply_submit">Envoyer</string>
     <string name="messages_reply_submit_confirm">Confirmer</string>
     <string name="messages_reply_actions_options">Options</string>
+    <!-- #387 — picker de smileys dans les éditeurs MP (demande de tinc). -->
+    <string name="messages_reply_actions_smileys">Smileys</string>
     <string name="messages_reply_options_title">Options</string>
     <string name="messages_reply_option_signature">Activer la signature</string>
     <string name="messages_reply_option_smiley_disabled">Désactiver les smileys</string>

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
+import fr.forumhfr.redface2.core.domain.smiley.SmileyRepository
 import fr.forumhfr.redface2.core.domain.write.PrivateMessageWriteRepository
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
@@ -17,6 +18,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -74,13 +76,29 @@ class PrivateMessageComposeViewModelTest {
         repository: PrivateMessageWriteRepository,
         initialRecipient: String? = null,
         confirmBeforePosting: Boolean = false,
+        smileyRepository: SmileyRepository = mockk(relaxed = true),
     ): PrivateMessageComposeViewModel = PrivateMessageComposeViewModel(
         initialRecipient = initialRecipient,
         repository = repository,
         previewParser = previewParser,
         userPreferencesRepository = userPreferences(confirmBeforePosting),
-        smileyRepository = mockk(relaxed = true),
+        smileyRepository = smileyRepository,
     )
+
+    @Test
+    fun `the wiki search carries the loaded form's userId (#440)`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchComposeForm(any()) } returns composeForm().copy(userId = 54596)
+        val smileys = mockk<SmileyRepository>(relaxed = true)
+
+        val vm = viewModel(repository, smileyRepository = smileys)
+
+        vm.smileyPicker.open()
+        vm.smileyPicker.onQueryChanged("jap")
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { smileys.searchWiki(54596, "jap") }
+    }
 
     @Test
     fun `loads the composer form on init and hydrates the signature default`() = runTest {

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModelTest.kt
@@ -79,6 +79,7 @@ class PrivateMessageComposeViewModelTest {
         repository = repository,
         previewParser = previewParser,
         userPreferencesRepository = userPreferences(confirmBeforePosting),
+        smileyRepository = mockk(relaxed = true),
     )
 
     @Test

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -92,6 +93,23 @@ class PrivateMessageReplyViewModelTest {
         assertFalse(state.formError)
         // The quick-reply form carries signature as a hidden `=1`, so the toggle defaults on.
         assertTrue("signature default should be hydrated from the hidden field", state.signatureEnabled)
+    }
+
+    @Test
+    fun `the wiki search carries the loaded form's userId (#440)`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form().copy(userId = 54596)
+        val smileys = smileyRepository()
+
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), smileys,
+        )
+
+        viewModel.smileyPicker.open()
+        viewModel.smileyPicker.onQueryChanged("jap")
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { smileys.searchWiki(54596, "jap") }
     }
 
     @Test

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
+import fr.forumhfr.redface2.core.domain.smiley.SmileyRepository
 import fr.forumhfr.redface2.core.domain.write.PrivateMessageWriteRepository
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.write.PrivateMessageReplyContext
@@ -53,6 +54,8 @@ class PrivateMessageReplyViewModelTest {
      * #312 — preferences mock. `observeConfirmBeforePosting` is the only member the reply
      * ViewModel consumes; a hot [MutableStateFlow] mirrors the DataStore observe shape.
      */
+    private fun smileyRepository(): SmileyRepository = mockk(relaxed = true)
+
     private fun userPreferences(confirmBeforePosting: Boolean = false): UserPreferencesRepository =
         mockk {
             every { observeConfirmBeforePosting() } returns MutableStateFlow(confirmBeforePosting)
@@ -79,7 +82,9 @@ class PrivateMessageReplyViewModelTest {
         val repository = mockk<PrivateMessageWriteRepository>()
         coEvery { repository.fetchReplyForm(any()) } returns form()
 
-        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser, userPreferences())
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), smileyRepository(),
+        )
 
         val state = viewModel.state.value
         assertFalse(state.isLoadingForm)
@@ -96,7 +101,9 @@ class PrivateMessageReplyViewModelTest {
         coEvery { repository.submitReply(any(), any(), any(), any()) } returns
             ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
 
-        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser, userPreferences())
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), smileyRepository(),
+        )
         viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
 
         viewModel.effects.test {
@@ -118,7 +125,9 @@ class PrivateMessageReplyViewModelTest {
         coEvery { repository.submitReply(any(), any(), any(), any()) } returns
             ReplySubmitResult.Failure(ReplyFailureReason.EmptyMessage)
 
-        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser, userPreferences())
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), smileyRepository(),
+        )
         viewModel.onContentChanged(TextFieldValue("non-blank"))
         viewModel.onSubmit()
 
@@ -135,7 +144,9 @@ class PrivateMessageReplyViewModelTest {
         coEvery { repository.submitReply(any(), any(), any(), any()) } returns
             ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)
 
-        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser, userPreferences())
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), smileyRepository(),
+        )
         viewModel.onContentChanged(TextFieldValue("hello"))
         viewModel.onSubmit()
 
@@ -151,7 +162,9 @@ class PrivateMessageReplyViewModelTest {
         coEvery { repository.submitReply(any(), any(), any(), any()) } returns
             ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)
 
-        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser, userPreferences())
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), smileyRepository(),
+        )
         // First load hydrates signature ON (hidden `signature=1`); the user turns it OFF.
         viewModel.onToggleSignature(false)
         viewModel.onContentChanged(TextFieldValue("hello"))
@@ -173,7 +186,9 @@ class PrivateMessageReplyViewModelTest {
         coEvery { repository.submitReply(any(), any(), any(), any()) } returns
             ReplySubmitResult.Failure(ReplyFailureReason.Unknown)
 
-        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser, userPreferences())
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), smileyRepository(),
+        )
         viewModel.onContentChanged(TextFieldValue("hello"))
         viewModel.onSubmit()
 
@@ -188,7 +203,9 @@ class PrivateMessageReplyViewModelTest {
         val repository = mockk<PrivateMessageWriteRepository>()
         coEvery { repository.fetchReplyForm(any()) } throws IOException("network down")
 
-        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser, userPreferences())
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), smileyRepository(),
+        )
 
         val state = viewModel.state.value
         assertTrue(state.formError)
@@ -201,7 +218,9 @@ class PrivateMessageReplyViewModelTest {
         val repository = mockk<PrivateMessageWriteRepository>()
         coEvery { repository.fetchReplyForm(any()) } returns form(isAnonymous = true)
 
-        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser, userPreferences())
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), smileyRepository(),
+        )
 
         assertTrue(viewModel.state.value.formError)
         assertFalse(viewModel.state.value.formAvailable)
@@ -224,7 +243,9 @@ class PrivateMessageReplyViewModelTest {
         coEvery { repository.submitReply(any(), any(), any(), any()) } returns
             ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
 
-        val viewModel = PrivateMessageReplyViewModel(request, repository, previewParser, userPreferences())
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), smileyRepository(),
+        )
         viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
         viewModel.onSubmit()
 
@@ -242,6 +263,7 @@ class PrivateMessageReplyViewModelTest {
             repository,
             previewParser,
             userPreferences(confirmBeforePosting = true),
+            smileyRepository(),
         )
         viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
         viewModel.onSubmit()
@@ -263,6 +285,7 @@ class PrivateMessageReplyViewModelTest {
             repository,
             previewParser,
             userPreferences(confirmBeforePosting = true),
+            smileyRepository(),
         )
         viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
         viewModel.onSubmit()
@@ -291,6 +314,7 @@ class PrivateMessageReplyViewModelTest {
             repository,
             previewParser,
             userPreferences(confirmBeforePosting = true),
+            smileyRepository(),
         )
         viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
         viewModel.onSubmit()
@@ -315,6 +339,7 @@ class PrivateMessageReplyViewModelTest {
             repository,
             previewParser,
             userPreferences(confirmBeforePosting = true),
+            smileyRepository(),
         )
         viewModel.onSubmit()
 
@@ -332,6 +357,7 @@ class PrivateMessageReplyViewModelTest {
             repository,
             previewParser,
             userPreferences(confirmBeforePosting = true),
+            smileyRepository(),
         )
         viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
         viewModel.onSubmit()
@@ -364,6 +390,7 @@ class PrivateMessageReplyViewModelTest {
             repository,
             previewParser,
             userPreferences(confirmBeforePosting = true),
+            smileyRepository(),
         )
         viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
         viewModel.onSubmit()


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi

Le sheet smileys (Standard + recherche Wiki) n'existait que dans `:feature:editor`. Plutôt que dupliquer :

- **Promotion vers `:core:ui`** : `SmileyPickerSheet` (git mv) + `SmileyPickerState`/`WikiSearchState` extraits + nouveau **`SmileyPickerController`** réutilisable — debounce 300 ms (parité `message.js` HFR), gate < 3 caractères, annulation au point de suspension + gardes d'égalité de query (pas de garde d'identité de job, documenté)
- `searchWiki` passé **en lambda** : `:core:ui` ne gagne aucune dépendance vers `:core:domain`
- Bouton **« Smileys »** dans `MessageSubmitBar` (masqué si confirmation armée) + host du sheet dans les deux écrans MP (réponse + nouveau message)
- VMs MP : ctor +`SmileyRepository`, `onSmileySelected` = insertion du token BBCode au curseur + dismiss
- `:feature:editor` : imports seulement — la **migration de ses VMs vers le contrôleur est un follow-up** (issue à venir)

## Validation

- detektAll + tests + assembleProdDebug + lintProdDebug verts (Docker, 2 parts)
- 7 tests contrôleur (debounce, gate, stale-drop, dismiss, fallback userId 0) + tests VMs adaptés
- Piège consigné : avec coroutines-test 1.11, `backgroundScope` + `advanceUntilIdle` n'avance pas les enfants → les tests passent le TestScope lui-même
- **Vérifié émulateur** : insertion `:pfff:` + recherche Wiki « toto » → grille de résultats, Envoyer activé

refs-#387. Fermeture à la promotion dev→main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)