### PR TITLE
feat(editor): upload multi-images — sélectionner et uploader plusieurs images d'un coup

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextField.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextField.kt
@@ -92,6 +92,9 @@ fun BbcodeTextField(
     modifier: Modifier = Modifier,
     placeholder: String? = null,
     fillViewport: Boolean = false,
+    // Multi-image upload — true makes the field non-editable while a batch is in flight so the user
+    // cannot move the caret between two programmatic [img] insertions. Default false = editable.
+    readOnly: Boolean = false,
 ) {
     if (fillViewport) {
         BoxWithConstraints(modifier = modifier) {
@@ -111,6 +114,7 @@ fun BbcodeTextField(
                     onValueChange = onValueChange,
                     label = label,
                     placeholder = placeholder,
+                    readOnly = readOnly,
                     modifier = Modifier
                         .fillMaxWidth()
                         .heightIn(min = viewportMinHeight),
@@ -123,6 +127,7 @@ fun BbcodeTextField(
             onValueChange = onValueChange,
             label = label,
             placeholder = placeholder,
+            readOnly = readOnly,
             modifier = modifier.fillMaxWidth(),
         )
     }
@@ -131,6 +136,8 @@ fun BbcodeTextField(
 /** Test tag of the #275/#410 scrollable viewport wrapping the grown field. */
 const val BBCODE_FIELD_VIEWPORT_TAG = "bbcode_field_viewport"
 
+@Suppress("LongParameterList") // Compose component impl: mirrors BbcodeTextField's idiomatic surface
+// (value/onValueChange/label/placeholder/modifier + readOnly) — a config holder would hurt clarity.
 @Composable
 private fun BbcodeFieldImpl(
     value: TextFieldValue,
@@ -138,6 +145,7 @@ private fun BbcodeFieldImpl(
     label: String,
     placeholder: String?,
     modifier: Modifier,
+    readOnly: Boolean = false,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
@@ -158,6 +166,7 @@ private fun BbcodeFieldImpl(
     BasicTextField(
         value = value,
         onValueChange = onValueChange,
+        readOnly = readOnly,
         // The real M3 OutlinedTextField merges the label into the field's semantics node and
         // reserves 8.dp above the box for the floating label's upper half (internal
         // `OutlinedTextFieldTopPadding`) — without it the minimized label is clipped at the top.

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorIntent.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorIntent.kt
@@ -65,6 +65,14 @@ sealed interface PostEditorIntent {
      */
     data class ImagePicked(val uri: String) : PostEditorIntent
 
+    /**
+     * Multi-image upload — the user picked several local images at once from the system photo
+     * picker. [uris] holds each `Uri.toString()`, in pick order. The ViewModel uploads them
+     * sequentially and inserts an `[img]url[/img]` at the caret for each success (order preserved);
+     * the batch stops at the first failure, leaving the already-inserted images in place.
+     */
+    data class ImagesPicked(val uris: List<String>) : PostEditorIntent
+
     /** #459 PR2 — user dismissed the upload-error banner. Clears [PostEditorState.uploadError]. */
     data object UploadErrorDismissed : PostEditorIntent
 

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -56,6 +56,24 @@ import fr.forumhfr.redface2.core.ui.editor.BbcodeTextField
 import fr.forumhfr.redface2.core.ui.editor.BbcodeToolbar
 import fr.forumhfr.redface2.core.ui.editor.EditorOptionsSheet
 
+/** Upload multi-images — cap on how many images one pick can queue, passed to the photo picker. */
+private const val MAX_IMAGES_PER_UPLOAD = 10
+
+/**
+ * Multi-image upload — « n/N » counter shown under the toolbar while a batch is in flight. Extracted
+ * so [PostEditorContent] stays under the cyclomatic-complexity budget. Emits nothing for a single
+ * image (null progress), which only flips the toolbar spinner.
+ */
+@Composable
+private fun UploadProgressLabel(progress: UploadProgress?) {
+    if (progress == null) return
+    Text(
+        text = stringResource(R.string.editor_upload_progress, progress.completed, progress.total),
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
 /**
  * Post-level editor screen. Phase 2C (#145) adds a Submit button that posts the
  * reply via [PostEditorViewModel.submit]. Successful submissions raise a one-shot
@@ -95,14 +113,15 @@ private fun PostEditorContent(
 ) {
     var imageUrlDialogOpen by remember { mutableStateOf(false) }
     var optionsSheetOpen by remember { mutableStateOf(false) }
-    // #459 PR2 — modern Android photo picker (no runtime permission). The contract returns a
-    // nullable Uri ; on a non-null pick we hand the ViewModel the Uri's string so the platform-free
-    // VM reads the bytes via ImageUploadReader and uploads. API confirmed via Context7
-    // (androidx ActivityResultContracts.PickVisualMedia, input PickVisualMediaRequest, output Uri?).
-    val pickImageLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.PickVisualMedia(),
-    ) { uri ->
-        if (uri != null) onIntent(PostEditorIntent.ImagePicked(uri.toString()))
+    // #459 PR2 — modern Android photo picker (no runtime permission). Multi-select variant: the
+    // contract returns a (possibly empty) List<Uri> ; we hand the platform-free VM each Uri's string
+    // and it reads + uploads them sequentially, inserting an [img] per success. API confirmed via
+    // Context7 (androidx ActivityResultContracts.PickMultipleVisualMedia(maxItems), input
+    // PickVisualMediaRequest, output List<Uri>). A single pick is just a one-element list.
+    val pickImagesLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickMultipleVisualMedia(MAX_IMAGES_PER_UPLOAD),
+    ) { uris ->
+        if (uris.isNotEmpty()) onIntent(PostEditorIntent.ImagesPicked(uris.map { it.toString() }))
     }
     // Reply (#145), Quote (#146) and Edit (#147) submit through HFR's reply/edit form ; the other
     // (defensive) modes show a disabled note instead of a submit bar.
@@ -137,12 +156,16 @@ private fun PostEditorContent(
                     onAction = { action -> onIntent(PostEditorIntent.ToolbarActionClicked(action)) },
                     onImageUrlRequested = { imageUrlDialogOpen = true },
                     onImageUploadRequested = {
-                        pickImageLauncher.launch(
+                        pickImagesLauncher.launch(
                             PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
                         )
                     },
                     uploading = state.isUploading,
                 )
+
+                // Multi-image upload — « n/N » progress under the toolbar while a batch (> 1 image)
+                // is in flight. A single upload keeps uploadProgress null (toolbar spinner only).
+                UploadProgressLabel(state.uploadProgress)
 
                 BbcodeTextField(
                     value = state.draft,

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -176,6 +176,9 @@ private fun PostEditorContent(
                     // #275/#410 — grow-with-content field in its own scrollable viewport so the
                     // cursor stays visible under the IME (typing AND refocus after the preview).
                     fillViewport = true,
+                    // Multi-image upload — lock editing during a batch so the user can't move the
+                    // caret between two programmatic [img] insertions (keeps them in pick order).
+                    readOnly = state.isUploading,
                 )
 
                 Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
@@ -114,6 +114,12 @@ data class PostEditorState(
      * error to show ». Cleared on a fresh content mutation or via [PostEditorIntent.UploadErrorDismissed].
      */
     val uploadError: UploadError? = null,
+    /**
+     * Multi-image upload — progress of the in-flight batch, or null when no batch (or a single
+     * image) is uploading. [UploadProgress.total] > 1 is what the editor uses to show an « n/N »
+     * counter; a one-image upload keeps this null and only flips [isUploading].
+     */
+    val uploadProgress: UploadProgress? = null,
 ) {
     /**
      * Submission is allowed when : we know the routing context (page + subcat + topicId),
@@ -184,6 +190,12 @@ sealed interface UploadError {
     /** No network / DNS / timeout — also covers an unreadable picked Uri (mapped to Network). */
     data object Network : UploadError
 }
+
+/**
+ * Progress of a multi-image upload batch: [completed] images uploaded and inserted out of [total]
+ * picked. Surfaced as an « n/N » counter while [PostEditorState.isUploading] is true.
+ */
+data class UploadProgress(val completed: Int, val total: Int)
 
 
 

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -446,13 +446,15 @@ class PostEditorViewModel @AssistedInject constructor(
                     return@launch
                 }
                 insertImageUrlAtCaret(uploaded.imageUrl)
+                // Persist after EACH insert, not once at the end: a later image failing must not
+                // lose the images already inserted into the draft (Codex review #490).
+                scheduleAutosave()
                 completed += 1
                 if (multiple) {
                     _state.update { it.copy(uploadProgress = UploadProgress(completed, targets.size)) }
                 }
             }
             _state.update { it.copy(isUploading = false, uploadError = null, uploadProgress = null) }
-            scheduleAutosave()
         }
     }
 

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -221,6 +221,7 @@ class PostEditorViewModel @AssistedInject constructor(
             is PostEditorIntent.SmileySelected -> onSmileySelected(intent.token)
             is PostEditorIntent.ImageUrlInserted -> onImageUrlInserted(intent.url)
             is PostEditorIntent.ImagePicked -> onImagePicked(intent.uri)
+            is PostEditorIntent.ImagesPicked -> onImagesPicked(intent.uris)
             PostEditorIntent.UploadErrorDismissed -> _state.update { it.copy(uploadError = null) }
             PostEditorIntent.DraftRestoreRequested -> onDraftRestoreRequested()
             PostEditorIntent.DraftDiscardRequested -> onDraftDiscardRequested()
@@ -409,29 +410,55 @@ class PostEditorViewModel @AssistedInject constructor(
      * the providers require an HFR session for the trace, and surfacing « connectez-vous » here
      * would duplicate the submit-time LoginRequired surface.
      */
-    private fun onImagePicked(uri: String) {
-        if (uploadJob?.isActive == true) return
-        val userId = activeUserId ?: return
-        _state.update { it.copy(isUploading = true, uploadError = null) }
-        uploadJob = viewModelScope.launch {
-            val outcome = runCatching {
-                val image = imageUploadReader.read(uri)
-                uploadRepository.uploadWithCurrentProvider(image, userId)
-            }
-            outcome.fold(
-                onSuccess = { uploaded ->
-                    insertImageUrlAtCaret(uploaded.imageUrl)
-                    _state.update { it.copy(isUploading = false, uploadError = null) }
-                    scheduleAutosave()
-                },
-                onFailure = ::handleUploadFailure,
+    private fun onImagePicked(uri: String) = onImagesPicked(listOf(uri))
+
+    /**
+     * Multi-image upload — uploads the picked [uris] sequentially (one in-flight at a time, same
+     * job/gate as the single path) and inserts `[img]url[/img]` at the caret for each success, in
+     * pick order (each insertion advances the caret so the next lands after it). The batch stops at
+     * the first failure: the already-inserted images stay and the typed [UploadError] is surfaced —
+     * the user fixes the cause and re-picks the rest. A blank list, an anonymous client (no userId),
+     * or an upload already in flight are ignored. [PostEditorState.uploadProgress] carries an « n/N »
+     * counter while more than one image is in the batch (null for a single image).
+     */
+    private fun onImagesPicked(uris: List<String>) {
+        val userId = activeUserId
+        val targets = uris.filter { it.isNotBlank() }
+        // One guard (ReturnCount): nothing in flight already, an authenticated owner, a non-empty pick.
+        if (uploadJob?.isActive == true || userId == null || targets.isEmpty()) return
+        val multiple = targets.size > 1
+        _state.update {
+            it.copy(
+                isUploading = true,
+                uploadError = null,
+                uploadProgress = if (multiple) UploadProgress(completed = 0, total = targets.size) else null,
             )
+        }
+        uploadJob = viewModelScope.launch {
+            var completed = 0
+            for (uri in targets) {
+                val outcome = runCatching {
+                    val image = imageUploadReader.read(uri)
+                    uploadRepository.uploadWithCurrentProvider(image, userId)
+                }
+                val uploaded = outcome.getOrElse { error ->
+                    handleUploadFailure(error)
+                    return@launch
+                }
+                insertImageUrlAtCaret(uploaded.imageUrl)
+                completed += 1
+                if (multiple) {
+                    _state.update { it.copy(uploadProgress = UploadProgress(completed, targets.size)) }
+                }
+            }
+            _state.update { it.copy(isUploading = false, uploadError = null, uploadProgress = null) }
+            scheduleAutosave()
         }
     }
 
     private fun handleUploadFailure(error: Throwable) {
         if (error is CancellationException) {
-            _state.update { it.copy(isUploading = false) }
+            _state.update { it.copy(isUploading = false, uploadProgress = null) }
             throw error
         }
         val mapped = when (error) {
@@ -449,7 +476,7 @@ class PostEditorViewModel @AssistedInject constructor(
             LOG_TAG_VM,
             "image upload failed: ${error::class.simpleName} → ${mapped::class.simpleName}",
         )
-        _state.update { it.copy(isUploading = false, uploadError = mapped) }
+        _state.update { it.copy(isUploading = false, uploadError = mapped, uploadProgress = null) }
     }
 
     private fun onContentChanged(value: TextFieldValue) {

--- a/feature/editor/src/main/res/values/strings.xml
+++ b/feature/editor/src/main/res/values/strings.xml
@@ -50,6 +50,8 @@
     <string name="editor_upload_error_server">L\'hébergeur %1$s a refusé l\'image (HTTP %2$d). Réessayez ou changez d\'hébergeur dans les réglages.</string>
     <string name="editor_upload_error_malformed">Réponse illisible de l\'hébergeur %1$s. Réessayez ou changez d\'hébergeur dans les réglages.</string>
     <string name="editor_upload_error_network">Erreur réseau pendant l\'upload. Vérifiez votre connexion et réessayez.</string>
+    <!-- Upload multi-images — compteur de progression « n/N » affiché pendant l\'envoi du lot. -->
+    <string name="editor_upload_progress">Envoi %1$d/%2$d…</string>
     <!-- Noms d\'hébergeurs d\'images affichés dans les messages d\'erreur (#474). -->
     <string name="editor_upload_provider_diberie">diberie</string>
     <string name="editor_upload_provider_imgur">imgur</string>

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -1223,6 +1223,11 @@ class PostEditorViewModelTest {
         testScheduler.advanceUntilIdle()
 
         assertEquals("every picked image is uploaded", 3, uploadRepository.uploadCalls)
+        assertEquals(
+            "images are read in pick order (sequential, not reordered)",
+            listOf("content://x/1", "content://x/2", "content://x/3"),
+            imageUploadReader.readUris,
+        )
         val state = viewModel.state.value
         val expected = "[img]https://h/Picture/Get/f/1[/img]" +
             "[img]https://h/Picture/Get/f/2[/img]" +
@@ -1234,11 +1239,14 @@ class PostEditorViewModelTest {
     }
 
     @Test
-    fun `ImagesPicked exposes n of N progress and clears it when the batch ends`() = runTest {
+    fun `ImagesPicked increments n of N as each image completes and clears it at the end`() = runTest {
         val authRepository = FakeAuthRepository(AuthState.Authenticated("alice"))
         imageUploadReader.result = ImageUpload(bytes = byteArrayOf(1), mimeType = "image/png", displayName = null)
         val gate = CompletableDeferred<Unit>()
         uploadRepository.uploadGate = gate
+        // Hold ONLY the 2nd upload so the batch settles at 1/2 — proving the counter increments
+        // past its initial 0/N (not just set-then-cleared).
+        uploadRepository.gateOnCall = 2
         uploadRepository.uploadResults = listOf(
             Result.success(uploadedImage("https://h/1")),
             Result.success(uploadedImage("https://h/2")),
@@ -1247,13 +1255,13 @@ class PostEditorViewModelTest {
         testScheduler.advanceUntilIdle()
 
         viewModel.submit(PostEditorIntent.ImagesPicked(listOf("content://x/1", "content://x/2")))
-        testScheduler.runCurrent()
+        testScheduler.advanceUntilIdle()
         assertEquals(
-            "a multi-image batch starts at 0/N",
-            UploadProgress(completed = 0, total = 2),
+            "after the first image completes the counter shows 1/2",
+            UploadProgress(completed = 1, total = 2),
             viewModel.state.value.uploadProgress,
         )
-        assertTrue("isUploading is true while the batch runs", viewModel.state.value.isUploading)
+        assertTrue("still uploading while the 2nd image is in flight", viewModel.state.value.isUploading)
 
         gate.complete(Unit)
         testScheduler.advanceUntilIdle()
@@ -1292,6 +1300,31 @@ class PostEditorViewModelTest {
         )
         assertFalse("upload flag cleared on failure", state.isUploading)
         assertNull("progress cleared on failure", state.uploadProgress)
+    }
+
+    @Test
+    fun `ImagesPicked autosaves the images inserted before a later image fails`() = runTest {
+        // Codex review #490 — a mid-batch failure must not lose the already-inserted images from
+        // draft persistence: each successful insert schedules an autosave, not just the whole batch.
+        replyRepository.formResult = Result.success(authenticatedForm())
+        val authRepository = FakeAuthRepository(AuthState.Authenticated("alice"))
+        imageUploadReader.result = ImageUpload(bytes = byteArrayOf(1), mimeType = "image/png", displayName = null)
+        uploadRepository.uploadResults = listOf(
+            Result.success(uploadedImage("https://h/Picture/Get/f/1")),
+            Result.failure(UploadException.Network(java.io.IOException("down"))),
+        )
+        val viewModel = newReplyViewModel(authRepository = authRepository)
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(PostEditorIntent.ImagesPicked(listOf("content://x/1", "content://x/2")))
+        testScheduler.advanceUntilIdle() // uploads run; 1st inserts + schedules autosave, 2nd fails; debounce elapses
+
+        val key = EditorDraftKey.reply(SAMPLE_CAT, SAMPLE_TOPIC_ID)
+        assertEquals(
+            "the image inserted before the failure must be persisted",
+            "[img]https://h/Picture/Get/f/1[/img]",
+            draftStore.saved[key]?.body,
+        )
     }
 
     private fun newEditViewModel(
@@ -1960,9 +1993,13 @@ class PostEditorViewModelTest {
         var readCalls: Int = 0
             private set
 
+        /** Multi-image upload — every uri passed to [read], in call order, to assert pick order. */
+        val readUris: MutableList<String> = mutableListOf()
+
         override suspend fun read(uri: String): ImageUpload {
             readCalls += 1
             lastUri = uri
+            readUris += uri
             exception?.let { throw it }
             return result
         }
@@ -1985,6 +2022,13 @@ class PostEditorViewModelTest {
         var uploadGate: CompletableDeferred<Unit>? = null
 
         /**
+         * Multi-image upload — when set, [uploadGate] is awaited ONLY on this 1-based call index
+         * (e.g. 2 holds the 2nd upload so a test can observe the « 1/2 » progress after the 1st).
+         * Null = the gate is awaited on every call (single-image gate tests).
+         */
+        var gateOnCall: Int? = null
+
+        /**
          * Multi-image upload — per-call outcomes, consumed in order (call N → `uploadResults[N-1]`).
          * When set it takes precedence over [uploadResult] / [uploadException], so a test can make
          * the 2nd of three uploads fail and assert the batch stops there.
@@ -1998,7 +2042,7 @@ class PostEditorViewModelTest {
         override suspend fun uploadWithCurrentProvider(image: ImageUpload, userId: String): UploadedImage {
             uploadCalls += 1
             lastUserId = userId
-            uploadGate?.await()
+            if (gateOnCall == null || gateOnCall == uploadCalls) uploadGate?.await()
             uploadResults?.let { return it[uploadCalls - 1].getOrThrow() }
             uploadException?.let { throw it }
             return uploadResult

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -1205,6 +1205,95 @@ class PostEditorViewModelTest {
         assertNull("dismissing clears the upload error", viewModel.state.value.uploadError)
     }
 
+    @Test
+    fun `ImagesPicked uploads every image and inserts an img per success in pick order`() = runTest {
+        val authRepository = FakeAuthRepository(AuthState.Authenticated("alice"))
+        imageUploadReader.result = ImageUpload(bytes = byteArrayOf(1), mimeType = "image/png", displayName = null)
+        uploadRepository.uploadResults = listOf(
+            Result.success(uploadedImage("https://h/Picture/Get/f/1")),
+            Result.success(uploadedImage("https://h/Picture/Get/f/2")),
+            Result.success(uploadedImage("https://h/Picture/Get/f/3")),
+        )
+        val viewModel = newReplyViewModel(authRepository = authRepository)
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(
+            PostEditorIntent.ImagesPicked(listOf("content://x/1", "content://x/2", "content://x/3")),
+        )
+        testScheduler.advanceUntilIdle()
+
+        assertEquals("every picked image is uploaded", 3, uploadRepository.uploadCalls)
+        val state = viewModel.state.value
+        val expected = "[img]https://h/Picture/Get/f/1[/img]" +
+            "[img]https://h/Picture/Get/f/2[/img]" +
+            "[img]https://h/Picture/Get/f/3[/img]"
+        assertEquals("one [img] per image, concatenated in pick order", expected, state.draft.text)
+        assertFalse("upload flag cleared at the end of the batch", state.isUploading)
+        assertNull("progress cleared at the end of the batch", state.uploadProgress)
+        assertNull("no error on a fully successful batch", state.uploadError)
+    }
+
+    @Test
+    fun `ImagesPicked exposes n of N progress and clears it when the batch ends`() = runTest {
+        val authRepository = FakeAuthRepository(AuthState.Authenticated("alice"))
+        imageUploadReader.result = ImageUpload(bytes = byteArrayOf(1), mimeType = "image/png", displayName = null)
+        val gate = CompletableDeferred<Unit>()
+        uploadRepository.uploadGate = gate
+        uploadRepository.uploadResults = listOf(
+            Result.success(uploadedImage("https://h/1")),
+            Result.success(uploadedImage("https://h/2")),
+        )
+        val viewModel = newReplyViewModel(authRepository = authRepository)
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(PostEditorIntent.ImagesPicked(listOf("content://x/1", "content://x/2")))
+        testScheduler.runCurrent()
+        assertEquals(
+            "a multi-image batch starts at 0/N",
+            UploadProgress(completed = 0, total = 2),
+            viewModel.state.value.uploadProgress,
+        )
+        assertTrue("isUploading is true while the batch runs", viewModel.state.value.isUploading)
+
+        gate.complete(Unit)
+        testScheduler.advanceUntilIdle()
+        assertNull("progress cleared once the batch resolves", viewModel.state.value.uploadProgress)
+        assertFalse("isUploading cleared once the batch resolves", viewModel.state.value.isUploading)
+    }
+
+    @Test
+    fun `ImagesPicked stops at the first failure and keeps the earlier images inserted`() = runTest {
+        val authRepository = FakeAuthRepository(AuthState.Authenticated("alice"))
+        imageUploadReader.result = ImageUpload(bytes = byteArrayOf(1), mimeType = "image/png", displayName = null)
+        uploadRepository.uploadResults = listOf(
+            Result.success(uploadedImage("https://h/Picture/Get/f/1")),
+            Result.failure(UploadException.Server(code = 500, providerId = UploadProviderId.DIBERIE)),
+            Result.success(uploadedImage("https://h/Picture/Get/f/3")),
+        )
+        val viewModel = newReplyViewModel(authRepository = authRepository)
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(
+            PostEditorIntent.ImagesPicked(listOf("content://x/1", "content://x/2", "content://x/3")),
+        )
+        testScheduler.advanceUntilIdle()
+
+        assertEquals("the batch stops after the failing upload — no 3rd attempt", 2, uploadRepository.uploadCalls)
+        val state = viewModel.state.value
+        assertEquals(
+            "only the image uploaded before the failure is inserted",
+            "[img]https://h/Picture/Get/f/1[/img]",
+            state.draft.text,
+        )
+        assertEquals(
+            "the typed error from the failing upload surfaces",
+            UploadError.Server(code = 500, providerId = UploadProviderId.DIBERIE),
+            state.uploadError,
+        )
+        assertFalse("upload flag cleared on failure", state.isUploading)
+        assertNull("progress cleared on failure", state.uploadProgress)
+    }
+
     private fun newEditViewModel(
         subcat: Int? = SAMPLE_SUBCAT,
         numreponse: Int? = SAMPLE_EDITED_NUMREPONSE,
@@ -1894,6 +1983,13 @@ class PostEditorViewModelTest {
         )
         var uploadException: Throwable? = null
         var uploadGate: CompletableDeferred<Unit>? = null
+
+        /**
+         * Multi-image upload — per-call outcomes, consumed in order (call N → `uploadResults[N-1]`).
+         * When set it takes precedence over [uploadResult] / [uploadException], so a test can make
+         * the 2nd of three uploads fail and assert the batch stops there.
+         */
+        var uploadResults: List<Result<UploadedImage>>? = null
         var uploadCalls: Int = 0
             private set
         var lastUserId: String? = null
@@ -1903,6 +1999,7 @@ class PostEditorViewModelTest {
             uploadCalls += 1
             lastUserId = userId
             uploadGate?.await()
+            uploadResults?.let { return it[uploadCalls - 1].getOrThrow() }
             uploadException?.let { throw it }
             return uploadResult
         }


### PR DESCRIPTION
> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

Demande directe de @XaTriX (topic DEV) : pouvoir uploader **plusieurs images d'un coup** depuis l'éditeur.

## Comportement
- Le bouton image de la toolbar ouvre désormais le **sélecteur photo multi** (`PickMultipleVisualMedia`, plafond 10 — API vérifiée Context7).
- Les images choisies sont uploadées **séquentiellement** via le chemin provider existant (donc diberie **et** imgur), et un `[img]url[/img]` est inséré au curseur pour chaque succès, **dans l'ordre de sélection** (chaque insertion fait avancer le curseur).
- **Abort au 1er échec** : le lot s'arrête à la première image en erreur, les images déjà insérées **restent**, et l'`UploadError` typée est remontée (l'utilisateur corrige et re-sélectionne le reste).
- Compteur **« n/N »** sous la toolbar pendant un lot (> 1 image) ; un upload unique garde l'ancien comportement (spinner seul).

## Conception
Provider-agnostique et minimal : réutilise le chemin mono-image déjà testé. `ImagePicked` (mono) route maintenant vers le même chemin de lot (liste à un élément), donc un seul code path, un seul job en vol (gate inchangée).

- `PostEditorIntent.ImagesPicked(uris)`
- `PostEditorViewModel.onImagesPicked` — boucle séquentielle, abort au 1er échec, progression
- `PostEditorState.UploadProgress(completed, total)` — null pour un upload unique
- `PostEditorScreen` — `PickMultipleVisualMedia(10)` + `UploadProgressLabel` extrait (budget complexité)
- Tests : ordre + insertion d'un `[img]` par image, progression 0/N puis clear, abort au 1er échec

## Vérification
`detektAll test :app:assembleProdDebug :app:lintProdDebug` → **vert** (hôte B, Docker). Émulateur HS sur la machine (SIGSEGV swiftshader) — couverture par tests ViewModel (fake reader/repo, résultats par-appel).
