### PR TITLE
ci: fan out CI by task type (assemble | test | lint | detekt)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,36 @@ permissions:
   contents: read
 
 jobs:
+  # Fan-out by task type (was a single `verify` job running every task in one invocation). Each
+  # entry runs on its own runner, so the four task groups parallelise PAST the 4-vCPU cap of a
+  # single runner. `setup-gradle` gives each entry its own incremental build cache (seeded on push
+  # to main/dev, read-only on PRs) so unchanged modules are not recompiled per job; the only
+  # duplication is recompiling the PR's *changed* modules in each entry — the build cache cannot be
+  # shared across jobs running concurrently.
+  #
+  # `:app` is flavored (#233 channels) so its variant tasks are flavored: the unqualified
+  # `lintDebug` / `:app:assembleDebug` no longer resolve for `:app`. Use the default `prod` flavor
+  # for the `:app` lint + APK; `lintDebug` / `test` / `testDebugUnitTest` still cover the
+  # (flavour-less) core/feature/jvm modules, and the unqualified `test` covers `:app`'s unit tests
+  # across variants (incl. the Konsist architecture test).
   verify:
-    name: Build, lint and test
+    name: ${{ matrix.task.name }}
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/cirruslabs/android-sdk:36@sha256:f9b3ea9ed2b5fc9522adae82c7b4622ab7aa54207ef532c8e615a347dca08f31
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        task:
+          - name: assemble
+            gradle: ":app:assembleProdDebug"
+          - name: test
+            gradle: "test testDebugUnitTest"
+          - name: lint
+            gradle: "lintDebug :app:lintProdDebug"
+          - name: detekt
+            gradle: "detektAll"
 
     steps:
       - name: Checkout
@@ -29,10 +53,24 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
 
-      - name: Verify
-        # `:app` now has product flavors (#233 channels) so its variant tasks are flavored:
-        # the unqualified `lintDebug` / `:app:assembleDebug` no longer resolve for `:app`. Use the
-        # default `prod` flavor for the `:app` lint + APK; `lintDebug`/`test`/`testDebugUnitTest`
-        # still cover the (flavour-less) core/feature/jvm modules, and the unqualified `test`
-        # covers `:app`'s unit tests across variants (incl. the Konsist architecture test).
-        run: ./gradlew detektAll lintDebug test testDebugUnitTest :app:lintProdDebug :app:assembleProdDebug
+      - name: ${{ matrix.task.name }}
+        run: ./gradlew ${{ matrix.task.gradle }}
+
+  # Single aggregate check whose name is the one `main`'s branch protection requires
+  # ("Build, lint and test"). Green iff every `verify` matrix entry succeeded, so the fan-out stays
+  # compatible with the existing required-status-check on `main` (dev→main promotion) without having
+  # to re-point branch protection at four separate contexts.
+  build-lint-and-test:
+    name: Build, lint and test
+    if: always()
+    needs: [verify]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Require all verify jobs to pass
+        run: |
+          result='${{ needs.verify.result }}'
+          echo "verify matrix result: $result"
+          if [ "$result" != "success" ]; then
+            echo "::error::One or more verify jobs did not succeed ($result)."
+            exit 1
+          fi


### PR DESCRIPTION
> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

Découpe le job unique `verify` en une **matrice à 4 entrées** (`assemble` | `test` | `lint` | `detekt`), chacune sur son propre runner → les 4 groupes parallélisent **au-delà** du plafond de 4 vCPU d'un seul runner. Un job d'agrégation nommé exactement **« Build, lint and test »** (`needs: [verify]`, `if: always()`) reste vert ssi les 4 entrées passent → le **required status check de `main`** (promotion dev→main) est inchangé, sans re-pointer la branch protection.

## Pourquoi (mesures)

Question de départ : « les modules sont-ils interdépendants ? sinon on peut paralléliser ». Réponse : c'est un **DAG** (`:app` → tous ; les 8 `:feature:*` mutuellement indépendants → `:core:domain`+`:core:ui`), et Gradle parallélise **déjà** ce DAG (`org.gradle.parallel=true` + caching + config-cache).

Décomposition d'un vrai run CI (run `27476430215`, dev) :

| Step | Durée |
|---|---|
| Set up job + Initialize containers (pull image 2,9 Go) | 2s + **32s** |
| Checkout + Setup Gradle | 5s + 15s |
| **Verify** (le build Gradle) | **366s** |
| **Total** | **426s (~7 min)** |

→ overhead fixe ≈ **54s**, le coût réel = les **366s** de Gradle. Profil cold sur l'hôte B (6 cœurs) : somme sérielle des tâches **18m21s**, wall **3m46s** → **parallélisme effectif ≈ 4,9×**. Mix : **lint ~23 %**, **test ~18 %**, **compile/ksp ~12 %**, le reste packaging/jar. Le facteur limitant n'est **pas** le graphe de modules mais le **nombre de cœurs** du runner (4 vCPU).

## Compromis (honnête)

- **Gain** : sur une PR à **cache chaud**, chaque entrée ne recompile que les modules *changés* (cache incrémental via `setup-gradle`, seedé sur push dev/main), et les 4 tournent en parallèle → wall-clock attendu nettement < 7 min.
- **Coût** : ~**N× les runner-minutes** (4 runners au lieu d'1) ; sur repo public les minutes sont gratuites. À **cache froid**, chaque entrée recompile sa part (compile dupliqué, non partageable entre jobs concurrents) → wall ≤ actuel mais minutes ×N.
- **Levier alternatif, plus simple et plus gros** : passer le runner à **8 vCPU** (larger runner / self-hosted) couperait les 366s à ~220s **sans restructurer la CI**, puisque Gradle sature déjà les cœurs. À considérer en complément ou à la place.

## Vérif
- YAML validé (`yaml.safe_load`).
- Le run CI de cette PR exercera la matrice → on lira le vrai avant/après (426s → ?).
- L'agrégat « Build, lint and test » préserve la branch protection de `main`.