### PR TITLE
feat(forum): filtre « Mes drapeaux » par (sous-)catégorie (#455)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/forum/DefaultForumRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/forum/DefaultForumRepository.kt
@@ -140,7 +140,7 @@ class DefaultForumRepository @Inject constructor(
         subcat: Int?,
         bucket: FlagFilterBucket,
     ): ForumResult<TopicListPage> = withContext(ioDispatcher) {
-        runCatching {
+        try {
             val body = apiClient.getCategoryFlagTopics(
                 cat = cat,
                 bucket = bucket.toRestBucket(),
@@ -149,14 +149,16 @@ class DefaultForumRepository @Inject constructor(
                 useAuth = true,
             )
             val envelope = json.decodeFromString<RestListEnvelope<RestTopic>>(body)
-            RestForumMappers.toTopicListPage(envelope, cat = cat, subcat = subcat)
-        }.fold(
-            onSuccess = { ForumResult.Success(it) },
-            onFailure = { throwable ->
-                Log.w(LOG_TAG, "Flag-filter fetch failed for cat=$cat subcat=$subcat bucket=$bucket", throwable)
-                ForumResult.Failure(throwable)
-            },
-        )
+            ForumResult.Success(RestForumMappers.toTopicListPage(envelope, cat = cat, subcat = subcat))
+        } catch (cancellation: kotlinx.coroutines.CancellationException) {
+            // The flag-filter fetch runs inside a ViewModel job cancelled on filter / subcat
+            // change; let cancellation propagate rather than mapping it to a Failure that would
+            // clobber flagFilterTopics with an Error (review #455). Same stance as prefetchTopicList.
+            throw cancellation
+        } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
+            Log.w(LOG_TAG, "Flag-filter fetch failed for cat=$cat subcat=$subcat bucket=$bucket", error)
+            ForumResult.Failure(error)
+        }
     }
 
     private fun FlagFilterBucket.toRestBucket(): HfrRestFlagBucket = when (this) {

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/forum/DefaultForumRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/forum/DefaultForumRepository.kt
@@ -3,12 +3,14 @@ package fr.forumhfr.redface2.core.data.forum
 import android.util.Log
 import fr.forumhfr.redface2.core.data.cache.CachePolicy
 import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
+import fr.forumhfr.redface2.core.domain.forum.FlagFilterBucket
 import fr.forumhfr.redface2.core.domain.forum.ForumRepository
 import fr.forumhfr.redface2.core.domain.forum.ForumResult
 import fr.forumhfr.redface2.core.model.Category
 import fr.forumhfr.redface2.core.model.SubCategory
 import fr.forumhfr.redface2.core.model.TopicListPage
 import fr.forumhfr.redface2.core.network.HfrApiClient
+import fr.forumhfr.redface2.core.network.HfrRestFlagBucket
 import java.time.Clock
 import java.time.Instant
 import javax.inject.Inject
@@ -122,6 +124,45 @@ class DefaultForumRepository @Inject constructor(
         val flow = topicListFlow(cat, subcat, page)
         flow.emit(ForumResult.Loading)
         flow.emit(fetchTopicList(cat, subcat, page))
+    }
+
+    /**
+     * #455 — one-shot fetch of the flagged topics of a (sub)category for [bucket]. Not
+     * cached (same stance as topic lists) and not paginated server-side: we request the
+     * max page size so a busy category's whole bucket comes back in one call (the flag
+     * buckets ignore real pagination — see [HfrApiClient.getCategoryFlagTopics]). Reuses
+     * the forum mapper [RestForumMappers.toTopicListPage] so the rows are [TopicSummary],
+     * NOT [fr.forumhfr.redface2.core.model.Flag] — the category screen needs the listing
+     * row model (author / sticky / locked) and the same "resume at last read page" path.
+     */
+    override suspend fun getFlagFilteredTopics(
+        cat: Int,
+        subcat: Int?,
+        bucket: FlagFilterBucket,
+    ): ForumResult<TopicListPage> = withContext(ioDispatcher) {
+        runCatching {
+            val body = apiClient.getCategoryFlagTopics(
+                cat = cat,
+                bucket = bucket.toRestBucket(),
+                subcat = subcat,
+                resultsPerPage = FLAG_FILTER_RESULTS_PER_PAGE,
+                useAuth = true,
+            )
+            val envelope = json.decodeFromString<RestListEnvelope<RestTopic>>(body)
+            RestForumMappers.toTopicListPage(envelope, cat = cat, subcat = subcat)
+        }.fold(
+            onSuccess = { ForumResult.Success(it) },
+            onFailure = { throwable ->
+                Log.w(LOG_TAG, "Flag-filter fetch failed for cat=$cat subcat=$subcat bucket=$bucket", throwable)
+                ForumResult.Failure(throwable)
+            },
+        )
+    }
+
+    private fun FlagFilterBucket.toRestBucket(): HfrRestFlagBucket = when (this) {
+        FlagFilterBucket.PARTICIPATED -> HfrRestFlagBucket.PARTICIPATED
+        FlagFilterBucket.READ -> HfrRestFlagBucket.READ
+        FlagFilterBucket.FAVORITES -> HfrRestFlagBucket.FAVORITES
     }
 
     /**
@@ -268,5 +309,9 @@ class DefaultForumRepository @Inject constructor(
     private companion object {
         const val LOG_TAG = "ForumRepository"
         const val DEFAULT_RESULTS_PER_PAGE = 50
+
+        // #455 — flag buckets are not paginated server-side; request the max page size so a
+        // busy (sub)category's whole bucket comes back in one call (HfrApiClient caps at 100).
+        const val FLAG_FILTER_RESULTS_PER_PAGE = 100
     }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/forum/DefaultForumRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/forum/DefaultForumRepositoryTest.kt
@@ -1,8 +1,10 @@
 package fr.forumhfr.redface2.core.data.forum
 
 import app.cash.turbine.test
+import fr.forumhfr.redface2.core.domain.forum.FlagFilterBucket
 import fr.forumhfr.redface2.core.domain.forum.ForumResult
 import fr.forumhfr.redface2.core.network.HfrApiClient
+import fr.forumhfr.redface2.core.network.HfrRestFlagBucket
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -207,6 +209,74 @@ class DefaultForumRepositoryTest {
         coVerify(exactly = 1) {
             apiClient.getTopicList(cat = 23, subcat = 550, page = 1, resultsPerPage = 50, useAuth = true)
         }
+    }
+
+    @Test
+    fun `getFlagFilteredTopics maps the participated bucket to a TopicListPage`() = runTest {
+        val apiClient = mockk<HfrApiClient> {
+            coEvery {
+                getCategoryFlagTopics(
+                    cat = 23,
+                    bucket = HfrRestFlagBucket.PARTICIPATED,
+                    subcat = null,
+                    page = any(),
+                    resultsPerPage = any(),
+                    useAuth = true,
+                )
+            } returns fixture("rest_cat23_participated.json")
+        }
+        val repo = repository(apiClient)
+
+        val result = repo.getFlagFilteredTopics(cat = 23, subcat = null, bucket = FlagFilterBucket.PARTICIPATED)
+
+        assertTrue("expected Success, got $result", result is ForumResult.Success)
+        val page = (result as ForumResult.Success).value
+        assertEquals(23, page.cat)
+        assertTrue("the bucket fixture should map at least one topic", page.topics.isNotEmpty())
+    }
+
+    @Test
+    fun `getFlagFilteredTopics forwards the subcat and bucket to the api client`() = runTest {
+        val apiClient = mockk<HfrApiClient> {
+            coEvery {
+                getCategoryFlagTopics(
+                    cat = 23,
+                    bucket = HfrRestFlagBucket.FAVORITES,
+                    subcat = 550,
+                    page = any(),
+                    resultsPerPage = any(),
+                    useAuth = true,
+                )
+            } returns fixture("rest_cat23_participated.json")
+        }
+        val repo = repository(apiClient)
+
+        repo.getFlagFilteredTopics(cat = 23, subcat = 550, bucket = FlagFilterBucket.FAVORITES)
+
+        coVerify(exactly = 1) {
+            apiClient.getCategoryFlagTopics(
+                cat = 23,
+                bucket = HfrRestFlagBucket.FAVORITES,
+                subcat = 550,
+                page = any(),
+                resultsPerPage = any(),
+                useAuth = true,
+            )
+        }
+    }
+
+    @Test
+    fun `getFlagFilteredTopics returns Failure on a network error`() = runTest {
+        val apiClient = mockk<HfrApiClient> {
+            coEvery {
+                getCategoryFlagTopics(any(), any(), any(), any(), any(), any())
+            } throws RuntimeException("boom")
+        }
+        val repo = repository(apiClient)
+
+        val result = repo.getFlagFilteredTopics(cat = 23, subcat = null, bucket = FlagFilterBucket.READ)
+
+        assertTrue("expected Failure, got $result", result is ForumResult.Failure)
     }
 
     private fun repository(

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/forum/ForumRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/forum/ForumRepository.kt
@@ -36,6 +36,26 @@ interface ForumRepository {
     suspend fun refreshTopicList(cat: Int, subcat: Int?, page: Int)
 
     /**
+     * Listing of the user's flagged topics for a (sub)category and the given [bucket] —
+     * the REST equivalent of the web `owntopic` filter (#455). Authenticated by nature
+     * (HFR has no flags for an anonymous session). The server returns the whole bucket in
+     * a single response (no real pagination), so this is a one-shot `suspend` call rather
+     * than an observable flow : the screen re-fetches on filter change / pull-to-refresh.
+     *
+     * Returns a [TopicListPage] — the SAME model as the regular listing — so the category
+     * screen reuses its row composable and the "resume at last read page" navigation
+     * contract unchanged (the flag bucket payload carries `last_post_read_id` and the
+     * last-read page, mapped exactly like the normal listing).
+     *
+     * [subcat] `null` queries the whole category, non-null narrows to the subcategory.
+     */
+    suspend fun getFlagFilteredTopics(
+        cat: Int,
+        subcat: Int?,
+        bucket: FlagFilterBucket,
+    ): ForumResult<TopicListPage>
+
+    /**
      * Anonymous prefetch — unauthenticated REST request (cf. ADR-003 §
      * Prefetch) for `(cat, subcat, page)`. The response payload is
      * **intentionally discarded** : there is no client-side cache populated
@@ -59,6 +79,14 @@ interface ForumRepository {
      */
     suspend fun prefetchTopicList(cat: Int, subcat: Int?, page: Int)
 }
+
+/**
+ * The three HFR drapeaux buckets, as a domain type so the ViewModel never depends on the
+ * `:core:network` `HfrRestFlagBucket` enum. Mirrors the web `owntopic` filter (#455):
+ * PARTICIPATED = `owntopic=1` (« sujets auxquels j'ai participé »), READ = `owntopic=2`
+ * (« lus uniquement »), FAVORITES = `owntopic=3` (« mes favoris »).
+ */
+enum class FlagFilterBucket { PARTICIPATED, READ, FAVORITES }
 
 /**
  * Tri-state outcome of a forum browsing fetch. The domain layer stays Compose-free so

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrApiClient.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrApiClient.kt
@@ -89,22 +89,34 @@ class HfrApiClient @Inject constructor(
     ): String = get(uri = "${CATEGORIES_URI}$cat/topics/$topicId/", useAuth = useAuth)
 
     /**
-     * Per-category drapeaux endpoint :
-     * `forums/hardwarefr/categories/{cat}/topics/{bucket}/`. Requires authentication —
-     * HFR redirects an anonymous request to login, surfaced as `SessionExpiredException`.
-     * The response is the same [RestListEnvelope]<RestTopic> shape used by the topic
-     * listing, contract proven by `rest_cat23_participated.json`.
+     * Per-(sub)category drapeaux endpoint :
+     * `forums/hardwarefr/categories/{cat}/topics/{bucket}/` (whole category) or
+     * `forums/hardwarefr/categories/{cat}/subcategories/{subcat}/topics/{bucket}/` when
+     * [subcat] is non-null. This is the REST equivalent of the web `owntopic=1|2|3` filter
+     * (#455): the server returns ONLY the user's flagged topics of that (sub)category, same
+     * `[RestListEnvelope]<RestTopic>` shape as the regular listing — contract proven live and
+     * by `rest_cat23_participated.json` / `rest_cat13_participated_favorites.json`. The flag
+     * buckets are not really paginated server-side (the whole bucket comes back in one page),
+     * but [page] / [resultsPerPage] are still sent for symmetry with [getTopicList].
      *
-     * `useAuth` defaults to `true` because a flags listing is by definition per-user.
-     * The bucket is taken from the [HfrRestFlagBucket] enum — no free-form string variant.
+     * Requires authentication — HFR redirects an anonymous request to login, surfaced as
+     * `SessionExpiredException`. `useAuth` defaults to `true` because a flags listing is by
+     * definition per-user. The bucket is taken from the [HfrRestFlagBucket] enum — no
+     * free-form string variant.
      *
      * The matching global endpoint (`forums/hardwarefr/topics/{bucket}/`) is intentionally
      * not exposed yet : its envelope is grouped-by-category and we have no captured
      * fixture for it. It can be added in a follow-up PR once a fixture exists.
      */
+    // 6 params: every one maps to a distinct REST URI segment / query param (cat, subcat,
+    // bucket, page, results_per_page) plus the auth toggle. They are not a cohesive object
+    // and bundling them would obscure the URL contract. Suppressing locally (#455) rather
+    // than relaxing the project-wide threshold.
+    @Suppress("LongParameterList")
     suspend fun getCategoryFlagTopics(
         cat: Int,
         bucket: HfrRestFlagBucket,
+        subcat: Int? = null,
         page: Int = 1,
         resultsPerPage: Int = DEFAULT_RESULTS_PER_PAGE,
         useAuth: Boolean = true,
@@ -113,8 +125,13 @@ class HfrApiClient @Inject constructor(
         require(resultsPerPage in 1..MAX_RESULTS_PER_PAGE) {
             "resultsPerPage must be in 1..$MAX_RESULTS_PER_PAGE, got $resultsPerPage"
         }
+        val uri = if (subcat == null) {
+            "${CATEGORIES_URI}$cat/topics/${bucket.uriSegment}/"
+        } else {
+            "${CATEGORIES_URI}$cat/subcategories/$subcat/topics/${bucket.uriSegment}/"
+        }
         return get(
-            uri = "${CATEGORIES_URI}$cat/topics/${bucket.uriSegment}/",
+            uri = uri,
             useAuth = useAuth,
             extraParams = mapOf(
                 PARAM_PAGE to page.toString(),

--- a/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/HfrApiClientTest.kt
+++ b/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/HfrApiClientTest.kt
@@ -108,6 +108,29 @@ class HfrApiClientTest {
     }
 
     @Test
+    fun `getCategoryFlagTopics with subcat scopes the URI to the subcategory bucket`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+
+        client.getCategoryFlagTopics(
+            cat = 13,
+            bucket = HfrRestFlagBucket.FAVORITES,
+            subcat = 422,
+            page = 1,
+            resultsPerPage = 100,
+            useAuth = true,
+        )
+
+        val recorded = server.takeRequest()
+        val url = requireNotNull(recorded.requestUrl)
+        assertEquals(
+            "forums/hardwarefr/categories/13/subcategories/422/topics/favorites/",
+            url.queryParameter("uri"),
+        )
+        assertEquals("1", url.queryParameter("page"))
+        assertEquals("100", url.queryParameter("results_per_page"))
+    }
+
+    @Test
     fun `getCategoryFlagTopics rejects page = 0 and out-of-range resultsPerPage`() = runTest {
         val zeroPage = runCatching {
             client.getCategoryFlagTopics(cat = 23, bucket = HfrRestFlagBucket.PARTICIPATED, page = 0)

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -9,6 +9,7 @@ import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.flags.FlagRepository
 import fr.forumhfr.redface2.core.domain.flags.FlagsResult
+import fr.forumhfr.redface2.core.domain.forum.FlagFilterBucket
 import fr.forumhfr.redface2.core.domain.forum.ForumRepository
 import fr.forumhfr.redface2.core.domain.forum.ForumResult
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
@@ -1472,6 +1473,13 @@ class FlagsViewModelTest {
         override suspend fun refreshTopicList(cat: Int, subcat: Int?, page: Int) = Unit
 
         override suspend fun prefetchTopicList(cat: Int, subcat: Int?, page: Int) = Unit
+
+        // #455 — not exercised by FlagsViewModel (the Drapeaux tab uses FlagRepository).
+        override suspend fun getFlagFilteredTopics(
+            cat: Int,
+            subcat: Int?,
+            bucket: FlagFilterBucket,
+        ): ForumResult<TopicListPage> = ForumResult.Failure(UnsupportedOperationException())
     }
 
     /**

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModel.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModel.kt
@@ -8,6 +8,7 @@ import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.error.classifyHfrError
+import fr.forumhfr.redface2.core.domain.forum.FlagFilterBucket
 import fr.forumhfr.redface2.core.domain.forum.ForumRepository
 import fr.forumhfr.redface2.core.domain.forum.ForumResult
 import fr.forumhfr.redface2.core.model.AuthState
@@ -71,6 +72,14 @@ class CategoryViewModel @AssistedInject constructor(
     private val page: MutableStateFlow<Int> = MutableStateFlow(request.initialPage.coerceAtLeast(1))
     private val searchQuery: MutableStateFlow<String> = MutableStateFlow("")
     private val isRefreshing: MutableStateFlow<Boolean> = MutableStateFlow(false)
+
+    // #455 — « Mes drapeaux » filter. Pushed state (not flatMapLatest) so refresh() can
+    // await the bucket fetch and drive [isRefreshing] correctly, and so a refresh keeps the
+    // current content instead of flashing Loading. ALL = the normal listing is the source;
+    // the bucket fetch only runs for the three flag modes. Seeded ALL, not from the route.
+    private val flagFilter: MutableStateFlow<CategoryFlagFilter> = MutableStateFlow(CategoryFlagFilter.ALL)
+    private val flagFilterTopics: MutableStateFlow<TopicsUiState> = MutableStateFlow(TopicsUiState.Loading)
+    private var flagFilterJob: Job? = null
 
     // scan keeps the last non-null name across `Loading` / `Failure` re-emissions so a
     // global refreshCategories() round-trip does not reflash the screen title back to
@@ -137,25 +146,41 @@ class CategoryViewModel @AssistedInject constructor(
         CoreCategoryState(subcat, currentPage, categoryName, subcategories, topics)
     }
 
+    // Fold the flag filter (#455) into a single slice so the final `combine` stays within
+    // the 5-arg typed overload (coreState already aggregates the 5 core sources).
+    private val filterSlice: Flow<FilterSlice> = combine(flagFilter, flagFilterTopics) { filter, topics ->
+        FilterSlice(filter, topics)
+    }
+
     val uiState: StateFlow<CategoryUiState> = combine(
         coreState,
+        filterSlice,
         searchQuery,
         isRefreshing,
         isAuthenticated,
-    ) { core, query, refreshing, authenticated ->
+    ) { core, filter, query, refreshing, authenticated ->
+        val filterActive = filter.flagFilter != CategoryFlagFilter.ALL
         CategoryUiState(
             cat = request.cat,
             categoryName = core.categoryName,
             initialSubcat = request.initialSubcat,
             selectedSubcat = core.subcat,
             page = core.page,
-            pageCount = core.topics.pageCount(),
+            // No pager in flag-filter mode: the buckets are not paginated server-side.
+            pageCount = if (filterActive) 1 else core.topics.pageCount(),
             subcategories = core.subcategories,
             topics = core.topics,
             searchQuery = query,
-            filteredTopics = core.topics.filterTopics(query),
+            // The text search applies to whichever listing is active (bucket or normal).
+            filteredTopics = if (filterActive) {
+                filter.flagFilterTopics.filterTopics(query)
+            } else {
+                core.topics.filterTopics(query)
+            },
             isRefreshing = refreshing,
             canCreateTopic = authenticated,
+            flagFilter = filter.flagFilter,
+            flagFilterTopics = filter.flagFilterTopics,
         )
     }.stateIn(
         scope = viewModelScope,
@@ -199,6 +224,17 @@ class CategoryViewModel @AssistedInject constructor(
                     prefetchJob?.cancel()
                 } else {
                     schedulePrefetch(trigger)
+                }
+            }
+            .launchIn(viewModelScope)
+
+        // #455 — re-fetch the active flag bucket for the new (sub)category when the user
+        // switches subcat. At init the filter is ALL, so the first (initial) emission is a
+        // no-op; only a genuine subcat change with a filter active triggers a fetch.
+        selectedSubcat
+            .onEach {
+                if (flagFilter.value != CategoryFlagFilter.ALL) {
+                    launchFlagFilterFetch(keepContent = false)
                 }
             }
             .launchIn(viewModelScope)
@@ -249,6 +285,49 @@ class CategoryViewModel @AssistedInject constructor(
     }
 
     /**
+     * #455 — selects the « Mes drapeaux » filter. [CategoryFlagFilter.ALL] restores the
+     * normal listing; any other value fetches the matching bucket for the current
+     * (sub)category. No-op when the value is unchanged.
+     */
+    fun selectFlagFilter(filter: CategoryFlagFilter) {
+        if (flagFilter.value == filter) return
+        flagFilter.value = filter
+        launchFlagFilterFetch(keepContent = false)
+    }
+
+    private fun launchFlagFilterFetch(keepContent: Boolean) {
+        flagFilterJob?.cancel()
+        flagFilterJob = viewModelScope.launch { fetchFlagFilter(keepContent) }
+    }
+
+    /**
+     * Fetches the active flag bucket for the current (sub)category and pushes it into
+     * [flagFilterTopics]. ALL resets the slot to `Loading` (not consumed in that case).
+     * [keepContent] `true` (pull-to-refresh of the same bucket) skips the intermediate
+     * `Loading` so the list does not blank; `false` (filter change / subcat switch) shows it.
+     */
+    private suspend fun fetchFlagFilter(keepContent: Boolean) {
+        val bucket = flagFilter.value.toDomainBucket()
+        if (bucket == null) {
+            flagFilterTopics.value = TopicsUiState.Loading
+            return
+        }
+        if (!keepContent || flagFilterTopics.value !is TopicsUiState.Content) {
+            flagFilterTopics.value = TopicsUiState.Loading
+        }
+        flagFilterTopics.value = forumRepository
+            .getFlagFilteredTopics(cat = request.cat, subcat = selectedSubcat.value, bucket = bucket)
+            .toTopicsUiState()
+    }
+
+    private fun CategoryFlagFilter.toDomainBucket(): FlagFilterBucket? = when (this) {
+        CategoryFlagFilter.ALL -> null
+        CategoryFlagFilter.PARTICIPATED -> FlagFilterBucket.PARTICIPATED
+        CategoryFlagFilter.READ -> FlagFilterBucket.READ
+        CategoryFlagFilter.FAVORITES -> FlagFilterBucket.FAVORITES
+    }
+
+    /**
      * Triggers a network refresh of the subcategories AND the current topic list.
      * Toggles [isRefreshing] for the duration so the PullToRefresh indicator stays
      * anchored. The repository's refresh* methods broadcast `Loading` then the
@@ -260,11 +339,19 @@ class CategoryViewModel @AssistedInject constructor(
             isRefreshing.value = true
             try {
                 forumRepository.refreshSubcategories(request.cat)
-                forumRepository.refreshTopicList(
-                    cat = request.cat,
-                    subcat = selectedSubcat.value,
-                    page = page.value,
-                )
+                if (flagFilter.value == CategoryFlagFilter.ALL) {
+                    forumRepository.refreshTopicList(
+                        cat = request.cat,
+                        subcat = selectedSubcat.value,
+                        page = page.value,
+                    )
+                } else {
+                    // #455 — re-fetch the active bucket inline (keep content) so [isRefreshing]
+                    // brackets the round-trip. Cancel any pending filter job to avoid a double
+                    // fetch racing this one.
+                    flagFilterJob?.cancel()
+                    fetchFlagFilter(keepContent = true)
+                }
             } finally {
                 isRefreshing.value = false
             }
@@ -322,6 +409,11 @@ class CategoryViewModel @AssistedInject constructor(
         val subcat: Int?,
         val currentPage: Int,
         val pageCount: Int,
+    )
+
+    private data class FilterSlice(
+        val flagFilter: CategoryFlagFilter,
+        val flagFilterTopics: TopicsUiState,
     )
 
     private companion object {

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModel.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModel.kt
@@ -238,6 +238,20 @@ class CategoryViewModel @AssistedInject constructor(
                 }
             }
             .launchIn(viewModelScope)
+
+        // #455 — on logout / session expiry the flag selector is hidden (anonymous has no
+        // flags); reset to ALL so the screen never stays stuck on a stale filtered list with
+        // no visible control to leave it (review Codex #455). The initial emission is `false`
+        // while the filter is already ALL, so it is a no-op until a real logout occurs.
+        isAuthenticated
+            .onEach { authenticated ->
+                if (!authenticated && flagFilter.value != CategoryFlagFilter.ALL) {
+                    flagFilterJob?.cancel()
+                    flagFilter.value = CategoryFlagFilter.ALL
+                    flagFilterTopics.value = TopicsUiState.Loading
+                }
+            }
+            .launchIn(viewModelScope)
     }
 
     private fun schedulePrefetch(trigger: ContentTrigger) {
@@ -307,7 +321,11 @@ class CategoryViewModel @AssistedInject constructor(
      * `Loading` so the list does not blank; `false` (filter change / subcat switch) shows it.
      */
     private suspend fun fetchFlagFilter(keepContent: Boolean) {
-        val bucket = flagFilter.value.toDomainBucket()
+        // Snapshot the (filter, subcat) this fetch is for so the tuple stays atomic across the
+        // suspension and a concurrent change can be detected before publishing (review #455).
+        val filter = flagFilter.value
+        val subcat = selectedSubcat.value
+        val bucket = filter.toDomainBucket()
         if (bucket == null) {
             flagFilterTopics.value = TopicsUiState.Loading
             return
@@ -315,9 +333,11 @@ class CategoryViewModel @AssistedInject constructor(
         if (!keepContent || flagFilterTopics.value !is TopicsUiState.Content) {
             flagFilterTopics.value = TopicsUiState.Loading
         }
-        flagFilterTopics.value = forumRepository
-            .getFlagFilteredTopics(cat = request.cat, subcat = selectedSubcat.value, bucket = bucket)
-            .toTopicsUiState()
+        val result = forumRepository.getFlagFilteredTopics(cat = request.cat, subcat = subcat, bucket = bucket)
+        // Stale-guard: only publish if the active (filter, subcat) is still the one we fetched.
+        if (flagFilter.value == filter && selectedSubcat.value == subcat) {
+            flagFilterTopics.value = result.toTopicsUiState()
+        }
     }
 
     private fun CategoryFlagFilter.toDomainBucket(): FlagFilterBucket? = when (this) {
@@ -346,11 +366,14 @@ class CategoryViewModel @AssistedInject constructor(
                         page = page.value,
                     )
                 } else {
-                    // #455 — re-fetch the active bucket inline (keep content) so [isRefreshing]
-                    // brackets the round-trip. Cancel any pending filter job to avoid a double
-                    // fetch racing this one.
+                    // #455 — re-fetch through [flagFilterJob] (NOT inline) so a concurrent
+                    // selectFlagFilter / subcat change can cancel it: an inline fetch had no
+                    // handle and could clobber flagFilterTopics out of order (review #455).
+                    // join() keeps [isRefreshing] bracketing the round-trip.
                     flagFilterJob?.cancel()
-                    fetchFlagFilter(keepContent = true)
+                    val job = viewModelScope.launch { fetchFlagFilter(keepContent = true) }
+                    flagFilterJob = job
+                    job.join()
                 }
             } finally {
                 isRefreshing.value = false

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
@@ -28,6 +28,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -113,18 +116,31 @@ fun ForumCategoryScreen(
 
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
 
+            // #455 — « Mes drapeaux » filter, mirroring the web `owntopic` toolbar. Only an
+            // authenticated session has flags, so the selector is hidden for anonymous users.
+            if (state.canCreateTopic) {
+                FlagFilterSelector(
+                    selected = state.flagFilter,
+                    onSelect = viewModel::selectFlagFilter,
+                )
+            }
+
             SearchField(
                 query = state.searchQuery,
                 onQueryChange = viewModel::updateSearchQuery,
             )
 
+            // In flag-filter mode the bucket listing is the source (and the pager is hidden,
+            // buckets are not paginated); ALL keeps the normal paginated listing.
+            val filterActive = state.flagFilter != CategoryFlagFilter.ALL
+            val activeTopics = if (filterActive) state.flagFilterTopics else state.topics
             PullToRefreshBox(
                 isRefreshing = state.isRefreshing,
                 onRefresh = viewModel::refresh,
                 modifier = Modifier.fillMaxSize(),
             ) {
                 TopicsBody(
-                    state = state.topics,
+                    state = activeTopics,
                     filteredTopics = state.filteredTopics,
                     searchQuery = state.searchQuery,
                     onOpenTopic = onOpenTopic,
@@ -132,6 +148,7 @@ fun ForumCategoryScreen(
                     onSelectPage = viewModel::selectPage,
                     currentPage = state.page,
                     pageCount = state.pageCount,
+                    showPager = !filterActive,
                     // #206 workaround — highlight only on the listing page/subcat reached
                     // immediately after create. If the user changes page or subcat, the route
                     // hint is ignored so an unrelated same-title topic is not highlighted there.
@@ -161,6 +178,39 @@ private fun SearchField(
         label = { Text(stringResource(R.string.category_search_label)) },
         placeholder = { Text(stringResource(R.string.category_search_placeholder)) },
     )
+}
+
+/**
+ * #455 — single-choice segmented row replicating the web `owntopic` toolbar: Tous /
+ * Participé / Lus / Favoris. No Material icon (detekt `ForbiddenImport` bans
+ * `androidx.compose.material.*`), labels only.
+ */
+@Composable
+private fun FlagFilterSelector(
+    selected: CategoryFlagFilter,
+    onSelect: (CategoryFlagFilter) -> Unit,
+) {
+    val options = listOf(
+        CategoryFlagFilter.ALL to R.string.category_flag_filter_all,
+        CategoryFlagFilter.PARTICIPATED to R.string.category_flag_filter_participated,
+        CategoryFlagFilter.READ to R.string.category_flag_filter_read,
+        CategoryFlagFilter.FAVORITES to R.string.category_flag_filter_favorites,
+    )
+    SingleChoiceSegmentedButtonRow(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        options.forEachIndexed { index, (mode, labelRes) ->
+            SegmentedButton(
+                selected = selected == mode,
+                onClick = { onSelect(mode) },
+                shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
+            ) {
+                Text(text = stringResource(labelRes), maxLines = 1)
+            }
+        }
+    }
 }
 
 @Composable
@@ -238,6 +288,7 @@ private fun TopicsBody(
     onSelectPage: (Int) -> Unit,
     currentPage: Int,
     pageCount: Int,
+    showPager: Boolean,
     highlightTitle: String?,
 ) {
     when (state) {
@@ -294,12 +345,14 @@ private fun TopicsBody(
                         HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
                     }
                 }
-                item {
-                    PagerRow(
-                        currentPage = currentPage,
-                        pageCount = pageCount,
-                        onSelectPage = onSelectPage,
-                    )
+                if (showPager) {
+                    item {
+                        PagerRow(
+                            currentPage = currentPage,
+                            pageCount = pageCount,
+                            onSelectPage = onSelectPage,
+                        )
+                    }
                 }
             }
         }

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumUiState.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumUiState.kt
@@ -30,6 +30,15 @@ sealed interface ForumUiState {
 }
 
 /**
+ * « Mes drapeaux » filter local to the category screen (#455), replicating the web
+ * `owntopic` toolbar. [ALL] is the normal paginated listing; the three other modes show
+ * ONLY the user's flagged topics of that (sub)category for the matching REST bucket — not
+ * a decoration of the listing. Reset to [ALL] when the screen leaves composition (the
+ * state lives in the ViewModel, not persisted).
+ */
+enum class CategoryFlagFilter { ALL, PARTICIPATED, READ, FAVORITES }
+
+/**
  * UI state for a category detail screen. We keep subcategories and topic list as
  * independent sub-states so the screen can render the topic list under a loading
  * skeleton while the subcategories are already shown (or vice-versa).
@@ -79,9 +88,22 @@ data class CategoryUiState(
      * « Nouveau topic » FAB visibility (Phase 2E #149) — HFR refuses the wire
      * POST in anonymous mode and Redface 2 has decided not to surface the
      * legacy anonymous composer (cf. `docs/specs/protocol-hfr.md` § Note
-     * anonyme).
+     * anonyme). Also gates the « Mes drapeaux » filter (#455): an anonymous
+     * session has no flags, so the selector is hidden.
      */
     val canCreateTopic: Boolean = false,
+    /**
+     * Active « Mes drapeaux » filter (#455). [CategoryFlagFilter.ALL] → the normal
+     * paginated [topics] listing; any other value → [flagFilterTopics] holds the
+     * bucket-only listing and the pager is hidden (the buckets are not paginated).
+     */
+    val flagFilter: CategoryFlagFilter = CategoryFlagFilter.ALL,
+    /**
+     * State of the flag-filtered listing, consumed by the screen only when
+     * [flagFilter] != ALL. Independent of [topics] (the normal listing). Holds
+     * [TopicsUiState.Loading] and is ignored while [flagFilter] == ALL.
+     */
+    val flagFilterTopics: TopicsUiState = TopicsUiState.Loading,
 )
 
 /**

--- a/feature/forum/src/main/res/values/strings.xml
+++ b/feature/forum/src/main/res/values/strings.xml
@@ -29,4 +29,10 @@
     <string name="category_flag_cyan">Drapeau mes sujets</string>
     <string name="category_flag_red">Drapeau lu uniquement</string>
     <string name="category_flag_favorite">Favori</string>
+
+    <!-- #455 — « Mes drapeaux » filter (web owntopic toolbar) -->
+    <string name="category_flag_filter_all">Tous</string>
+    <string name="category_flag_filter_participated">Participé</string>
+    <string name="category_flag_filter_read">Lus</string>
+    <string name="category_flag_filter_favorites">Favoris</string>
 </resources>

--- a/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModelTest.kt
+++ b/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModelTest.kt
@@ -2,6 +2,7 @@ package fr.forumhfr.redface2.feature.forum
 
 import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
+import fr.forumhfr.redface2.core.domain.forum.FlagFilterBucket
 import fr.forumhfr.redface2.core.domain.forum.ForumRepository
 import fr.forumhfr.redface2.core.domain.forum.ForumResult
 import fr.forumhfr.redface2.core.model.AuthState
@@ -567,6 +568,125 @@ class CategoryViewModelTest {
         )
     }
 
+    // ---- #455 — « Mes drapeaux » filter ----------------------------------------------
+
+    @Test
+    fun `flag filter defaults to ALL and shows the normal listing`() = runTest {
+        val repo = FakeForumRepository()
+        val vm = categoryVm(repo)
+        vm.uiState.test {
+            repo.emitTopicList(23, null, 1, ForumResult.Success(pageOf(topicSummary(1, "Normal"))))
+            val content = awaitContent { it.topics is TopicsUiState.Content }
+            assertEquals(CategoryFlagFilter.ALL, content.flagFilter)
+            assertEquals(listOf(1), content.filteredTopics.map { it.topicId })
+            assertTrue("no bucket fetch in ALL mode", repo.getFlagFilteredTopicsCalls.isEmpty())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `selecting a flag filter fetches the bucket and shows only its topics`() = runTest {
+        val repo = FakeForumRepository()
+        repo.flagFilterResponder = { _, _, _ -> ForumResult.Success(pageOf(topicSummary(99, "Flagged"))) }
+        val vm = categoryVm(repo)
+        vm.uiState.test {
+            repo.emitTopicList(23, null, 1, ForumResult.Success(pageOf(topicSummary(1, "Normal"))))
+            awaitContent { it.topics is TopicsUiState.Content }
+            vm.selectFlagFilter(CategoryFlagFilter.PARTICIPATED)
+            val filtered = awaitContent {
+                it.flagFilter == CategoryFlagFilter.PARTICIPATED && it.flagFilterTopics is TopicsUiState.Content
+            }
+            assertEquals(listOf(99), filtered.filteredTopics.map { it.topicId })
+            assertEquals(
+                listOf(Triple(23, null, FlagFilterBucket.PARTICIPATED)),
+                repo.getFlagFilteredTopicsCalls,
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `switching back to ALL restores the normal listing`() = runTest {
+        val repo = FakeForumRepository()
+        repo.flagFilterResponder = { _, _, _ -> ForumResult.Success(pageOf(topicSummary(99, "Flagged"))) }
+        val vm = categoryVm(repo)
+        vm.uiState.test {
+            repo.emitTopicList(23, null, 1, ForumResult.Success(pageOf(topicSummary(1, "Normal"))))
+            awaitContent { it.topics is TopicsUiState.Content }
+            vm.selectFlagFilter(CategoryFlagFilter.FAVORITES)
+            awaitContent {
+                it.flagFilter == CategoryFlagFilter.FAVORITES && it.flagFilterTopics is TopicsUiState.Content
+            }
+            vm.selectFlagFilter(CategoryFlagFilter.ALL)
+            val back = awaitContent { it.flagFilter == CategoryFlagFilter.ALL }
+            assertEquals(listOf(1), back.filteredTopics.map { it.topicId })
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `changing subcat while a filter is active refetches the bucket for the new subcat`() = runTest {
+        val repo = FakeForumRepository()
+        repo.flagFilterResponder = { _, subcat, _ -> ForumResult.Success(pageOf(topicSummary(subcat ?: 0, "x"))) }
+        val vm = categoryVm(repo)
+        vm.uiState.test {
+            repo.emitTopicList(23, null, 1, ForumResult.Success(EMPTY_PAGE))
+            awaitContent { it.topics is TopicsUiState.Content }
+            vm.selectFlagFilter(CategoryFlagFilter.READ)
+            awaitContent { it.flagFilter == CategoryFlagFilter.READ && it.flagFilterTopics is TopicsUiState.Content }
+            vm.selectSubcategory(550)
+            awaitContent { it.selectedSubcat == 550 && it.flagFilterTopics is TopicsUiState.Content }
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(
+            listOf(Triple(23, null, FlagFilterBucket.READ), Triple(23, 550, FlagFilterBucket.READ)),
+            repo.getFlagFilteredTopicsCalls,
+        )
+    }
+
+    @Test
+    fun `a failed bucket fetch surfaces an Error state`() = runTest {
+        val repo = FakeForumRepository()
+        repo.flagFilterResponder = { _, _, _ -> ForumResult.Failure(RuntimeException("boom")) }
+        val vm = categoryVm(repo)
+        vm.uiState.test {
+            repo.emitTopicList(23, null, 1, ForumResult.Success(EMPTY_PAGE))
+            awaitContent { it.topics is TopicsUiState.Content }
+            vm.selectFlagFilter(CategoryFlagFilter.PARTICIPATED)
+            val errored = awaitContent {
+                it.flagFilter == CategoryFlagFilter.PARTICIPATED && it.flagFilterTopics is TopicsUiState.Error
+            }
+            assertTrue(errored.flagFilterTopics is TopicsUiState.Error)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `reselecting the active filter does not refetch`() = runTest {
+        val repo = FakeForumRepository()
+        repo.flagFilterResponder = { _, _, _ -> ForumResult.Success(EMPTY_PAGE) }
+        val vm = categoryVm(repo)
+        vm.uiState.test {
+            repo.emitTopicList(23, null, 1, ForumResult.Success(EMPTY_PAGE))
+            awaitContent { it.topics is TopicsUiState.Content }
+            vm.selectFlagFilter(CategoryFlagFilter.PARTICIPATED)
+            awaitContent { it.flagFilterTopics is TopicsUiState.Content }
+            vm.selectFlagFilter(CategoryFlagFilter.PARTICIPATED)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(1, repo.getFlagFilteredTopicsCalls.size)
+    }
+
+    private fun categoryVm(
+        repo: FakeForumRepository,
+        auth: AuthRepository = FakeAuthRepository(),
+        request: CategoryRequest = CategoryRequest(cat = 23, initialSubcat = null),
+    ): CategoryViewModel = CategoryViewModel(
+        request = request,
+        forumRepository = repo,
+        authRepository = auth,
+    )
+
     private companion object {
         val SUBCAT_550 = SubCategory(id = 550, name = "Android", parentCategoryId = 23)
         val EMPTY_PAGE = TopicListPage(
@@ -578,6 +698,15 @@ class CategoryViewModelTest {
             topics = emptyList<TopicSummary>(),
         )
         const val AWAIT_CONTENT_TIMEOUT_MS = 2_000L
+
+        fun pageOf(vararg topics: TopicSummary): TopicListPage = TopicListPage(
+            cat = 23,
+            subcat = null,
+            page = 1,
+            resultsPerPage = 100,
+            totalTopics = topics.size,
+            topics = topics.toList(),
+        )
 
         fun topicSummary(
             id: Int,
@@ -635,6 +764,14 @@ class CategoryViewModelTest {
         var prefetchTopicListCalls: List<Triple<Int, Int?, Int>> = emptyList()
             private set
 
+        // #455 — flag-filter fetch. [flagFilterResponder] lets a test return Success/Failure
+        // per (cat, subcat, bucket); [getFlagFilteredTopicsCalls] records the args so a test
+        // can assert the right bucket / subcat were requested. Default = empty Success page.
+        var flagFilterResponder: (Int, Int?, FlagFilterBucket) -> ForumResult<TopicListPage> =
+            { cat, subcat, _ -> ForumResult.Success(TopicListPage(cat, subcat, 1, 100, 0, emptyList())) }
+        var getFlagFilteredTopicsCalls: List<Triple<Int, Int?, FlagFilterBucket>> = emptyList()
+            private set
+
         /**
          * Optional gate consumed by [refreshSubcategories] — when set, the suspending
          * stub awaits the gate before recording the call and returning. Lets a test
@@ -675,6 +812,15 @@ class CategoryViewModelTest {
         override suspend fun prefetchTopicList(cat: Int, subcat: Int?, page: Int) {
             prefetchTopicListCalls = prefetchTopicListCalls + Triple(cat, subcat, page)
             prefetchHook?.invoke(cat, subcat, page)
+        }
+
+        override suspend fun getFlagFilteredTopics(
+            cat: Int,
+            subcat: Int?,
+            bucket: FlagFilterBucket,
+        ): ForumResult<TopicListPage> {
+            getFlagFilteredTopicsCalls = getFlagFilteredTopicsCalls + Triple(cat, subcat, bucket)
+            return flagFilterResponder(cat, subcat, bucket)
         }
 
         suspend fun emitCategories(result: ForumResult<List<Category>>) {

--- a/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModelTest.kt
+++ b/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/CategoryViewModelTest.kt
@@ -677,6 +677,86 @@ class CategoryViewModelTest {
         assertEquals(1, repo.getFlagFilteredTopicsCalls.size)
     }
 
+    @Test
+    fun `refresh in flag-filter mode re-fetches the same bucket and brackets isRefreshing`() = runTest {
+        val repo = FakeForumRepository()
+        repo.flagFilterResponder = { _, _, _ -> ForumResult.Success(pageOf(topicSummary(7, "Flagged"))) }
+        val vm = categoryVm(repo)
+        vm.uiState.test {
+            repo.emitTopicList(23, null, 1, ForumResult.Success(EMPTY_PAGE))
+            awaitContent { it.topics is TopicsUiState.Content }
+            vm.selectFlagFilter(CategoryFlagFilter.PARTICIPATED)
+            awaitContent { it.flagFilterTopics is TopicsUiState.Content }
+            vm.refresh()
+            awaitContent { !it.isRefreshing && it.flagFilterTopics is TopicsUiState.Content }
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(
+            listOf(
+                Triple(23, null, FlagFilterBucket.PARTICIPATED),
+                Triple(23, null, FlagFilterBucket.PARTICIPATED),
+            ),
+            repo.getFlagFilteredTopicsCalls,
+        )
+    }
+
+    @Test
+    fun `a filter change during a filtered refresh wins over the stale refresh result`() = runTest {
+        val repo = FakeForumRepository()
+        repo.flagFilterResponder = { _, _, bucket ->
+            ForumResult.Success(pageOf(topicSummary(bucket.ordinal, bucket.name)))
+        }
+        val vm = categoryVm(repo)
+        vm.uiState.test {
+            repo.emitTopicList(23, null, 1, ForumResult.Success(EMPTY_PAGE))
+            awaitContent { it.topics is TopicsUiState.Content }
+            vm.selectFlagFilter(CategoryFlagFilter.PARTICIPATED)
+            awaitContent {
+                it.flagFilter == CategoryFlagFilter.PARTICIPATED && it.flagFilterTopics is TopicsUiState.Content
+            }
+            // Gate the refresh fetch so it stays in-flight while we switch filters.
+            val gate = CompletableDeferred<Unit>()
+            repo.suspendNextFlagFetchUntil = gate
+            vm.refresh()
+            // Switching filter must cancel the in-flight (gated) refresh fetch.
+            vm.selectFlagFilter(CategoryFlagFilter.FAVORITES)
+            // Release the (cancelled) refresh fetch: if the fix were absent it would resume and
+            // clobber flagFilterTopics with the stale PARTICIPATED bucket.
+            gate.complete(Unit)
+            // Wait for the FAVORITES content specifically (id == FAVORITES.ordinal). A precise
+            // predicate skips the transient (FAVORITES filter + old PARTICIPATED content) state
+            // emitted right when the filter flips, before the new fetch posts Loading. If the
+            // stale refresh had won, this would never reach [2] and time out.
+            val favorites = awaitContent {
+                it.flagFilter == CategoryFlagFilter.FAVORITES &&
+                    it.filteredTopics.map { t -> t.topicId } == listOf(FlagFilterBucket.FAVORITES.ordinal)
+            }
+            assertEquals(
+                listOf(FlagFilterBucket.FAVORITES.ordinal),
+                favorites.filteredTopics.map { it.topicId },
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `losing auth resets the flag filter to ALL`() = runTest {
+        val repo = FakeForumRepository()
+        repo.flagFilterResponder = { _, _, _ -> ForumResult.Success(pageOf(topicSummary(9, "Flagged"))) }
+        val auth = FakeAuthRepository(initial = AuthState.Authenticated("xat"))
+        val vm = categoryVm(repo, auth)
+        vm.uiState.test {
+            repo.emitTopicList(23, null, 1, ForumResult.Success(EMPTY_PAGE))
+            awaitContent { it.canCreateTopic && it.topics is TopicsUiState.Content }
+            vm.selectFlagFilter(CategoryFlagFilter.FAVORITES)
+            awaitContent { it.flagFilter == CategoryFlagFilter.FAVORITES }
+            auth.logout()
+            val reset = awaitContent { it.flagFilter == CategoryFlagFilter.ALL }
+            assertFalse("selector hidden once anonymous", reset.canCreateTopic)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
     private fun categoryVm(
         repo: FakeForumRepository,
         auth: AuthRepository = FakeAuthRepository(),
@@ -814,12 +894,25 @@ class CategoryViewModelTest {
             prefetchHook?.invoke(cat, subcat, page)
         }
 
+        /**
+         * When set, the NEXT [getFlagFilteredTopics] call awaits this gate before returning,
+         * letting a test pin an in-flight bucket fetch (e.g. a gated refresh) while another
+         * action runs. Consumed (reset to null) on first use. The await happens on the
+         * ViewModel's Main dispatcher (no separate scheduler), so cancellation/completion
+         * resolve eagerly under [UnconfinedTestDispatcher] — no risk of a hung test.
+         */
+        var suspendNextFlagFetchUntil: CompletableDeferred<Unit>? = null
+
         override suspend fun getFlagFilteredTopics(
             cat: Int,
             subcat: Int?,
             bucket: FlagFilterBucket,
         ): ForumResult<TopicListPage> {
             getFlagFilteredTopicsCalls = getFlagFilteredTopicsCalls + Triple(cat, subcat, bucket)
+            suspendNextFlagFetchUntil?.let { gate ->
+                suspendNextFlagFetchUntil = null
+                gate.await()
+            }
             return flagFilterResponder(cat, subcat, bucket)
         }
 

--- a/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/ForumViewModelTest.kt
+++ b/feature/forum/src/test/kotlin/fr/forumhfr/redface2/feature/forum/ForumViewModelTest.kt
@@ -3,6 +3,7 @@ package fr.forumhfr.redface2.feature.forum
 import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.domain.error.HfrServerException
+import fr.forumhfr.redface2.core.domain.forum.FlagFilterBucket
 import fr.forumhfr.redface2.core.domain.forum.ForumRepository
 import fr.forumhfr.redface2.core.domain.forum.ForumResult
 import fr.forumhfr.redface2.core.model.Category
@@ -183,6 +184,13 @@ class ForumViewModelTest {
         override suspend fun refreshTopicList(cat: Int, subcat: Int?, page: Int) = Unit
 
         override suspend fun prefetchTopicList(cat: Int, subcat: Int?, page: Int) = Unit
+
+        // #455 — not exercised by ForumViewModel (Forum home lists categories, not flags).
+        override suspend fun getFlagFilteredTopics(
+            cat: Int,
+            subcat: Int?,
+            bucket: FlagFilterBucket,
+        ): ForumResult<TopicListPage> = ForumResult.Failure(UnsupportedOperationException())
 
         suspend fun emitCategories(result: ForumResult<List<Category>>) {
             categories.emit(result)


### PR DESCRIPTION
## Objectif

Réplique le filtre serveur « owntopic » de HFR web (la barre d'icônes « Tous mes favoris » / « sujets auxquels j'ai participé » / « lus uniquement ») dans la vue **catégorie et sous-catégorie** de Redface 2. refs-#455

Recherche live ayant tranché la conception (commentaires sur l'issue) : l'API REST expose `categories/{cat}[/subcategories/{sub}]/topics/{participated,read,favorites}/`, même enveloppe `RestListEnvelope<RestTopic>` que le listing normal, pas de pagination serveur. Le filtre est donc un **vrai listing serveur**, pas une décoration locale.

## Comportement

- Sélecteur segmenté en tête : **Tous · Participé · Lus · Favoris**.
- `Tous` = listing paginé normal. Un filtre actif = **uniquement** les sujets drapalisés du bucket (le pager disparaît, les buckets ne sont pas paginés).
- Clic sur un sujet → reprise à la dernière page lue (le modèle de ligne reste `TopicSummary`, donc le contrat de nav est inchangé).
- Sélecteur **masqué en session anonyme** (pas de drapeaux sans compte).
- État local à l'écran (non persisté).

## Implémentation

| Couche | Changement |
|---|---|
| `:core:network` | `getCategoryFlagTopics` + variante `subcat` (URI `.../subcategories/{sub}/topics/{bucket}/`) |
| `:core:domain` | enum `FlagFilterBucket` + `ForumRepository.getFlagFilteredTopics(cat, subcat, bucket)` |
| `:core:data` | impl one-shot, réutilise `RestForumMappers.toTopicListPage` (modèle `TopicSummary`, `resultsPerPage=100`) |
| `:feature:forum` | enum `CategoryFlagFilter`, état filtre poussé dans le VM (`isRefreshing` correct, refetch au changement de sous-cat), `FlagFilterSelector` (SegmentedButton) |

Choix d'archi documenté dans le code : **modèle de ligne `TopicSummary`** (pas `Flag`) — l'enveloppe bucket est identique au listing, donc `TopicRow`/nav/highlight inchangés ; `DefaultFlagRepository` / `Flag` / `RestFlagMappers` non touchés. Le piège #384 (`flag_owntopic` ≠ bucket) est documenté pour ne pas être « corrigé » à tort.

## Tests

- Réseau : URI sous-catégorie (`HfrApiClientTest`).
- Data : mapping bucket → `TopicListPage`, propagation subcat/bucket, échec → `Failure` (`DefaultForumRepositoryTest`).
- VM : défaut ALL, fetch bucket, retour ALL, refetch au switch de sous-cat, échec → Error, no-op si même filtre (`CategoryViewModelTest`).
- 4 fakes `ForumRepository` alignés.

## Validation locale

`detektAll test :app:assembleProdDebug` ✅ — `:app:lintProdDebug` ✅ (Docker pin).

> Action par Claude Fable 5 (demandée par @XaTriX)
