### PR TITLE
feat(messages): ouvrir un MP sur sa dernière page + reprise de lecture locale (refs-#430)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -992,7 +992,7 @@ private fun RedfaceNavHost(
             entry<MessagesRoute> {
                 MessagesScreen(
                     readThreadIds = privateMessageNavState.readThreadIds,
-                    onOpenThread = { threadId, isMultiRecipient ->
+                    onOpenThread = { threadId, isMultiRecipient, openAtPage ->
                         // Record the multi-recipient hint in memory only; the route stays opaque.
                         if (isMultiRecipient) {
                             privateMessageNavState.onThreadOpenedAsMulti(threadId)
@@ -1000,6 +1000,10 @@ private fun RedfaceNavHost(
                         backStack.add(
                             PrivateMessageThreadRoute(
                                 threadId = threadId,
+                                // #430 — web parity: open on the conversation's last page (the
+                                // inbox "Pages" link), not page 1. The ViewModel may still land
+                                // further via the locally saved reading position.
+                                page = openAtPage,
                             ),
                         )
                     },

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/cache/CacheInvalidator.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/cache/CacheInvalidator.kt
@@ -2,6 +2,7 @@ package fr.forumhfr.redface2.core.data.cache
 
 import android.util.Log
 import fr.forumhfr.redface2.core.database.dao.FlagDao
+import fr.forumhfr.redface2.core.database.dao.MpReadPositionDao
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
 import fr.forumhfr.redface2.core.domain.flags.FlagRepository
@@ -31,6 +32,10 @@ import kotlinx.coroutines.plus
  *    them on disk grows the table indefinitely; we wipe `userId = previous`
  *    on transition.
  *
+ * The same two reasons apply to `mp_read_positions` (#430): the rows only hold page numbers,
+ * but they reveal which conversations exist for the previous account, so they are wiped on the
+ * same transition.
+ *
  * On a `Authenticated(A) → Authenticated(B)` switch (login, then logout, then
  * login as someone else), we wipe rows owned by A explicitly. The session
  * cache held in [FlagRepository.clearSessionCache] is also flushed so that the
@@ -47,6 +52,7 @@ import kotlinx.coroutines.plus
 class CacheInvalidator @Inject constructor(
     private val authRepository: AuthRepository,
     private val flagDao: FlagDao,
+    private val mpReadPositionDao: MpReadPositionDao,
     private val flagRepository: FlagRepository,
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
@@ -72,6 +78,8 @@ class CacheInvalidator @Inject constructor(
                 if (state.shouldPurge) {
                     runCatching { flagDao.deleteAllForUser(previousPseudo) }
                         .onFailure { Log.w(LOG_TAG, "Failed to purge flag cache for $previousPseudo", it) }
+                    runCatching { mpReadPositionDao.deleteAllForUser(previousPseudo) }
+                        .onFailure { Log.w(LOG_TAG, "Failed to purge MP positions for $previousPseudo", it) }
                     flagRepository.clearSessionCache()
                 }
             }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/messages/MessagesRepositoryModule.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/messages/MessagesRepositoryModule.kt
@@ -5,6 +5,7 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import fr.forumhfr.redface2.core.domain.messages.MessagesRepository
+import fr.forumhfr.redface2.core.domain.messages.PrivateMessageReadPositionStore
 import javax.inject.Singleton
 
 @Module
@@ -14,4 +15,10 @@ abstract class MessagesRepositoryModule {
     @Binds
     @Singleton
     abstract fun bindMessagesRepository(impl: DefaultMessagesRepository): MessagesRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindPrivateMessageReadPositionStore(
+        impl: RoomPrivateMessageReadPositionStore,
+    ): PrivateMessageReadPositionStore
 }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/messages/RoomPrivateMessageReadPositionStore.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/messages/RoomPrivateMessageReadPositionStore.kt
@@ -1,0 +1,47 @@
+package fr.forumhfr.redface2.core.data.messages
+
+import fr.forumhfr.redface2.core.database.dao.MpReadPositionDao
+import fr.forumhfr.redface2.core.database.entities.MpReadPositionEntity
+import fr.forumhfr.redface2.core.domain.auth.AuthRepository
+import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
+import fr.forumhfr.redface2.core.domain.messages.PrivateMessageReadPositionStore
+import fr.forumhfr.redface2.core.model.AuthState
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+
+/**
+ * Room-backed [PrivateMessageReadPositionStore] (#430). Rows are keyed by the lowercased pseudo
+ * of the CURRENT session (snapshotted per call from [AuthRepository]); with no active session
+ * both operations are no-ops — an anonymous client has no inbox, and a save racing a logout must
+ * not write a row the purge pass has already swept (CacheInvalidator wipes by previous pseudo).
+ */
+@Singleton
+class RoomPrivateMessageReadPositionStore @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val mpReadPositionDao: MpReadPositionDao,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) : PrivateMessageReadPositionStore {
+
+    override suspend fun readPage(threadId: Int): Int? = withContext(ioDispatcher) {
+        val userId = activeUserId() ?: return@withContext null
+        mpReadPositionDao.readPage(userId = userId, threadId = threadId)
+    }
+
+    override suspend fun savePage(threadId: Int, page: Int) {
+        if (page < 1) return
+        withContext(ioDispatcher) {
+            val userId = activeUserId() ?: return@withContext
+            mpReadPositionDao.upsert(
+                MpReadPositionEntity(userId = userId, threadId = threadId, page = page),
+            )
+        }
+    }
+
+    private suspend fun activeUserId(): String? =
+        (authRepository.observeAuthState().first() as? AuthState.Authenticated)
+            ?.pseudo
+            ?.lowercase()
+}

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/cache/CacheInvalidatorTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/cache/CacheInvalidatorTest.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.core.data.cache
 
 import fr.forumhfr.redface2.core.database.dao.FlagDao
+import fr.forumhfr.redface2.core.database.dao.MpReadPositionDao
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.flags.FlagRepository
 import fr.forumhfr.redface2.core.model.AuthState
@@ -21,70 +22,84 @@ class CacheInvalidatorTest {
     @Test
     fun `first login from Anonymous does not purge anyone`() = runTest {
         val state = MutableStateFlow<AuthState>(AuthState.Anonymous)
-        val (invalidator, flagDao, flagRepository) = invalidator(state)
-        invalidator.start()
+        val fixture = invalidator(state)
+        fixture.invalidator.start()
 
         state.value = AuthState.Authenticated("alice")
 
-        coVerify(exactly = 0) { flagDao.deleteAllForUser(any()) }
-        verify(exactly = 0) { flagRepository.clearSessionCache() }
+        coVerify(exactly = 0) { fixture.flagDao.deleteAllForUser(any()) }
+        coVerify(exactly = 0) { fixture.mpReadPositionDao.deleteAllForUser(any()) }
+        verify(exactly = 0) { fixture.flagRepository.clearSessionCache() }
     }
 
     @Test
-    fun `logout purges the previous user's flag rows and the session cache`() = runTest {
+    fun `logout purges the previous user's flag rows, MP positions and the session cache`() = runTest {
         val state = MutableStateFlow<AuthState>(AuthState.Authenticated("alice"))
-        val (invalidator, flagDao, flagRepository) = invalidator(state)
-        invalidator.start()
+        val fixture = invalidator(state)
+        fixture.invalidator.start()
 
         state.value = AuthState.Anonymous
 
         coVerifyOrder {
-            flagDao.deleteAllForUser("alice")
+            fixture.flagDao.deleteAllForUser("alice")
+            fixture.mpReadPositionDao.deleteAllForUser("alice")
         }
-        verify { flagRepository.clearSessionCache() }
+        verify { fixture.flagRepository.clearSessionCache() }
     }
 
     @Test
     fun `account switch purges the outgoing pseudo not the incoming one`() = runTest {
         val state = MutableStateFlow<AuthState>(AuthState.Authenticated("Alice"))
-        val (invalidator, flagDao, flagRepository) = invalidator(state)
-        invalidator.start()
+        val fixture = invalidator(state)
+        fixture.invalidator.start()
 
         state.value = AuthState.Authenticated("Bob")
 
         // Pseudo lowercased so "Alice" and "alice" both purge the same row set —
         // HFR is case-insensitive on pseudo display but cookies sometimes mix case.
-        coVerify { flagDao.deleteAllForUser("alice") }
-        coVerify(exactly = 0) { flagDao.deleteAllForUser("bob") }
-        verify { flagRepository.clearSessionCache() }
+        coVerify { fixture.flagDao.deleteAllForUser("alice") }
+        coVerify { fixture.mpReadPositionDao.deleteAllForUser("alice") }
+        coVerify(exactly = 0) { fixture.flagDao.deleteAllForUser("bob") }
+        coVerify(exactly = 0) { fixture.mpReadPositionDao.deleteAllForUser("bob") }
+        verify { fixture.flagRepository.clearSessionCache() }
     }
 
     @Test
     fun `same pseudo emitted twice does not trigger a purge`() = runTest {
         val state = MutableStateFlow<AuthState>(AuthState.Authenticated("alice"))
-        val (invalidator, flagDao, flagRepository) = invalidator(state)
-        invalidator.start()
+        val fixture = invalidator(state)
+        fixture.invalidator.start()
 
         // distinctUntilChanged collapses identical Authenticated emissions, but
         // even if it didn't, the case-folding pseudo comparison must short-circuit.
         state.value = AuthState.Authenticated("Alice")
 
-        coVerify(exactly = 0) { flagDao.deleteAllForUser(any()) }
-        verify(exactly = 0) { flagRepository.clearSessionCache() }
+        coVerify(exactly = 0) { fixture.flagDao.deleteAllForUser(any()) }
+        coVerify(exactly = 0) { fixture.mpReadPositionDao.deleteAllForUser(any()) }
+        verify(exactly = 0) { fixture.flagRepository.clearSessionCache() }
     }
 
-    private fun invalidator(stateFlow: Flow<AuthState>): Triple<CacheInvalidator, FlagDao, FlagRepository> {
+    private data class Fixture(
+        val invalidator: CacheInvalidator,
+        val flagDao: FlagDao,
+        val mpReadPositionDao: MpReadPositionDao,
+        val flagRepository: FlagRepository,
+    )
+
+    private fun invalidator(stateFlow: Flow<AuthState>): Fixture {
         val authRepository = mockk<AuthRepository>(relaxed = true) {
             io.mockk.every { observeAuthState() } returns stateFlow
         }
         val flagDao = mockk<FlagDao>(relaxed = true)
+        val mpReadPositionDao = mockk<MpReadPositionDao>(relaxed = true)
         val flagRepository = mockk<FlagRepository>(relaxed = true)
         val invalidator = CacheInvalidator(
             authRepository = authRepository,
             flagDao = flagDao,
+            mpReadPositionDao = mpReadPositionDao,
             flagRepository = flagRepository,
             ioDispatcher = UnconfinedTestDispatcher(),
         )
-        return Triple(invalidator, flagDao, flagRepository)
+        return Fixture(invalidator, flagDao, mpReadPositionDao, flagRepository)
     }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/messages/RoomPrivateMessageReadPositionStoreTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/messages/RoomPrivateMessageReadPositionStoreTest.kt
@@ -1,0 +1,64 @@
+package fr.forumhfr.redface2.core.data.messages
+
+import fr.forumhfr.redface2.core.database.dao.MpReadPositionDao
+import fr.forumhfr.redface2.core.database.entities.MpReadPositionEntity
+import fr.forumhfr.redface2.core.domain.auth.AuthRepository
+import fr.forumhfr.redface2.core.model.AuthState
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RoomPrivateMessageReadPositionStoreTest {
+
+    private val dao = mockk<MpReadPositionDao>(relaxed = true)
+
+    private fun store(authState: AuthState) = RoomPrivateMessageReadPositionStore(
+        authRepository = mockk<AuthRepository> {
+            every { observeAuthState() } returns MutableStateFlow(authState)
+        },
+        mpReadPositionDao = dao,
+        ioDispatcher = UnconfinedTestDispatcher(),
+    )
+
+    @Test
+    fun `anonymous session reads null and never touches the DAO`() = runTest {
+        val store = store(AuthState.Anonymous)
+
+        assertNull(store.readPage(threadId = 42))
+        store.savePage(threadId = 42, page = 7)
+
+        coVerify(exactly = 0) { dao.readPage(any(), any()) }
+        coVerify(exactly = 0) { dao.upsert(any()) }
+    }
+
+    @Test
+    fun `authenticated calls delegate with the lowercased pseudo`() = runTest {
+        coEvery { dao.readPage(userId = "xatrix", threadId = 42) } returns 7
+        val store = store(AuthState.Authenticated("XaTriX"))
+
+        assertEquals(7, store.readPage(threadId = 42))
+        store.savePage(threadId = 42, page = 9)
+
+        coVerify {
+            dao.upsert(MpReadPositionEntity(userId = "xatrix", threadId = 42, page = 9))
+        }
+    }
+
+    @Test
+    fun `savePage rejects a page below 1`() = runTest {
+        val store = store(AuthState.Authenticated("xatrix"))
+
+        store.savePage(threadId = 42, page = 0)
+
+        coVerify(exactly = 0) { dao.upsert(any()) }
+    }
+}

--- a/core/database/schemas/fr.forumhfr.redface2.core.database.RedfaceDatabase/10.json
+++ b/core/database/schemas/fr.forumhfr.redface2.core.database.RedfaceDatabase/10.json
@@ -1,0 +1,383 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 10,
+    "identityHash": "ac68782bb787d21391790a42672a1ef1",
+    "entities": [
+      {
+        "tableName": "topic_pages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cat` INTEGER NOT NULL, `post` INTEGER NOT NULL, `page` INTEGER NOT NULL, `title` TEXT NOT NULL, `totalPages` INTEGER NOT NULL, `isFirstPostOwner` INTEGER NOT NULL, `pollJson` TEXT, `numreponses` TEXT NOT NULL, `fetchedAt` INTEGER NOT NULL, `authMode` TEXT NOT NULL, `subcat` INTEGER NOT NULL, `canReply` INTEGER NOT NULL, PRIMARY KEY(`cat`, `post`, `page`))",
+        "fields": [
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "post",
+            "columnName": "post",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPages",
+            "columnName": "totalPages",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFirstPostOwner",
+            "columnName": "isFirstPostOwner",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pollJson",
+            "columnName": "pollJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "numreponses",
+            "columnName": "numreponses",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authMode",
+            "columnName": "authMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subcat",
+            "columnName": "subcat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canReply",
+            "columnName": "canReply",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cat",
+            "post",
+            "page"
+          ]
+        }
+      },
+      {
+        "tableName": "posts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cat` INTEGER NOT NULL, `numreponse` INTEGER NOT NULL, `post` INTEGER NOT NULL, `author` TEXT NOT NULL, `date` INTEGER NOT NULL, `content` TEXT NOT NULL, `avatarUrl` TEXT, `isEditable` INTEGER NOT NULL, `isOwnPost` INTEGER NOT NULL, `quotedAuthors` TEXT NOT NULL, `postIndex` INTEGER, `fetchedAt` INTEGER NOT NULL, `authMode` TEXT NOT NULL, `quoteRef` INTEGER, `profileId` INTEGER, `editedAt` INTEGER, PRIMARY KEY(`cat`, `numreponse`))",
+        "fields": [
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numreponse",
+            "columnName": "numreponse",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "post",
+            "columnName": "post",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isEditable",
+            "columnName": "isEditable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOwnPost",
+            "columnName": "isOwnPost",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quotedAuthors",
+            "columnName": "quotedAuthors",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postIndex",
+            "columnName": "postIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authMode",
+            "columnName": "authMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quoteRef",
+            "columnName": "quoteRef",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "editedAt",
+            "columnName": "editedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cat",
+            "numreponse"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_posts_cat_post",
+            "unique": false,
+            "columnNames": [
+              "cat",
+              "post"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_posts_cat_post` ON `${TABLE_NAME}` (`cat`, `post`)"
+          }
+        ]
+      },
+      {
+        "tableName": "flag_topics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `type` TEXT NOT NULL, `cat` INTEGER NOT NULL, `subcat` INTEGER, `topicId` INTEGER NOT NULL, `title` TEXT NOT NULL, `totalPages` INTEGER NOT NULL, `replyCount` INTEGER NOT NULL, `isFavorite` INTEGER NOT NULL DEFAULT 0, `hasUnread` INTEGER NOT NULL, `lastReadPage` INTEGER NOT NULL, `lastPostReadId` INTEGER, `firstPostAuthor` TEXT NOT NULL, `lastReplyAuthor` TEXT NOT NULL, `lastReplyAt` TEXT NOT NULL, `fetchedAt` INTEGER NOT NULL, `authMode` TEXT NOT NULL, PRIMARY KEY(`userId`, `type`, `cat`, `topicId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subcat",
+            "columnName": "subcat",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "topicId",
+            "columnName": "topicId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPages",
+            "columnName": "totalPages",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "replyCount",
+            "columnName": "replyCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hasUnread",
+            "columnName": "hasUnread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadPage",
+            "columnName": "lastReadPage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPostReadId",
+            "columnName": "lastPostReadId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "firstPostAuthor",
+            "columnName": "firstPostAuthor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReplyAuthor",
+            "columnName": "lastReplyAuthor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReplyAt",
+            "columnName": "lastReplyAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authMode",
+            "columnName": "authMode",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "type",
+            "cat",
+            "topicId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_flag_topics_userId_type",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_flag_topics_userId_type` ON `${TABLE_NAME}` (`userId`, `type`)"
+          },
+          {
+            "name": "index_flag_topics_userId_fetchedAt",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "fetchedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_flag_topics_userId_fetchedAt` ON `${TABLE_NAME}` (`userId`, `fetchedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "mp_read_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `threadId` INTEGER NOT NULL, `page` INTEGER NOT NULL, PRIMARY KEY(`userId`, `threadId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "threadId",
+            "columnName": "threadId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "threadId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ac68782bb787d21391790a42672a1ef1')"
+    ]
+  }
+}

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/RedfaceDatabase.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/RedfaceDatabase.kt
@@ -5,20 +5,28 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import fr.forumhfr.redface2.core.database.converters.Converters
 import fr.forumhfr.redface2.core.database.dao.FlagDao
+import fr.forumhfr.redface2.core.database.dao.MpReadPositionDao
 import fr.forumhfr.redface2.core.database.dao.TopicDao
 import fr.forumhfr.redface2.core.database.entities.FlagTopicEntity
+import fr.forumhfr.redface2.core.database.entities.MpReadPositionEntity
 import fr.forumhfr.redface2.core.database.entities.PostEntity
 import fr.forumhfr.redface2.core.database.entities.TopicEntity
 
 @Database(
-    entities = [TopicEntity::class, PostEntity::class, FlagTopicEntity::class],
-    version = 9,
+    entities = [
+        TopicEntity::class,
+        PostEntity::class,
+        FlagTopicEntity::class,
+        MpReadPositionEntity::class,
+    ],
+    version = 10,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)
 abstract class RedfaceDatabase : RoomDatabase() {
     abstract fun topicDao(): TopicDao
     abstract fun flagDao(): FlagDao
+    abstract fun mpReadPositionDao(): MpReadPositionDao
 
     companion object {
         const val DATABASE_NAME: String = "redface.db"

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/dao/MpReadPositionDao.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/dao/MpReadPositionDao.kt
@@ -1,0 +1,24 @@
+package fr.forumhfr.redface2.core.database.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import fr.forumhfr.redface2.core.database.entities.MpReadPositionEntity
+
+/**
+ * Read/write access to the per-account MP reading positions (#430). One row per
+ * `(userId, threadId)`; see [MpReadPositionEntity] for the privacy contract.
+ */
+@Dao
+interface MpReadPositionDao {
+
+    @Query("SELECT page FROM mp_read_positions WHERE userId = :userId AND threadId = :threadId")
+    suspend fun readPage(userId: String, threadId: Int): Int?
+
+    @Upsert
+    suspend fun upsert(position: MpReadPositionEntity)
+
+    /** Wipes every position owned by [userId] — logout / account-switch purge (CacheInvalidator). */
+    @Query("DELETE FROM mp_read_positions WHERE userId = :userId")
+    suspend fun deleteAllForUser(userId: String)
+}

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/di/DatabaseModule.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import fr.forumhfr.redface2.core.database.RedfaceDatabase
 import fr.forumhfr.redface2.core.database.dao.FlagDao
+import fr.forumhfr.redface2.core.database.dao.MpReadPositionDao
 import fr.forumhfr.redface2.core.database.dao.TopicDao
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_1_2
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_2_3
@@ -18,6 +19,7 @@ import fr.forumhfr.redface2.core.database.migrations.MIGRATION_5_6
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_6_7
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_7_8
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_8_9
+import fr.forumhfr.redface2.core.database.migrations.MIGRATION_9_10
 import javax.inject.Singleton
 
 @Module
@@ -41,6 +43,7 @@ object DatabaseModule {
             MIGRATION_6_7,
             MIGRATION_7_8,
             MIGRATION_8_9,
+            MIGRATION_9_10,
         )
         .build()
 
@@ -49,4 +52,8 @@ object DatabaseModule {
 
     @Provides
     fun provideFlagDao(database: RedfaceDatabase): FlagDao = database.flagDao()
+
+    @Provides
+    fun provideMpReadPositionDao(database: RedfaceDatabase): MpReadPositionDao =
+        database.mpReadPositionDao()
 }

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/entities/MpReadPositionEntity.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/entities/MpReadPositionEntity.kt
@@ -1,0 +1,28 @@
+package fr.forumhfr.redface2.core.database.entities
+
+import androidx.room.Entity
+
+/**
+ * Last page the user actually displayed in one private-message conversation (#430, ADR-013
+ * stage 1). Written on every successfully landed page; read once when (re)opening the
+ * conversation so a process death — or a later re-opening from the inbox — resumes past the
+ * route's frozen opening page.
+ *
+ * Per-account isolation follows [FlagTopicEntity]: [userId] (HFR pseudo, lowercase) is part of
+ * the primary key and the table is wiped by user on logout/account switch (cf. CacheInvalidator)
+ * — MP metadata is private, no row may survive the session that produced it. Only the page
+ * NUMBER is stored: no subject, no correspondent, no message content (same privacy rule as the
+ * deliberately opaque `PrivateMessageThreadRoute`).
+ */
+@Entity(
+    tableName = "mp_read_positions",
+    primaryKeys = ["userId", "threadId"],
+)
+data class MpReadPositionEntity(
+    /** Lowercased HFR pseudo of the account that owns this row. */
+    val userId: String,
+    /** HFR `post` id of the conversation (unique within `cat=prive`). */
+    val threadId: Int,
+    /** Last conversation page the user had on screen. */
+    val page: Int,
+)

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/migrations/Migrations.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/migrations/Migrations.kt
@@ -255,3 +255,25 @@ val MIGRATION_8_9: Migration = object : Migration(8, 9) {
         db.execSQL("ALTER TABLE flag_topics ADD COLUMN isFavorite INTEGER NOT NULL DEFAULT 0")
     }
 }
+
+/**
+ * v9 → v10 — `mp_read_positions` (#430, ADR-013 stage 1): per-account last-displayed page of
+ * each private-message conversation, so reopening (or restoring after process death) lands past
+ * the route's frozen opening page. Pure DDL, no backfill: positions only exist once the user
+ * navigates with the new build, and the opening fallback (the inbox's last-page link) covers
+ * absent rows.
+ */
+val MIGRATION_9_10: Migration = object : Migration(9, 10) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `mp_read_positions` (
+                `userId` TEXT NOT NULL,
+                `threadId` INTEGER NOT NULL,
+                `page` INTEGER NOT NULL,
+                PRIMARY KEY(`userId`, `threadId`)
+            )
+            """.trimIndent(),
+        )
+    }
+}

--- a/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/migrations/MigrationTest.kt
+++ b/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/migrations/MigrationTest.kt
@@ -22,8 +22,10 @@ import org.robolectric.annotation.Config
  * Robolectric-driven migration tests for every hand-written Room migration in the schema
  * — currently `MIGRATION_1_2`, `MIGRATION_2_3`, `MIGRATION_3_4`, `MIGRATION_4_5`,
  * `MIGRATION_5_6` (Phase 2 finish #208 added `Post.profileId` in v6), `MIGRATION_6_7`
- * (#213 added `Topic.canReply` in v7) and `MIGRATION_7_8` (#362 added `Post.editedAt`
- * in v8). Without these tests a typo (missing column, wrong index name, wrong default)
+ * (#213 added `Topic.canReply` in v7), `MIGRATION_7_8` (#362 added `Post.editedAt`
+ * in v8), `MIGRATION_8_9` (#384 follow-up added `FlagTopic.isFavorite` in v9) and
+ * `MIGRATION_9_10` (#430 added the `mp_read_positions` table in v10).
+ * Without these tests a typo (missing column, wrong index name, wrong default)
  * would only crash on a real upgrade-in-place install, where the diagnostic loop is
  * days long. The tests take seconds.
  */
@@ -116,6 +118,7 @@ class MigrationTest {
                 MIGRATION_6_7,
                 MIGRATION_7_8,
                 MIGRATION_8_9,
+                MIGRATION_9_10,
             )
             .build()
 
@@ -255,6 +258,7 @@ class MigrationTest {
                 MIGRATION_6_7,
                 MIGRATION_7_8,
                 MIGRATION_8_9,
+                MIGRATION_9_10,
             )
             .build()
 
@@ -354,6 +358,7 @@ class MigrationTest {
                 MIGRATION_6_7,
                 MIGRATION_7_8,
                 MIGRATION_8_9,
+                MIGRATION_9_10,
             )
             .build()
 
@@ -425,6 +430,7 @@ class MigrationTest {
                 MIGRATION_6_7,
                 MIGRATION_7_8,
                 MIGRATION_8_9,
+                MIGRATION_9_10,
             )
             .build()
 
@@ -492,6 +498,7 @@ class MigrationTest {
                 MIGRATION_6_7,
                 MIGRATION_7_8,
                 MIGRATION_8_9,
+                MIGRATION_9_10,
             )
             .build()
 
@@ -550,6 +557,7 @@ class MigrationTest {
                 MIGRATION_6_7,
                 MIGRATION_7_8,
                 MIGRATION_8_9,
+                MIGRATION_9_10,
             )
             .build()
 
@@ -622,6 +630,7 @@ class MigrationTest {
                 MIGRATION_6_7,
                 MIGRATION_7_8,
                 MIGRATION_8_9,
+                MIGRATION_9_10,
             )
             .build()
 
@@ -681,6 +690,7 @@ class MigrationTest {
                 MIGRATION_6_7,
                 MIGRATION_7_8,
                 MIGRATION_8_9,
+                MIGRATION_9_10,
             )
             .build()
 
@@ -690,6 +700,59 @@ class MigrationTest {
             ).use { cursor ->
                 assertTrue("pre-v9 flag row must survive MIGRATION_8_9", cursor.moveToFirst())
                 assertEquals("isFavorite must default to 0 for pre-v9 rows", 0, cursor.getInt(0))
+            }
+        } finally {
+            migrated.close()
+        }
+    }
+
+    /**
+     * #430 — v9 → v10 creates `mp_read_positions` (per-account MP reading positions).
+     *
+     * Verifies:
+     * 1. The migration runs cleanly against the v9 fixture and matches the exported v10 schema.
+     * 2. The production Room database (full migration chain) can write and read a position row
+     *    through the new table.
+     */
+    @Test
+    fun migrate_9_to_10_creates_mp_read_positions() {
+        val dbName = "migration_9_10_test"
+
+        // 1. Create a v9 database (no MP-position rows can pre-exist the table).
+        helper.createDatabase(dbName, 9).close()
+
+        // 2. Run MIGRATION_9_10 and validate against the exported v10 schema.
+        helper.runMigrationsAndValidate(dbName, 10, true, MIGRATION_9_10).close()
+
+        // 3. Open the production Room database (which chains every migration).
+        val migrated = Room.databaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            RedfaceDatabase::class.java,
+            dbName,
+        )
+            .allowMainThreadQueries()
+            .addMigrations(
+                MIGRATION_1_2,
+                MIGRATION_2_3,
+                MIGRATION_3_4,
+                MIGRATION_4_5,
+                MIGRATION_5_6,
+                MIGRATION_6_7,
+                MIGRATION_7_8,
+                MIGRATION_8_9,
+                MIGRATION_9_10,
+            )
+            .build()
+
+        try {
+            migrated.openHelper.writableDatabase.execSQL(
+                "INSERT INTO mp_read_positions (userId, threadId, page) VALUES ('xatrix', 42, 7)",
+            )
+            migrated.openHelper.readableDatabase.query(
+                "SELECT page FROM mp_read_positions WHERE userId = 'xatrix' AND threadId = 42",
+            ).use { cursor ->
+                assertTrue("the migrated table must accept and return a row", cursor.moveToFirst())
+                assertEquals(7, cursor.getInt(0))
             }
         } finally {
             migrated.close()

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/messages/PrivateMessageReadPositionStore.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/messages/PrivateMessageReadPositionStore.kt
@@ -1,0 +1,18 @@
+package fr.forumhfr.redface2.core.domain.messages
+
+/**
+ * Per-account local store of the last page the user displayed in each private-message
+ * conversation (#430, ADR-013 stage 1 — the server keeps no MP position at all, cf. #361).
+ *
+ * Implementations resolve the active account themselves and MUST be a no-op when no session is
+ * active: positions are private per-account data, wiped on logout/account switch. Only page
+ * NUMBERS ever reach the store — no subject, correspondent or content.
+ */
+interface PrivateMessageReadPositionStore {
+
+    /** Last page displayed for [threadId] by the active account, or `null` when unknown. */
+    suspend fun readPage(threadId: Int): Int?
+
+    /** Records [page] as the last displayed page of [threadId] for the active account. */
+    suspend fun savePage(threadId: Int, page: Int)
+}

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/messages/PrivateMessageSummary.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/messages/PrivateMessageSummary.kt
@@ -18,6 +18,11 @@ import java.time.Instant
  *   [fr.forumhfr.redface2.core.parser.messages.PrivateMessageListParser].
  * @property isMultiRecipient `true` for a multi-recipient conversation (MultiMP / "DT"): the
  *   `Interlocuteur` cell is a "Interlocuteurs multiples" label rather than a profile link.
+ * @property lastPage number of the conversation's last page, read from the inbox "Pages" cell
+ *   (`td.sujetCase4`). HFR only renders that link for conversations spanning several pages, so a
+ *   single-page conversation stays at the default `1`. Web parity (#430): the web inbox subject
+ *   link goes to page 1 and the trailing page number goes to the last page — the app uses
+ *   [lastPage] as the opening page so a long conversation lands on its most recent messages.
  */
 data class PrivateMessageSummary(
     val threadId: Int,
@@ -26,4 +31,5 @@ data class PrivateMessageSummary(
     val date: Instant,
     val hasUnread: Boolean,
     val isMultiRecipient: Boolean = false,
+    val lastPage: Int = 1,
 )

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/common/HfrSelectors.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/common/HfrSelectors.kt
@@ -40,6 +40,9 @@ object HfrSelectors {
     const val MP_LIST_ROW = "tr.sujet"
     const val MP_LIST_ICON = "td.sujetCase1 img[src]"
     const val MP_LIST_SUBJECT_LINK = "td.sujetCase3 a.cCatTopic"
+    // "Pages" cell: HFR renders a link to the conversation's LAST page there, but only when the
+    // conversation spans several pages — a single-page row holds a bare `&nbsp;` (#430).
+    const val MP_LIST_LAST_PAGE_LINK = "td.sujetCase4 a.cCatTopic"
     const val MP_LIST_CORRESPONDENT = "td.sujetCase6 a"
     // Multi-recipient (MultiMP / "DT") rows have no profile link: the Interlocuteur cell is a
     // `<span title="…truncated participant list…">Interlocuteurs multiples</span>` instead.

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/messages/PrivateMessageListParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/messages/PrivateMessageListParser.kt
@@ -90,6 +90,14 @@ class PrivateMessageListParser(
             ?.let(::isUnreadIcon)
             ?: false
 
+        // "Pages" cell (#430): a link to the conversation's last page, rendered by HFR only for
+        // multi-page conversations — its absence means the conversation fits on one page.
+        val lastPage = row.selectFirst(HfrSelectors.MP_LIST_LAST_PAGE_LINK)
+            ?.let { PAGE_REGEX.find(it.attr("href")) }
+            ?.groupValues?.getOrNull(1)
+            ?.toIntOrNull()
+            ?: 1
+
         return PrivateMessageSummary(
             threadId = threadId,
             correspondent = correspondent,
@@ -97,6 +105,7 @@ class PrivateMessageListParser(
             date = date,
             hasUnread = hasUnread,
             isMultiRecipient = isMultiRecipient,
+            lastPage = lastPage,
         )
     }
 
@@ -128,5 +137,6 @@ class PrivateMessageListParser(
         // (MultiMP / "DT"), in place of a profile link.
         const val MULTI_RECIPIENT_MARKER = "Interlocuteurs multiples"
         val THREAD_ID_REGEX = Regex("""[?&]post=(\d+)""")
+        val PAGE_REGEX = Regex("""[?&]page=(\d+)""")
     }
 }

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/messages/PrivateMessageListParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/messages/PrivateMessageListParserTest.kt
@@ -201,6 +201,22 @@ class PrivateMessageListParserTest {
         assertTrue(items.all { it.threadId > 0 })
     }
 
+    @Test
+    fun `parseList reads the last-page link and defaults to 1 without one (#430)`() {
+        val html = readFixture("private_messages_list_multi.html")
+
+        val items = parser.parseList(html).items
+
+        // Web parity: the "Pages" cell (sujetCase4) links the conversation's LAST page while the
+        // subject link always points to page 1 — the parser must read the dedicated cell, never
+        // the subject href's page parameter.
+        assertEquals(24, items.first { it.threadId == 3195369 }.lastPage)
+        assertEquals(876, items.first { it.threadId == 2716413 }.lastPage)
+        // HFR renders a bare `&nbsp;` cell for a single-page conversation → default 1.
+        assertEquals(1, items.first { it.threadId == 3195237 }.lastPage)
+        assertTrue(items.all { it.lastPage >= 1 })
+    }
+
     private fun readFixture(name: String): String {
         val resource = javaClass.classLoader.getResourceAsStream("fixtures/$name")
             ?: error("Missing fixture: fixtures/$name")

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessagesScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessagesScreen.kt
@@ -59,8 +59,10 @@ import java.util.Locale
 @Suppress("LongParameterList") // Tab surface : nav callbacks + chrome slots + the sent signal.
 fun MessagesScreen(
     // isMultiRecipient is an ephemeral UI hint forwarded to the thread screen (the route stays
-    // opaque — it never persists this private metadata in the back stack).
-    onOpenThread: (threadId: Int, isMultiRecipient: Boolean) -> Unit,
+    // opaque — it never persists this private metadata in the back stack). openAtPage is the
+    // conversation's last page read from the inbox (#430, web parity: the inbox "Pages" cell
+    // links the last page) — a bare page number is not private metadata.
+    onOpenThread: (threadId: Int, isMultiRecipient: Boolean, openAtPage: Int) -> Unit,
     readThreadIds: Set<Int> = emptySet(),
     topBarActions: @Composable (() -> Unit)? = null,
     // #301 follow-up — opens the new-conversation composer. Null hides the button.
@@ -178,7 +180,11 @@ fun MessagesScreen(
                         ),
                         onSelectPage = viewModel::selectPage,
                         onConversationClick = { conversation ->
-                            onOpenThread(conversation.threadId, conversation.isMultiRecipient)
+                            onOpenThread(
+                                conversation.threadId,
+                                conversation.isMultiRecipient,
+                                conversation.lastPage,
+                            )
                         },
                     )
                 }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModel.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.messages.MessagesRepository
+import fr.forumhfr.redface2.core.domain.messages.PrivateMessageReadPositionStore
 import fr.forumhfr.redface2.core.model.AuthState
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
@@ -33,6 +34,7 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
     @Assisted private val request: PrivateMessageThreadRequest,
     private val repository: MessagesRepository,
     private val authRepository: AuthRepository,
+    private val readPositionStore: PrivateMessageReadPositionStore,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(PrivateMessageThreadUiState.initial(request))
@@ -55,7 +57,7 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
                         AuthState.Anonymous -> clearPrivateState()
                         is AuthState.Authenticated -> {
                             authenticatedPseudo = authState.pseudo
-                            load(request.page.coerceAtLeast(1))
+                            load(openingPage())
                         }
                     }
                 }
@@ -87,6 +89,24 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
         loadJob?.cancel()
         _state.value = PrivateMessageThreadUiState.initial(request)
             .copy(mode = PrivateMessageThreadUiState.Mode.RequiresLogin)
+    }
+
+    /**
+     * Page the conversation opens on (#430). The route freezes the page known at opening time
+     * (the inbox passes its last-page link — web parity), while the local per-account store
+     * remembers the page actually displayed last (it survives process death, the original #430
+     * bug). `max` of the two: a conversation that grew since the last visit opens on its NEW
+     * last page (fresh messages win over an older resume point), and a reader who advanced past
+     * the frozen opening page resumes where they actually were. A store failure falls back to
+     * the route — opening the conversation must never break on a local read.
+     */
+    private suspend fun openingPage(): Int {
+        val saved = try {
+            readPositionStore.readPage(request.threadId)
+        } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
+            null
+        }
+        return maxOf(saved ?: 1, request.page.coerceAtLeast(1))
     }
 
     private fun load(page: Int) {
@@ -123,6 +143,7 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
                         isRefreshing = false,
                     )
                 }
+                savePosition(thread.page)
             } catch (cancellation: CancellationException) {
                 // Deliberately does NOT clear isRefreshing: a cancellation only comes from a
                 // superseding load() (which owns the flag from its own start) or from
@@ -149,6 +170,18 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * #430 — records the landed page so the next opening (or a process-death restoration)
+     * resumes here. Launched in its own coroutine so a quick page change cancelling [loadJob]
+     * cannot abort a write for a page that WAS displayed; best-effort (a lost write only costs
+     * the resume position, the store itself no-ops when the session ended meanwhile).
+     */
+    private fun savePosition(page: Int) {
+        viewModelScope.launch {
+            runCatching { readPositionStore.savePage(request.threadId, page) }
         }
     }
 

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModel.kt
@@ -46,6 +46,8 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
     // A new page load (or retry) cancels the previous in-flight one so a stale result cannot
     // overwrite the page the user is actually on.
     private var loadJob: Job? = null
+    // #430 — single in-flight position write, latest-wins (cf. savePosition).
+    private var saveJob: Job? = null
     private var authenticatedPseudo: String? = null
 
     init {
@@ -57,7 +59,7 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
                         AuthState.Anonymous -> clearPrivateState()
                         is AuthState.Authenticated -> {
                             authenticatedPseudo = authState.pseudo
-                            load(openingPage())
+                            loadInitial()
                         }
                     }
                 }
@@ -87,6 +89,7 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
     private fun clearPrivateState() {
         authenticatedPseudo = null
         loadJob?.cancel()
+        saveJob?.cancel()
         _state.value = PrivateMessageThreadUiState.initial(request)
             .copy(mode = PrivateMessageThreadUiState.Mode.RequiresLogin)
     }
@@ -109,6 +112,20 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
         return maxOf(saved ?: 1, request.page.coerceAtLeast(1))
     }
 
+    /**
+     * Initial load of a (re)authenticated session (#430). The previous session's in-flight load
+     * is cancelled BEFORE the first suspension point (the position-store read inside
+     * [openingPage]): on an `Authenticated(A) → Authenticated(B)` switch, A's fetch could
+     * otherwise land inside that window, pose A's conversation state and save A's position
+     * under B's userId (review Codex PR #462).
+     */
+    private fun loadInitial() {
+        loadJob?.cancel()
+        loadJob = viewModelScope.launch {
+            fetchPage(openingPage())
+        }
+    }
+
     private fun load(page: Int) {
         if (authenticatedPseudo == null) {
             clearPrivateState()
@@ -116,58 +133,64 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
         }
         loadJob?.cancel()
         loadJob = viewModelScope.launch {
-            // #351 — keep the displayed conversation on screen while (re)loading. There is no MP
-            // cache (ADR-013: nothing persisted), so a page change or a pull-to-refresh from a
-            // loaded page is a full network round-trip; wiping to Mode.Loading would flash a
-            // full-screen spinner on every page turn. `page` is NOT advanced optimistically: the
-            // pager keeps describing the page on screen until the new one actually lands.
-            val keepContent = _state.value.mode is PrivateMessageThreadUiState.Mode.Content
-            _state.update {
-                if (keepContent) {
-                    it.copy(isRefreshing = true)
-                } else {
-                    it.copy(mode = PrivateMessageThreadUiState.Mode.Loading, page = page)
-                }
+            fetchPage(page)
+        }
+    }
+
+    private suspend fun fetchPage(page: Int) {
+        // Snapshot of the session that issued this fetch — savePosition is sealed to it (#462).
+        val owner = authenticatedPseudo ?: return
+        // #351 — keep the displayed conversation on screen while (re)loading. There is no MP
+        // cache (ADR-013: nothing persisted), so a page change or a pull-to-refresh from a
+        // loaded page is a full network round-trip; wiping to Mode.Loading would flash a
+        // full-screen spinner on every page turn. `page` is NOT advanced optimistically: the
+        // pager keeps describing the page on screen until the new one actually lands.
+        val keepContent = _state.value.mode is PrivateMessageThreadUiState.Mode.Content
+        _state.update {
+            if (keepContent) {
+                it.copy(isRefreshing = true)
+            } else {
+                it.copy(mode = PrivateMessageThreadUiState.Mode.Loading, page = page)
             }
-            try {
-                val thread = repository.getPrivateMessageThread(
-                    threadId = request.threadId,
-                    page = page,
-                    fallbackCorrespondent = null,
+        }
+        try {
+            val thread = repository.getPrivateMessageThread(
+                threadId = request.threadId,
+                page = page,
+                fallbackCorrespondent = null,
+            )
+            _state.update {
+                it.copy(
+                    mode = PrivateMessageThreadUiState.Mode.Content(thread),
+                    page = thread.page,
+                    totalPages = thread.totalPages,
+                    isRefreshing = false,
                 )
+            }
+            savePosition(thread.page, owner)
+        } catch (cancellation: CancellationException) {
+            // Deliberately does NOT clear isRefreshing: a cancellation only comes from a
+            // superseding load() (which owns the flag from its own start) or from
+            // clearPrivateState() (which resets the whole state) — clearing it here could
+            // race the superseding load and hide its in-flight indicator.
+            throw cancellation
+        } catch (
+            // The throwable MESSAGE is intentionally NOT propagated to the UI state — it can
+            // embed the private forum2.php?cat=prive&post=<id> URL (#316), so it must reach
+            // neither the screen nor the exportable DiagnosticsLog. The Error state only
+            // carries the #324 kind, a closed enum derived from the exception TYPE
+            // (classifyHfrError) so the screen can tell an HFR 5xx outage from a network cut.
+            @Suppress("TooGenericExceptionCaught") error: Exception,
+        ) {
+            if (keepContent) {
+                // #351 — the page on screen stays put (it is still valid); the screen surfaces
+                // a one-shot Toast instead of swapping a readable conversation for an Error
+                // placeholder. Initial loads (nothing on screen) keep the Error + Retry path.
+                _state.update { it.copy(isRefreshing = false) }
+                _effects.send(PrivateMessageThreadEffect.RefreshFailed)
+            } else {
                 _state.update {
-                    it.copy(
-                        mode = PrivateMessageThreadUiState.Mode.Content(thread),
-                        page = thread.page,
-                        totalPages = thread.totalPages,
-                        isRefreshing = false,
-                    )
-                }
-                savePosition(thread.page)
-            } catch (cancellation: CancellationException) {
-                // Deliberately does NOT clear isRefreshing: a cancellation only comes from a
-                // superseding load() (which owns the flag from its own start) or from
-                // clearPrivateState() (which resets the whole state) — clearing it here could
-                // race the superseding load and hide its in-flight indicator.
-                throw cancellation
-            } catch (
-                // The throwable MESSAGE is intentionally NOT propagated to the UI state — it can
-                // embed the private forum2.php?cat=prive&post=<id> URL (#316), so it must reach
-                // neither the screen nor the exportable DiagnosticsLog. The Error state only
-                // carries the #324 kind, a closed enum derived from the exception TYPE
-                // (classifyHfrError) so the screen can tell an HFR 5xx outage from a network cut.
-                @Suppress("TooGenericExceptionCaught") error: Exception,
-            ) {
-                if (keepContent) {
-                    // #351 — the page on screen stays put (it is still valid); the screen surfaces
-                    // a one-shot Toast instead of swapping a readable conversation for an Error
-                    // placeholder. Initial loads (nothing on screen) keep the Error + Retry path.
-                    _state.update { it.copy(isRefreshing = false) }
-                    _effects.send(PrivateMessageThreadEffect.RefreshFailed)
-                } else {
-                    _state.update {
-                        it.copy(mode = PrivateMessageThreadUiState.Mode.Error(classifyHfrError(error)))
-                    }
+                    it.copy(mode = PrivateMessageThreadUiState.Mode.Error(classifyHfrError(error)))
                 }
             }
         }
@@ -175,13 +198,28 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
 
     /**
      * #430 — records the landed page so the next opening (or a process-death restoration)
-     * resumes here. Launched in its own coroutine so a quick page change cancelling [loadJob]
-     * cannot abort a write for a page that WAS displayed; best-effort (a lost write only costs
-     * the resume position, the store itself no-ops when the session ended meanwhile).
+     * resumes here. Best-effort: a lost write only costs the resume position. Two guards from
+     * the Codex review of PR #462:
+     *
+     * - **Serialized, latest-wins**: a new landing cancels the previous in-flight write
+     *   ([saveJob]), so a save delayed by IO can never overwrite a more recent position
+     *   (the cancelled write either never commits or had already committed BEFORE the newer
+     *   one — Room serializes writers).
+     * - **Sealed to the loading session**: [owner] is the pseudo snapshotted when the fetch
+     *   started; if the active session changed before this write fires, it is dropped (the
+     *   store also re-resolves the active session and no-ops when none is left).
      */
-    private fun savePosition(page: Int) {
-        viewModelScope.launch {
-            runCatching { readPositionStore.savePage(request.threadId, page) }
+    private fun savePosition(page: Int, owner: String) {
+        saveJob?.cancel()
+        saveJob = viewModelScope.launch {
+            if (owner != authenticatedPseudo) return@launch
+            try {
+                readPositionStore.savePage(request.threadId, page)
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
+                // Swallowed: the resume position is a nicety, never worth surfacing an error.
+            }
         }
     }
 

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModelTest.kt
@@ -316,6 +316,56 @@ class PrivateMessageThreadViewModelTest {
         assertEquals(5, store.saved[42])
     }
 
+    @Test
+    fun `an account switch seals the previous session's load and position save (#462)`() = runTest {
+        // Authenticated(A) → Authenticated(B) without an Anonymous hop: A's in-flight fetch must
+        // be cancelled BEFORE the new session's first suspension point, so its result can never
+        // pose state — nor save a position — under B (Codex review on PR #462).
+        val repository = mockk<MessagesRepository>()
+        val gate = CompletableDeferred<PrivateMessageThread>()
+        var calls = 0
+        coEvery {
+            repository.getPrivateMessageThread(threadId = 42, page = 1, fallbackCorrespondent = null)
+        } coAnswers { if (calls++ == 0) gate.await() else thread(page = 1, totalPages = 1) }
+        val authRepository = FakeAuthRepository(AuthState.Authenticated("alice"))
+        val store = FakeReadPositionStore()
+
+        threadViewModel(repository, authRepository, store)
+        // alice's fetch is parked on the gate; switch the account.
+        authRepository.emit(AuthState.Authenticated("bob"))
+        advanceUntilIdle()
+        // Releasing alice's gate must be inert — her job was cancelled at the switch.
+        gate.complete(thread(page = 3, totalPages = 9))
+        advanceUntilIdle()
+
+        assertEquals("only bob's landing may be recorded", 1, store.saved[42])
+    }
+
+    @Test
+    fun `a stale position save cannot overwrite a newer landing (#462)`() = runTest {
+        // save(1) parks on IO while page 5 lands: the newer landing must cancel the stale write
+        // (latest-wins serialization), otherwise a delayed upsert would regress the position.
+        val repository = mockk<MessagesRepository>()
+        coEvery {
+            repository.getPrivateMessageThread(threadId = 42, page = 1, fallbackCorrespondent = null)
+        } returns thread(page = 1, totalPages = 9)
+        coEvery {
+            repository.getPrivateMessageThread(threadId = 42, page = 5, fallbackCorrespondent = null)
+        } returns thread(page = 5, totalPages = 9)
+        val store = FakeReadPositionStore()
+        val saveGate = CompletableDeferred<Unit>()
+        store.blockNextSave = saveGate
+
+        val viewModel = threadViewModel(repository, readPositionStore = store)
+        viewModel.selectPage(5)
+        advanceUntilIdle()
+        // Releasing the parked save(1) must NOT resurrect it after save(5) committed.
+        saveGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(5, store.saved[42])
+    }
+
     private fun thread(page: Int, totalPages: Int) = PrivateMessageThread(
         threadId = 42,
         subject = "Sujet",
@@ -351,9 +401,16 @@ class PrivateMessageThreadViewModelTest {
     ) : PrivateMessageReadPositionStore {
         val saved = initial.toMutableMap()
 
+        /** When set, the NEXT [savePage] parks on it before writing (cleared on consumption). */
+        var blockNextSave: CompletableDeferred<Unit>? = null
+
         override suspend fun readPage(threadId: Int): Int? = saved[threadId]
 
         override suspend fun savePage(threadId: Int, page: Int) {
+            blockNextSave?.let { gate ->
+                blockNextSave = null
+                gate.await()
+            }
             saved[threadId] = page
         }
     }

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModelTest.kt
@@ -4,6 +4,7 @@ import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.domain.messages.MessagesRepository
+import fr.forumhfr.redface2.core.domain.messages.PrivateMessageReadPositionStore
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.messages.PrivateMessageThread
 import io.mockk.coEvery
@@ -47,6 +48,12 @@ class PrivateMessageThreadViewModelTest {
         page = 1,
     )
 
+    private fun threadViewModel(
+        repository: MessagesRepository,
+        authRepository: AuthRepository = FakeAuthRepository(),
+        readPositionStore: PrivateMessageReadPositionStore = FakeReadPositionStore(),
+    ) = PrivateMessageThreadViewModel(request, repository, authRepository, readPositionStore)
+
     @Test
     fun `loads the thread on init without private route metadata fallback`() = runTest {
         val repository = mockk<MessagesRepository>()
@@ -55,7 +62,7 @@ class PrivateMessageThreadViewModelTest {
             repository.getPrivateMessageThread(threadId = 42, page = 1, fallbackCorrespondent = null)
         } returns thread
 
-        val viewModel = PrivateMessageThreadViewModel(request, repository, FakeAuthRepository())
+        val viewModel = threadViewModel(repository)
 
         val state = viewModel.state.value
         assertTrue(state.mode is PrivateMessageThreadUiState.Mode.Content)
@@ -75,6 +82,7 @@ class PrivateMessageThreadViewModelTest {
             request = request,
             repository = repository,
             authRepository = FakeAuthRepository(AuthState.Anonymous),
+            readPositionStore = FakeReadPositionStore(),
         )
 
         assertEquals(PrivateMessageThreadUiState.Mode.RequiresLogin, viewModel.state.value.mode)
@@ -90,7 +98,7 @@ class PrivateMessageThreadViewModelTest {
             repository.getPrivateMessageThread(threadId = 42, page = 1, fallbackCorrespondent = null)
         } throws IOException("offline")
 
-        val viewModel = PrivateMessageThreadViewModel(request, repository, FakeAuthRepository())
+        val viewModel = threadViewModel(repository)
 
         // #316: the Error mode carries NO raw throwable message (privacy — it can embed the private
         // conversation URL). The only detail is the #324 type-derived kind (safe closed enum).
@@ -109,7 +117,7 @@ class PrivateMessageThreadViewModelTest {
             repository.getPrivateMessageThread(threadId = 42, page = 1, fallbackCorrespondent = null)
         } throws HfrServerException(code = 500, url = "https://forum.hardware.fr/forum2.php")
 
-        val viewModel = PrivateMessageThreadViewModel(request, repository, FakeAuthRepository())
+        val viewModel = threadViewModel(repository)
 
         val mode = viewModel.state.value.mode
         assertTrue(mode is PrivateMessageThreadUiState.Mode.Error)
@@ -126,7 +134,7 @@ class PrivateMessageThreadViewModelTest {
             repository.getPrivateMessageThread(threadId = 42, page = 2, fallbackCorrespondent = null)
         } returns thread(page = 2, totalPages = 2)
 
-        val viewModel = PrivateMessageThreadViewModel(request, repository, FakeAuthRepository())
+        val viewModel = threadViewModel(repository)
         viewModel.selectPage(2)
 
         val state = viewModel.state.value
@@ -150,7 +158,7 @@ class PrivateMessageThreadViewModelTest {
             repository.getPrivateMessageThread(threadId = 42, page = 2, fallbackCorrespondent = null)
         } coAnswers { gate.await() }
 
-        val viewModel = PrivateMessageThreadViewModel(request, repository, FakeAuthRepository())
+        val viewModel = threadViewModel(repository)
         viewModel.selectPage(2)
 
         // Page 2 is in flight: page 1 is still what the user sees.
@@ -176,7 +184,7 @@ class PrivateMessageThreadViewModelTest {
             repository.getPrivateMessageThread(threadId = 42, page = 1, fallbackCorrespondent = null)
         } returns first andThen updated
 
-        val viewModel = PrivateMessageThreadViewModel(request, repository, FakeAuthRepository())
+        val viewModel = threadViewModel(repository)
         viewModel.refresh()
 
         val state = viewModel.state.value
@@ -198,7 +206,7 @@ class PrivateMessageThreadViewModelTest {
             repository.getPrivateMessageThread(threadId = 42, page = 1, fallbackCorrespondent = null)
         } returns pageOne andThenThrows IOException("offline")
 
-        val viewModel = PrivateMessageThreadViewModel(request, repository, FakeAuthRepository())
+        val viewModel = threadViewModel(repository)
         viewModel.refresh()
 
         val state = viewModel.state.value
@@ -214,7 +222,7 @@ class PrivateMessageThreadViewModelTest {
             repository.getPrivateMessageThread(threadId = 42, page = 1, fallbackCorrespondent = null)
         } throws IOException("offline")
 
-        val viewModel = PrivateMessageThreadViewModel(request, repository, FakeAuthRepository())
+        val viewModel = threadViewModel(repository)
         assertTrue(viewModel.state.value.mode is PrivateMessageThreadUiState.Mode.Error)
         viewModel.refresh()
 
@@ -233,7 +241,7 @@ class PrivateMessageThreadViewModelTest {
             repository.getPrivateMessageThread(threadId = 42, page = 1, fallbackCorrespondent = null)
         } returns thread(page = 1, totalPages = 1)
 
-        val viewModel = PrivateMessageThreadViewModel(request, repository, authRepository)
+        val viewModel = threadViewModel(repository, authRepository)
         assertTrue(viewModel.state.value.mode is PrivateMessageThreadUiState.Mode.Content)
 
         authRepository.emit(AuthState.Anonymous)
@@ -243,6 +251,69 @@ class PrivateMessageThreadViewModelTest {
         authRepository.emit(AuthState.Authenticated("other"))
         advanceUntilIdle()
         assertTrue(viewModel.state.value.mode is PrivateMessageThreadUiState.Mode.Content)
+    }
+
+    @Test
+    fun `opening resumes from the saved position when it is past the route page (#430)`() = runTest {
+        // Process-death restoration: the route is frozen on the page the conversation was opened
+        // on, the local store remembers the page actually displayed last — the store wins.
+        val repository = mockk<MessagesRepository>()
+        coEvery {
+            repository.getPrivateMessageThread(threadId = 42, page = 7, fallbackCorrespondent = null)
+        } returns thread(page = 7, totalPages = 9)
+
+        PrivateMessageThreadViewModel(
+            request = request,
+            repository = repository,
+            authRepository = FakeAuthRepository(),
+            readPositionStore = FakeReadPositionStore(initial = mapOf(42 to 7)),
+        )
+
+        coVerify(exactly = 1) {
+            repository.getPrivateMessageThread(threadId = 42, page = 7, fallbackCorrespondent = null)
+        }
+    }
+
+    @Test
+    fun `opening prefers a route page past the saved position (#430)`() = runTest {
+        // The conversation grew since the last visit: the inbox's fresh last-page link (carried
+        // by the route) is further than the stale resume point — new messages win.
+        val repository = mockk<MessagesRepository>()
+        coEvery {
+            repository.getPrivateMessageThread(threadId = 42, page = 9, fallbackCorrespondent = null)
+        } returns thread(page = 9, totalPages = 9)
+
+        PrivateMessageThreadViewModel(
+            request = PrivateMessageThreadRequest(threadId = 42, page = 9),
+            repository = repository,
+            authRepository = FakeAuthRepository(),
+            readPositionStore = FakeReadPositionStore(initial = mapOf(42 to 3)),
+        )
+
+        coVerify(exactly = 1) {
+            repository.getPrivateMessageThread(threadId = 42, page = 9, fallbackCorrespondent = null)
+        }
+    }
+
+    @Test
+    fun `a landed page is saved as the reading position (#430)`() = runTest {
+        val repository = mockk<MessagesRepository>()
+        coEvery {
+            repository.getPrivateMessageThread(threadId = 42, page = 1, fallbackCorrespondent = null)
+        } returns thread(page = 1, totalPages = 9)
+        coEvery {
+            repository.getPrivateMessageThread(threadId = 42, page = 5, fallbackCorrespondent = null)
+        } returns thread(page = 5, totalPages = 9)
+        val store = FakeReadPositionStore()
+
+        val viewModel =
+            PrivateMessageThreadViewModel(request, repository, FakeAuthRepository(), store)
+        assertEquals(1, store.saved[42])
+
+        viewModel.selectPage(5)
+        advanceUntilIdle()
+
+        assertEquals(5, store.saved[42])
     }
 
     private fun thread(page: Int, totalPages: Int) = PrivateMessageThread(
@@ -271,6 +342,19 @@ class PrivateMessageThreadViewModelTest {
 
         suspend fun emit(authState: AuthState) {
             state.emit(authState)
+        }
+    }
+
+    /** In-memory [PrivateMessageReadPositionStore] — `saved` exposes writes for assertions. */
+    private class FakeReadPositionStore(
+        initial: Map<Int, Int> = emptyMap(),
+    ) : PrivateMessageReadPositionStore {
+        val saved = initial.toMutableMap()
+
+        override suspend fun readPage(threadId: Int): Int? = saved[threadId]
+
+        override suspend fun savePage(threadId: Int, page: Int) {
+            saved[threadId] = page
         }
     }
 }


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi

Mandat nuit 2026-06-13 : « MP : la lecture doit être iso fonctionnalité avec la version web dans un premier temps (pas arriver à la premier page/premier post) ». Implémente le plan posté sur #430 (ADR-013 étage 1).

### Parité web — dernière page
- Le parser de la liste MP lit désormais le lien **« Pages »** (`td.sujetCase4 a.cCatTopic`) → `PrivateMessageSummary.lastPage` (défaut 1 quand la cellule est vide = conversation mono-page). Contrat vérifié live : le titre pointe `page=1`, le numéro de dernière page pointe la dernière page.
- L'ouverture depuis la liste passe `lastPage` à `PrivateMessageThreadRoute.page` — une conversation longue n'atterrit plus jamais page 1.

### Reprise de lecture locale (process death)
- Nouvelle table Room `mp_read_positions` (migration **v9→v10**) : dernière page réellement affichée, par compte (pseudo lowercase dans la PK, esprit `flag_topics`).
- Écrite à chaque page posée (`selectPage`/refresh réussi), via `PrivateMessageReadPositionStore` (`:core:domain`) + impl Room (`:core:data`, `withContext(io)`).
- **Atterrissage = `max(position locale, page de la route)`** : un MP qui a grandi depuis la dernière visite ouvre sur sa **nouvelle** dernière page (les nouveaux messages priment), un process death reprend la lecture là où elle était.
- Purge par compte au logout/changement de compte (`CacheInvalidator`), comme les drapeaux — la route reste opaque (aucune métadonnée privée sérialisée, seul un numéro de page).

### Non inclus (différé, cf. #430/#6)
Seed/sync MPStorage (`mpFlags`) — « on verra pour le stockage mpstorage ».

## Tests
- Parser : fixture réelle multi (lastPage 24 et 876, mono-page → 1).
- Migration 9→10 : Robolectric, validation schéma exporté + chaîne complète.
- Store Room : no-op anonyme, délégation pseudo lowercase, rejet `page<1`.
- ViewModel : reprise depuis la position sauvée, route fraîche prioritaire, sauvegarde à chaque page posée.
- Validation locale : `detektAll test :app:assembleProdDebug` + `:app:lintProdDebug` verts (545 tests sur les modules touchés).

Refs-#430 (fermeture manuelle après vérification device).