### PR TITLE
feat(editor): #405 cache Room des brouillons d'éditeur — fondations (PR1)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/RedfaceApplication.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/RedfaceApplication.kt
@@ -8,6 +8,7 @@ import coil3.gif.AnimatedImageDecoder
 import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import dagger.hilt.android.HiltAndroidApp
 import fr.forumhfr.redface2.core.data.cache.CacheInvalidator
+import fr.forumhfr.redface2.core.data.editor.DraftRetentionPurger
 import fr.forumhfr.redface2.core.network.qualifiers.AnonymousClient
 import javax.inject.Inject
 import okhttp3.OkHttpClient
@@ -34,6 +35,8 @@ class RedfaceApplication : Application(), SingletonImageLoader.Factory {
 
     @Inject lateinit var cacheInvalidator: CacheInvalidator
 
+    @Inject lateinit var draftRetentionPurger: DraftRetentionPurger
+
     @Inject
     @AnonymousClient
     lateinit var imageClient: OkHttpClient
@@ -56,5 +59,8 @@ class RedfaceApplication : Application(), SingletonImageLoader.Factory {
         // is alive for the full process lifetime — there is no point trying to
         // stop it before the process dies.
         cacheInvalidator.start()
+        // One-shot retention sweep dropping editor drafts older than the TTL (#405). Independent
+        // of the auth state, so it runs alongside the invalidator rather than inside it.
+        draftRetentionPurger.purge()
     }
 }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/cache/CacheInvalidator.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/cache/CacheInvalidator.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.core.data.cache
 
 import android.util.Log
+import fr.forumhfr.redface2.core.database.dao.EditorDraftDao
 import fr.forumhfr.redface2.core.database.dao.FlagDao
 import fr.forumhfr.redface2.core.database.dao.MpReadPositionDao
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
@@ -36,6 +37,11 @@ import kotlinx.coroutines.plus
  * but they reveal which conversations exist for the previous account, so they are wiped on the
  * same transition.
  *
+ * MP editor drafts (`editor_drafts` rows with `isPrivate = 1`, #405) are wiped on the same
+ * transition too: an unsent MP draft reveals a recipient and a private message. Public post
+ * drafts (`isPrivate = 0`) are NOT purged here — they survive logout and are bounded only by the
+ * app-start retention sweep (cf. `DraftRetentionPurger`).
+ *
  * On a `Authenticated(A) → Authenticated(B)` switch (login, then logout, then
  * login as someone else), we wipe rows owned by A explicitly. The session
  * cache held in [FlagRepository.clearSessionCache] is also flushed so that the
@@ -53,6 +59,7 @@ class CacheInvalidator @Inject constructor(
     private val authRepository: AuthRepository,
     private val flagDao: FlagDao,
     private val mpReadPositionDao: MpReadPositionDao,
+    private val editorDraftDao: EditorDraftDao,
     private val flagRepository: FlagRepository,
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
@@ -80,6 +87,8 @@ class CacheInvalidator @Inject constructor(
                         .onFailure { Log.w(LOG_TAG, "Failed to purge flag cache for $previousPseudo", it) }
                     runCatching { mpReadPositionDao.deleteAllForUser(previousPseudo) }
                         .onFailure { Log.w(LOG_TAG, "Failed to purge MP positions for $previousPseudo", it) }
+                    runCatching { editorDraftDao.deletePrivateForUser(previousPseudo) }
+                        .onFailure { Log.w(LOG_TAG, "Failed to purge MP drafts for $previousPseudo", it) }
                     flagRepository.clearSessionCache()
                 }
             }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/editor/DraftRetentionPurger.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/editor/DraftRetentionPurger.kt
@@ -1,0 +1,51 @@
+package fr.forumhfr.redface2.core.data.editor
+
+import android.util.Log
+import fr.forumhfr.redface2.core.database.dao.EditorDraftDao
+import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
+import java.time.Clock
+import java.time.Duration
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+/**
+ * One-shot retention sweep of the `editor_drafts` table run at app start (#405): drops every draft
+ * (public or MP) last touched more than [RETENTION] ago, so an abandoned draft cannot linger on
+ * disk indefinitely. Independent of the auth state — unlike the logout purge owned by
+ * `CacheInvalidator` — hence its own component rather than a branch inside the auth-driven
+ * invalidator.
+ *
+ * The cutoff is sourced from an injectable [Clock] so the sweep is testable, and the DAO call
+ * runs on the IO dispatcher off the main thread. Nothing about draft content is ever logged.
+ */
+@Singleton
+class DraftRetentionPurger @Inject constructor(
+    private val editorDraftDao: EditorDraftDao,
+    private val clock: Clock,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) {
+
+    /**
+     * Launches the retention sweep on a fresh IO scope (parented on [parent] when provided, so the
+     * platform `Application` can cancel it on process death). Best-effort: a DAO failure is logged
+     * without crashing app start. Returns the launched [Job].
+     */
+    fun purge(parent: Job? = null): Job {
+        val scope = CoroutineScope(ioDispatcher + (parent ?: SupervisorJob()))
+        return scope.launch {
+            val cutoff = clock.millis() - RETENTION.toMillis()
+            runCatching { editorDraftDao.deleteOlderThan(cutoff) }
+                .onFailure { Log.w(LOG_TAG, "Failed to purge stale editor drafts", it) }
+        }
+    }
+
+    private companion object {
+        const val LOG_TAG = "DraftRetentionPurger"
+        val RETENTION: Duration = Duration.ofDays(30)
+    }
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/editor/EditorDataModule.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/editor/EditorDataModule.kt
@@ -1,0 +1,17 @@
+package fr.forumhfr.redface2.core.data.editor
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import fr.forumhfr.redface2.core.domain.editor.EditorDraftStore
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class EditorDataModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindEditorDraftStore(impl: RoomEditorDraftStore): EditorDraftStore
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/editor/RoomEditorDraftStore.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/editor/RoomEditorDraftStore.kt
@@ -1,0 +1,77 @@
+package fr.forumhfr.redface2.core.data.editor
+
+import fr.forumhfr.redface2.core.database.dao.EditorDraftDao
+import fr.forumhfr.redface2.core.database.entities.EditorDraftEntity
+import fr.forumhfr.redface2.core.domain.auth.AuthRepository
+import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
+import fr.forumhfr.redface2.core.domain.editor.EditorDraftStore
+import fr.forumhfr.redface2.core.domain.editor.EditorDraftStore.Draft
+import fr.forumhfr.redface2.core.model.AuthState
+import java.time.Clock
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+
+/**
+ * Room-backed [EditorDraftStore] (#405). The active account is snapshotted per call from
+ * [AuthRepository]; with no session both reads and writes are no-ops — an anonymous client cannot
+ * post (HFR's write forms require a session), so it has no draft, and a save racing a logout must
+ * not write a row the purge pass has already swept (CacheInvalidator wipes by previous pseudo).
+ *
+ * The row key folds the owning account into the domain context key (`"<ownerId>|<contextKey>"`)
+ * so two accounts editing the same topic never collide. No draft content is ever logged.
+ */
+@Singleton
+class RoomEditorDraftStore @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val editorDraftDao: EditorDraftDao,
+    private val clock: Clock,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) : EditorDraftStore {
+
+    override suspend fun load(key: String): Draft? = withContext(ioDispatcher) {
+        val owner = activeOwnerId() ?: return@withContext null
+        editorDraftDao.get(rowKey(owner, key))?.let { entity ->
+            Draft(
+                body = entity.body,
+                subject = entity.subject,
+                recipients = entity.recipients,
+                isPrivate = entity.isPrivate,
+                updatedAt = entity.updatedAt,
+            )
+        }
+    }
+
+    override suspend fun save(key: String, draft: Draft) {
+        withContext(ioDispatcher) {
+            val owner = activeOwnerId() ?: return@withContext
+            editorDraftDao.upsert(
+                EditorDraftEntity(
+                    draftKey = rowKey(owner, key),
+                    ownerId = owner,
+                    body = draft.body,
+                    subject = draft.subject,
+                    recipients = draft.recipients,
+                    updatedAt = clock.millis(),
+                    isPrivate = draft.isPrivate,
+                ),
+            )
+        }
+    }
+
+    override suspend fun delete(key: String) {
+        withContext(ioDispatcher) {
+            val owner = activeOwnerId() ?: return@withContext
+            editorDraftDao.deleteByKey(rowKey(owner, key))
+        }
+    }
+
+    private fun rowKey(owner: String, key: String): String = "$owner|$key"
+
+    private suspend fun activeOwnerId(): String? =
+        (authRepository.observeAuthState().first() as? AuthState.Authenticated)
+            ?.pseudo
+            ?.lowercase()
+}

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/cache/CacheInvalidatorTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/cache/CacheInvalidatorTest.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.core.data.cache
 
+import fr.forumhfr.redface2.core.database.dao.EditorDraftDao
 import fr.forumhfr.redface2.core.database.dao.FlagDao
 import fr.forumhfr.redface2.core.database.dao.MpReadPositionDao
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
@@ -29,11 +30,12 @@ class CacheInvalidatorTest {
 
         coVerify(exactly = 0) { fixture.flagDao.deleteAllForUser(any()) }
         coVerify(exactly = 0) { fixture.mpReadPositionDao.deleteAllForUser(any()) }
+        coVerify(exactly = 0) { fixture.editorDraftDao.deletePrivateForUser(any()) }
         verify(exactly = 0) { fixture.flagRepository.clearSessionCache() }
     }
 
     @Test
-    fun `logout purges the previous user's flag rows, MP positions and the session cache`() = runTest {
+    fun `logout purges the previous user's flag rows, MP positions, MP drafts and session cache`() = runTest {
         val state = MutableStateFlow<AuthState>(AuthState.Authenticated("alice"))
         val fixture = invalidator(state)
         fixture.invalidator.start()
@@ -43,6 +45,7 @@ class CacheInvalidatorTest {
         coVerifyOrder {
             fixture.flagDao.deleteAllForUser("alice")
             fixture.mpReadPositionDao.deleteAllForUser("alice")
+            fixture.editorDraftDao.deletePrivateForUser("alice")
         }
         verify { fixture.flagRepository.clearSessionCache() }
     }
@@ -59,8 +62,10 @@ class CacheInvalidatorTest {
         // HFR is case-insensitive on pseudo display but cookies sometimes mix case.
         coVerify { fixture.flagDao.deleteAllForUser("alice") }
         coVerify { fixture.mpReadPositionDao.deleteAllForUser("alice") }
+        coVerify { fixture.editorDraftDao.deletePrivateForUser("alice") }
         coVerify(exactly = 0) { fixture.flagDao.deleteAllForUser("bob") }
         coVerify(exactly = 0) { fixture.mpReadPositionDao.deleteAllForUser("bob") }
+        coVerify(exactly = 0) { fixture.editorDraftDao.deletePrivateForUser("bob") }
         verify { fixture.flagRepository.clearSessionCache() }
     }
 
@@ -76,6 +81,7 @@ class CacheInvalidatorTest {
 
         coVerify(exactly = 0) { fixture.flagDao.deleteAllForUser(any()) }
         coVerify(exactly = 0) { fixture.mpReadPositionDao.deleteAllForUser(any()) }
+        coVerify(exactly = 0) { fixture.editorDraftDao.deletePrivateForUser(any()) }
         verify(exactly = 0) { fixture.flagRepository.clearSessionCache() }
     }
 
@@ -83,6 +89,7 @@ class CacheInvalidatorTest {
         val invalidator: CacheInvalidator,
         val flagDao: FlagDao,
         val mpReadPositionDao: MpReadPositionDao,
+        val editorDraftDao: EditorDraftDao,
         val flagRepository: FlagRepository,
     )
 
@@ -92,14 +99,16 @@ class CacheInvalidatorTest {
         }
         val flagDao = mockk<FlagDao>(relaxed = true)
         val mpReadPositionDao = mockk<MpReadPositionDao>(relaxed = true)
+        val editorDraftDao = mockk<EditorDraftDao>(relaxed = true)
         val flagRepository = mockk<FlagRepository>(relaxed = true)
         val invalidator = CacheInvalidator(
             authRepository = authRepository,
             flagDao = flagDao,
             mpReadPositionDao = mpReadPositionDao,
+            editorDraftDao = editorDraftDao,
             flagRepository = flagRepository,
             ioDispatcher = UnconfinedTestDispatcher(),
         )
-        return Fixture(invalidator, flagDao, mpReadPositionDao, flagRepository)
+        return Fixture(invalidator, flagDao, mpReadPositionDao, editorDraftDao, flagRepository)
     }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/editor/DraftRetentionPurgerTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/editor/DraftRetentionPurgerTest.kt
@@ -1,0 +1,35 @@
+package fr.forumhfr.redface2.core.data.editor
+
+import fr.forumhfr.redface2.core.database.dao.EditorDraftDao
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DraftRetentionPurgerTest {
+
+    private val dao = mockk<EditorDraftDao>(relaxed = true)
+    private val now = Instant.ofEpochMilli(1_700_000_000_000L)
+    private val fixedClock = Clock.fixed(now, ZoneOffset.UTC)
+
+    private val purger = DraftRetentionPurger(
+        editorDraftDao = dao,
+        clock = fixedClock,
+        ioDispatcher = UnconfinedTestDispatcher(),
+    )
+
+    @Test
+    fun `purge drops drafts older than the 30-day retention from the clock`() = runTest {
+        purger.purge().join()
+
+        val expectedCutoff = now.toEpochMilli() - Duration.ofDays(30).toMillis()
+        coVerify { dao.deleteOlderThan(expectedCutoff) }
+    }
+}

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/editor/RoomEditorDraftStoreTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/editor/RoomEditorDraftStoreTest.kt
@@ -1,0 +1,130 @@
+package fr.forumhfr.redface2.core.data.editor
+
+import fr.forumhfr.redface2.core.database.dao.EditorDraftDao
+import fr.forumhfr.redface2.core.database.entities.EditorDraftEntity
+import fr.forumhfr.redface2.core.domain.auth.AuthRepository
+import fr.forumhfr.redface2.core.domain.editor.EditorDraftStore.Draft
+import fr.forumhfr.redface2.core.model.AuthState
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RoomEditorDraftStoreTest {
+
+    private val dao = mockk<EditorDraftDao>(relaxed = true)
+    private val fixedClock = Clock.fixed(Instant.ofEpochMilli(1_700_000_000_000L), ZoneOffset.UTC)
+
+    private fun store(authState: AuthState) = RoomEditorDraftStore(
+        authRepository = mockk<AuthRepository> {
+            every { observeAuthState() } returns MutableStateFlow(authState)
+        },
+        editorDraftDao = dao,
+        clock = fixedClock,
+        ioDispatcher = UnconfinedTestDispatcher(),
+    )
+
+    @Test
+    fun `anonymous session reads null and never touches the DAO`() = runTest {
+        val store = store(AuthState.Anonymous)
+
+        assertNull(store.load(key = "reply:29:123456"))
+        store.save(key = "reply:29:123456", draft = Draft(body = "wip"))
+        store.delete(key = "reply:29:123456")
+
+        coVerify(exactly = 0) { dao.get(any()) }
+        coVerify(exactly = 0) { dao.upsert(any()) }
+        coVerify(exactly = 0) { dao.deleteByKey(any()) }
+    }
+
+    @Test
+    fun `save folds the lowercased owner into the row key and stamps the clock`() = runTest {
+        val store = store(AuthState.Authenticated("XaTriX"))
+
+        store.save(
+            key = "reply:29:123456",
+            draft = Draft(body = "wip body", isPrivate = false, updatedAt = 42L),
+        )
+
+        coVerify {
+            dao.upsert(
+                EditorDraftEntity(
+                    draftKey = "xatrix|reply:29:123456",
+                    ownerId = "xatrix",
+                    body = "wip body",
+                    subject = null,
+                    recipients = null,
+                    updatedAt = 1_700_000_000_000L,
+                    isPrivate = false,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `load round-trips the stored draft for the active account`() = runTest {
+        coEvery { dao.get("xatrix|mpnew") } returns EditorDraftEntity(
+            draftKey = "xatrix|mpnew",
+            ownerId = "xatrix",
+            body = "private body",
+            subject = "private subject",
+            recipients = "bob",
+            updatedAt = 1_700_000_000_000L,
+            isPrivate = true,
+        )
+        val store = store(AuthState.Authenticated("xatrix"))
+
+        assertEquals(
+            Draft(
+                body = "private body",
+                subject = "private subject",
+                recipients = "bob",
+                isPrivate = true,
+                updatedAt = 1_700_000_000_000L,
+            ),
+            store.load(key = "mpnew"),
+        )
+    }
+
+    @Test
+    fun `drafts are isolated per account`() = runTest {
+        // Account A wrote a row; account B must never read it.
+        coEvery { dao.get("alice|reply:29:123456") } returns EditorDraftEntity(
+            draftKey = "alice|reply:29:123456",
+            ownerId = "alice",
+            body = "alice wip",
+            subject = null,
+            recipients = null,
+            updatedAt = 1_700_000_000_000L,
+            isPrivate = false,
+        )
+        // Bob has no row under his own key — a real DAO returns null (the relaxed mock would
+        // otherwise hand back a dummy entity, masking the isolation we are asserting).
+        coEvery { dao.get("bob|reply:29:123456") } returns null
+        val storeForBob = store(AuthState.Authenticated("bob"))
+
+        // Bob's read targets "bob|..." — the DAO has no such row, so it returns null.
+        assertNull(storeForBob.load(key = "reply:29:123456"))
+        coVerify { dao.get("bob|reply:29:123456") }
+    }
+
+    @Test
+    fun `delete targets the owner-scoped row key`() = runTest {
+        val store = store(AuthState.Authenticated("xatrix"))
+
+        store.delete(key = "edit:23:35395")
+
+        coVerify { dao.deleteByKey("xatrix|edit:23:35395") }
+    }
+}

--- a/core/database/schemas/fr.forumhfr.redface2.core.database.RedfaceDatabase/11.json
+++ b/core/database/schemas/fr.forumhfr.redface2.core.database.RedfaceDatabase/11.json
@@ -1,0 +1,435 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 11,
+    "identityHash": "c40a2dc997318c3d9b64189c5a1b5a8c",
+    "entities": [
+      {
+        "tableName": "topic_pages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cat` INTEGER NOT NULL, `post` INTEGER NOT NULL, `page` INTEGER NOT NULL, `title` TEXT NOT NULL, `totalPages` INTEGER NOT NULL, `isFirstPostOwner` INTEGER NOT NULL, `pollJson` TEXT, `numreponses` TEXT NOT NULL, `fetchedAt` INTEGER NOT NULL, `authMode` TEXT NOT NULL, `subcat` INTEGER NOT NULL, `canReply` INTEGER NOT NULL, PRIMARY KEY(`cat`, `post`, `page`))",
+        "fields": [
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "post",
+            "columnName": "post",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPages",
+            "columnName": "totalPages",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFirstPostOwner",
+            "columnName": "isFirstPostOwner",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pollJson",
+            "columnName": "pollJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "numreponses",
+            "columnName": "numreponses",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authMode",
+            "columnName": "authMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subcat",
+            "columnName": "subcat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canReply",
+            "columnName": "canReply",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cat",
+            "post",
+            "page"
+          ]
+        }
+      },
+      {
+        "tableName": "posts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cat` INTEGER NOT NULL, `numreponse` INTEGER NOT NULL, `post` INTEGER NOT NULL, `author` TEXT NOT NULL, `date` INTEGER NOT NULL, `content` TEXT NOT NULL, `avatarUrl` TEXT, `isEditable` INTEGER NOT NULL, `isOwnPost` INTEGER NOT NULL, `quotedAuthors` TEXT NOT NULL, `postIndex` INTEGER, `fetchedAt` INTEGER NOT NULL, `authMode` TEXT NOT NULL, `quoteRef` INTEGER, `profileId` INTEGER, `editedAt` INTEGER, PRIMARY KEY(`cat`, `numreponse`))",
+        "fields": [
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numreponse",
+            "columnName": "numreponse",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "post",
+            "columnName": "post",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isEditable",
+            "columnName": "isEditable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOwnPost",
+            "columnName": "isOwnPost",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quotedAuthors",
+            "columnName": "quotedAuthors",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postIndex",
+            "columnName": "postIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authMode",
+            "columnName": "authMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quoteRef",
+            "columnName": "quoteRef",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "editedAt",
+            "columnName": "editedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cat",
+            "numreponse"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_posts_cat_post",
+            "unique": false,
+            "columnNames": [
+              "cat",
+              "post"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_posts_cat_post` ON `${TABLE_NAME}` (`cat`, `post`)"
+          }
+        ]
+      },
+      {
+        "tableName": "flag_topics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `type` TEXT NOT NULL, `cat` INTEGER NOT NULL, `subcat` INTEGER, `topicId` INTEGER NOT NULL, `title` TEXT NOT NULL, `totalPages` INTEGER NOT NULL, `replyCount` INTEGER NOT NULL, `isFavorite` INTEGER NOT NULL DEFAULT 0, `hasUnread` INTEGER NOT NULL, `lastReadPage` INTEGER NOT NULL, `lastPostReadId` INTEGER, `firstPostAuthor` TEXT NOT NULL, `lastReplyAuthor` TEXT NOT NULL, `lastReplyAt` TEXT NOT NULL, `fetchedAt` INTEGER NOT NULL, `authMode` TEXT NOT NULL, PRIMARY KEY(`userId`, `type`, `cat`, `topicId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subcat",
+            "columnName": "subcat",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "topicId",
+            "columnName": "topicId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPages",
+            "columnName": "totalPages",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "replyCount",
+            "columnName": "replyCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hasUnread",
+            "columnName": "hasUnread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadPage",
+            "columnName": "lastReadPage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPostReadId",
+            "columnName": "lastPostReadId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "firstPostAuthor",
+            "columnName": "firstPostAuthor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReplyAuthor",
+            "columnName": "lastReplyAuthor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReplyAt",
+            "columnName": "lastReplyAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authMode",
+            "columnName": "authMode",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "type",
+            "cat",
+            "topicId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_flag_topics_userId_type",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_flag_topics_userId_type` ON `${TABLE_NAME}` (`userId`, `type`)"
+          },
+          {
+            "name": "index_flag_topics_userId_fetchedAt",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "fetchedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_flag_topics_userId_fetchedAt` ON `${TABLE_NAME}` (`userId`, `fetchedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "mp_read_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `threadId` INTEGER NOT NULL, `page` INTEGER NOT NULL, PRIMARY KEY(`userId`, `threadId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "threadId",
+            "columnName": "threadId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "threadId"
+          ]
+        }
+      },
+      {
+        "tableName": "editor_drafts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`draftKey` TEXT NOT NULL, `ownerId` TEXT NOT NULL, `body` TEXT NOT NULL, `subject` TEXT, `recipients` TEXT, `updatedAt` INTEGER NOT NULL, `isPrivate` INTEGER NOT NULL, PRIMARY KEY(`draftKey`))",
+        "fields": [
+          {
+            "fieldPath": "draftKey",
+            "columnName": "draftKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subject",
+            "columnName": "subject",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "recipients",
+            "columnName": "recipients",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrivate",
+            "columnName": "isPrivate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "draftKey"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c40a2dc997318c3d9b64189c5a1b5a8c')"
+    ]
+  }
+}

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/RedfaceDatabase.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/RedfaceDatabase.kt
@@ -4,9 +4,11 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import fr.forumhfr.redface2.core.database.converters.Converters
+import fr.forumhfr.redface2.core.database.dao.EditorDraftDao
 import fr.forumhfr.redface2.core.database.dao.FlagDao
 import fr.forumhfr.redface2.core.database.dao.MpReadPositionDao
 import fr.forumhfr.redface2.core.database.dao.TopicDao
+import fr.forumhfr.redface2.core.database.entities.EditorDraftEntity
 import fr.forumhfr.redface2.core.database.entities.FlagTopicEntity
 import fr.forumhfr.redface2.core.database.entities.MpReadPositionEntity
 import fr.forumhfr.redface2.core.database.entities.PostEntity
@@ -18,8 +20,9 @@ import fr.forumhfr.redface2.core.database.entities.TopicEntity
         PostEntity::class,
         FlagTopicEntity::class,
         MpReadPositionEntity::class,
+        EditorDraftEntity::class,
     ],
-    version = 10,
+    version = 11,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)
@@ -27,6 +30,7 @@ abstract class RedfaceDatabase : RoomDatabase() {
     abstract fun topicDao(): TopicDao
     abstract fun flagDao(): FlagDao
     abstract fun mpReadPositionDao(): MpReadPositionDao
+    abstract fun editorDraftDao(): EditorDraftDao
 
     companion object {
         const val DATABASE_NAME: String = "redface.db"

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/dao/EditorDraftDao.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/dao/EditorDraftDao.kt
@@ -1,0 +1,31 @@
+package fr.forumhfr.redface2.core.database.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import fr.forumhfr.redface2.core.database.entities.EditorDraftEntity
+
+/**
+ * Read/write access to the per-account editor drafts (#405). See [EditorDraftEntity] for the
+ * privacy contract.
+ */
+@Dao
+interface EditorDraftDao {
+
+    @Query("SELECT * FROM editor_drafts WHERE draftKey = :draftKey")
+    suspend fun get(draftKey: String): EditorDraftEntity?
+
+    @Upsert
+    suspend fun upsert(draft: EditorDraftEntity)
+
+    @Query("DELETE FROM editor_drafts WHERE draftKey = :draftKey")
+    suspend fun deleteByKey(draftKey: String)
+
+    /** Logout / account-switch purge of MP drafts owned by [ownerId] (CacheInvalidator). */
+    @Query("DELETE FROM editor_drafts WHERE ownerId = :ownerId AND isPrivate = 1")
+    suspend fun deletePrivateForUser(ownerId: String)
+
+    /** Retention purge run on app start: drops drafts last touched before [cutoffMillis]. */
+    @Query("DELETE FROM editor_drafts WHERE updatedAt < :cutoffMillis")
+    suspend fun deleteOlderThan(cutoffMillis: Long)
+}

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/di/DatabaseModule.kt
@@ -8,9 +8,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import fr.forumhfr.redface2.core.database.RedfaceDatabase
+import fr.forumhfr.redface2.core.database.dao.EditorDraftDao
 import fr.forumhfr.redface2.core.database.dao.FlagDao
 import fr.forumhfr.redface2.core.database.dao.MpReadPositionDao
 import fr.forumhfr.redface2.core.database.dao.TopicDao
+import fr.forumhfr.redface2.core.database.migrations.MIGRATION_10_11
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_1_2
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_2_3
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_3_4
@@ -44,6 +46,7 @@ object DatabaseModule {
             MIGRATION_7_8,
             MIGRATION_8_9,
             MIGRATION_9_10,
+            MIGRATION_10_11,
         )
         .build()
 
@@ -56,4 +59,8 @@ object DatabaseModule {
     @Provides
     fun provideMpReadPositionDao(database: RedfaceDatabase): MpReadPositionDao =
         database.mpReadPositionDao()
+
+    @Provides
+    fun provideEditorDraftDao(database: RedfaceDatabase): EditorDraftDao =
+        database.editorDraftDao()
 }

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/entities/EditorDraftEntity.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/entities/EditorDraftEntity.kt
@@ -1,0 +1,34 @@
+package fr.forumhfr.redface2.core.database.entities
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Cached in-progress editor content (#405). One row per (account, edit context); [draftKey] is
+ * `"<ownerId>|<contextKey>"` so it stays globally unique while embedding the owning account.
+ * The `|` separator is safe: HFR pseudos use the charset `[a-zA-Z0-9 _-]`, so a pseudo can never
+ * contain `|`.
+ *
+ * Privacy: [ownerId] (HFR pseudo, lowercase) lets the logout/account-switch purge wipe a single
+ * account's drafts exactly (CacheInvalidator), without a LIKE-prefix scan. [isPrivate] rows are
+ * MP drafts — wiped on the same transition (an MP draft reveals a recipient + message). Public
+ * post drafts survive logout but are bounded by the 30-day retention purge run on app start.
+ * Stored content is never logged or sent to diagnostics (#405).
+ */
+@Entity(tableName = "editor_drafts")
+data class EditorDraftEntity(
+    /** Row key: `"<ownerId>|<contextKey>"` ([EditorDraftKey] context prefixed with [ownerId]). */
+    @PrimaryKey val draftKey: String,
+    /** Lowercased HFR pseudo of the account that owns this draft (purge by user). */
+    val ownerId: String,
+    /** Raw editor body (BBCode) — never logged. */
+    val body: String,
+    /** Raw subject for the editors that have one (new topic, edit first post, MP compose). */
+    val subject: String?,
+    /** Raw recipient list — only the new-MP composer fills it; private, purged on logout. */
+    val recipients: String?,
+    /** Epoch millis of last write, stamped from the clock. */
+    val updatedAt: Long,
+    /** True for MP drafts (`mpreply`/`mpnew`): wiped on logout/account switch. */
+    val isPrivate: Boolean,
+)

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/migrations/Migrations.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/migrations/Migrations.kt
@@ -277,3 +277,31 @@ val MIGRATION_9_10: Migration = object : Migration(9, 10) {
         )
     }
 }
+
+/**
+ * v10 → v11 — `editor_drafts` (#405): per-account cache of in-progress editor content so a
+ * draft survives nav-entry destruction / process death. Pure DDL, no backfill. MP drafts
+ * (`isPrivate = 1`) are purged on logout / account switch; every row is bounded by a 30-day
+ * retention purge run on app start. The `draftKey` PK is `"<ownerId>|<contextKey>"` and the
+ * dedicated `ownerId` column lets the logout purge target one account exactly (no LIKE scan).
+ * The DDL matches the exported `11.json` `createSql` (column order, NOT NULL, nullable
+ * `subject`/`recipients`, PK) so `runMigrationsAndValidate` is satisfied.
+ */
+val MIGRATION_10_11: Migration = object : Migration(10, 11) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `editor_drafts` (
+                `draftKey` TEXT NOT NULL,
+                `ownerId` TEXT NOT NULL,
+                `body` TEXT NOT NULL,
+                `subject` TEXT,
+                `recipients` TEXT,
+                `updatedAt` INTEGER NOT NULL,
+                `isPrivate` INTEGER NOT NULL,
+                PRIMARY KEY(`draftKey`)
+            )
+            """.trimIndent(),
+        )
+    }
+}

--- a/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/dao/EditorDraftDaoTest.kt
+++ b/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/dao/EditorDraftDaoTest.kt
@@ -1,0 +1,134 @@
+package fr.forumhfr.redface2.core.database.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import fr.forumhfr.redface2.core.database.RedfaceDatabase
+import fr.forumhfr.redface2.core.database.entities.EditorDraftEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Real-DB coverage of the privacy-critical DELETE clauses on [EditorDraftDao] (#405). Unlike the
+ * store/CacheInvalidator tests (which only `coVerify` the call on a mock), these exercise the SQL
+ * EFFECT against an in-memory Room database, so a regression that drops or inverts the
+ * `AND isPrivate = 1` filter — or flips the TTL comparison — fails loudly here.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class EditorDraftDaoTest {
+
+    private lateinit var database: RedfaceDatabase
+    private lateinit var dao: EditorDraftDao
+
+    @Before
+    fun setUp() {
+        database = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext<android.content.Context>(),
+            RedfaceDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        dao = database.editorDraftDao()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun `upsert then get round-trips every column`() = runTest {
+        dao.upsert(
+            draft(
+                draftKey = "alice|mpnew",
+                ownerId = "alice",
+                body = "secret body",
+                subject = "secret subject",
+                recipients = "bob",
+                updatedAt = 1_700_000_000_000L,
+                isPrivate = true,
+            ),
+        )
+
+        val stored = dao.get("alice|mpnew")
+        assertNotNull(stored)
+        assertEquals("secret body", stored!!.body)
+        assertEquals("secret subject", stored.subject)
+        assertEquals("bob", stored.recipients)
+        assertEquals(true, stored.isPrivate)
+    }
+
+    @Test
+    fun `deletePrivateForUser removes ONLY the targeted owner's private drafts`() = runTest {
+        dao.upsert(draft("alice|mpreply:1", ownerId = "alice", isPrivate = true))
+        // A public draft of the SAME owner must survive logout — only MP drafts are sensitive.
+        dao.upsert(draft("alice|reply:23:1", ownerId = "alice", isPrivate = false))
+        // Another account's private draft must never be touched by alice's logout.
+        dao.upsert(draft("bob|mpreply:2", ownerId = "bob", isPrivate = true))
+
+        dao.deletePrivateForUser("alice")
+
+        // Alice's MP draft is gone …
+        assertNull(dao.get("alice|mpreply:1"))
+        // … her public post draft survives (bounded only by the TTL purge) …
+        assertNotNull(dao.get("alice|reply:23:1"))
+        // … and Bob's MP draft is untouched.
+        assertNotNull(dao.get("bob|mpreply:2"))
+    }
+
+    @Test
+    fun `deleteOlderThan is a strict less-than at the cutoff boundary`() = runTest {
+        val cutoff = 1_700_000_000_000L
+        dao.upsert(draft("alice|old", ownerId = "alice", updatedAt = cutoff - 1))
+        dao.upsert(draft("alice|exact", ownerId = "alice", updatedAt = cutoff))
+        dao.upsert(draft("alice|fresh", ownerId = "alice", updatedAt = cutoff + 1))
+
+        dao.deleteOlderThan(cutoff)
+
+        // Strictly older than the cutoff is purged …
+        assertNull(dao.get("alice|old"))
+        // … the row exactly at the cutoff is KEPT (strict `<`, no off-by-one) …
+        assertNotNull(dao.get("alice|exact"))
+        // … and anything newer is obviously kept.
+        assertNotNull(dao.get("alice|fresh"))
+    }
+
+    @Test
+    fun `deleteByKey removes a single row`() = runTest {
+        dao.upsert(draft("alice|edit:23:99", ownerId = "alice"))
+        dao.upsert(draft("alice|reply:23:1", ownerId = "alice"))
+
+        dao.deleteByKey("alice|edit:23:99")
+
+        assertNull(dao.get("alice|edit:23:99"))
+        assertNotNull(dao.get("alice|reply:23:1"))
+    }
+
+    // One parameter per entity column — a faithful test factory, not a design smell.
+    @Suppress("LongParameterList")
+    private fun draft(
+        draftKey: String,
+        ownerId: String,
+        body: String = "body",
+        subject: String? = null,
+        recipients: String? = null,
+        updatedAt: Long = 1_700_000_000_000L,
+        isPrivate: Boolean = false,
+    ) = EditorDraftEntity(
+        draftKey = draftKey,
+        ownerId = ownerId,
+        body = body,
+        subject = subject,
+        recipients = recipients,
+        updatedAt = updatedAt,
+        isPrivate = isPrivate,
+    )
+}

--- a/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/migrations/MigrationTest.kt
+++ b/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/migrations/MigrationTest.kt
@@ -23,8 +23,9 @@ import org.robolectric.annotation.Config
  * — currently `MIGRATION_1_2`, `MIGRATION_2_3`, `MIGRATION_3_4`, `MIGRATION_4_5`,
  * `MIGRATION_5_6` (Phase 2 finish #208 added `Post.profileId` in v6), `MIGRATION_6_7`
  * (#213 added `Topic.canReply` in v7), `MIGRATION_7_8` (#362 added `Post.editedAt`
- * in v8), `MIGRATION_8_9` (#384 follow-up added `FlagTopic.isFavorite` in v9) and
- * `MIGRATION_9_10` (#430 added the `mp_read_positions` table in v10).
+ * in v8), `MIGRATION_8_9` (#384 follow-up added `FlagTopic.isFavorite` in v9),
+ * `MIGRATION_9_10` (#430 added the `mp_read_positions` table in v10) and
+ * `MIGRATION_10_11` (#405 added the `editor_drafts` table in v11).
  * Without these tests a typo (missing column, wrong index name, wrong default)
  * would only crash on a real upgrade-in-place install, where the diagnostic loop is
  * days long. The tests take seconds.
@@ -119,6 +120,7 @@ class MigrationTest {
                 MIGRATION_7_8,
                 MIGRATION_8_9,
                 MIGRATION_9_10,
+                MIGRATION_10_11,
             )
             .build()
 
@@ -259,6 +261,7 @@ class MigrationTest {
                 MIGRATION_7_8,
                 MIGRATION_8_9,
                 MIGRATION_9_10,
+                MIGRATION_10_11,
             )
             .build()
 
@@ -359,6 +362,7 @@ class MigrationTest {
                 MIGRATION_7_8,
                 MIGRATION_8_9,
                 MIGRATION_9_10,
+                MIGRATION_10_11,
             )
             .build()
 
@@ -431,6 +435,7 @@ class MigrationTest {
                 MIGRATION_7_8,
                 MIGRATION_8_9,
                 MIGRATION_9_10,
+                MIGRATION_10_11,
             )
             .build()
 
@@ -499,6 +504,7 @@ class MigrationTest {
                 MIGRATION_7_8,
                 MIGRATION_8_9,
                 MIGRATION_9_10,
+                MIGRATION_10_11,
             )
             .build()
 
@@ -558,6 +564,7 @@ class MigrationTest {
                 MIGRATION_7_8,
                 MIGRATION_8_9,
                 MIGRATION_9_10,
+                MIGRATION_10_11,
             )
             .build()
 
@@ -631,6 +638,7 @@ class MigrationTest {
                 MIGRATION_7_8,
                 MIGRATION_8_9,
                 MIGRATION_9_10,
+                MIGRATION_10_11,
             )
             .build()
 
@@ -691,6 +699,7 @@ class MigrationTest {
                 MIGRATION_7_8,
                 MIGRATION_8_9,
                 MIGRATION_9_10,
+                MIGRATION_10_11,
             )
             .build()
 
@@ -741,6 +750,7 @@ class MigrationTest {
                 MIGRATION_7_8,
                 MIGRATION_8_9,
                 MIGRATION_9_10,
+                MIGRATION_10_11,
             )
             .build()
 
@@ -753,6 +763,67 @@ class MigrationTest {
             ).use { cursor ->
                 assertTrue("the migrated table must accept and return a row", cursor.moveToFirst())
                 assertEquals(7, cursor.getInt(0))
+            }
+        } finally {
+            migrated.close()
+        }
+    }
+
+    /**
+     * #405 — v10 → v11 creates `editor_drafts` (per-account cache of in-progress editor content).
+     *
+     * Verifies:
+     * 1. The migration runs cleanly against the v10 fixture and matches the exported v11 schema.
+     * 2. The production Room database (full migration chain) can write and read a draft row through
+     *    the new table — including the nullable `subject`/`recipients` columns and a private
+     *    (`isPrivate = 1`) MP draft.
+     */
+    @Test
+    fun migrate_10_to_11_creates_editor_drafts() {
+        val dbName = "migration_10_11_test"
+
+        // 1. Create a v10 database (no editor-draft rows can pre-exist the table).
+        helper.createDatabase(dbName, 10).close()
+
+        // 2. Run MIGRATION_10_11 and validate against the exported v11 schema.
+        helper.runMigrationsAndValidate(dbName, 11, true, MIGRATION_10_11).close()
+
+        // 3. Open the production Room database (which chains every migration).
+        val migrated = Room.databaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            RedfaceDatabase::class.java,
+            dbName,
+        )
+            .allowMainThreadQueries()
+            .addMigrations(
+                MIGRATION_1_2,
+                MIGRATION_2_3,
+                MIGRATION_3_4,
+                MIGRATION_4_5,
+                MIGRATION_5_6,
+                MIGRATION_6_7,
+                MIGRATION_7_8,
+                MIGRATION_8_9,
+                MIGRATION_9_10,
+                MIGRATION_10_11,
+            )
+            .build()
+
+        try {
+            migrated.openHelper.writableDatabase.execSQL(
+                "INSERT INTO editor_drafts (draftKey, ownerId, body, subject, recipients, " +
+                    "updatedAt, isPrivate) " +
+                    "VALUES ('xatrix|mpreply:42', 'xatrix', 'draft body', NULL, NULL, 1000, 1)",
+            )
+            migrated.openHelper.readableDatabase.query(
+                "SELECT body, subject, recipients, isPrivate FROM editor_drafts " +
+                    "WHERE draftKey = 'xatrix|mpreply:42'",
+            ).use { cursor ->
+                assertTrue("the migrated table must accept and return a row", cursor.moveToFirst())
+                assertEquals("draft body", cursor.getString(0))
+                assertTrue("subject must round-trip NULL", cursor.isNull(1))
+                assertTrue("recipients must round-trip NULL", cursor.isNull(2))
+                assertEquals("MP draft must persist isPrivate = 1", 1, cursor.getInt(3))
             }
         } finally {
             migrated.close()

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/editor/EditorDraftKey.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/editor/EditorDraftKey.kt
@@ -1,0 +1,24 @@
+package fr.forumhfr.redface2.core.domain.editor
+
+/**
+ * Builds the stable, content-free context key under which an editor's draft is cached (#405).
+ * The key encodes ONLY routing identity (mode + ids) — never any message body, subject or
+ * recipient. The owning account is prepended by the store, not here. `numreponse` is unique per
+ * category, so edit keys carry `cat` to stay globally unique.
+ *
+ * The reply key intentionally does NOT carry the quoted `numreponse`: per #405 a quote is appended
+ * to the restored draft, so the key must stay stable for a given topic regardless of which post is
+ * being cited (otherwise each « Citer » would fork a separate draft).
+ */
+object EditorDraftKey {
+    fun reply(cat: Int, topicId: Int): String = "reply:$cat:$topicId"
+    fun newTopic(cat: Int): String = "newtopic:$cat"
+    fun editPost(cat: Int, numreponse: Int): String = "edit:$cat:$numreponse"
+    fun editFirstPost(cat: Int, numreponse: Int): String = "editfp:$cat:$numreponse"
+    fun mpReply(threadId: Int): String = "mpreply:$threadId"
+
+    // A function (not a const) for API symmetry with the sibling key builders above: there is a
+    // single MP-compose draft at a time, so the key is fixed.
+    @Suppress("FunctionOnlyReturningConstant")
+    fun mpCompose(): String = "mpnew"
+}

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/editor/EditorDraftStore.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/editor/EditorDraftStore.kt
@@ -1,0 +1,36 @@
+package fr.forumhfr.redface2.core.domain.editor
+
+/**
+ * Per-account local cache of in-progress editor content (#405). Implementations resolve the
+ * active account themselves and MUST be a no-op (read returns null / save & delete do nothing)
+ * when no session is active — drafts are private per-account data.
+ *
+ * [load]/[save]/[delete] take a stable, content-free context [key] built by [EditorDraftKey]; it
+ * never embeds message bodies, subjects or recipients. MP drafts ([Draft.isPrivate] == true) are
+ * wiped on logout/account switch (CacheInvalidator); all drafts older than the retention TTL are
+ * pruned on app start. No draft content is ever logged or surfaced in diagnostics.
+ */
+interface EditorDraftStore {
+
+    /** One-shot read of the draft stored under [key] for the active account, or null. */
+    suspend fun load(key: String): Draft?
+
+    /**
+     * Upserts [draft] under [key] for the active account, stamping `updatedAt` from the clock.
+     * No-op without an active session. [Draft.body]/[Draft.subject]/[Draft.recipients] are the
+     * raw editor fields; [Draft.isPrivate] marks MP drafts for the logout purge.
+     */
+    suspend fun save(key: String, draft: Draft)
+
+    /** Deletes the draft under [key] for the active account (called on a successful POST). */
+    suspend fun delete(key: String)
+
+    data class Draft(
+        val body: String,
+        val subject: String? = null,
+        val recipients: String? = null,
+        val isPrivate: Boolean = false,
+        /** Epoch millis of last write; set by the store, ignored on save input. */
+        val updatedAt: Long = 0L,
+    )
+}

--- a/core/domain/src/test/kotlin/fr/forumhfr/redface2/core/domain/editor/EditorDraftKeyTest.kt
+++ b/core/domain/src/test/kotlin/fr/forumhfr/redface2/core/domain/editor/EditorDraftKeyTest.kt
@@ -1,0 +1,43 @@
+package fr.forumhfr.redface2.core.domain.editor
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the exact grammar of every draft key (#405). The key is the row identity of a cached
+ * draft: any change to the format silently orphans every previously saved draft, so these strings
+ * are a contract, not an implementation detail. The reply key must NOT vary with the quoted post.
+ */
+class EditorDraftKeyTest {
+
+    @Test
+    fun `reply key carries cat and topic id`() {
+        assertEquals("reply:29:123456", EditorDraftKey.reply(cat = 29, topicId = 123456))
+    }
+
+    @Test
+    fun `new topic key carries cat only`() {
+        assertEquals("newtopic:29", EditorDraftKey.newTopic(cat = 29))
+    }
+
+    @Test
+    fun `edit post key carries cat and numreponse`() {
+        // numreponse is unique per category, so the key carries cat to stay globally unique.
+        assertEquals("edit:23:35395", EditorDraftKey.editPost(cat = 23, numreponse = 35395))
+    }
+
+    @Test
+    fun `edit first post key is distinct from edit post key`() {
+        assertEquals("editfp:23:35395", EditorDraftKey.editFirstPost(cat = 23, numreponse = 35395))
+    }
+
+    @Test
+    fun `mp reply key carries thread id only`() {
+        assertEquals("mpreply:42", EditorDraftKey.mpReply(threadId = 42))
+    }
+
+    @Test
+    fun `mp compose key is a fixed singleton`() {
+        assertEquals("mpnew", EditorDraftKey.mpCompose())
+    }
+}


### PR DESCRIPTION
## PR1 (fondations) du chantier #405 — brouillons d'éditeur

Première des deux PRs pour #405. Ce lot pose les **fondations isolées et testables** (store, table Room, migration, purges) **sans toucher aux éditeurs**. La PR2 câblera l'autosave + restauration + bandeau dans les 5 éditeurs.

**Décision actée** : restauration **in-place uniquement** (pas d'écran « liste de brouillons »).

### Contenu
- **`EditorDraftStore`** (`:core:domain`) — interface du cache, no-op hors session (les brouillons sont des données privées par compte).
- **`EditorDraftKey`** — grammaire de clés stable et sans contenu (`reply:cat:topicId`, `newtopic:cat`, `edit:cat:numreponse`, `editfp:…`, `mpreply:threadId`, `mpnew`). La clé reply ne porte **pas** le `numreponse` cité : une citation s'**ajoute** au brouillon restauré (jamais l'inverse), donc la clé reste stable par sujet.
- **Table Room `editor_drafts`** (migration **10→11**, schéma `11.json` exporté) — PK `draftKey` = `"<ownerId>|<contextKey>"` + colonne `ownerId` dédiée pour une purge logout **exacte** (pas de `LIKE`). Colonne `recipients` pour le nouveau MP.
- **`RoomEditorDraftStore`** — owner-scoped, `withContext(ioDispatcher)`, no-op sans session, `updatedAt` estampillé par un `Clock` injecté.
- **`DraftRetentionPurger`** — purge TTL 30 jours au démarrage (à côté de `cacheInvalidator.start()`).
- **Purge MP au logout** — `CacheInvalidator` supprime les brouillons MP (`isPrivate = 1`) au logout / changement de compte.
- **Confidentialité** : aucun contenu (body/subject/recipients) n'est jamais loggé ni envoyé aux diagnostics.

### Tests
`MigrationTest` 10→11 (insert/read réel), `RoomEditorDraftStoreTest` (no-op anonyme, round-trip, **isolation par compte**, clé owner-scoped), `EditorDraftKeyTest` (grammaire), `DraftRetentionPurgerTest`, `CacheInvalidatorTest` (purge MP au logout/switch, pas au first-login).

### Validation
Docker (image pin) — tout vert : `detektAll` + `test` (238) + `:app:assembleProdDebug` + `:app:lintProdDebug`.

### Suivi
- refs-#405 (fondations). Fermeture à la promotion dev→main, après la PR2 (câblage des éditeurs).
- PR2 : autosave (debounce + flush ON_STOP), restauration in-place, bandeau « Brouillon restauré / effacer », suppression au POST réussi, dans les 5 éditeurs.

> Action par Claude Fable 5 (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)