### PR TITLE
fix(prefs): écritures de préférences sur un scope applicatif (#507)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/di/PlatformBindingsModule.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/di/PlatformBindingsModule.kt
@@ -4,6 +4,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import fr.forumhfr.redface2.core.domain.coroutines.ApplicationScope
 import fr.forumhfr.redface2.core.domain.coroutines.DefaultDispatcher
 import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
 import fr.forumhfr.redface2.core.domain.coroutines.MainDispatcher
@@ -14,7 +15,9 @@ import fr.forumhfr.redface2.core.parser.messages.PrivateMessageThreadParser
 import java.time.Clock
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -37,6 +40,18 @@ object PlatformBindingsModule {
     @Singleton
     @MainDispatcher
     fun provideMainDispatcher(): CoroutineDispatcher = Dispatchers.Main.immediate
+
+    /**
+     * Process-lifetime scope for writes that must complete regardless of the caller's lifecycle
+     * (#507). `SupervisorJob` so one failed write never tears down the scope; on [IoDispatcher] since
+     * its only client today is DataStore commits. Never cancelled (it lives for the whole process).
+     */
+    @Provides
+    @Singleton
+    @ApplicationScope
+    fun provideApplicationScope(
+        @IoDispatcher ioDispatcher: CoroutineDispatcher,
+    ): CoroutineScope = CoroutineScope(SupervisorJob() + ioDispatcher)
 
     @Provides
     @Singleton

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -52,6 +52,10 @@ class DataStoreUserPreferencesRepository @Inject constructor(
      * (#507). `await()` re-throws a write failure to the caller, preserving the ViewModels' optimistic
      * rollback; if the caller is already gone, the failure is held in the (un-awaited) Deferred and the
      * `SupervisorJob` keeps the scope alive for the next write.
+     *
+     * Use for DISCRETE writes (toggles, pickers, Save buttons). Do NOT use for write-on-keystroke
+     * setters that rely on caller cancellation to serialise (last-write-wins) — see [setImgurClientId],
+     * which deliberately stays on the caller's cancellable scope.
      */
     private suspend fun persist(block: suspend () -> Unit) {
         externalScope.async { block() }.await()
@@ -412,8 +416,13 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .distinctUntilChanged()
             .catch { emit("") }
 
+    // NOT routed through persist(): unlike the discrete toggles/pickers, the Client-ID is written on
+    // EVERY keystroke and SettingsViewModel cancels the previous in-flight write so only the latest text
+    // commits (last-write-wins, #459). Detaching it onto the application scope would let a cancelled
+    // older write survive and land after a newer one, stranding a stale value (#508 Codex review). Here
+    // cancellation IS the intended behaviour, so this write stays on the caller's (cancellable) scope.
     override suspend fun setImgurClientId(clientId: String) {
-        persist {
+        withContext(ioDispatcher) {
             dataStore.edit { prefs ->
                 prefs[KEY_IMGUR_CLIENT_ID] = clientId.trim()
             }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
+import fr.forumhfr.redface2.core.domain.coroutines.ApplicationScope
 import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
@@ -23,6 +24,8 @@ import fr.forumhfr.redface2.core.model.FlagType
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -38,7 +41,21 @@ class DataStoreUserPreferencesRepository @Inject constructor(
     private val themeBootstrapStore: ThemeBootstrapStore,
     private val startScreenBootstrapStore: StartScreenBootstrapStore,
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    @param:ApplicationScope private val externalScope: CoroutineScope,
 ) : UserPreferencesRepository {
+
+    /**
+     * Runs a preference write on [externalScope] (process-lifetime) instead of the caller's job, then
+     * awaits it. A settings sub-page popped mid-write cancels the caller's `viewModelScope` — and thus
+     * this `await()` — but the `async` is parented to [externalScope], so the DataStore commit (and any
+     * bootstrap-mirror write in the same block) still completes and the change is not silently lost
+     * (#507). `await()` re-throws a write failure to the caller, preserving the ViewModels' optimistic
+     * rollback; if the caller is already gone, the failure is held in the (un-awaited) Deferred and the
+     * `SupervisorJob` keeps the scope alive for the next write.
+     */
+    private suspend fun persist(block: suspend () -> Unit) {
+        externalScope.async { block() }.await()
+    }
 
     override fun observeProxyConfig(): Flow<ProxyConfig> =
         dataStore.data
@@ -47,7 +64,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
 
     override suspend fun saveProxyConfig(config: ProxyConfig) {
         val normalized = config.normalized()
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_PROXY_ENABLED] = normalized.enabled
                 prefs[KEY_PROXY_HOST] = normalized.host
@@ -70,7 +87,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(false) }
 
     override suspend fun setIgnoreTopicCache(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_IGNORE_TOPIC_CACHE] = enabled
             }
@@ -84,7 +101,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(true) }
 
     override suspend fun setFlagsGroupByCategory(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_FLAGS_GROUP_BY_CATEGORY] = enabled
             }
@@ -98,7 +115,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(false) }
 
     override suspend fun setFlagsHideReadCategories(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_FLAGS_HIDE_READ_CATEGORIES] = enabled
             }
@@ -112,7 +129,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(false) }
 
     override suspend fun setFlagsPerTabOverride(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_FLAGS_PER_TAB_OVERRIDE] = enabled
             }
@@ -132,7 +149,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(FlagsViewSettings(unreadOnly = defaultUnreadOnly(type))) }
 
     override suspend fun setFlagsGroupByCategoryForType(type: FlagType, enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[flagsGroupByCategoryKey(type)] = enabled
             }
@@ -140,7 +157,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
     }
 
     override suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[flagsHideReadCategoriesKey(type)] = enabled
             }
@@ -148,7 +165,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
     }
 
     override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[flagsUnreadOnlyKey(type)] = enabled
             }
@@ -172,7 +189,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(ThemeMode.SYSTEM) }
 
     override suspend fun setThemeMode(mode: ThemeMode) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_THEME_MODE] = mode.name
             }
@@ -195,7 +212,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(false) }
 
     override suspend fun setAmoledEnabled(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_AMOLED_ENABLED] = enabled
             }
@@ -211,7 +228,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(false) }
 
     override suspend fun setTopicTopBarAutoHide(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_TOPIC_TOPBAR_AUTO_HIDE] = enabled
             }
@@ -226,7 +243,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(false) }
 
     override suspend fun setConfirmBeforePosting(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_CONFIRM_BEFORE_POSTING] = enabled
             }
@@ -241,7 +258,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(false) }
 
     override suspend fun setShowDtSection(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_FLAGS_SHOW_DT_SECTION] = enabled
             }
@@ -257,7 +274,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(true) }
 
     override suspend fun setFlagsAutoRefresh(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_FLAGS_AUTO_REFRESH] = enabled
             }
@@ -273,7 +290,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(true) }
 
     override suspend fun setTopicPageFabs(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_TOPIC_PAGE_FABS] = enabled
             }
@@ -289,7 +306,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(false) }
 
     override suspend fun setTopicPollsExpanded(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_TOPIC_POLLS_EXPANDED] = enabled
             }
@@ -314,7 +331,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(StartScreenPreference()) }
 
     override suspend fun setStartScreen(preference: StartScreenPreference) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_START_SCREEN] = preference.screen.name
                 val catId = preference.forumCatId
@@ -349,7 +366,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(true) }
 
     override suspend fun setMpUnreadBadge(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_MP_UNREAD_BADGE] = enabled
             }
@@ -364,7 +381,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(UploadProviderId.DIBERIE) }
 
     override suspend fun setUploadProvider(provider: UploadProviderId) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_UPLOAD_PROVIDER] = provider.name
             }
@@ -381,7 +398,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(DisplayDensity.COMFORT) }
 
     override suspend fun setDisplayDensity(density: DisplayDensity) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_DISPLAY_DENSITY] = density.name
             }
@@ -396,7 +413,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit("") }
 
     override suspend fun setImgurClientId(clientId: String) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_IMGUR_CLIENT_ID] = clientId.trim()
             }
@@ -411,7 +428,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(EditorImageInsert.REDUCED) }
 
     override suspend fun setEditorImageInsert(mode: EditorImageInsert) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_EDITOR_IMAGE_INSERT] = mode.name
             }
@@ -426,7 +443,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(FontScalePreference.M) }
 
     override suspend fun setFontScale(scale: FontScalePreference) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_FONT_SCALE] = scale.name
             }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -18,8 +18,17 @@ import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import fr.forumhfr.redface2.core.model.FlagType
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -37,6 +46,7 @@ class DataStoreUserPreferencesRepositoryTest {
     private lateinit var dataStore: DataStore<Preferences>
     private lateinit var repository: DataStoreUserPreferencesRepository
     private val dispatcher = UnconfinedTestDispatcher()
+    private val externalScope = CoroutineScope(dispatcher + SupervisorJob())
 
     /** In-memory [ThemeBootstrapStore] — the SharedPreferences impl has its own Robolectric test. */
     private val themeBootstrapStore = object : ThemeBootstrapStore {
@@ -69,7 +79,46 @@ class DataStoreUserPreferencesRepositoryTest {
             themeBootstrapStore = themeBootstrapStore,
             startScreenBootstrapStore = startScreenBootstrapStore,
             ioDispatcher = dispatcher,
+            externalScope = externalScope,
         )
+    }
+
+    /**
+     * #507 — observable contract: a preference write whose initiating coroutine is cancelled (a
+     * settings sub-page popped right after a toggle, cancelling its `viewModelScope`) must still land,
+     * because the commit runs on the injected application scope, not the caller's. Built on a paused
+     * [StandardTestDispatcher] so the write is provably only *started* (dispatched onto the app scope,
+     * caller suspended at `await`) — not yet committed — when the caller is cancelled. Deterministic
+     * (no real time / threads): the assertion is the persisted value after the scheduler drains.
+     */
+    @Test
+    fun `setter write lands even when the initiating coroutine is cancelled`() = runTest {
+        val ioDispatcher = StandardTestDispatcher(testScheduler)
+        val dataStoreScope = CoroutineScope(ioDispatcher + Job())
+        val appScope = CoroutineScope(ioDispatcher + SupervisorJob())
+        val survivalStore = PreferenceDataStoreFactory.create(
+            scope = dataStoreScope,
+            produceFile = { tempFolder.newFile("survival.preferences_pb") },
+        )
+        val survivalRepository = DataStoreUserPreferencesRepository(
+            dataStore = survivalStore,
+            themeBootstrapStore = themeBootstrapStore,
+            startScreenBootstrapStore = startScreenBootstrapStore,
+            ioDispatcher = ioDispatcher,
+            externalScope = appScope,
+        )
+
+        // setFlagsAutoRefresh defaults to true; flip it to false from a cancellable caller scope.
+        val callerScope = CoroutineScope(ioDispatcher + Job())
+        callerScope.launch { survivalRepository.setFlagsAutoRefresh(false) }
+        runCurrent() // caller dispatched the write onto appScope, then suspended on await — not committed
+        callerScope.cancel() // the sub-page is popped before the commit completes
+        advanceUntilIdle() // appScope (not the cancelled caller) drives the commit to completion
+
+        assertFalse(survivalRepository.observeFlagsAutoRefresh().first())
+
+        appScope.cancel()
+        dataStoreScope.cancel()
     }
 
     @Test

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/coroutines/ApplicationScope.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/coroutines/ApplicationScope.kt
@@ -1,0 +1,13 @@
+package fr.forumhfr.redface2.core.domain.coroutines
+
+import javax.inject.Qualifier
+
+/**
+ * Qualifies the process-lifetime [kotlinx.coroutines.CoroutineScope] (a `SupervisorJob` on the IO
+ * dispatcher) used for writes that MUST outlive the component that triggered them — typically a
+ * DataStore commit started from a screen whose `viewModelScope` may be cancelled before the write
+ * lands (#507). Not for general background work: most coroutines should stay scoped to their owner.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ApplicationScope


### PR DESCRIPTION
> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

Closes #507. Suivi du finding Codex P2-a de la refonte des réglages (#494 / PR #506).

## Problème

Chaque sous-page de réglages bind son propre `SettingsViewModel` (entrée nav3 distincte = `ViewModelStore` distinct). Les setters tournaient dans le `viewModelScope` de l'appelant (`viewModelScope.launch { repo.setX() }` → `withContext(ioDispatcher) { dataStore.edit {} }`). Régler un paramètre dans une sous-page puis taper « retour » immédiatement annule le `viewModelScope` et pouvait abandonner le commit DataStore avant qu'il aboutisse → perte silencieuse de la modif.

## Correctif

- Nouveau qualifier `@ApplicationScope` + provider `@Singleton CoroutineScope(SupervisorJob() + IO)` dans `PlatformBindingsModule`.
- `DataStoreUserPreferencesRepository` route chaque setter via un helper privé `persist {}` qui exécute l'écriture (DataStore edit + l'éventuelle écriture du miroir bootstrap dans le même bloc) sur le scope applicatif via `async {}.await()` : l'appelant attend toujours le résultat (les échecs d'écriture continuent de remonter au rollback optimiste des ViewModels), mais annuler l'appelant n'annule plus le commit. Le backfill du miroir start-screen (#458) reste sur l'appelant (idempotent, re-joué à la prochaine collecte).
- Test : une écriture aboutit même si la coroutine initiatrice est annulée (déterministe, `StandardTestDispatcher` en pause).

## Validation (build host, arbre synchronisé)

`detektAll`, `:core:data:testDebugUnitTest`, `:app:compileDevDebugKotlin` (graphe Hilt), `:core:data:lintDebug` — tous verts.