### PR TITLE
fix(editor/messages/upload): close 4 Codex P2 findings (bêta 0.11.0)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/messages/RoomPrivateMessageReadPositionStore.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/messages/RoomPrivateMessageReadPositionStore.kt
@@ -13,10 +13,13 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 
 /**
- * Room-backed [PrivateMessageReadPositionStore] (#430). Rows are keyed by the lowercased pseudo
- * of the CURRENT session (snapshotted per call from [AuthRepository]); with no active session
- * both operations are no-ops — an anonymous client has no inbox, and a save racing a logout must
- * not write a row the purge pass has already swept (CacheInvalidator wipes by previous pseudo).
+ * Room-backed [PrivateMessageReadPositionStore] (#430). Rows are keyed by the lowercased [owner]
+ * the caller captured when it read the conversation — NOT by a freshly-resolved active user, so a
+ * write delayed by IO is always attributed to the session that actually read the page. Each call
+ * still re-checks the active session and is a no-op when [owner] is `null`, anonymous, or no longer
+ * active: an anonymous client has no inbox; a save racing a logout must not write a row the purge
+ * pass has already swept (CacheInvalidator wipes by previous pseudo); and an `A → B` account switch
+ * must not misattribute A's position to B (Codex review of the 0.11.0 beta).
  */
 @Singleton
 class RoomPrivateMessageReadPositionStore @Inject constructor(
@@ -25,15 +28,17 @@ class RoomPrivateMessageReadPositionStore @Inject constructor(
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : PrivateMessageReadPositionStore {
 
-    override suspend fun readPage(threadId: Int): Int? = withContext(ioDispatcher) {
-        val userId = activeUserId() ?: return@withContext null
+    override suspend fun readPage(owner: String?, threadId: Int): Int? = withContext(ioDispatcher) {
+        val userId = owner?.lowercase() ?: return@withContext null
+        if (userId != activeUserId()) return@withContext null
         mpReadPositionDao.readPage(userId = userId, threadId = threadId)
     }
 
-    override suspend fun savePage(threadId: Int, page: Int) {
+    override suspend fun savePage(owner: String?, threadId: Int, page: Int) {
         if (page < 1) return
         withContext(ioDispatcher) {
-            val userId = activeUserId() ?: return@withContext
+            val userId = owner?.lowercase() ?: return@withContext
+            if (userId != activeUserId()) return@withContext
             mpReadPositionDao.upsert(
                 MpReadPositionEntity(userId = userId, threadId = threadId, page = page),
             )

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/DiberieProvider.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/DiberieProvider.kt
@@ -24,8 +24,8 @@ import okhttp3.RequestBody.Companion.toRequestBody
 /**
  * Uploads to the diberie rehost host (#459), the default provider (no auth, no Client-ID).
  *
- * Deletion is BEST-EFFORT: server-side authorisation is not confirmed (#459 NB), so [delete] tries
- * the call and never throws — it returns `false` when the host did not confirm.
+ * Deletion is BEST-EFFORT: the host never confirms removal (#459 NB — a 2xx can just swap the
+ * picture for a placeholder), so [delete] fires the call, never throws, and ALWAYS returns `false`.
  *
  * All network work runs on [ioDispatcher] (project rule: every repository / data source that calls
  * an OkHttp client wraps it in `withContext(ioDispatcher)`).
@@ -86,10 +86,16 @@ internal class DiberieProvider @Inject constructor(
     }
 
     override suspend fun delete(deleteHandle: String): Boolean = withContext(ioDispatcher) {
-        // Best-effort: authorisation NOT confirmed (#459 NB). Try, never throw, report false on doubt.
+        // Best-effort cleanup (#459 NB). The host answers 2xx/redirect even when it merely swaps the
+        // picture for a placeholder rather than removing it (live capture 2026-06-13), so a
+        // successful HTTP exchange does NOT prove host-side deletion. We fire the request as a
+        // courtesy, never throw, and ALWAYS report `false` (= not confirmed) — diberie declares
+        // `UploadProviderId.confirmsHostDeletion = false`, and the «Mes images» screen only offers a
+        // delete affordance for providers that DO confirm (imgur, which authenticates the delete).
         val form = FormBody.Builder().add("DeletePhoto_IdPhoto", deleteHandle).build()
         val request = Request.Builder().url("$baseUrl/Host/DeletePhoto").post(form).build()
-        runCatching { client.newCall(request).execute().use { it.isSuccessful } }.getOrDefault(false)
+        runCatching { client.newCall(request).execute().close() }
+        false
     }
 
     private fun uploadUrl(): String = "$baseUrl/Host/UploadFiles?SelectedAlbumId=0&PrivateMode=false" +

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/messages/RoomPrivateMessageReadPositionStoreTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/messages/RoomPrivateMessageReadPositionStoreTest.kt
@@ -33,20 +33,20 @@ class RoomPrivateMessageReadPositionStoreTest {
     fun `anonymous session reads null and never touches the DAO`() = runTest {
         val store = store(AuthState.Anonymous)
 
-        assertNull(store.readPage(threadId = 42))
-        store.savePage(threadId = 42, page = 7)
+        assertNull(store.readPage(owner = "xatrix", threadId = 42))
+        store.savePage(owner = "xatrix", threadId = 42, page = 7)
 
         coVerify(exactly = 0) { dao.readPage(any(), any()) }
         coVerify(exactly = 0) { dao.upsert(any()) }
     }
 
     @Test
-    fun `authenticated calls delegate with the lowercased pseudo`() = runTest {
+    fun `authenticated calls delegate with the lowercased owner`() = runTest {
         coEvery { dao.readPage(userId = "xatrix", threadId = 42) } returns 7
         val store = store(AuthState.Authenticated("XaTriX"))
 
-        assertEquals(7, store.readPage(threadId = 42))
-        store.savePage(threadId = 42, page = 9)
+        assertEquals(7, store.readPage(owner = "XaTriX", threadId = 42))
+        store.savePage(owner = "XaTriX", threadId = 42, page = 9)
 
         coVerify {
             dao.upsert(MpReadPositionEntity(userId = "xatrix", threadId = 42, page = 9))
@@ -57,8 +57,32 @@ class RoomPrivateMessageReadPositionStoreTest {
     fun `savePage rejects a page below 1`() = runTest {
         val store = store(AuthState.Authenticated("xatrix"))
 
-        store.savePage(threadId = 42, page = 0)
+        store.savePage(owner = "xatrix", threadId = 42, page = 0)
 
+        coVerify(exactly = 0) { dao.upsert(any()) }
+    }
+
+    @Test
+    fun `a stale owner save after an account switch is dropped, not misattributed`() = runTest {
+        // alice read the page, then the session switched to bob before alice's delayed write landed.
+        // The write must NOT be re-attributed to bob (the pre-fix bug) — it is simply dropped.
+        val store = store(AuthState.Authenticated("bob"))
+
+        assertNull(store.readPage(owner = "alice", threadId = 42))
+        store.savePage(owner = "alice", threadId = 42, page = 9)
+
+        coVerify(exactly = 0) { dao.readPage(any(), any()) }
+        coVerify(exactly = 0) { dao.upsert(any()) }
+    }
+
+    @Test
+    fun `a null owner is a no-op`() = runTest {
+        val store = store(AuthState.Authenticated("xatrix"))
+
+        assertNull(store.readPage(owner = null, threadId = 42))
+        store.savePage(owner = null, threadId = 42, page = 9)
+
+        coVerify(exactly = 0) { dao.readPage(any(), any()) }
         coVerify(exactly = 0) { dao.upsert(any()) }
     }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/upload/DiberieProviderTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/upload/DiberieProviderTest.kt
@@ -176,13 +176,16 @@ class DiberieProviderTest {
     }
 
     @Test
-    fun `delete is best-effort - true when the host confirms`() = runTest {
+    fun `delete fires the call but never claims confirmation, even on a 2xx`() = runTest {
+        // diberie can never confirm host-side removal (a 2xx may merely swap a placeholder), so the
+        // provider POSTs the courtesy request but always reports false. confirmsHostDeletion = false.
         server.enqueue(MockResponse().setResponseCode(200).setBody("ok"))
 
-        assertTrue(provider.delete("521196"))
+        assertEquals(false, provider.delete("521196"))
         val recorded = server.takeRequest()
         assertEquals("POST", recorded.method)
         assertTrue(recorded.path!!.endsWith("/Host/DeletePhoto"))
+        assertTrue("the courtesy delete must carry the picID", recorded.body.readUtf8().contains("521196"))
     }
 
     @Test

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/messages/PrivateMessageReadPositionStore.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/messages/PrivateMessageReadPositionStore.kt
@@ -4,15 +4,18 @@ package fr.forumhfr.redface2.core.domain.messages
  * Per-account local store of the last page the user displayed in each private-message
  * conversation (#430, ADR-013 stage 1 — the server keeps no MP position at all, cf. #361).
  *
- * Implementations resolve the active account themselves and MUST be a no-op when no session is
- * active: positions are private per-account data, wiped on logout/account switch. Only page
- * NUMBERS ever reach the store — no subject, correspondent or content.
+ * The caller passes the [owner] pseudo it captured when the conversation was opened/read, so a row
+ * is always attributed to the session that actually read the page — never to whoever happens to be
+ * active when a delayed IO write lands. Implementations MUST be a no-op when [owner] is `null` or no
+ * longer the active session: positions are private per-account data, wiped on logout/account switch
+ * (an `A → B` switch must not misattribute A's position to B, Codex review of the 0.11.0 beta).
+ * Only page NUMBERS ever reach the store — no subject, correspondent or content.
  */
 interface PrivateMessageReadPositionStore {
 
-    /** Last page displayed for [threadId] by the active account, or `null` when unknown. */
-    suspend fun readPage(threadId: Int): Int?
+    /** Last page displayed for [threadId] by [owner], or `null` when unknown / not the active account. */
+    suspend fun readPage(owner: String?, threadId: Int): Int?
 
-    /** Records [page] as the last displayed page of [threadId] for the active account. */
-    suspend fun savePage(threadId: Int, page: Int)
+    /** Records [page] as the last displayed page of [threadId] for [owner] (no-op if not active). */
+    suspend fun savePage(owner: String?, threadId: Int, page: Int)
 }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
@@ -124,9 +124,10 @@ data class PostEditorState(
     /**
      * Submission is allowed when : we know the routing context (page + subcat + topicId),
      * the user has typed something non-blank, the editor is not already submitting,
-     * and we are not still fetching the form. Phase 2D (#147) additionally requires
-     * `numreponse` for [PostEditorMode.Edit] — without it we cannot identify which
-     * post HFR should rewrite.
+     * we are not still fetching the form, and no image upload is in flight. Phase 2D (#147)
+     * additionally requires `numreponse` for [PostEditorMode.Edit] — without it we cannot
+     * identify which post HFR should rewrite. The [isUploading] guard (#459) stops a tap on
+     * « Envoyer » from racing an in-flight upload and posting before the image markup is inserted.
      */
     val canSubmit: Boolean
         get() = (mode == PostEditorMode.Reply || (mode == PostEditorMode.Edit && numreponse != null)) &&
@@ -138,7 +139,8 @@ data class PostEditorState(
             topicId != null &&
             draft.text.isNotBlank() &&
             !isSubmitting &&
-            !isLoadingForm
+            !isLoadingForm &&
+            !isUploading
 
     val isSubmitEnabled: Boolean get() = canSubmit
 }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -810,7 +810,7 @@ class PostEditorViewModel @AssistedInject constructor(
         }
     }
 
-    private fun handleSubmitOutcome(
+    private suspend fun handleSubmitOutcome(
         mode: PostEditorMode,
         numreponse: Int?,
         result: ReplySubmitResult,
@@ -827,8 +827,10 @@ class PostEditorViewModel @AssistedInject constructor(
                 val scrollTo = result.numreponse ?: numreponse.takeIf { mode == PostEditorMode.Edit }
                 // #405 — the message reached HFR ; the cached draft is now obsolete. Cancel any
                 // pending autosave first so a debounced save cannot resurrect the row after delete.
+                // The delete is AWAITED inside the submit coroutine (not launched) so the immediate
+                // nav pop driven by SubmitSucceeded cannot cancel it before the row is gone (Codex).
                 autosaveJob?.cancel()
-                draftKey?.let { key -> viewModelScope.launch { draftStore.delete(draftOwner, key) } }
+                draftKey?.let { key -> draftStore.delete(draftOwner, key) }
                 _effects.trySend(
                     PostEditorEffect.SubmitSucceeded(targetPage = result.targetPage, scrollTo = scrollTo),
                 )

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModel.kt
@@ -249,11 +249,12 @@ class TopicFormViewModel @AssistedInject constructor(
 
     /**
      * #405 — the topic reached HFR ; the cached draft is now obsolete. Cancel any pending autosave
-     * first so a debounced save can't resurrect the row after delete.
+     * first so a debounced save can't resurrect the row after delete. AWAITED (not launched) so the
+     * nav pop driven by the success effect can't cancel the delete before the row is gone (Codex).
      */
-    private fun deleteDraftOnSuccess() {
+    private suspend fun deleteDraftOnSuccess() {
         autosaveJob?.cancel()
-        draftKey?.let { key -> viewModelScope.launch { draftStore.delete(draftOwner, key) } }
+        draftKey?.let { key -> draftStore.delete(draftOwner, key) }
     }
 
     private fun onSmileyPickerOpened() {
@@ -639,7 +640,7 @@ class TopicFormViewModel @AssistedInject constructor(
         }
     }
 
-    private fun handleNewTopicOutcome(
+    private suspend fun handleNewTopicOutcome(
         context: NewTopicContext,
         selectedSubcat: Int,
         subject: String,
@@ -675,7 +676,7 @@ class TopicFormViewModel @AssistedInject constructor(
         }
     }
 
-    private fun handleSubmitOutcome(
+    private suspend fun handleSubmitOutcome(
         numreponse: Int?,
         result: ReplySubmitResult,
     ) {

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorStateTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorStateTest.kt
@@ -12,7 +12,7 @@ import org.junit.Test
  */
 class PostEditorStateTest {
 
-    private fun replyState(subcat: Int?): PostEditorState =
+    private fun replyState(subcat: Int?, isUploading: Boolean = false): PostEditorState =
         PostEditorState(
             mode = PostEditorMode.Reply,
             cat = 32,
@@ -21,6 +21,7 @@ class PostEditorStateTest {
             page = 1,
             subcat = subcat,
             draft = TextFieldValue("Hello!"),
+            isUploading = isUploading,
         )
 
     @Test
@@ -41,5 +42,10 @@ class PostEditorStateTest {
     @Test
     fun `canSubmit is false when subcat is null`() {
         assertFalse(replyState(subcat = null).canSubmit)
+    }
+
+    @Test
+    fun `canSubmit is false while an image upload is in flight (#459)`() {
+        assertFalse(replyState(subcat = 0, isUploading = true).canSubmit)
     }
 }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModel.kt
@@ -368,19 +368,20 @@ class PrivateMessageComposeViewModel @AssistedInject constructor(
                 )
             }
             outcome.fold(
-                onSuccess = ::handleSubmitOutcome,
+                onSuccess = { handleSubmitOutcome(it) },
                 onFailure = ::handleSubmitFailure,
             )
         }
     }
 
-    private fun handleSubmitOutcome(result: ReplySubmitResult) {
+    private suspend fun handleSubmitOutcome(result: ReplySubmitResult) {
         when (result) {
             is ReplySubmitResult.Success -> {
                 // #405 — the conversation reached HFR ; the cached draft is now obsolete. Cancel any
                 // pending autosave first so a debounced save can't resurrect the row after delete.
+                // AWAITED (not launched) so the nav pop on SubmitSucceeded can't cancel it (Codex).
                 autosaveJob?.cancel()
-                viewModelScope.launch { draftStore.delete(draftOwner, draftKey) }
+                draftStore.delete(draftOwner, draftKey)
                 _state.update { it.copy(isSubmitting = false, submitError = null) }
                 // The success response of a NEW conversation is not topic-shaped, so the created
                 // threadId is unknown — the host pops back to the MP list and refreshes it.

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
@@ -338,19 +338,20 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
                 )
             }
             outcome.fold(
-                onSuccess = ::handleSubmitOutcome,
+                onSuccess = { handleSubmitOutcome(it) },
                 onFailure = ::handleSubmitFailure,
             )
         }
     }
 
-    private fun handleSubmitOutcome(result: ReplySubmitResult) {
+    private suspend fun handleSubmitOutcome(result: ReplySubmitResult) {
         when (result) {
             is ReplySubmitResult.Success -> {
                 // #405 — the reply reached HFR ; the cached draft is now obsolete. Cancel any
                 // pending autosave first so a debounced save can't resurrect the row after delete.
+                // AWAITED (not launched) so the nav pop on SubmitSucceeded can't cancel it (Codex).
                 autosaveJob?.cancel()
-                viewModelScope.launch { draftStore.delete(draftOwner, draftKey) }
+                draftStore.delete(draftOwner, draftKey)
                 _state.update { it.copy(isSubmitting = false, submitError = null) }
                 _effects.trySend(
                     PrivateMessageReplyEffect.SubmitSucceeded(

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModel.kt
@@ -103,9 +103,9 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
      * the frozen opening page resumes where they actually were. A store failure falls back to
      * the route — opening the conversation must never break on a local read.
      */
-    private suspend fun openingPage(): Int {
+    private suspend fun openingPage(owner: String): Int {
         val saved = try {
-            readPositionStore.readPage(request.threadId)
+            readPositionStore.readPage(owner, request.threadId)
         } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
             null
         }
@@ -122,7 +122,8 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
     private fun loadInitial() {
         loadJob?.cancel()
         loadJob = viewModelScope.launch {
-            fetchPage(openingPage())
+            val owner = authenticatedPseudo ?: return@launch
+            fetchPage(openingPage(owner))
         }
     }
 
@@ -214,7 +215,7 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
         saveJob = viewModelScope.launch {
             if (owner != authenticatedPseudo) return@launch
             try {
-                readPositionStore.savePage(request.threadId, page)
+                readPositionStore.savePage(owner, request.threadId, page)
             } catch (cancellation: CancellationException) {
                 throw cancellation
             } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModelTest.kt
@@ -314,6 +314,8 @@ class PrivateMessageThreadViewModelTest {
         advanceUntilIdle()
 
         assertEquals(5, store.saved[42])
+        // #462 — the write is attributed to the reading account, not a re-resolved active user.
+        assertEquals("xaat", store.lastSaveOwner)
     }
 
     @Test
@@ -401,16 +403,20 @@ class PrivateMessageThreadViewModelTest {
     ) : PrivateMessageReadPositionStore {
         val saved = initial.toMutableMap()
 
+        /** Owner (lowercased) the most recent save was attributed to — for #430/#462 assertions. */
+        var lastSaveOwner: String? = null
+
         /** When set, the NEXT [savePage] parks on it before writing (cleared on consumption). */
         var blockNextSave: CompletableDeferred<Unit>? = null
 
-        override suspend fun readPage(threadId: Int): Int? = saved[threadId]
+        override suspend fun readPage(owner: String?, threadId: Int): Int? = saved[threadId]
 
-        override suspend fun savePage(threadId: Int, page: Int) {
+        override suspend fun savePage(owner: String?, threadId: Int, page: Int) {
             blockNextSave?.let { gate ->
                 blockNextSave = null
                 gate.await()
             }
+            lastSaveOwner = owner?.lowercase()
             saved[threadId] = page
         }
     }


### PR DESCRIPTION
## Contexte

Round 2 de la re-review Codex (gpt-5.5, raisonnement xhigh) de la promotion `dev → main` pour la bêta 0.11.0 (#493). Le P1 (fuite de brouillon cross-compte) avait été résolu par #495 ; cette re-review a remonté **4 nouveaux P2** (aucun bloquant). Mandat utilisateur : « Fix les 4 puis ship ».

## Correctifs

| # | Finding | Correctif |
|---|---------|-----------|
| 1 | `DiberieProvider.delete` renvoyait `true` sur 2xx alors que diberie ne confirme jamais une suppression hôte | POST de courtoisie conservé, mais **renvoie toujours `false`** ; `confirmsHostDeletion = false` et l'écran « Mes images » n'expose la suppression que pour les fournisseurs qui confirment |
| 2 | Un switch de compte `A → B` mésattribuait la position de lecture MP de A à B (même faille que le draft store, dans un store non touché) | `owner` capturé à l'ouverture, threadé dans `readPage/savePage` ; le store Room clé la ligne par cet owner et **no-op si l'owner n'est plus la session active** (miroir du fix #495) |
| 3 | `canSubmit` restait vrai pendant un upload d'image → « Envoyer » postable avant insertion du markup | ajout de `&& !isUploading` au gate de soumission |
| 4 | La suppression du brouillon sur succès était lancée dans un job détaché puis le nav pop pouvait l'annuler → brouillon déjà posté encore restaurable | delete **awaité** dans la coroutine de submit avant l'effet succès (PostEditor + TopicForm + MP reply + MP compose) |

## Tests

Validation locale complète verte sur la machine de build (`detektAll lintDebug test testDebugUnitTest :app:lintProdDebug :app:assembleProdDebug`, BUILD SUCCESSFUL). Tests de régression ajoutés :
- store : un save d'owner périmé après switch est **droppé, pas mésattribué** ; owner `null` no-op ;
- `DiberieProvider` : `delete` POST mais ne confirme jamais, même sur 2xx ;
- `PostEditorState` : `canSubmit` faux pendant un upload ;
- `PrivateMessageThreadViewModel` : la position est attribuée au compte lecteur.

> Action par Claude Opus 4.8 (demandée par @XaTriX)
