### PR TITLE
feat(search): repli du formulaire en bandeau compact une fois la recherche lancée (refs-#433)

### DIFF
--- a/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchScreen.kt
@@ -172,20 +172,32 @@ internal fun SearchContent(
                     .padding(start = 16.dp, end = 16.dp, bottom = 12.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                SearchField(
-                    query = state.query,
-                    pseudo = state.pseudo,
-                    // HFR accepts query-only, author-only, and combined searches.
-                    isSubmitEnabled = !state.isLoading &&
-                        (state.query.isNotBlank() || state.pseudo.isNotBlank()),
-                    onQueryChange = { onIntent(SearchIntent.QueryChanged(it)) },
-                    onPseudoChange = { onIntent(SearchIntent.PseudoChanged(it)) },
-                    onSubmit = { onIntent(SearchIntent.Submit) },
-                )
-                SearchOptions(
-                    textScope = state.textScope,
-                    onTextScopeSelected = { onIntent(SearchIntent.TextScopeSelected(it)) },
-                )
+                // #433 — once a search is launched, the form gives the screen back to the
+                // results : a one-line criteria banner replaces the two fields + scope
+                // chips, and tapping it (or « Modifier ») re-expands the full form. The
+                // pivot chips stay visible in both modes — re-scoping is a consultation
+                // action on the CURRENT results, not an edit of the criteria.
+                if (state.formCollapsed) {
+                    CollapsedCriteriaBanner(
+                        state = state,
+                        onEdit = { onIntent(SearchIntent.EditCriteria) },
+                    )
+                } else {
+                    SearchField(
+                        query = state.query,
+                        pseudo = state.pseudo,
+                        // HFR accepts query-only, author-only, and combined searches.
+                        isSubmitEnabled = !state.isLoading &&
+                            (state.query.isNotBlank() || state.pseudo.isNotBlank()),
+                        onQueryChange = { onIntent(SearchIntent.QueryChanged(it)) },
+                        onPseudoChange = { onIntent(SearchIntent.PseudoChanged(it)) },
+                        onSubmit = { onIntent(SearchIntent.Submit) },
+                    )
+                    SearchOptions(
+                        textScope = state.textScope,
+                        onTextScopeSelected = { onIntent(SearchIntent.TextScopeSelected(it)) },
+                    )
+                }
                 if (state.pivotCategories.isNotEmpty()) {
                     PivotChips(
                         pivot = state.pivotCategories,
@@ -208,6 +220,62 @@ internal fun SearchContent(
             }
         }
     }
+}
+
+/**
+ * #433 — compact summary of the launched search : `« query » · par pseudo · scope`,
+ * single line, the whole card is the « edit » affordance. The scope segment only
+ * shows when it differs from the default (no noise on the nominal case).
+ */
+@Composable
+private fun CollapsedCriteriaBanner(
+    state: SearchUiState,
+    onEdit: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        onClick = onEdit,
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = collapsedCriteriaSummary(state),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                text = stringResource(R.string.search_criteria_edit),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+    }
+}
+
+@Composable
+private fun collapsedCriteriaSummary(state: SearchUiState): String {
+    val parts = buildList {
+        if (state.query.isNotBlank()) {
+            add(stringResource(R.string.search_criteria_query, state.query))
+        }
+        if (state.pseudo.isNotBlank()) {
+            add(stringResource(R.string.search_criteria_author, state.pseudo))
+        }
+        if (state.textScope != SearchTextScope.TitlesAndPosts) {
+            add(stringResource(state.textScope.labelResId()))
+        }
+    }
+    return parts.joinToString(separator = " · ")
 }
 
 @Composable

--- a/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchUiState.kt
+++ b/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchUiState.kt
@@ -32,6 +32,13 @@ data class SearchUiState(
     val isLoading: Boolean = false,
     val errorMessage: HfrErrorKind? = null,
     val hasSearched: Boolean = false,
+    /**
+     * #433 — once a search is launched the form collapses into a compact one-line
+     * criteria banner so the results own the screen height. EVERY search path flips
+     * it to `true` (submit, retry, pivot re-scope, text-scope re-search, the
+     * profile's author entry point) ; [SearchIntent.EditCriteria] re-expands.
+     */
+    val formCollapsed: Boolean = false,
 )
 
 /**
@@ -50,6 +57,9 @@ sealed interface SearchIntent {
     data object Retry : SearchIntent
     data class CategorySelected(val category: SearchPivotCategory) : SearchIntent
     data class OpenResult(val result: SearchTopicResult) : SearchIntent
+
+    /** #433 — re-expand the collapsed criteria banner back into the full form. */
+    data object EditCriteria : SearchIntent
 }
 
 /**

--- a/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchViewModel.kt
+++ b/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchViewModel.kt
@@ -118,6 +118,7 @@ class SearchViewModel @AssistedInject constructor(
             SearchIntent.Retry -> onRetry()
             is SearchIntent.CategorySelected -> onCategorySelected(intent.category)
             is SearchIntent.OpenResult -> onOpenResult(intent.result)
+            SearchIntent.EditCriteria -> _state.update { it.copy(formCollapsed = false) }
         }
     }
 
@@ -285,6 +286,9 @@ class SearchViewModel @AssistedInject constructor(
                 isLoading = true,
                 errorMessage = null,
                 hasSearched = true,
+                // #433 — every launched search collapses the form ; the single
+                // launch point keeps submit/retry/pivot/profile-entry consistent.
+                formCollapsed = true,
             )
         }
         searchJob = viewModelScope.launch {

--- a/feature/search/src/main/res/values/strings.xml
+++ b/feature/search/src/main/res/values/strings.xml
@@ -6,6 +6,10 @@
     <string name="search_pseudo_placeholder">Topics où ce membre a posté…</string>
     <string name="search_back">Retour</string>
     <string name="search_submit">Rechercher</string>
+    <!-- #433 — bandeau compact des critères, affiché une fois la recherche lancée. -->
+    <string name="search_criteria_edit">Modifier</string>
+    <string name="search_criteria_query">« %1$s »</string>
+    <string name="search_criteria_author">par %1$s</string>
     <string name="search_retry">Réessayer</string>
     <string name="search_idle_hint">Saisissez un mot-clé et/ou un pseudo. Le pseudo seul liste les topics où ce membre a posté. Quand HFR fournit un extrait, le résultat ouvre le message correspondant ; sinon il ouvre le topic.</string>
     <string name="search_loading">Recherche en cours…</string>

--- a/feature/search/src/test/kotlin/fr/forumhfr/redface2/feature/search/SearchViewModelTest.kt
+++ b/feature/search/src/test/kotlin/fr/forumhfr/redface2/feature/search/SearchViewModelTest.kt
@@ -71,6 +71,52 @@ class SearchViewModelTest {
     }
 
     @Test
+    fun `a launched search collapses the form and EditCriteria re-expands it (#433)`() = runTest {
+        coEvery { repo.search(any()) } returns fakePage(topics = emptyList(), pivot = emptyList())
+        val vm = SearchViewModel(repo, initialPseudo = null)
+        assertFalse(vm.state.value.formCollapsed)
+
+        vm.submit(SearchIntent.QueryChanged("kotlin"))
+        vm.submit(SearchIntent.Submit)
+        assertTrue("every launched search must collapse the form", vm.state.value.formCollapsed)
+
+        vm.submit(SearchIntent.EditCriteria)
+        assertFalse(vm.state.value.formCollapsed)
+    }
+
+    @Test
+    fun `a blank Submit does not collapse the form (#433)`() = runTest {
+        val vm = SearchViewModel(repo, initialPseudo = null)
+        vm.submit(SearchIntent.QueryChanged("   "))
+        vm.submit(SearchIntent.Submit)
+        assertFalse(vm.state.value.formCollapsed)
+    }
+
+    @Test
+    fun `a pivot re-scope launched from the expanded form collapses it again (#433)`() = runTest {
+        val pivot = SearchPivotCategory(id = 10, label = "Hardware", isSelected = false)
+        coEvery { repo.search(any()) } returns fakePage(topics = emptyList(), pivot = listOf(pivot))
+        val vm = SearchViewModel(repo, initialPseudo = null)
+        vm.submit(SearchIntent.QueryChanged("kotlin"))
+        vm.submit(SearchIntent.Submit)
+        vm.submit(SearchIntent.EditCriteria)
+
+        vm.submit(SearchIntent.CategorySelected(pivot))
+
+        assertTrue("a re-scope IS a launched search", vm.state.value.formCollapsed)
+    }
+
+    @Test
+    fun `the profile author entry point starts collapsed (#433)`() = runTest {
+        coEvery { repo.search(any()) } returns fakePage(topics = emptyList(), pivot = emptyList())
+        val vm = SearchViewModel(repo, initialPseudo = "Marc")
+        assertTrue(
+            "the init-time author search must land on results, not on the form",
+            vm.state.value.formCollapsed,
+        )
+    }
+
+    @Test
     fun `Submit success populates results pivot and selectedCategory`() = runTest {
         coEvery { repo.search(any()) } returns fakePage(
             topics = listOf(fakeTopic(topicId = 1, title = "Hello kotlin")),


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi

Option A arbitrée sur #433 : le formulaire de recherche ne monopolise plus l'écran une fois une recherche lancée.

- **Toute recherche lancée** (submit, retry, re-scope pivot, changement de champ de recherche, entrée profil « Derniers messages ») replie le formulaire en **bandeau compact une ligne** : `« asus » · par Marc · Titres seuls` + **Modifier**. Les segments pseudo/scope n'apparaissent que s'ils sont actifs (pas de bruit sur le cas nominal).
- Tap sur le bandeau (toute la carte) = ré-expansion du formulaire complet, critères intacts, résultats conservés.
- Les **chips pivot restent visibles dans les deux modes** — re-scoper est une action de consultation des résultats, pas une édition de critères.
- `formCollapsed` est posé au **point unique `launchSearch`** : tous les chemins de recherche sont cohérents par construction (l'entrée profil arrive donc directement sur les résultats, formulaire replié).

## Validation

- detektAll + tests + assembleProdDebug + lintProdDebug verts (Docker, 2 parts) ; 4 tests VM (collapse au lancement, ré-expansion, blank n'replie pas, re-scope depuis le formulaire étendu re-replie, entrée profil repliée)
- **Vérifié émulateur** : recherche « asus » → bandeau + 4 cartes de résultats visibles (avant : 1-2) ; « Modifier » restaure le formulaire avec les critères

refs-#433. Fermeture à la promotion dev→main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)