### PR TITLE
fix(mpstorage): pager MP obfusqué (cryptlink) — découverte s'arrêtait page 2 (refs-#6)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepository.kt
@@ -173,7 +173,11 @@ class DefaultMpStorageRepository @Inject constructor(
         var outcome: Discovery? = null
         while (outcome == null && page <= totalPages && page <= MAX_DISCOVERY_PAGES) {
             val listPage = listParser.parseList(hfrClient.getPrivateMessageListPage(page))
-            totalPages = listPage.totalPages
+            // Never let the scan bound SHRINK across pages: HFR's pager only shows a window around
+            // the current page, so a later page can report a smaller `totalPages` than page 1 did.
+            // Taking the running max keeps a deep storage MP reachable even if one page under-reports
+            // the count (defence-in-depth alongside the cryptlink-aware pager parse, #6).
+            totalPages = maxOf(totalPages, listPage.totalPages)
             val hit = listPage.items.firstOrNull { it.subject == MpStorageRepository.STORAGE_SUBJECT_HASH }
             if (hit != null) {
                 // The subject is matched : the scan ends here whether or not the first post is

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/common/HfrSelectors.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/common/HfrSelectors.kt
@@ -49,4 +49,9 @@ object HfrSelectors {
     const val MP_LIST_CORRESPONDENT_GROUP = "td.sujetCase6 span"
     const val MP_LIST_DATE = "td.sujetCase9 a"
     const val MP_LIST_TOP_PAGER = "tr.fondForum1PagesHaut"
+    // On an AUTHENTICATED inbox, the pager's forward page-number links are `a.cHeader` on page 1
+    // only; on page 2+ HFR obfuscates them as `<span class="md_cryptlink…">N</span>`. The page
+    // count must read these too, otherwise `totalPages` collapses to the current page from page 2
+    // on, and a paged scan (MPStorage discovery, #6) terminates after page 2.
+    const val MP_LIST_PAGER_CRYPTLINK = "span[class^=md_cryptlink]"
 }

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/messages/PrivateMessageListParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/messages/PrivateMessageListParser.kt
@@ -120,8 +120,12 @@ class PrivateMessageListParser(
             ?.mapNotNull { it.text().trim().toIntOrNull() }
             ?.lastOrNull()
             ?: 1
+        // Page-number links are `a.cHeader` on page 1 but obfuscated `span.md_cryptlink…` on
+        // authenticated pages 2+. Read BOTH shapes, otherwise the max linked page collapses to the
+        // current page from page 2 on and `totalPages` is under-reported (a paged inbox scan would
+        // then stop after page 2 — MPStorage discovery #6).
         val linkedPages = pagerLeft
-            ?.select(HfrSelectors.TOP_PAGER_LINK)
+            ?.select("${HfrSelectors.TOP_PAGER_LINK}, ${HfrSelectors.MP_LIST_PAGER_CRYPTLINK}")
             ?.mapNotNull { it.text().trim().toIntOrNull() }
             .orEmpty()
         val total = maxOf(current, linkedPages.maxOrNull() ?: current)

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/messages/PrivateMessageListParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/messages/PrivateMessageListParserTest.kt
@@ -132,6 +132,44 @@ class PrivateMessageListParserTest {
     }
 
     @Test
+    fun `parseList reads totalPages from the obfuscated cryptlink pager on authenticated pages`() {
+        // Regression (#6): on an AUTHENTICATED inbox the pager uses `a.cHeader` page links on
+        // page 1 only; on page 2+ HFR obfuscates them as `<span class="md_cryptlink…">N</span>`.
+        // The old parser read `a.cHeader` exclusively, so from page 2 on `totalPages` collapsed to
+        // the current page — which made the MPStorage inbox scan terminate after page 2 and miss a
+        // storage MP sitting deeper (NotFound on a real 42-page inbox). Pager shape modeled on a
+        // real page-2 capture; the conversation row is synthetic (no real thread id / pseudo).
+        val html = """
+            <html><body><table>
+            <tr class="cBackHeader fondForum1PagesHaut"><td class="padding"><div class="left">
+              <b>&nbsp;Page&nbsp;: </b>
+              <span class="md_cryptlink1F444FC1C34E2A19">1</span>
+              <b>2</b>
+              <span class="md_cryptlink2A19C045C02F424F">3</span>
+              <span class="md_cryptlink424F4944464C2E45">10</span>
+              <span class="md_cryptlink44464C2E4544C119">20</span>
+              <span class="md_cryptlink4C2E4544C1194649">30</span>
+              <span class="md_cryptlink2E4544C119464942">40</span>
+            </div></td></tr>
+            <tr class="sujet ligne_booleen">
+              <td class="sujetCase1"><img src="/themes_static/images/silk/closedp.gif" /></td>
+              <td class="sujetCase3"><a href="/forum2.php?config=hfr.inc&cat=prive&post=9100200&page=1" class="cCatTopic">Sujet</a></td>
+              <td class="sujetCase6"><a href="/profilebdd.php?pseudo=Alice" class="Tableau">Alice</a></td>
+              <td class="sujetCase9"><a href="#bas">06-01-2020&nbsp;à&nbsp;22:08<br /><b>Alice</b></a></td>
+            </tr>
+            </table></body></html>
+        """.trimIndent()
+
+        val page = parser.parseList(html)
+
+        assertEquals(2, page.page)
+        // The forward links are cryptlink spans, not a.cHeader: the count must still resolve to 40,
+        // never collapse to the current page (2).
+        assertEquals(40, page.totalPages)
+        assertEquals(1, page.items.size)
+    }
+
+    @Test
     fun `parseList flags a multi-recipient conversation and leaves its correspondent empty`() {
         // MultiMP / "DT" row: the Interlocuteur cell is a "Interlocuteurs multiples" <span>
         // (truncated participant list in its title), NOT a profile link. Hand-written stub with


### PR DESCRIPTION
## Symptôme

L'inspecteur MP storage (#502, livré v134) affiche **« Aucun MP de stockage trouvé »** (`NotFound`) sur un compte réel — alors que le MP de stockage **existe**. Vérifié live (compte XaTriX, autorisé par le mainteneur) : conteneur `DTCloud_GM` (sujet = hash `a2bcc09b…`, 46 positions DT + clés hfr4k/superFavs/blacklist/…) en **page 11** d'une boîte de **42 pages**. Diagnostics in-app : `MpStorageRepository discovery: no storage MP`.

## Cause racine

Sur une boîte MP **authentifiée**, le pager n'utilise des liens `a.cHeader` qu'en **page 1** ; dès la **page 2**, HFR obfusque les numéros de page en `<span class="md_cryptlink…">N</span>` (cf. `reference_hfr_cryptlink_decode` — l'obfuscation diffère selon l'auth).

`PrivateMessageListParser.parsePageInfo` ne lisait que `a.cHeader` → `totalPages` retombait à la **page courante** dès la page 2. Or `discoverByInboxScan` relit `totalPages` à chaque itération :

```
page 1 → total=40 → page 2 → total=2 → (page 3 ≤ 2) FAUX → STOP
```

Le scan s'arrêtait **après la page 2** → le MP en page 11 n'était jamais atteint → `Discovery.Absent` → `NotFound`.

## Fix

- `parsePageInfo` lit les numéros de page des **deux** formes (`a.cHeader` **ET** `span[class^=md_cryptlink]`), scopé au `.left` du pager → `totalPages` correct dès la page 2.
- `discoverByInboxScan` : `totalPages = maxOf(totalPages, listPage.totalPages)` — le bound du scan ne rétrécit jamais (défense en profondeur, le pager HFR n'affiche qu'une fenêtre).
- Test de régression parser : pager cryptlink (page courante 2 + liens span) → `totalPages=40`, pas 2.

## Pourquoi pas attrapé

La fixture liste MP est une **page 1** (liens `a.cHeader`) ; aucune fixture page 2+ authentifiée avec pager obfusqué.

## Validation (machine B)

`:core:parser:test` + `:core:data:testDebugUnitTest` + `detektAll` + `:app:assembleDevDebug` → **BUILD SUCCESSFUL**.

Demandé par @XaTriX (debug live de l'inspecteur, retours device).

🤖 Generated with [Claude Code](https://claude.com/claude-code)