### PR TITLE
feat(editor): bouton d'upload d'image dans l'éditeur + insertion [img] (PR2/3, refs-#459)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/AndroidImageUploadReader.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/AndroidImageUploadReader.kt
@@ -1,0 +1,66 @@
+package fr.forumhfr.redface2.core.data.upload
+
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import dagger.hilt.android.qualifiers.ApplicationContext
+import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
+import fr.forumhfr.redface2.core.domain.upload.ImageUpload
+import fr.forumhfr.redface2.core.domain.upload.ImageUploadReader
+import fr.forumhfr.redface2.core.domain.upload.UploadException
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+
+/**
+ * Android [ImageUploadReader] (#459 PR2): resolves a photo-picker `Uri` into the platform-free
+ * [ImageUpload] via [android.content.ContentResolver]. Lives in `:core:data` (an Android library
+ * that already injects `@ApplicationContext`) so the editor ViewModel never touches `Uri` /
+ * `ContentResolver` and stays JVM-unit-testable with a fake reader.
+ *
+ * All I/O hops to [ioDispatcher] (project rule: data sources own their dispatcher). A failure to
+ * open / read the stream is mapped to [UploadException.Network] — the same typed surface the upload
+ * itself uses — so the editor renders one coherent error path. The size cap is NOT enforced here :
+ * the provider owns the per-host limit and throws [UploadException.TooLarge], keeping a single source
+ * of truth for what each host accepts.
+ */
+@Singleton
+internal class AndroidImageUploadReader @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) : ImageUploadReader {
+
+    override suspend fun read(uri: String): ImageUpload = withContext(ioDispatcher) {
+        val parsed = Uri.parse(uri)
+        val resolver = context.contentResolver
+        val mimeType = resolver.getType(parsed) ?: DEFAULT_MIME_TYPE
+        val displayName = resolveDisplayName(parsed)
+        val bytes = runCatching {
+            resolver.openInputStream(parsed)?.use { it.readBytes() }
+                ?: throw IOException("ContentResolver returned no stream for $parsed")
+        }.getOrElse { error -> throw UploadException.Network(error) }
+        ImageUpload(bytes = bytes, mimeType = mimeType, displayName = displayName)
+    }
+
+    /**
+     * Best-effort original file name from the picker's `OpenableColumns.DISPLAY_NAME`. Returns null
+     * when the provider does not expose it (the upload providers then fall back to a constant
+     * filename) ; a query failure is swallowed rather than failing the whole read — the name is
+     * cosmetic, the bytes are what matter.
+     */
+    private fun resolveDisplayName(uri: Uri): String? = runCatching {
+        context.contentResolver
+            .query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+            ?.use { cursor ->
+                val index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (index >= 0 && cursor.moveToFirst()) cursor.getString(index) else null
+            }
+    }.getOrNull()
+
+    private companion object {
+        /** Generic image MIME when the resolver cannot type the content (providers tolerate it). */
+        private const val DEFAULT_MIME_TYPE = "image/*"
+    }
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/AndroidImageUploadReader.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/AndroidImageUploadReader.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.core.data.upload
 
+import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
 import android.provider.OpenableColumns
@@ -8,6 +9,7 @@ import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
 import fr.forumhfr.redface2.core.domain.upload.ImageUpload
 import fr.forumhfr.redface2.core.domain.upload.ImageUploadReader
 import fr.forumhfr.redface2.core.domain.upload.UploadException
+import java.io.ByteArrayOutputStream
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -22,9 +24,10 @@ import kotlinx.coroutines.withContext
  *
  * All I/O hops to [ioDispatcher] (project rule: data sources own their dispatcher). A failure to
  * open / read the stream is mapped to [UploadException.Network] — the same typed surface the upload
- * itself uses — so the editor renders one coherent error path. The size cap is NOT enforced here :
- * the provider owns the per-host limit and throws [UploadException.TooLarge], keeping a single source
- * of truth for what each host accepts.
+ * itself uses — so the editor renders one coherent error path. A hard safety ceiling
+ * ([MAX_READ_BYTES]) bounds the read to avoid an OOM on a pathological input BEFORE the provider can
+ * act ; the per-host accepted size stays the provider's responsibility (it throws
+ * [UploadException.TooLarge] for its own, smaller limit).
  */
 @Singleton
 internal class AndroidImageUploadReader @Inject constructor(
@@ -37,11 +40,33 @@ internal class AndroidImageUploadReader @Inject constructor(
         val resolver = context.contentResolver
         val mimeType = resolver.getType(parsed) ?: DEFAULT_MIME_TYPE
         val displayName = resolveDisplayName(parsed)
-        val bytes = runCatching {
-            resolver.openInputStream(parsed)?.use { it.readBytes() }
-                ?: throw IOException("ContentResolver returned no stream for $parsed")
-        }.getOrElse { error -> throw UploadException.Network(error) }
+        val bytes = readBounded(resolver, parsed)
         ImageUpload(bytes = bytes, mimeType = mimeType, displayName = displayName)
+    }
+
+    /**
+     * Reads the stream in chunks, rejecting anything past [MAX_READ_BYTES] as [UploadException.TooLarge]
+     * BEFORE the whole payload is materialised — so a pathological input fails typed instead of OOM-ing.
+     * Open/read failures map to [UploadException.Network] (same surface as the upload itself).
+     */
+    private fun readBounded(resolver: ContentResolver, uri: Uri): ByteArray = try {
+        resolver.openInputStream(uri)?.use { stream ->
+            val buffer = ByteArrayOutputStream(DEFAULT_BUFFER_SIZE)
+            val chunk = ByteArray(DEFAULT_BUFFER_SIZE)
+            var total = 0L
+            while (true) {
+                val read = stream.read(chunk)
+                if (read < 0) break
+                total += read
+                if (total > MAX_READ_BYTES) throw UploadException.TooLarge(MAX_READ_BYTES)
+                buffer.write(chunk, 0, read)
+            }
+            buffer.toByteArray()
+        } ?: throw IOException("ContentResolver returned no stream for $uri")
+    } catch (e: UploadException) {
+        throw e
+    } catch (e: IOException) {
+        throw UploadException.Network(e)
     }
 
     /**
@@ -62,5 +87,11 @@ internal class AndroidImageUploadReader @Inject constructor(
     private companion object {
         /** Generic image MIME when the resolver cannot type the content (providers tolerate it). */
         private const val DEFAULT_MIME_TYPE = "image/*"
+
+        /**
+         * Hard anti-OOM ceiling (32 MiB) — well above any real photo-picker image, far below the
+         * heap. NOT a per-host policy : the upload providers reject their own (smaller) limits.
+         */
+        private const val MAX_READ_BYTES = 32L * 1024 * 1024
     }
 }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/AndroidImageUploadReader.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/AndroidImageUploadReader.kt
@@ -11,6 +11,7 @@ import fr.forumhfr.redface2.core.domain.upload.ImageUploadReader
 import fr.forumhfr.redface2.core.domain.upload.UploadException
 import java.io.ByteArrayOutputStream
 import java.io.IOException
+import java.io.InputStream
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
@@ -50,23 +51,27 @@ internal class AndroidImageUploadReader @Inject constructor(
      * Open/read failures map to [UploadException.Network] (same surface as the upload itself).
      */
     private fun readBounded(resolver: ContentResolver, uri: Uri): ByteArray = try {
-        resolver.openInputStream(uri)?.use { stream ->
-            val buffer = ByteArrayOutputStream(DEFAULT_BUFFER_SIZE)
-            val chunk = ByteArray(DEFAULT_BUFFER_SIZE)
-            var total = 0L
-            while (true) {
-                val read = stream.read(chunk)
-                if (read < 0) break
-                total += read
-                if (total > MAX_READ_BYTES) throw UploadException.TooLarge(MAX_READ_BYTES)
-                buffer.write(chunk, 0, read)
-            }
-            buffer.toByteArray()
-        } ?: throw IOException("ContentResolver returned no stream for $uri")
+        resolver.openInputStream(uri)?.use { drainBounded(it) }
+            ?: throw IOException("ContentResolver returned no stream for $uri")
     } catch (e: UploadException) {
         throw e
     } catch (e: IOException) {
         throw UploadException.Network(e)
+    }
+
+    /** Copies [stream] into a byte array, throwing [UploadException.TooLarge] past [MAX_READ_BYTES]. */
+    private fun drainBounded(stream: InputStream): ByteArray {
+        val buffer = ByteArrayOutputStream(DEFAULT_BUFFER_SIZE)
+        val chunk = ByteArray(DEFAULT_BUFFER_SIZE)
+        var total = 0L
+        while (true) {
+            val read = stream.read(chunk)
+            if (read < 0) break
+            total += read
+            if (total > MAX_READ_BYTES) throw UploadException.TooLarge(MAX_READ_BYTES)
+            buffer.write(chunk, 0, read)
+        }
+        return buffer.toByteArray()
     }
 
     /**

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/UploadModule.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/UploadModule.kt
@@ -8,6 +8,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
+import fr.forumhfr.redface2.core.domain.upload.ImageUploadReader
 import fr.forumhfr.redface2.core.domain.upload.UploadProvider
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.domain.upload.UploadRepository
@@ -42,6 +43,12 @@ internal interface UploadProviderBindingsModule {
     @Binds
     @Singleton
     fun bindUploadRepository(impl: DefaultUploadRepository): UploadRepository
+
+    // PR2 (#459) — the editor reads the picked Uri's bytes through this seam ; the Android impl
+    // lives here (it needs ContentResolver) so the editor ViewModel stays platform-free.
+    @Binds
+    @Singleton
+    fun bindImageUploadReader(impl: AndroidImageUploadReader): ImageUploadReader
 
     @Binds
     @IntoMap

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/upload/ImageUploadReader.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/upload/ImageUploadReader.kt
@@ -1,0 +1,23 @@
+package fr.forumhfr.redface2.core.domain.upload
+
+/**
+ * Resolves a picked image reference (an opaque `Uri` string handed over by the Android photo picker)
+ * into the platform-free [ImageUpload] the upload providers consume (#459 PR2).
+ *
+ * The seam exists so the editor ViewModel stays platform-free and unit-testable : reading the bytes
+ * needs a `ContentResolver` (`openInputStream` + `getType`), which lives in the Android layer
+ * (`:core:data`). The ViewModel only knows this interface and is tested with a fake. The Screen owns
+ * the picker, gets a `Uri`, and dispatches its `toString()` to the ViewModel ; the ViewModel calls
+ * [read] to obtain the bytes before delegating to [UploadRepository.uploadWithCurrentProvider].
+ */
+interface ImageUploadReader {
+
+    /**
+     * Reads the content behind [uri] (a `Uri.toString()` from the photo picker) into an
+     * [ImageUpload]. Throws [UploadException] on failure — typically [UploadException.Network] for an
+     * I/O error (stream unreadable, content gone) so the ViewModel surfaces it through the same typed
+     * error path as the upload itself. Runs its I/O off the main thread (the implementation hops to
+     * the IO dispatcher, per the project rule that data sources own their dispatcher).
+     */
+    suspend fun read(uri: String): ImageUpload
+}

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeToolbar.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeToolbar.kt
@@ -13,8 +13,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -24,6 +26,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -45,6 +48,8 @@ fun BbcodeToolbar(
     onAction: (BbcodeAction) -> Unit,
     modifier: Modifier = Modifier,
     onImageUrlRequested: (() -> Unit)? = null,
+    onImageUploadRequested: (() -> Unit)? = null,
+    uploading: Boolean = false,
 ) {
     Row(
         modifier = modifier
@@ -60,8 +65,41 @@ fun BbcodeToolbar(
                 onImageUrlRequested = onImageUrlRequested,
             )
         }
+        // #459 PR2 — image-upload affordance, rendered only when the host screen wires the picker
+        // (the post editor) ; MP / topic-form surfaces pass null and keep the toolbar unchanged.
+        onImageUploadRequested?.let { ImageUploadChip(onClick = it, uploading = uploading) }
         ColorChip(onAction = onAction)
     }
+}
+
+/**
+ * #459 PR2 — chip launching the system photo picker (the upload itself is the host ViewModel's job).
+ * While an upload is in flight it shows a small [CircularProgressIndicator] and is disabled so a
+ * second pick cannot race the first. M3-only icon (a `:core:ui` vector + [Icon]) — material-icons is
+ * forbidden by detekt.
+ */
+@Composable
+private fun ImageUploadChip(
+    onClick: () -> Unit,
+    uploading: Boolean,
+) {
+    AssistChip(
+        enabled = !uploading,
+        onClick = onClick,
+        label = { Text(stringResource(R.string.bbcode_action_image_upload)) },
+        leadingIcon = {
+            if (uploading) {
+                CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+            } else {
+                Icon(
+                    painter = painterResource(R.drawable.ic_image_upload),
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        },
+        border = AssistChipDefaults.assistChipBorder(enabled = !uploading),
+    )
 }
 
 /**

--- a/core/ui/src/main/res/drawable/ic_image_upload.xml
+++ b/core/ui/src/main/res/drawable/ic_image_upload.xml
@@ -2,8 +2,7 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
+    android:viewportHeight="24">
     <path
         android:fillColor="#FF000000"
         android:pathData="M5,21q-0.825,0 -1.413,-0.588Q3,19.825 3,19V5q0,-0.825 0.587,-1.413Q4.175,3 5,3h14q0.825,0 1.413,0.587Q21,4.175 21,5v14q0,0.825 -0.587,1.412Q19.825,21 19,21zM5,19h14V5H5zM6,17h12l-3.75,-5 -3,4 -2.25,-3zM13,9q0.425,0 0.713,-0.288Q14,8.425 14,8q0,-0.425 -0.287,-0.713Q13.425,7 13,7q-0.425,0 -0.712,0.287Q12,7.575 12,8q0,0.425 0.288,0.712Q12.575,9 13,9z" />

--- a/core/ui/src/main/res/drawable/ic_image_upload.xml
+++ b/core/ui/src/main/res/drawable/ic_image_upload.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M5,21q-0.825,0 -1.413,-0.588Q3,19.825 3,19V5q0,-0.825 0.587,-1.413Q4.175,3 5,3h14q0.825,0 1.413,0.587Q21,4.175 21,5v14q0,0.825 -0.587,1.412Q19.825,21 19,21zM5,19h14V5H5zM6,17h12l-3.75,-5 -3,4 -2.25,-3zM13,9q0.425,0 0.713,-0.288Q14,8.425 14,8q0,-0.425 -0.287,-0.713Q13.425,7 13,7q-0.425,0 -0.712,0.287Q12,7.575 12,8q0,0.425 0.288,0.712Q12.575,9 13,9z" />
+</vector>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -24,6 +24,8 @@
     <string name="bbcode_action_spoiler">Spoiler</string>
     <string name="bbcode_action_url">Lien</string>
     <string name="bbcode_action_image">Image</string>
+    <!-- #459 PR2 — chip ouvrant le sélecteur de photos pour uploader puis insérer une image. -->
+    <string name="bbcode_action_image_upload">Uploader</string>
     <string name="bbcode_action_color">Couleur</string>
     <string name="bbcode_action_color_menu_description">Sélectionner une couleur de texte</string>
     <string name="bbcode_color_red">Rouge</string>

--- a/feature/editor/build.gradle.kts
+++ b/feature/editor/build.gradle.kts
@@ -15,6 +15,9 @@ dependencies {
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.runtime.compose)
+    // #459 PR2 — rememberLauncherForActivityResult + ActivityResultContracts.PickVisualMedia for the
+    // in-editor photo picker (modern Android photo picker, no runtime permission).
+    implementation(libs.androidx.activity.compose)
     implementation(libs.kotlinx.coroutines.android)
     // Phase 2F-B (#11) — the smiley picker renders perso smileys served from the HFR CDN ;
     // Coil's AsyncImage is the same code path :core:ui already uses for post rendering.

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorIntent.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorIntent.kt
@@ -58,6 +58,16 @@ sealed interface PostEditorIntent {
     /** Phase 2F-E (#189) — insert `[img]url[/img]` for a validated remote image URL. */
     data class ImageUrlInserted(val url: String) : PostEditorIntent
 
+    /**
+     * #459 PR2 — the user picked a local image from the system photo picker. [uri] is the
+     * picker's `Uri.toString()`. The ViewModel reads the bytes (off the platform layer), uploads
+     * to the selected host, and inserts the resulting `[img]url[/img]` at the caret on success.
+     */
+    data class ImagePicked(val uri: String) : PostEditorIntent
+
+    /** #459 PR2 — user dismissed the upload-error banner. Clears [PostEditorState.uploadError]. */
+    data object UploadErrorDismissed : PostEditorIntent
+
     /** #405 — user tapped « Restaurer » on the draft banner: pre-fill the editor from the cached draft. */
     data object DraftRestoreRequested : PostEditorIntent
 

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -2,6 +2,9 @@ package fr.forumhfr.redface2.feature.editor
 
 import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 import fr.forumhfr.redface2.core.ui.editor.SmileyPickerSheet
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -91,6 +94,15 @@ private fun PostEditorContent(
 ) {
     var imageUrlDialogOpen by remember { mutableStateOf(false) }
     var optionsSheetOpen by remember { mutableStateOf(false) }
+    // #459 PR2 — modern Android photo picker (no runtime permission). The contract returns a
+    // nullable Uri ; on a non-null pick we hand the ViewModel the Uri's string so the platform-free
+    // VM reads the bytes via ImageUploadReader and uploads. API confirmed via Context7
+    // (androidx ActivityResultContracts.PickVisualMedia, input PickVisualMediaRequest, output Uri?).
+    val pickImageLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickVisualMedia(),
+    ) { uri ->
+        if (uri != null) onIntent(PostEditorIntent.ImagePicked(uri.toString()))
+    }
     // Reply (#145), Quote (#146) and Edit (#147) submit through HFR's reply/edit form ; the other
     // (defensive) modes show a disabled note instead of a submit bar.
     val showSubmitBar = state.mode == PostEditorMode.Reply || state.mode == PostEditorMode.Edit
@@ -123,6 +135,12 @@ private fun PostEditorContent(
                 BbcodeToolbar(
                     onAction = { action -> onIntent(PostEditorIntent.ToolbarActionClicked(action)) },
                     onImageUrlRequested = { imageUrlDialogOpen = true },
+                    onImageUploadRequested = {
+                        pickImageLauncher.launch(
+                            PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
+                        )
+                    },
+                    uploading = state.isUploading,
                 )
 
                 BbcodeTextField(
@@ -177,6 +195,17 @@ private fun PostEditorContent(
                         color = MaterialTheme.colorScheme.error,
                     )
                     TextButton(onClick = { onIntent(PostEditorIntent.ErrorDismissed) }) {
+                        Text(text = stringResource(R.string.editor_error_dismiss))
+                    }
+                }
+
+                state.uploadError?.let { error ->
+                    Text(
+                        text = stringResource(error.bannerResId),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                    TextButton(onClick = { onIntent(PostEditorIntent.UploadErrorDismissed) }) {
                         Text(text = stringResource(R.string.editor_error_dismiss))
                     }
                 }
@@ -466,6 +495,14 @@ private val PostEditorMode.titleResId: Int
     get() = when (this) {
         PostEditorMode.Reply -> R.string.editor_post_reply_title
         PostEditorMode.Edit -> R.string.editor_post_edit_title
+    }
+
+private val UploadError.bannerResId: Int
+    get() = when (this) {
+        UploadError.TooLarge -> R.string.editor_upload_error_too_large
+        UploadError.UnsupportedType -> R.string.editor_upload_error_unsupported_type
+        UploadError.Host -> R.string.editor_upload_error_host
+        UploadError.Network -> R.string.editor_upload_error_network
     }
 
 private val SubmitError.bannerResId: Int

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
@@ -102,6 +102,17 @@ data class PostEditorState(
      * quote prefill is not clobbered ; it is also never silently lost — discarding deletes the row.
      */
     val restorableDraft: String? = null,
+    /**
+     * #459 PR2 — `true` while an image picked from the photo picker is being read + uploaded to the
+     * selected host. The toolbar's image-upload affordance shows a progress indicator and is
+     * disabled so a second pick cannot race the in-flight upload.
+     */
+    val isUploading: Boolean = false,
+    /**
+     * #459 PR2 — typed upload failure surfaced after a failed pick→read→upload. Null means « no
+     * error to show ». Cleared on a fresh content mutation or via [PostEditorIntent.UploadErrorDismissed].
+     */
+    val uploadError: UploadError? = null,
 ) {
     /**
      * Submission is allowed when : we know the routing context (page + subcat + topicId),
@@ -147,6 +158,26 @@ sealed interface SubmitError {
     data object MissingSubcat : SubmitError
 }
 
+/**
+ * #459 PR2 — UI-facing image-upload failure. Maps the `:core:domain`
+ * [fr.forumhfr.redface2.core.domain.upload.UploadException] variants onto an actionable message
+ * (too large / unsupported type / host outage / network / unreadable) instead of a generic
+ * « échec ». Anonymous clients never get here — the ViewModel ignores a pick without a userId.
+ */
+sealed interface UploadError {
+    /** The picked image exceeds the host's accepted size. */
+    data object TooLarge : UploadError
+
+    /** The host rejected the MIME type. */
+    data object UnsupportedType : UploadError
+
+    /** The host answered a non-2xx status, or 2xx with an unreadable body. */
+    data object Host : UploadError
+
+    /** No network / DNS / timeout — also covers an unreadable picked Uri (mapped to Network). */
+    data object Network : UploadError
+}
+
 
 
 internal fun PostEditorState.withDraft(updated: TextFieldValue): PostEditorState =
@@ -157,4 +188,7 @@ internal fun PostEditorState.withDraft(updated: TextFieldValue): PostEditorState
         // accepted that we will try again. Keep it on toolbar-only mutations though
         // (caller resets `submitError` directly when needed).
         submitError = if (updated.text != draft.text) null else submitError,
+        // #459 PR2 — same rule for the image-upload error : a fresh text edit dismisses the stale
+        // banner. A successful upload INSERTS text via this path, which also clears any prior error.
+        uploadError = if (updated.text != draft.text) null else uploadError,
     )

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -10,6 +10,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
 import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
@@ -17,8 +18,12 @@ import fr.forumhfr.redface2.core.domain.editor.EditorDraftKey
 import fr.forumhfr.redface2.core.domain.editor.EditorDraftStore
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.smiley.SmileyRepository
+import fr.forumhfr.redface2.core.domain.upload.ImageUploadReader
+import fr.forumhfr.redface2.core.domain.upload.UploadException
+import fr.forumhfr.redface2.core.domain.upload.UploadRepository
 import fr.forumhfr.redface2.core.domain.write.EditPostRepository
 import fr.forumhfr.redface2.core.domain.write.ReplyRepository
+import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.write.EditPostContext
 import fr.forumhfr.redface2.core.model.write.ReplyContext
@@ -59,7 +64,12 @@ import kotlinx.coroutines.launch
  * by the repository are surfaced via [SubmitError]; the draft is preserved.
  */
 @HiltViewModel(assistedFactory = PostEditorViewModel.Factory::class)
-@Suppress("LongParameterList") // Hilt constructor injection — one dependency per collaborator.
+@Suppress("LongParameterList", "LargeClass")
+// LongParameterList — Hilt constructor injection, one dependency per collaborator (#459 PR2 adds
+// the upload reader + repository + auth source for the in-editor image upload).
+// LargeClass — one class per ViewModel co-locates every code path (#145 reply / #146 quote /
+// #147 edit / #11 smiley / #189 image-url / #405 draft / #459 image-upload) with its dispatcher ;
+// splitting per phase would shred the shared state transformers (same rationale as TopicFormVM).
 class PostEditorViewModel @AssistedInject constructor(
     @Assisted private val request: PostEditorRequest,
     private val previewParser: BbcodePreviewParser,
@@ -69,6 +79,9 @@ class PostEditorViewModel @AssistedInject constructor(
     private val userPreferencesRepository: UserPreferencesRepository,
     private val draftStore: EditorDraftStore,
     private val diagnostics: DiagnosticsLog,
+    private val uploadRepository: UploadRepository,
+    private val imageUploadReader: ImageUploadReader,
+    private val authRepository: AuthRepository,
 ) : ViewModel() {
 
     private val _state: MutableStateFlow<PostEditorState> = MutableStateFlow(
@@ -119,10 +132,30 @@ class PostEditorViewModel @AssistedInject constructor(
      */
     private var confirmBeforePosting: Boolean = false
 
+    /**
+     * #459 PR2 — active lowercased HFR pseudo (the upload `userId`), or null when anonymous.
+     * Captured from the auth stream exactly like `MyImagesViewModel` / `FlagsViewModel` so an
+     * [PostEditorIntent.ImagePicked] can scope the upload to the right owner without re-reading the
+     * flow. Kept off [PostEditorState] : the editor never renders the pseudo, only gates on its
+     * presence.
+     */
+    private var activeUserId: String? = null
+
+    /** #459 PR2 — in-flight image upload job ; one at a time, cancelled on [onCleared]. */
+    private var uploadJob: Job? = null
+
     init {
         viewModelScope.launch {
             userPreferencesRepository.observeConfirmBeforePosting().collect { enabled ->
                 confirmBeforePosting = enabled
+            }
+        }
+        viewModelScope.launch {
+            authRepository.observeAuthState().collect { authState ->
+                activeUserId = when (authState) {
+                    AuthState.Anonymous -> null
+                    is AuthState.Authenticated -> authState.pseudo.lowercase()
+                }
             }
         }
         restoreDraftIfAny()
@@ -187,6 +220,8 @@ class PostEditorViewModel @AssistedInject constructor(
             is PostEditorIntent.SmileySearchQueryChanged -> onSmileySearchQueryChanged(intent.query)
             is PostEditorIntent.SmileySelected -> onSmileySelected(intent.token)
             is PostEditorIntent.ImageUrlInserted -> onImageUrlInserted(intent.url)
+            is PostEditorIntent.ImagePicked -> onImagePicked(intent.uri)
+            PostEditorIntent.UploadErrorDismissed -> _state.update { it.copy(uploadError = null) }
             PostEditorIntent.DraftRestoreRequested -> onDraftRestoreRequested()
             PostEditorIntent.DraftDiscardRequested -> onDraftDiscardRequested()
         }
@@ -328,7 +363,19 @@ class PostEditorViewModel @AssistedInject constructor(
     }
 
     private fun onImageUrlInserted(url: String) {
-        val token = imageBbcodeTokenOrNull(url) ?: return
+        if (insertImageUrlAtCaret(url)) scheduleAutosave()
+    }
+
+    /**
+     * #189 / #459 PR2 — shared `[img]url[/img]` insertion at the caret. Reuses the smiley path's
+     * pure helpers ([imageBbcodeTokenOrNull] validates the scheme, [insertBbcodeToken] inserts while
+     * preserving the selection) so the cursor-insertion contract is identical to `onSmileySelected`.
+     * The image token is inserted WITHOUT surrounding spaces (an `[img]` is a self-contained block,
+     * unlike a smiley which would fuse with an adjacent one). Returns `true` when the URL was valid
+     * and inserted (so callers can decide whether to schedule an autosave), `false` otherwise.
+     */
+    private fun insertImageUrlAtCaret(url: String): Boolean {
+        val token = imageBbcodeTokenOrNull(url) ?: return false
         _state.update { current ->
             val draft = current.draft
             val selection = draft.selection
@@ -350,7 +397,56 @@ class PostEditorViewModel @AssistedInject constructor(
                 withDraft
             }
         }
-        scheduleAutosave()
+        return true
+    }
+
+    /**
+     * #459 PR2 — pick→read→upload→insert. Reads the picked Uri's bytes (off-platform via
+     * [ImageUploadReader]), uploads to the host of the current preference scoped to the active
+     * [activeUserId] (lowercased pseudo), and on success inserts `[img]imageUrl[/img]` at the caret
+     * via [insertImageUrlAtCaret] (same cursor contract as the smiley / URL paths). A typed
+     * [UploadException] is mapped onto [UploadError] ; an anonymous client (no userId) is ignored —
+     * the providers require an HFR session for the trace, and surfacing « connectez-vous » here
+     * would duplicate the submit-time LoginRequired surface.
+     */
+    private fun onImagePicked(uri: String) {
+        if (uploadJob?.isActive == true) return
+        val userId = activeUserId ?: return
+        _state.update { it.copy(isUploading = true, uploadError = null) }
+        uploadJob = viewModelScope.launch {
+            val outcome = runCatching {
+                val image = imageUploadReader.read(uri)
+                uploadRepository.uploadWithCurrentProvider(image, userId)
+            }
+            outcome.fold(
+                onSuccess = { uploaded ->
+                    insertImageUrlAtCaret(uploaded.imageUrl)
+                    _state.update { it.copy(isUploading = false, uploadError = null) }
+                    scheduleAutosave()
+                },
+                onFailure = ::handleUploadFailure,
+            )
+        }
+    }
+
+    private fun handleUploadFailure(error: Throwable) {
+        if (error is CancellationException) {
+            _state.update { it.copy(isUploading = false) }
+            throw error
+        }
+        val mapped = when (error) {
+            is UploadException.TooLarge -> UploadError.TooLarge
+            is UploadException.UnsupportedType -> UploadError.UnsupportedType
+            is UploadException.Server, is UploadException.Malformed -> UploadError.Host
+            is UploadException.Network -> UploadError.Network
+            else -> UploadError.Network
+        }
+        diagnostics.record(
+            DiagnosticsLog.Level.WARN,
+            LOG_TAG_VM,
+            "image upload failed: ${error::class.simpleName} → ${mapped::class.simpleName}",
+        )
+        _state.update { it.copy(isUploading = false, uploadError = mapped) }
     }
 
     private fun onContentChanged(value: TextFieldValue) {
@@ -766,6 +862,17 @@ class PostEditorViewModel @AssistedInject constructor(
             quotedNumreponse = snapshot.quotedNumreponse,
             quoteRef = snapshot.quoteRef,
         )
+    }
+
+    /**
+     * #459 PR2 — cancel any in-flight image upload when the editor is torn down. `viewModelScope`
+     * is already cancelled by the lifecycle, so this is belt-and-braces (the read/upload is then a
+     * no-op against a dead state) — but it makes the « one upload, no leak » contract explicit and
+     * lets a future non-viewModelScope job stay covered.
+     */
+    override fun onCleared() {
+        uploadJob?.cancel()
+        super.onCleared()
     }
 
     @AssistedFactory

--- a/feature/editor/src/main/res/values/strings.xml
+++ b/feature/editor/src/main/res/values/strings.xml
@@ -43,4 +43,9 @@
     <string name="editor_draft_restore_message">Un brouillon non envoyé a été retrouvé pour ce message.</string>
     <string name="editor_draft_restore">Restaurer</string>
     <string name="editor_draft_discard">Ignorer</string>
+    <!-- #459 PR2 — erreurs d\'upload d\'image (mappées depuis UploadException). -->
+    <string name="editor_upload_error_too_large">Image trop volumineuse pour cet hébergeur. Choisissez une image plus légère.</string>
+    <string name="editor_upload_error_unsupported_type">Type d\'image non accepté par l\'hébergeur.</string>
+    <string name="editor_upload_error_host">L\'hébergeur d\'images a renvoyé une erreur. Réessayez ou changez d\'hébergeur dans les réglages.</string>
+    <string name="editor_upload_error_network">Erreur réseau pendant l\'upload. Vérifiez votre connexion et réessayez.</string>
 </resources>

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -16,9 +16,17 @@ import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
+import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
+import fr.forumhfr.redface2.core.domain.upload.ImageUpload
+import fr.forumhfr.redface2.core.domain.upload.ImageUploadReader
+import fr.forumhfr.redface2.core.domain.upload.UploadException
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
+import fr.forumhfr.redface2.core.domain.upload.UploadRepository
+import fr.forumhfr.redface2.core.domain.upload.UploadedImage
+import fr.forumhfr.redface2.core.domain.upload.UploadedImageRecord
 import fr.forumhfr.redface2.core.domain.write.ReplyRepository
+import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.PostBlock
 import fr.forumhfr.redface2.core.model.PostContent
@@ -61,6 +69,8 @@ class PostEditorViewModelTest {
     private val editPostRepository = FakeEditPostRepository()
     private val smileyRepository = FakeSmileyRepository()
     private val draftStore = FakeEditorDraftStore()
+    private val uploadRepository = FakeUploadRepository()
+    private val imageUploadReader = FakeImageUploadReader()
 
     @Before
     fun setUp() {
@@ -772,6 +782,7 @@ class PostEditorViewModelTest {
         extraQuoteNumreponses: List<Int> = emptyList(),
         diagnostics: DiagnosticsLog = DiagnosticsLog(),
         userPreferencesRepository: UserPreferencesRepository = FakeUserPreferencesRepository(),
+        authRepository: AuthRepository = FakeAuthRepository(),
     ): PostEditorViewModel =
         PostEditorViewModel(
             request = PostEditorRequest(
@@ -792,6 +803,9 @@ class PostEditorViewModelTest {
             userPreferencesRepository = userPreferencesRepository,
             draftStore = draftStore,
             diagnostics = diagnostics,
+            uploadRepository = uploadRepository,
+            imageUploadReader = imageUploadReader,
+            authRepository = authRepository,
         )
 
     // ----- Phase 2F-B (#11) : smiley picker ----------------------------------
@@ -989,11 +1003,184 @@ class PostEditorViewModelTest {
         }
     }
 
+    // ----- #459 PR2 : image upload from the photo picker ---------------------
+
+    @Test
+    fun `ImagePicked reads the uri uploads with the lowercased userId and inserts img at caret`() = runTest {
+        // Authenticated with a MIXED-CASE pseudo to prove the userId is lowercased before reaching
+        // the repository (the upload foundation byte-matches on the lowercased pseudo).
+        val authRepository = FakeAuthRepository(AuthState.Authenticated("XaTriX"))
+        imageUploadReader.result =
+            ImageUpload(bytes = byteArrayOf(1, 2, 3), mimeType = "image/png", displayName = "p.png")
+        uploadRepository.uploadResult = uploadedImage("https://rehost.diberie.com/Picture/Get/f/42")
+        val viewModel = newReplyViewModel(authRepository = authRepository)
+        testScheduler.advanceUntilIdle()
+
+        val pickedUri = "content://media/external/images/99"
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("photo: ", TextRange(7))))
+        viewModel.submit(PostEditorIntent.ImagePicked(pickedUri))
+        testScheduler.advanceUntilIdle()
+
+        assertEquals("the picked uri must be read once", pickedUri, imageUploadReader.lastUri)
+        assertEquals("upload called once", 1, uploadRepository.uploadCalls)
+        assertEquals("userId must be lowercased before the upload", "xatrix", uploadRepository.lastUserId)
+        viewModel.state.test {
+            val state = expectMostRecentItem()
+            val expected = "photo: [img]https://rehost.diberie.com/Picture/Get/f/42[/img]"
+            assertEquals("img token inserted at the caret on success", expected, state.draft.text)
+            assertEquals("caret lands after the inserted token", expected.length, state.draft.selection.start)
+            assertFalse("upload flag cleared on success", state.isUploading)
+            assertNull("no error on success", state.uploadError)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `ImagePicked surfaces a typed error and inserts nothing when the upload fails`() = runTest {
+        val authRepository = FakeAuthRepository(AuthState.Authenticated("alice"))
+        imageUploadReader.result = ImageUpload(bytes = byteArrayOf(1), mimeType = "image/jpeg", displayName = null)
+        uploadRepository.uploadException = UploadException.Server(code = 503, providerId = UploadProviderId.DIBERIE)
+        val viewModel = newReplyViewModel(authRepository = authRepository)
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("photo: ", TextRange(7))))
+        viewModel.submit(PostEditorIntent.ImagePicked("content://media/external/images/1"))
+        testScheduler.advanceUntilIdle()
+
+        viewModel.state.test {
+            val state = expectMostRecentItem()
+            assertEquals("draft is untouched on failure", "photo: ", state.draft.text)
+            assertEquals("Server failure maps to the Host error surface", UploadError.Host, state.uploadError)
+            assertFalse("upload flag cleared on failure", state.isUploading)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `ImagePicked maps TooLarge UnsupportedType and Network onto distinct UploadError variants`() = runTest {
+        val authRepository = FakeAuthRepository(AuthState.Authenticated("alice"))
+        imageUploadReader.result = ImageUpload(bytes = byteArrayOf(1), mimeType = "image/gif", displayName = null)
+
+        uploadRepository.uploadException = UploadException.TooLarge(maxBytes = 1024)
+        val tooLarge = newReplyViewModel(authRepository = authRepository)
+        testScheduler.advanceUntilIdle()
+        tooLarge.submit(PostEditorIntent.ImagePicked("content://x/1"))
+        testScheduler.advanceUntilIdle()
+        assertEquals(UploadError.TooLarge, tooLarge.state.value.uploadError)
+
+        uploadRepository.uploadException = UploadException.UnsupportedType(mimeType = "image/gif")
+        val unsupported = newReplyViewModel(authRepository = authRepository)
+        testScheduler.advanceUntilIdle()
+        unsupported.submit(PostEditorIntent.ImagePicked("content://x/2"))
+        testScheduler.advanceUntilIdle()
+        assertEquals(UploadError.UnsupportedType, unsupported.state.value.uploadError)
+
+        uploadRepository.uploadException = UploadException.Network(java.io.IOException("offline"))
+        val network = newReplyViewModel(authRepository = authRepository)
+        testScheduler.advanceUntilIdle()
+        network.submit(PostEditorIntent.ImagePicked("content://x/3"))
+        testScheduler.advanceUntilIdle()
+        assertEquals(UploadError.Network, network.state.value.uploadError)
+    }
+
+    @Test
+    fun `ImagePicked maps an unreadable picked uri onto the Network error and inserts nothing`() = runTest {
+        val authRepository = FakeAuthRepository(AuthState.Authenticated("alice"))
+        // The reader fails (UploadException.Network) BEFORE the upload — the repository must never
+        // be reached, and the editor surfaces the same Network surface as a transport failure.
+        imageUploadReader.exception = UploadException.Network(java.io.IOException("stream gone"))
+        val viewModel = newReplyViewModel(authRepository = authRepository)
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("photo: ", TextRange(7))))
+        viewModel.submit(PostEditorIntent.ImagePicked("content://x/1"))
+        testScheduler.advanceUntilIdle()
+
+        assertEquals("a failed read must not reach the upload", 0, uploadRepository.uploadCalls)
+        val state = viewModel.state.value
+        assertEquals("draft untouched when the read fails", "photo: ", state.draft.text)
+        assertEquals(UploadError.Network, state.uploadError)
+        assertFalse(state.isUploading)
+    }
+
+    @Test
+    fun `ImagePicked toggles isUploading while the upload is in flight`() = runTest {
+        val authRepository = FakeAuthRepository(AuthState.Authenticated("alice"))
+        imageUploadReader.result = ImageUpload(bytes = byteArrayOf(1), mimeType = "image/png", displayName = null)
+        // Hold the upload pending so we can observe the intermediate isUploading = true.
+        val gate = CompletableDeferred<Unit>()
+        uploadRepository.uploadGate = gate
+        uploadRepository.uploadResult = uploadedImage("https://rehost.diberie.com/Picture/Get/f/7")
+        val viewModel = newReplyViewModel(authRepository = authRepository)
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(PostEditorIntent.ImagePicked("content://x/1"))
+        testScheduler.runCurrent()
+        assertTrue("isUploading must be true while the upload is in flight", viewModel.state.value.isUploading)
+
+        gate.complete(Unit)
+        testScheduler.advanceUntilIdle()
+        assertFalse("isUploading must clear once the upload resolves", viewModel.state.value.isUploading)
+    }
+
+    @Test
+    fun `ImagePicked is ignored for an anonymous client (no upload, no error)`() = runTest {
+        imageUploadReader.result = ImageUpload(bytes = byteArrayOf(1), mimeType = "image/png", displayName = null)
+        val viewModel = newReplyViewModel(authRepository = FakeAuthRepository(AuthState.Anonymous))
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("hi", TextRange(2))))
+        viewModel.submit(PostEditorIntent.ImagePicked("content://x/1"))
+        testScheduler.advanceUntilIdle()
+
+        assertEquals("anonymous pick must not read the uri", 0, imageUploadReader.readCalls)
+        assertEquals("anonymous pick must not upload", 0, uploadRepository.uploadCalls)
+        val state = viewModel.state.value
+        assertEquals("hi", state.draft.text)
+        assertFalse(state.isUploading)
+        assertNull(state.uploadError)
+    }
+
+    @Test
+    fun `a second ImagePicked is ignored while the first upload is still in flight`() = runTest {
+        val authRepository = FakeAuthRepository(AuthState.Authenticated("alice"))
+        imageUploadReader.result = ImageUpload(bytes = byteArrayOf(1), mimeType = "image/png", displayName = null)
+        val gate = CompletableDeferred<Unit>()
+        uploadRepository.uploadGate = gate
+        uploadRepository.uploadResult = uploadedImage("https://rehost.diberie.com/Picture/Get/f/7")
+        val viewModel = newReplyViewModel(authRepository = authRepository)
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(PostEditorIntent.ImagePicked("content://x/1")) // launches, suspends on gate
+        viewModel.submit(PostEditorIntent.ImagePicked("content://x/2")) // must be a no-op
+        gate.complete(Unit)
+        testScheduler.advanceUntilIdle()
+
+        assertEquals("only the first pick uploads", 1, uploadRepository.uploadCalls)
+    }
+
+    @Test
+    fun `UploadErrorDismissed clears the upload error banner`() = runTest {
+        val authRepository = FakeAuthRepository(AuthState.Authenticated("alice"))
+        imageUploadReader.result = ImageUpload(bytes = byteArrayOf(1), mimeType = "image/png", displayName = null)
+        uploadRepository.uploadException = UploadException.Network(java.io.IOException("offline"))
+        val viewModel = newReplyViewModel(authRepository = authRepository)
+        testScheduler.advanceUntilIdle()
+        viewModel.submit(PostEditorIntent.ImagePicked("content://x/1"))
+        testScheduler.advanceUntilIdle()
+        assertEquals(UploadError.Network, viewModel.state.value.uploadError)
+
+        viewModel.submit(PostEditorIntent.UploadErrorDismissed)
+
+        assertNull("dismissing clears the upload error", viewModel.state.value.uploadError)
+    }
+
     private fun newEditViewModel(
         subcat: Int? = SAMPLE_SUBCAT,
         numreponse: Int? = SAMPLE_EDITED_NUMREPONSE,
         diagnostics: DiagnosticsLog = DiagnosticsLog(),
         userPreferencesRepository: UserPreferencesRepository = FakeUserPreferencesRepository(),
+        authRepository: AuthRepository = FakeAuthRepository(),
     ): PostEditorViewModel =
         PostEditorViewModel(
             request = PostEditorRequest(
@@ -1011,6 +1198,9 @@ class PostEditorViewModelTest {
             userPreferencesRepository = userPreferencesRepository,
             draftStore = draftStore,
             diagnostics = diagnostics,
+            uploadRepository = uploadRepository,
+            imageUploadReader = imageUploadReader,
+            authRepository = authRepository,
         )
 
     // ----- #312 : confirmation avant publication ------------------------------
@@ -1625,6 +1815,85 @@ class PostEditorViewModelTest {
             deletedKeys += key
             saved.remove(key)
         }
+    }
+
+    private fun uploadedImage(imageUrl: String): UploadedImage = UploadedImage(
+        provider = UploadProviderId.DIBERIE,
+        imageUrl = imageUrl,
+        thumbnailUrl = null,
+        deleteHandle = null,
+        expiresAt = null,
+    )
+
+    /**
+     * #459 PR2 — fake [ImageUploadReader]. Returns a canned [ImageUpload] (or throws a preset
+     * exception) and records the picked uri so the VM test can assert the read happened with the
+     * right argument. Defaults to a 1-byte PNG so a happy-path test that does not set [result]
+     * still gets a valid image.
+     */
+    private class FakeImageUploadReader : ImageUploadReader {
+        var result: ImageUpload = ImageUpload(bytes = byteArrayOf(0), mimeType = "image/png", displayName = null)
+
+        /** Set to make [read] throw — exercises the « unreadable picked Uri → Network » mapping. */
+        var exception: Throwable? = null
+        var lastUri: String? = null
+            private set
+        var readCalls: Int = 0
+            private set
+
+        override suspend fun read(uri: String): ImageUpload {
+            readCalls += 1
+            lastUri = uri
+            exception?.let { throw it }
+            return result
+        }
+    }
+
+    /**
+     * #459 PR2 — fake [UploadRepository]. Only [uploadWithCurrentProvider] matters to the editor ;
+     * the history / delete members are stubbed. [uploadGate] lets a test hold the upload pending to
+     * observe the intermediate `isUploading = true`.
+     */
+    private class FakeUploadRepository : UploadRepository {
+        var uploadResult: UploadedImage = UploadedImage(
+            provider = UploadProviderId.DIBERIE,
+            imageUrl = "https://rehost.diberie.com/Picture/Get/f/1",
+            thumbnailUrl = null,
+            deleteHandle = null,
+            expiresAt = null,
+        )
+        var uploadException: Throwable? = null
+        var uploadGate: CompletableDeferred<Unit>? = null
+        var uploadCalls: Int = 0
+            private set
+        var lastUserId: String? = null
+            private set
+
+        override suspend fun uploadWithCurrentProvider(image: ImageUpload, userId: String): UploadedImage {
+            uploadCalls += 1
+            lastUserId = userId
+            uploadGate?.await()
+            uploadException?.let { throw it }
+            return uploadResult
+        }
+
+        override fun observeUploads(userId: String): Flow<List<UploadedImageRecord>> =
+            MutableStateFlow(emptyList())
+
+        override suspend fun delete(record: UploadedImageRecord, userId: String): Boolean = false
+    }
+
+    /**
+     * #459 PR2 — fake [AuthRepository]. Emits a fixed [AuthState] so the VM resolves (or does not
+     * resolve) an upload `userId`. Login / logout are no-ops — the editor only observes.
+     */
+    private class FakeAuthRepository(
+        private val authState: AuthState = AuthState.Authenticated("alice"),
+    ) : AuthRepository {
+        override fun observeAuthState(): Flow<AuthState> = MutableStateFlow(authState)
+        override suspend fun login(pseudo: String, password: String): Result<AuthState.Authenticated> =
+            Result.success(AuthState.Authenticated(pseudo))
+        override suspend fun logout() = Unit
     }
 
     private companion object {


### PR DESCRIPTION
PR2/3 de l'issue refs-#459 (les fondations upload PR1 #473 et l'écran « Mes images » PR3 #475 sont déjà sur `dev`). Cette PR câble l'upload d'image dans le post-editor (réponse / édition) : l'utilisateur pique une image, elle est uploadée vers l'hébergeur sélectionné, et le BBCode `[img]…[/img]` est inséré au curseur.

## Picker
Photo picker Android moderne via `rememberLauncherForActivityResult` + `ActivityResultContracts.PickVisualMedia()` (input `PickVisualMediaRequest(PickVisualMedia.ImageOnly)`, output `Uri?`), **sans permission runtime**. API vérifiée via Context7 (« androidx ActivityResultContracts.PickVisualMedia stable release » — contrat input/output, builder `PickVisualMediaRequest`, objet `ImageOnly`). Sur pick non-null, le `Screen` dispatch `ImagePicked(uri.toString())` au VM.

## Architecture reader (VM platform-free)
Le ViewModel ne touche jamais `Uri` / `ContentResolver` / `Context`. Nouvelle interface `ImageUploadReader { suspend fun read(uri: String): ImageUpload }` dans `:core:domain` (package `upload`), implémentée par `AndroidImageUploadReader` dans `:core:data` (`@ApplicationContext Context` + `ContentResolver` : `openInputStream().readBytes()`, `getType()` pour le MIME, `DISPLAY_NAME` best-effort), I/O wrappée dans `withContext(ioDispatcher)`, échec d'ouverture/lecture mappé sur `UploadException.Network`. Le cap de taille reste géré par les providers (`UploadException.TooLarge`), une seule source de vérité par hébergeur. Bind Hilt dans `UploadProviderBindingsModule`.

## Câblage ViewModel
- Injection `UploadRepository` + `ImageUploadReader` + `AuthRepository`.
- `userId` = pseudo HFR actif **lowercased**, résolu via `observeAuthState()` exactement comme `MyImagesViewModel` / `FlagsViewModel`.
- État : `isUploading` + `uploadError` (typée : `TooLarge` / `UnsupportedType` / `Host` / `Network`, mappée depuis `UploadException`).
- Intent `ImagePicked(uri)` → `isUploading = true` → `reader.read(uri)` → `uploadRepository.uploadWithCurrentProvider(image, userId)` → succès : insertion `[img]${imageUrl}[/img]` au curseur → `isUploading = false`. Échec : `isUploading = false` + message typé. Anonyme (pas de userId) : ignoré (pas de doublon avec le `LoginRequired` du submit).
- Un seul upload à la fois (`uploadJob?.isActive` garde) ; `uploadJob` annulé dans `onCleared` (et `viewModelScope` déjà annulé par le lifecycle).

## Insertion au curseur (réutilisation)
La réponse à upload réussi appelle le helper `insertImageUrlAtCaret`, extrait de l'ancien `onImageUrlInserted` (#189), qui réutilise **les mêmes helpers purs que l'insertion smiley** : `imageBbcodeTokenOrNull` (valide le schéma http/https) + `insertBbcodeToken(..., surroundWithSpaces = false)` (préserve la sélection, place le curseur après le token). Contrat curseur strictement identique à `onSmileySelected`.

## Bouton éditeur
Chip « Uploader » ajouté dans la `BbcodeToolbar` (`:core:ui`), à côté de l'action `[img]` URL existante, rendu seulement quand le `Screen` câble le picker (MP / TopicForm passent `null` → toolbar inchangée). Icône **M3 only** : vecteur `:core:ui/ic_image_upload.xml` rendu via `Icon` (jamais material-icons, bloqué par detekt `ForbiddenImport`). Spinner `CircularProgressIndicator` + chip désactivé pendant `isUploading`. Bannière d'erreur typée + dismiss, strings FR.

## Tests
`PostEditorViewModelTest` (MockK + coroutines-test + Turbine, fakes `ImageUploadReader` / `UploadRepository` / `AuthRepository`) :
- `ImagePicked` → `reader.read` appelé, `uploadWithCurrentProvider` appelé avec **userId lowercased** (pseudo « XaTriX » → « xatrix »), `[img]url[/img]` inséré au curseur, `isUploading` clear, pas d'erreur ;
- `UploadException.Server` → `UploadError.Host`, draft intact, pas d'insertion ;
- mapping des 4 variantes (`TooLarge` / `UnsupportedType` / `Network`) sur `UploadError` ;
- `reader` échoué → `Network` sans atteindre l'upload, sans insertion ;
- toggle `isUploading` pendant l'upload (gate) ;
- anonyme ignoré (pas de read, pas d'upload) ;
- second pick ignoré pendant le premier ;
- `UploadErrorDismissed` clear la bannière.

**Tests écrits, non exécutés** (gate sur machine B).

## Portée / follow-up
Scope : `PostEditor` (réponse + édition). MP (`feature/messages`, ViewModels distincts) et TopicForm laissés en follow-up pour garder la PR self-contained et low-risk.

## detekt / gate
`@Suppress("LongParameterList", "LargeClass")` sur le VM (ctor passe à 11 deps ; LargeClass par accumulation de phases — même pattern que `TopicFormViewModel`), justifications inline. MaxLineLength 120 respecté. M3 only.

**Build + gate exécutés séparément sur machine B.**

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)