### PR TITLE
fix(editor): le champ suit le curseur pendant la frappe (#447 point 1)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextField.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextField.kt
@@ -78,8 +78,9 @@ import androidx.compose.ui.unit.isFinite
  * [OutlinedTextFieldDefaults.DecorationBox] for pixel parity, and issues an explicit
  * [BringIntoViewRequester.bringIntoView] on the caret rect (`TextLayoutResult.getCursorRect`)
  * whenever the selection or the text layout changes while the field is focused. The requester
- * is attached to the INNER text node — the caret rect is in its coordinate space, not the
- * decorated box's.
+ * lives on a wrapper `Box` around the inner text field; that wrapper MUST stay offset-free
+ * (no padding/alignment of its own) so its coordinate space coincides with the text layout's —
+ * the caret rect is expressed there, not in the decorated box's space.
  */
 @Suppress("LongParameterList") // Compose component API: optional defaulted params (modifier,
 // placeholder, fillViewport) are the idiomatic surface — a config holder would hurt call-sites.
@@ -179,6 +180,8 @@ private fun BbcodeFieldImpl(
             OutlinedTextFieldDefaults.DecorationBox(
                 value = value.text,
                 innerTextField = {
+                    // Offset-free wrapper by contract (see KDoc): its origin must coincide
+                    // with the text layout's so the caret rect needs no translation.
                     Box(Modifier.bringIntoViewRequester(bringCursorIntoView)) {
                         innerTextField()
                     }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextField.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextField.kt
@@ -1,19 +1,39 @@
 package fr.forumhfr.redface2.core.ui.editor
 
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.isFinite
 
 /**
@@ -47,6 +67,19 @@ import androidx.compose.ui.unit.isFinite
  * not enable it inside an outer `verticalScroll` — nested same-direction scrollables with
  * unbounded height are a Compose error; `TopicFormScreen` (outer scroll layout) keeps the
  * default and relies on its own column, which is the same machinery.
+ *
+ * ## Cursor follow while typing (#447)
+ *
+ * With the field in external-scroll mode (both [fillViewport] and the `TopicFormScreen`
+ * outer-scroll layout), Compose only wires the keep-cursor-visible machinery when the text
+ * field owns its internal scroll — a growing field never asks the ancestor scrollable to follow
+ * the caret while typing. The implementation therefore uses the foundation [BasicTextField]
+ * (M3 `OutlinedTextField` does not expose `onTextLayout`) dressed with
+ * [OutlinedTextFieldDefaults.DecorationBox] for pixel parity, and issues an explicit
+ * [BringIntoViewRequester.bringIntoView] on the caret rect (`TextLayoutResult.getCursorRect`)
+ * whenever the selection or the text layout changes while the field is focused. The requester
+ * is attached to the INNER text node — the caret rect is in its coordinate space, not the
+ * decorated box's.
  */
 @Suppress("LongParameterList") // Compose component API: optional defaulted params (modifier,
 // placeholder, fillViewport) are the idiomatic surface — a config holder would hurt call-sites.
@@ -105,15 +138,58 @@ private fun BbcodeFieldImpl(
     placeholder: String?,
     modifier: Modifier,
 ) {
-    OutlinedTextField(
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+    val bringCursorIntoView = remember { BringIntoViewRequester() }
+    var textLayout by remember { mutableStateOf<TextLayoutResult?>(null) }
+
+    // #447 — follow the caret through the EXTERNAL scrollable while typing. Keyed on the
+    // layout result (a new one lands after every text change) AND the selection (caret moves
+    // without relayout: taps, arrow keys), never on `value.text` alone — that would fire
+    // against the stale layout of the previous text.
+    LaunchedEffect(isFocused, value.selection, textLayout) {
+        if (!isFocused) return@LaunchedEffect
+        val layout = textLayout ?: return@LaunchedEffect
+        val cursorOffset = value.selection.end.coerceIn(0, layout.layoutInput.text.length)
+        bringCursorIntoView.bringIntoView(layout.getCursorRect(cursorOffset))
+    }
+
+    BasicTextField(
         value = value,
         onValueChange = onValueChange,
-        modifier = modifier,
-        label = { Text(label) },
-        placeholder = placeholder?.let { hint -> { Text(hint) } },
-        minLines = 5,
+        // The real M3 OutlinedTextField merges the label into the field's semantics node and
+        // reserves 8.dp above the box for the floating label's upper half (internal
+        // `OutlinedTextFieldTopPadding`) — without it the minimized label is clipped at the top.
+        modifier = modifier
+            .semantics(mergeDescendants = true) {}
+            .padding(top = 8.dp),
+        // M3 OutlinedTextField defaults the content to LocalTextStyle coloured onSurface and
+        // the caret to primary — replicated here since BasicTextField has no colour scheme.
+        textStyle = LocalTextStyle.current.merge(
+            TextStyle(color = MaterialTheme.colorScheme.onSurface),
+        ),
         // #237 — Compose ne capitalise rien par défaut (≠ EditText/RF1 en `textCapSentences`).
         // `Sentences` rend la majuscule en début de message ET après `. ! ?`, parité RF1.
         keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
+        minLines = 5,
+        onTextLayout = { textLayout = it },
+        interactionSource = interactionSource,
+        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+        decorationBox = { innerTextField ->
+            OutlinedTextFieldDefaults.DecorationBox(
+                value = value.text,
+                innerTextField = {
+                    Box(Modifier.bringIntoViewRequester(bringCursorIntoView)) {
+                        innerTextField()
+                    }
+                },
+                enabled = true,
+                singleLine = false,
+                visualTransformation = VisualTransformation.None,
+                interactionSource = interactionSource,
+                label = { Text(label) },
+                placeholder = placeholder?.let { hint -> { Text(hint) } },
+            )
+        },
     )
 }

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextFieldViewportTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextFieldViewportTest.kt
@@ -5,11 +5,16 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.requestFocus
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.ui.RedfaceTheme
@@ -76,6 +81,57 @@ class BbcodeTextFieldViewportTest {
             field.size.height > viewport.size.height,
         )
     }
+
+    @Test
+    fun `moving the cursor to the end of long content scrolls the viewport to reveal it`() {
+        // #447 — the field grows in external-scroll mode, so Compose never asks the wrapping
+        // column to follow the caret on its own; this pins the explicit bring-into-view wiring.
+        lateinit var value: MutableState<TextFieldValue>
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                Surface(color = MaterialTheme.colorScheme.surface) {
+                    Box(Modifier.size(320.dp, 400.dp)) {
+                        value = remember {
+                            mutableStateOf(
+                                TextFieldValue(
+                                    text = (1..200).joinToString("\n") { "ligne $it" },
+                                    selection = TextRange.Zero,
+                                ),
+                            )
+                        }
+                        BbcodeTextField(
+                            value = value.value,
+                            onValueChange = { value.value = it },
+                            label = "Message",
+                            modifier = Modifier.fillMaxSize(),
+                            fillViewport = true,
+                        )
+                    }
+                }
+            }
+        }
+
+        composeTestRule.onNode(hasSetTextAction()).requestFocus()
+        composeTestRule.waitForIdle()
+        val scrollBefore = viewportScrollValue()
+
+        composeTestRule.runOnIdle {
+            value.value = value.value.copy(selection = TextRange(value.value.text.length))
+        }
+        composeTestRule.waitForIdle()
+
+        val scrollAfter = viewportScrollValue()
+        assertTrue(
+            "the viewport scrolled toward the caret (before=$scrollBefore after=$scrollAfter)",
+            scrollAfter > scrollBefore && scrollAfter > 0f,
+        )
+    }
+
+    private fun viewportScrollValue(): Float = composeTestRule
+        .onNodeWithTag(BBCODE_FIELD_VIEWPORT_TAG)
+        .fetchSemanticsNode()
+        .config[SemanticsProperties.VerticalScrollAxisRange]
+        .value()
 
     @Test
     fun `default mode keeps the plain bounded field`() {

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextFieldViewportTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextFieldViewportTest.kt
@@ -1,14 +1,18 @@
 package fr.forumhfr.redface2.core.ui.editor
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.junit4.v2.createComposeRule
@@ -48,6 +52,10 @@ class BbcodeTextFieldViewportTest {
 
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    private companion object {
+        const val OUTER_SCROLL_TAG = "outer_scroll"
+    }
 
     @Test
     fun `short content - the field fills the viewport and nothing scrolls`() {
@@ -113,22 +121,78 @@ class BbcodeTextFieldViewportTest {
 
         composeTestRule.onNode(hasSetTextAction()).requestFocus()
         composeTestRule.waitForIdle()
-        val scrollBefore = viewportScrollValue()
+        assertCaretEndRevealed(BBCODE_FIELD_VIEWPORT_TAG, value)
+    }
+
+    @Test
+    fun `default mode in an outer scrollable also follows the caret to the end`() {
+        // #447 — same contract for the grow-with-content default inside an external
+        // verticalScroll (the TopicFormScreen layout): the caret request must reach the
+        // OUTER scrollable, which the field knows nothing about.
+        lateinit var value: MutableState<TextFieldValue>
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                Surface(color = MaterialTheme.colorScheme.surface) {
+                    Box(Modifier.size(320.dp, 400.dp)) {
+                        value = remember {
+                            mutableStateOf(
+                                TextFieldValue(
+                                    text = (1..200).joinToString("\n") { "ligne $it" },
+                                    selection = TextRange.Zero,
+                                ),
+                            )
+                        }
+                        Column(
+                            modifier = Modifier
+                                .verticalScroll(rememberScrollState())
+                                .testTag(OUTER_SCROLL_TAG),
+                        ) {
+                            BbcodeTextField(
+                                value = value.value,
+                                onValueChange = { value.value = it },
+                                label = "Message",
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        composeTestRule.onNode(hasSetTextAction()).requestFocus()
+        composeTestRule.waitForIdle()
+        assertCaretEndRevealed(OUTER_SCROLL_TAG, value)
+    }
+
+    /**
+     * Moves the caret to the very end of [value] and asserts the scrollable [scrollableTag]
+     * landed near its max range — the caret lives on the LAST line, so revealing it means
+     * scrolling within one viewport-fraction of the bottom. A requester attached to the wrong
+     * ancestor (or a rect read in the decorated box's coordinate space) under-scrolls by a
+     * constant offset and fails the 95% bar; `> scrollBefore` alone would still pass.
+     */
+    private fun assertCaretEndRevealed(scrollableTag: String, value: MutableState<TextFieldValue>) {
+        val scrollBefore = scrollValue(scrollableTag)
 
         composeTestRule.runOnIdle {
             value.value = value.value.copy(selection = TextRange(value.value.text.length))
         }
         composeTestRule.waitForIdle()
 
-        val scrollAfter = viewportScrollValue()
+        val range = composeTestRule
+            .onNodeWithTag(scrollableTag)
+            .fetchSemanticsNode()
+            .config[SemanticsProperties.VerticalScrollAxisRange]
+        val scrollAfter = range.value()
+        val maxValue = range.maxValue()
         assertTrue(
-            "the viewport scrolled toward the caret (before=$scrollBefore after=$scrollAfter)",
-            scrollAfter > scrollBefore && scrollAfter > 0f,
+            "the scrollable followed the caret to the end " +
+                "(before=$scrollBefore after=$scrollAfter max=$maxValue)",
+            scrollAfter > scrollBefore && maxValue > 0f && scrollAfter >= maxValue * 0.95f,
         )
     }
 
-    private fun viewportScrollValue(): Float = composeTestRule
-        .onNodeWithTag(BBCODE_FIELD_VIEWPORT_TAG)
+    private fun scrollValue(tag: String): Float = composeTestRule
+        .onNodeWithTag(tag)
         .fetchSemanticsNode()
         .config[SemanticsProperties.VerticalScrollAxisRange]
         .value()


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

refs-#447 (point 1 — le point 2, drag-to-scroll de sélection, reste ouvert et sera traité séparément). Retour bêta-dev v123 de **Dintr-un lemn** ([post #2787456](https://forum.hardware.fr/forum2.php?config=hfr.inc&cat=23&subcat=550&post=35421&page=10#t2787456)).

## Problème

Depuis le passage du champ en scroll externe (#422/#434), Compose ne suit plus le caret pendant la frappe : ce suivi n'est câblé nativement que quand le TextField possède son propre scroll interne. Quand la frappe fait descendre le caret sous la zone visible (clavier ouvert), il fallait scroller à la main.

## Solution

- `BbcodeFieldImpl` réécrit : **`BasicTextField` (overload `TextFieldValue`, qui expose `onTextLayout` — M3 `OutlinedTextField` ne l'expose pas) habillé par `OutlinedTextFieldDefaults.DecorationBox`** pour la parité visuelle (label flottant, bordure focus, couleurs M3). APIs vérifiées dans les artefacts réels du cache Gradle : DecorationBox stable en M3 1.4.0, BringIntoViewRequester stable en foundation 1.11.2.
- `BringIntoViewRequester` attaché au **nœud texte interne** (le rect de `TextLayoutResult.getCursorRect` est dans son espace de coordonnées, pas celui de la boîte décorée), déclenché par `LaunchedEffect(isFocused, selection, textLayout)` — jamais sur `value.text` seul, qui ferait viser le layout périmé du texte précédent.
- Parité M3 répliquée : `semantics(mergeDescendants)` + `padding(top = 8.dp)` (réserve la moitié haute du label flottant — **vérifié rogné sans**, screenshot émulateur), `textStyle` onSurface, caret primary, capitalisation `Sentences` (#237 conservé).

## Validation

- Docker 2 parts : `detektAll test :app:assembleProdDebug` puis `:app:lintProdDebug` — verts (re-run incrémental après le fix padding : 4/4 tests `BbcodeTextFieldViewportTest` dont le nouveau).
- Test Robolectric ajouté : sélection déplacée en fin de contenu long → le viewport scrolle (> 0) pour révéler le caret.
- Émulateur : 30 lignes tapées au clavier → le viewport suit la frappe, caret visible au-dessus de l'IME ; label flottant entier ; états focused/unfocused conformes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)