### PR TITLE
feat(flags): swipe entre les onglets de drapeaux + suppression par appui long (refs-#457)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
@@ -2,11 +2,11 @@ package fr.forumhfr.redface2.core.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -38,20 +38,19 @@ import fr.forumhfr.redface2.core.ui.theme.FlagPalette
  * because `:core:ui` has no localized resources of its own — keeping the i18n boundary
  * clean per the convention recorded in `docs/guides/contributing.md`.
  *
- * [trailingAction] is an optional slot at the end of the row for an inline affordance (e.g.
- * an overflow / quick action). When present, the title column takes the remaining width via
- * `weight(1f)` so the action stays pinned to the right and the text ellipsises instead of
- * overlapping it. When absent (default), the column fills the row as before.
- *
  * [FlagMetadata.end] is an optional end-aligned segment of the footer line (#325
  * follow-up: the last-reply timestamp). It is NEVER truncated — the start segment takes
  * the remaining width and ellipsises instead, so on narrow screens the date survives and
  * the author/pagination clip first (dogfooding feedback on v102: the timestamp, placed
  * last in a single string, was the part being cut off).
  *
- * Note (#99): the « Retirer le drapeau » affordance is no longer an inline `trailingAction`
- * button — `:feature:flags` now wraps this row in a Material 3 `SwipeToDismissBox`
- * (swipe-to-remove + confirmation dialog). The slot is kept for future inline actions.
+ * Note (#99 → #457): the « Retirer le drapeau » affordance went from an inline trailing button
+ * to a `SwipeToDismissBox` (#99), then to a **long-press** ([longPress], #457) — the horizontal
+ * swipe now changes the flag tab, so a row-level horizontal gesture would steal it. The
+ * never-consumed `trailingAction` slot was dropped in the same change (detekt parameter budget).
+ *
+ * [longPress] is optional so the other consumers of this row keep the plain tap behaviour;
+ * when null the row uses [clickable] unchanged (no long-press semantics advertised at all).
  */
 @Composable
 fun FlagItem(
@@ -59,19 +58,28 @@ fun FlagItem(
     metadata: FlagMetadata,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    trailingAction: (@Composable RowScope.() -> Unit)? = null,
+    longPress: FlagItemLongPress? = null,
 ) {
+    val rowInteraction = if (longPress != null) {
+        Modifier.combinedClickable(
+            onLongClick = longPress.onLongPress,
+            onLongClickLabel = longPress.label,
+            onClick = onClick,
+        )
+    } else {
+        Modifier.clickable(onClick = onClick)
+    }
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
+            .then(rowInteraction)
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         FlagDot(type = flag.type, isFavorite = flag.isFavorite, hasUnread = flag.hasUnread)
         Column(
-            modifier = if (trailingAction != null) Modifier.weight(1f) else Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(2.dp),
         ) {
             Text(
@@ -109,7 +117,6 @@ fun FlagItem(
                 }
             }
         }
-        trailingAction?.invoke(this)
     }
 }
 
@@ -117,6 +124,15 @@ fun FlagItem(
  * Bottom divider mirroring the visual rhythm of HFR topic listings. Exposed separately
  * from [FlagItem] so callers can choose whether to draw it (e.g. last item of a page).
  */
+/**
+ * Optional long-press affordance of a [FlagItem] row (#457). [label] doubles as the
+ * accessibility `onLongClickLabel` announced for the long-press action.
+ */
+data class FlagItemLongPress(
+    val label: String,
+    val onLongPress: () -> Unit,
+)
+
 @Composable
 fun FlagItemDivider(modifier: Modifier = Modifier) {
     HorizontalDivider(

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -35,30 +35,29 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
-import androidx.compose.material3.SwipeToDismissBox
-import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.rememberModalBottomSheetState
-import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -71,6 +70,7 @@ import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.ui.FlagItem
 import fr.forumhfr.redface2.core.ui.FlagItemDivider
+import fr.forumhfr.redface2.core.ui.FlagItemLongPress
 import fr.forumhfr.redface2.core.ui.FlagMetadata
 import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.formatLastReplyTimestamp
@@ -92,11 +92,10 @@ import kotlinx.coroutines.launch
  * - Refresh is now a Material 3 `PullToRefreshBox` (swipe down) instead of a header button,
  *   matching `feature/forum`. The error state still surfaces a `Retry` affordance because
  *   it's a recovery action, not a permanent secondary control.
- * - Flag removal (#99) is now a Material 3 `SwipeToDismissBox` (swipe end-to-start) instead
- *   of a trailing « Retirer » button. The swipe only *opens* the existing confirmation dialog
- *   ([requestRemoveFlag]) — it never dismisses the row on its own. See [SwipeableFlagItem] for
- *   the « confirm before network » detail (the row is reset to settled, so it stays in place
- *   until the user confirms and the repository evicts it from the cache).
+ * - Flag removal went trailing button → swipe-to-dismiss (#99) → **long-press** (#457): the
+ *   horizontal swipe now changes the flag tab ([flagsTabSwipe]), so the row-level dismiss
+ *   gesture was retired. The long-press only *opens* the existing confirmation dialog
+ *   ([requestRemoveFlag]) — see [RemovableFlagItem].
  */
 @OptIn(ExperimentalMaterial3Api::class)
 // Intentional: the Scaffold here only anchors the SnackbarHost above system bars; the inner
@@ -601,28 +600,67 @@ private fun ColumnScope.AuthenticatedBody(
         }
     }
 
-    if (selectedTab == FlagTab.Super) {
-        // Placeholder — no backend, no fetch, no pull-to-refresh (cf. FlagTab.Super KDoc).
-        SuperPlaceholderBody()
-        return
+    // #457 — horizontal swipe between flag tabs, carried by the whole body under the tab row
+    // (placeholders included, so a swipe can leave Super/DT too). The committed target INDEX is
+    // mapped back to a FlagTab against the same `tabs` list the row renders — read through
+    // rememberUpdatedState because the gesture is keyed on Unit and never restarts, while the
+    // tab list itself can change (the DT tab is a Settings toggle).
+    val haptics = LocalHapticFeedback.current
+    val dragOffset = remember { mutableFloatStateOf(0f) }
+    val updatedTabs = rememberUpdatedState(tabs)
+    val updatedSelectedIndex = rememberUpdatedState(selectedIndex)
+    val updatedActions = rememberUpdatedState(actions)
+    val swipeHandlers = remember(haptics) {
+        FlagsTabSwipeHandlers(
+            haptics = haptics,
+            onSelectTab = { index ->
+                updatedTabs.value.getOrNull(index)
+                    ?.let { (tab, _) -> updatedActions.value.onSelectTab(tab) }
+            },
+        )
     }
-    if (selectedTab == FlagTab.Dt) {
-        // Placeholder — content arrives with the MPStorage sync (#6), cf. FlagTab.Dt KDoc.
-        DtPlaceholderBody()
-        return
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            // Without weight(1f) the box would not claim the remaining vertical space inside
+            // the parent Column, breaking the gesture areas on short lists.
+            .weight(1f)
+            .flagsTabSwipe(
+                currentIndex = { updatedSelectedIndex.value },
+                tabCount = { updatedTabs.value.size },
+                dragOffset = dragOffset,
+                handlers = swipeHandlers,
+            ),
+    ) {
+        when (selectedTab) {
+            // Placeholders — no backend, no fetch, no pull-to-refresh (cf. their KDoc).
+            FlagTab.Super -> SuperPlaceholderBody()
+            FlagTab.Dt -> DtPlaceholderBody()
+            else -> FlagListBody(state = state, actions = actions, listState = listState)
+        }
     }
+}
 
+/**
+ * The real flag-list body of a [FlagTab] with a backend (Cyan/Red/Favorite) — extracted from
+ * [AuthenticatedBody] when the #457 tab-swipe wrapper landed, so the swipe surface (placeholders
+ * included) and the pull-to-refresh surface stay two distinct layers.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun FlagListBody(
+    state: FlagsBodyState,
+    actions: AuthenticatedActions,
+    listState: LazyListState,
+) {
+    val selectedTab = state.selectedTab
     // Pull-to-refresh (swipe down) replaces the legacy header « Actualiser » button, matching
     // feature/forum. It wraps the whole flag body so the indicator stays anchored over the
     // existing content during the refresh round-trip (Material 3 stable, cf. Context7).
     PullToRefreshBox(
         isRefreshing = state.isRefreshing,
         onRefresh = actions.onRefresh,
-        modifier = Modifier
-            .fillMaxWidth()
-            // Without weight(1f) the box would not claim the remaining vertical space inside
-            // the parent Column, breaking the swipe gesture area on short lists.
-            .weight(1f),
+        modifier = Modifier.fillMaxSize(),
     ) {
         when (val current = state.flagsState) {
             null, FlagsListUiState.Loading -> Box(
@@ -809,7 +847,7 @@ private fun CategorySectionedFlagList(
                     // across the list. `removeFlagState` is Removing only between confirm and the
                     // repository result (a brief window); the modal dialog already blocks the
                     // Confirming phase and the ViewModel rejects re-entry.
-                    SwipeableFlagItem(
+                    RemovableFlagItem(
                         flag = flag,
                         metadata = flagRowMetadata(flag),
                         removalInFlight = removalInFlight,
@@ -876,8 +914,8 @@ private fun emptySectionLabel(tab: FlagTab): Int = when (tab) {
  * with no category bands. Like [CategorySectionedFlagList] it is a single [LazyColumn] so the
  * surrounding `PullToRefreshBox` keeps a scrollable child to anchor the pull gesture on (#229);
  * an empty list still emits one placeholder item so the « rien à afficher » wording is shown and
- * the pull gesture has a target. Rows reuse [SwipeableFlagItem] so the #99 swipe-to-remove and
- * accessibility action behave identically to the grouped view.
+ * the pull gesture has a target. Rows reuse [RemovableFlagItem] so the long-press removal (#457)
+ * and accessibility action behave identically to the grouped view.
  */
 @Composable
 private fun FlatFlagList(
@@ -908,7 +946,7 @@ private fun FlatFlagList(
                 key = { "${it.cat}-${it.topicId}" },
                 contentType = { CONTENT_TYPE_ROW },
             ) { flag ->
-                SwipeableFlagItem(
+                RemovableFlagItem(
                     flag = flag,
                     metadata = flagRowMetadata(flag),
                     removalInFlight = removalInFlight,
@@ -932,104 +970,47 @@ private fun flatEmptyLabel(tab: FlagTab): Int = when (tab) {
 }
 
 /**
- * One swipeable flag row (#99). Wraps [FlagItem] in a Material 3 [SwipeToDismissBox] so a swipe
- * **end-to-start** raises the existing confirmation dialog via [onRequestRemove].
+ * One removable flag row. The « Retirer » affordance went swipe-to-dismiss (#99) → **long-press**
+ * (#457): the horizontal swipe now changes the flag tab, and a row-level `SwipeToDismissBox`
+ * would consume the horizontal drag first and steal the tab gesture. The long-press only
+ * *raises* the existing confirmation dialog via [onRequestRemove] — the actual removal still
+ * happens after the user confirms (the repository then evicts the item from the cache, which
+ * recomposes the list away). Arbitrage XaTriX (#457): the swipe-to-remove may come back later
+ * in another form.
  *
- * Crucial « confirm before network » detail: the swipe must **not** dismiss the row on its own.
- * The actual removal only happens after the user confirms in the dialog (the repository then
- * evicts the item from the cache, which recomposes the list away). So from the non-deprecated
- * [SwipeToDismissBox] `onDismiss` callback we both fire [onRequestRemove] **and** immediately
- * `reset()` the box back to [SwipeToDismissBoxValue.Settled] — the row snaps back whether the user
- * confirms or cancels. This is the canonical Material 3 stable pattern (cf. Context7
- * `SwipeToDismissBox` sample).
- *
- * Resetting from a separate `LaunchedEffect` keyed on `currentValue` looks equivalent but is
- * racy: `reset()` = `animateTo(Settled)` flips `currentValue` early, re-keying the effect and
- * cancelling the reset mid-animation, which leaves the row **stuck at the dismissed offset** once
- * the dialog grabs focus (reproduced on device). Resetting inside `onDismiss` avoids the race.
- *
- * We do **not** use the `confirmValueChange` veto overload of [rememberSwipeToDismissBoxState]:
- * it is deprecated in the locked Material 3 (BOM 2026.04.01) — the verified message is
- * « confirmValueChange is deprecated without replacement ». `onDismiss` + `reset()` is the
- * supported equivalent (cf. Context7 + the locked material3 classes.jar).
- *
- * Only swipe-to-start is enabled ([enableDismissFromStartToEnd] = false): a single, predictable
- * gesture, with no accidental removal on a start-to-end pan. The swipe is also the *only* removal
- * affordance, so the row carries a TalkBack/switch-access `customActions` entry mirroring it.
- * While a removal is in flight ([removalInFlight]), gestures are disabled across the list (the
- * ViewModel also guards re-entry) — `Removing` is only the brief confirm→result window.
+ * The long-press being invisible, the row keeps the TalkBack/switch-access `customActions`
+ * entry (#99) in addition to the `onLongClickLabel` semantics. While a removal is in flight
+ * ([removalInFlight]) the long-press is a no-op — the ViewModel also guards re-entry;
+ * `Removing` is only the brief confirm→result window.
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SwipeableFlagItem(
+private fun RemovableFlagItem(
     flag: Flag,
     metadata: FlagMetadata,
     removalInFlight: Boolean,
     onClick: () -> Unit,
     onRequestRemove: () -> Unit,
 ) {
-    val dismissState = rememberSwipeToDismissBoxState()
-    val scope = rememberCoroutineScope()
     val removeLabel = stringResource(R.string.flags_remove_action)
 
-    SwipeToDismissBox(
-        state = dismissState,
-        enableDismissFromStartToEnd = false,
-        enableDismissFromEndToStart = true,
-        gesturesEnabled = !removalInFlight,
-        // The swipe only *triggers* the confirmation — it must never dismiss the row itself.
-        // Raise the dialog and snap the box back from the SAME callback (canonical M3 stable
-        // pattern). Doing the reset() here instead of a LaunchedEffect(currentValue) avoids the
-        // re-key race that otherwise leaves the row stuck at the dismissed offset.
-        onDismiss = {
-            onRequestRemove()
-            scope.launch { dismissState.reset() }
+    FlagItem(
+        flag = flag,
+        metadata = metadata,
+        onClick = onClick,
+        longPress = FlagItemLongPress(label = removeLabel) {
+            if (!removalInFlight) onRequestRemove()
         },
-        backgroundContent = { SwipeRemoveBackground() },
-    ) {
-        FlagItem(
-            flag = flag,
-            metadata = metadata,
-            onClick = onClick,
-            // Opaque background so the destructive backdrop never bleeds through the row while
-            // it is animating back to settled. Swipe is the only removal affordance now, so we
-            // also expose a TalkBack/switch-access custom action mirroring it.
-            modifier = Modifier
-                .background(MaterialTheme.colorScheme.surface)
-                .semantics {
-                    customActions = listOf(
-                        CustomAccessibilityAction(removeLabel) {
-                            onRequestRemove()
-                            true
-                        },
-                    )
-                },
-        )
-    }
-}
-
-/**
- * Destructive M3 backdrop revealed under a flag row while swiping end-to-start (#99). Uses
- * `errorContainer` / `onErrorContainer` from the theme — no hardcoded color — and a text label
- * (« Retirer ») rather than a Material Icons glyph, because the icons-extended dependency is not
- * on the classpath in this module.
- */
-@Composable
-private fun SwipeRemoveBackground() {
-    Box(
         modifier = Modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.errorContainer)
-            .padding(horizontal = 24.dp),
-        contentAlignment = Alignment.CenterEnd,
-    ) {
-        Text(
-            text = stringResource(R.string.flags_remove_action),
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.onErrorContainer,
-            textAlign = TextAlign.End,
-        )
-    }
+            .background(MaterialTheme.colorScheme.surface)
+            .semantics {
+                customActions = listOf(
+                    CustomAccessibilityAction(removeLabel) {
+                        onRequestRemove()
+                        true
+                    },
+                )
+            },
+    )
 }
 
 /**
@@ -1037,11 +1018,10 @@ private fun SwipeRemoveBackground() {
  * network call — just an explanatory message until the feature ships.
  */
 @Composable
-private fun ColumnScope.SuperPlaceholderBody() {
+private fun SuperPlaceholderBody() {
     Column(
         modifier = Modifier
-            .fillMaxWidth()
-            .weight(1f)
+            .fillMaxSize()
             .padding(horizontal = 24.dp, vertical = 32.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
@@ -1079,11 +1059,10 @@ private fun DtTabFallbackEffect(
  * discussions whose flags sync through the MPStorage document, #6) lands later.
  */
 @Composable
-private fun ColumnScope.DtPlaceholderBody() {
+private fun DtPlaceholderBody() {
     Column(
         modifier = Modifier
-            .fillMaxWidth()
-            .weight(1f)
+            .fillMaxSize()
             .padding(horizontal = 24.dp, vertical = 32.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTabSwipe.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTabSwipe.kt
@@ -1,0 +1,165 @@
+package fr.forumhfr.redface2.feature.flags
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitHorizontalTouchSlopOrCancellation
+import androidx.compose.foundation.gestures.horizontalDrag
+import androidx.compose.runtime.MutableFloatState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.input.pointer.util.VelocityTracker
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.ui.pager.FLING_VELOCITY_THRESHOLD
+import fr.forumhfr.redface2.core.ui.pager.MIN_COMMIT_DISTANCE
+import fr.forumhfr.redface2.core.ui.pager.swipeArmed
+import fr.forumhfr.redface2.core.ui.pager.swipeCommitDirection
+import fr.forumhfr.redface2.core.ui.pager.swipeCommitDistancePx
+import fr.forumhfr.redface2.core.ui.pager.swipeFollowOffset
+import fr.forumhfr.redface2.core.ui.pager.swipeTargetPage
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Horizontal swipe → change flag tab (#457): the tab-index counterpart of the MP conversation's
+ * in-place `threadPageSwipe` (#351b). The *feel* is identical by construction — thresholds,
+ * drag-follow shaping and edge hint all come from the shared pure geometry in `:core:ui`
+ * (`core.ui.pager.PageSwipe`) — with "page" mapped to the **tab index** (0-based, left-to-right):
+ * swiping the content left commits to the tab on the right, exactly like turning to the next
+ * page. The tab row itself is NOT part of the gesture surface — it already has taps.
+ *
+ * In-place mechanics mirror the thread gesture (the composition survives the tab change, so a
+ * committed swipe springs back to rest while the new tab's content swaps in — instantly on a
+ * cache hit, behind the existing loading state otherwise):
+ *
+ * - **Commit → [FlagsTabSwipeHandlers.onSelectTab]** with the target index; the caller maps it
+ *   back to a `FlagTab` (the DT tab is conditional, so the index↔tab mapping lives where the tab
+ *   list is built). The ViewModel's re-tap toggle (Cyan « +lus ») is unreachable by construction:
+ *   [swipeTargetPage] never returns the current index.
+ * - [currentIndex] and [tabCount] are lambdas: the selected tab changes UNDER this live
+ *   composition (gesture keyed on `Unit`, never re-keyed), both must be read fresh per frame.
+ * - No re-entrance latch and no enabled-gate: a tab switch is local state + cached list, there
+ *   is no in-flight window to guard (the thread gesture's gate exists for its network reload).
+ *
+ * Coexistence contract: horizontal slop only — the vertical list scroll and the pull-to-refresh
+ * nested-scroll are never stolen. This gesture only became possible once the rows' horizontal
+ * `SwipeToDismissBox` (#99) was retired in this same change: a child consuming the horizontal
+ * drag first cancels ours. Edges (first/last tab) are a damped no-op wall.
+ */
+internal fun Modifier.flagsTabSwipe(
+    currentIndex: () -> Int,
+    tabCount: () -> Int,
+    dragOffset: MutableFloatState,
+    handlers: FlagsTabSwipeHandlers,
+): Modifier = this
+    // `pointerInput` BEFORE `graphicsLayer`, same constraint as the topic/thread gestures:
+    // deltas must be read in the untranslated coordinate space (inside the translated layer each
+    // frame's `positionChange()` would be Δfinger − Δtranslation → halved tracking).
+    .pointerInput(Unit) {
+        val commitDistancePx = swipeCommitDistancePx(size.width.toFloat(), MIN_COMMIT_DISTANCE.toPx())
+        val flingThresholdPx = FLING_VELOCITY_THRESHOLD.toPx()
+        val release = Animatable(0f)
+        coroutineScope {
+            val animationScope = this
+            var releaseJob: Job? = null
+            awaitEachGesture {
+                val down = awaitFirstDown(requireUnconsumed = false)
+                val velocityTracker = VelocityTracker()
+                velocityTracker.addPosition(down.uptimeMillis, down.position)
+                var overSlop = 0f
+                val drag = awaitHorizontalTouchSlopOrCancellation(down.id) { change, slop ->
+                    change.consume()
+                    overSlop = slop
+                } ?: return@awaitEachGesture
+                // Cancel a running spring-back deterministically at slop crossing (not at `down`,
+                // which would let a mere tap interrupt it) — same reasoning as #282/#351b.
+                releaseJob?.cancel()
+                var totalDx = overSlop
+                var armed = false
+                velocityTracker.addPosition(drag.uptimeMillis, drag.position)
+                dragOffset.floatValue =
+                    tabFollowOffset(totalDx, commitDistancePx, currentIndex(), tabCount())
+                val completed = horizontalDrag(drag.id) { change ->
+                    totalDx += change.positionChange().x
+                    velocityTracker.addPosition(change.uptimeMillis, change.position)
+                    val offset =
+                        tabFollowOffset(totalDx, commitDistancePx, currentIndex(), tabCount())
+                    dragOffset.floatValue = offset
+                    val nowArmed = swipeArmed(offset, commitDistancePx)
+                    if (nowArmed && !armed) {
+                        handlers.haptics.performHapticFeedback(
+                            HapticFeedbackType.GestureThresholdActivate,
+                        )
+                    }
+                    armed = nowArmed
+                    change.consume()
+                }
+                if (completed) {
+                    val velocityX = velocityTracker.calculateVelocity().x
+                    val forward =
+                        swipeCommitDirection(totalDx, velocityX, commitDistancePx, flingThresholdPx)
+                    val target = forward?.let { swipeTargetIndex(currentIndex(), tabCount(), it) }
+                    if (forward != null && target != null) {
+                        handlers.haptics.performHapticFeedback(HapticFeedbackType.Confirm)
+                        handlers.onSelectTab(target)
+                    }
+                }
+                // ALWAYS spring back — commit included: the composition is kept, the new tab's
+                // content swaps in at rest (cache hit = instant, otherwise the loading state).
+                releaseJob = animationScope.launch {
+                    release.snapTo(dragOffset.floatValue)
+                    release.animateTo(0f, TAB_SPRING_BACK) { dragOffset.floatValue = value }
+                }
+            }
+        }
+    }
+    // Draw-only translation + armed elevation lift, same draw-phase contract as the other swipe
+    // gestures (reads `dragOffset` without recomposition).
+    .graphicsLayer {
+        val offset = dragOffset.floatValue
+        translationX = offset
+        val commitDistancePx = swipeCommitDistancePx(size.width, MIN_COMMIT_DISTANCE.toPx())
+        shadowElevation =
+            if (swipeArmed(offset, commitDistancePx)) TAB_COMMIT_SHADOW_ELEVATION_DP.dp.toPx() else 0f
+    }
+
+/**
+ * Non-per-frame inputs of [flagsTabSwipe], bundled (same shape as `ThreadSwipeHandlers`) so the
+ * gesture's parameter list stays within the project's limit. [onSelectTab] receives the target
+ * **tab index** in the currently displayed tab list.
+ */
+internal class FlagsTabSwipeHandlers(
+    val haptics: HapticFeedback,
+    val onSelectTab: (Int) -> Unit,
+)
+
+/**
+ * The shared pager geometry speaks 1-based pages; tabs are 0-based indices. Shift by one for
+ * [swipeTargetPage] so its `1..totalPages` bounds check becomes a `0..tabCount-1` check.
+ */
+private fun swipeTargetIndex(currentIndex: Int, tabCount: Int, forward: Boolean): Int? =
+    swipeTargetPage(currentIndex + 1, tabCount, forward)?.minus(1)
+
+private fun tabFollowOffset(
+    totalDx: Float,
+    commitDistancePx: Float,
+    currentIndex: Int,
+    tabCount: Int,
+): Float {
+    val hasTarget = swipeTargetIndex(currentIndex, tabCount, forward = totalDx < 0f) != null
+    return swipeFollowOffset(totalDx, commitDistancePx, hasTarget)
+}
+
+private const val TAB_COMMIT_SHADOW_ELEVATION_DP = 8f
+
+private val TAB_SPRING_BACK = spring<Float>(
+    dampingRatio = Spring.DampingRatioNoBouncy,
+    stiffness = Spring.StiffnessMedium,
+)


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi

Mandat nuit 2026-06-13 : « Swiper entre catégorie de drapeaux » + décision actée « virer la suppression de drapal par swipe (reviendra en 2e temps) ».

### Swipe d'onglets
- `FlagsTabSwipe` : geste **in-place** calqué sur `threadPageSwipe` (#351b) — même géométrie pure partagée `core.ui.pager` (seuils de commit, drag-follow, overpull amorti aux bords, haptique armé/commit, spring-back systématique), « page » → **index d'onglet** (décalage ±1 sur `swipeTargetPage`).
- Porté par tout le corps sous la `PrimaryTabRow` (placeholders Super/DT inclus — on peut en sortir au swipe). Slop horizontal uniquement : le scroll vertical et le pull-to-refresh ne sont jamais volés.
- Mapping index→`FlagTab` fait contre la liste d'onglets FRAÎCHE (`rememberUpdatedState` — l'onglet DT est un toggle Réglages, le geste est keyé `Unit`). Le toggle « re-tap Cyan = +lus » est inatteignable par construction (jamais de commit vers l'onglet courant).

### Suppression par appui long
- Le `SwipeToDismissBox` (#99) consommait le drag horizontal en premier → retiré.
- `FlagItem` gagne un paramètre `longPress` optionnel (`combinedClickable` stable + `onLongClickLabel`) ; `RemovableFlagItem` ouvre le même dialog de confirmation qu'avant, custom action TalkBack « Retirer » conservée, no-op pendant un retrait en vol.
- Slot `trailingAction` jamais consommé supprimé (budget paramètres detekt).
- `FlagListBody` extrait d'`AuthenticatedBody` : la surface du swipe d'onglets (tout le corps) et celle du PTR (listes réelles) restent deux couches distinctes.

## Tests
- La géométrie du geste est celle déjà couverte par `PageSwipeTest` (35 tests) ; le shim ±1 est trivial et exercé par compile.
- Validation locale : `detektAll :feature:flags:testDebugUnitTest :core:ui:testDebugUnitTest :app:assembleProdDebug` + `:app:lintProdDebug` verts.
- Vérification émulateur prévue avant la release dev de fin de nuit.

Refs-#457 (fermeture après vérification device).