### PR TITLE
fix(editor): make draft delete best-effort (post-success hardening, suite #496)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/editor/RoomEditorDraftStore.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/editor/RoomEditorDraftStore.kt
@@ -10,6 +10,7 @@ import fr.forumhfr.redface2.core.model.AuthState
 import java.time.Clock
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
@@ -71,7 +72,19 @@ class RoomEditorDraftStore @Inject constructor(
     override suspend fun delete(owner: String?, key: String) {
         withContext(ioDispatcher) {
             if (owner == null) return@withContext
-            editorDraftDao.deleteByKey(rowKey(owner, key))
+            // Best-effort: callers AWAIT this on the post-success path (so the nav pop can't cancel
+            // the delete before the row is gone), which means a throw here would abort the success
+            // flow on a message HFR already accepted — crashing or stranding the editor. A local
+            // DELETE-by-key can still fail (disk full / DB locked); swallow it. A surviving row only
+            // costs a spurious « restore draft » prompt. CancellationException is rethrown so genuine
+            // coroutine cancellation still propagates.
+            try {
+                editorDraftDao.deleteByKey(rowKey(owner, key))
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
+                // Best-effort cleanup — never block a successful post on a failed local delete.
+            }
         }
     }
 

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/editor/RoomEditorDraftStoreTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/editor/RoomEditorDraftStoreTest.kt
@@ -143,4 +143,16 @@ class RoomEditorDraftStoreTest {
 
         coVerify { dao.deleteByKey("xatrix|edit:23:35395") }
     }
+
+    @Test
+    fun `delete swallows a DAO failure so a successful post is never aborted`() = runTest {
+        // delete is awaited on the post-success path (before the nav pop), so a local DB failure
+        // must NOT propagate and abort the success flow on a message HFR already accepted.
+        val store = store(AuthState.Authenticated("xatrix"))
+        coEvery { dao.deleteByKey(any()) } throws RuntimeException("db locked")
+
+        store.delete(owner = "xatrix", key = "reply:29:123456")
+
+        coVerify { dao.deleteByKey("xatrix|reply:29:123456") }
+    }
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/editor/EditorDraftStore.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/editor/EditorDraftStore.kt
@@ -37,7 +37,12 @@ interface EditorDraftStore {
      */
     suspend fun save(owner: String?, key: String, draft: Draft)
 
-    /** Deletes [owner]'s draft under [key] (called on a successful POST). No-op when [owner] is null. */
+    /**
+     * Deletes [owner]'s draft under [key] (called on a successful POST). No-op when [owner] is null.
+     * Best-effort: it is awaited on the post-success path, so it MUST NOT throw on a local DB
+     * failure — a surviving row only costs a spurious restore prompt and must never abort a
+     * successful post. (Genuine coroutine cancellation still propagates.)
+     */
     suspend fun delete(owner: String?, key: String)
 
     data class Draft(


### PR DESCRIPTION
## Contexte

Suite à #496 (correction des 4 P2 Codex). La **review interne multi-agents** de #496 a remonté un point substantiel sur le fix #4 : en déplaçant la suppression du brouillon sur le chemin de succès et en l'**awaitant avant la nav pop** (correct, pour que la nav n'annule pas le delete), un throw du delete Room remonte désormais hors de la coroutine de submit et **avorte le bookkeeping de succès** (pas de nav, `isSubmitting` bloqué, ou crash non capturé) — sur un message **déjà accepté par HFR**. Régression sur le chemin rare d'échec DB (disque plein / DB locked).

## Correctif

`RoomEditorDraftStore.delete` devient **best-effort** : il avale un échec DAO non-cancellation (la `CancellationException` est re-lancée pour préserver la concurrence structurée). Une ligne survivante ne coûte qu'un prompt « restaurer le brouillon » superflu ; un post réussi ne doit jamais dépendre d'un delete local. Ça durcit aussi les chemins discard / autosave-vide détachés, qui pouvaient déjà crasher sur un échec DB avant ce changement.

Contrat acté dans la KDoc de l'interface `EditorDraftStore.delete`.

## Tests

Validation locale complète verte (`detektAll lintDebug test testDebugUnitTest :app:lintProdDebug :app:assembleProdDebug`, BUILD SUCCESSFUL 2m22s, dont `:core:data:testDebugUnitTest`). Test de régression ajouté : un `deleteByKey` qui throw ne se propage pas.

> Action par Claude Opus 4.8 (demandée par @XaTriX)
