### PR TITLE
feat(settings): inspecteur MP storage (debug, lecture seule) (refs-#6)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -273,6 +273,13 @@ data object SettingsRoute : RedfaceNavKey
 data object MyImagesRoute : RedfaceNavKey
 
 /**
+ * #6 — read-only MPStorage inspector (debug). Reached from the Settings screen, only when the DT
+ * section is enabled. Opaque route, no params (the screen owns its own fetch).
+ */
+@Serializable
+data object MpStorageInspectorRoute : RedfaceNavKey
+
+/**
  * Phase 2 finish (#208) — full profile page route.
  *
  * Navigation is always [userId]-first. [pseudo] and [avatarUrl] are display hints shown
@@ -1135,11 +1142,21 @@ private fun RedfaceNavHost(
             entry<SettingsRoute> {
                 SettingsScreen(
                     onOpenMyImages = { backStack.add(MyImagesRoute) },
+                    onOpenMpStorageInspector = { backStack.add(MpStorageInspectorRoute) },
                 )
             }
             entry<MyImagesRoute> {
                 MyImagesScreen(
                     onBack = {
+                        if (backStack.size > 1) {
+                            backStack.removeAt(backStack.lastIndex)
+                        }
+                    },
+                )
+            }
+            entry<MpStorageInspectorRoute> {
+                fr.forumhfr.redface2.feature.settings.MpStorageInspectorScreen(
+                    onClose = {
                         if (backStack.size > 1) {
                             backStack.removeAt(backStack.lastIndex)
                         }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/MpStorageInspectorScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/MpStorageInspectorScreen.kt
@@ -1,0 +1,294 @@
+package fr.forumhfr.redface2.feature.settings
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.auth.AuthRepository
+import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageLocation
+import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageLocationStore
+import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
+import fr.forumhfr.redface2.core.model.AuthState
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageFlagEntry
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageResult
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * #6 — read-only debug inspector for the cross-app MPStorage MP. Surfaces what RF2 discovers and
+ * parses (the same `fetchStorage()` the seeder uses), so a tester can confirm RF2 sees the same
+ * container as DTCloud/MultiMP. No write/delete — purely diagnostic.
+ */
+sealed interface MpStorageInspectorUiState {
+    data object Loading : MpStorageInspectorUiState
+
+    /** No HFR session → the storage MP can't be fetched. */
+    data object NotAuthenticated : MpStorageInspectorUiState
+
+    /** Authenticated, but the inbox scan found no storage MP for this account. */
+    data object NotFound : MpStorageInspectorUiState
+
+    /** Storage MP located but its content is not parseable (non-JSON / invalid envelope). */
+    data object Unreadable : MpStorageInspectorUiState
+
+    /** Transport / unexpected failure while fetching. */
+    data class Error(val message: String) : MpStorageInspectorUiState
+
+    data class Loaded(
+        val sourceName: String?,
+        val location: MpStorageLocation?,
+        val entries: List<MpStorageFlagEntry>,
+        val rawEnvelope: String,
+    ) : MpStorageInspectorUiState
+}
+
+@HiltViewModel
+class MpStorageInspectorViewModel @Inject constructor(
+    private val mpStorageRepository: MpStorageRepository,
+    private val mpStorageLocationStore: MpStorageLocationStore,
+    private val authRepository: AuthRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<MpStorageInspectorUiState>(MpStorageInspectorUiState.Loading)
+    val state: StateFlow<MpStorageInspectorUiState> = _state.asStateFlow()
+
+    /** One fetch at a time; preempted on an owner change (see [load]). */
+    private var loadJob: Job? = null
+
+    /**
+     * Owner (lowercased pseudo, or null = anonymous) the current state was loaded for. Tracked so a
+     * mid-life logout / account switch — e.g. the inspector left in the back stack — re-scopes the
+     * load and never keeps the PREVIOUS account's raw envelope on screen / copyable (Codex review).
+     */
+    private var currentOwner: String? = null
+    private var initialized = false
+
+    init {
+        // React to auth changes for the whole ViewModel lifetime, not just once: the first emission
+        // drives the initial load, and any later owner change (logout → null, or switch → other pseudo)
+        // cancels the in-flight load and reloads for the new owner.
+        viewModelScope.launch {
+            authRepository.observeAuthState().collect { authState ->
+                val owner = (authState as? AuthState.Authenticated)?.pseudo?.lowercase()
+                if (!initialized || owner != currentOwner) {
+                    initialized = true
+                    currentOwner = owner
+                    load(owner)
+                }
+            }
+        }
+    }
+
+    /** Manual « Rafraîchir » — reloads for the current owner; a no-op while a load is in flight. */
+    fun refresh() {
+        if (loadJob?.isActive == true) return
+        load(currentOwner)
+    }
+
+    private fun load(owner: String?) {
+        // Preempt any in-flight load so an account switch can't be overtaken by the previous owner's
+        // fetch landing late, and clear the old state immediately.
+        loadJob?.cancel()
+        _state.value = MpStorageInspectorUiState.Loading
+        loadJob = viewModelScope.launch {
+            val next = if (owner == null) {
+                // Anonymous can't fetch a private-message container, so short-circuit before the network.
+                MpStorageInspectorUiState.NotAuthenticated
+            } else {
+                runCatching { mpStorageRepository.fetchStorage() }.fold(
+                    onSuccess = { result ->
+                        when (result) {
+                            MpStorageResult.NotFound -> MpStorageInspectorUiState.NotFound
+                            MpStorageResult.Unreadable -> MpStorageInspectorUiState.Unreadable
+                            is MpStorageResult.Found -> MpStorageInspectorUiState.Loaded(
+                                sourceName = result.document.sourceName,
+                                // Read AFTER fetchStorage so a fresh discovery has already populated the cache.
+                                location = mpStorageLocationStore.read(owner),
+                                entries = result.document.mpFlags,
+                                rawEnvelope = result.document.rawEnvelope,
+                            )
+                        }
+                    },
+                    onFailure = { error ->
+                        // A superseding load (logout / account switch) cancelled us — propagate, never
+                        // publish, and don't let runCatching map it to a bogus Error (Codex review).
+                        if (error is CancellationException) throw error
+                        MpStorageInspectorUiState.Error(error.message ?: error::class.simpleName ?: "erreur inconnue")
+                    },
+                )
+            }
+            // Publish ONLY if this load is still for the current owner. A later switch/logout has already
+            // re-scoped `currentOwner` (and launched its own load), so a late completion of this one must
+            // not clobber it with the previous account's data — the core of the cross-account leak guard
+            // for the success race where cancellation arrives after the last suspension point (Codex review).
+            if (owner == currentOwner) {
+                _state.value = next
+            }
+        }
+    }
+}
+
+/**
+ * Read-only MPStorage inspector screen (debug). Hardcoded French labels, mirroring `DiagnosticsScreen`
+ * (the other debug-grade utility) rather than going through `strings.xml`.
+ */
+@Composable
+fun MpStorageInspectorScreen(onClose: () -> Unit) {
+    val viewModel: MpStorageInspectorViewModel = hiltViewModel()
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surface) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .statusBarsPadding()
+                .navigationBarsPadding(),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "Inspecteur MP storage",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(Modifier.weight(1f))
+                (state as? MpStorageInspectorUiState.Loaded)?.let { loaded ->
+                    TextButton(onClick = { copyEnvelopeToClipboard(context, loaded.rawEnvelope) }) {
+                        Text("Copier")
+                    }
+                }
+                TextButton(
+                    enabled = state !is MpStorageInspectorUiState.Loading,
+                    onClick = viewModel::refresh,
+                ) { Text("Rafraîchir") }
+                TextButton(onClick = onClose) { Text("Fermer") }
+            }
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                when (val s = state) {
+                    MpStorageInspectorUiState.Loading -> Row(verticalAlignment = Alignment.CenterVertically) {
+                        CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                        Spacer(Modifier.size(12.dp))
+                        InspectorBody("Lecture du MP storage…")
+                    }
+                    MpStorageInspectorUiState.NotAuthenticated ->
+                        InspectorBody("Connecte-toi pour inspecter le MP storage.")
+                    MpStorageInspectorUiState.NotFound ->
+                        InspectorBody("Aucun MP de stockage trouvé (scan de la boîte MP infructueux).")
+                    MpStorageInspectorUiState.Unreadable ->
+                        InspectorBody("MP de stockage trouvé mais illisible (contenu non-JSON / invalide).")
+                    is MpStorageInspectorUiState.Error ->
+                        InspectorBody("Erreur : ${s.message}")
+                    is MpStorageInspectorUiState.Loaded -> LoadedContent(s)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadedContent(state: MpStorageInspectorUiState.Loaded) {
+    InspectorLabel("Source", state.sourceName ?: "inconnue")
+    InspectorLabel(
+        label = "Emplacement",
+        value = state.location?.let { "thread ${it.threadId}, numrép ${it.numreponse}" } ?: "non caché",
+    )
+    InspectorLabel("Entrées DT", state.entries.size.toString())
+    state.entries.forEach { entry ->
+        Text(
+            text = "• thread=${entry.threadId} page=${entry.page} " +
+                "numrép=${entry.numreponse ?: "—"} uri=${entry.uri ?: "—"}",
+            fontFamily = FontFamily.Monospace,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+    Text(
+        text = "Enveloppe brute",
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.onSurface,
+    )
+    Text(
+        text = state.rawEnvelope.ifBlank { "(vide)" },
+        fontFamily = FontFamily.Monospace,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+@Composable
+private fun InspectorLabel(label: String, value: String) {
+    Row {
+        Text(
+            text = "$label : ",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+@Composable
+private fun InspectorBody(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+private fun copyEnvelopeToClipboard(context: Context, envelope: String) {
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    clipboard.setPrimaryClip(ClipData.newPlainText("redface2 mpstorage", envelope))
+}

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -55,6 +55,9 @@ fun SettingsScreen(
     // #459 PR3 — navigates to the « Mes images uploadées » screen. Default no-op so previews and
     // the multi-pane illustrative call sites stay valid ; wired from RedfaceApp.
     onOpenMyImages: () -> Unit = {},
+    // #6 — navigates to the read-only MPStorage inspector (debug). Only surfaced when the DT section
+    // is enabled (gated below). Default no-op so previews / illustrative call sites stay valid.
+    onOpenMpStorageInspector: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel(),
     // #458 — the « Démarrage » section has its own ViewModel (cf. its KDoc).
     startScreenViewModel: StartScreenSettingsViewModel = hiltViewModel(),
@@ -66,14 +69,15 @@ fun SettingsScreen(
         onIntent = viewModel::submit,
         modifier = modifier,
         onOpenMyImages = onOpenMyImages,
+        onOpenMpStorageInspector = onOpenMpStorageInspector,
         startScreenState = startScreenState,
         onStartScreenIntent = startScreenViewModel::submit,
     )
 }
 
 // MVI screen content : state + intent + modifier + rappels de navigation/feature (#458 démarrage,
-// #459 « Mes images »). 6 paramètres = la surface complète de l'écran ; les regrouper derrière un
-// objet masquerait le site d'appel sans gain réel. Seuil detekt LongParameterList à 6.
+// #459 « Mes images », #6 inspecteur MPStorage). 7 paramètres = la surface complète de l'écran ;
+// les regrouper derrière un objet masquerait le site d'appel sans gain réel.
 @Suppress("LongParameterList")
 @Composable
 internal fun SettingsContent(
@@ -81,6 +85,7 @@ internal fun SettingsContent(
     onIntent: (SettingsIntent) -> Unit,
     modifier: Modifier = Modifier,
     onOpenMyImages: () -> Unit = {},
+    onOpenMpStorageInspector: () -> Unit = {},
     startScreenState: StartScreenSettingsState = StartScreenSettingsState(),
     onStartScreenIntent: (StartScreenSettingsIntent) -> Unit = {},
 ) {
@@ -297,6 +302,11 @@ internal fun SettingsContent(
                 state = state,
                 onIntent = onIntent,
             )
+            // #6 — read-only MPStorage inspector (debug). Gated on the DT section toggle so it stays
+            // hidden from regular users and only power users who opted into DT features see it.
+            if (state.showDtSection) {
+                MpStorageInspectorCard(onOpen = onOpenMpStorageInspector)
+            }
             FutureSettingsCard(
                 items = listOf(
                     R.string.settings_future_mp_notifications to issueTag(313),
@@ -765,6 +775,37 @@ private fun MyImagesCard(onOpenMyImages: () -> Unit) {
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(stringResource(R.string.settings_my_images_open))
+            }
+        }
+    }
+}
+
+/**
+ * #6 — entry point to the read-only MPStorage inspector. Same shape as [MyImagesCard] (a routing
+ * card, not a preference toggle). Only rendered when the DT section is enabled (see call site).
+ */
+@Composable
+private fun MpStorageInspectorCard(onOpen: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_mpstorage_inspector_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = stringResource(R.string.settings_mpstorage_inspector_description),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            OutlinedButton(
+                onClick = onOpen,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.settings_mpstorage_inspector_open))
             }
         }
     }

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -186,6 +186,11 @@
     <string name="settings_my_images_description">Consultez les images que vous avez envoyées et supprimez-les.</string>
     <string name="settings_my_images_open">Voir mes images</string>
 
+    <!-- #6 — inspecteur MP storage (debug, visible seulement quand la section DT est activée). -->
+    <string name="settings_mpstorage_inspector_title">Inspecteur MP storage</string>
+    <string name="settings_mpstorage_inspector_description">Outil de debug : inspecte le conteneur MPStorage découvert (source, positions DT, enveloppe brute), en lecture seule.</string>
+    <string name="settings_mpstorage_inspector_open">Ouvrir l\'inspecteur</string>
+
     <!-- #459 — Hébergeur d'images. Choisit l'hébergeur des uploads de l'éditeur ; le Client-ID
          imgur n'apparaît que pour imgur. Persisté en DataStore, lu par l'éditeur à chaque upload. -->
     <string name="settings_upload_provider_title">Hébergeur d\'images</string>

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/MpStorageInspectorViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/MpStorageInspectorViewModelTest.kt
@@ -1,0 +1,256 @@
+package fr.forumhfr.redface2.feature.settings
+
+import fr.forumhfr.redface2.core.domain.auth.AuthRepository
+import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageLocation
+import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageLocationStore
+import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
+import fr.forumhfr.redface2.core.model.AuthState
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageDocument
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageFlagEntry
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageResult
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MpStorageInspectorViewModelTest {
+
+    @Before
+    fun setUp() {
+        // Unconfined → the init refresh() runs eagerly to completion, so state.value is terminal.
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `anonymous yields NotAuthenticated and never fetches`() = runTest {
+        val repo = FakeMpStorageRepository(MpStorageResult.NotFound)
+
+        val viewModel = MpStorageInspectorViewModel(repo, FakeLocationStore(), FakeAuthRepository(AuthState.Anonymous))
+
+        assertEquals(MpStorageInspectorUiState.NotAuthenticated, viewModel.state.value)
+        assertEquals("anonymous must not hit the network", 0, repo.fetchCount)
+    }
+
+    @Test
+    fun `found document maps to Loaded with source, entries, envelope and cached location`() = runTest {
+        val entries = listOf(
+            MpStorageFlagEntry(threadId = 9100200, page = 12, numreponse = 9100201, uri = "t9100201"),
+        )
+        val document = MpStorageDocument(sourceName = "DTCloud", mpFlags = entries, rawEnvelope = "{\"data\":[]}")
+        val location = MpStorageLocation(threadId = 9100200, numreponse = 9100201)
+
+        val viewModel = MpStorageInspectorViewModel(
+            FakeMpStorageRepository(MpStorageResult.Found(document)),
+            FakeLocationStore(location),
+            FakeAuthRepository(AuthState.Authenticated("XaTelitte")),
+        )
+
+        val state = viewModel.state.value
+        assertTrue(state is MpStorageInspectorUiState.Loaded)
+        state as MpStorageInspectorUiState.Loaded
+        assertEquals("DTCloud", state.sourceName)
+        assertEquals(entries, state.entries)
+        assertEquals("{\"data\":[]}", state.rawEnvelope)
+        assertEquals(location, state.location)
+    }
+
+    @Test
+    fun `location store is queried with the lowercased pseudo`() = runTest {
+        val store = FakeLocationStore(MpStorageLocation(1, 2))
+
+        MpStorageInspectorViewModel(
+            FakeMpStorageRepository(MpStorageResult.Found(MpStorageDocument(null, emptyList(), "{}"))),
+            store,
+            FakeAuthRepository(AuthState.Authenticated("XaTelitte")),
+        )
+
+        assertEquals("xatelitte", store.lastOwner)
+    }
+
+    @Test
+    fun `not found maps to NotFound`() = runTest {
+        val viewModel = MpStorageInspectorViewModel(
+            FakeMpStorageRepository(MpStorageResult.NotFound),
+            FakeLocationStore(),
+            FakeAuthRepository(AuthState.Authenticated("XaTelitte")),
+        )
+
+        assertEquals(MpStorageInspectorUiState.NotFound, viewModel.state.value)
+    }
+
+    @Test
+    fun `unreadable maps to Unreadable`() = runTest {
+        val viewModel = MpStorageInspectorViewModel(
+            FakeMpStorageRepository(MpStorageResult.Unreadable),
+            FakeLocationStore(),
+            FakeAuthRepository(AuthState.Authenticated("XaTelitte")),
+        )
+
+        assertEquals(MpStorageInspectorUiState.Unreadable, viewModel.state.value)
+    }
+
+    @Test
+    fun `fetch failure maps to Error carrying the message`() = runTest {
+        val viewModel = MpStorageInspectorViewModel(
+            FakeMpStorageRepository(error = IllegalStateException("boom")),
+            FakeLocationStore(),
+            FakeAuthRepository(AuthState.Authenticated("XaTelitte")),
+        )
+
+        val state = viewModel.state.value
+        assertTrue(state is MpStorageInspectorUiState.Error)
+        assertEquals("boom", (state as MpStorageInspectorUiState.Error).message)
+    }
+
+    @Test
+    fun `logout while loaded clears the previous account's envelope to NotAuthenticated`() = runTest {
+        // Codex review — a mid-life logout must not leave the previous account's raw envelope on screen.
+        val auth = FakeAuthRepository(AuthState.Authenticated("XaTelitte"))
+        val document = MpStorageDocument(sourceName = "DTCloud", mpFlags = emptyList(), rawEnvelope = "{\"secret\":1}")
+        val viewModel = MpStorageInspectorViewModel(
+            FakeMpStorageRepository(MpStorageResult.Found(document)),
+            FakeLocationStore(MpStorageLocation(1, 2)),
+            auth,
+        )
+        assertTrue(viewModel.state.value is MpStorageInspectorUiState.Loaded)
+
+        auth.setState(AuthState.Anonymous)
+
+        assertEquals(MpStorageInspectorUiState.NotAuthenticated, viewModel.state.value)
+    }
+
+    @Test
+    fun `account switch reloads scoped to the new owner`() = runTest {
+        val auth = FakeAuthRepository(AuthState.Authenticated("Alice"))
+        val store = FakeLocationStore(MpStorageLocation(1, 2))
+        val repo = FakeMpStorageRepository(MpStorageResult.Found(MpStorageDocument(null, emptyList(), "{}")))
+        MpStorageInspectorViewModel(repo, store, auth)
+        assertEquals("alice", store.lastOwner)
+        assertEquals(1, repo.fetchCount)
+
+        auth.setState(AuthState.Authenticated("Bob"))
+
+        assertEquals("bob", store.lastOwner)
+        assertEquals(2, repo.fetchCount)
+    }
+
+    @Test
+    fun `a switch mid-fetch never publishes the previous owner's data`() = runTest {
+        // Codex review (success-race): the first owner's in-flight fetch must not clobber the new
+        // owner's state when it completes late.
+        val gate = CompletableDeferred<Unit>()
+        val repo = object : MpStorageRepository {
+            var calls = 0
+            override suspend fun fetchStorage(): MpStorageResult {
+                calls += 1
+                val first = calls == 1
+                if (first) gate.await() // park the first (Alice) fetch until released
+                return MpStorageResult.Found(
+                    MpStorageDocument(
+                        sourceName = if (first) "ALICE" else "BOB",
+                        mpFlags = emptyList(),
+                        rawEnvelope = if (first) "{\"alice\":1}" else "{\"bob\":1}",
+                    ),
+                )
+            }
+        }
+        val auth = FakeAuthRepository(AuthState.Authenticated("Alice"))
+        val viewModel = MpStorageInspectorViewModel(repo, FakeLocationStore(), auth)
+        assertEquals(MpStorageInspectorUiState.Loading, viewModel.state.value)
+
+        auth.setState(AuthState.Authenticated("Bob"))
+        val afterSwitch = viewModel.state.value
+        assertTrue(afterSwitch is MpStorageInspectorUiState.Loaded)
+        assertEquals("BOB", (afterSwitch as MpStorageInspectorUiState.Loaded).sourceName)
+
+        // Release Alice's late fetch — must NOT overwrite Bob's state.
+        gate.complete(Unit)
+        advanceUntilIdle()
+        val finalState = viewModel.state.value
+        assertTrue(finalState is MpStorageInspectorUiState.Loaded)
+        assertEquals("BOB", (finalState as MpStorageInspectorUiState.Loaded).sourceName)
+    }
+
+    @Test
+    fun `refresh re-fetches the storage`() = runTest {
+        val repo = FakeMpStorageRepository(MpStorageResult.NotFound)
+        val viewModel = MpStorageInspectorViewModel(
+            repo,
+            FakeLocationStore(),
+            FakeAuthRepository(AuthState.Authenticated("XaTelitte")),
+        )
+        assertEquals(1, repo.fetchCount)
+
+        viewModel.refresh()
+
+        assertEquals(2, repo.fetchCount)
+    }
+
+    private class FakeMpStorageRepository(
+        private val result: MpStorageResult = MpStorageResult.NotFound,
+        private val error: Throwable? = null,
+    ) : MpStorageRepository {
+        var fetchCount = 0
+            private set
+
+        override suspend fun fetchStorage(): MpStorageResult {
+            fetchCount++
+            error?.let { throw it }
+            return result
+        }
+    }
+
+    private class FakeLocationStore(
+        private val location: MpStorageLocation? = null,
+    ) : MpStorageLocationStore {
+        var lastOwner: String? = null
+            private set
+
+        override suspend fun read(owner: String?): MpStorageLocation? {
+            lastOwner = owner
+            return location
+        }
+
+        override suspend fun save(owner: String?, threadId: Int, numreponse: Int) = Unit
+
+        override suspend fun clear(owner: String?) = Unit
+    }
+
+    private class FakeAuthRepository(
+        initial: AuthState = AuthState.Authenticated("xaat"),
+    ) : AuthRepository {
+        private val state = MutableStateFlow(initial)
+
+        override fun observeAuthState(): Flow<AuthState> = state.asStateFlow()
+
+        override suspend fun login(pseudo: String, password: String): Result<AuthState.Authenticated> =
+            Result.failure(IllegalStateException("not used"))
+
+        override suspend fun logout() {
+            state.value = AuthState.Anonymous
+        }
+
+        /** Drive an auth transition (logout / account switch) so the ViewModel's collector reacts. */
+        fun setState(newState: AuthState) {
+            state.value = newState
+        }
+    }
+}


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaTriX)

## Contexte
Demandé par @XaTriX sur le topic DEV (2787830 puis 2787835 « @claude implemente »), suite au moteur MPStorage livré en #499. Lié à `refs-#6`.

## Quoi
Écran de **debug en lecture seule** qui surface ce que RF2 découvre/parse du conteneur MPStorage (via le même `fetchStorage()` que le seeder), pour confirmer que RF2 voit le même conteneur que DTCloud/MultiMP :
- **source** (dernier outil ayant écrit), **emplacement résolu** (thread + numreponse, depuis le cache), **entrées DT** (thread/page/numrép/uri), **enveloppe JSON brute** (copiable).
- bouton **Rafraîchir** (relance discovery+lecture) ; états Loading / NotAuthenticated / NotFound / Unreadable / Error / Loaded.
- **aucune écriture / suppression**.

## Où / accès
Réglages → section *Messages privés* → carte **gated sur le toggle « section DT »** (`state.showDtSection`) : cachée pour les utilisateurs normaux, visible pour ceux qui ont activé les fonctions DT. Route opaque `MpStorageInspectorRoute`.

## Fichiers
- `MpStorageInspectorScreen.kt` (`:feature:settings`) — State scellé + `MpStorageInspectorViewModel` (@HiltViewModel) + écran (libellés en dur, comme `DiagnosticsScreen`).
- `SettingsScreen.kt` — callback `onOpenMpStorageInspector` + carte gated `MpStorageInspectorCard`.
- `RedfaceNavigation.kt` — route + entry + câblage depuis `SettingsRoute`.
- 3 strings ; **7 tests** ViewModel (Fakes : anonymous→NotAuthenticated, Found→Loaded, NotFound, Unreadable, Error, owner lowercased, refresh re-fetch).

## Validation (machine de build, verte)
`:feature:settings:testDebugUnitTest` + `:app:testDevDebugUnitTest` (Konsist) + `detektAll` + `:feature:settings:lintDebug` + `:app:assembleDevDebug`. Review Codex en cours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
