### PR TITLE
fix(flags): « Mes sujets » ne wrappe plus sur deux lignes dans la rangée d'onglets

### DIFF
--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -55,6 +57,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -567,11 +570,30 @@ private fun ColumnScope.AuthenticatedBody(
             } else {
                 label
             }
+            // Low-level `content` overload INSTEAD of the `text` slot : the text slot pads a
+            // non-configurable 16 dp each side, which left « Mes sujets » with exactly its own
+            // measured width in a 4-tab equal-width PrimaryTabRow — wrapping it to two lines
+            // on a density-dependent pixel boundary. 8 dp gutters + single line + ellipsis
+            // (the « +lus » suffixed label ellipsizes by design — arbitrage XaTriX 2026-06-12).
+            // Colors are passed explicitly because this overload defaults BOTH states to
+            // LocalContentColor (no selected/unselected distinction out of the box).
             Tab(
                 selected = index == selectedIndex,
                 onClick = { actions.onSelectTab(tab) },
-                text = { Text(displayLabel, style = MaterialTheme.typography.labelLarge) },
-            )
+                selectedContentColor = MaterialTheme.colorScheme.primary,
+                unselectedContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            ) {
+                Text(
+                    text = displayLabel,
+                    style = MaterialTheme.typography.labelLarge,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier
+                        .height(48.dp)
+                        .wrapContentHeight()
+                        .padding(horizontal = 8.dp),
+                )
+            }
         }
     }
 


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi

Retour XaTriX (session radiographie UI) : « Mes sujets » revenait à la ligne alors qu'il semblait y avoir la place. Diagnostic chiffré via `uiautomator dump` : deux contraintes invisibles —

1. `PrimaryTabRow` distribue à **largeur égale** (4 onglets × 259 px) : la « place » à droite appartient à l'onglet voisin ;
2. le slot `text` de `Tab` impose **16 dp de padding non paramétrable** par côté → ~175 px utiles, soit **exactement** la largeur mesurée du label en `labelLarge` → wrap à la frontière du pixel, dépendant de la densité.

## Fix (option A arbitrée + ellipse)

Bascule sur la **surcharge bas niveau `content`** de `Tab` (signature et défauts vérifiés Context7) : gouttières 8 dp, `maxLines = 1`, `overflow = Ellipsis`. Le label suffixé « +lus » s'**ellipse par design** (« Mes sujets·… », arbitrage XaTriX). Couleurs passées explicitement (`primary` sélectionné / `onSurfaceVariant` sinon) car cette surcharge met les deux états à `LocalContentColor` — rendu identique à l'existant.

## Validation

- detektAll + tests + assembleProdDebug + lintProdDebug verts (Docker, 2 parts)
- **Vérifié émulateur** : une ligne en nominal (4 onglets alignés), « Mes sujets·… » ellipsé en mode +lus, couleurs inchangées

Pas d'issue dédiée (retour de session, même précédent que la PR #338).

🤖 Generated with [Claude Code](https://claude.com/claude-code)