### PR TITLE
feat(ui): #398 retrait gouttière globale + #287 densité des listes (Lot A)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -25,13 +25,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
@@ -595,7 +592,11 @@ fun RedfaceApp(intent: Intent?) {
                 }
             },
         ) {
-            Surface(modifier = Modifier.padding(horizontal = 8.dp)) {
+            // #398 — no global side gutter here. Each screen owns its own lateral rhythm
+            // (listings keep their 16/24 dp content padding, readers compensate explicitly),
+            // so the nav host no longer steals 8 dp/side from every screen. The Surface is kept
+            // for the theme background/elevation; only its horizontal padding was removed.
+            Surface {
                 val activeBackStack = backStacks.getValue(currentDestination)
                 val accountMenu: @Composable () -> Unit = {
                     RedfaceAccountMenu(

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
@@ -73,7 +73,8 @@ fun FlagItem(
         modifier = modifier
             .fillMaxWidth()
             .then(rowInteraction)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+            // #287 — denser feed: tighter vertical rhythm on listing rows (12 → 10 dp).
+            .padding(horizontal = 16.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
@@ -420,7 +420,8 @@ private fun TopicRow(
             },
         )
         .clickable(onClick = onClick)
-        .padding(horizontal = 24.dp, vertical = 12.dp)
+        // #287 — denser feed: tighter vertical rhythm on listing rows (12 → 10 dp).
+        .padding(horizontal = 24.dp, vertical = 10.dp)
     Row(
         modifier = rowModifier,
         verticalAlignment = Alignment.CenterVertically,

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -897,10 +897,9 @@ private fun TopicLoadedContent(
         // #283 — extra bottom padding so the last post's right-aligned actions clear the floating
         // bottom-action cluster (the Scaffold FAB slot floats over the content). Harmless extra
         // breathing room when the cluster is absent (anon + single page).
-        // NO side gutters here : the nav host already pads every screen by 8 dp per side
-        // (RedfaceNavigation's global Surface) — adding 8 more made the real gutter 16 dp
-        // (dogfooding v111). 0 + 8 (host) = the intended 8 dp, matching the vertical rhythm.
-        contentPadding = PaddingValues(start = 0.dp, top = 16.dp, end = 0.dp, bottom = 88.dp),
+        // #398 — the nav host no longer pads screens by 8 dp/side, so the reader carries its own
+        // 8 dp side gutter here (previously 0 + 8 host = 8). Same effective 8 dp, now owned locally.
+        contentPadding = PaddingValues(start = 8.dp, top = 16.dp, end = 8.dp, bottom = 88.dp),
         // 8 dp vertical rhythm, matching the 8 dp effective side gutters — a uniform grid (and
         // a denser feed, cf. the #287 density feedback).
         verticalArrangement = Arrangement.spacedBy(8.dp),


### PR DESCRIPTION
## Lot A de #287 — espace structurel & densité (sans réglage)

Premier des deux PRs pour #287. Ce lot ne touche QUE le layout (constantes dp), aucun réglage utilisateur. Le Lot B+C (préréglages Confort/Compact + police 3 crans) suivra.

### #398 — retrait de la gouttière globale du NavHost
La `Surface` du NavHost appliquait `Modifier.padding(horizontal = 8.dp)` à **tous** les écrans, volant 8 dp/côté de largeur utile. On le retire : chaque écran porte désormais son propre rythme latéral.

**Portée — c'est un changement global, assumé comme normalisation M3 :** après le retrait, la gouttière effective de chaque écran (chrome + contenu) passe de `8 (host) + N` à `N`, soit **−8 dp/côté partout** (TopAppBar/titres d'onglets 32→24, listings 24→16 ou 16→16+contenu, etc.). C'est l'effet « +16 dp de largeur utile » demandé en #398. **Aucune collision** : toutes les valeurs restent ≥ 16 dp, la marge M3 canonique.

**Compensation locale — un seul écran :** le seul conteneur scrollable au padding horizontal **nul** est le `LazyColumn` de contenu du lecteur de sujet (`TopicScreen`), qui n'est dans aucun parent paddé horizontalement → à 0 dp il collerait au bord. Il est compensé à 8 dp (`contentPadding` start/end `0 → 8`) pour conserver exactement son rendu. Tous les autres écrans (recherche, profil, login, éditeurs, settings, MP) ont un parent ou des enfants qui portent déjà ≥ 16 dp et n'ont besoin d'aucune compensation.

### #287 — densification du flux (premier cran, sans réglage)
- `ForumCategoryScreen.TopicRow` et `FlagItem` : rythme vertical `12 → 10 dp`.
- Le corps de lecture du sujet reste à 12 dp (largeur de texte préservée ; la densité Compact viendra du Lot B).

### Revue
- **Codex** + **workflow 4-lentilles (5 agents Opus)** — convergence : aucune régression réelle (pas d'écran au ras du bord, pas d'inset perdu, pas d'import vivant retiré, conforme detekt/CLAUDE.md).
- Un finding a conduit à **retirer une sur-compensation** que j'avais d'abord posée sur `SearchScreen` : les cartes de résultats sont déjà protégées par le `Column` parent (16 dp), donc elles suivent désormais le même −8 dp que toutes les autres listes (24→16 dp) au lieu de rester à 24 dp — cohérence du flux plus large.

### Validation
Docker (image pin) — tout vert : `detektAll` + `test` + `:app:assembleProdDebug` + `:app:lintProdDebug`.
Changement purement layout (constantes dp) → pas de test unitaire ajouté ; les suites existantes passent.

### Suivi
- refs-#398 (gouttière) et refs-#287 (densité). Fermeture des issues à la promotion dev→main.
- Lot B+C (#287) : préréglages densité Confort/Compact + police 3 crans S/M/L via DataStore + Settings.

> Action par Claude Fable 5 (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)