### PR TITLE
feat(settings): sélection de l'hébergeur d'images + Client-ID Imgur, et erreur d'upload précise (refs-#459, refs-#474)

### DIFF
--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
 import fr.forumhfr.redface2.core.ui.editor.ArmedSubmitActions
 import fr.forumhfr.redface2.core.ui.editor.ArmedSubmitButton
@@ -201,7 +202,7 @@ private fun PostEditorContent(
 
                 state.uploadError?.let { error ->
                     Text(
-                        text = stringResource(error.bannerResId),
+                        text = error.bannerText(),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.error,
                     )
@@ -497,13 +498,28 @@ private val PostEditorMode.titleResId: Int
         PostEditorMode.Edit -> R.string.editor_post_edit_title
     }
 
-private val UploadError.bannerResId: Int
-    get() = when (this) {
-        UploadError.TooLarge -> R.string.editor_upload_error_too_large
-        UploadError.UnsupportedType -> R.string.editor_upload_error_unsupported_type
-        UploadError.Host -> R.string.editor_upload_error_host
-        UploadError.Network -> R.string.editor_upload_error_network
-    }
+/**
+ * #474 — resolves the upload-error banner text. [UploadError.Server] / [UploadError.Malformed] carry
+ * the host (and the HTTP code for Server), so they need string args and a `@Composable` resolver
+ * rather than a plain `@StringRes Int` — the others stay argument-free.
+ */
+@Composable
+private fun UploadError.bannerText(): String = when (this) {
+    UploadError.TooLarge -> stringResource(R.string.editor_upload_error_too_large)
+    UploadError.UnsupportedType -> stringResource(R.string.editor_upload_error_unsupported_type)
+    is UploadError.Server ->
+        stringResource(R.string.editor_upload_error_server, providerId.displayName(), code)
+    is UploadError.Malformed ->
+        stringResource(R.string.editor_upload_error_malformed, providerId.displayName())
+    UploadError.Network -> stringResource(R.string.editor_upload_error_network)
+}
+
+/** French display name of an image host, for the upload-error banner (#474). */
+@Composable
+private fun UploadProviderId.displayName(): String = when (this) {
+    UploadProviderId.DIBERIE -> stringResource(R.string.editor_upload_provider_diberie)
+    UploadProviderId.IMGUR -> stringResource(R.string.editor_upload_provider_imgur)
+}
 
 private val SubmitError.bannerResId: Int
     get() = when (this) {

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
@@ -4,6 +4,7 @@ import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 import androidx.compose.ui.text.input.TextFieldValue
 import fr.forumhfr.redface2.core.domain.editor.BbcodeValidation
 import fr.forumhfr.redface2.core.domain.editor.validateBbcodeDraft
+import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.EditorSmiley
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
@@ -159,10 +160,13 @@ sealed interface SubmitError {
 }
 
 /**
- * #459 PR2 — UI-facing image-upload failure. Maps the `:core:domain`
+ * #459 PR2 / #474 — UI-facing image-upload failure. Maps the `:core:domain`
  * [fr.forumhfr.redface2.core.domain.upload.UploadException] variants onto an actionable message
- * (too large / unsupported type / host outage / network / unreadable) instead of a generic
- * « échec ». Anonymous clients never get here — the ViewModel ignores a pick without a userId.
+ * (too large / unsupported type / host HTTP error / unreadable host response / network) instead of
+ * a generic « erreur de l'hébergeur ». The HTTP [Server] case carries the status [code] and the
+ * [providerId] so the banner can name the host and the exact code (#474); [Malformed] stays distinct
+ * so an unreadable-but-2xx body reads differently from a flat HTTP refusal. Anonymous clients never
+ * get here — the ViewModel ignores a pick without a userId.
  */
 sealed interface UploadError {
     /** The picked image exceeds the host's accepted size. */
@@ -171,8 +175,11 @@ sealed interface UploadError {
     /** The host rejected the MIME type. */
     data object UnsupportedType : UploadError
 
-    /** The host answered a non-2xx status, or 2xx with an unreadable body. */
-    data object Host : UploadError
+    /** The host answered a non-2xx HTTP status. [code] is the status, [providerId] the host (#474). */
+    data class Server(val code: Int, val providerId: UploadProviderId) : UploadError
+
+    /** The host answered 2xx but the body could not be parsed into the expected shape (#474). */
+    data class Malformed(val providerId: UploadProviderId) : UploadError
 
     /** No network / DNS / timeout — also covers an unreadable picked Uri (mapped to Network). */
     data object Network : UploadError

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -437,7 +437,10 @@ class PostEditorViewModel @AssistedInject constructor(
         val mapped = when (error) {
             is UploadException.TooLarge -> UploadError.TooLarge
             is UploadException.UnsupportedType -> UploadError.UnsupportedType
-            is UploadException.Server, is UploadException.Malformed -> UploadError.Host
+            // #474 — keep Server and Malformed distinct so the banner names the host + HTTP code
+            // (Server) vs. an unreadable host response (Malformed), instead of one vague message.
+            is UploadException.Server -> UploadError.Server(code = error.code, providerId = error.providerId)
+            is UploadException.Malformed -> UploadError.Malformed(providerId = error.providerId)
             is UploadException.Network -> UploadError.Network
             else -> UploadError.Network
         }

--- a/feature/editor/src/main/res/values/strings.xml
+++ b/feature/editor/src/main/res/values/strings.xml
@@ -43,9 +43,14 @@
     <string name="editor_draft_restore_message">Un brouillon non envoyé a été retrouvé pour ce message.</string>
     <string name="editor_draft_restore">Restaurer</string>
     <string name="editor_draft_discard">Ignorer</string>
-    <!-- #459 PR2 — erreurs d\'upload d\'image (mappées depuis UploadException). -->
+    <!-- #459 PR2 / #474 — erreurs d\'upload d\'image (mappées depuis UploadException). Server et
+         Malformed nomment l\'hébergeur (et le code HTTP pour Server) au lieu d\'un message vague. -->
     <string name="editor_upload_error_too_large">Image trop volumineuse pour cet hébergeur. Choisissez une image plus légère.</string>
     <string name="editor_upload_error_unsupported_type">Type d\'image non accepté par l\'hébergeur.</string>
-    <string name="editor_upload_error_host">L\'hébergeur d\'images a renvoyé une erreur. Réessayez ou changez d\'hébergeur dans les réglages.</string>
+    <string name="editor_upload_error_server">L\'hébergeur %1$s a refusé l\'image (HTTP %2$d). Réessayez ou changez d\'hébergeur dans les réglages.</string>
+    <string name="editor_upload_error_malformed">Réponse illisible de l\'hébergeur %1$s. Réessayez ou changez d\'hébergeur dans les réglages.</string>
     <string name="editor_upload_error_network">Erreur réseau pendant l\'upload. Vérifiez votre connexion et réessayez.</string>
+    <!-- Noms d\'hébergeurs d\'images affichés dans les messages d\'erreur (#474). -->
+    <string name="editor_upload_provider_diberie">diberie</string>
+    <string name="editor_upload_provider_imgur">imgur</string>
 </resources>

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -1050,10 +1050,40 @@ class PostEditorViewModelTest {
         viewModel.state.test {
             val state = expectMostRecentItem()
             assertEquals("draft is untouched on failure", "photo: ", state.draft.text)
-            assertEquals("Server failure maps to the Host error surface", UploadError.Host, state.uploadError)
+            // #474 — a non-2xx response maps to a Server error carrying the HTTP code + host, so the
+            // banner can name « diberie » and « HTTP 503 » instead of one vague « erreur de l'hébergeur ».
+            assertEquals(
+                "Server failure maps to a Server upload error with the code + provider",
+                UploadError.Server(code = 503, providerId = UploadProviderId.DIBERIE),
+                state.uploadError,
+            )
             assertFalse("upload flag cleared on failure", state.isUploading)
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun `ImagePicked maps a Malformed host response onto a distinct Malformed error`() = runTest {
+        // #474 — a 2xx-but-unreadable body must NOT collapse into the same surface as an HTTP refusal:
+        // it carries the host so the banner reads « Réponse illisible de l'hébergeur imgur ».
+        val authRepository = FakeAuthRepository(AuthState.Authenticated("alice"))
+        imageUploadReader.result = ImageUpload(bytes = byteArrayOf(1), mimeType = "image/png", displayName = null)
+        uploadRepository.uploadException = UploadException.Malformed(providerId = UploadProviderId.IMGUR)
+        val viewModel = newReplyViewModel(authRepository = authRepository)
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("photo: ", TextRange(7))))
+        viewModel.submit(PostEditorIntent.ImagePicked("content://media/external/images/2"))
+        testScheduler.advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertEquals("draft is untouched on a malformed response", "photo: ", state.draft.text)
+        assertEquals(
+            "Malformed maps to a distinct Malformed upload error carrying the provider",
+            UploadError.Malformed(providerId = UploadProviderId.IMGUR),
+            state.uploadError,
+        )
+        assertFalse("upload flag cleared on failure", state.isUploading)
     }
 
     @Test

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -46,6 +46,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
+import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 
 @Composable
 fun SettingsScreen(
@@ -284,6 +285,10 @@ internal fun SettingsContent(
             )
 
             SettingsSectionHeader(stringResource(R.string.settings_section_images))
+            UploadProviderPreferencesCard(
+                state = state,
+                onIntent = onIntent,
+            )
             MyImagesCard(onOpenMyImages = onOpenMyImages)
 
             SettingsSectionHeader(stringResource(R.string.settings_section_mp))
@@ -759,6 +764,72 @@ private fun MyImagesCard(onOpenMyImages: () -> Unit) {
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(stringResource(R.string.settings_my_images_open))
+            }
+        }
+    }
+}
+
+/**
+ * #459 — « Hébergeur d'images » : choisit l'hébergeur des uploads de l'éditeur (diberie sans
+ * compte, imgur avec un Client-ID que l'utilisateur colle). Le champ Client-ID n'apparaît que pour
+ * imgur. Persisté en DataStore et lu par l'éditeur à chaque upload. Boutons segmentés en texte seul
+ * (pas d'icônes Material — l'import `androidx.compose.material.*` est interdit dans le projet).
+ */
+@Composable
+private fun UploadProviderPreferencesCard(
+    state: SettingsState,
+    onIntent: (SettingsIntent) -> Unit,
+) {
+    val options = listOf(
+        UploadProviderId.DIBERIE to stringResource(R.string.settings_upload_provider_diberie),
+        UploadProviderId.IMGUR to stringResource(R.string.settings_upload_provider_imgur),
+    )
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_upload_provider_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = stringResource(R.string.settings_upload_provider_intro),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                options.forEachIndexed { index, (provider, label) ->
+                    SegmentedButton(
+                        selected = state.uploadProvider == provider,
+                        enabled = state.canChangeUploadProvider,
+                        onClick = { onIntent(SettingsIntent.SetUploadProvider(provider)) },
+                        shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
+                    ) {
+                        Text(label)
+                    }
+                }
+            }
+            if (state.uploadProviderError) {
+                PreferencePersistError(R.string.settings_upload_provider_persist_failed)
+            }
+            // The Client-ID field is only meaningful for imgur (diberie needs no credentials).
+            if (state.uploadProvider == UploadProviderId.IMGUR) {
+                OutlinedTextField(
+                    value = state.imgurClientId,
+                    onValueChange = { onIntent(SettingsIntent.SetImgurClientId(it)) },
+                    singleLine = true,
+                    label = { Text(stringResource(R.string.settings_upload_imgur_client_id_label)) },
+                    supportingText = {
+                        Text(stringResource(R.string.settings_upload_imgur_client_id_helper))
+                    },
+                    isError = state.imgurClientIdError,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                if (state.imgurClientIdError) {
+                    PreferencePersistError(R.string.settings_upload_imgur_client_id_persist_failed)
+                }
             }
         }
     }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -316,8 +316,8 @@ sealed interface SettingsIntent {
 
     // #459 — Hébergeur d'images. `provider` is the desired selection (applied optimistically with
     // revert-on-failure, like ThemeModeChanged); `text` is the desired imgur Client-ID (persisted on
-    // each change). The provider selector hides IMGUR until a Client-ID is set, so the user can never
-    // strand themselves on an unusable host.
+    // each change). Selecting IMGUR reveals the Client-ID field ; an empty Client-ID is NOT blocked at
+    // the UI layer — the upload then fails with a precise host error (cf. #474) instead of silently.
     data class SetUploadProvider(val provider: UploadProviderId) : SettingsIntent
     data class SetImgurClientId(val text: String) : SettingsIntent
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -3,6 +3,7 @@ package fr.forumhfr.redface2.feature.settings
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
+import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 
 data class SettingsState(
     val proxyEnabled: Boolean = false,
@@ -130,6 +131,21 @@ data class SettingsState(
     val isUpdatingFontScale: Boolean = false,
     val fontScaleError: Boolean = false,
     val fontScaleTouchedLocally: Boolean = false,
+    // #459 — Hébergeur d'images. The provider is an enum, so it uses the bespoke optimistic-flip
+    // shape (like themeMode): `uploadProvider` is the displayed selection, `isUpdating*` gates the
+    // control while DataStore writes, `*Error` surfaces a persist failure, `*TouchedLocally` forbids
+    // a late `init` hydration from clobbering a fast user change. Default DIBERIE (no Client-ID).
+    val uploadProvider: UploadProviderId = UploadProviderId.DIBERIE,
+    val isUpdatingUploadProvider: Boolean = false,
+    val uploadProviderError: Boolean = false,
+    val uploadProviderTouchedLocally: Boolean = false,
+    // #459 — imgur Client-ID text field. `imgurClientId` is the displayed/edited value, persisted on
+    // each change (no save button — same as the optimistic prefs). `*Error` surfaces a persist
+    // failure; `*TouchedLocally` forbids the late hydration from overwriting in-progress typing.
+    // Default empty = imgur not configured.
+    val imgurClientId: String = "",
+    val imgurClientIdError: Boolean = false,
+    val imgurClientIdTouchedLocally: Boolean = false,
 ) {
     val canSave: Boolean
         get() = !isSaving
@@ -195,6 +211,10 @@ data class SettingsState(
 
     val canChangeFontScale: Boolean
         get() = !isUpdatingFontScale
+
+    // #459 — the provider selector is gated only by its own in-flight write.
+    val canChangeUploadProvider: Boolean
+        get() = !isUpdatingUploadProvider
 }
 
 sealed interface SettingsError {
@@ -293,4 +313,11 @@ sealed interface SettingsIntent {
     // optimistically with revert-on-failure, like ThemeModeChanged.
     data class DisplayDensityChanged(val density: DisplayDensity) : SettingsIntent
     data class FontScaleChanged(val scale: FontScalePreference) : SettingsIntent
+
+    // #459 — Hébergeur d'images. `provider` is the desired selection (applied optimistically with
+    // revert-on-failure, like ThemeModeChanged); `text` is the desired imgur Client-ID (persisted on
+    // each change). The provider selector hides IMGUR until a Client-ID is set, so the user can never
+    // strand themselves on an unusable host.
+    data class SetUploadProvider(val provider: UploadProviderId) : SettingsIntent
+    data class SetImgurClientId(val text: String) : SettingsIntent
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -12,6 +12,8 @@ import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -542,6 +544,12 @@ class SettingsViewModel @Inject constructor(
     // The optimistic value is shown immediately and the touched-locally guard blocks a late
     // hydration from clobbering in-progress typing; a persist failure raises the error flag without
     // reverting the typed text (it would be hostile to wipe what the user just typed).
+    // Persist-on-keystroke writes are serialised : each keystroke cancels the previous in-flight write
+    // so a slower/older write (or its failure) can never land after a newer one and strand a stale
+    // Client-ID or a spurious error flag (review #459). CancellationException is rethrown, not treated
+    // as a persistence failure.
+    private var imgurClientIdJob: Job? = null
+
     private fun updateImgurClientId(text: String) {
         _state.update {
             it.copy(
@@ -550,9 +558,13 @@ class SettingsViewModel @Inject constructor(
                 imgurClientIdTouchedLocally = true,
             )
         }
-        viewModelScope.launch {
+        imgurClientIdJob?.cancel()
+        imgurClientIdJob = viewModelScope.launch {
             runCatching { userPreferencesRepository.setImgurClientId(text) }
-                .onFailure { _state.update { it.copy(imgurClientIdError = true) } }
+                .onFailure { error ->
+                    if (error is CancellationException) throw error
+                    _state.update { it.copy(imgurClientIdError = true) }
+                }
         }
     }
 

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -10,6 +10,7 @@ import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
+import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -118,6 +119,18 @@ class SettingsViewModel @Inject constructor(
             isLocked = { it.fontScaleTouchedLocally || it.isUpdatingFontScale },
             apply = { state, value -> state.copy(fontScale = value) },
         )
+        // #459 — Hébergeur d'images : provider (enum) + imgur Client-ID (text). Same one-shot
+        // hydration + touched-locally guard as the other prefs.
+        hydratePreference(
+            read = { userPreferencesRepository.observeUploadProvider().first() },
+            isLocked = { it.uploadProviderTouchedLocally || it.isUpdatingUploadProvider },
+            apply = { state, value -> state.copy(uploadProvider = value) },
+        )
+        hydratePreference(
+            read = { userPreferencesRepository.observeImgurClientId().first() },
+            isLocked = { it.imgurClientIdTouchedLocally },
+            apply = { state, value -> state.copy(imgurClientId = value) },
+        )
     }
 
     /**
@@ -185,6 +198,8 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.FlagsAutoRefreshChanged -> updateFlagsAutoRefresh(intent.enabled)
             is SettingsIntent.DisplayDensityChanged -> updateDisplayDensity(intent.density)
             is SettingsIntent.FontScaleChanged -> updateFontScale(intent.scale)
+            is SettingsIntent.SetUploadProvider -> updateUploadProvider(intent.provider)
+            is SettingsIntent.SetImgurClientId -> updateImgurClientId(intent.text)
         }
     }
 
@@ -492,6 +507,52 @@ class SettingsViewModel @Inject constructor(
                         )
                     }
                 }
+        }
+    }
+
+    // #459 — upload provider is an enum, same bespoke optimistic-flip shape as updateThemeMode.
+    private fun updateUploadProvider(desired: UploadProviderId) {
+        val previous = _state.value.uploadProvider
+        _state.update {
+            it.copy(
+                uploadProvider = desired,
+                isUpdatingUploadProvider = true,
+                uploadProviderError = false,
+                uploadProviderTouchedLocally = true,
+            )
+        }
+        viewModelScope.launch {
+            runCatching { userPreferencesRepository.setUploadProvider(desired) }
+                .onSuccess {
+                    _state.update { it.copy(uploadProvider = desired, isUpdatingUploadProvider = false) }
+                }
+                .onFailure {
+                    _state.update {
+                        it.copy(
+                            uploadProvider = previous,
+                            isUpdatingUploadProvider = false,
+                            uploadProviderError = true,
+                        )
+                    }
+                }
+        }
+    }
+
+    // #459 — imgur Client-ID is a free-text preference persisted on each change (no save button).
+    // The optimistic value is shown immediately and the touched-locally guard blocks a late
+    // hydration from clobbering in-progress typing; a persist failure raises the error flag without
+    // reverting the typed text (it would be hostile to wipe what the user just typed).
+    private fun updateImgurClientId(text: String) {
+        _state.update {
+            it.copy(
+                imgurClientId = text,
+                imgurClientIdError = false,
+                imgurClientIdTouchedLocally = true,
+            )
+        }
+        viewModelScope.launch {
+            runCatching { userPreferencesRepository.setImgurClientId(text) }
+                .onFailure { _state.update { it.copy(imgurClientIdError = true) } }
         }
     }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -186,6 +186,17 @@
     <string name="settings_my_images_description">Consultez les images que vous avez envoyées et supprimez-les.</string>
     <string name="settings_my_images_open">Voir mes images</string>
 
+    <!-- #459 — Hébergeur d'images. Choisit l'hébergeur des uploads de l'éditeur ; le Client-ID
+         imgur n'apparaît que pour imgur. Persisté en DataStore, lu par l'éditeur à chaque upload. -->
+    <string name="settings_upload_provider_title">Hébergeur d\'images</string>
+    <string name="settings_upload_provider_intro">Choisissez où envoyer les images insérées dans vos messages. Diberie fonctionne sans compte ; imgur nécessite un Client-ID d\'application.</string>
+    <string name="settings_upload_provider_diberie">diberie (sans compte)</string>
+    <string name="settings_upload_provider_imgur">imgur (Client-ID requis)</string>
+    <string name="settings_upload_provider_persist_failed">Impossible de mémoriser l\'hébergeur. Réessayez.</string>
+    <string name="settings_upload_imgur_client_id_label">Client-ID imgur</string>
+    <string name="settings_upload_imgur_client_id_helper">Client-ID d\'application Imgur</string>
+    <string name="settings_upload_imgur_client_id_persist_failed">Impossible de mémoriser le Client-ID. Réessayez.</string>
+
     <!-- #459 PR3 — écran « Mes images uploadées » (liste + suppression). -->
     <string name="my_images_title">Mes images uploadées</string>
     <string name="my_images_back">Retour</string>

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -1098,6 +1098,109 @@ class SettingsViewModelTest {
             assertEquals(FontScalePreference.L, repository.lastFontScaleSet)
         }
 
+    // ──────────────────────────────────────────────────────────────────────
+    // Hébergeur d'images — provider + imgur Client-ID (#459)
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `init hydrates upload provider and imgur client id from storage`() = runTest {
+        repository.emitUploadProvider(UploadProviderId.IMGUR)
+        repository.emitImgurClientId("abc123")
+
+        val viewModel = newViewModel()
+        val state = viewModel.state.value
+
+        assertEquals(UploadProviderId.IMGUR, state.uploadProvider)
+        assertEquals("abc123", state.imgurClientId)
+    }
+
+    @Test
+    fun `SetUploadProvider persists the new provider and clears the updating flag`() = runTest {
+        val viewModel = newViewModel()
+        assertEquals("DIBERIE is the default", UploadProviderId.DIBERIE, viewModel.state.value.uploadProvider)
+
+        viewModel.submit(SettingsIntent.SetUploadProvider(UploadProviderId.IMGUR))
+
+        val state = viewModel.state.value
+        assertEquals(UploadProviderId.IMGUR, state.uploadProvider)
+        assertFalse(state.isUpdatingUploadProvider)
+        assertFalse(state.uploadProviderError)
+        assertEquals(1, repository.uploadProviderSetCalls)
+        assertEquals(UploadProviderId.IMGUR, repository.lastUploadProviderSet)
+    }
+
+    @Test
+    fun `SetUploadProvider reverts to the previous provider and raises the error flag on persist failure`() =
+        runTest {
+            repository.failOnUploadProviderSet = true
+            val viewModel = newViewModel()
+
+            viewModel.submit(SettingsIntent.SetUploadProvider(UploadProviderId.IMGUR))
+
+            val state = viewModel.state.value
+            assertEquals(
+                "must revert to the previous provider on failure",
+                UploadProviderId.DIBERIE,
+                state.uploadProvider,
+            )
+            assertFalse(state.isUpdatingUploadProvider)
+            assertTrue(state.uploadProviderError)
+        }
+
+    @Test
+    fun `SetImgurClientId persists the text and exposes it`() = runTest {
+        val viewModel = newViewModel()
+        assertEquals("client id is empty by default", "", viewModel.state.value.imgurClientId)
+
+        viewModel.submit(SettingsIntent.SetImgurClientId("CID-42"))
+
+        val state = viewModel.state.value
+        assertEquals("CID-42", state.imgurClientId)
+        assertFalse(state.imgurClientIdError)
+        assertEquals(1, repository.imgurClientIdSetCalls)
+        assertEquals("CID-42", repository.lastImgurClientIdSet)
+    }
+
+    @Test
+    fun `SetImgurClientId raises the error flag on persist failure but keeps the typed text`() = runTest {
+        repository.failOnImgurClientIdSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.SetImgurClientId("CID-42"))
+
+        val state = viewModel.state.value
+        // The optimistic value is kept — wiping what the user just typed would be hostile.
+        assertEquals("typed text is preserved on persist failure", "CID-42", state.imgurClientId)
+        assertTrue(state.imgurClientIdError)
+        assertEquals(1, repository.imgurClientIdSetCalls)
+    }
+
+    @Test
+    fun `upload provider hydration race - a stale initial emission must not overwrite a local change`() =
+        runTest {
+            // Same startup-race contract as ThemeMode (#459): the user picks IMGUR while init is still
+            // suspended on observeUploadProvider().first(); the late stale DIBERIE must be skipped by
+            // the touchedLocally guard.
+            val initialHydrationFlow = MutableSharedFlow<UploadProviderId>(replay = 0)
+            repository.uploadProviderObserveOverride = initialHydrationFlow
+            val viewModel = newViewModel()
+
+            viewModel.submit(SettingsIntent.SetUploadProvider(UploadProviderId.IMGUR))
+            assertEquals(UploadProviderId.IMGUR, viewModel.state.value.uploadProvider)
+            assertTrue(viewModel.state.value.uploadProviderTouchedLocally)
+
+            initialHydrationFlow.emit(UploadProviderId.DIBERIE)
+
+            val finalState = viewModel.state.value
+            assertEquals(
+                "stale hydration must NOT overwrite the local provider change",
+                UploadProviderId.IMGUR,
+                finalState.uploadProvider,
+            )
+            assertEquals(1, repository.uploadProviderSetCalls)
+            assertEquals(UploadProviderId.IMGUR, repository.lastUploadProviderSet)
+        }
+
     private fun newViewModel(): SettingsViewModel =
         SettingsViewModel(repository, topicCacheMaintenance, imageCacheMaintenance)
 
@@ -1356,15 +1459,51 @@ class SettingsViewModelTest {
 
         override suspend fun setStartScreen(preference: StartScreenPreference) = Unit
 
-        // #459 — upload provider / imgur Client-ID not exercised by these tests; default stubs.
+        // #459 — upload provider / imgur Client-ID. Same optimistic-flip seam as the theme controls
+        // so the Settings tests can assert hydration, the repo call, and the revert-on-failure path.
+        private val uploadProvider = MutableStateFlow(UploadProviderId.DIBERIE)
+        var uploadProviderSetCalls: Int = 0
+            private set
+        var lastUploadProviderSet: UploadProviderId? = null
+            private set
+        var failOnUploadProviderSet: Boolean = false
+
+        /** Startup-race seam, mirroring [themeModeObserveOverride] (#459). */
+        var uploadProviderObserveOverride: Flow<UploadProviderId>? = null
+
         override fun observeUploadProvider(): Flow<UploadProviderId> =
-            MutableStateFlow(UploadProviderId.DIBERIE)
+            uploadProviderObserveOverride ?: uploadProvider
 
-        override suspend fun setUploadProvider(provider: UploadProviderId) = Unit
+        override suspend fun setUploadProvider(provider: UploadProviderId) {
+            uploadProviderSetCalls += 1
+            check(!failOnUploadProviderSet) { "boom" }
+            lastUploadProviderSet = provider
+            uploadProvider.value = provider
+        }
 
-        override fun observeImgurClientId(): Flow<String> = MutableStateFlow("")
+        fun emitUploadProvider(value: UploadProviderId) {
+            uploadProvider.value = value
+        }
 
-        override suspend fun setImgurClientId(clientId: String) = Unit
+        private val imgurClientId = MutableStateFlow("")
+        var imgurClientIdSetCalls: Int = 0
+            private set
+        var lastImgurClientIdSet: String? = null
+            private set
+        var failOnImgurClientIdSet: Boolean = false
+
+        override fun observeImgurClientId(): Flow<String> = imgurClientId
+
+        override suspend fun setImgurClientId(clientId: String) {
+            imgurClientIdSetCalls += 1
+            check(!failOnImgurClientIdSet) { "boom" }
+            lastImgurClientIdSet = clientId
+            imgurClientId.value = clientId
+        }
+
+        fun emitImgurClientId(value: String) {
+            imgurClientId.value = value
+        }
 
         // #312 — confirm-before-posting. Same optimistic-flip seam as the topic top-bar toggle.
         private val confirmBeforePosting = MutableStateFlow(false)


### PR DESCRIPTION
Comble deux manques remontés en production après la livraison de l'upload d'images (refs-#459) : pas d'UI pour choisir l'hébergeur, et un message d'erreur d'upload trop vague (refs-#474).

## Réglage « Hébergeur d'images » (refs-#459)

La plomberie de préférences (`observeUploadProvider` / `setUploadProvider` / `observeImgurClientId` / `setImgurClientId`) existait depuis refs-#459 mais n'était **jamais exposée** : l'utilisateur restait bloqué sur diberie par défaut, sans moyen de basculer sur imgur ni de saisir son Client-ID.

- **`SettingsState`** : `uploadProvider` (enum, schéma optimistic-flip identique à `themeMode` : valeur affichée + `isUpdating` + `error` + `touchedLocally`) et `imgurClientId` (texte). Getter `canChangeUploadProvider`.
- **`SettingsViewModel`** : hydratation one-shot des deux prefs (même garde `touchedLocally` que les autres réglages, anti-clobber d'une hydratation tardive). Intents `SetUploadProvider` (revert-on-failure) et `SetImgurClientId` (persisté à chaque frappe ; le texte tapé est **conservé** en cas d'échec de persistance, ne jamais effacer la saisie). `UserPreferencesRepository` déjà injecté.
- **`SettingsScreen`** : carte « Hébergeur d'images » dans la section Images, cohérente avec les cartes thème/densité/démarrage (mêmes `Card`/`Text`/`SingleChoiceSegmentedButtonRow`). Choix par boutons segmentés M3 : « diberie (sans compte) » / « imgur (Client-ID requis) ». Le champ `OutlinedTextField` du Client-ID (label + texte d'aide « Client-ID d'application Imgur ») n'apparaît **que** quand imgur est sélectionné. M3 uniquement (l'import `androidx.compose.material.*` est interdit par detekt).

**Ce que chaque hébergeur attend** : diberie fonctionne sans aucune authentification (défaut) ; imgur nécessite un Client-ID d'application public que l'utilisateur colle dans le champ (l'app n'en embarque aucun).

## Erreur d'upload précise (refs-#474)

`Server` (HTTP non-2xx) et `Malformed` (corps illisible) s'effondraient tous deux dans un unique `UploadError.Host` « erreur de l'hébergeur » générique, masquant la cause réelle.

- **`UploadError`** : `Host` remplacé par `Server(code, providerId)` et `Malformed(providerId)` distincts. `TooLarge` (avec la taille), `UnsupportedType` (avec le mime), `Network` inchangés.
- **`handleUploadFailure`** : `UploadException.Server` → `UploadError.Server(code, providerId)`, `UploadException.Malformed` → `UploadError.Malformed(providerId)`. Le rethrow `CancellationException` et le log diagnostics ne sont **pas** modifiés.
- **`PostEditorScreen`** : l'extension `bannerResId` (`@StringRes Int` fixe) est remplacée pour `uploadError` par un résolveur `@Composable bannerText()` qui passe les arguments. Messages exacts :
  - Server → « L'hébergeur %1$s a refusé l'image (HTTP %2$d). Réessayez ou changez d'hébergeur dans les réglages. »
  - Malformed → « Réponse illisible de l'hébergeur %1$s. Réessayez ou changez d'hébergeur dans les réglages. »

Le rendu reste un `Text` rouge inline sous l'éditeur (pas un snackbar) + bouton « Masquer », comme le `submitError` voisin.

## Tests

- **`SettingsViewModelTest`** : hydratation provider + Client-ID dans le state, `SetUploadProvider` appelle le repo + flip optimiste + revert-on-failure, `SetImgurClientId` appelle le repo + conservation du texte en cas d'échec, course d'hydratation (émission tardive ne clobbe pas un changement local). Fake repo étendu (compteurs + seams fail/override).
- **`PostEditorViewModelTest`** : `Server(503, DIBERIE)` → `UploadError.Server(code, host)`, nouveau test `Malformed(IMGUR)` → `UploadError.Malformed(host)` distinct ; TooLarge / UnsupportedType / Network inchangés.

**Tests écrits, non exécutés** — build + gate exécutés séparément sur machine B.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
