### PR TITLE
feat(settings): #287 préréglages densité + police de lecture 3 crans (Lot B+C)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
@@ -3,6 +3,8 @@ package fr.forumhfr.redface2.navigation
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
+import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
@@ -24,7 +26,7 @@ import kotlinx.coroutines.flow.stateIn
  */
 @HiltViewModel
 class AppThemeViewModel @Inject constructor(
-    userPreferencesRepository: UserPreferencesRepository,
+    private val userPreferencesRepository: UserPreferencesRepository,
     themeBootstrapStore: ThemeBootstrapStore,
 ) : ViewModel() {
 
@@ -37,4 +39,14 @@ class AppThemeViewModel @Inject constructor(
     val amoledEnabled: StateFlow<Boolean> =
         userPreferencesRepository.observeAmoledEnabled()
             .stateIn(viewModelScope, SharingStarted.Eagerly, bootstrap.amoledEnabled)
+
+    // #287 — reading presets. No bootstrap mirror (they do not paint the pre-first-frame window),
+    // so the seed is just the enum default; DataStore resolves on the first Eagerly read.
+    val displayDensity: StateFlow<DisplayDensity> =
+        userPreferencesRepository.observeDisplayDensity()
+            .stateIn(viewModelScope, SharingStarted.Eagerly, DisplayDensity.COMFORT)
+
+    val fontScale: StateFlow<FontScalePreference> =
+        userPreferencesRepository.observeFontScale()
+            .stateIn(viewModelScope, SharingStarted.Eagerly, FontScalePreference.M)
 }

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -57,6 +57,7 @@ import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.ui.RedfaceTheme
 import fr.forumhfr.redface2.core.ui.account.RedfaceAccountMenu
+import fr.forumhfr.redface2.core.ui.theme.ReadingDisplaySettings
 import fr.forumhfr.redface2.feature.auth.LoginScreen
 import fr.forumhfr.redface2.feature.editor.PostEditorMode
 import fr.forumhfr.redface2.feature.editor.PostEditorRequest
@@ -404,6 +405,9 @@ fun RedfaceApp(intent: Intent?) {
     val themeViewModel: AppThemeViewModel = hiltViewModel()
     val themeMode by themeViewModel.themeMode.collectAsStateWithLifecycle()
     val amoledEnabled by themeViewModel.amoledEnabled.collectAsStateWithLifecycle()
+    // #287 — reading presets (density + font scale) resolved at the root and bundled for RedfaceTheme.
+    val displayDensity by themeViewModel.displayDensity.collectAsStateWithLifecycle()
+    val fontScale by themeViewModel.fontScale.collectAsStateWithLifecycle()
     val darkTheme = when (themeMode) {
         ThemeMode.LIGHT -> false
         ThemeMode.DARK -> true
@@ -426,7 +430,11 @@ fun RedfaceApp(intent: Intent?) {
             controller.isAppearanceLightNavigationBars = !darkTheme
         }
     }
-    RedfaceTheme(darkTheme = darkTheme, amoledTheme = amoledEnabled) {
+    RedfaceTheme(
+        darkTheme = darkTheme,
+        amoledTheme = amoledEnabled,
+        reading = ReadingDisplaySettings(density = displayDensity, fontScale = fontScale),
+    ) {
         // #458 — cold-start screen, read synchronously from the bootstrap mirror and frozen for
         // the session. Only the INITIAL values below consume it: rememberSaveable and
         // rememberNavBackStack restore saved state first, so rotations / process restores keep

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModelTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModelTest.kt
@@ -1,5 +1,7 @@
 package fr.forumhfr.redface2.navigation
 
+import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
+import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrap
 import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
@@ -47,6 +49,9 @@ class AppThemeViewModelTest {
             // A SharedFlow that never emits = DataStore still hydrating on a cold start.
             every { observeThemeMode() } returns MutableSharedFlow()
             every { observeAmoledEnabled() } returns MutableSharedFlow()
+            // #287 — eagerly collected by the VM; defaults are enough for this theme-focused test.
+            every { observeDisplayDensity() } returns MutableStateFlow(DisplayDensity.COMFORT)
+            every { observeFontScale() } returns MutableStateFlow(FontScalePreference.M)
         }
 
         val vm = AppThemeViewModel(
@@ -64,6 +69,8 @@ class AppThemeViewModelTest {
         val repository = mockk<UserPreferencesRepository> {
             every { observeThemeMode() } returns MutableStateFlow(ThemeMode.LIGHT)
             every { observeAmoledEnabled() } returns MutableStateFlow(false)
+            every { observeDisplayDensity() } returns MutableStateFlow(DisplayDensity.COMFORT)
+            every { observeFontScale() } returns MutableStateFlow(FontScalePreference.M)
         }
 
         val vm = AppThemeViewModel(

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -7,7 +7,9 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
+import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
+import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
@@ -352,6 +354,57 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeDisplayDensity(): Flow<DisplayDensity> =
+        dataStore.data
+            // Default COMFORT (#287): the historical structural rhythm unless the user opts into
+            // the denser COMPACT preset. No bootstrap mirror — this preset does not paint the
+            // pre-first-frame window, so a SYSTEM-style cold-start flash is not a concern here.
+            .map(::readDisplayDensity)
+            .distinctUntilChanged()
+            .catch { emit(DisplayDensity.COMFORT) }
+
+    override suspend fun setDisplayDensity(density: DisplayDensity) {
+        withContext(ioDispatcher) {
+            dataStore.edit { prefs ->
+                prefs[KEY_DISPLAY_DENSITY] = density.name
+            }
+        }
+    }
+
+    override fun observeFontScale(): Flow<FontScalePreference> =
+        dataStore.data
+            // Default M (#287): the M3 reference sizes unless the user picks S / L.
+            .map(::readFontScale)
+            .distinctUntilChanged()
+            .catch { emit(FontScalePreference.M) }
+
+    override suspend fun setFontScale(scale: FontScalePreference) {
+        withContext(ioDispatcher) {
+            dataStore.edit { prefs ->
+                prefs[KEY_FONT_SCALE] = scale.name
+            }
+        }
+    }
+
+    /**
+     * Reads [KEY_DISPLAY_DENSITY] defensively (#287): an unknown / corrupt stored value (older
+     * build, manual edit) falls back to [DisplayDensity.COMFORT] instead of crashing on
+     * `DisplayDensity.valueOf`, same stance as [readThemeMode].
+     */
+    private fun readDisplayDensity(prefs: Preferences): DisplayDensity =
+        prefs[KEY_DISPLAY_DENSITY]
+            ?.let { stored -> runCatching { DisplayDensity.valueOf(stored) }.getOrNull() }
+            ?: DisplayDensity.COMFORT
+
+    /**
+     * Reads [KEY_FONT_SCALE] defensively (#287): an unknown / corrupt stored value falls back to
+     * [FontScalePreference.M] instead of crashing on `FontScalePreference.valueOf`.
+     */
+    private fun readFontScale(prefs: Preferences): FontScalePreference =
+        prefs[KEY_FONT_SCALE]
+            ?.let { stored -> runCatching { FontScalePreference.valueOf(stored) }.getOrNull() }
+            ?: FontScalePreference.M
+
     /**
      * Reads [KEY_THEME_MODE] defensively: an unknown / corrupt stored value (older build with a
      * renamed enum, manual edit) falls back to [ThemeMode.SYSTEM] instead of crashing on
@@ -459,5 +512,10 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         // category id (absent unless screen == FORUM and a category was picked).
         val KEY_START_SCREEN = stringPreferencesKey("start_screen")
         val KEY_START_FORUM_CAT = intPreferencesKey("start_forum_cat")
+
+        // #287 — reading display presets: density (DisplayDensity.name) + font scale
+        // (FontScalePreference.name), both defensively parsed. No bootstrap mirror (cf. observers).
+        val KEY_DISPLAY_DENSITY = stringPreferencesKey("display_density")
+        val KEY_FONT_SCALE = stringPreferencesKey("font_scale")
     }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -6,6 +6,8 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import app.cash.turbine.test
+import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
+import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
@@ -551,5 +553,73 @@ class DataStoreUserPreferencesRepositoryTest {
         assertEquals(null, config.port)
         assertEquals(null, config.username)
         assertEquals(null, config.password)
+    }
+
+    @Test
+    fun `observeDisplayDensity defaults to COMFORT on an empty store`() = runTest(dispatcher) {
+        // #287 — COMFORT is the default (historical rhythm), never the enum's first ordinal by chance.
+        repository.observeDisplayDensity().test {
+            assertEquals(DisplayDensity.COMFORT, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setDisplayDensity persists and round-trips COMPACT then COMFORT`() = runTest(dispatcher) {
+        repository.setDisplayDensity(DisplayDensity.COMPACT)
+        repository.observeDisplayDensity().test {
+            assertEquals(DisplayDensity.COMPACT, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setDisplayDensity(DisplayDensity.COMFORT)
+        repository.observeDisplayDensity().test {
+            assertEquals(DisplayDensity.COMFORT, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `corrupt display_density value falls back to COMFORT instead of crashing`() = runTest(dispatcher) {
+        // An unknown value (older build / manual edit) must degrade to COMFORT, not crash valueOf.
+        dataStore.edit { prefs -> prefs[stringPreferencesKey("display_density")] = "ULTRA" }
+
+        repository.observeDisplayDensity().test {
+            assertEquals(DisplayDensity.COMFORT, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `observeFontScale defaults to M on an empty store`() = runTest(dispatcher) {
+        repository.observeFontScale().test {
+            assertEquals(FontScalePreference.M, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setFontScale persists and round-trips S then L`() = runTest(dispatcher) {
+        repository.setFontScale(FontScalePreference.S)
+        repository.observeFontScale().test {
+            assertEquals(FontScalePreference.S, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setFontScale(FontScalePreference.L)
+        repository.observeFontScale().test {
+            assertEquals(FontScalePreference.L, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `corrupt font_scale value falls back to M instead of crashing`() = runTest(dispatcher) {
+        dataStore.edit { prefs -> prefs[stringPreferencesKey("font_scale")] = "XXL" }
+
+        repository.observeFontScale().test {
+            assertEquals(FontScalePreference.M, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -6,7 +6,9 @@ import app.cash.turbine.test
 import fr.forumhfr.redface2.core.database.RedfaceDatabase
 import fr.forumhfr.redface2.core.database.dao.TopicDao
 import fr.forumhfr.redface2.core.database.entities.FetchMode
+import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
+import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
@@ -573,5 +575,14 @@ class TopicRepositoryImplTest {
             MutableStateFlow(StartScreenPreference())
 
         override suspend fun setStartScreen(preference: StartScreenPreference) = Unit
+
+        // #287 — reading display presets are irrelevant to TopicRepository; stubbed at defaults.
+        override fun observeDisplayDensity(): Flow<DisplayDensity> = MutableStateFlow(DisplayDensity.COMFORT)
+
+        override suspend fun setDisplayDensity(density: DisplayDensity) = Unit
+
+        override fun observeFontScale(): Flow<FontScalePreference> = MutableStateFlow(FontScalePreference.M)
+
+        override suspend fun setFontScale(scale: FontScalePreference) = Unit
     }
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/DisplayDensity.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/DisplayDensity.kt
@@ -1,0 +1,18 @@
+package fr.forumhfr.redface2.core.domain.preferences
+
+/**
+ * Reading-density preset (#287 lot B).
+ *
+ * - [COMFORT] (default) keeps the historical structural rhythm — the listing-row and
+ *   post-body paddings shipped by the #398 structural pass, calibrated for comfortable reading.
+ * - [COMPACT] tightens those same paddings so more posts / listing rows fit on screen, for
+ *   users who asked for a denser feed in the beta feedback.
+ *
+ * The preset only drives the structural spacing exposed through `LocalDisplayMetrics`; it never
+ * touches the typography (that is [FontScalePreference]) nor the system font zoom. Modelled on
+ * [ThemeMode]: persisted by its [name] and observed at the app root.
+ */
+enum class DisplayDensity {
+    COMFORT,
+    COMPACT,
+}

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FontScalePreference.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FontScalePreference.kt
@@ -1,0 +1,22 @@
+package fr.forumhfr.redface2.core.domain.preferences
+
+/**
+ * Reading font-size preset (#287 lot C), in three steps.
+ *
+ * [factor] is a multiplier applied to the app `Typography` (font size + line height of every
+ * role) on top of the OS font-zoom — never instead of it. So the effective on-screen size is
+ * `sp_role × factor × systemFontScale`: the preset modulates the reading size additively and
+ * always respects the accessibility zoom.
+ *
+ * - [S] slightly smaller (0.9×) for users who want denser text.
+ * - [M] (default) the M3 reference sizes, identity multiplier — no scaling work at all.
+ * - [L] larger (1.15×) for comfortable reading.
+ *
+ * The [factor] is pure data (no Compose dependency), so it lives in `:core:domain` and is read by
+ * the theme layer. Persisted by [name] and observed at the app root, modelled on [ThemeMode].
+ */
+enum class FontScalePreference(val factor: Float) {
+    S(0.9f),
+    M(1.0f),
+    L(1.15f),
+}

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -219,4 +219,26 @@ interface UserPreferencesRepository {
 
     /** Persists [observeMpUnreadBadge]. Default `true` until the first call. */
     suspend fun setMpUnreadBadge(enabled: Boolean)
+
+    /**
+     * Reading-density preset (#287): [DisplayDensity.COMFORT] (default) keeps the historical
+     * structural rhythm; [DisplayDensity.COMPACT] tightens the listing-row and post-body paddings
+     * for a denser feed. Observed at the app root ([fr.forumhfr.redface2.navigation.RedfaceApp]) to
+     * provide `LocalDisplayMetrics` to the whole tree, and mirrored in Settings.
+     */
+    fun observeDisplayDensity(): Flow<DisplayDensity>
+
+    /** Persists [observeDisplayDensity]. Default [DisplayDensity.COMFORT] until the first call. */
+    suspend fun setDisplayDensity(density: DisplayDensity)
+
+    /**
+     * Reading font-size preset (#287): [FontScalePreference.M] (default) is the M3 reference size;
+     * [FontScalePreference.S] / [FontScalePreference.L] scale the reading typography by the preset
+     * [FontScalePreference.factor], applied ON TOP of the OS font zoom (never replacing it).
+     * Observed at the app root to scale the theme `Typography`, and mirrored in Settings.
+     */
+    fun observeFontScale(): Flow<FontScalePreference>
+
+    /** Persists [observeFontScale]. Default [FontScalePreference.M] until the first call. */
+    suspend fun setFontScale(scale: FontScalePreference)
 }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.ui.theme.FlagPalette
+import fr.forumhfr.redface2.core.ui.theme.LocalDisplayMetrics
 
 /**
  * Renders one row of the user's drapeaux list.
@@ -69,12 +70,13 @@ fun FlagItem(
     } else {
         Modifier.clickable(onClick = onClick)
     }
+    // #287 — listing-row vertical rhythm from the density preset (Comfort = 10 dp, the lot A value).
+    val m = LocalDisplayMetrics.current
     Row(
         modifier = modifier
             .fillMaxWidth()
             .then(rowInteraction)
-            // #287 — denser feed: tighter vertical rhythm on listing rows (12 → 10 dp).
-            .padding(horizontal = 16.dp, vertical = 10.dp),
+            .padding(horizontal = 16.dp, vertical = m.listRowVertical),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/RedfaceTheme.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/RedfaceTheme.kt
@@ -6,17 +6,25 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalContext
+import fr.forumhfr.redface2.core.ui.theme.DisplayMetrics
+import fr.forumhfr.redface2.core.ui.theme.LocalDisplayMetrics
+import fr.forumhfr.redface2.core.ui.theme.ReadingDisplaySettings
 import fr.forumhfr.redface2.core.ui.theme.RedfaceAmoledColorScheme
 import fr.forumhfr.redface2.core.ui.theme.RedfaceDarkColorScheme
 import fr.forumhfr.redface2.core.ui.theme.RedfaceLightColorScheme
 import fr.forumhfr.redface2.core.ui.theme.RedfaceShapes
 import fr.forumhfr.redface2.core.ui.theme.RedfaceTypography
+import fr.forumhfr.redface2.core.ui.theme.scaledForReading
 
 @Composable
 fun RedfaceTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     amoledTheme: Boolean = false,
+    // #287 — reading presets (density + font scale) bundled into one param to keep the parameter
+    // list within detekt's LongParameterList budget.
+    reading: ReadingDisplaySettings = ReadingDisplaySettings(),
     dynamicColor: Boolean = false,
     content: @Composable () -> Unit,
 ) {
@@ -29,10 +37,15 @@ fun RedfaceTheme(
         else -> RedfaceLightColorScheme
     }
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = RedfaceTypography,
-        shapes = RedfaceShapes,
-        content = content,
-    )
+    CompositionLocalProvider(
+        LocalDisplayMetrics provides DisplayMetrics.of(reading.density),
+    ) {
+        MaterialTheme(
+            colorScheme = colorScheme,
+            // #287 — scale the reading typography by the font-size preset (identity at M).
+            typography = RedfaceTypography.scaledForReading(reading.fontScale.factor),
+            shapes = RedfaceShapes,
+            content = content,
+        )
+    }
 }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/DisplayMetrics.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/DisplayMetrics.kt
@@ -1,0 +1,63 @@
+package fr.forumhfr.redface2.core.ui.theme
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
+
+/**
+ * Structural spacing metrics driven by the [DisplayDensity] preset (#287 lot B).
+ *
+ * Only the listing-row and post-card paddings that govern the reading rhythm are exposed here;
+ * absolute chrome dimensions (gutters, FAB clearance) stay hard-coded where they live. Marked
+ * [Immutable] so Compose treats the value as stable — providing it through a CompositionLocal
+ * does not churn recompositions of readers when the preset does not change.
+ *
+ * [Comfort] reproduces EXACTLY the paddings shipped by the #398 structural pass (lot A), so the
+ * default preset is a no-op visual change relative to the current build.
+ */
+@Immutable
+data class DisplayMetrics(
+    val cardBodyHorizontal: Dp,
+    val cardBodyTop: Dp,
+    val cardBodyBottom: Dp,
+    val cardHeaderVertical: Dp,
+    val listRowVertical: Dp,
+    val postSpacing: Dp,
+) {
+    companion object {
+        /** Historical rhythm (lot A): unchanged default. */
+        val Comfort = DisplayMetrics(
+            cardBodyHorizontal = 12.dp,
+            cardBodyTop = 10.dp,
+            cardBodyBottom = 8.dp,
+            cardHeaderVertical = 6.dp,
+            listRowVertical = 10.dp,
+            postSpacing = 8.dp,
+        )
+
+        /** Denser feed (#287 beta feedback). */
+        val Compact = DisplayMetrics(
+            cardBodyHorizontal = 10.dp,
+            cardBodyTop = 6.dp,
+            cardBodyBottom = 5.dp,
+            cardHeaderVertical = 4.dp,
+            listRowVertical = 6.dp,
+            postSpacing = 4.dp,
+        )
+
+        fun of(density: DisplayDensity): DisplayMetrics = when (density) {
+            DisplayDensity.COMFORT -> Comfort
+            DisplayDensity.COMPACT -> Compact
+        }
+    }
+}
+
+/**
+ * Project CompositionLocal carrying the resolved [DisplayMetrics]. `staticCompositionLocalOf`
+ * (not `compositionLocalOf`): the value changes only when the user switches preset, so we skip
+ * the fine-grained read tracking and accept a single recomposition of the subtree on change.
+ * Defaults to [DisplayMetrics.Comfort] for previews / hosts that do not provide it.
+ */
+val LocalDisplayMetrics = staticCompositionLocalOf { DisplayMetrics.Comfort }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/ReadingDisplaySettings.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/ReadingDisplaySettings.kt
@@ -1,0 +1,18 @@
+package fr.forumhfr.redface2.core.ui.theme
+
+import androidx.compose.runtime.Immutable
+import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
+import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
+
+/**
+ * Bundle of the two #287 reading presets passed to `RedfaceTheme` as a single parameter.
+ *
+ * Grouping [density] and [fontScale] keeps `RedfaceTheme` within detekt's `LongParameterList`
+ * budget (the default threshold would otherwise trip once both presets are wired alongside
+ * darkTheme / amoledTheme / dynamicColor / content). [Immutable] for Compose stability.
+ */
+@Immutable
+data class ReadingDisplaySettings(
+    val density: DisplayDensity = DisplayDensity.COMFORT,
+    val fontScale: FontScalePreference = FontScalePreference.M,
+)

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/Type.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/Type.kt
@@ -4,6 +4,8 @@ import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.unit.sp
 
 private val Sans = FontFamily.SansSerif
@@ -115,3 +117,43 @@ val RedfaceTypography = Typography(
         letterSpacing = 0.5.sp,
     ),
 )
+
+/**
+ * Returns a copy of this [Typography] with the font size and line height of every role multiplied
+ * by [factor] (#287 lot C). [factor] is the `FontScalePreference` multiplier, applied on top of the
+ * OS font zoom (never instead of it).
+ *
+ * `letterSpacing` is NOT scaled: M3 expresses it in `sp` but it is conceptually relative to the
+ * glyph size, so scaling it would double the effect and loosen the tracking unnaturally.
+ *
+ * Short-circuits to `this` when [factor] is `1f` (the M preset), so the default path allocates
+ * nothing and stays referentially identical.
+ */
+fun Typography.scaledForReading(factor: Float): Typography {
+    if (factor == 1f) return this
+    fun TextStyle.scale(): TextStyle = copy(
+        fontSize = fontSize.scaleSp(factor),
+        lineHeight = lineHeight.scaleSp(factor),
+    )
+    return copy(
+        displayLarge = displayLarge.scale(),
+        displayMedium = displayMedium.scale(),
+        displaySmall = displaySmall.scale(),
+        headlineLarge = headlineLarge.scale(),
+        headlineMedium = headlineMedium.scale(),
+        headlineSmall = headlineSmall.scale(),
+        titleLarge = titleLarge.scale(),
+        titleMedium = titleMedium.scale(),
+        titleSmall = titleSmall.scale(),
+        bodyLarge = bodyLarge.scale(),
+        bodyMedium = bodyMedium.scale(),
+        bodySmall = bodySmall.scale(),
+        labelLarge = labelLarge.scale(),
+        labelMedium = labelMedium.scale(),
+        labelSmall = labelSmall.scale(),
+    )
+}
+
+/** Multiplies a specified [TextUnit] by [factor]; an unspecified unit is left untouched. */
+private fun TextUnit.scaleSp(factor: Float): TextUnit =
+    if (isSpecified) (value * factor).sp else this

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/theme/DisplayMetricsTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/theme/DisplayMetricsTest.kt
@@ -1,0 +1,44 @@
+package fr.forumhfr.redface2.core.ui.theme
+
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the [DisplayMetrics.Comfort] preset to the EXACT paddings shipped by the #398 structural
+ * pass (lot A). This is the cheapest guard for the most expensive risk of #287 lot B: editing any
+ * of these numbers (tuning Compact, a refactor, a copy-paste) would silently regress the DEFAULT
+ * rendering with the CI staying green. If a value here must change, it is a deliberate product
+ * decision and this test should change with it.
+ */
+class DisplayMetricsTest {
+
+    @Test
+    fun `Comfort reproduces the lot A shipped rhythm exactly`() {
+        val comfort = DisplayMetrics.Comfort
+        assertEquals(12.dp, comfort.cardBodyHorizontal)
+        assertEquals(10.dp, comfort.cardBodyTop)
+        assertEquals(8.dp, comfort.cardBodyBottom)
+        assertEquals(6.dp, comfort.cardHeaderVertical)
+        assertEquals(10.dp, comfort.listRowVertical)
+        assertEquals(8.dp, comfort.postSpacing)
+    }
+
+    @Test
+    fun `of maps each density to its preset`() {
+        assertEquals(DisplayMetrics.Comfort, DisplayMetrics.of(DisplayDensity.COMFORT))
+        assertEquals(DisplayMetrics.Compact, DisplayMetrics.of(DisplayDensity.COMPACT))
+    }
+
+    @Test
+    fun `Compact is strictly denser than Comfort on every vertical metric`() {
+        val comfort = DisplayMetrics.Comfort
+        val compact = DisplayMetrics.Compact
+        assertEquals(true, compact.cardBodyTop.value < comfort.cardBodyTop.value)
+        assertEquals(true, compact.cardBodyBottom.value < comfort.cardBodyBottom.value)
+        assertEquals(true, compact.cardHeaderVertical.value < comfort.cardHeaderVertical.value)
+        assertEquals(true, compact.listRowVertical.value < comfort.listRowVertical.value)
+        assertEquals(true, compact.postSpacing.value < comfort.postSpacing.value)
+    }
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/theme/TypeTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/theme/TypeTest.kt
@@ -1,0 +1,72 @@
+package fr.forumhfr.redface2.core.ui.theme
+
+import androidx.compose.ui.unit.sp
+import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+/**
+ * Pure-JVM tests for [scaledForReading] (#287 lot C). No Compose runtime needed: it is a pure
+ * transform over [androidx.compose.material3.Typography].
+ */
+class TypeTest {
+
+    @Test
+    fun `FontScalePreference factors are pinned to the shipped reading sizes`() {
+        // The scaling tests below derive their expected values from these factors, so they would
+        // stay green if someone changed a factor — but the app would ship wrong sizes. Pin the
+        // contract here so any enum edit fails loudly (and M must stay exactly 1f for the
+        // short-circuit in scaledForReading to keep firing).
+        assertEquals(0.9f, FontScalePreference.S.factor, EPSILON)
+        assertEquals(1f, FontScalePreference.M.factor, EPSILON)
+        assertEquals(1.15f, FontScalePreference.L.factor, EPSILON)
+    }
+
+    @Test
+    fun `scaledForReading at identity factor returns the same Typography instance`() {
+        // M preset short-circuits — no allocation, referentially identical.
+        assertSame(RedfaceTypography, RedfaceTypography.scaledForReading(FontScalePreference.M.factor))
+    }
+
+    @Test
+    fun `scaledForReading at L multiplies font size and line height of a role`() {
+        val scaled = RedfaceTypography.scaledForReading(FACTOR_L)
+
+        // bodyMedium is 14 sp / 20 sp at the M3 reference; L = 1.15x.
+        assertEquals(14f * FACTOR_L, scaled.bodyMedium.fontSize.value, EPSILON)
+        assertEquals(20f * FACTOR_L, scaled.bodyMedium.lineHeight.value, EPSILON)
+    }
+
+    @Test
+    fun `scaledForReading scales every body role consistently`() {
+        val scaled = RedfaceTypography.scaledForReading(FACTOR_L)
+
+        assertEquals(16f * FACTOR_L, scaled.bodyLarge.fontSize.value, EPSILON)
+        assertEquals(12f * FACTOR_L, scaled.bodySmall.fontSize.value, EPSILON)
+        assertEquals(22f * FACTOR_L, scaled.titleLarge.fontSize.value, EPSILON)
+    }
+
+    @Test
+    fun `scaledForReading leaves letterSpacing untouched`() {
+        val scaled = RedfaceTypography.scaledForReading(FACTOR_L)
+
+        // letterSpacing is conceptually glyph-relative, so it must NOT be multiplied.
+        assertEquals(0.25.sp, scaled.bodyMedium.letterSpacing)
+        assertEquals(RedfaceTypography.bodyLarge.letterSpacing, scaled.bodyLarge.letterSpacing)
+    }
+
+    @Test
+    fun `scaledForReading at S shrinks the reading size`() {
+        val scaled = RedfaceTypography.scaledForReading(FACTOR_S)
+
+        assertEquals(14f * FACTOR_S, scaled.bodyMedium.fontSize.value, EPSILON)
+        assertEquals(20f * FACTOR_S, scaled.bodyMedium.lineHeight.value, EPSILON)
+    }
+
+    private companion object {
+        val FACTOR_S = FontScalePreference.S.factor
+        val FACTOR_L = FontScalePreference.L.factor
+        const val EPSILON = 0.001f
+    }
+}

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -8,7 +8,9 @@ import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
 import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
 import fr.forumhfr.redface2.core.domain.editor.BbcodeValidation
+import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
+import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
@@ -1422,6 +1424,15 @@ class PostEditorViewModelTest {
             MutableStateFlow(StartScreenPreference())
 
         override suspend fun setStartScreen(preference: StartScreenPreference) = Unit
+
+        // #287 — reading display presets are irrelevant to the editor; stubbed at defaults.
+        override fun observeDisplayDensity(): Flow<DisplayDensity> = MutableStateFlow(DisplayDensity.COMFORT)
+
+        override suspend fun setDisplayDensity(density: DisplayDensity) = Unit
+
+        override fun observeFontScale(): Flow<FontScalePreference> = MutableStateFlow(FontScalePreference.M)
+
+        override suspend fun setFontScale(scale: FontScalePreference) = Unit
     }
 
     private companion object {

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -7,7 +7,9 @@ import androidx.compose.ui.text.input.TextFieldValue
 import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
 import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
+import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
+import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
@@ -1275,6 +1277,15 @@ class TopicFormViewModelTest {
             MutableStateFlow(StartScreenPreference())
 
         override suspend fun setStartScreen(preference: StartScreenPreference) = Unit
+
+        // #287 — reading display presets are irrelevant to the topic form; stubbed at defaults.
+        override fun observeDisplayDensity(): Flow<DisplayDensity> = MutableStateFlow(DisplayDensity.COMFORT)
+
+        override suspend fun setDisplayDensity(density: DisplayDensity) = Unit
+
+        override fun observeFontScale(): Flow<FontScalePreference> = MutableStateFlow(FontScalePreference.M)
+
+        override suspend fun setFontScale(scale: FontScalePreference) = Unit
     }
 
     private companion object {

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -12,7 +12,9 @@ import fr.forumhfr.redface2.core.domain.flags.FlagsResult
 import fr.forumhfr.redface2.core.domain.forum.FlagFilterBucket
 import fr.forumhfr.redface2.core.domain.forum.ForumRepository
 import fr.forumhfr.redface2.core.domain.forum.ForumResult
+import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
+import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
@@ -1644,5 +1646,14 @@ class FlagsViewModelTest {
         fun setPerTabOverride(value: Boolean) {
             perTab.value = value
         }
+
+        // #287 — reading display presets are irrelevant to FlagsViewModel; stubbed at defaults.
+        override fun observeDisplayDensity(): Flow<DisplayDensity> = MutableStateFlow(DisplayDensity.COMFORT)
+
+        override suspend fun setDisplayDensity(density: DisplayDensity) = Unit
+
+        override fun observeFontScale(): Flow<FontScalePreference> = MutableStateFlow(FontScalePreference.M)
+
+        override suspend fun setFontScale(scale: FontScalePreference) = Unit
     }
 }

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
@@ -53,6 +53,7 @@ import fr.forumhfr.redface2.core.model.TopicSummary
 import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.formatLastReplyTimestamp
 import fr.forumhfr.redface2.core.ui.theme.FlagPalette
+import fr.forumhfr.redface2.core.ui.theme.LocalDisplayMetrics
 
 /**
  * Per-category screen: chip row of subcategories ("Toutes" + each subcat) on top, list
@@ -408,6 +409,8 @@ private fun TopicRow(
     } else {
         MaterialTheme.colorScheme.onSurfaceVariant
     }
+    // #287 — listing-row vertical rhythm from the density preset (Comfort = 10 dp, the lot A value).
+    val m = LocalDisplayMetrics.current
     val rowModifier = Modifier
         .fillMaxWidth()
         .then(
@@ -420,8 +423,7 @@ private fun TopicRow(
             },
         )
         .clickable(onClick = onClick)
-        // #287 — denser feed: tighter vertical rhythm on listing rows (12 → 10 dp).
-        .padding(horizontal = 24.dp, vertical = 10.dp)
+        .padding(horizontal = 24.dp, vertical = m.listRowVertical)
     Row(
         modifier = rowModifier,
         verticalAlignment = Alignment.CenterVertically,

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -43,6 +43,8 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
+import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 
 @Composable
@@ -227,9 +229,12 @@ internal fun SettingsContent(
                 state = state,
                 onIntent = onIntent,
             )
+            DisplayPreferencesCard(
+                state = state,
+                onIntent = onIntent,
+            )
             FutureSettingsCard(
                 items = listOf(
-                    R.string.settings_future_reading_density to issueTag(287),
                     R.string.settings_future_ui_colors to issueTag(296),
                     R.string.settings_future_material_you to stringResource(R.string.settings_phase_future),
                     R.string.settings_future_classic_theme to stringResource(R.string.settings_phase_future_far),
@@ -465,6 +470,80 @@ private fun ThemePreferencesCard(
             )
             if (state.amoledError) {
                 PreferencePersistError(R.string.settings_theme_amoled_persist_failed)
+            }
+        }
+    }
+}
+
+/**
+ * Reading display presets (#287): a density preset (Confort / Compact, structural spacing) and a
+ * reading font-size preset (S / M / L). Both are persisted via DataStore and observed at the app
+ * root, so a change here re-themes the whole app live. Text-only segmented buttons (no Material
+ * icons — the `androidx.compose.material.*` import is forbidden project-wide).
+ */
+@Composable
+private fun DisplayPreferencesCard(
+    state: SettingsState,
+    onIntent: (SettingsIntent) -> Unit,
+) {
+    val densityOptions = listOf(
+        DisplayDensity.COMFORT to stringResource(R.string.settings_display_density_comfort),
+        DisplayDensity.COMPACT to stringResource(R.string.settings_display_density_compact),
+    )
+    val fontScaleOptions = listOf(
+        FontScalePreference.S to stringResource(R.string.settings_display_font_scale_small),
+        FontScalePreference.M to stringResource(R.string.settings_display_font_scale_medium),
+        FontScalePreference.L to stringResource(R.string.settings_display_font_scale_large),
+    )
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_display_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = stringResource(R.string.settings_display_density_intro),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                densityOptions.forEachIndexed { index, (density, label) ->
+                    SegmentedButton(
+                        selected = state.displayDensity == density,
+                        enabled = state.canChangeDisplayDensity,
+                        onClick = { onIntent(SettingsIntent.DisplayDensityChanged(density)) },
+                        shape = SegmentedButtonDefaults.itemShape(index = index, count = densityOptions.size),
+                    ) {
+                        Text(label)
+                    }
+                }
+            }
+            if (state.displayDensityError) {
+                PreferencePersistError(R.string.settings_display_density_persist_failed)
+            }
+            Text(
+                text = stringResource(R.string.settings_display_font_scale_intro),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                fontScaleOptions.forEachIndexed { index, (scale, label) ->
+                    SegmentedButton(
+                        selected = state.fontScale == scale,
+                        enabled = state.canChangeFontScale,
+                        onClick = { onIntent(SettingsIntent.FontScaleChanged(scale)) },
+                        shape = SegmentedButtonDefaults.itemShape(index = index, count = fontScaleOptions.size),
+                    ) {
+                        Text(label)
+                    }
+                }
+            }
+            if (state.fontScaleError) {
+                PreferencePersistError(R.string.settings_display_font_scale_persist_failed)
             }
         }
     }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -1,5 +1,7 @@
 package fr.forumhfr.redface2.feature.settings
 
+import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
+import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 
 data class SettingsState(
@@ -115,6 +117,19 @@ data class SettingsState(
     val isUpdatingFlagsAutoRefresh: Boolean = false,
     val flagsAutoRefreshError: Boolean = false,
     val flagsAutoRefreshTouchedLocally: Boolean = false,
+    // Reading display presets (#287). Same optimistic-flip + startup-race-guard machinery as the
+    // theme controls (both are enums, so the bespoke shape): the value is the displayed selection,
+    // `isUpdating*` gates the control while DataStore writes, `*Error` surfaces a persist failure,
+    // `*TouchedLocally` forbids a late `init` hydration from clobbering a fast user change. Defaults
+    // match the DataStore defaults (COMFORT density, M font scale).
+    val displayDensity: DisplayDensity = DisplayDensity.COMFORT,
+    val isUpdatingDisplayDensity: Boolean = false,
+    val displayDensityError: Boolean = false,
+    val displayDensityTouchedLocally: Boolean = false,
+    val fontScale: FontScalePreference = FontScalePreference.M,
+    val isUpdatingFontScale: Boolean = false,
+    val fontScaleError: Boolean = false,
+    val fontScaleTouchedLocally: Boolean = false,
 ) {
     val canSave: Boolean
         get() = !isSaving
@@ -173,6 +188,13 @@ data class SettingsState(
     // #378 — flags auto-refresh, gated only by its own write.
     val canToggleFlagsAutoRefresh: Boolean
         get() = !isUpdatingFlagsAutoRefresh
+
+    // #287 — the reading-density / font-scale selectors are each gated only by their own write.
+    val canChangeDisplayDensity: Boolean
+        get() = !isUpdatingDisplayDensity
+
+    val canChangeFontScale: Boolean
+        get() = !isUpdatingFontScale
 }
 
 sealed interface SettingsError {
@@ -266,4 +288,9 @@ sealed interface SettingsIntent {
     // Drapeaux — #378 auto-refresh on landing. Optimistic-flip contract, like the flags
     // toggles: the boolean is the desired post-flip state.
     data class FlagsAutoRefreshChanged(val enabled: Boolean) : SettingsIntent
+
+    // #287 — reading display presets. `density` / `scale` are the desired selections, applied
+    // optimistically with revert-on-failure, like ThemeModeChanged.
+    data class DisplayDensityChanged(val density: DisplayDensity) : SettingsIntent
+    data class FontScaleChanged(val scale: FontScalePreference) : SettingsIntent
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.cache.ImageCacheMaintenance
 import fr.forumhfr.redface2.core.domain.cache.TopicCacheMaintenance
+import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
+import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
@@ -16,6 +18,11 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
+// Flat MVI dispatcher: one small, near-identical optimistic-flip handler per user preference.
+// The size comes from breadth (many independent settings live here cohesively), not from deep
+// logic — same reason `submit()` carries @Suppress("CyclomaticComplexMethod"). A generic
+// `updateEnumPreference` helper could fold the enum handlers together later (see PR notes).
+@Suppress("LargeClass")
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val userPreferencesRepository: UserPreferencesRepository,
@@ -101,6 +108,16 @@ class SettingsViewModel @Inject constructor(
             isLocked = { it.flagsAutoRefreshTouchedLocally || it.isUpdatingFlagsAutoRefresh },
             apply = { state, value -> state.copy(flagsAutoRefresh = value) },
         )
+        hydratePreference(
+            read = { userPreferencesRepository.observeDisplayDensity().first() },
+            isLocked = { it.displayDensityTouchedLocally || it.isUpdatingDisplayDensity },
+            apply = { state, value -> state.copy(displayDensity = value) },
+        )
+        hydratePreference(
+            read = { userPreferencesRepository.observeFontScale().first() },
+            isLocked = { it.fontScaleTouchedLocally || it.isUpdatingFontScale },
+            apply = { state, value -> state.copy(fontScale = value) },
+        )
     }
 
     /**
@@ -166,6 +183,8 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.ShowDtSectionChanged -> updateShowDtSection(intent.enabled)
             is SettingsIntent.ConfirmBeforePostingChanged -> updateConfirmBeforePosting(intent.enabled)
             is SettingsIntent.FlagsAutoRefreshChanged -> updateFlagsAutoRefresh(intent.enabled)
+            is SettingsIntent.DisplayDensityChanged -> updateDisplayDensity(intent.density)
+            is SettingsIntent.FontScaleChanged -> updateFontScale(intent.scale)
         }
     }
 
@@ -413,6 +432,63 @@ class SettingsViewModel @Inject constructor(
                             themeMode = previous,
                             isUpdatingThemeMode = false,
                             themeModeError = true,
+                        )
+                    }
+                }
+        }
+    }
+
+    // #287 — display density is an enum, so it uses the bespoke optimistic-flip shape (like
+    // updateThemeMode) rather than updateBooleanPreference. previous is captured for revert.
+    private fun updateDisplayDensity(desired: DisplayDensity) {
+        val previous = _state.value.displayDensity
+        _state.update {
+            it.copy(
+                displayDensity = desired,
+                isUpdatingDisplayDensity = true,
+                displayDensityError = false,
+                displayDensityTouchedLocally = true,
+            )
+        }
+        viewModelScope.launch {
+            runCatching { userPreferencesRepository.setDisplayDensity(desired) }
+                .onSuccess {
+                    _state.update { it.copy(displayDensity = desired, isUpdatingDisplayDensity = false) }
+                }
+                .onFailure {
+                    _state.update {
+                        it.copy(
+                            displayDensity = previous,
+                            isUpdatingDisplayDensity = false,
+                            displayDensityError = true,
+                        )
+                    }
+                }
+        }
+    }
+
+    // #287 — font scale is an enum too; same bespoke optimistic-flip shape as updateDisplayDensity.
+    private fun updateFontScale(desired: FontScalePreference) {
+        val previous = _state.value.fontScale
+        _state.update {
+            it.copy(
+                fontScale = desired,
+                isUpdatingFontScale = true,
+                fontScaleError = false,
+                fontScaleTouchedLocally = true,
+            )
+        }
+        viewModelScope.launch {
+            runCatching { userPreferencesRepository.setFontScale(desired) }
+                .onSuccess {
+                    _state.update { it.copy(fontScale = desired, isUpdatingFontScale = false) }
+                }
+                .onFailure {
+                    _state.update {
+                        it.copy(
+                            fontScale = previous,
+                            isUpdatingFontScale = false,
+                            fontScaleError = true,
                         )
                     }
                 }

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -37,7 +37,6 @@
     <string name="settings_phase_5">Phase 5</string>
     <!-- Pastille de tag d'un réglage à venir rattaché à une issue GitHub (identifiant technique). -->
     <string name="settings_future_issue_tag">#%1$d</string>
-    <string name="settings_future_reading_density">Densité et compacité de lecture</string>
     <string name="settings_future_ui_colors">Personnalisation des couleurs</string>
     <string name="settings_future_material_you">Material You (thème dynamique)</string>
     <string name="settings_future_classic_theme">Thème HFR Classique</string>
@@ -140,6 +139,20 @@
     <string name="settings_theme_amoled_title">Thème AMOLED (vrai noir)</string>
     <string name="settings_theme_amoled_description">Fond noir pur pour les écrans OLED. S\'applique uniquement en thème sombre.</string>
     <string name="settings_theme_amoled_persist_failed">Impossible de mémoriser le réglage AMOLED. Réessayez.</string>
+
+    <!-- #287 — Préréglages de lecture. Densité (Confort/Compact = espacement des listes et des
+         messages) + taille de la police de lecture (S/M/L, appliquée en plus du zoom du système),
+         persistés en DataStore et appliqués à toute l'app en direct. -->
+    <string name="settings_display_title">Densité et police de lecture</string>
+    <string name="settings_display_density_intro">Réglez l\'espacement des listes et des messages.</string>
+    <string name="settings_display_density_comfort">Confort</string>
+    <string name="settings_display_density_compact">Compact</string>
+    <string name="settings_display_density_persist_failed">Impossible de mémoriser la densité. Réessayez.</string>
+    <string name="settings_display_font_scale_intro">Taille de la police de lecture. Elle s\'ajoute au zoom du système.</string>
+    <string name="settings_display_font_scale_small">Petite</string>
+    <string name="settings_display_font_scale_medium">Moyenne</string>
+    <string name="settings_display_font_scale_large">Grande</string>
+    <string name="settings_display_font_scale_persist_failed">Impossible de mémoriser la taille de police. Réessayez.</string>
 
     <!-- Build 89 follow-up — Lecture des sujets. Masquer la barre du haut (titre + numéro de page)
          en défilant vers le bas pour libérer de la place ; persisté en DataStore et appliqué en direct. -->

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -2,7 +2,9 @@ package fr.forumhfr.redface2.feature.settings
 
 import fr.forumhfr.redface2.core.domain.cache.ImageCacheMaintenance
 import fr.forumhfr.redface2.core.domain.cache.TopicCacheMaintenance
+import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
+import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
@@ -734,6 +736,75 @@ class SettingsViewModelTest {
     }
 
     @Test
+    fun `init hydrates reading display presets from storage`() = runTest {
+        repository.emitDisplayDensity(DisplayDensity.COMPACT)
+        repository.emitFontScale(FontScalePreference.L)
+
+        val viewModel = newViewModel()
+        val state = viewModel.state.value
+
+        assertEquals(DisplayDensity.COMPACT, state.displayDensity)
+        assertEquals(FontScalePreference.L, state.fontScale)
+    }
+
+    @Test
+    fun `DisplayDensityChanged persists the new preset and clears the updating flag`() = runTest {
+        val viewModel = newViewModel()
+        assertEquals("COMFORT is the default", DisplayDensity.COMFORT, viewModel.state.value.displayDensity)
+
+        viewModel.submit(SettingsIntent.DisplayDensityChanged(DisplayDensity.COMPACT))
+
+        val state = viewModel.state.value
+        assertEquals(DisplayDensity.COMPACT, state.displayDensity)
+        assertFalse(state.isUpdatingDisplayDensity)
+        assertFalse(state.displayDensityError)
+        assertEquals(1, repository.displayDensitySetCalls)
+        assertEquals(DisplayDensity.COMPACT, repository.lastDisplayDensitySet)
+    }
+
+    @Test
+    fun `DisplayDensityChanged reverts to the previous preset and raises the error flag on persist failure`() =
+        runTest {
+            repository.failOnDisplayDensitySet = true
+            val viewModel = newViewModel()
+
+            viewModel.submit(SettingsIntent.DisplayDensityChanged(DisplayDensity.COMPACT))
+
+            val state = viewModel.state.value
+            assertEquals("must revert to the previous preset on failure", DisplayDensity.COMFORT, state.displayDensity)
+            assertFalse(state.isUpdatingDisplayDensity)
+            assertTrue(state.displayDensityError)
+        }
+
+    @Test
+    fun `FontScaleChanged persists the new preset and clears the updating flag`() = runTest {
+        val viewModel = newViewModel()
+        assertEquals("M is the default", FontScalePreference.M, viewModel.state.value.fontScale)
+
+        viewModel.submit(SettingsIntent.FontScaleChanged(FontScalePreference.L))
+
+        val state = viewModel.state.value
+        assertEquals(FontScalePreference.L, state.fontScale)
+        assertFalse(state.isUpdatingFontScale)
+        assertFalse(state.fontScaleError)
+        assertEquals(1, repository.fontScaleSetCalls)
+        assertEquals(FontScalePreference.L, repository.lastFontScaleSet)
+    }
+
+    @Test
+    fun `FontScaleChanged reverts to the previous preset and raises the error flag on persist failure`() = runTest {
+        repository.failOnFontScaleSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.FontScaleChanged(FontScalePreference.S))
+
+        val state = viewModel.state.value
+        assertEquals("must revert to the previous preset on failure", FontScalePreference.M, state.fontScale)
+        assertFalse(state.isUpdatingFontScale)
+        assertTrue(state.fontScaleError)
+    }
+
+    @Test
     fun `TopicTopBarAutoHideChanged persists the flip`() = runTest {
         val viewModel = newViewModel()
         assertFalse("auto-hide is off by default", viewModel.state.value.topicTopBarAutoHide)
@@ -973,6 +1044,59 @@ class SettingsViewModelTest {
             assertEquals(ThemeMode.DARK, repository.lastThemeModeSet)
         }
 
+    @Test
+    fun `displayDensity hydration race - a stale initial emission must not overwrite a local change`() =
+        runTest {
+            // Same startup-race contract as ThemeMode (#287): the user picks COMPACT while init is
+            // still suspended on observeDisplayDensity().first(); the late stale COMFORT must be
+            // skipped by the touchedLocally guard.
+            val initialHydrationFlow = MutableSharedFlow<DisplayDensity>(replay = 0)
+            repository.displayDensityObserveOverride = initialHydrationFlow
+            val viewModel = newViewModel()
+
+            viewModel.submit(SettingsIntent.DisplayDensityChanged(DisplayDensity.COMPACT))
+            assertEquals(DisplayDensity.COMPACT, viewModel.state.value.displayDensity)
+            assertTrue(viewModel.state.value.displayDensityTouchedLocally)
+
+            initialHydrationFlow.emit(DisplayDensity.COMFORT)
+
+            val finalState = viewModel.state.value
+            assertEquals(
+                "stale hydration must NOT overwrite the local density change",
+                DisplayDensity.COMPACT,
+                finalState.displayDensity,
+            )
+            assertFalse(finalState.isUpdatingDisplayDensity)
+            assertFalse(finalState.displayDensityError)
+            assertEquals(1, repository.displayDensitySetCalls)
+            assertEquals(DisplayDensity.COMPACT, repository.lastDisplayDensitySet)
+        }
+
+    @Test
+    fun `fontScale hydration race - a stale initial emission must not overwrite a local change`() =
+        runTest {
+            val initialHydrationFlow = MutableSharedFlow<FontScalePreference>(replay = 0)
+            repository.fontScaleObserveOverride = initialHydrationFlow
+            val viewModel = newViewModel()
+
+            viewModel.submit(SettingsIntent.FontScaleChanged(FontScalePreference.L))
+            assertEquals(FontScalePreference.L, viewModel.state.value.fontScale)
+            assertTrue(viewModel.state.value.fontScaleTouchedLocally)
+
+            initialHydrationFlow.emit(FontScalePreference.M)
+
+            val finalState = viewModel.state.value
+            assertEquals(
+                "stale hydration must NOT overwrite the local font-scale change",
+                FontScalePreference.L,
+                finalState.fontScale,
+            )
+            assertFalse(finalState.isUpdatingFontScale)
+            assertFalse(finalState.fontScaleError)
+            assertEquals(1, repository.fontScaleSetCalls)
+            assertEquals(FontScalePreference.L, repository.lastFontScaleSet)
+        }
+
     private fun newViewModel(): SettingsViewModel =
         SettingsViewModel(repository, topicCacheMaintenance, imageCacheMaintenance)
 
@@ -1102,6 +1226,55 @@ class SettingsViewModelTest {
             amoledSetCalls += 1
             check(!failOnAmoledSet) { "boom" }
             amoledEnabled.value = enabled
+        }
+
+        // #287 — reading display presets. Same optimistic-flip seams as the theme controls.
+        private val displayDensity = MutableStateFlow(DisplayDensity.COMFORT)
+        var displayDensitySetCalls: Int = 0
+            private set
+        var lastDisplayDensitySet: DisplayDensity? = null
+            private set
+        var failOnDisplayDensitySet: Boolean = false
+
+        /** Startup-race seam, mirroring [themeModeObserveOverride] (#287). */
+        var displayDensityObserveOverride: Flow<DisplayDensity>? = null
+
+        override fun observeDisplayDensity(): Flow<DisplayDensity> =
+            displayDensityObserveOverride ?: displayDensity
+
+        override suspend fun setDisplayDensity(density: DisplayDensity) {
+            displayDensitySetCalls += 1
+            check(!failOnDisplayDensitySet) { "boom" }
+            lastDisplayDensitySet = density
+            displayDensity.value = density
+        }
+
+        fun emitDisplayDensity(value: DisplayDensity) {
+            displayDensity.value = value
+        }
+
+        private val fontScale = MutableStateFlow(FontScalePreference.M)
+        var fontScaleSetCalls: Int = 0
+            private set
+        var lastFontScaleSet: FontScalePreference? = null
+            private set
+        var failOnFontScaleSet: Boolean = false
+
+        /** Startup-race seam, mirroring [themeModeObserveOverride] (#287). */
+        var fontScaleObserveOverride: Flow<FontScalePreference>? = null
+
+        override fun observeFontScale(): Flow<FontScalePreference> =
+            fontScaleObserveOverride ?: fontScale
+
+        override suspend fun setFontScale(scale: FontScalePreference) {
+            fontScaleSetCalls += 1
+            check(!failOnFontScaleSet) { "boom" }
+            lastFontScaleSet = scale
+            fontScale.value = scale
+        }
+
+        fun emitFontScale(value: FontScalePreference) {
+            fontScale.value = value
         }
 
         // Build 89 follow-up — topic top-bar auto-hide. Same optimistic-flip seam as amoled.

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -83,6 +83,7 @@ import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.list.LazyListScrollbar
 import fr.forumhfr.redface2.core.ui.pager.pageSwipeEdgeHint
 import fr.forumhfr.redface2.core.ui.post.PostRenderer
+import fr.forumhfr.redface2.core.ui.theme.LocalDisplayMetrics
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -1337,6 +1338,8 @@ private fun TopicPostCard(
      */
     multiQuoteSelected: Boolean = false,
 ) {
+    // #287 — structural spacing from the active density preset (Comfort = the historical rhythm).
+    val m = LocalDisplayMetrics.current
     Card(
         border = if (multiQuoteSelected) {
             BorderStroke(width = 2.dp, color = MaterialTheme.colorScheme.primary)
@@ -1409,7 +1412,8 @@ private fun TopicPostCard(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 12.dp, vertical = 6.dp),
+                    // #287 — header band vertical padding tightens under the Compact preset.
+                    .padding(horizontal = 12.dp, vertical = m.cardHeaderVertical),
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 // Centre the avatar against the name+date block so the identity line reads as one
                 // tidy unit (the previous Top alignment + the inflated pseudo made the pseudo look
@@ -1520,10 +1524,16 @@ private fun TopicPostCard(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                // 12 dp inner gutters (was 16) — combined with the list's 8 dp this buys the
-                // post body ~24 dp of extra reading width per line on a phone.
-                .padding(start = 12.dp, top = 10.dp, end = 12.dp, bottom = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+                // #287 — post-body inner gutters from the density preset. Comfort = the lot A
+                // values (12/10/12/8) that buy the body ~24 dp of extra reading width per line;
+                // Compact tightens them for a denser feed.
+                .padding(
+                    start = m.cardBodyHorizontal,
+                    top = m.cardBodyTop,
+                    end = m.cardBodyHorizontal,
+                    bottom = m.cardBodyBottom,
+                ),
+            verticalArrangement = Arrangement.spacedBy(m.postSpacing),
         ) {
             // #281 — topic posts are selectable/copyable (opt-in; default is OFF in PostRenderer).
             PostRenderer(content = post.content, selectable = true)

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -4,7 +4,9 @@ import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.domain.error.HfrServerException
+import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
+import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
@@ -1382,4 +1384,13 @@ private class FakeUserPreferencesRepository(
         MutableStateFlow(StartScreenPreference())
 
     override suspend fun setStartScreen(preference: StartScreenPreference) = Unit
+
+    // #287 — reading display presets are irrelevant to TopicViewModel; stubbed at defaults.
+    override fun observeDisplayDensity(): Flow<DisplayDensity> = MutableStateFlow(DisplayDensity.COMFORT)
+
+    override suspend fun setDisplayDensity(density: DisplayDensity) = Unit
+
+    override fun observeFontScale(): Flow<FontScalePreference> = MutableStateFlow(FontScalePreference.M)
+
+    override suspend fun setFontScale(scale: FontScalePreference) = Unit
 }


### PR DESCRIPTION
## Lot B+C de #287 — préréglages d'affichage de lecture

Second et dernier lot de #287 (après le Lot A #468 : gouttière #398 + premier cran de densité). Ajoute deux réglages persistés et appliqués en direct.

### Densité — Confort / Compact
- Enum `DisplayDensity { COMFORT, COMPACT }` (`:core:domain`).
- `DisplayMetrics` (`@Immutable`) exposé via `LocalDisplayMetrics` (`staticCompositionLocalOf`) — rythme vertical des lignes de listing, paddings du corps de post, espacement inter-éléments.
- **Invariant anti-régression** : `DisplayMetrics.Comfort` reproduit **exactement** les valeurs shippées par le Lot A (lignes 10 dp, corps 12/10/12/8, spacing 8) → le rendu par défaut ne change pas au merge. Compact densifie ces verticaux.
- Consommé par `TopicScreen` (corps + spacing + header band), `FlagItem`, `ForumCategoryScreen`.

### Police de lecture — S / M / L
- Enum `FontScalePreference { S(0.9), M(1.0), L(1.15) }`.
- `Typography.scaledForReading(factor)` scale `fontSize` **et** `lineHeight` de chaque rôle M3 (pas le `letterSpacing`, relatif ; short-circuit `factor == 1f`). Appliqué via `MaterialTheme(typography = …)`.
- **Ne touche pas `LocalDensity.fontScale`** (le zoom OS d'accessibilité) : le cran produit se compose multiplicativement par-dessus, sans écraser le zoom système ni double-compter les caps média des smileys (lus par `PostRenderer`).

### Plomberie
- `RedfaceTheme` prend un seul param `reading: ReadingDisplaySettings(density, fontScale)` (regroupé pour rester ≤ 5 params — `LongParameterList`).
- DataStore : clés `display_density`/`font_scale`, lectures défensives (valeur corrompue → défaut), `distinctUntilChanged`. `AppThemeViewModel` expose les deux flux ; `RedfaceNavigation` les collecte et les passe au thème.
- Paramètres : `DisplayPreferencesCard` (2 `SingleChoiceSegmentedButtonRow` — Confort/Compact + S/M/L), avec la mécanique optimiste + revert-sur-échec des autres réglages. La ligne « densité de lecture (à venir) » est retirée de `FutureSettingsCard`.

### Revue & validation
- **Codex** + **workflow 4-lentilles** (5 agents Opus) sur le diff.
- Docker (image pin) : `detektAll` + `test` + `:app:assembleProdDebug` + `:app:lintProdDebug` verts.
- Tests : `TypeTest` (scaling exact, identité `factor==1f`, `letterSpacing` inchangé), DataStore round-trip + valeur corrompue, `SettingsViewModel` flip + revert.

### Note (charte « pas de décision silencieuse »)
`@Suppress("LargeClass")` ajouté sur `SettingsViewModel` (dispatcher MVI plat, un handler par préférence). Follow-up possible : un helper générique `updateEnumPreference` pour folder les handlers enum (theme/densité/police) et réduire la duplication.

### Suivi
refs-#287 — **clôt le périmètre #287** (Lot A + Lot B+C). Fermeture à la promotion dev→main.

> Action par Claude Fable 5 (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)