### PR TITLE
chore(release): bump 0.11.0 + changelog/whatsnew (candidat bêta)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,10 +16,39 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## v132 — `0.11.0` — 2026-06-13
+
+**Statut** : `local` (candidat bêta — numéro anticipé ledger 131+1, à confirmer au dispatch `channel=beta`)
+**Commit** : à venir (promotion dev→main)
+**Fichier** : AAB `bundleProdRelease` → track open testing + tag pour F-Droid beta
+
+**Contenu depuis la 0.10.0/v126** : dogfoodé sur le canal dev (v127 → v131).
+
+### Added
+- **Upload d'images depuis l'éditeur** (#459) : bouton « Uploader » → sélection galerie, upload chez l'hébergeur, insertion `[img]` au curseur.
+- **Upload multi-images** (#490) : sélecteur multi (jusqu'à 10), upload séquentiel dans l'ordre de sélection, compteur « n/N », arrêt à la première erreur (images déjà insérées conservées) ; validé sur S10e.
+- **Choix de l'hébergeur d'images** dans les Réglages (#459/#474) : diberie ou imgur (Client-ID Imgur perso) ; message d'erreur d'upload précis (hébergeur + code HTTP).
+- **Écran « Mes images uploadées »** avec suppression (#459).
+- **Brouillons d'éditeur** (#405) : sauvegarde et restauration automatiques (cache Room).
+- **Multi-quote** : bouton « + » par post pour empiler des citations (#436).
+- **Sondages** : repliés par défaut + réglage « Déplier les sondages » (#456).
+- **Drapeaux** : swipe entre les onglets + suppression par appui long (#457) ; filtre « Mes drapeaux » par (sous-)catégorie (#455) ; bandeau de catégorie cliquable vers le listing (#414).
+- **Messages privés** : ouverture d'un MP sur sa dernière page + reprise de lecture locale (#430).
+- **Affichage** : préréglages de densité + taille de police de lecture sur 3 crans (#287) ; écran de démarrage configurable — onglet + catégorie Forum au lancement (#458).
+
+### Fixed
+- **Upload diberie cassé** (#459/#474) : le `picID` renvoyé par diberie est un nombre JSON (pas une chaîne) — chaque upload échouait au parsing. Corrigé + test de régression sur fixture réelle.
+
+### Changed
+- **`versionName` 0.10.0 → 0.11.0**.
+- Listes densifiées : gouttière globale du NavHost retirée (#398/#287).
+
+---
+
 ## v126 — `0.10.0` — 2026-06-12
 
-**Statut** : `local` (candidat bêta — numéro anticipé ledger 125+1, à confirmer au dispatch `channel=beta`)
-**Commit** : à venir (promotion dev→main)
+**Statut** : `open` (track open testing) + F-Droid `.beta`
+**Commit** : merge de promotion `fe6bda5e` (#451), tag `app-v126` (versionCode 126)
 **Fichier** : AAB `bundleProdRelease` → track open testing + tag pour F-Droid beta
 
 **Contenu depuis la 0.9.0/v113** : night-run 2026-06-11→12 + arbitrages du 12 + dernier round, dogfoodés sur le canal dev (v114 → v125).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.10.0"
+        versionName = "0.11.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,11 +1,13 @@
-Redface 2 v0.10.0 — beta.
+Redface 2 v0.11.0 — beta.
 
 New:
-- Private messages: compose new PMs, smiley picker, unread badge, page swipe, pull-to-refresh.
-- Multi-quote, with visual marking of picked posts.
-- Search: author filter, collapsible form.
-- Reading: end-of-topic marker, display options.
+- Image upload in the editor: from the gallery, several at once, host choice (diberie/imgur), "My images" screen.
+- Editor drafts saved automatically.
+- Multi-quote, collapsible polls.
+- Flags: swipe between tabs, long-press to remove, filter by category.
+- PMs: open on the last page, resume reading.
+- Display: adjustable density/font, configurable start screen.
 
-Fixes: editor follows the cursor while typing, flags/favorites, keyboard, theme, rendering.
+Fix: diberie upload repaired.
 
 Report bugs via the beta or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,11 +1,11 @@
-Redface 2 v0.10.0 — bêta.
+Redface 2 v0.11.0 — bêta.
 
 Nouveautés :
-- Messages privés : rédaction d'un nouveau MP, smileys dans l'éditeur, badge de non-lus, swipe de pages, pull-to-refresh.
-- Citation multiple, avec marquage des posts ajoutés.
-- Recherche : filtre par auteur, formulaire repliable.
-- Lecture : marqueur de fin de sujet, options d'affichage.
+- Upload d'images dans l'éditeur : galerie, plusieurs d'un coup, choix de l'hébergeur (diberie/imgur), écran « Mes images ».
+- Brouillons d'éditeur sauvegardés automatiquement.
+- Multi-quote, sondages repliables.
+- Drapeaux : swipe entre onglets, suppr. appui long, filtre par catégorie.
+- MP : ouverture sur la dernière page lue.
+- Affichage : densité/police réglables, démarrage configurable.
 
-Correctifs : l'éditeur suit le curseur en frappe, drapeaux/favoris, clavier, thème, rendu.
-
-Signale les bugs via la bêta ou GitHub.
+Correctif : upload diberie réparé.


### PR DESCRIPTION
> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

Prépare la **promotion bêta 0.11.0** (étape 1/2 : bump sur `dev`, comme #444→#451 pour la 0.10.0). La PR de promotion `dev → main` suivra.

- `versionName` **0.10.0 → 0.11.0** (`app/build.gradle.kts`) — requis par le guard CI avant ship bêta.
- `app/CHANGELOG.md` : entrée **v132 / 0.11.0** (contenu dogfoodé dev v127→v131) + statut **v126/0.10.0 passé à `open`** (shippée le 12/06, merge `fe6bda5e` #451).
- Notes Play `whatsnew-fr-FR` (471 car.) + `whatsnew-en-US` (465 car.) — sous le cap 500.

Contenu 0.11.0 (depuis la 0.10.0) : upload d'images dans l'éditeur + **multi-images** (#459/#490), choix d'hébergeur diberie/imgur (#474), écran « Mes images », brouillons d'éditeur (#405), multi-quote (#436), sondages repliables (#456), drapeaux swipe/suppression/filtre (#457/#455/#414), MP dernière page (#430), densité/police (#287), écran de démarrage (#458) ; **fix upload diberie** (#488).