### PR TITLE
chore(release): bump 0.12.0 + changelog/whatsnew bêta

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,23 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## v136 — `0.12.0` — 2026-06-14
+
+**Statut** : `open` (track open testing — canal beta, Play Edit committed) + F-Droid `.beta`
+**Commit** : promotion dev→main (cf. PR de promotion)
+**Contenu depuis la 0.11.0/v132** : dogfoodé sur le canal dev (v133 → v135).
+
+> `0.11.0` ayant déjà été shippé en bêta (v132), le `versionName` est bumpé en `0.12.0` (la garde CI refuse deux bêtas au même `versionName`).
+
+### Added
+- **Éditeur — mode d'insertion d'image** (#500) : choix entre image réduite (défaut) et pleine taille dans les Réglages ; saut de ligne automatique entre les images d'un upload multiple ; bouton « Uploader » désormais toujours visible.
+- **(DT) Stockage MP cross-app** (#499, #502) : moteur de découverte/lecture du conteneur MPStorage partagé (compatible DTCloud/MultiMP) + écran d'inspection en lecture seule, accessible depuis Réglages → section DT (caché pour les utilisateurs normaux).
+
+### Fixed
+- **Pagination des listes MP au-delà de la page 2** (#503) : sur une boîte authentifiée, les numéros de page sont des liens obfusqués (`md_cryptlink`) dès la page 2 ; ils n'étaient pas lus, donc le total de pages retombait à la page courante. Affectait notamment la découverte du conteneur MPStorage (« aucun MP de stockage » à tort sur des comptes qui en possèdent un). Test de régression ajouté.
+
+---
+
 ## v132 — `0.11.0` — 2026-06-13
 
 **Statut** : `open` (track open testing — canal beta, Play Edit committed) + F-Droid `.beta`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.11.0"
+        versionName = "0.12.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,13 +1,10 @@
-Redface 2 v0.11.0 — beta.
+Redface 2 v0.12.0 — beta.
 
 New:
-- Image upload in the editor: from the gallery, several at once, host choice (diberie/imgur), "My images" screen.
-- Editor drafts saved automatically.
-- Multi-quote, collapsible polls.
-- Flags: swipe between tabs, long-press to remove, filter by category.
-- PMs: open on the last page, resume reading.
-- Display: adjustable density/font, configurable start screen.
+- Editor: insert images at reduced or full size (your choice in Settings), line break between images of a multi-upload, "Upload" button always visible.
+- (DT) Cross-app MP storage inspector for DT users (Settings → DT section).
 
-Fix: diberie upload repaired.
+Fix:
+- MP list pagination beyond page 2.
 
 Report bugs via the beta or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,11 +1,10 @@
-Redface 2 v0.11.0 — bêta.
+Redface 2 v0.12.0 — bêta.
 
 Nouveautés :
-- Upload d'images dans l'éditeur : galerie, plusieurs d'un coup, choix de l'hébergeur (diberie/imgur), écran « Mes images ».
-- Brouillons d'éditeur sauvegardés automatiquement.
-- Multi-quote, sondages repliables.
-- Drapeaux : swipe entre onglets, suppr. appui long, filtre par catégorie.
-- MP : ouverture sur la dernière page lue.
-- Affichage : densité/police réglables, démarrage configurable.
+- Éditeur : insertion d'image en taille réduite ou pleine taille (au choix dans les Réglages), saut de ligne entre les images d'un envoi multiple, bouton « Uploader » toujours visible.
+- (DT) Inspecteur du stockage MP cross-app pour les utilisateurs DT (Réglages → section DT).
 
-Correctif : upload diberie réparé.
+Correctif :
+- Pagination des MP au-delà de la page 2.
+
+Signalez les bugs via la bêta ou GitHub.


### PR DESCRIPTION
Préparation de la promotion bêta (demandée par @XaTriX).

`0.11.0` a déjà été shippé en bêta (**v132/app-v132**, 2026-06-13) → la garde CI versionName refuse une 2ᵉ bêta au même versionName. Bump **0.11.0 → 0.12.0**.

## Contenu de la 0.12.0 (depuis la bêta 0.11.0, dogfoodé dev v133→v135)
- Éditeur : mode d'insertion image réduite/pleine + saut de ligne multi-upload + bouton « Uploader » visible (#500)
- (DT) moteur + inspecteur MP storage cross-app (#499, #502)
- Fix pagination MP au-delà de la page 2 / découverte MPStorage (#503)

## Fichiers
- `app/build.gradle.kts` : versionName 0.12.0
- `app/CHANGELOG.md` : section v136/0.12.0 (statut `open`)
- `app/src/main/play/whatsnew/whatsnew-{fr-FR,en-US}` : notes Play 0.12.0 (415 / 339 car, < 500)

Étape suivante (après merge dev + confirmation) : promotion no-ff dev→main puis dispatch `release.yml --ref main -f channel=beta` → Play open testing + F-Droid .beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)