### PR TITLE
feat(editor): modes d'insertion image + retour ligne multi-upload + bouton upload visible (refs-#459)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -18,6 +18,7 @@ import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
+import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import fr.forumhfr.redface2.core.model.FlagType
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -402,6 +403,21 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeEditorImageInsert(): Flow<EditorImageInsert> =
+        dataStore.data
+            // Default REDUCED (#459 PR-images follow-up): the classic HFR "vignette cliquable".
+            .map(::readEditorImageInsert)
+            .distinctUntilChanged()
+            .catch { emit(EditorImageInsert.REDUCED) }
+
+    override suspend fun setEditorImageInsert(mode: EditorImageInsert) {
+        withContext(ioDispatcher) {
+            dataStore.edit { prefs ->
+                prefs[KEY_EDITOR_IMAGE_INSERT] = mode.name
+            }
+        }
+    }
+
     override fun observeFontScale(): Flow<FontScalePreference> =
         dataStore.data
             // Default M (#287): the M3 reference sizes unless the user picks S / L.
@@ -426,6 +442,12 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         prefs[KEY_UPLOAD_PROVIDER]
             ?.let { stored -> runCatching { UploadProviderId.valueOf(stored) }.getOrNull() }
             ?: UploadProviderId.DIBERIE
+
+    /** Reads [KEY_EDITOR_IMAGE_INSERT] defensively; unknown / corrupt value → [EditorImageInsert.REDUCED]. */
+    private fun readEditorImageInsert(prefs: Preferences): EditorImageInsert =
+        prefs[KEY_EDITOR_IMAGE_INSERT]
+            ?.let { stored -> runCatching { EditorImageInsert.valueOf(stored) }.getOrNull() }
+            ?: EditorImageInsert.REDUCED
 
     /**
      * Reads [KEY_DISPLAY_DENSITY] defensively (#287): an unknown / corrupt stored value (older
@@ -558,6 +580,8 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         // imgur Client-ID (empty = imgur unconfigured, option B: never committed).
         val KEY_UPLOAD_PROVIDER = stringPreferencesKey("upload_provider")
         val KEY_IMGUR_CLIENT_ID = stringPreferencesKey("imgur_client_id")
+        // #459 PR-images follow-up — editor image insert mode (EditorImageInsert.name, defensively parsed).
+        val KEY_EDITOR_IMAGE_INSERT = stringPreferencesKey("editor_image_insert")
 
         // #287 — reading display presets: density (DisplayDensity.name) + font scale
         // (FontScalePreference.name), both defensively parsed. No bootstrap mirror (cf. observers).

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/DiberieProvider.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/DiberieProvider.kt
@@ -78,6 +78,8 @@ internal class DiberieProvider @Inject constructor(
                 provider = id,
                 imageUrl = dto.picUrl ?: "$baseUrl/Picture/Get/f/$picId",
                 thumbnailUrl = dto.thumbUrl ?: "$baseUrl/Picture/Get/t/$picId",
+                // `.../Get/r/{id}` is diberie's ~300px reduced variant (the "vignette cliquable").
+                resizedUrl = dto.resizedUrl ?: "$baseUrl/Picture/Get/r/$picId",
                 deleteHandle = picId.toString(),
                 // SelectedExpiryType=0 in the upload query → no advertised expiration.
                 expiresAt = null,

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/ImgurProvider.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/ImgurProvider.kt
@@ -70,6 +70,9 @@ internal class ImgurProvider @Inject constructor(
                 provider = id,
                 imageUrl = data.link ?: throw UploadException.Malformed(id),
                 thumbnailUrl = null,
+                // imgur exposes size variants via URL suffixes, but the v1 contract does not derive
+                // them — the editor's reduced mode falls back to the full link for imgur.
+                resizedUrl = null,
                 deleteHandle = data.deleteHash,
                 expiresAt = null,
             )

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -16,6 +16,7 @@ import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrap
 import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
+import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import fr.forumhfr.redface2.core.model.FlagType
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -561,6 +562,30 @@ class DataStoreUserPreferencesRepositoryTest {
         // #459 — DIBERIE is the default (no auth, no Client-ID), never the enum's first ordinal alone.
         repository.observeUploadProvider().test {
             assertEquals(UploadProviderId.DIBERIE, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `observeEditorImageInsert defaults to REDUCED on an empty store`() = runTest(dispatcher) {
+        // #459 PR-images follow-up — REDUCED is the default (the HFR "vignette cliquable").
+        repository.observeEditorImageInsert().test {
+            assertEquals(EditorImageInsert.REDUCED, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setEditorImageInsert persists and round-trips FULL then REDUCED`() = runTest(dispatcher) {
+        repository.setEditorImageInsert(EditorImageInsert.FULL)
+        repository.observeEditorImageInsert().test {
+            assertEquals(EditorImageInsert.FULL, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setEditorImageInsert(EditorImageInsert.REDUCED)
+        repository.observeEditorImageInsert().test {
+            assertEquals(EditorImageInsert.REDUCED, awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -14,6 +14,7 @@ import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
+import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.network.HfrClient
 import fr.forumhfr.redface2.core.parser.HfrParser
@@ -586,6 +587,11 @@ class TopicRepositoryImplTest {
         override fun observeImgurClientId(): Flow<String> = MutableStateFlow("")
 
         override suspend fun setImgurClientId(clientId: String) = Unit
+
+        override fun observeEditorImageInsert(): Flow<EditorImageInsert> =
+            MutableStateFlow(EditorImageInsert.REDUCED)
+
+        override suspend fun setEditorImageInsert(mode: EditorImageInsert) = Unit
 
         // #287 — reading display presets are irrelevant to TopicRepository; stubbed at defaults.
         override fun observeDisplayDensity(): Flow<DisplayDensity> = MutableStateFlow(DisplayDensity.COMFORT)

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/upload/DefaultUploadRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/upload/DefaultUploadRepositoryTest.kt
@@ -71,6 +71,7 @@ class DefaultUploadRepositoryTest {
             provider = UploadProviderId.DIBERIE,
             imageUrl = "https://host/f/NOHANDLE",
             thumbnailUrl = null,
+            resizedUrl = null,
             deleteHandle = null,
             expiresAt = null,
         )
@@ -135,6 +136,7 @@ class DefaultUploadRepositoryTest {
         provider = UploadProviderId.IMGUR,
         imageUrl = "https://i.imgur.com/x.png",
         thumbnailUrl = null,
+        resizedUrl = null,
         deleteHandle = "DELHASH",
         expiresAt = null,
     )

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/upload/DiberieProviderTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/upload/DiberieProviderTest.kt
@@ -60,6 +60,7 @@ class DiberieProviderTest {
         assertEquals(UploadProviderId.DIBERIE, result.provider)
         assertEquals("https://rehost.diberie.com/Picture/Get/f/521196", result.imageUrl)
         assertEquals("https://rehost.diberie.com/Picture/Get/t/521196", result.thumbnailUrl)
+        assertEquals("https://rehost.diberie.com/Picture/Get/r/521196", result.resizedUrl)
         // picID is the integer 521196 on the wire; the delete handle is its string form.
         assertEquals("521196", result.deleteHandle)
         assertEquals(null, result.expiresAt)
@@ -97,6 +98,7 @@ class DiberieProviderTest {
 
         assertTrue("imageUrl must be derived from picID", result.imageUrl.endsWith("/Picture/Get/f/777"))
         assertTrue("thumbnailUrl must be derived from picID", result.thumbnailUrl!!.endsWith("/Picture/Get/t/777"))
+        assertTrue("resizedUrl must be derived from picID", result.resizedUrl!!.endsWith("/Picture/Get/r/777"))
     }
 
     @Test

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -2,6 +2,7 @@ package fr.forumhfr.redface2.core.domain.preferences
 
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.FlagType
+import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import kotlinx.coroutines.flow.Flow
 
 interface UserPreferencesRepository {
@@ -240,6 +241,17 @@ interface UserPreferencesRepository {
 
     /** Persists [observeImgurClientId]. Default empty string until the first call. */
     suspend fun setImgurClientId(clientId: String)
+
+    /**
+     * How the editor wraps an inserted image (#459 PR-images follow-up). Default
+     * [EditorImageInsert.REDUCED] — the classic HFR "vignette cliquable" (a reduced image linking to
+     * the original), matching Redface v1's default for diberie. A corrupt / unknown stored value
+     * degrades to the default.
+     */
+    fun observeEditorImageInsert(): Flow<EditorImageInsert>
+
+    /** Persists [observeEditorImageInsert]. Default [EditorImageInsert.REDUCED] until the first call. */
+    suspend fun setEditorImageInsert(mode: EditorImageInsert)
 
     /**
      * Reading-density preset (#287): [DisplayDensity.COMFORT] (default) keeps the historical

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/upload/UploadProvider.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/upload/UploadProvider.kt
@@ -64,6 +64,12 @@ data class UploadedImage(
     val imageUrl: String,
     /** Thumbnail URL when the host exposes one (diberie `.../Get/t/{id}`), otherwise `null`. */
     val thumbnailUrl: String?,
+    /**
+     * A REDUCED (but not thumbnail-tiny) URL when the host exposes one — diberie `.../Get/r/{id}`,
+     * ~300px. Used by the editor's "vignette cliquable" insert mode; `null` when the host has no
+     * such variant (imgur), so the editor falls back to [imageUrl].
+     */
+    val resizedUrl: String?,
     /** `deletehash` (imgur) | `picID` (diberie) | `null` when no deletion handle is available. */
     val deleteHandle: String?,
     /** Expiry instant when the host advertises one; `null` means no known expiration. */

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/editor/EditorImageInsert.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/editor/EditorImageInsert.kt
@@ -1,0 +1,23 @@
+package fr.forumhfr.redface2.core.model.editor
+
+/**
+ * How the editor wraps an inserted image (#459 PR-images follow-up). Chosen in Settings, applied to
+ * both uploaded images (which expose a reduced URL) and pasted image URLs (which do not — they
+ * degrade [REDUCED] to [LINKED]).
+ *
+ * The enum [name] is serialised verbatim into DataStore — renaming an entry needs a defensive read.
+ */
+enum class EditorImageInsert {
+    /** `[img]full[/img]` — the raw full-size image, not a link. */
+    FULL,
+
+    /** `[url=full][img]full[/img][/url]` — full-size image, click opens the original. */
+    LINKED,
+
+    /**
+     * `[url=full][img]reduced[/img][/url]` — a reduced thumbnail, click opens the original. The
+     * classic HFR "vignette cliquable"; falls back to the full URL when the host exposes no reduced
+     * variant (e.g. imgur), which makes it identical to [LINKED].
+     */
+    REDUCED,
+}

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeFormatter.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeFormatter.kt
@@ -1,5 +1,7 @@
 package fr.forumhfr.redface2.core.ui.editor
 
+import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
+
 /**
  * BBCode actions the Phase 2B toolbar can apply to the editor selection.
  *
@@ -208,7 +210,34 @@ fun insertBbcodeToken(
  * only generates `[img]` for http(s) schemes so dangerous local/app schemes
  * (`file:`, `content:`, `data:`, `javascript:`) never leave the editor helper.
  */
-fun imageBbcodeTokenOrNull(rawUrl: String): String? {
+fun imageBbcodeTokenOrNull(rawUrl: String): String? =
+    webImageUrlOrNull(rawUrl)?.let { "[img]$it[/img]" }
+
+/**
+ * #459 PR-images follow-up — builds the BBCode for an inserted image according to the user's
+ * [EditorImageInsert] preference. [fullUrl] is the original (the click target); [displayUrl] is what
+ * is shown inline (the reduced URL for [EditorImageInsert.REDUCED], else the full URL).
+ *
+ * Returns `null` when [fullUrl] is not a safe http(s) image URL (same scheme guard as
+ * [imageBbcodeTokenOrNull]); a non-web [displayUrl] degrades to [fullUrl] rather than failing.
+ * [EditorImageInsert.REDUCED] with no distinct reduced URL is identical to [EditorImageInsert.LINKED].
+ */
+fun imageInsertBbcodeOrNull(
+    fullUrl: String,
+    displayUrl: String = fullUrl,
+    mode: EditorImageInsert,
+): String? {
+    val full = webImageUrlOrNull(fullUrl) ?: return null
+    val display = webImageUrlOrNull(displayUrl) ?: full
+    return when (mode) {
+        EditorImageInsert.FULL -> "[img]$full[/img]"
+        EditorImageInsert.LINKED -> "[url=$full][img]$full[/img][/url]"
+        EditorImageInsert.REDUCED -> "[url=$full][img]$display[/img][/url]"
+    }
+}
+
+/** Trims [rawUrl] and returns it only when it is a non-empty http(s) URL with a host, else `null`. */
+private fun webImageUrlOrNull(rawUrl: String): String? {
     val trimmed = rawUrl.trim()
     val parsed = runCatching { java.net.URI(trimmed) }.getOrNull()
     val scheme = parsed?.scheme?.lowercase()
@@ -217,6 +246,5 @@ fun imageBbcodeTokenOrNull(rawUrl: String): String? {
         trimmed.isNotEmpty() &&
             (scheme == "http" || scheme == "https") &&
             !host.isNullOrBlank()
-
-    return if (isWebImageUrl) "[img]$trimmed[/img]" else null
+    return if (isWebImageUrl) trimmed else null
 }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeToolbar.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeToolbar.kt
@@ -6,16 +6,20 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -23,6 +27,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -54,52 +59,62 @@ fun BbcodeToolbar(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .horizontalScroll(rememberScrollState())
             .padding(horizontal = 4.dp, vertical = 4.dp),
         horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        ToolbarOrder.forEach { action ->
-            ActionChip(
-                action = action,
-                onAction = onAction,
-                onImageUrlRequested = onImageUrlRequested,
-            )
+        // #459 PR-images follow-up — the image-upload button is PINNED at the leading edge (outside
+        // the horizontal scroll) and styled as a filled-tonal button so it stands out from the
+        // outlined formatting chips and never scrolls out of sight. Rendered only when the host
+        // wires the picker (the post editor) ; MP / topic-form surfaces pass null.
+        onImageUploadRequested?.let { ImageUploadButton(onClick = it, uploading = uploading) }
+        Row(
+            modifier = Modifier
+                .weight(1f)
+                .horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            ToolbarOrder.forEach { action ->
+                ActionChip(
+                    action = action,
+                    onAction = onAction,
+                    onImageUrlRequested = onImageUrlRequested,
+                )
+            }
+            ColorChip(onAction = onAction)
         }
-        // #459 PR2 — image-upload affordance, rendered only when the host screen wires the picker
-        // (the post editor) ; MP / topic-form surfaces pass null and keep the toolbar unchanged.
-        onImageUploadRequested?.let { ImageUploadChip(onClick = it, uploading = uploading) }
-        ColorChip(onAction = onAction)
     }
 }
 
 /**
- * #459 PR2 — chip launching the system photo picker (the upload itself is the host ViewModel's job).
- * While an upload is in flight it shows a small [CircularProgressIndicator] and is disabled so a
- * second pick cannot race the first. M3-only icon (a `:core:ui` vector + [Icon]) — material-icons is
- * forbidden by detekt.
+ * #459 PR-images follow-up — the prominent, pinned image-upload affordance: a filled-tonal button
+ * launching the system photo picker (the upload itself is the host ViewModel's job). While an upload
+ * is in flight it shows a small [CircularProgressIndicator] and is disabled so a second pick cannot
+ * race the first. M3-only icon (a `:core:ui` vector + [Icon]) — material-icons is forbidden by detekt.
  */
 @Composable
-private fun ImageUploadChip(
+private fun ImageUploadButton(
     onClick: () -> Unit,
     uploading: Boolean,
 ) {
-    AssistChip(
+    FilledTonalButton(
         enabled = !uploading,
         onClick = onClick,
-        label = { Text(stringResource(R.string.bbcode_action_image_upload)) },
-        leadingIcon = {
-            if (uploading) {
-                CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
-            } else {
-                Icon(
-                    painter = painterResource(R.drawable.ic_image_upload),
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp),
-                )
-            }
-        },
-        border = AssistChipDefaults.assistChipBorder(enabled = !uploading),
-    )
+        contentPadding = ButtonDefaults.ContentPadding,
+    ) {
+        if (uploading) {
+            CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+        } else {
+            Icon(
+                painter = painterResource(R.drawable.ic_image_upload),
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+            )
+        }
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(stringResource(R.string.bbcode_action_image_upload))
+    }
 }
 
 /**

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeFormatterTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeFormatterTest.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.core.ui.editor
 
+import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -326,5 +327,48 @@ class BbcodeFormatterTest {
         ).forEach { candidate ->
             assertEquals("expected <$candidate> to be rejected", null, imageBbcodeTokenOrNull(candidate))
         }
+    }
+
+    // ----- #459 PR-images follow-up : image insert modes ---------------------
+
+    @Test
+    fun `imageInsert FULL is a plain img token`() {
+        assertEquals(
+            "[img]https://h/f/1[/img]",
+            imageInsertBbcodeOrNull("https://h/f/1", "https://h/r/1", EditorImageInsert.FULL),
+        )
+    }
+
+    @Test
+    fun `imageInsert LINKED wraps the full url in a url to itself`() {
+        assertEquals(
+            "[url=https://h/f/1][img]https://h/f/1[/img][/url]",
+            imageInsertBbcodeOrNull("https://h/f/1", "https://h/r/1", EditorImageInsert.LINKED),
+        )
+    }
+
+    @Test
+    fun `imageInsert REDUCED shows the display url linked to the full url`() {
+        assertEquals(
+            "[url=https://h/f/1][img]https://h/r/1[/img][/url]",
+            imageInsertBbcodeOrNull("https://h/f/1", "https://h/r/1", EditorImageInsert.REDUCED),
+        )
+    }
+
+    @Test
+    fun `imageInsert REDUCED with a non-web display url falls back to the full url`() {
+        assertEquals(
+            "[url=https://h/f/1][img]https://h/f/1[/img][/url]",
+            imageInsertBbcodeOrNull("https://h/f/1", "content://nope", EditorImageInsert.REDUCED),
+        )
+    }
+
+    @Test
+    fun `imageInsert trims the full url and rejects a non-web full url`() {
+        assertEquals(
+            "[img]https://h/f/1[/img]",
+            imageInsertBbcodeOrNull(" https://h/f/1 ", mode = EditorImageInsert.FULL),
+        )
+        assertEquals(null, imageInsertBbcodeOrNull("file:///pic.jpg", mode = EditorImageInsert.REDUCED))
     }
 }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -25,6 +25,7 @@ import fr.forumhfr.redface2.core.domain.write.EditPostRepository
 import fr.forumhfr.redface2.core.domain.write.ReplyRepository
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import fr.forumhfr.redface2.core.model.write.EditPostContext
 import fr.forumhfr.redface2.core.model.write.ReplyContext
 import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
@@ -33,7 +34,7 @@ import fr.forumhfr.redface2.core.model.write.ReplyFormOptions
 import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
 import fr.forumhfr.redface2.core.ui.editor.BbcodeAction
 import fr.forumhfr.redface2.core.ui.editor.applyBbcodeAction
-import fr.forumhfr.redface2.core.ui.editor.imageBbcodeTokenOrNull
+import fr.forumhfr.redface2.core.ui.editor.imageInsertBbcodeOrNull
 import fr.forumhfr.redface2.core.ui.editor.insertBbcodeToken
 import java.io.IOException
 import kotlinx.coroutines.CancellationException
@@ -133,6 +134,15 @@ class PostEditorViewModel @AssistedInject constructor(
     private var confirmBeforePosting: Boolean = false
 
     /**
+     * #459 PR2 — mirror of the persisted [EditorImageInsert] preference (full / linked / reduced).
+     * Collected on init like [confirmBeforePosting] and read SYNCHRONOUSLY at insert time so the
+     * image-URL / upload paths can mutate the draft in the same frame as the user action (no
+     * suspend between the action and the draft mutation — Codex PR2 review). Default mirrors the
+     * repository's REDUCED default until the first emission lands.
+     */
+    private var imageInsertMode: EditorImageInsert = EditorImageInsert.REDUCED
+
+    /**
      * #459 PR2 — active lowercased HFR pseudo (the upload `userId`), or null when anonymous.
      * Captured from the auth stream exactly like `MyImagesViewModel` / `FlagsViewModel` so an
      * [PostEditorIntent.ImagePicked] can scope the upload to the right owner without re-reading the
@@ -155,6 +165,11 @@ class PostEditorViewModel @AssistedInject constructor(
         viewModelScope.launch {
             userPreferencesRepository.observeConfirmBeforePosting().collect { enabled ->
                 confirmBeforePosting = enabled
+            }
+        }
+        viewModelScope.launch {
+            userPreferencesRepository.observeEditorImageInsert().collect { mode ->
+                imageInsertMode = mode
             }
         }
         viewModelScope.launch {
@@ -380,23 +395,33 @@ class PostEditorViewModel @AssistedInject constructor(
         scheduleAutosave()
     }
 
+    /**
+     * #189 / #459 — a user-pasted image URL. The BBCode is shaped by the [EditorImageInsert]
+     * preference ([imageInsertBbcodeOrNull] validates the http(s) scheme and applies full / linked /
+     * reduced — a pasted URL has no reduced variant, so REDUCED degrades to LINKED). Reads the cached
+     * [imageInsertMode] synchronously so the draft mutates in the same frame as the user action
+     * (no suspend between the intent and the caret insertion — Codex PR2 review).
+     */
     private fun onImageUrlInserted(url: String) {
-        if (insertImageUrlAtCaret(url)) scheduleAutosave()
+        val bbcode = imageInsertBbcodeOrNull(fullUrl = url, mode = imageInsertMode) ?: return
+        insertImageBbcodeAtCaret(bbcode, leadingNewline = false)
+        scheduleAutosave()
     }
 
     /**
-     * #189 / #459 PR2 — shared `[img]url[/img]` insertion at the caret. Reuses the smiley path's
-     * pure helpers ([imageBbcodeTokenOrNull] validates the scheme, [insertBbcodeToken] inserts while
-     * preserving the selection) so the cursor-insertion contract is identical to `onSmileySelected`.
-     * The image token is inserted WITHOUT surrounding spaces (an `[img]` is a self-contained block,
-     * unlike a smiley which would fuse with an adjacent one). Returns `true` when the URL was valid
-     * and inserted (so callers can decide whether to schedule an autosave), `false` otherwise.
+     * #459 — inserts an already-built image BBCode fragment at the caret. Same cursor contract as the
+     * smiley path ([insertBbcodeToken] preserves the selection, the preview is refreshed), WITHOUT
+     * surrounding spaces (an image is self-contained). [leadingNewline] prefixes a newline when the
+     * caret is not already at a line start, so consecutive uploads land on their own lines instead of
+     * running together.
      */
-    private fun insertImageUrlAtCaret(url: String): Boolean {
-        val token = imageBbcodeTokenOrNull(url) ?: return false
+    private fun insertImageBbcodeAtCaret(bbcode: String, leadingNewline: Boolean) {
         _state.update { current ->
             val draft = current.draft
             val selection = draft.selection
+            val caret = selection.start.coerceIn(0, draft.text.length)
+            val needsNewline = leadingNewline && caret > 0 && draft.text[caret - 1] != '\n'
+            val token = if (needsNewline) "\n$bbcode" else bbcode
             val outcome = insertBbcodeToken(
                 token = token,
                 text = draft.text,
@@ -415,7 +440,6 @@ class PostEditorViewModel @AssistedInject constructor(
                 withDraft
             }
         }
-        return true
     }
 
     /**
@@ -452,6 +476,10 @@ class PostEditorViewModel @AssistedInject constructor(
             )
         }
         uploadJob = viewModelScope.launch {
+            // Snapshot the cached preference once at batch start so all N inserts use a consistent
+            // mode even if the user flips the setting mid-upload. Reading the cached field (not the
+            // flow) keeps the upload free of an extra suspend point.
+            val mode = imageInsertMode
             var completed = 0
             for (uri in targets) {
                 val outcome = runCatching {
@@ -462,10 +490,20 @@ class PostEditorViewModel @AssistedInject constructor(
                     handleUploadFailure(error)
                     return@launch
                 }
-                insertImageUrlAtCaret(uploaded.imageUrl)
-                // Persist after EACH insert, not once at the end: a later image failing must not
-                // lose the images already inserted into the draft (Codex review #490).
-                scheduleAutosave()
+                // BBCode shaped by the preference (full / linked / reduced) ; the reduced URL is the
+                // host's smaller variant when it exposes one, else the full URL.
+                val bbcode = imageInsertBbcodeOrNull(
+                    fullUrl = uploaded.imageUrl,
+                    displayUrl = uploaded.resizedUrl ?: uploaded.imageUrl,
+                    mode = mode,
+                )
+                if (bbcode != null) {
+                    // Each image after the first lands on its own line (no more run-together uploads).
+                    insertImageBbcodeAtCaret(bbcode, leadingNewline = completed > 0)
+                    // Persist after EACH insert, not once at the end: a later image failing must not
+                    // lose the images already inserted into the draft (Codex review #490).
+                    scheduleAutosave()
+                }
                 completed += 1
                 if (multiple) {
                     _state.update { it.copy(uploadProgress = UploadProgress(completed, targets.size)) }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModel.kt
@@ -19,6 +19,7 @@ import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.smiley.SmileyRepository
 import fr.forumhfr.redface2.core.domain.write.TopicFormRepository
 import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import fr.forumhfr.redface2.core.model.write.EditFirstPostContext
 import fr.forumhfr.redface2.core.model.write.NewTopicContext
 import fr.forumhfr.redface2.core.model.write.NewTopicSubmitResult
@@ -28,7 +29,7 @@ import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
 import fr.forumhfr.redface2.core.model.write.TopicForm
 import fr.forumhfr.redface2.core.ui.editor.BbcodeAction
 import fr.forumhfr.redface2.core.ui.editor.applyBbcodeAction
-import fr.forumhfr.redface2.core.ui.editor.imageBbcodeTokenOrNull
+import fr.forumhfr.redface2.core.ui.editor.imageInsertBbcodeOrNull
 import fr.forumhfr.redface2.core.ui.editor.insertBbcodeToken
 import java.io.IOException
 import kotlinx.coroutines.CancellationException
@@ -132,10 +133,23 @@ class TopicFormViewModel @AssistedInject constructor(
      */
     private var confirmBeforePosting: Boolean = false
 
+    /**
+     * #459 PR2 — mirror of the persisted [EditorImageInsert] preference, read synchronously at insert
+     * time so [onImageUrlInserted] mutates the draft in the same frame as the user action (cf.
+     * `PostEditorViewModel.imageInsertMode`). A pasted URL has no reduced variant, so REDUCED degrades
+     * to LINKED. Default mirrors the repository's REDUCED default until the first emission lands.
+     */
+    private var imageInsertMode: EditorImageInsert = EditorImageInsert.REDUCED
+
     init {
         viewModelScope.launch {
             userPreferencesRepository.observeConfirmBeforePosting().collect { enabled ->
                 confirmBeforePosting = enabled
+            }
+        }
+        viewModelScope.launch {
+            userPreferencesRepository.observeEditorImageInsert().collect { mode ->
+                imageInsertMode = mode
             }
         }
         restoreDraftIfAny()
@@ -360,8 +374,14 @@ class TopicFormViewModel @AssistedInject constructor(
         scheduleAutosave()
     }
 
+    /**
+     * #189 / #459 — a user-pasted image URL, shaped by the cached [EditorImageInsert] preference
+     * ([imageInsertBbcodeOrNull] validates the http(s) scheme ; a pasted URL has no reduced variant,
+     * so REDUCED degrades to LINKED). Read synchronously so the draft mutates in the same frame as
+     * the intent (Codex PR2 review — the topic composer must honour the preference too).
+     */
     private fun onImageUrlInserted(url: String) {
-        val token = imageBbcodeTokenOrNull(url) ?: return
+        val token = imageInsertBbcodeOrNull(fullUrl = url, mode = imageInsertMode) ?: return
         _state.update { current ->
             val draft = current.draft
             val selection = draft.selection

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -22,6 +22,7 @@ import fr.forumhfr.redface2.core.domain.upload.ImageUpload
 import fr.forumhfr.redface2.core.domain.upload.ImageUploadReader
 import fr.forumhfr.redface2.core.domain.upload.UploadException
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
+import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import fr.forumhfr.redface2.core.domain.upload.UploadRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadedImage
 import fr.forumhfr.redface2.core.domain.upload.UploadedImageRecord
@@ -1229,10 +1230,12 @@ class PostEditorViewModelTest {
             imageUploadReader.readUris,
         )
         val state = viewModel.state.value
-        val expected = "[img]https://h/Picture/Get/f/1[/img]" +
-            "[img]https://h/Picture/Get/f/2[/img]" +
+        // #459 PR-images follow-up — each image after the first lands on its OWN line (no more
+        // run-together uploads). FULL mode here (the fake's default) keeps the plain [img] shape.
+        val expected = "[img]https://h/Picture/Get/f/1[/img]\n" +
+            "[img]https://h/Picture/Get/f/2[/img]\n" +
             "[img]https://h/Picture/Get/f/3[/img]"
-        assertEquals("one [img] per image, concatenated in pick order", expected, state.draft.text)
+        assertEquals("one [img] per image, each on its own line, in pick order", expected, state.draft.text)
         assertFalse("upload flag cleared at the end of the batch", state.isUploading)
         assertNull("progress cleared at the end of the batch", state.uploadProgress)
         assertNull("no error on a fully successful batch", state.uploadError)
@@ -1324,6 +1327,74 @@ class PostEditorViewModelTest {
             "the image inserted before the failure must be persisted",
             "[img]https://h/Picture/Get/f/1[/img]",
             draftStore.saved[key]?.body,
+        )
+    }
+
+    @Test
+    fun `ImagePicked in REDUCED mode wraps the reduced image in a url to the original`() = runTest {
+        val authRepository = FakeAuthRepository(AuthState.Authenticated("alice"))
+        imageUploadReader.result = ImageUpload(bytes = byteArrayOf(1), mimeType = "image/png", displayName = null)
+        uploadRepository.uploadResult = uploadedImage(
+            imageUrl = "https://rehost.diberie.com/Picture/Get/f/42",
+            resizedUrl = "https://rehost.diberie.com/Picture/Get/r/42",
+        )
+        val viewModel = newReplyViewModel(
+            authRepository = authRepository,
+            userPreferencesRepository = FakeUserPreferencesRepository(editorImageInsert = EditorImageInsert.REDUCED),
+        )
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(PostEditorIntent.ImagePicked("content://x/1"))
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(
+            "REDUCED shows the reduced URL, clickable to the original",
+            "[url=https://rehost.diberie.com/Picture/Get/f/42]" +
+                "[img]https://rehost.diberie.com/Picture/Get/r/42[/img][/url]",
+            viewModel.state.value.draft.text,
+        )
+    }
+
+    @Test
+    fun `ImagePicked in LINKED mode wraps the full image in a url to itself`() = runTest {
+        val authRepository = FakeAuthRepository(AuthState.Authenticated("alice"))
+        imageUploadReader.result = ImageUpload(bytes = byteArrayOf(1), mimeType = "image/png", displayName = null)
+        uploadRepository.uploadResult = uploadedImage("https://h/Picture/Get/f/42")
+        val viewModel = newReplyViewModel(
+            authRepository = authRepository,
+            userPreferencesRepository = FakeUserPreferencesRepository(editorImageInsert = EditorImageInsert.LINKED),
+        )
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(PostEditorIntent.ImagePicked("content://x/1"))
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(
+            "LINKED wraps the full image so a click opens the original",
+            "[url=https://h/Picture/Get/f/42][img]https://h/Picture/Get/f/42[/img][/url]",
+            viewModel.state.value.draft.text,
+        )
+    }
+
+    @Test
+    fun `ImagePicked in REDUCED mode with no reduced url falls back to the full url`() = runTest {
+        val authRepository = FakeAuthRepository(AuthState.Authenticated("alice"))
+        imageUploadReader.result = ImageUpload(bytes = byteArrayOf(1), mimeType = "image/png", displayName = null)
+        // imgur exposes no reduced variant (resizedUrl null) → REDUCED degrades to LINKED.
+        uploadRepository.uploadResult = uploadedImage("https://i.imgur.com/x.png")
+        val viewModel = newReplyViewModel(
+            authRepository = authRepository,
+            userPreferencesRepository = FakeUserPreferencesRepository(editorImageInsert = EditorImageInsert.REDUCED),
+        )
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(PostEditorIntent.ImagePicked("content://x/1"))
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(
+            "no reduced URL → REDUCED falls back to the full URL (same as LINKED)",
+            "[url=https://i.imgur.com/x.png][img]https://i.imgur.com/x.png[/img][/url]",
+            viewModel.state.value.draft.text,
         )
     }
 
@@ -1865,6 +1936,10 @@ class PostEditorViewModelTest {
      */
     private class FakeUserPreferencesRepository(
         confirmBeforePosting: Boolean = false,
+        // Default FULL so the existing single-image insert tests keep asserting `[img]url[/img]`;
+        // production defaults to REDUCED (cf. DataStoreUserPreferencesRepository), exercised by the
+        // dedicated mode tests below.
+        editorImageInsert: EditorImageInsert = EditorImageInsert.FULL,
     ) : UserPreferencesRepository {
         private val confirmBeforePosting = MutableStateFlow(confirmBeforePosting)
 
@@ -1930,6 +2005,15 @@ class PostEditorViewModelTest {
 
         override suspend fun setImgurClientId(clientId: String) = Unit
 
+        // #459 PR-images follow-up — editor image insert mode, configurable per test.
+        private val editorImageInsert = MutableStateFlow(editorImageInsert)
+
+        override fun observeEditorImageInsert(): Flow<EditorImageInsert> = editorImageInsert
+
+        override suspend fun setEditorImageInsert(mode: EditorImageInsert) {
+            editorImageInsert.value = mode
+        }
+
         // #287 — reading display presets are irrelevant to the editor; stubbed at defaults.
         override fun observeDisplayDensity(): Flow<DisplayDensity> = MutableStateFlow(DisplayDensity.COMFORT)
 
@@ -1971,10 +2055,11 @@ class PostEditorViewModelTest {
         }
     }
 
-    private fun uploadedImage(imageUrl: String): UploadedImage = UploadedImage(
+    private fun uploadedImage(imageUrl: String, resizedUrl: String? = null): UploadedImage = UploadedImage(
         provider = UploadProviderId.DIBERIE,
         imageUrl = imageUrl,
         thumbnailUrl = null,
+        resizedUrl = resizedUrl,
         deleteHandle = null,
         expiresAt = null,
     )
@@ -2017,6 +2102,7 @@ class PostEditorViewModelTest {
             provider = UploadProviderId.DIBERIE,
             imageUrl = "https://rehost.diberie.com/Picture/Get/f/1",
             thumbnailUrl = null,
+            resizedUrl = null,
             deleteHandle = null,
             expiresAt = null,
         )

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -18,6 +18,7 @@ import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.smiley.SmileyRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
+import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import fr.forumhfr.redface2.core.domain.write.TopicFormRepository
 import fr.forumhfr.redface2.core.model.EditorSmiley
 import fr.forumhfr.redface2.core.model.EditorSmileySource
@@ -768,6 +769,27 @@ class TopicFormViewModelTest {
         assertEquals("image: ", viewModel.state.value.draft.text)
     }
 
+    @Test
+    fun `ImageUrlInserted honours the EditorImageInsert preference in topic-level forms`() = runTest {
+        // #459 PR2 (Codex P2#1) — the topic composer must respect the same preference as the post
+        // editor. A pasted URL has no reduced variant, so REDUCED wraps the full URL in [url].
+        val viewModel = newViewModel(
+            userPreferencesRepository =
+                FakeUserPreferencesRepository(editorImageInsert = EditorImageInsert.REDUCED),
+        )
+        viewModel.state.test {
+            awaitHydratedState()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        viewModel.submit(TopicFormIntent.ContentChanged(TextFieldValue("image: ", TextRange(7))))
+        viewModel.submit(TopicFormIntent.ImageUrlInserted("https://example.com/pic.gif"))
+
+        val expected =
+            "image: [url=https://example.com/pic.gif][img]https://example.com/pic.gif[/img][/url]"
+        assertEquals(expected, viewModel.state.value.draft.text)
+    }
+
     // ----- #312 : confirmation avant publication ------------------------------
 
     @Test
@@ -1316,8 +1338,10 @@ class TopicFormViewModelTest {
      */
     private class FakeUserPreferencesRepository(
         confirmBeforePosting: Boolean = false,
+        editorImageInsert: EditorImageInsert = EditorImageInsert.FULL,
     ) : UserPreferencesRepository {
         private val confirmBeforePosting = MutableStateFlow(confirmBeforePosting)
+        private val editorImageInsert = MutableStateFlow(editorImageInsert)
 
         override fun observeProxyConfig(): Flow<ProxyConfig> = MutableStateFlow(ProxyConfig())
         override suspend fun saveProxyConfig(config: ProxyConfig) = Unit
@@ -1380,6 +1404,12 @@ class TopicFormViewModelTest {
         override fun observeImgurClientId(): Flow<String> = MutableStateFlow("")
 
         override suspend fun setImgurClientId(clientId: String) = Unit
+
+        override fun observeEditorImageInsert(): Flow<EditorImageInsert> = editorImageInsert
+
+        override suspend fun setEditorImageInsert(mode: EditorImageInsert) {
+            editorImageInsert.value = mode
+        }
 
         // #287 — reading display presets are irrelevant to the topic form; stubbed at defaults.
         override fun observeDisplayDensity(): Flow<DisplayDensity> = MutableStateFlow(DisplayDensity.COMFORT)

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -20,6 +20,7 @@ import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
+import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.Category
 import fr.forumhfr.redface2.core.model.Flag
@@ -1627,6 +1628,11 @@ class FlagsViewModelTest {
         override fun observeImgurClientId(): Flow<String> = MutableStateFlow("")
 
         override suspend fun setImgurClientId(clientId: String) = Unit
+
+        override fun observeEditorImageInsert(): Flow<EditorImageInsert> =
+            MutableStateFlow(EditorImageInsert.REDUCED)
+
+        override suspend fun setEditorImageInsert(mode: EditorImageInsert) = Unit
 
         // #312 — confirm-before-posting is irrelevant to FlagsViewModel; stubbed at its default.
         override fun observeConfirmBeforePosting(): Flow<Boolean> = MutableStateFlow(false)

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -47,6 +47,7 @@ import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
+import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 
 @Composable
 fun SettingsScreen(
@@ -830,6 +831,38 @@ private fun UploadProviderPreferencesCard(
                 if (state.imgurClientIdError) {
                     PreferencePersistError(R.string.settings_upload_imgur_client_id_persist_failed)
                 }
+            }
+            // #459 PR-images follow-up — how the editor wraps an inserted image (applies to uploads
+            // and pasted URLs). Reduced = the HFR "vignette cliquable" (default).
+            Text(
+                text = stringResource(R.string.settings_image_insert_title),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = stringResource(R.string.settings_image_insert_intro),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            val imageInsertOptions = listOf(
+                EditorImageInsert.FULL to stringResource(R.string.settings_image_insert_full),
+                EditorImageInsert.LINKED to stringResource(R.string.settings_image_insert_linked),
+                EditorImageInsert.REDUCED to stringResource(R.string.settings_image_insert_reduced),
+            )
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                imageInsertOptions.forEachIndexed { index, (mode, label) ->
+                    SegmentedButton(
+                        selected = state.editorImageInsert == mode,
+                        enabled = !state.isUpdatingEditorImageInsert,
+                        onClick = { onIntent(SettingsIntent.SetEditorImageInsert(mode)) },
+                        shape = SegmentedButtonDefaults.itemShape(index = index, count = imageInsertOptions.size),
+                    ) {
+                        Text(label)
+                    }
+                }
+            }
+            if (state.editorImageInsertError) {
+                PreferencePersistError(R.string.settings_image_insert_persist_failed)
             }
         }
     }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -4,6 +4,7 @@ import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
+import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 
 data class SettingsState(
     val proxyEnabled: Boolean = false,
@@ -146,6 +147,12 @@ data class SettingsState(
     val imgurClientId: String = "",
     val imgurClientIdError: Boolean = false,
     val imgurClientIdTouchedLocally: Boolean = false,
+    // #459 PR-images follow-up — how the editor wraps an inserted image (full / linked / reduced).
+    // Same optimistic-flip shape as [uploadProvider]. Default REDUCED (the HFR "vignette cliquable").
+    val editorImageInsert: EditorImageInsert = EditorImageInsert.REDUCED,
+    val isUpdatingEditorImageInsert: Boolean = false,
+    val editorImageInsertError: Boolean = false,
+    val editorImageInsertTouchedLocally: Boolean = false,
 ) {
     val canSave: Boolean
         get() = !isSaving
@@ -320,4 +327,7 @@ sealed interface SettingsIntent {
     // the UI layer — the upload then fails with a precise host error (cf. #474) instead of silently.
     data class SetUploadProvider(val provider: UploadProviderId) : SettingsIntent
     data class SetImgurClientId(val text: String) : SettingsIntent
+
+    /** #459 PR-images follow-up — choose how the editor wraps an inserted image. */
+    data class SetEditorImageInsert(val mode: EditorImageInsert) : SettingsIntent
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -11,6 +11,7 @@ import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
+import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
@@ -133,6 +134,12 @@ class SettingsViewModel @Inject constructor(
             isLocked = { it.imgurClientIdTouchedLocally },
             apply = { state, value -> state.copy(imgurClientId = value) },
         )
+        // #459 PR-images follow-up — editor image insert mode (enum), same hydration shape.
+        hydratePreference(
+            read = { userPreferencesRepository.observeEditorImageInsert().first() },
+            isLocked = { it.editorImageInsertTouchedLocally || it.isUpdatingEditorImageInsert },
+            apply = { state, value -> state.copy(editorImageInsert = value) },
+        )
     }
 
     /**
@@ -202,6 +209,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.FontScaleChanged -> updateFontScale(intent.scale)
             is SettingsIntent.SetUploadProvider -> updateUploadProvider(intent.provider)
             is SettingsIntent.SetImgurClientId -> updateImgurClientId(intent.text)
+            is SettingsIntent.SetEditorImageInsert -> updateEditorImageInsert(intent.mode)
         }
     }
 
@@ -534,6 +542,34 @@ class SettingsViewModel @Inject constructor(
                             uploadProvider = previous,
                             isUpdatingUploadProvider = false,
                             uploadProviderError = true,
+                        )
+                    }
+                }
+        }
+    }
+
+    // #459 PR-images follow-up — editor image insert mode is an enum, same optimistic-flip shape.
+    private fun updateEditorImageInsert(desired: EditorImageInsert) {
+        val previous = _state.value.editorImageInsert
+        _state.update {
+            it.copy(
+                editorImageInsert = desired,
+                isUpdatingEditorImageInsert = true,
+                editorImageInsertError = false,
+                editorImageInsertTouchedLocally = true,
+            )
+        }
+        viewModelScope.launch {
+            runCatching { userPreferencesRepository.setEditorImageInsert(desired) }
+                .onSuccess {
+                    _state.update { it.copy(editorImageInsert = desired, isUpdatingEditorImageInsert = false) }
+                }
+                .onFailure {
+                    _state.update {
+                        it.copy(
+                            editorImageInsert = previous,
+                            isUpdatingEditorImageInsert = false,
+                            editorImageInsertError = true,
                         )
                     }
                 }

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -197,6 +197,14 @@
     <string name="settings_upload_imgur_client_id_helper">Client-ID d\'application Imgur</string>
     <string name="settings_upload_imgur_client_id_persist_failed">Impossible de mémoriser le Client-ID. Réessayez.</string>
 
+    <!-- #459 PR-images follow-up — mode d'insertion des images dans l'éditeur. -->
+    <string name="settings_image_insert_title">Insertion des images</string>
+    <string name="settings_image_insert_intro">Comment insérer une image (upload ou URL collée). « Réduite » insère une vignette cliquable qui ouvre l\'image originale en grand.</string>
+    <string name="settings_image_insert_full">Complète</string>
+    <string name="settings_image_insert_linked">Cliquable</string>
+    <string name="settings_image_insert_reduced">Réduite</string>
+    <string name="settings_image_insert_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
+
     <!-- #459 PR3 — écran « Mes images uploadées » (liste + suppression). -->
     <string name="my_images_title">Mes images uploadées</string>
     <string name="my_images_back">Retour</string>

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -10,6 +10,7 @@ import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
+import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import fr.forumhfr.redface2.core.model.FlagType
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -1148,6 +1149,33 @@ class SettingsViewModelTest {
         }
 
     @Test
+    fun `SetEditorImageInsert persists the new mode and clears the updating flag`() = runTest {
+        val viewModel = newViewModel()
+        assertEquals("REDUCED is the default", EditorImageInsert.REDUCED, viewModel.state.value.editorImageInsert)
+
+        viewModel.submit(SettingsIntent.SetEditorImageInsert(EditorImageInsert.FULL))
+
+        val state = viewModel.state.value
+        assertEquals(EditorImageInsert.FULL, state.editorImageInsert)
+        assertFalse(state.isUpdatingEditorImageInsert)
+        assertFalse(state.editorImageInsertError)
+        assertEquals(EditorImageInsert.FULL, repository.lastEditorImageInsertSet)
+    }
+
+    @Test
+    fun `SetEditorImageInsert reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnEditorImageInsertSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.SetEditorImageInsert(EditorImageInsert.FULL))
+
+        val state = viewModel.state.value
+        assertEquals("must revert on failure", EditorImageInsert.REDUCED, state.editorImageInsert)
+        assertFalse(state.isUpdatingEditorImageInsert)
+        assertTrue(state.editorImageInsertError)
+    }
+
+    @Test
     fun `SetImgurClientId persists the text and exposes it`() = runTest {
         val viewModel = newViewModel()
         assertEquals("client id is empty by default", "", viewModel.state.value.imgurClientId)
@@ -1503,6 +1531,20 @@ class SettingsViewModelTest {
 
         fun emitImgurClientId(value: String) {
             imgurClientId.value = value
+        }
+
+        // #459 PR-images follow-up — editor image insert mode. Same optimistic-flip seam.
+        private val editorImageInsert = MutableStateFlow(EditorImageInsert.REDUCED)
+        var lastEditorImageInsertSet: EditorImageInsert? = null
+            private set
+        var failOnEditorImageInsertSet: Boolean = false
+
+        override fun observeEditorImageInsert(): Flow<EditorImageInsert> = editorImageInsert
+
+        override suspend fun setEditorImageInsert(mode: EditorImageInsert) {
+            check(!failOnEditorImageInsertSet) { "boom" }
+            lastEditorImageInsertSet = mode
+            editorImageInsert.value = mode
         }
 
         // #312 — confirm-before-posting. Same optimistic-flip seam as the topic top-bar toggle.

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -13,6 +13,7 @@ import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.topic.TopicRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
+import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import fr.forumhfr.redface2.core.domain.write.DeletePostRepository
 import fr.forumhfr.redface2.core.domain.write.DeletePostResult
 import fr.forumhfr.redface2.core.model.AuthState
@@ -1395,6 +1396,11 @@ private class FakeUserPreferencesRepository(
     override fun observeImgurClientId(): Flow<String> = MutableStateFlow("")
 
     override suspend fun setImgurClientId(clientId: String) = Unit
+
+    override fun observeEditorImageInsert(): Flow<EditorImageInsert> =
+        MutableStateFlow(EditorImageInsert.REDUCED)
+
+    override suspend fun setEditorImageInsert(mode: EditorImageInsert) = Unit
 
     // #287 — reading display presets are irrelevant to TopicViewModel; stubbed at defaults.
     override fun observeDisplayDensity(): Flow<DisplayDensity> = MutableStateFlow(DisplayDensity.COMFORT)


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaTriX)

## Contexte

Suite de #459 (PR-images) — quatre améliorations éditeur/upload demandées par @XaTriX. Lié à `refs-#459`.

## Changements

1. **Retour à la ligne automatique en multi-upload** — chaque image après la première est insérée sur sa propre ligne (newline en tête) au lieu d'être collée à la précédente.
2. **Image cliquable vers l'originale** — nouvelle préférence `EditorImageInsert` (Réglages → Hébergeur d'images) :
   - `FULL` : `[img]…[/img]`
   - `LINKED` : `[url=full][img]full[/img][/url]`
   - `REDUCED` (défaut) : `[url=full][img]reduced[/img][/url]` — la « vignette cliquable » classique HFR, comme le défaut diberie de RF1.
3. **Taille d'image** — `DiberieProvider` expose l'URL réduite de l'hébergeur (`.../Get/r/{id}`, ~300px) via `UploadedImage.resizedUrl`. `REDUCED` l'utilise, avec repli sur l'URL pleine quand l'hébergeur n'en a pas (imgur). Pas de paramètre de resize sur diberie — c'est le chemin `/r/` qui est la variante.
4. **Bouton upload mis en évidence** — épinglé au bord gauche de la barre d'outils (hors du scroll horizontal) et stylé en `FilledTonalButton`, pour ne plus le chercher parmi les chips de formatage.

Le mode s'applique aussi aux URLs d'images collées (une URL collée n'a pas de variante réduite, donc `REDUCED` dégrade en `LINKED`).

## Méthodo

Code Opus, build dev validé sur machine de build (tests `:feature:editor` / `:feature:settings` / `:core:ui` / `:core:data` + `detektAll` + `lint` + `:app:assembleDevDebug` verts), review Codex.

## Suite review Codex (2 findings P2, corrigés)

1. Le composer de nouveau sujet (`TopicFormViewModel.onImageUrlInserted`) ignorait la préférence et codait `[img]` en dur → il lit désormais `EditorImageInsert` comme l'éditeur de post (+ test dédié).
2. L'éditeur de post lisait la préférence en suspendant entre l'action et la mutation du brouillon → la préférence est désormais mise en cache à l'init (collector) et lue de façon synchrone, l'insertion d'URL collée mute le brouillon dans la même frame que l'action utilisateur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
