### PR TITLE
feat(topic): bouton « + » multi-quote par post (refs-#436)

### DIFF
--- a/feature/topic/build.gradle.kts
+++ b/feature/topic/build.gradle.kts
@@ -14,6 +14,10 @@ android {
             // no-ops in JVM tests instead of throwing "not mocked". Same convention as
             // :core:network and :core:data.
             isReturnDefaultValues = true
+            // #436 — TopicPostCardMultiQuoteTest mounts the card via `createComposeRule()` and
+            // reads `stringResource`, so the host activity needs the merged Android resources at
+            // JVM unit-test time. Same convention as :core:ui (Compose UI tests).
+            isIncludeAndroidResources = true
         }
     }
 }
@@ -38,4 +42,15 @@ dependencies {
     testImplementation(libs.junit4)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.turbine)
+    // #436 — Robolectric hosts `createComposeRule()` on the JVM so TopicPostCardMultiQuoteTest
+    // can exercise the per-post « + » affordance (gating, label flip, tap callback) without a
+    // device. Non-roborazzi (no screenshot baseline), so the AGP-9 roborazzi plugin gap does not
+    // apply. The BOM aligns the ui-test artifacts with the production Compose versions; the
+    // ui-test-manifest (debug-only) pulls the Activity surrogate the rule mounts internally.
+    // Same harness as :core:ui.
+    testImplementation(platform(libs.androidx.compose.bom))
+    testImplementation(libs.androidx.compose.ui.test.junit4)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.test.core)
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -947,10 +947,18 @@ private fun TopicLoadedContent(
             // pinned topics ship them as `md_noclass_cryptlink`, cf. #227) no longer
             // hides Citer. `quoteRef` is forwarded when known (positional, cosmetic)
             // and may be null — the whole quote chain tolerates it.
-            val quoteAction: (() -> Unit)? = if (shouldShowQuoteAction(topic, state.isAuthenticated)) {
-                { onQuote(topic.subcat, topic.page, post.numreponse, post.quoteRef) }
+            // « Citer » and the « + » multi-quote affordance share ONE gate (multi-quote is a
+            // flavour of quoting : a topic the user cannot reply to has nothing to quote). Deriving
+            // both inside the same branch keeps them in lock-step — they can never drift apart — and
+            // avoids a second decision point in this already-dense list builder.
+            val quoteAction: (() -> Unit)?
+            val multiQuoteToggle: (() -> Unit)?
+            if (shouldShowQuoteAction(topic, state.isAuthenticated)) {
+                quoteAction = { onQuote(topic.subcat, topic.page, post.numreponse, post.quoteRef) }
+                multiQuoteToggle = { onToggleMultiQuote(post.numreponse) }
             } else {
-                null
+                quoteAction = null
+                multiQuoteToggle = null
             }
             // Phase 2D (#147) — « Modifier » is exposed by HFR only on the
             // user's own posts of an unlocked topic. Same canReply gate as
@@ -976,6 +984,10 @@ private fun TopicLoadedContent(
                 onOpenMenu = { menuPost = post },
                 // #436 — same membership source as the menu entry (PostMenuSheet).
                 multiQuoteSelected = post.numreponse in multiQuoteSelection,
+                // #436 — per-post add/remove affordance (RF1 quote+/quote- parity), reachable
+                // without opening the « … » menu. Null/non-null under the SAME gate as « Citer »
+                // (derived together above), so the « + » and « Citer » always appear as a pair.
+                onToggleMultiQuote = multiQuoteToggle,
             )
         }
         // #379 — explicit end-of-topic marker after the last post of the LAST page. The
@@ -1309,8 +1321,15 @@ private fun TopicPollCard(poll: Poll, expandedDefault: Boolean) {
 }
 
 @Composable
-@Suppress("LongParameterList") // state-hoisted Composable : each param has a distinct call-site.
-private fun TopicPostCard(
+// Rich post card : each optional affordance (highlight anchor, multi-quote border + pill + « + »
+// toggle, citation badge, profile tap, contextual menu, edit, quote) is its own guarded branch, so
+// the cyclomatic count is inherently high — same call as PostRenderer. Splitting it would scatter a
+// single visual unit across helpers. LongParameterList : state-hoisted, each param has a distinct
+// call-site.
+@Suppress("LongParameterList", "CyclomaticComplexMethod")
+// `internal` (#436): TopicPostCardMultiQuoteTest mounts the card directly to assert the per-post
+// « + » affordance (gating, label flip, tap). Same visibility relaxation as other tested internals.
+internal fun TopicPostCard(
     post: Post,
     highlighted: Boolean,
     /**
@@ -1337,6 +1356,14 @@ private fun TopicPostCard(
      * container tint compose without colliding.
      */
     multiQuoteSelected: Boolean = false,
+    /**
+     * #436 — toggles this post in/out of the multi-quote basket directly from the card footer
+     * (RF1 quote+/quote- parity), without opening the « … » menu. Null under the same gate as
+     * [onQuote] (a non-postable topic has nothing to quote), so the « + » action and « Citer »
+     * appear together or not at all. The same [multiQuoteSelected] flag drives the glyph/label
+     * here, the border, and the pill — one source of truth, they can never desynchronise.
+     */
+    onToggleMultiQuote: (() -> Unit)? = null,
 ) {
     // #287 — structural spacing from the active density preset (Comfort = the historical rhythm).
     val m = LocalDisplayMetrics.current
@@ -1537,7 +1564,7 @@ private fun TopicPostCard(
         ) {
             // #281 — topic posts are selectable/copyable (opt-in; default is OFF in PostRenderer).
             PostRenderer(content = post.content, selectable = true)
-            if (onQuote != null || onEdit != null) {
+            if (onQuote != null || onEdit != null || onToggleMultiQuote != null) {
                 // Actions row at the bottom of the post card, sober TextButtons
                 // so they stay subordinate to the post content. « Modifier »
                 // (Phase 2D, #147) appears only on the user's own editable posts
@@ -1552,6 +1579,43 @@ private fun TopicPostCard(
                     if (onEdit != null) {
                         TextButton(onClick = onEdit) {
                             Text(text = stringResource(R.string.topic_post_edit))
+                        }
+                    }
+                    if (onToggleMultiQuote != null) {
+                        // #436 — per-post add/remove to the multi-quote basket (RF1
+                        // quote+/quote- parity), next to « Citer » (same gate). The glyph +
+                        // word switch on multiQuoteSelected, echoing the card border + pill.
+                        // The colour (muted onSurfaceVariant when absent, primary when present)
+                        // is a SECONDARY cue : the « + »/« ✓ » glyph and the word change carry
+                        // the state without relying on colour. TalkBack reads the long add/remove
+                        // label via contentDescription, not the terse glyph.
+                        val mqContentDesc = stringResource(
+                            if (multiQuoteSelected) {
+                                R.string.topic_post_menu_multi_quote_remove
+                            } else {
+                                R.string.topic_post_menu_multi_quote_add
+                            },
+                        )
+                        TextButton(
+                            onClick = onToggleMultiQuote,
+                            colors = if (multiQuoteSelected) {
+                                ButtonDefaults.textButtonColors()
+                            } else {
+                                ButtonDefaults.textButtonColors(
+                                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            },
+                            modifier = Modifier.semantics { contentDescription = mqContentDesc },
+                        ) {
+                            Text(
+                                text = stringResource(
+                                    if (multiQuoteSelected) {
+                                        R.string.topic_post_multiquote_remove_short
+                                    } else {
+                                        R.string.topic_post_multiquote_add_short
+                                    },
+                                ),
+                            )
                         }
                     }
                     if (onQuote != null) {

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
@@ -1605,7 +1606,15 @@ internal fun TopicPostCard(
                                     contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
                             },
-                            modifier = Modifier.semantics { contentDescription = mqContentDesc },
+                            // #436 — the contentDescription carries the ACTION (« Ajouter/Retirer
+                            // de la citation multiple »); `selected` carries the STATE so TalkBack
+                            // announces « sélectionné » independently of the action verb (a real
+                            // toggle, not a one-shot button). Sighted state stays non-colour-only
+                            // via the glyph + word + border + pill.
+                            modifier = Modifier.semantics {
+                                contentDescription = mqContentDesc
+                                selected = multiQuoteSelected
+                            },
                         ) {
                             Text(
                                 text = stringResource(

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -27,6 +27,11 @@
     <!-- #362 — per-post contextual menu (post number, permalink copy, edit marker, citations). -->
     <!-- #436 — pastille de la bande d'identité quand le post est au panier multi-quote (#291). -->
     <string name="topic_post_multiquote_selected">Ajouté à la citation</string>
+    <!-- #436 — libellés courts du bouton « + » en pied de carte (parité web quote+/quote-). Le
+         glyphe et le mot basculent avec l'appartenance au panier ; le contentDescription long
+         réutilise topic_post_menu_multi_quote_add/remove pour TalkBack. -->
+    <string name="topic_post_multiquote_add_short">+ Citer</string>
+    <string name="topic_post_multiquote_remove_short">✓ Cité</string>
     <string name="topic_post_menu_action">Options du post</string>
     <string name="topic_post_menu_number">Post n°%1$d</string>
     <string name="topic_post_menu_copy_link">Copier le lien de ce post</string>

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicPostCardMultiQuoteTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicPostCardMultiQuoteTest.kt
@@ -1,0 +1,129 @@
+package fr.forumhfr.redface2.feature.topic
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import fr.forumhfr.redface2.core.model.Post
+import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import java.time.Instant
+
+/**
+ * #436 — the per-post « + » multi-quote affordance in [TopicPostCard]'s footer (RF1 quote+/quote-
+ * parity). The card already received the SELECTED state (border + pill, #436 lot 1) ; this proves
+ * the new ACTION: it shows under the same gate as « Citer », flips its label/contentDescription on
+ * membership, and fires the toggle on tap. Pure UI behaviour — the visibility gate itself
+ * (`shouldShowQuoteAction`) is unit-tested in [TopicActionGatesTest] ; here we pin the wiring that
+ * turns that gate into a tappable control.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@OptIn(ExperimentalTestApi::class)
+class TopicPostCardMultiQuoteTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `unselected post shows the add affordance and a tap fires the toggle`() {
+        var toggles = 0
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                TopicPostCard(
+                    post = samplePost(),
+                    highlighted = false,
+                    citedCount = 0,
+                    onQuote = {},
+                    onEdit = null,
+                    multiQuoteSelected = false,
+                    onToggleMultiQuote = { toggles++ },
+                )
+            }
+        }
+
+        // Visible label = the « add » short form ; TalkBack reads the long menu label.
+        composeTestRule.onNodeWithText(ADD_LABEL).assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription(ADD_DESC)
+            .assertHasClickAction()
+            .performClick()
+        assertEquals(1, toggles)
+    }
+
+    @Test
+    fun `selected post flips the label and contentDescription to remove`() {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                TopicPostCard(
+                    post = samplePost(),
+                    highlighted = false,
+                    citedCount = 0,
+                    onQuote = {},
+                    onEdit = null,
+                    multiQuoteSelected = true,
+                    onToggleMultiQuote = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(REMOVE_LABEL).assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription(REMOVE_DESC).assertIsDisplayed()
+        // The add state must be gone — the control is a single toggle, not two buttons.
+        composeTestRule.onNodeWithText(ADD_LABEL).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a non-quotable post keeps Citer hidden and the add affordance absent`() {
+        // onToggleMultiQuote = null mirrors the call-site gate (quoteAction null → no « + »).
+        // « Citer » is also gated out (onQuote = null), but the row still renders here via onEdit,
+        // so the absence below is a real assertion, not an empty-row artefact.
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                TopicPostCard(
+                    post = samplePost(),
+                    highlighted = false,
+                    citedCount = 0,
+                    onQuote = null,
+                    onEdit = {},
+                    multiQuoteSelected = false,
+                    onToggleMultiQuote = null,
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(ADD_LABEL).assertDoesNotExist()
+        composeTestRule.onNodeWithContentDescription(ADD_DESC).assertDoesNotExist()
+    }
+
+    private fun samplePost(): Post = Post(
+        numreponse = 16244,
+        author = "XaTriX",
+        date = Instant.EPOCH,
+        content = PostContent(blocks = emptyList()),
+        avatarUrl = null,
+        isEditable = false,
+        isOwnPost = false,
+        quotedAuthors = emptyList(),
+        postIndex = null,
+        quoteRef = 1,
+        profileId = null,
+    )
+
+    private companion object {
+        const val ADD_LABEL = "+ Citer"
+        const val REMOVE_LABEL = "✓ Cité"
+        const val ADD_DESC = "Ajouter à la citation multiple"
+        const val REMOVE_DESC = "Retirer de la citation multiple"
+    }
+}

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicPostCardMultiQuoteTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicPostCardMultiQuoteTest.kt
@@ -3,6 +3,8 @@ package fr.forumhfr.redface2.feature.topic
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -57,6 +59,8 @@ class TopicPostCardMultiQuoteTest {
         composeTestRule.onNodeWithText(ADD_LABEL).assertIsDisplayed()
         composeTestRule.onNodeWithContentDescription(ADD_DESC)
             .assertHasClickAction()
+            // #436 — a11y : the toggle exposes its state, not just the action verb.
+            .assertIsNotSelected()
             .performClick()
         assertEquals(1, toggles)
     }
@@ -78,7 +82,9 @@ class TopicPostCardMultiQuoteTest {
         }
 
         composeTestRule.onNodeWithText(REMOVE_LABEL).assertIsDisplayed()
-        composeTestRule.onNodeWithContentDescription(REMOVE_DESC).assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription(REMOVE_DESC)
+            // #436 — a11y : TalkBack hears « sélectionné », not only the « Retirer » verb.
+            .assertIsSelected()
         // The add state must be gone — the control is a single toggle, not two buttons.
         composeTestRule.onNodeWithText(ADD_LABEL).assertDoesNotExist()
     }


### PR DESCRIPTION
## Bouton « + » multi-quote par post (#436, parité RF1)

Suite de #436 lot 1 (marquage visuel des posts au panier, déjà livré). Ce PR ajoute **l'affordance d'action** correspondante : un bouton « + » dans le pied de chaque carte de post pour ajouter/retirer du panier de citation multiple **sans ouvrir le menu « … »**, comme le `quote+`/`quote-` du web et de RF1.

### Comportement
- Bouton en pied de carte, à côté de « Citer », sous **la même gate** que « Citer » (`shouldShowQuoteAction`). Les deux callbacks sont désormais dérivés dans un **seul `if/else`** dans `TopicLoadedContent` → impossibles à désynchroniser.
- État porté par le **glyphe + le mot** (« + Citer » → « ✓ Cité ») et la teinte (muted → primary), en écho à la bordure + pastille du lot 1. La couleur est un indice **secondaire** (pas de signal couleur-only).
- a11y : `contentDescription` = libellé long du menu (« Ajouter/Retirer de la citation multiple ») pour TalkBack, pas le glyphe.
- Le panier (hoisté dans `RedfaceApp`, #291) et la remontée nav sont **inchangés** : le « + » et l'entrée de menu mutent le même panier.

### Détails techniques
- `TopicPostCard` : nouveau param `onToggleMultiQuote` + rendu `TextButton`. `@Suppress("CyclomaticComplexMethod")` justifié (carte riche à 8+ affordances, même motif que `PostRenderer`).
- `TopicLoadedContent` : `quoteAction` + `multiQuoteToggle` dérivés ensemble (un seul point de décision, complexité inchangée).
- `feature/topic` gagne son **1er harness Compose UI** (Robolectric + `createComposeRule`, non-roborazzi → pas de baseline, pas de fragilité plugin AGP 9). `TopicPostCardMultiQuoteTest` : 3 tests (gating, bascule label/desc, tap déclenche le toggle).

### Validation locale
`detektAll` + `test` + `:app:assembleProdDebug` + `:app:lintProdDebug` verts en conteneur (gate complet 2 parties). `TopicPostCardMultiQuoteTest` : 3 tests, 0 échec.

### Hors scope
Point 3 de #436 (« Tout vider » le panier) **non traité ici** — l'issue reste ouverte. Ce PR couvre l'affordance d'ajout/retrait par post.

refs-#436

> Action par Claude Opus 4.8 (demandée par @XaaT)
