### PR TITLE
feat(settings): écran de démarrage configurable — onglet + catégorie Forum (refs-#458)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -440,13 +440,20 @@ fun RedfaceApp(intent: Intent?) {
         val flagsBackStack = rememberNavBackStack(FlagsListRoute)
         val forumStartCat = startScreen.forumCatId
             ?.takeIf { startScreen.screen == StartScreenChoice.FORUM }
-        val forumBackStack = if (forumStartCat != null) {
-            // Pre-stacked category listing: back from it lands on the forum root, like a manual
-            // navigation would.
-            rememberNavBackStack(ForumRoute, CategoryRoute(cat = forumStartCat))
+        // SINGLE rememberNavBackStack call site on purpose (review Codex PR #464): two
+        // conditional calls would occupy different saveable slots, so flipping the preference
+        // between launches could orphan the saved Forum stack and reset it to the seed instead
+        // of restoring. The pre-stacked category listing means back from it lands on the forum
+        // root, like a manual navigation would.
+        val forumInitialStack = if (forumStartCat != null) {
+            arrayOf<NavKey>(ForumRoute, CategoryRoute(cat = forumStartCat))
         } else {
-            rememberNavBackStack(ForumRoute)
+            arrayOf<NavKey>(ForumRoute)
         }
+        // The spread copies a 1-2 element array once per cold start — the price of keeping the
+        // single call site (rememberNavBackStack only has a vararg overload).
+        @Suppress("SpreadOperator")
+        val forumBackStack = rememberNavBackStack(*forumInitialStack)
         val searchBackStack = rememberNavBackStack(SearchRoute)
         val messagesBackStack = rememberNavBackStack(MessagesRoute)
 

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -56,6 +56,7 @@ import androidx.navigation3.ui.NavDisplay
 import fr.forumhfr.redface2.BuildConfig
 import fr.forumhfr.redface2.R
 import fr.forumhfr.redface2.core.model.AuthState
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.ui.RedfaceTheme
 import fr.forumhfr.redface2.core.ui.account.RedfaceAccountMenu
@@ -306,6 +307,13 @@ internal enum class TopLevelDestination(
     Messages(R.string.nav_messages, MessagesRoute),
 }
 
+/** #458 — maps the persisted cold-start choice onto the navigation's own destination enum. */
+private fun StartScreenChoice.toTopLevelDestination(): TopLevelDestination = when (this) {
+    StartScreenChoice.FLAGS -> TopLevelDestination.Flags
+    StartScreenChoice.FORUM -> TopLevelDestination.Forum
+    StartScreenChoice.MESSAGES -> TopLevelDestination.Messages
+}
+
 /** #313 — badge cap : beyond this the badge shows « 9+ » (page-1 proxy, cf. MpUnreadBadgeViewModel). */
 private const val MAX_BADGE_COUNT = 9
 
@@ -422,12 +430,29 @@ fun RedfaceApp(intent: Intent?) {
         }
     }
     RedfaceTheme(darkTheme = darkTheme, amoledTheme = amoledEnabled) {
+        // #458 — cold-start screen, read synchronously from the bootstrap mirror and frozen for
+        // the session. Only the INITIAL values below consume it: rememberSaveable and
+        // rememberNavBackStack restore saved state first, so rotations / process restores keep
+        // the user where they were, and a Settings change only applies on the next launch.
+        val startScreenViewModel: StartScreenViewModel = hiltViewModel()
+        val startScreen = startScreenViewModel.startScreen
+
         val flagsBackStack = rememberNavBackStack(FlagsListRoute)
-        val forumBackStack = rememberNavBackStack(ForumRoute)
+        val forumStartCat = startScreen.forumCatId
+            ?.takeIf { startScreen.screen == StartScreenChoice.FORUM }
+        val forumBackStack = if (forumStartCat != null) {
+            // Pre-stacked category listing: back from it lands on the forum root, like a manual
+            // navigation would.
+            rememberNavBackStack(ForumRoute, CategoryRoute(cat = forumStartCat))
+        } else {
+            rememberNavBackStack(ForumRoute)
+        }
         val searchBackStack = rememberNavBackStack(SearchRoute)
         val messagesBackStack = rememberNavBackStack(MessagesRoute)
 
-        var currentDestination by rememberSaveable { mutableStateOf(TopLevelDestination.Flags) }
+        var currentDestination by rememberSaveable {
+            mutableStateOf(startScreen.screen.toTopLevelDestination())
+        }
 
         // Phase 2 finish (#208) — profile bottom sheet state, hoisted to `:app` so that
         // `:feature:topic` never depends on `:feature:profile`. The sheet is opened from

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/StartScreenViewModel.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/StartScreenViewModel.kt
@@ -1,0 +1,26 @@
+package fr.forumhfr.redface2.navigation
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenBootstrapStore
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
+import javax.inject.Inject
+
+/**
+ * Cold-start screen selection (#458), frozen at creation from the SYNCHRONOUS
+ * [StartScreenBootstrapStore] mirror — the navigation seeds its initial tab and the Forum back
+ * stack during the very first composition, before DataStore's first emission could land
+ * (same cold-start rationale as [AppThemeViewModel] / #386).
+ *
+ * Deliberately NOT observed live: the preference describes what a cold start opens on. Changing
+ * it in Settings must not teleport the running session; it applies on the next launch. Saved
+ * instance state still wins over this seed (`rememberSaveable` / `rememberNavBackStack` only
+ * consume their initial value when there is nothing to restore).
+ */
+@HiltViewModel
+class StartScreenViewModel @Inject constructor(
+    startScreenBootstrapStore: StartScreenBootstrapStore,
+) : ViewModel() {
+
+    val startScreen: StartScreenPreference = startScreenBootstrapStore.read()
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -9,6 +9,9 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenBootstrapStore
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
@@ -29,6 +32,7 @@ import kotlinx.coroutines.withContext
 class DataStoreUserPreferencesRepository @Inject constructor(
     @param:UserPreferencesDataStore private val dataStore: DataStore<Preferences>,
     private val themeBootstrapStore: ThemeBootstrapStore,
+    private val startScreenBootstrapStore: StartScreenBootstrapStore,
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : UserPreferencesRepository {
 
@@ -288,6 +292,47 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeStartScreen(): Flow<StartScreenPreference> =
+        dataStore.data
+            .map(::readStartScreen)
+            .distinctUntilChanged()
+            // #458 backfill, same contract as the theme mirror (#386): converge the synchronous
+            // bootstrap copy from the observed truth (idempotent, write-on-diff).
+            .onEach { preference ->
+                if (startScreenBootstrapStore.read() != preference) {
+                    startScreenBootstrapStore.write(preference)
+                }
+            }
+            .catch { emit(StartScreenPreference()) }
+
+    override suspend fun setStartScreen(preference: StartScreenPreference) {
+        withContext(ioDispatcher) {
+            dataStore.edit { prefs ->
+                prefs[KEY_START_SCREEN] = preference.screen.name
+                val catId = preference.forumCatId
+                if (preference.screen == StartScreenChoice.FORUM && catId != null) {
+                    prefs[KEY_START_FORUM_CAT] = catId
+                } else {
+                    prefs.remove(KEY_START_FORUM_CAT)
+                }
+            }
+            // Mirror for the synchronous cold-start read (#458) — DataStore stays the source
+            // of truth, the mirror only seeds the first frame.
+            startScreenBootstrapStore.write(preference)
+        }
+    }
+
+    private fun readStartScreen(prefs: Preferences): StartScreenPreference {
+        // Defensive read: an unknown stored value (downgrade, manual edit) falls back to the
+        // FLAGS default instead of crashing, same stance as readThemeMode.
+        val screen = prefs[KEY_START_SCREEN]
+            ?.let { stored -> StartScreenChoice.entries.firstOrNull { it.name == stored } }
+            ?: StartScreenChoice.FLAGS
+        val catId = prefs[KEY_START_FORUM_CAT]
+            ?.takeIf { screen == StartScreenChoice.FORUM && it > 0 }
+        return StartScreenPreference(screen = screen, forumCatId = catId)
+    }
+
     override fun observeMpUnreadBadge(): Flow<Boolean> =
         dataStore.data
             // Default `true` (#313): the badge is the feature; opting OUT is the preference.
@@ -405,5 +450,10 @@ class DataStoreUserPreferencesRepository @Inject constructor(
 
         // #456 — polls expanded by default in topic reading (default false = collapsed).
         val KEY_TOPIC_POLLS_EXPANDED = booleanPreferencesKey("topic_polls_expanded")
+
+        // #458 — cold-start tab (StartScreenChoice.name, defensively parsed) + optional Forum
+        // category id (absent unless screen == FORUM and a category was picked).
+        val KEY_START_SCREEN = stringPreferencesKey("start_screen")
+        val KEY_START_FORUM_CAT = intPreferencesKey("start_forum_cat")
     }
 }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -297,10 +297,14 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .map(::readStartScreen)
             .distinctUntilChanged()
             // #458 backfill, same contract as the theme mirror (#386): converge the synchronous
-            // bootstrap copy from the observed truth (idempotent, write-on-diff).
+            // bootstrap copy from the observed truth (idempotent, write-on-diff). Hops to IO
+            // because the mirror write is a synchronous commit() (cf. its KDoc) and this flow
+            // is collected on Main by the Settings ViewModel.
             .onEach { preference ->
-                if (startScreenBootstrapStore.read() != preference) {
-                    startScreenBootstrapStore.write(preference)
+                withContext(ioDispatcher) {
+                    if (startScreenBootstrapStore.read() != preference) {
+                        startScreenBootstrapStore.write(preference)
+                    }
                 }
             }
             .catch { emit(StartScreenPreference()) }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/SharedPreferencesStartScreenBootstrapStore.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/SharedPreferencesStartScreenBootstrapStore.kt
@@ -1,0 +1,47 @@
+package fr.forumhfr.redface2.core.data.preferences
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenBootstrapStore
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * [StartScreenBootstrapStore] over a tiny dedicated `SharedPreferences` file (#458), same
+ * pattern as [SharedPreferencesThemeBootstrapStore] (#386): SharedPreferences on purpose —
+ * the navigation needs a SYNCHRONOUS read in its very first composition, which DataStore
+ * cannot provide. Two keys, nothing sensitive (a tab name and a public forum category id).
+ */
+@Singleton
+class SharedPreferencesStartScreenBootstrapStore @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+) : StartScreenBootstrapStore {
+
+    private val prefs by lazy { context.getSharedPreferences(FILE_NAME, Context.MODE_PRIVATE) }
+
+    override fun read(): StartScreenPreference {
+        // Defensive read, same stance as the DataStore side: unknown stored value → FLAGS.
+        val screen = prefs.getString(KEY_SCREEN, null)
+            ?.let { stored -> StartScreenChoice.entries.firstOrNull { it.name == stored } }
+            ?: StartScreenChoice.FLAGS
+        val catId = prefs.getInt(KEY_FORUM_CAT, NO_CATEGORY)
+            .takeIf { screen == StartScreenChoice.FORUM && it > 0 }
+        return StartScreenPreference(screen = screen, forumCatId = catId)
+    }
+
+    override fun write(preference: StartScreenPreference) {
+        prefs.edit()
+            .putString(KEY_SCREEN, preference.screen.name)
+            .putInt(KEY_FORUM_CAT, preference.forumCatId ?: NO_CATEGORY)
+            .apply()
+    }
+
+    private companion object {
+        const val FILE_NAME = "start_screen_bootstrap"
+        const val KEY_SCREEN = "start_screen"
+        const val KEY_FORUM_CAT = "start_forum_cat"
+        const val NO_CATEGORY = 0
+    }
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/SharedPreferencesStartScreenBootstrapStore.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/SharedPreferencesStartScreenBootstrapStore.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.core.data.preferences
 
+import android.annotation.SuppressLint
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenBootstrapStore
@@ -31,11 +32,17 @@ class SharedPreferencesStartScreenBootstrapStore @Inject constructor(
         return StartScreenPreference(screen = screen, forumCatId = catId)
     }
 
+    // commit() over apply() on purpose (review Codex PR #464): unlike the theme mirror, the
+    // start-screen mirror is only ever READ at cold start — nothing re-observes DataStore at
+    // runtime to repair a divergence, so a process death before apply()'s async flush would
+    // leave the stale mirror winning every subsequent launch. Writes are rare (a Settings tap)
+    // and both call sites run on the IO dispatcher, so the synchronous flush is free.
+    @SuppressLint("ApplySharedPref")
     override fun write(preference: StartScreenPreference) {
         prefs.edit()
             .putString(KEY_SCREEN, preference.screen.name)
             .putInt(KEY_FORUM_CAT, preference.forumCatId ?: NO_CATEGORY)
-            .apply()
+            .commit()
     }
 
     private companion object {

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/UserPreferencesModule.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/UserPreferencesModule.kt
@@ -11,6 +11,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import javax.inject.Singleton
@@ -45,4 +46,10 @@ abstract class UserPreferencesBindingsModule {
     abstract fun bindThemeBootstrapStore(
         impl: SharedPreferencesThemeBootstrapStore,
     ): ThemeBootstrapStore
+
+    @Binds
+    @Singleton
+    abstract fun bindStartScreenBootstrapStore(
+        impl: SharedPreferencesStartScreenBootstrapStore,
+    ): StartScreenBootstrapStore
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -7,6 +7,9 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenBootstrapStore
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrap
 import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
@@ -43,6 +46,15 @@ class DataStoreUserPreferencesRepositoryTest {
         }
     }
 
+    /** In-memory [StartScreenBootstrapStore] (#458) — same stance as the theme mirror above. */
+    private val startScreenBootstrapStore = object : StartScreenBootstrapStore {
+        var stored = StartScreenPreference()
+        override fun read(): StartScreenPreference = stored
+        override fun write(preference: StartScreenPreference) {
+            stored = preference
+        }
+    }
+
     @Before
     fun setUp() {
         dataStore = PreferenceDataStoreFactory.create(
@@ -51,6 +63,7 @@ class DataStoreUserPreferencesRepositoryTest {
         repository = DataStoreUserPreferencesRepository(
             dataStore = dataStore,
             themeBootstrapStore = themeBootstrapStore,
+            startScreenBootstrapStore = startScreenBootstrapStore,
             ioDispatcher = dispatcher,
         )
     }
@@ -382,6 +395,64 @@ class DataStoreUserPreferencesRepositoryTest {
         }
 
         assertEquals(ThemeMode.DARK, themeBootstrapStore.read().themeMode)
+    }
+
+    @Test
+    fun `observeStartScreen defaults to the Drapeaux tab on an empty store`() = runTest(dispatcher) {
+        repository.observeStartScreen().test {
+            assertEquals(StartScreenPreference(), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setStartScreen round-trips a Forum category and mirrors it (#458)`() = runTest(dispatcher) {
+        val forumHardware = StartScreenPreference(StartScreenChoice.FORUM, forumCatId = 13)
+        repository.setStartScreen(forumHardware)
+
+        repository.observeStartScreen().test {
+            assertEquals(forumHardware, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(forumHardware, startScreenBootstrapStore.read())
+    }
+
+    @Test
+    fun `setStartScreen drops the category when the screen is not FORUM`() = runTest(dispatcher) {
+        repository.setStartScreen(StartScreenPreference(StartScreenChoice.FORUM, forumCatId = 13))
+        repository.setStartScreen(StartScreenPreference(StartScreenChoice.MESSAGES, forumCatId = 13))
+
+        repository.observeStartScreen().test {
+            // The stale category id must not resurface on a later FLAGS/MESSAGES read.
+            assertEquals(StartScreenPreference(StartScreenChoice.MESSAGES), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `corrupt start_screen value falls back to FLAGS instead of crashing`() = runTest(dispatcher) {
+        dataStore.edit { prefs -> prefs[stringPreferencesKey("start_screen")] = "DESKTOP" }
+
+        repository.observeStartScreen().test {
+            assertEquals(StartScreenPreference(), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `observing the start screen backfills an empty mirror from the persisted value`() = runTest(dispatcher) {
+        // #458 — same convergence contract as the theme mirror (#386).
+        dataStore.edit { prefs ->
+            prefs[stringPreferencesKey("start_screen")] = StartScreenChoice.MESSAGES.name
+        }
+        assertEquals(StartScreenPreference(), startScreenBootstrapStore.read())
+
+        repository.observeStartScreen().test {
+            assertEquals(StartScreenPreference(StartScreenChoice.MESSAGES), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        assertEquals(StartScreenPreference(StartScreenChoice.MESSAGES), startScreenBootstrapStore.read())
     }
 
     @Test

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/SharedPreferencesStartScreenBootstrapStoreTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/SharedPreferencesStartScreenBootstrapStoreTest.kt
@@ -1,0 +1,55 @@
+package fr.forumhfr.redface2.core.data.preferences
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/** Synchronous start-screen mirror over SharedPreferences (#458). */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class SharedPreferencesStartScreenBootstrapStoreTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val store = SharedPreferencesStartScreenBootstrapStore(context)
+
+    @Test
+    fun `an empty mirror reads as the Drapeaux default`() {
+        assertEquals(StartScreenPreference(), store.read())
+    }
+
+    @Test
+    fun `writes round-trip a Forum category selection`() {
+        store.write(StartScreenPreference(StartScreenChoice.FORUM, forumCatId = 13))
+
+        assertEquals(StartScreenPreference(StartScreenChoice.FORUM, forumCatId = 13), store.read())
+    }
+
+    @Test
+    fun `a category id stored under a non-Forum screen is ignored on read`() {
+        // The atomic write keeps the pair consistent, but a manual edit / partial restore must
+        // not resurrect a category on the FLAGS/MESSAGES screens.
+        context.getSharedPreferences("start_screen_bootstrap", Context.MODE_PRIVATE)
+            .edit()
+            .putString("start_screen", StartScreenChoice.MESSAGES.name)
+            .putInt("start_forum_cat", 13)
+            .commit()
+
+        assertEquals(StartScreenPreference(StartScreenChoice.MESSAGES), store.read())
+    }
+
+    @Test
+    fun `an unknown stored screen degrades to FLAGS instead of crashing`() {
+        context.getSharedPreferences("start_screen_bootstrap", Context.MODE_PRIVATE)
+            .edit()
+            .putString("start_screen", "DESKTOP")
+            .commit()
+
+        assertEquals(StartScreenChoice.FLAGS, store.read().screen)
+    }
+}

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -8,6 +8,7 @@ import fr.forumhfr.redface2.core.database.dao.TopicDao
 import fr.forumhfr.redface2.core.database.entities.FetchMode
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.model.FlagType
@@ -567,5 +568,10 @@ class TopicRepositoryImplTest {
         override fun observeTopicPollsExpanded(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setTopicPollsExpanded(enabled: Boolean) = Unit
+
+        override fun observeStartScreen(): Flow<StartScreenPreference> =
+            MutableStateFlow(StartScreenPreference())
+
+        override suspend fun setStartScreen(preference: StartScreenPreference) = Unit
     }
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/StartScreenPreference.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/StartScreenPreference.kt
@@ -1,0 +1,29 @@
+package fr.forumhfr.redface2.core.domain.preferences
+
+/** Which top-level tab a cold start lands on (#458). */
+enum class StartScreenChoice { FLAGS, FORUM, MESSAGES }
+
+/**
+ * Start-screen selection (#458): which tab — and for the Forum tab, optionally which category —
+ * the app opens on. [forumCatId] is only meaningful when [screen] is [StartScreenChoice.FORUM]:
+ * a positive id pre-stacks that category's topic listing on the Forum tab, `null` opens the
+ * forum root. Defaults preserve the historical behaviour (Drapeaux tab).
+ */
+data class StartScreenPreference(
+    val screen: StartScreenChoice = StartScreenChoice.FLAGS,
+    val forumCatId: Int? = null,
+)
+
+/**
+ * Synchronous mirror of the persisted start-screen preference (#458), same rationale as
+ * [ThemeBootstrapStore] (#386): the navigation seeds its initial tab and back stack during the
+ * very first composition, long before DataStore's first emission — a hard-coded default there
+ * would flash the Drapeaux tab before jumping. Written by the preferences repository on every
+ * change (and backfilled from the observed DataStore value); DataStore stays the source of
+ * truth. Unlike the theme mirror, [write] persists the whole pair atomically — both fields are
+ * always set together from the single Settings flow.
+ */
+interface StartScreenBootstrapStore {
+    fun read(): StartScreenPreference
+    fun write(preference: StartScreenPreference)
+}

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -199,6 +199,17 @@ interface UserPreferencesRepository {
     suspend fun setTopicPollsExpanded(enabled: Boolean)
 
     /**
+     * #458 — which top-level tab (and optional Forum category) a cold start opens on. Default
+     * [StartScreenChoice.FLAGS] (historical behaviour). The navigation reads the SYNCHRONOUS
+     * [StartScreenBootstrapStore] mirror at cold start; this flow is the source of truth and
+     * feeds the Settings screen.
+     */
+    fun observeStartScreen(): Flow<StartScreenPreference>
+
+    /** Persists [observeStartScreen] (both fields atomically) and refreshes the mirror. */
+    suspend fun setStartScreen(preference: StartScreenPreference)
+
+    /**
      * #313 — unread-MP badge on the « Messages » destination of the navigation bar. When
      * `true` (default) the badge shows the count of unread conversations for the authenticated
      * session ; `false` hides it entirely (no fetch is saved — the underlying count flow is

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -10,6 +10,7 @@ import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
 import fr.forumhfr.redface2.core.domain.editor.BbcodeValidation
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.write.ReplyRepository
@@ -1416,6 +1417,11 @@ class PostEditorViewModelTest {
         override fun observeTopicPollsExpanded(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setTopicPollsExpanded(enabled: Boolean) = Unit
+
+        override fun observeStartScreen(): Flow<StartScreenPreference> =
+            MutableStateFlow(StartScreenPreference())
+
+        override suspend fun setStartScreen(preference: StartScreenPreference) = Unit
     }
 
     private companion object {

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -9,6 +9,7 @@ import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
 import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.smiley.SmileyRepository
@@ -1269,6 +1270,11 @@ class TopicFormViewModelTest {
         override fun observeTopicPollsExpanded(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setTopicPollsExpanded(enabled: Boolean) = Unit
+
+        override fun observeStartScreen(): Flow<StartScreenPreference> =
+            MutableStateFlow(StartScreenPreference())
+
+        override suspend fun setStartScreen(preference: StartScreenPreference) = Unit
     }
 
     private companion object {

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -13,6 +13,7 @@ import fr.forumhfr.redface2.core.domain.forum.ForumRepository
 import fr.forumhfr.redface2.core.domain.forum.ForumResult
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.model.AuthState
@@ -1600,6 +1601,11 @@ class FlagsViewModelTest {
         override fun observeTopicPollsExpanded(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setTopicPollsExpanded(enabled: Boolean) = Unit
+
+        override fun observeStartScreen(): Flow<StartScreenPreference> =
+            MutableStateFlow(StartScreenPreference())
+
+        override suspend fun setStartScreen(preference: StartScreenPreference) = Unit
 
         // #312 — confirm-before-posting is irrelevant to FlagsViewModel; stubbed at its default.
         override fun observeConfirmBeforePosting(): Flow<Boolean> = MutableStateFlow(false)

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -18,5 +18,6 @@ dependencies {
 
     testImplementation(libs.junit4)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.mockk)
     testImplementation(libs.turbine)
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -49,12 +49,17 @@ import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 fun SettingsScreen(
     modifier: Modifier = Modifier,
     viewModel: SettingsViewModel = hiltViewModel(),
+    // #458 — the « Démarrage » section has its own ViewModel (cf. its KDoc).
+    startScreenViewModel: StartScreenSettingsViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val startScreenState by startScreenViewModel.state.collectAsStateWithLifecycle()
     SettingsContent(
         state = state,
         onIntent = viewModel::submit,
         modifier = modifier,
+        startScreenState = startScreenState,
+        onStartScreenIntent = startScreenViewModel::submit,
     )
 }
 
@@ -63,6 +68,8 @@ internal fun SettingsContent(
     state: SettingsState,
     onIntent: (SettingsIntent) -> Unit,
     modifier: Modifier = Modifier,
+    startScreenState: StartScreenSettingsState = StartScreenSettingsState(),
+    onStartScreenIntent: (StartScreenSettingsIntent) -> Unit = {},
 ) {
     Surface(
         modifier = modifier.fillMaxSize(),
@@ -207,6 +214,12 @@ internal fun SettingsContent(
                 items = listOf(
                     R.string.settings_future_data_saver to issueTag(310),
                 ),
+            )
+
+            SettingsSectionHeader(stringResource(R.string.settings_section_start))
+            StartScreenPreferencesCard(
+                state = startScreenState,
+                onIntent = onStartScreenIntent,
             )
 
             SettingsSectionHeader(stringResource(R.string.settings_section_display))
@@ -700,7 +713,7 @@ private fun PreferenceSwitchRow(
 
 /** Inline persist-failure message for a [PreferenceSwitchRow], shown below the row. */
 @Composable
-private fun PreferencePersistError(messageRes: Int) {
+internal fun PreferencePersistError(messageRes: Int) {
     Text(
         text = stringResource(messageRes),
         style = MaterialTheme.typography.bodySmall,

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/StartScreenPreferencesCard.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/StartScreenPreferencesCard.kt
@@ -1,0 +1,149 @@
+package fr.forumhfr.redface2.feature.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
+
+/**
+ * Settings card « Écran de démarrage » (#458): segmented choice of the cold-start tab, plus —
+ * for the Forum tab — an optional category picker (« Accueil du forum » = no pre-stacked
+ * category). The selection applies on the NEXT launch (the intro line says so): the running
+ * session is never teleported.
+ */
+@Composable
+internal fun StartScreenPreferencesCard(
+    state: StartScreenSettingsState,
+    onIntent: (StartScreenSettingsIntent) -> Unit,
+) {
+    val options = listOf(
+        StartScreenChoice.FLAGS to stringResource(R.string.settings_start_screen_flags),
+        StartScreenChoice.FORUM to stringResource(R.string.settings_start_screen_forum),
+        StartScreenChoice.MESSAGES to stringResource(R.string.settings_start_screen_messages),
+    )
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_start_screen_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = stringResource(R.string.settings_start_screen_intro),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                options.forEachIndexed { index, (choice, label) ->
+                    SegmentedButton(
+                        selected = state.preference.screen == choice,
+                        enabled = state.canChange,
+                        onClick = { onIntent(StartScreenSettingsIntent.ScreenChanged(choice)) },
+                        shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
+                    ) {
+                        Text(label)
+                    }
+                }
+            }
+            if (state.preference.screen == StartScreenChoice.FORUM) {
+                StartForumCategoryPicker(state = state, onIntent = onIntent)
+            }
+            if (state.persistError) {
+                PreferencePersistError(R.string.settings_start_screen_persist_failed)
+            }
+        }
+    }
+}
+
+/**
+ * Category picker of the Forum start screen — same `ExposedDropdownMenuBox` + read-only field
+ * pattern as the editor's subcategory dropdown. The first entry (« Accueil du forum ») maps to
+ * `forumCatId = null`; a failed category fetch only degrades the helper text, the root choice
+ * keeps working offline.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun StartForumCategoryPicker(
+    state: StartScreenSettingsState,
+    onIntent: (StartScreenSettingsIntent) -> Unit,
+) {
+    val rootLabel = stringResource(R.string.settings_start_screen_category_root)
+    val selectedLabel = state.categories
+        .firstOrNull { it.id == state.preference.forumCatId }
+        ?.name
+        ?: rootLabel
+    var expanded by remember { mutableStateOf(false) }
+    val menuEnabled = state.canChange
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = menuEnabled && it },
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        OutlinedTextField(
+            value = selectedLabel,
+            onValueChange = {},
+            readOnly = true,
+            enabled = menuEnabled,
+            label = { Text(stringResource(R.string.settings_start_screen_category_label)) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable, enabled = menuEnabled),
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            DropdownMenuItem(
+                text = { Text(rootLabel) },
+                onClick = {
+                    expanded = false
+                    onIntent(StartScreenSettingsIntent.ForumCategoryChanged(null))
+                },
+                contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
+            )
+            state.categories.forEach { category ->
+                DropdownMenuItem(
+                    text = { Text(category.name) },
+                    onClick = {
+                        expanded = false
+                        onIntent(StartScreenSettingsIntent.ForumCategoryChanged(category.id))
+                    },
+                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
+                )
+            }
+        }
+    }
+    if (state.categoriesError) {
+        Text(
+            text = stringResource(R.string.settings_start_screen_categories_error),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/StartScreenPreferencesCard.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/StartScreenPreferencesCard.kt
@@ -92,10 +92,15 @@ private fun StartForumCategoryPicker(
     onIntent: (StartScreenSettingsIntent) -> Unit,
 ) {
     val rootLabel = stringResource(R.string.settings_start_screen_category_root)
-    val selectedLabel = state.categories
-        .firstOrNull { it.id == state.preference.forumCatId }
-        ?.name
-        ?: rootLabel
+    val selectedCatId = state.preference.forumCatId
+    // A persisted category that the (not yet loaded / failed / stale) category list cannot
+    // resolve must NOT read as « Accueil du forum » — the next launch would still open it
+    // (review Codex PR #464). Show an explicit id-based fallback instead.
+    val selectedLabel = when (selectedCatId) {
+        null -> rootLabel
+        else -> state.categories.firstOrNull { it.id == selectedCatId }?.name
+            ?: stringResource(R.string.settings_start_screen_category_unresolved, selectedCatId)
+    }
     var expanded by remember { mutableStateOf(false) }
     val menuEnabled = state.canChange
 

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/StartScreenSettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/StartScreenSettingsViewModel.kt
@@ -1,0 +1,137 @@
+package fr.forumhfr.redface2.feature.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.forum.ForumRepository
+import fr.forumhfr.redface2.core.domain.forum.ForumResult
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
+import fr.forumhfr.redface2.core.model.Category
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Settings section « Démarrage » (#458), its OWN ViewModel instead of more state on the already
+ * detekt-budget-bound [SettingsViewModel]: the section bundles a preference pair (screen +
+ * optional Forum category) with the category list it needs for its picker — an isolated concern
+ * with an isolated lifecycle.
+ *
+ * Hydration follows the [SettingsViewModel] convention: read-once from the repository, guarded
+ * against overwriting a selection the user already made locally ([StartScreenSettingsState
+ * .touchedLocally]). Persistence is the usual optimistic-flip with rollback + error flag.
+ */
+@HiltViewModel
+class StartScreenSettingsViewModel @Inject constructor(
+    private val userPreferencesRepository: UserPreferencesRepository,
+    forumRepository: ForumRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(StartScreenSettingsState())
+    val state: StateFlow<StartScreenSettingsState> = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            val persisted = userPreferencesRepository.observeStartScreen().first()
+            _state.update { current ->
+                if (current.touchedLocally) current else current.copy(preference = persisted)
+            }
+        }
+        // Category list for the Forum picker. Loading/Failure only drive the picker's helper
+        // text — the segmented choice itself never depends on the network.
+        forumRepository.observeCategories()
+            .onEach { result ->
+                _state.update { current ->
+                    when (result) {
+                        ForumResult.Loading -> current.copy(categoriesLoading = true)
+                        is ForumResult.Success -> current.copy(
+                            categoriesLoading = false,
+                            categoriesError = false,
+                            categories = result.value,
+                        )
+                        is ForumResult.Failure -> current.copy(
+                            categoriesLoading = false,
+                            categoriesError = true,
+                        )
+                    }
+                }
+            }
+            .launchIn(viewModelScope)
+    }
+
+    fun submit(intent: StartScreenSettingsIntent) {
+        when (intent) {
+            is StartScreenSettingsIntent.ScreenChanged -> {
+                val current = _state.value.preference
+                update(
+                    StartScreenPreference(
+                        screen = intent.screen,
+                        // Keep a previously picked category when flipping back to FORUM; any
+                        // other screen drops it (it would be meaningless and is not persisted).
+                        forumCatId = current.forumCatId
+                            .takeIf { intent.screen == StartScreenChoice.FORUM },
+                    ),
+                )
+            }
+            is StartScreenSettingsIntent.ForumCategoryChanged -> update(
+                _state.value.preference.copy(forumCatId = intent.catId),
+            )
+        }
+    }
+
+    private fun update(preference: StartScreenPreference) {
+        val previous = _state.value.preference
+        if (previous == preference) return
+        _state.update {
+            it.copy(
+                preference = preference,
+                isUpdating = true,
+                persistError = false,
+                touchedLocally = true,
+            )
+        }
+        viewModelScope.launch {
+            try {
+                userPreferencesRepository.setStartScreen(preference)
+                _state.update { it.copy(isUpdating = false) }
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
+                _state.update {
+                    it.copy(preference = previous, isUpdating = false, persistError = true)
+                }
+            }
+        }
+    }
+}
+
+/** UI state of the « Démarrage » section (#458). */
+data class StartScreenSettingsState(
+    val preference: StartScreenPreference = StartScreenPreference(),
+    val isUpdating: Boolean = false,
+    val persistError: Boolean = false,
+    /** Set on the first local change — the late hydration read must not overwrite it. */
+    val touchedLocally: Boolean = false,
+    val categories: List<Category> = emptyList(),
+    val categoriesLoading: Boolean = false,
+    val categoriesError: Boolean = false,
+) {
+    val canChange: Boolean
+        get() = !isUpdating
+}
+
+sealed interface StartScreenSettingsIntent {
+    data class ScreenChanged(val screen: StartScreenChoice) : StartScreenSettingsIntent
+
+    /** `null` = forum root (no pre-stacked category). */
+    data class ForumCategoryChanged(val catId: Int?) : StartScreenSettingsIntent
+}

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="settings_start_screen_messages">Messages</string>
     <string name="settings_start_screen_category_label">Catégorie à l\'ouverture</string>
     <string name="settings_start_screen_category_root">Accueil du forum</string>
+    <string name="settings_start_screen_category_unresolved">Catégorie %1$d</string>
     <string name="settings_start_screen_categories_error">Liste des catégories indisponible pour le moment — « Accueil du forum » reste utilisable.</string>
     <string name="settings_start_screen_persist_failed">Impossible d\'enregistrer ce réglage pour le moment.</string>
     <string name="settings_section_display">Affichage</string>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -4,6 +4,17 @@
          et catalogue des réglages futurs (grisés, avec tag d’issue ou de phase). -->
     <string name="settings_intro">La plupart des réglages sont enregistrés sur cet appareil. Ceux du compte HFR (section dédiée) seront synchronisés depuis votre profil et arriveront plus tard. Les réglages à venir sont affichés en grisé avec leur étiquette.</string>
     <string name="settings_section_network">Réseau et cache</string>
+    <!-- #458 — écran de démarrage (onglet + catégorie Forum optionnelle, appliqué au prochain lancement). -->
+    <string name="settings_section_start">Démarrage</string>
+    <string name="settings_start_screen_title">Écran de démarrage</string>
+    <string name="settings_start_screen_intro">Choisissez ce que l\'app ouvre au lancement. Appliqué au prochain démarrage.</string>
+    <string name="settings_start_screen_flags">Drapeaux</string>
+    <string name="settings_start_screen_forum">Forum</string>
+    <string name="settings_start_screen_messages">Messages</string>
+    <string name="settings_start_screen_category_label">Catégorie à l\'ouverture</string>
+    <string name="settings_start_screen_category_root">Accueil du forum</string>
+    <string name="settings_start_screen_categories_error">Liste des catégories indisponible pour le moment — « Accueil du forum » reste utilisable.</string>
+    <string name="settings_start_screen_persist_failed">Impossible d\'enregistrer ce réglage pour le moment.</string>
     <string name="settings_section_display">Affichage</string>
     <string name="settings_section_flags">Drapeaux</string>
     <string name="settings_section_topic">Sujet et lecture</string>

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -4,6 +4,7 @@ import fr.forumhfr.redface2.core.domain.cache.ImageCacheMaintenance
 import fr.forumhfr.redface2.core.domain.cache.TopicCacheMaintenance
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.model.FlagType
@@ -1173,6 +1174,13 @@ class SettingsViewModelTest {
         fun emitTopicPollsExpanded(value: Boolean) {
             topicPollsExpanded.value = value
         }
+
+        // #458 — start screen lives on its own StartScreenSettingsViewModel; this fake only
+        // satisfies the interface for the main Settings ViewModel under test.
+        override fun observeStartScreen(): Flow<StartScreenPreference> =
+            MutableStateFlow(StartScreenPreference())
+
+        override suspend fun setStartScreen(preference: StartScreenPreference) = Unit
 
         // #312 — confirm-before-posting. Same optimistic-flip seam as the topic top-bar toggle.
         private val confirmBeforePosting = MutableStateFlow(false)

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/StartScreenSettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/StartScreenSettingsViewModelTest.kt
@@ -1,0 +1,156 @@
+package fr.forumhfr.redface2.feature.settings
+
+import fr.forumhfr.redface2.core.domain.forum.ForumRepository
+import fr.forumhfr.redface2.core.domain.forum.ForumResult
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
+import fr.forumhfr.redface2.core.model.Category
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import java.io.IOException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StartScreenSettingsViewModelTest {
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private val hardware = Category(id = 13, name = "Hardware", forceSubcat = false, subcategoryCount = 9)
+
+    private fun preferencesRepository(
+        persisted: StartScreenPreference = StartScreenPreference(),
+    ): UserPreferencesRepository = mockk {
+        every { observeStartScreen() } returns MutableStateFlow(persisted)
+        coEvery { setStartScreen(any()) } just Runs
+    }
+
+    private fun forumRepository(
+        result: ForumResult<List<Category>> = ForumResult.Success(listOf(hardware)),
+    ): ForumRepository = mockk {
+        every { observeCategories() } returns flowOf(result)
+    }
+
+    @Test
+    fun `init hydrates the persisted preference and the category list`() = runTest {
+        val viewModel = StartScreenSettingsViewModel(
+            userPreferencesRepository = preferencesRepository(
+                StartScreenPreference(StartScreenChoice.FORUM, forumCatId = 13),
+            ),
+            forumRepository = forumRepository(),
+        )
+
+        val state = viewModel.state.value
+        assertEquals(StartScreenPreference(StartScreenChoice.FORUM, forumCatId = 13), state.preference)
+        assertEquals(listOf(hardware), state.categories)
+        assertFalse(state.categoriesError)
+    }
+
+    @Test
+    fun `a categories fetch failure only raises the picker flag`() = runTest {
+        val viewModel = StartScreenSettingsViewModel(
+            userPreferencesRepository = preferencesRepository(),
+            forumRepository = forumRepository(ForumResult.Failure(IOException("offline"))),
+        )
+
+        val state = viewModel.state.value
+        assertTrue(state.categoriesError)
+        // The segmented choice itself never depends on the network.
+        assertEquals(StartScreenPreference(), state.preference)
+    }
+
+    @Test
+    fun `ScreenChanged persists the choice and drops the category off FORUM`() = runTest {
+        val preferences = preferencesRepository(
+            StartScreenPreference(StartScreenChoice.FORUM, forumCatId = 13),
+        )
+        val viewModel = StartScreenSettingsViewModel(preferences, forumRepository())
+
+        viewModel.submit(StartScreenSettingsIntent.ScreenChanged(StartScreenChoice.MESSAGES))
+
+        assertEquals(
+            StartScreenPreference(StartScreenChoice.MESSAGES),
+            viewModel.state.value.preference,
+        )
+        coVerify { preferences.setStartScreen(StartScreenPreference(StartScreenChoice.MESSAGES)) }
+    }
+
+    @Test
+    fun `ForumCategoryChanged persists the picked category`() = runTest {
+        val preferences = preferencesRepository(StartScreenPreference(StartScreenChoice.FORUM))
+        val viewModel = StartScreenSettingsViewModel(preferences, forumRepository())
+
+        viewModel.submit(StartScreenSettingsIntent.ForumCategoryChanged(13))
+
+        assertEquals(
+            StartScreenPreference(StartScreenChoice.FORUM, forumCatId = 13),
+            viewModel.state.value.preference,
+        )
+        coVerify {
+            preferences.setStartScreen(StartScreenPreference(StartScreenChoice.FORUM, forumCatId = 13))
+        }
+    }
+
+    @Test
+    fun `a persist failure rolls the selection back and raises the error flag`() = runTest {
+        val preferences = preferencesRepository()
+        coEvery { preferences.setStartScreen(any()) } throws IOException("disk full")
+        val viewModel = StartScreenSettingsViewModel(preferences, forumRepository())
+
+        viewModel.submit(StartScreenSettingsIntent.ScreenChanged(StartScreenChoice.FORUM))
+
+        val state = viewModel.state.value
+        assertEquals("failed persist must revert", StartScreenPreference(), state.preference)
+        assertTrue(state.persistError)
+        assertFalse(state.isUpdating)
+    }
+
+    @Test
+    fun `late hydration does not overwrite a selection the user already made`() = runTest {
+        // The persisted read is gated so the user's local change lands FIRST — the stale
+        // hydration value must then be discarded (touchedLocally guard).
+        val gate = CompletableDeferred<StartScreenPreference>()
+        val preferences = mockk<UserPreferencesRepository> {
+            every { observeStartScreen() } returns flow { emit(gate.await()) }
+            coEvery { setStartScreen(any()) } just Runs
+        }
+        val viewModel = StartScreenSettingsViewModel(preferences, forumRepository())
+
+        viewModel.submit(StartScreenSettingsIntent.ScreenChanged(StartScreenChoice.MESSAGES))
+        gate.complete(StartScreenPreference(StartScreenChoice.FORUM, forumCatId = 13))
+        advanceUntilIdle()
+
+        assertEquals(
+            StartScreenPreference(StartScreenChoice.MESSAGES),
+            viewModel.state.value.preference,
+        )
+    }
+}

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -6,6 +6,7 @@ import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
+import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.topic.TopicRepository
@@ -1376,4 +1377,9 @@ private class FakeUserPreferencesRepository(
     override fun observeTopicPollsExpanded(): Flow<Boolean> = MutableStateFlow(topicPollsExpanded)
 
     override suspend fun setTopicPollsExpanded(enabled: Boolean) = Unit
+
+    override fun observeStartScreen(): Flow<StartScreenPreference> =
+        MutableStateFlow(StartScreenPreference())
+
+    override suspend fun setStartScreen(preference: StartScreenPreference) = Unit
 }


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi

Mandat nuit 2026-06-13 : « Catégorie par défaut (utile à l'ouverture de l'app) » — consolidé avec le retour bêta #323 (@Azgor).

### Préférence + bootstrap synchrone
- `StartScreenPreference(screen, forumCatId?)` — Drapeaux (défaut historique) / Forum (avec catégorie optionnelle) / Messages.
- DataStore = source de vérité ; **mirror SharedPreferences synchrone** (`start_screen_bootstrap`, pattern #386/#407) lu à la première composition, avec backfill write-on-diff — pas de flash de l'onglet Drapeaux avant bascule.

### Navigation
- `StartScreenViewModel` fige la préférence au cold start ; `currentDestination` est seedé via `rememberSaveable` et le back stack Forum pré-empile `CategoryRoute(catId)` (retour → accueil du forum, comme une navigation manuelle).
- Les restaurations d'état (rotation, process restore) gardent la priorité ; un changement du réglage s'applique **au prochain lancement** (l'intro de la carte le dit).
- Le deep link continue d'écraser la destination après le seed (ordre inchangé).

### Réglages
- Nouvelle section « Démarrage » avec **ViewModel dédié** (`StartScreenSettingsViewModel`) pour ne pas gonfler le `SettingsViewModel` (budget detekt) : segmented Drapeaux/Forum/Messages + picker de catégorie (`ExposedDropdownMenuBox`, même pattern que le picker de sous-catégorie de l'éditeur), « Accueil du forum » = racine, helper dégradé si la liste des catégories échoue (le choix d'onglet ne dépend jamais du réseau).

## Tests
- Repo DataStore : défaut FLAGS, round-trip Forum+cat avec mirror, drop du catId hors FORUM, valeur corrompue → FLAGS, backfill du mirror vide.
- Mirror : 4 tests Robolectric (défauts, round-trip, catId ignoré hors Forum, valeur inconnue).
- ViewModel section : hydratation, échec catégories (flag seul), persist des 2 intents, rollback+erreur, garde anti-course hydration/local.
- Fakes `UserPreferencesRepository` des 6 modules alignés sur les 2 nouvelles méthodes.
- Validation locale : `detektAll test :app:assembleProdDebug` + `:app:lintProdDebug` verts.

Refs-#458 (fermeture après vérification device).