### PR TITLE
fix(editor/upload): bind drafts to owning account + honest diberie deletion wording

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/editor/RoomEditorDraftStore.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/editor/RoomEditorDraftStore.kt
@@ -15,13 +15,15 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 
 /**
- * Room-backed [EditorDraftStore] (#405). The active account is snapshotted per call from
- * [AuthRepository]; with no session both reads and writes are no-ops — an anonymous client cannot
- * post (HFR's write forms require a session), so it has no draft, and a save racing a logout must
- * not write a row the purge pass has already swept (CacheInvalidator wipes by previous pseudo).
+ * Room-backed [EditorDraftStore] (#405). Drafts are keyed by the OWNING account the caller
+ * captured via [currentOwner] when the editor opened, never by whatever account is active when a
+ * late write lands. The row key folds that owner into the domain context key
+ * (`"<ownerId>|<contextKey>"`) so two accounts editing the same topic never collide.
  *
- * The row key folds the owning account into the domain context key (`"<ownerId>|<contextKey>"`)
- * so two accounts editing the same topic never collide. No draft content is ever logged.
+ * [save] additionally drops the write when the captured [owner] is no longer the active account
+ * (switch or logout): a debounced autosave racing an account change must not leak account A's
+ * content under account B, nor revive a row A's logout purge already swept (CacheInvalidator wipes
+ * by the previous pseudo). No draft content is ever logged.
  */
 @Singleton
 class RoomEditorDraftStore @Inject constructor(
@@ -31,8 +33,10 @@ class RoomEditorDraftStore @Inject constructor(
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : EditorDraftStore {
 
-    override suspend fun load(key: String): Draft? = withContext(ioDispatcher) {
-        val owner = activeOwnerId() ?: return@withContext null
+    override suspend fun currentOwner(): String? = withContext(ioDispatcher) { activeOwnerId() }
+
+    override suspend fun load(owner: String?, key: String): Draft? = withContext(ioDispatcher) {
+        if (owner == null) return@withContext null
         editorDraftDao.get(rowKey(owner, key))?.let { entity ->
             Draft(
                 body = entity.body,
@@ -44,9 +48,12 @@ class RoomEditorDraftStore @Inject constructor(
         }
     }
 
-    override suspend fun save(key: String, draft: Draft) {
+    override suspend fun save(owner: String?, key: String, draft: Draft) {
         withContext(ioDispatcher) {
-            val owner = activeOwnerId() ?: return@withContext
+            // No-op for an anonymous session, OR when the session's account is no longer active:
+            // the draft belongs to a session whose owner switched/logged out, so writing it would
+            // leak A's content under B or revive a row the logout purge already swept.
+            if (owner == null || owner != activeOwnerId()) return@withContext
             editorDraftDao.upsert(
                 EditorDraftEntity(
                     draftKey = rowKey(owner, key),
@@ -61,9 +68,9 @@ class RoomEditorDraftStore @Inject constructor(
         }
     }
 
-    override suspend fun delete(key: String) {
+    override suspend fun delete(owner: String?, key: String) {
         withContext(ioDispatcher) {
-            val owner = activeOwnerId() ?: return@withContext
+            if (owner == null) return@withContext
             editorDraftDao.deleteByKey(rowKey(owner, key))
         }
     }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/editor/RoomEditorDraftStoreTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/editor/RoomEditorDraftStoreTest.kt
@@ -36,12 +36,18 @@ class RoomEditorDraftStoreTest {
     )
 
     @Test
-    fun `anonymous session reads null and never touches the DAO`() = runTest {
+    fun `currentOwner is the lowercased active pseudo, null when anonymous`() = runTest {
+        assertEquals("xatrix", store(AuthState.Authenticated("XaTriX")).currentOwner())
+        assertNull(store(AuthState.Anonymous).currentOwner())
+    }
+
+    @Test
+    fun `anonymous owner reads null and never touches the DAO`() = runTest {
         val store = store(AuthState.Anonymous)
 
-        assertNull(store.load(key = "reply:29:123456"))
-        store.save(key = "reply:29:123456", draft = Draft(body = "wip"))
-        store.delete(key = "reply:29:123456")
+        assertNull(store.load(owner = null, key = "reply:29:123456"))
+        store.save(owner = null, key = "reply:29:123456", draft = Draft(body = "wip"))
+        store.delete(owner = null, key = "reply:29:123456")
 
         coVerify(exactly = 0) { dao.get(any()) }
         coVerify(exactly = 0) { dao.upsert(any()) }
@@ -49,10 +55,11 @@ class RoomEditorDraftStoreTest {
     }
 
     @Test
-    fun `save folds the lowercased owner into the row key and stamps the clock`() = runTest {
+    fun `save folds the owner into the row key and stamps the clock`() = runTest {
         val store = store(AuthState.Authenticated("XaTriX"))
 
         store.save(
+            owner = "xatrix",
             key = "reply:29:123456",
             draft = Draft(body = "wip body", isPrivate = false, updatedAt = 42L),
         )
@@ -73,7 +80,19 @@ class RoomEditorDraftStoreTest {
     }
 
     @Test
-    fun `load round-trips the stored draft for the active account`() = runTest {
+    fun `save is dropped when the owning account is no longer active (cross-account leak guard)`() = runTest {
+        // Editor opened as alice (owner = "alice"); the user has since switched to bob (active).
+        // A debounced autosave must NOT write alice's body — neither under bob (leak) nor under
+        // alice (the logout purge already swept alice). The DAO is never touched.
+        val store = store(AuthState.Authenticated("bob"))
+
+        store.save(owner = "alice", key = "mpnew", draft = Draft(body = "alice private body", isPrivate = true))
+
+        coVerify(exactly = 0) { dao.upsert(any()) }
+    }
+
+    @Test
+    fun `load round-trips the stored draft for the owner`() = runTest {
         coEvery { dao.get("xatrix|mpnew") } returns EditorDraftEntity(
             draftKey = "xatrix|mpnew",
             ownerId = "xatrix",
@@ -93,12 +112,12 @@ class RoomEditorDraftStoreTest {
                 isPrivate = true,
                 updatedAt = 1_700_000_000_000L,
             ),
-            store.load(key = "mpnew"),
+            store.load(owner = "xatrix", key = "mpnew"),
         )
     }
 
     @Test
-    fun `drafts are isolated per account`() = runTest {
+    fun `drafts are isolated per owner`() = runTest {
         // Account A wrote a row; account B must never read it.
         coEvery { dao.get("alice|reply:29:123456") } returns EditorDraftEntity(
             draftKey = "alice|reply:29:123456",
@@ -109,13 +128,10 @@ class RoomEditorDraftStoreTest {
             updatedAt = 1_700_000_000_000L,
             isPrivate = false,
         )
-        // Bob has no row under his own key — a real DAO returns null (the relaxed mock would
-        // otherwise hand back a dummy entity, masking the isolation we are asserting).
         coEvery { dao.get("bob|reply:29:123456") } returns null
         val storeForBob = store(AuthState.Authenticated("bob"))
 
-        // Bob's read targets "bob|..." — the DAO has no such row, so it returns null.
-        assertNull(storeForBob.load(key = "reply:29:123456"))
+        assertNull(storeForBob.load(owner = "bob", key = "reply:29:123456"))
         coVerify { dao.get("bob|reply:29:123456") }
     }
 
@@ -123,7 +139,7 @@ class RoomEditorDraftStoreTest {
     fun `delete targets the owner-scoped row key`() = runTest {
         val store = store(AuthState.Authenticated("xatrix"))
 
-        store.delete(key = "edit:23:35395")
+        store.delete(owner = "xatrix", key = "edit:23:35395")
 
         coVerify { dao.deleteByKey("xatrix|edit:23:35395") }
     }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/editor/EditorDraftStore.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/editor/EditorDraftStore.kt
@@ -1,9 +1,14 @@
 package fr.forumhfr.redface2.core.domain.editor
 
 /**
- * Per-account local cache of in-progress editor content (#405). Implementations resolve the
- * active account themselves and MUST be a no-op (read returns null / save & delete do nothing)
- * when no session is active — drafts are private per-account data.
+ * Per-account local cache of in-progress editor content (#405).
+ *
+ * Drafts are bound to the account that OWNED the editor session, not to whatever account happens
+ * to be active when a (debounced) write lands. The caller snapshots [currentOwner] once when the
+ * editor opens and threads it through every [load]/[save]/[delete] of that session. This closes a
+ * cross-account leak: a logout or account switch between opening the editor and a late autosave
+ * could otherwise write account A's body/recipients under account B's row key — B would then read
+ * A's private draft, and A's logout purge (keyed by A) would miss it.
  *
  * [load]/[save]/[delete] take a stable, content-free context [key] built by [EditorDraftKey]; it
  * never embeds message bodies, subjects or recipients. MP drafts ([Draft.isPrivate] == true) are
@@ -12,18 +17,28 @@ package fr.forumhfr.redface2.core.domain.editor
  */
 interface EditorDraftStore {
 
-    /** One-shot read of the draft stored under [key] for the active account, or null. */
-    suspend fun load(key: String): Draft?
+    /**
+     * Snapshot of the account that owns drafts written right now (lowercased pseudo), or null when
+     * anonymous. Capture this ONCE when the editor opens and pass it back to [load]/[save]/[delete];
+     * a later account change then cannot attribute this session's content to a different account.
+     */
+    suspend fun currentOwner(): String?
+
+    /** One-shot read of [owner]'s draft under [key], or null (incl. when [owner] is null). */
+    suspend fun load(owner: String?, key: String): Draft?
 
     /**
-     * Upserts [draft] under [key] for the active account, stamping `updatedAt` from the clock.
-     * No-op without an active session. [Draft.body]/[Draft.subject]/[Draft.recipients] are the
-     * raw editor fields; [Draft.isPrivate] marks MP drafts for the logout purge.
+     * Upserts [draft] under [key] for [owner], stamping `updatedAt` from the clock. No-op when
+     * [owner] is null (anonymous session) OR when [owner] is no longer the active account: the
+     * draft belongs to a session whose account has switched or logged out, so persisting it would
+     * either leak it to the new account or revive a row the logout purge already swept.
+     * [Draft.body]/[Draft.subject]/[Draft.recipients] are the raw editor fields; [Draft.isPrivate]
+     * marks MP drafts for the logout purge.
      */
-    suspend fun save(key: String, draft: Draft)
+    suspend fun save(owner: String?, key: String, draft: Draft)
 
-    /** Deletes the draft under [key] for the active account (called on a successful POST). */
-    suspend fun delete(key: String)
+    /** Deletes [owner]'s draft under [key] (called on a successful POST). No-op when [owner] is null. */
+    suspend fun delete(owner: String?, key: String)
 
     data class Draft(
         val body: String,

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/upload/UploadProvider.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/upload/UploadProvider.kt
@@ -8,7 +8,18 @@ import java.time.Instant
  * entry is a schema-affecting change and would need a migration plus a defensive read. `reho.st` /
  * `super-h` are reserved for a post-v1 iteration (see `docs/specs/extensions.md`).
  */
-enum class UploadProviderId { DIBERIE, IMGUR }
+enum class UploadProviderId(
+    /**
+     * Whether the host CONFIRMS a server-side deletion. imgur returns an authenticated delete
+     * confirmation; diberie's delete is best-effort (no server-side authorisation is confirmed),
+     * so the UI must not promise the image is gone from the host. Drives the « Mes images » delete
+     * confirmation wording (Codex beta review). Does not affect the serialised [name].
+     */
+    val confirmsHostDeletion: Boolean,
+) {
+    DIBERIE(confirmsHostDeletion = false),
+    IMGUR(confirmsHostDeletion = true),
+}
 
 /**
  * Raw bytes to upload, already resolved from the picked `Uri` by the Android layer (via

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -141,6 +141,13 @@ class PostEditorViewModel @AssistedInject constructor(
      */
     private var activeUserId: String? = null
 
+    /**
+     * #405 — account that owned this editor when it opened, snapshotted from [draftStore] so a
+     * mid-edit account switch can't write this session's body under another account (Codex beta
+     * review). Captured in [restoreDraftIfAny]; null until then / for an anonymous session.
+     */
+    private var draftOwner: String? = null
+
     /** #459 PR2 — in-flight image upload job ; one at a time, cancelled on [onCleared]. */
     private var uploadJob: Job? = null
 
@@ -152,10 +159,19 @@ class PostEditorViewModel @AssistedInject constructor(
         }
         viewModelScope.launch {
             authRepository.observeAuthState().collect { authState ->
-                activeUserId = when (authState) {
+                val newUserId = when (authState) {
                     AuthState.Anonymous -> null
                     is AuthState.Authenticated -> authState.pseudo.lowercase()
                 }
+                // Account switched/logged out mid-session: cancel any in-flight upload and pending
+                // autosave so this session's image URL / body is never attributed to the new
+                // account (Codex beta review). The draft store also drops the now-stale save.
+                if (activeUserId != null && newUserId != activeUserId) {
+                    uploadJob?.cancel()
+                    autosaveJob?.cancel()
+                    _state.update { it.copy(isUploading = false, uploadProgress = null) }
+                }
+                activeUserId = newUserId
             }
         }
         restoreDraftIfAny()
@@ -172,7 +188,8 @@ class PostEditorViewModel @AssistedInject constructor(
     private fun restoreDraftIfAny() {
         val key = draftKey ?: return
         viewModelScope.launch {
-            val body = draftStore.load(key)?.body
+            draftOwner = draftStore.currentOwner()
+            val body = draftStore.load(draftOwner, key)?.body
             if (!body.isNullOrBlank()) {
                 _state.update { it.copy(restorableDraft = body) }
             }
@@ -191,9 +208,9 @@ class PostEditorViewModel @AssistedInject constructor(
         autosaveJob = viewModelScope.launch {
             delay(AUTOSAVE_DEBOUNCE_MS)
             if (body.isBlank()) {
-                draftStore.delete(key)
+                draftStore.delete(draftOwner, key)
             } else {
-                draftStore.save(key, EditorDraftStore.Draft(body = body))
+                draftStore.save(draftOwner, key, EditorDraftStore.Draft(body = body))
             }
         }
     }
@@ -246,7 +263,7 @@ class PostEditorViewModel @AssistedInject constructor(
     private fun onDraftDiscardRequested() {
         _state.update { it.copy(restorableDraft = null) }
         val key = draftKey ?: return
-        viewModelScope.launch { draftStore.delete(key) }
+        viewModelScope.launch { draftStore.delete(draftOwner, key) }
     }
 
     private fun onSmileyPickerOpened() {
@@ -811,7 +828,7 @@ class PostEditorViewModel @AssistedInject constructor(
                 // #405 — the message reached HFR ; the cached draft is now obsolete. Cancel any
                 // pending autosave first so a debounced save cannot resurrect the row after delete.
                 autosaveJob?.cancel()
-                draftKey?.let { key -> viewModelScope.launch { draftStore.delete(key) } }
+                draftKey?.let { key -> viewModelScope.launch { draftStore.delete(draftOwner, key) } }
                 _effects.trySend(
                     PostEditorEffect.SubmitSucceeded(targetPage = result.targetPage, scrollTo = scrollTo),
                 )

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModel.kt
@@ -119,6 +119,13 @@ class TopicFormViewModel @AssistedInject constructor(
     private var autosaveJob: Job? = null
 
     /**
+     * #405 — account that owned this editor when it opened, snapshotted from [draftStore] so a
+     * mid-edit account switch can't write this session's draft under another account (Codex beta
+     * review). Captured in [restoreDraftIfAny]; null until then / for an anonymous session.
+     */
+    private var draftOwner: String? = null
+
+    /**
      * #312 — mirror of the persisted « Confirmation avant publication » preference. Collected on
      * init (same DataStore-consumption shape as `TopicViewModel.observeTopicTopBarAutoHide`) and
      * read synchronously at submit time, identical to `PostEditorViewModel`.
@@ -146,7 +153,8 @@ class TopicFormViewModel @AssistedInject constructor(
     private fun restoreDraftIfAny() {
         val key = draftKey ?: return
         viewModelScope.launch {
-            val draft = draftStore.load(key) ?: return@launch
+            draftOwner = draftStore.currentOwner()
+            val draft = draftStore.load(draftOwner, key) ?: return@launch
             if (draft.body.isNotBlank() || !draft.subject.isNullOrBlank()) {
                 _state.update {
                     it.copy(restorableDraft = draft.body, restorableSubject = draft.subject)
@@ -168,9 +176,10 @@ class TopicFormViewModel @AssistedInject constructor(
         autosaveJob = viewModelScope.launch {
             delay(AUTOSAVE_DEBOUNCE_MS)
             if (body.isBlank() && subject.isBlank()) {
-                draftStore.delete(key)
+                draftStore.delete(draftOwner, key)
             } else {
                 draftStore.save(
+                    draftOwner,
                     key,
                     EditorDraftStore.Draft(body = body, subject = subject.ifBlank { null }),
                 )
@@ -235,7 +244,7 @@ class TopicFormViewModel @AssistedInject constructor(
     private fun onDraftDiscardRequested() {
         _state.update { it.copy(restorableDraft = null, restorableSubject = null) }
         val key = draftKey ?: return
-        viewModelScope.launch { draftStore.delete(key) }
+        viewModelScope.launch { draftStore.delete(draftOwner, key) }
     }
 
     /**
@@ -244,7 +253,7 @@ class TopicFormViewModel @AssistedInject constructor(
      */
     private fun deleteDraftOnSuccess() {
         autosaveJob?.cancel()
-        draftKey?.let { key -> viewModelScope.launch { draftStore.delete(key) } }
+        draftKey?.let { key -> viewModelScope.launch { draftStore.delete(draftOwner, key) } }
     }
 
     private fun onSmileyPickerOpened() {

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -1956,14 +1956,16 @@ class PostEditorViewModelTest {
             saved[key] = draft
         }
 
-        override suspend fun load(key: String): EditorDraftStore.Draft? = saved[key]
+        override suspend fun currentOwner(): String? = "tester"
 
-        override suspend fun save(key: String, draft: EditorDraftStore.Draft) {
+        override suspend fun load(owner: String?, key: String): EditorDraftStore.Draft? = saved[key]
+
+        override suspend fun save(owner: String?, key: String, draft: EditorDraftStore.Draft) {
             saveCount += 1
             saved[key] = draft
         }
 
-        override suspend fun delete(key: String) {
+        override suspend fun delete(owner: String?, key: String) {
             deletedKeys += key
             saved.remove(key)
         }

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1402,14 +1402,16 @@ class TopicFormViewModelTest {
             saved[key] = draft
         }
 
-        override suspend fun load(key: String): EditorDraftStore.Draft? = saved[key]
+        override suspend fun currentOwner(): String? = "tester"
 
-        override suspend fun save(key: String, draft: EditorDraftStore.Draft) {
+        override suspend fun load(owner: String?, key: String): EditorDraftStore.Draft? = saved[key]
+
+        override suspend fun save(owner: String?, key: String, draft: EditorDraftStore.Draft) {
             saveCount += 1
             saved[key] = draft
         }
 
-        override suspend fun delete(key: String) {
+        override suspend fun delete(owner: String?, key: String) {
             deletedKeys += key
             saved.remove(key)
         }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModel.kt
@@ -78,6 +78,13 @@ class PrivateMessageComposeViewModel @AssistedInject constructor(
     /** #405 — debounced autosave coroutine ; relaunched (cancelling the previous) on each edit. */
     private var autosaveJob: Job? = null
 
+    /**
+     * #405 — account that owned this MP composer when it opened, snapshotted from [draftStore] so a
+     * mid-edit account switch can't write this session's PRIVATE draft (recipients + body) under
+     * another account (Codex beta review). Captured in [restoreDraftIfAny]; null until then.
+     */
+    private var draftOwner: String? = null
+
     /** #312 — mirror of the persisted « Confirmation avant publication » preference. */
     private var confirmBeforePosting: Boolean = false
 
@@ -100,7 +107,8 @@ class PrivateMessageComposeViewModel @AssistedInject constructor(
      */
     private fun restoreDraftIfAny() {
         viewModelScope.launch {
-            val draft = draftStore.load(draftKey) ?: return@launch
+            draftOwner = draftStore.currentOwner()
+            val draft = draftStore.load(draftOwner, draftKey) ?: return@launch
             val hasContent = draft.body.isNotBlank() ||
                 !draft.subject.isNullOrBlank() ||
                 !draft.recipients.isNullOrBlank()
@@ -129,9 +137,10 @@ class PrivateMessageComposeViewModel @AssistedInject constructor(
         autosaveJob = viewModelScope.launch {
             delay(AUTOSAVE_DEBOUNCE_MS)
             if (body.isBlank() && subject.isBlank() && recipients.isBlank()) {
-                draftStore.delete(draftKey)
+                draftStore.delete(draftOwner, draftKey)
             } else {
                 draftStore.save(
+                    draftOwner,
                     draftKey,
                     EditorDraftStore.Draft(
                         body = body,
@@ -166,7 +175,7 @@ class PrivateMessageComposeViewModel @AssistedInject constructor(
         _state.update {
             it.copy(restorableDraft = null, restorableSubject = null, restorableRecipients = null)
         }
-        viewModelScope.launch { draftStore.delete(draftKey) }
+        viewModelScope.launch { draftStore.delete(draftOwner, draftKey) }
     }
 
     private fun loadForm() {
@@ -371,7 +380,7 @@ class PrivateMessageComposeViewModel @AssistedInject constructor(
                 // #405 — the conversation reached HFR ; the cached draft is now obsolete. Cancel any
                 // pending autosave first so a debounced save can't resurrect the row after delete.
                 autosaveJob?.cancel()
-                viewModelScope.launch { draftStore.delete(draftKey) }
+                viewModelScope.launch { draftStore.delete(draftOwner, draftKey) }
                 _state.update { it.copy(isSubmitting = false, submitError = null) }
                 // The success response of a NEW conversation is not topic-shaped, so the created
                 // threadId is unknown — the host pops back to the MP list and refreshes it.

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
@@ -82,6 +82,13 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
     private var autosaveJob: Job? = null
 
     /**
+     * #405 — account that owned this MP editor when it opened, snapshotted from [draftStore] so a
+     * mid-edit account switch can't write this session's PRIVATE draft under another account
+     * (Codex beta review). Captured in [restoreDraftIfAny]; null until then / when anonymous.
+     */
+    private var draftOwner: String? = null
+
+    /**
      * #312 — mirror of the persisted « Confirmation avant publication » preference. Collected on
      * init (same DataStore-consumption shape as `TopicViewModel.observeTopicTopBarAutoHide`) and
      * read synchronously at submit time, identical to the post editor.
@@ -103,7 +110,8 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
     /** #405 — surface a cached draft on the banner (never auto-applied). Empty drafts are ignored. */
     private fun restoreDraftIfAny() {
         viewModelScope.launch {
-            val body = draftStore.load(draftKey)?.body
+            draftOwner = draftStore.currentOwner()
+            val body = draftStore.load(draftOwner, draftKey)?.body
             if (!body.isNullOrBlank()) {
                 _state.update { it.copy(restorableDraft = body) }
             }
@@ -120,9 +128,9 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
         autosaveJob = viewModelScope.launch {
             delay(AUTOSAVE_DEBOUNCE_MS)
             if (body.isBlank()) {
-                draftStore.delete(draftKey)
+                draftStore.delete(draftOwner, draftKey)
             } else {
-                draftStore.save(draftKey, EditorDraftStore.Draft(body = body, isPrivate = true))
+                draftStore.save(draftOwner, draftKey, EditorDraftStore.Draft(body = body, isPrivate = true))
             }
         }
     }
@@ -140,7 +148,7 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
     /** #405 — discard the cached draft : delete the row and clear the banner. */
     fun onDraftDiscardRequested() {
         _state.update { it.copy(restorableDraft = null) }
-        viewModelScope.launch { draftStore.delete(draftKey) }
+        viewModelScope.launch { draftStore.delete(draftOwner, draftKey) }
     }
 
     private fun loadForm() {
@@ -342,7 +350,7 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
                 // #405 — the reply reached HFR ; the cached draft is now obsolete. Cancel any
                 // pending autosave first so a debounced save can't resurrect the row after delete.
                 autosaveJob?.cancel()
-                viewModelScope.launch { draftStore.delete(draftKey) }
+                viewModelScope.launch { draftStore.delete(draftOwner, draftKey) }
                 _state.update { it.copy(isSubmitting = false, submitError = null) }
                 _effects.trySend(
                     PrivateMessageReplyEffect.SubmitSucceeded(

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModelTest.kt
@@ -381,13 +381,15 @@ class PrivateMessageComposeViewModelTest {
             saved[key] = draft
         }
 
-        override suspend fun load(key: String): EditorDraftStore.Draft? = saved[key]
+        override suspend fun currentOwner(): String? = "tester"
 
-        override suspend fun save(key: String, draft: EditorDraftStore.Draft) {
+        override suspend fun load(owner: String?, key: String): EditorDraftStore.Draft? = saved[key]
+
+        override suspend fun save(owner: String?, key: String, draft: EditorDraftStore.Draft) {
             saved[key] = draft
         }
 
-        override suspend fun delete(key: String) {
+        override suspend fun delete(owner: String?, key: String) {
             deletedKeys += key
             saved.remove(key)
         }

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
@@ -521,13 +521,15 @@ class PrivateMessageReplyViewModelTest {
             saved[key] = draft
         }
 
-        override suspend fun load(key: String): EditorDraftStore.Draft? = saved[key]
+        override suspend fun currentOwner(): String? = "tester"
 
-        override suspend fun save(key: String, draft: EditorDraftStore.Draft) {
+        override suspend fun load(owner: String?, key: String): EditorDraftStore.Draft? = saved[key]
+
+        override suspend fun save(owner: String?, key: String, draft: EditorDraftStore.Draft) {
             saved[key] = draft
         }
 
-        override suspend fun delete(key: String) {
+        override suspend fun delete(owner: String?, key: String) {
             deletedKeys += key
             saved.remove(key)
         }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/MyImagesScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/MyImagesScreen.kt
@@ -234,9 +234,11 @@ private fun DeleteConfirmDialog(
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    // Best-effort hosts (diberie) can never confirm a server-side deletion ; warn the user that
-    // the image may linger on the host even though the local trace will be removed.
-    val bodyRes = if (record.deleteHandle != null) {
+    // The "removed from the host" wording is only honest for a host that CONFIRMS deletion (imgur).
+    // Best-effort hosts (diberie) have a delete handle (the picID) but never confirm a server-side
+    // deletion, so they fall back to the no-handle wording that only promises the local trace is
+    // removed and warns the image may linger on the host (Codex beta review).
+    val bodyRes = if (record.deleteHandle != null && record.provider.confirmsHostDeletion) {
         R.string.my_images_delete_confirm_body
     } else {
         R.string.my_images_delete_confirm_body_no_handle


### PR DESCRIPTION
> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

Corrige les **3 findings de la review finale Codex gpt-5.5/xhigh** de la promotion bêta 0.11.0 (#493). À merger sur `dev` avant la promotion.

### [P1] Fuite de brouillon inter-comptes — `RoomEditorDraftStore`
Un autosave débouncé d'un éditeur ouvert sous le compte A, déclenché après bascule vers B, écrivait le corps (MP **privé**) de A sous la clé de B → B pouvait lire le brouillon privé de A, et la purge de logout de A le ratait.
**Fix** : `EditorDraftStore` lie le brouillon au compte **propriétaire de la session** (capturé via `currentOwner()` à l'ouverture, threadé dans `load/save/delete` des 4 ViewModels éditeur). `save()` **abandonne** l'écriture si le compte actif ≠ propriétaire → pas de fuite, pas de résurrection post-purge. Test de régression ajouté (`save dropped when owning account no longer active`).

### [P2] Upload périmé après changement de compte — `PostEditorViewModel`
L'observer auth **annule l'upload en vol + l'autosave en attente** au changement de compte → l'URL d'image de l'ancien compte n'est jamais insérée.

### [P2] Texte de suppression trompeur — `MyImagesScreen`
Nouvelle capability `UploadProviderId.confirmsHostDeletion` (imgur=true / diberie=false) : le texte « supprimée de l'hébergeur » n'apparaît que pour un hôte qui confirme ; diberie passe au texte honnête « trace locale retirée, peut rester chez l'hôte ». `name()` sérialisé inchangé → pas d'impact schéma Room/DataStore.

### Vérif
CI verte sur l'hôte B (`detektAll lintDebug test testDebugUnitTest :app:lintProdDebug :app:assembleProdDebug`, 1m cache chaud). 4 fakes de test mis à jour à la nouvelle signature.