### PR TITLE
feat(topic): sondages repliés par défaut + réglage (#456)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -272,6 +272,22 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeTopicPollsExpanded(): Flow<Boolean> =
+        dataStore.data
+            // Default `false` (#456): polls start collapsed — the in-card toggle still reveals
+            // them per topic; this preference only seeds the initial state.
+            .map { prefs -> prefs[KEY_TOPIC_POLLS_EXPANDED] ?: false }
+            .distinctUntilChanged()
+            .catch { emit(false) }
+
+    override suspend fun setTopicPollsExpanded(enabled: Boolean) {
+        withContext(ioDispatcher) {
+            dataStore.edit { prefs ->
+                prefs[KEY_TOPIC_POLLS_EXPANDED] = enabled
+            }
+        }
+    }
+
     override fun observeMpUnreadBadge(): Flow<Boolean> =
         dataStore.data
             // Default `true` (#313): the badge is the feature; opting OUT is the preference.
@@ -386,5 +402,8 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         val KEY_FLAGS_AUTO_REFRESH = booleanPreferencesKey("flags_auto_refresh")
         val KEY_TOPIC_PAGE_FABS = booleanPreferencesKey("topic_page_fabs")
         val KEY_MP_UNREAD_BADGE = booleanPreferencesKey("mp_unread_badge")
+
+        // #456 — polls expanded by default in topic reading (default false = collapsed).
+        val KEY_TOPIC_POLLS_EXPANDED = booleanPreferencesKey("topic_polls_expanded")
     }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -563,5 +563,9 @@ class TopicRepositoryImplTest {
         override fun observeMpUnreadBadge(): Flow<Boolean> = MutableStateFlow(true)
 
         override suspend fun setMpUnreadBadge(enabled: Boolean) = Unit
+
+        override fun observeTopicPollsExpanded(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setTopicPollsExpanded(enabled: Boolean) = Unit
     }
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -187,6 +187,18 @@ interface UserPreferencesRepository {
     suspend fun setTopicPageFabs(enabled: Boolean)
 
     /**
+     * #456 — whether topic polls render EXPANDED by default. Default `false` (collapsed to the
+     * one-line « Sondage — afficher » card): most readers scroll past the poll, and a long
+     * option list pushes the first post below the fold. The per-topic reveal toggle in the
+     * poll card keeps working either way — this only seeds its initial state. Observed by
+     * `:feature:topic`, toggled in Settings.
+     */
+    fun observeTopicPollsExpanded(): Flow<Boolean>
+
+    /** Persists [observeTopicPollsExpanded]. Default `false` until the first call. */
+    suspend fun setTopicPollsExpanded(enabled: Boolean)
+
+    /**
      * #313 — unread-MP badge on the « Messages » destination of the navigation bar. When
      * `true` (default) the badge shows the count of unread conversations for the authenticated
      * session ; `false` hides it entirely (no fetch is saved — the underlying count flow is

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -1412,6 +1412,10 @@ class PostEditorViewModelTest {
         override fun observeMpUnreadBadge(): Flow<Boolean> = MutableStateFlow(true)
 
         override suspend fun setMpUnreadBadge(enabled: Boolean) = Unit
+
+        override fun observeTopicPollsExpanded(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setTopicPollsExpanded(enabled: Boolean) = Unit
     }
 
     private companion object {

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1265,6 +1265,10 @@ class TopicFormViewModelTest {
         override fun observeMpUnreadBadge(): Flow<Boolean> = MutableStateFlow(true)
 
         override suspend fun setMpUnreadBadge(enabled: Boolean) = Unit
+
+        override fun observeTopicPollsExpanded(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setTopicPollsExpanded(enabled: Boolean) = Unit
     }
 
     private companion object {

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1597,6 +1597,10 @@ class FlagsViewModelTest {
 
         override suspend fun setMpUnreadBadge(enabled: Boolean) = Unit
 
+        override fun observeTopicPollsExpanded(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setTopicPollsExpanded(enabled: Boolean) = Unit
+
         // #312 — confirm-before-posting is irrelevant to FlagsViewModel; stubbed at its default.
         override fun observeConfirmBeforePosting(): Flow<Boolean> = MutableStateFlow(false)
 

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -579,6 +579,16 @@ private fun TopicPreferencesCard(
             if (state.topicPageFabsError) {
                 PreferencePersistError(R.string.settings_topic_page_fabs_persist_failed)
             }
+            PreferenceSwitchRow(
+                title = stringResource(R.string.settings_topic_polls_expanded_title),
+                description = stringResource(R.string.settings_topic_polls_expanded_description),
+                checked = state.topicPollsExpanded,
+                enabled = state.canToggleTopicPollsExpanded,
+                onCheckedChange = { onIntent(SettingsIntent.TopicPollsExpandedChanged(it)) },
+            )
+            if (state.topicPollsExpandedError) {
+                PreferencePersistError(R.string.settings_topic_polls_expanded_persist_failed)
+            }
         }
     }
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -89,6 +89,12 @@ data class SettingsState(
     val isUpdatingMpUnreadBadge: Boolean = false,
     val mpUnreadBadgeError: Boolean = false,
     val mpUnreadBadgeTouchedLocally: Boolean = false,
+    // #456 — sondages dépliés par défaut dans la lecture de sujet. Default FALSE (repliés) :
+    // la carte reste dépliable/repliable par sujet, le réglage ne sème que l'état initial.
+    val topicPollsExpanded: Boolean = false,
+    val isUpdatingTopicPollsExpanded: Boolean = false,
+    val topicPollsExpandedError: Boolean = false,
+    val topicPollsExpandedTouchedLocally: Boolean = false,
     // Publishing preferences (#312). Same optimistic-flip + startup-race-guard machinery:
     // `confirmBeforePosting` is the displayed value, `isUpdating*` gates the switch while DataStore
     // writes, `*Error` surfaces a persist failure, `*TouchedLocally` forbids a late `init` hydration
@@ -151,6 +157,10 @@ data class SettingsState(
 
     val canToggleMpUnreadBadge: Boolean
         get() = !isUpdatingMpUnreadBadge
+
+    // #456 — the polls toggle is gated only by its own write.
+    val canToggleTopicPollsExpanded: Boolean
+        get() = !isUpdatingTopicPollsExpanded
 
     // #312 — the confirm-before-posting toggle is gated only by its own write.
     val canToggleConfirmBeforePosting: Boolean
@@ -241,6 +251,9 @@ sealed interface SettingsIntent {
 
     /** #313 — badge MP non lus (barre de navigation). */
     data class MpUnreadBadgeChanged(val enabled: Boolean) : SettingsIntent
+
+    /** #456 — sondages dépliés par défaut dans la lecture de sujet. */
+    data class TopicPollsExpandedChanged(val enabled: Boolean) : SettingsIntent
 
     // #312 — confirm-before-posting toggle. Optimistic-flip contract, like the flags toggles:
     // the boolean is the desired post-flip state.

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -36,129 +36,87 @@ class SettingsViewModel @Inject constructor(
             val config = userPreferencesRepository.observeProxyConfig().first()
             _state.update { it.copyFromProxy(config) }
         }
+        hydratePreference(
+            read = { userPreferencesRepository.observeIgnoreTopicCache().first() },
+            isLocked = { it.ignoreTopicCacheTouchedLocally || it.isUpdatingIgnoreTopicCache },
+            apply = { state, value -> state.copy(ignoreTopicCache = value) },
+        )
+        hydratePreference(
+            read = { userPreferencesRepository.observeFlagsGroupByCategory().first() },
+            isLocked = { it.flagsGroupByCategoryTouchedLocally || it.isUpdatingFlagsGroupByCategory },
+            apply = { state, value -> state.copy(flagsGroupByCategory = value) },
+        )
+        hydratePreference(
+            read = { userPreferencesRepository.observeFlagsHideReadCategories().first() },
+            isLocked = { it.flagsHideReadCategoriesTouchedLocally || it.isUpdatingFlagsHideReadCategories },
+            apply = { state, value -> state.copy(flagsHideReadCategories = value) },
+        )
+        hydratePreference(
+            read = { userPreferencesRepository.observeFlagsPerTabOverride().first() },
+            isLocked = { it.flagsPerTabOverrideTouchedLocally || it.isUpdatingFlagsPerTabOverride },
+            apply = { state, value -> state.copy(flagsPerTabOverride = value) },
+        )
+        hydratePreference(
+            read = { userPreferencesRepository.observeThemeMode().first() },
+            isLocked = { it.themeModeTouchedLocally || it.isUpdatingThemeMode },
+            apply = { state, value -> state.copy(themeMode = value) },
+        )
+        hydratePreference(
+            read = { userPreferencesRepository.observeAmoledEnabled().first() },
+            isLocked = { it.amoledTouchedLocally || it.isUpdatingAmoled },
+            apply = { state, value -> state.copy(amoledEnabled = value) },
+        )
+        hydratePreference(
+            read = { userPreferencesRepository.observeTopicTopBarAutoHide().first() },
+            isLocked = { it.topicTopBarAutoHideTouchedLocally || it.isUpdatingTopicTopBarAutoHide },
+            apply = { state, value -> state.copy(topicTopBarAutoHide = value) },
+        )
+        hydratePreference(
+            read = { userPreferencesRepository.observeTopicPageFabs().first() },
+            isLocked = { it.topicPageFabsTouchedLocally || it.isUpdatingTopicPageFabs },
+            apply = { state, value -> state.copy(topicPageFabs = value) },
+        )
+        hydratePreference(
+            read = { userPreferencesRepository.observeMpUnreadBadge().first() },
+            isLocked = { it.mpUnreadBadgeTouchedLocally || it.isUpdatingMpUnreadBadge },
+            apply = { state, value -> state.copy(mpUnreadBadge = value) },
+        )
+        hydratePreference(
+            read = { userPreferencesRepository.observeTopicPollsExpanded().first() },
+            isLocked = { it.topicPollsExpandedTouchedLocally || it.isUpdatingTopicPollsExpanded },
+            apply = { state, value -> state.copy(topicPollsExpanded = value) },
+        )
+        hydratePreference(
+            read = { userPreferencesRepository.observeConfirmBeforePosting().first() },
+            isLocked = { it.confirmBeforePostingTouchedLocally || it.isUpdatingConfirmBeforePosting },
+            apply = { state, value -> state.copy(confirmBeforePosting = value) },
+        )
+        hydratePreference(
+            read = { userPreferencesRepository.observeShowDtSection().first() },
+            isLocked = { it.showDtSectionTouchedLocally || it.isUpdatingShowDtSection },
+            apply = { state, value -> state.copy(showDtSection = value) },
+        )
+        hydratePreference(
+            read = { userPreferencesRepository.observeFlagsAutoRefresh().first() },
+            isLocked = { it.flagsAutoRefreshTouchedLocally || it.isUpdatingFlagsAutoRefresh },
+            apply = { state, value -> state.copy(flagsAutoRefresh = value) },
+        )
+    }
+
+    /**
+     * One-shot hydration of a persisted preference into [_state] (point-in-time `first()`,
+     * cf. the init comment). [isLocked] is the startup-race guard: if the user already
+     * flipped the toggle (or a write is in flight) while this coroutine was suspended on
+     * the read, the stale snapshot must NOT overwrite the local change.
+     */
+    private fun <T> hydratePreference(
+        read: suspend () -> T,
+        isLocked: (SettingsState) -> Boolean,
+        apply: (SettingsState, T) -> SettingsState,
+    ) {
         viewModelScope.launch {
-            val ignore = userPreferencesRepository.observeIgnoreTopicCache().first()
-            _state.update { current ->
-                // Startup race guard: if the user already flipped the toggle (or a write is in
-                // flight) while this hydration coroutine was suspended on `.first()`, do NOT
-                // overwrite the local change with the stale snapshot we just collected. The
-                // toggle is an alpha diagnostic — it must not lie about its own state.
-                if (current.ignoreTopicCacheTouchedLocally || current.isUpdatingIgnoreTopicCache) {
-                    current
-                } else {
-                    current.copy(ignoreTopicCache = ignore)
-                }
-            }
-        }
-        viewModelScope.launch {
-            val grouped = userPreferencesRepository.observeFlagsGroupByCategory().first()
-            _state.update { current ->
-                if (current.flagsGroupByCategoryTouchedLocally || current.isUpdatingFlagsGroupByCategory) {
-                    current
-                } else {
-                    current.copy(flagsGroupByCategory = grouped)
-                }
-            }
-        }
-        viewModelScope.launch {
-            val hideRead = userPreferencesRepository.observeFlagsHideReadCategories().first()
-            _state.update { current ->
-                if (current.flagsHideReadCategoriesTouchedLocally || current.isUpdatingFlagsHideReadCategories) {
-                    current
-                } else {
-                    current.copy(flagsHideReadCategories = hideRead)
-                }
-            }
-        }
-        viewModelScope.launch {
-            val perTab = userPreferencesRepository.observeFlagsPerTabOverride().first()
-            _state.update { current ->
-                if (current.flagsPerTabOverrideTouchedLocally || current.isUpdatingFlagsPerTabOverride) {
-                    current
-                } else {
-                    current.copy(flagsPerTabOverride = perTab)
-                }
-            }
-        }
-        viewModelScope.launch {
-            val mode = userPreferencesRepository.observeThemeMode().first()
-            _state.update { current ->
-                if (current.themeModeTouchedLocally || current.isUpdatingThemeMode) {
-                    current
-                } else {
-                    current.copy(themeMode = mode)
-                }
-            }
-        }
-        viewModelScope.launch {
-            val amoled = userPreferencesRepository.observeAmoledEnabled().first()
-            _state.update { current ->
-                if (current.amoledTouchedLocally || current.isUpdatingAmoled) {
-                    current
-                } else {
-                    current.copy(amoledEnabled = amoled)
-                }
-            }
-        }
-        viewModelScope.launch {
-            val autoHide = userPreferencesRepository.observeTopicTopBarAutoHide().first()
-            _state.update { current ->
-                if (current.topicTopBarAutoHideTouchedLocally || current.isUpdatingTopicTopBarAutoHide) {
-                    current
-                } else {
-                    current.copy(topicTopBarAutoHide = autoHide)
-                }
-            }
-        }
-        viewModelScope.launch {
-            val pageFabs = userPreferencesRepository.observeTopicPageFabs().first()
-            _state.update { current ->
-                if (current.topicPageFabsTouchedLocally || current.isUpdatingTopicPageFabs) {
-                    current
-                } else {
-                    current.copy(topicPageFabs = pageFabs)
-                }
-            }
-        }
-        viewModelScope.launch {
-            val mpBadge = userPreferencesRepository.observeMpUnreadBadge().first()
-            _state.update { current ->
-                if (current.mpUnreadBadgeTouchedLocally || current.isUpdatingMpUnreadBadge) {
-                    current
-                } else {
-                    current.copy(mpUnreadBadge = mpBadge)
-                }
-            }
-        }
-        viewModelScope.launch {
-            val confirm = userPreferencesRepository.observeConfirmBeforePosting().first()
-            _state.update { current ->
-                if (current.confirmBeforePostingTouchedLocally || current.isUpdatingConfirmBeforePosting) {
-                    current
-                } else {
-                    current.copy(confirmBeforePosting = confirm)
-                }
-            }
-        }
-        viewModelScope.launch {
-            val showDt = userPreferencesRepository.observeShowDtSection().first()
-            _state.update { current ->
-                if (current.showDtSectionTouchedLocally || current.isUpdatingShowDtSection) {
-                    current
-                } else {
-                    current.copy(showDtSection = showDt)
-                }
-            }
-        }
-        viewModelScope.launch {
-            val autoRefresh = userPreferencesRepository.observeFlagsAutoRefresh().first()
-            _state.update { current ->
-                if (current.flagsAutoRefreshTouchedLocally || current.isUpdatingFlagsAutoRefresh) {
-                    current
-                } else {
-                    current.copy(flagsAutoRefresh = autoRefresh)
-                }
-            }
+            val value = read()
+            _state.update { current -> if (isLocked(current)) current else apply(current, value) }
         }
     }
 
@@ -204,6 +162,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.TopicTopBarAutoHideChanged -> updateTopicTopBarAutoHide(intent.enabled)
             is SettingsIntent.TopicPageFabsChanged -> updateTopicPageFabs(intent.enabled)
             is SettingsIntent.MpUnreadBadgeChanged -> updateMpUnreadBadge(intent.enabled)
+            is SettingsIntent.TopicPollsExpandedChanged -> updateTopicPollsExpanded(intent.enabled)
             is SettingsIntent.ShowDtSectionChanged -> updateShowDtSection(intent.enabled)
             is SettingsIntent.ConfirmBeforePostingChanged -> updateConfirmBeforePosting(intent.enabled)
             is SettingsIntent.FlagsAutoRefreshChanged -> updateFlagsAutoRefresh(intent.enabled)
@@ -534,6 +493,33 @@ class SettingsViewModel @Inject constructor(
                 }
             },
             persist = userPreferencesRepository::setTopicPageFabs,
+        )
+    }
+
+    private fun updateTopicPollsExpanded(desired: Boolean) {
+        val previous = _state.value.topicPollsExpanded
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    topicPollsExpanded = desired,
+                    isUpdatingTopicPollsExpanded = true,
+                    topicPollsExpandedError = false,
+                    topicPollsExpandedTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(topicPollsExpanded = desired, isUpdatingTopicPollsExpanded = false)
+                } else {
+                    state.copy(
+                        topicPollsExpanded = previous,
+                        isUpdatingTopicPollsExpanded = false,
+                        topicPollsExpandedError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setTopicPollsExpanded,
         )
     }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -141,6 +141,10 @@
     <string name="settings_topic_page_fabs_title">Boutons de changement de page</string>
     <string name="settings_topic_page_fabs_description">Affiche les boutons flottants ‹ et › en bas du sujet. Désactivez-les si vous changez de page au glissement ; le bouton Répondre reste affiché.</string>
     <string name="settings_topic_page_fabs_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
+    <!-- #456 — sondages dépliés par défaut dans la lecture de sujet. -->
+    <string name="settings_topic_polls_expanded_title">Déplier les sondages</string>
+    <string name="settings_topic_polls_expanded_description">Affiche les sondages dépliés en haut des sujets. Désactivé : une ligne « Sondage » repliée, à déplier d\'un appui.</string>
+    <string name="settings_topic_polls_expanded_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
 
     <!-- #312 — Publication. Confirmation avant chaque envoi (réponse/édition de message, sujet,
          message privé) ; persisté en DataStore et lu en direct par les éditeurs.

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -1113,6 +1113,10 @@ class SettingsViewModelTest {
             mpUnreadBadge.value = enabled
         }
 
+        override fun observeTopicPollsExpanded(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setTopicPollsExpanded(enabled: Boolean) = Unit
+
         fun emitMpUnreadBadge(value: Boolean) {
             mpUnreadBadge.value = value
         }

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -860,6 +860,45 @@ class SettingsViewModelTest {
     }
 
     // ──────────────────────────────────────────────────────────────────────
+    // Sondages dépliés par défaut (#456)
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `init hydrates topicPollsExpanded from a persisted true`() = runTest {
+        // Default is false — only a persisted opt-in exercises the hydration path.
+        repository.emitTopicPollsExpanded(true)
+
+        val viewModel = newViewModel()
+
+        assertTrue(viewModel.state.value.topicPollsExpanded)
+        assertFalse(viewModel.state.value.topicPollsExpandedError)
+    }
+
+    @Test
+    fun `TopicPollsExpandedChanged persists the flip`() = runTest {
+        val viewModel = newViewModel()
+        assertFalse("polls are collapsed by default", viewModel.state.value.topicPollsExpanded)
+
+        viewModel.submit(SettingsIntent.TopicPollsExpandedChanged(true))
+
+        assertTrue(viewModel.state.value.topicPollsExpanded)
+        assertFalse(viewModel.state.value.isUpdatingTopicPollsExpanded)
+        assertEquals(1, repository.topicPollsExpandedSetCalls)
+    }
+
+    @Test
+    fun `TopicPollsExpandedChanged reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnTopicPollsExpandedSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.TopicPollsExpandedChanged(true))
+
+        assertFalse("failed persist must revert to the previous value", viewModel.state.value.topicPollsExpanded)
+        assertFalse(viewModel.state.value.isUpdatingTopicPollsExpanded)
+        assertTrue(viewModel.state.value.topicPollsExpandedError)
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
     // Confirm before posting (#312)
     // ──────────────────────────────────────────────────────────────────────
 
@@ -1113,12 +1152,26 @@ class SettingsViewModelTest {
             mpUnreadBadge.value = enabled
         }
 
-        override fun observeTopicPollsExpanded(): Flow<Boolean> = MutableStateFlow(false)
-
-        override suspend fun setTopicPollsExpanded(enabled: Boolean) = Unit
-
         fun emitMpUnreadBadge(value: Boolean) {
             mpUnreadBadge.value = value
+        }
+
+        // #456 — sondages dépliés par défaut. Même seam optimistic-flip que mpUnreadBadge.
+        private val topicPollsExpanded = MutableStateFlow(false)
+        var topicPollsExpandedSetCalls: Int = 0
+            private set
+        var failOnTopicPollsExpandedSet: Boolean = false
+
+        override fun observeTopicPollsExpanded(): Flow<Boolean> = topicPollsExpanded
+
+        override suspend fun setTopicPollsExpanded(enabled: Boolean) {
+            topicPollsExpandedSetCalls += 1
+            check(!failOnTopicPollsExpandedSet) { "boom" }
+            topicPollsExpanded.value = enabled
+        }
+
+        fun emitTopicPollsExpanded(value: Boolean) {
+            topicPollsExpanded.value = value
         }
 
         // #312 — confirm-before-posting. Same optimistic-flip seam as the topic top-bar toggle.

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1113,7 +1113,7 @@ private fun TopicHeaderCard(
                 onOpenPage = onOpenPage,
             )
             topic.poll?.let { poll ->
-                TopicPollCard(poll)
+                TopicPollCard(poll, expandedDefault = state.pollsExpandedDefault)
             }
             Button(
                 onClick = { onReply(topic.subcat, topic.page) },
@@ -1240,8 +1240,11 @@ private fun TopicPageJumpField(
 }
 
 @Composable
-private fun TopicPollCard(poll: Poll) {
-    var revealed by rememberSaveable(poll) { mutableStateOf(true) }
+private fun TopicPollCard(poll: Poll, expandedDefault: Boolean) {
+    // #456 — the preference seeds the initial state only; the tap toggle stays per-topic and
+    // survives rotation (rememberSaveable). Keyed on the poll AND the seed so the card follows
+    // a Settings change without restart (the saved value wins otherwise).
+    var revealed by rememberSaveable(poll, expandedDefault) { mutableStateOf(expandedDefault) }
     Card(
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainerLow,

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -40,6 +40,12 @@ data class TopicUiState(
      */
     val showPageFabs: Boolean = true,
     /**
+     * #456 — mirrors `UserPreferencesRepository.observeTopicPollsExpanded()`. Seeds the poll
+     * card's initial revealed state; the in-card « afficher / masquer » toggle stays per-topic.
+     * Default `false`: polls start collapsed.
+     */
+    val pollsExpandedDefault: Boolean = false,
+    /**
      * #335 — `true` while a manual pull-to-refresh of the current page is in flight. Drives the
      * Material3 `PullToRefreshBox` spinner. Set on the `Refresh` intent, cleared in the refresh
      * coroutine's `finally` (so a cancellation — e.g. a delete starting mid-refresh — never leaves

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -115,6 +115,13 @@ class TopicViewModel @AssistedInject constructor(
                 _state.update { it.copy(showPageFabs = enabled) }
             }
             .launchIn(viewModelScope)
+        // #456 — mirror the polls-expanded preference: seeds the poll card's initial revealed
+        // state (the in-card toggle stays per-topic on top of it).
+        userPreferencesRepository.observeTopicPollsExpanded()
+            .onEach { expanded ->
+                _state.update { it.copy(pollsExpandedDefault = expanded) }
+            }
+            .launchIn(viewModelScope)
     }
 
     fun send(intent: TopicIntent) {

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -447,6 +447,25 @@ class TopicViewModelTest {
     }
 
     @Test
+    fun `state pollsExpandedDefault reflects the user preference (#456)`() = runTest {
+        val collapsed = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            userPreferencesRepository = FakeUserPreferencesRepository(topicPollsExpanded = false),
+        )
+        assertEquals(false, collapsed.state.value.pollsExpandedDefault)
+
+        val expanded = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            userPreferencesRepository = FakeUserPreferencesRepository(topicPollsExpanded = true),
+        )
+        assertEquals(true, expanded.state.value.pollsExpandedDefault)
+    }
+
+    @Test
     fun `DeletePost success emits PostDeleted and force-refreshes the current page (#292)`() = runTest {
         // Page 2 so the editable post 777 is NOT the first post (the FP lives on page 1 and is
         // excluded from deletion). Editable + authenticated + canReply → the VM gate lets it through.
@@ -1287,6 +1306,7 @@ private class FakeStreamingTopicRepository(
 private class FakeUserPreferencesRepository(
     private val topicTopBarAutoHide: Boolean = false,
     private val topicPageFabs: Boolean = true,
+    private val topicPollsExpanded: Boolean = false,
 ) : UserPreferencesRepository {
     override fun observeProxyConfig(): Flow<ProxyConfig> = MutableStateFlow(ProxyConfig())
 
@@ -1351,4 +1371,8 @@ private class FakeUserPreferencesRepository(
     override fun observeMpUnreadBadge(): Flow<Boolean> = MutableStateFlow(true)
 
     override suspend fun setMpUnreadBadge(enabled: Boolean) = Unit
+
+    override fun observeTopicPollsExpanded(): Flow<Boolean> = MutableStateFlow(topicPollsExpanded)
+
+    override suspend fun setTopicPollsExpanded(enabled: Boolean) = Unit
 }

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -1299,9 +1299,10 @@ private class FakeStreamingTopicRepository(
 
 /**
  * No-op preferences fake for the topic ViewModel tests. Only [observeTopicTopBarAutoHide]
- * (build 89 follow-up) and [observeTopicPageFabs] (#383) are read by [TopicViewModel] —
- * everything else returns the DataStore default so the fake stays a thin stand-in. The two
- * relevant values are constructor-injectable so tests can assert they reach state.
+ * (build 89 follow-up), [observeTopicPageFabs] (#383) and [observeTopicPollsExpanded] (#456)
+ * are read by [TopicViewModel] — everything else returns the DataStore default so the fake
+ * stays a thin stand-in. The three relevant values are constructor-injectable so tests can
+ * assert they reach state.
  */
 private class FakeUserPreferencesRepository(
     private val topicTopBarAutoHide: Boolean = false,


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

refs-#456 (session nuit 2026-06-13 : « masquer les sondages, par défaut »).

- La carte sondage démarre **repliée** (la question reste lisible, « Afficher » la déplie) ; le toggle par sujet existant continue de marcher — le réglage ne sème que l'état initial (`rememberSaveable` re-keyé sur le seed).
- Nouveau réglage **Réglages › Lecture › « Déplier les sondages »** (défaut désactivé), pipeline préférence standard (#383) : DataStore → mirror TopicViewModel → `TopicUiState.pollsExpandedDefault`.
- **Refactor detekt** : l'ajout franchissait `LargeClass` sur `SettingsViewModel` (volontairement strict en prod) → les 13 blocs d'hydratation init, tous identiques, sont factorisés en `hydratePreference<T>` (garde anti-course startup conservée à l'identique).

Tests : mirror VM (#456) + 6 fakes mis à jour ; 53 tests settings + 41 topic verts ; Docker 2 parts verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)