### PR TITLE
feat(flags): bandeau de catégorie cliquable vers le listing (#414)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -906,6 +906,11 @@ private fun RedfaceNavHost(
                     onLoginRequested = {
                         backStack.add(LoginRoute)
                     },
+                    // #414 — category band tap: push the listing INSIDE the Flags tab so back
+                    // returns to the flags list (less surprising than switching to the Forum tab).
+                    onOpenCategory = { catId ->
+                        backStack.add(CategoryRoute(cat = catId, subcat = null, page = 1))
+                    },
                     topBarActions = accountMenu,
                 )
             }

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -3,6 +3,7 @@ package fr.forumhfr.redface2.feature.flags
 import android.annotation.SuppressLint
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -105,6 +106,7 @@ import kotlinx.coroutines.launch
 fun FlagsRoute(
     onOpenFlag: (Flag) -> Unit,
     onLoginRequested: () -> Unit,
+    onOpenCategory: (Int) -> Unit = {},
     topBarActions: @Composable (() -> Unit)? = null,
 ) {
     val viewModel: FlagsViewModel = hiltViewModel()
@@ -237,6 +239,7 @@ fun FlagsRoute(
                                 onRefresh = viewModel::refresh,
                                 onLoginRequested = onLoginRequested,
                                 onRequestRemoveFlag = viewModel::requestRemoveFlag,
+                                onOpenCategory = onOpenCategory,
                             ),
                             listState = flagsListState,
                         )
@@ -781,6 +784,8 @@ private fun CategorySectionedFlagList(
                 CategoryHeaderBand(
                     label = section.catName
                         ?: stringResource(R.string.flags_category_fallback, section.catId),
+                    // #414 — parité RF1 : the band navigates to the category's topic listing.
+                    onClick = { actions.onOpenCategory(section.catId) },
                 )
             }
 
@@ -821,18 +826,34 @@ private fun CategorySectionedFlagList(
  * Opaque category separator band for the grouped list (#179). Uses `surfaceVariant` /
  * `onSurfaceVariant` from the theme (no hardcoded color) so it reads as a sticky header over
  * the scrolling rows without bleed-through.
+ *
+ * #414 — the whole band is tappable and opens the category's topic listing (RF1 parity); the
+ * trailing « › » glyph (same vector-text pattern as the page FABs, #283) is the affordance.
  */
 @Composable
-private fun CategoryHeaderBand(label: String) {
-    Text(
-        text = label,
-        style = MaterialTheme.typography.titleSmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
+private fun CategoryHeaderBand(label: String, onClick: () -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.surfaceVariant)
+            .clickable(onClickLabel = stringResource(R.string.flags_category_open_label)) {
+                onClick()
+            }
             .padding(horizontal = 24.dp, vertical = 8.dp),
-    )
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = "›",
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
 }
 
 /**
@@ -1096,6 +1117,8 @@ private data class AuthenticatedActions(
     val onRefresh: () -> Unit,
     val onLoginRequested: () -> Unit,
     val onRequestRemoveFlag: (Flag) -> Unit,
+    /** #414 — tap on a category band opens that category's topic listing. */
+    val onOpenCategory: (Int) -> Unit,
 )
 
 /**

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -829,6 +830,8 @@ private fun CategorySectionedFlagList(
  *
  * #414 — the whole band is tappable and opens the category's topic listing (RF1 parity); the
  * trailing « › » glyph (same vector-text pattern as the page FABs, #283) is the affordance.
+ * Foundation [clickable] does not enforce the 48dp Material touch-target minimum, hence the
+ * explicit [heightIn].
  */
 @Composable
 private fun CategoryHeaderBand(label: String, onClick: () -> Unit) {
@@ -837,6 +840,7 @@ private fun CategoryHeaderBand(label: String, onClick: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.surfaceVariant)
+            .heightIn(min = 48.dp)
             .clickable(onClickLabel = stringResource(R.string.flags_category_open_label)) {
                 onClick()
             }

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -35,6 +35,8 @@
     <!-- Fallback de libellé pour une catégorie absente du catalogue REST (anti-régression #251).
          %1$d = identifiant de la catégorie. -->
     <string name="flags_category_fallback">Catégorie %1$d</string>
+    <!-- #414 — libellé d'action (a11y) du bandeau de catégorie cliquable. -->
+    <string name="flags_category_open_label">Ouvrir la catégorie</string>
     <!-- #179 follow-up — Vue à plat (legacy) : message quand la liste est vide. Sans le mot
          « catégorie » (il n'y a pas de regroupement dans cette vue). -->
     <string name="flags_list_empty_cyan">Aucun nouveau message</string>


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

refs-#414 (arbitrage « go — quick win »). Demande re-confirmée session nuit 2026-06-13 (« clic sur le nom des catégories sur la vue Drapal renvoie sur la catégorie ciblée »).

Dans la vue groupée par catégorie (#179), le bandeau sticky de chaque catégorie est désormais **cliquable** et ouvre le **listing de sujets de la catégorie**, poussé dans l'onglet Drapeaux (back → liste des drapeaux, moins surprenant qu'un saut d'onglet). Chevron « › » en affordance (pattern texte-vectoriel des FABs #283, pas de material-icons), `onClickLabel` pour l'a11y.

Validation : Docker 2 parts verts (detektAll, tests, assembleProdDebug, lintProdDebug). Vérification émulateur prévue dans le lot nuit avant release dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)