### PR TITLE
feat(settings): racine groupée + Search app bar du shell réglages v2 (#494)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/RedfaceSearchAppBar.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/RedfaceSearchAppBar.kt
@@ -1,0 +1,100 @@
+package fr.forumhfr.redface2.core.ui.settings.shell
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.ui.R
+
+/**
+ * #494 v2 — Search app bar (docked search bar M3) du shell de configuration : icône menu (hamburger,
+ * rôle à définir) · champ de recherche cliquable · avatar de compte. Custom STABLE (Surface + Row +
+ * pill cliquable), pas la `SearchBar`/`DockedSearchBar` `@ExperimentalMaterial3Api` : cette barre est
+ * le chrome PERMANENT de la zone réglages (et un pilote app-wide), on veut le contrôle total des
+ * insets edge-to-edge, du back et de l'IME sans opt-in expérimental.
+ *
+ * Edge-to-edge : la barre applique `statusBarsPadding()` pour se loger sous la status bar transparente.
+ * Le pill ouvre la recherche ([onSearchClick]) ; le filtrage/résultats vivent au niveau du shell.
+ */
+@Composable
+@Suppress("LongParameterList") // Top-bar API : placeholder + 2 a11y labels + 2 callbacks + slot avatar.
+fun RedfaceSearchAppBar(
+    placeholder: String,
+    menuContentDescription: String,
+    searchContentDescription: String,
+    onMenuClick: () -> Unit,
+    onSearchClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    avatar: @Composable () -> Unit = { DefaultAvatarPlaceholder() },
+) {
+    Surface(modifier = modifier.fillMaxWidth(), color = MaterialTheme.colorScheme.surface) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .statusBarsPadding()
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            IconButton(
+                onClick = onMenuClick,
+                modifier = Modifier.semantics { contentDescription = menuContentDescription },
+            ) {
+                Icon(painter = painterResource(R.drawable.ic_ms_menu), contentDescription = null)
+            }
+            Surface(
+                onClick = onSearchClick,
+                modifier = Modifier
+                    .weight(1f)
+                    .height(56.dp) // gabarit docked search bar M3 ; porte l'app bar à ~72dp (Claude+Codex)
+                    .semantics { contentDescription = searchContentDescription },
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_search),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = placeholder,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            avatar()
+        }
+    }
+}
+
+/** Avatar de compte par défaut (placeholder) — remplacé par l'avatar HFR réel quand connecté (#479). */
+@Composable
+private fun DefaultAvatarPlaceholder() {
+    Surface(
+        modifier = Modifier.size(40.dp),
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.primaryContainer,
+    ) {}
+}

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeScreen.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeScreen.kt
@@ -1,0 +1,154 @@
+package fr.forumhfr.redface2.core.ui.settings.shell
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.ui.R
+
+/**
+ * #494 v2 — une catégorie de la racine « catégories d'abord ». Identité visuelle : icône dans un
+ * conteneur tonal rond + titre + sous-titre optionnel + chevron. La racine n'expose QUE des catégories
+ * (aucun toggle/bouton inline) : chaque ligne ouvre une sous-vue de réglages.
+ */
+data class SettingsCategoryUi(
+    val id: String,
+    val title: String,
+    val subtitle: String?,
+    @param:DrawableRes val iconRes: Int,
+)
+
+/**
+ * #494 v2 — un groupe de catégories (famille) de la racine, avec un en-tête de section. Le regroupement
+ * (D4 léger) donne une carte mentale à la liste sans exposer de réglage inline. Le groupage est
+ * éditorial et fourni par la couche feature ; `:core:ui` ne fait que le rendre.
+ */
+data class SettingsCategoryGroup(
+    val id: String,
+    val title: String,
+    val categories: List<SettingsCategoryUi>,
+)
+
+/**
+ * #494 v2 — racine du menu de configuration (direction verrouillée 2026-06-15, Claude + Codex) :
+ * [RedfaceSearchAppBar] + liste de catégories REGROUPÉES par familles (D4 léger), chaque ligne en
+ * cercle tonal + sous-titre + chevron (D1). En-têtes de section sobres (espace blanc plutôt que
+ * separator). Stateless et Roborazzi-able sans nav/Hilt (groupes + callbacks hoistés).
+ */
+@Composable
+@Suppress("LongParameterList") // shell racine : data + placeholder + 2 a11y + 3 callbacks, tous distincts.
+fun SettingsHomeScreen(
+    groups: List<SettingsCategoryGroup>,
+    searchPlaceholder: String,
+    menuContentDescription: String,
+    searchContentDescription: String,
+    onMenuClick: () -> Unit,
+    onSearchClick: () -> Unit,
+    onCategoryClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface),
+    ) {
+        RedfaceSearchAppBar(
+            placeholder = searchPlaceholder,
+            menuContentDescription = menuContentDescription,
+            searchContentDescription = searchContentDescription,
+            onMenuClick = onMenuClick,
+            onSearchClick = onSearchClick,
+        )
+        LazyColumn(modifier = Modifier.fillMaxWidth()) {
+            groups.forEachIndexed { index, group ->
+                item(key = "header_${group.id}") {
+                    SettingsSectionHeader(title = group.title, first = index == 0)
+                }
+                items(group.categories, key = { it.id }) { category ->
+                    SettingsCategoryRow(
+                        category = category,
+                        onClick = { onCategoryClick(category.id) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * En-tête de section sobre : `titleSmall`, teinte primaire, padding start 16dp. Le premier en-tête
+ * (juste sous l'app bar) a un top réduit (16dp) ; les suivants respirent davantage (24dp) — gabarit
+ * M3 « espace plutôt que divider ».
+ */
+@Composable
+private fun SettingsSectionHeader(title: String, first: Boolean) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(
+            start = 16.dp,
+            end = 16.dp,
+            top = if (first) 16.dp else 24.dp,
+            bottom = 8.dp,
+        ),
+    )
+}
+
+@Composable
+private fun SettingsCategoryRow(
+    category: SettingsCategoryUi,
+    onClick: () -> Unit,
+) {
+    ListItem(
+        headlineContent = { Text(category.title) },
+        supportingContent = category.subtitle?.let { sub -> { Text(sub) } },
+        leadingContent = {
+            Surface(
+                modifier = Modifier.size(40.dp),
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.secondaryContainer,
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        painter = painterResource(category.iconRes),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.size(24.dp),
+                    )
+                }
+            }
+        },
+        trailingContent = {
+            Icon(
+                painter = painterResource(R.drawable.ic_chevron_right),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(role = Role.Button, onClick = onClick),
+        colors = ListItemDefaults.colors(containerColor = MaterialTheme.colorScheme.surface),
+    )
+}

--- a/core/ui/src/main/res/drawable/ic_ms_account_circle.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_account_circle.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (account_circle), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M234-276q51-39 114-61.5T480-360q69 0 132 22.5T726-276q35-41 54.5-93T800-480q0-133-93.5-226.5T480-800q-133 0-226.5 93.5T160-480q0 59 19.5 111t54.5 93Zm246-164q-59 0-99.5-40.5T340-580q0-59 40.5-99.5T480-720q59 0 99.5 40.5T620-580q0 59-40.5 99.5T480-440Zm0 360q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q53 0 100-15.5t86-44.5q-39-29-86-44.5T480-280q-53 0-100 15.5T294-220q39 29 86 44.5T480-160Zm0-360q26 0 43-17t17-43q0-26-17-43t-43-17q-26 0-43 17t-17 43q0 26 17 43t43 17Zm0-60Zm0 360Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_add_photo_alternate.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_add_photo_alternate.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (add_photo_alternate), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h360v80H200v560h560v-360h80v360q0 33-23.5 56.5T760-120H200Zm480-480v-80h-80v-80h80v-80h80v80h80v80h-80v80h-80ZM240-280h480L570-480 450-320l-90-120-120 160Zm-40-480v560-560Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_article.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_article.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (article), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M280-280h280v-80H280v80Zm0-160h400v-80H280v80Zm0-160h400v-80H280v80Zm-80 480q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h560q33 0 56.5 23.5T840-760v560q0 33-23.5 56.5T760-120H200Zm0-80h560v-560H200v560Zm0-560v560-560Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_cached.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_cached.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (cached), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M482-160q-134 0-228-93t-94-227v-7l-64 64-56-56 160-160 160 160-56 56-64-64v7q0 100 70.5 170T482-240q26 0 51-6t49-18l60 60q-38 22-78 33t-82 11Zm278-161L600-481l56-56 64 64v-7q0-100-70.5-170T478-720q-26 0-51 6t-49 18l-60-60q38-22 78-33t82-11q134 0 228 93t94 227v7l64-64 56 56-160 160Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_display_settings.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_display_settings.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (display_settings), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M300-360h60v-160h-60v50h-60v60h60v50Zm100-50h320v-60H400v60Zm200-110h60v-50h60v-60h-60v-50h-60v160Zm-360-50h320v-60H240v60Zm80 450v-80H160q-33 0-56.5-23.5T80-280v-480q0-33 23.5-56.5T160-840h640q33 0 56.5 23.5T880-760v480q0 33-23.5 56.5T800-200H640v80H320ZM160-280h640v-480H160v480Zm0 0v-480 480Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_edit_square.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_edit_square.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (edit_square), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h357l-80 80H200v560h560v-278l80-80v358q0 33-23.5 56.5T760-120H200Zm280-360ZM360-360v-170l367-367q12-12 27-18t30-6q16 0 30.5 6t26.5 18l56 57q11 12 17 26.5t6 29.5q0 15-5.5 29.5T897-728L530-360H360Zm481-424-56-56 56 56ZM440-440h56l232-232-28-28-29-28-231 231v57Zm260-260-29-28 29 28 28 28-28-28Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_flag.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_flag.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (flag), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M200-120v-680h360l16 80h224v400H520l-16-80H280v280h-80Zm300-440Zm86 160h134v-240H510l-16-80H280v240h290l16 80Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_forum.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_forum.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (forum), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M280-240q-17 0-28.5-11.5T240-280v-80h520v-360h80q17 0 28.5 11.5T880-680v600L720-240H280ZM80-280v-560q0-17 11.5-28.5T120-880h520q17 0 28.5 11.5T680-840v360q0 17-11.5 28.5T640-440H240L80-280Zm520-240v-280H160v280h440Zm-440 0v-280 280Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_mail.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_mail.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (mail), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M160-160q-33 0-56.5-23.5T80-240v-480q0-33 23.5-56.5T160-800h640q33 0 56.5 23.5T880-720v480q0 33-23.5 56.5T800-160H160Zm320-280L160-640v400h640v-400L480-440Zm0-80 320-200H160l320 200ZM160-640v-80 480-400Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_menu.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_menu.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M3,18h18v-2H3v2zM3,13h18v-2H3v2zM3,6v2h18V6H3z" />
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_rocket_launch.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_rocket_launch.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (rocket_launch), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="m226-559 78 33q14-28 29-54t33-52l-56-11-84 84Zm142 83 114 113q42-16 90-49t90-75q70-70 109.5-155.5T806-800q-72-5-158 34.5T492-656q-42 42-75 90t-49 90Zm178-65q-23-23-23-56.5t23-56.5q23-23 57-23t57 23q23 23 23 56.5T660-541q-23 23-57 23t-57-23Zm19 321 84-84-11-56q-26 18-52 32.5T532-299l33 79Zm313-653q19 121-23.5 235.5T708-419l20 99q4 20-2 39t-20 33L538-80l-84-197-171-171-197-84 167-168q14-14 33.5-20t39.5-2l99 20q104-104 218-147t235-24ZM157-321q35-35 85.5-35.5T328-322q35 35 34.5 85.5T327-151q-25 25-83.5 43T82-76q14-103 32-161.5t43-83.5Zm57 56q-10 10-20 36.5T180-175q27-4 53.5-13.5T270-208q12-12 13-29t-11-29q-12-12-29-11.5T214-265Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_search.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_search.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (search), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M784-120 532-372q-30 24-69 38t-83 14q-109 0-184.5-75.5T120-580q0-109 75.5-184.5T380-840q109 0 184.5 75.5T640-580q0 44-14 83t-38 69l252 252-56 56ZM380-400q75 0 127.5-52.5T560-580q0-75-52.5-127.5T380-760q-75 0-127.5 52.5T200-580q0 75 52.5 127.5T380-400Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_settings.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_settings.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (settings), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="m370-80-16-128q-13-5-24.5-12T307-235l-119 50L78-375l103-78q-1-7-1-13.5v-27q0-6.5 1-13.5L78-585l110-190 119 50q11-8 23-15t24-12l16-128h220l16 128q13 5 24.5 12t22.5 15l119-50 110 190-103 78q1 7 1 13.5v27q0 6.5-2 13.5l103 78-110 190-118-50q-11 8-23 15t-24 12L590-80H370Zm70-80h79l14-106q31-8 57.5-23.5T639-327l99 41 39-68-86-65q5-14 7-29.5t2-31.5q0-16-2-31.5t-7-29.5l86-65-39-68-99 42q-22-23-48.5-38.5T533-694l-13-106h-79l-14 106q-31 8-57.5 23.5T321-633l-99-41-39 68 86 64q-5 15-7 30t-2 32q0 16 2 31t7 30l-86 65 39 68 99-42q22 23 48.5 38.5T427-266l13 106Zm42-180q58 0 99-41t41-99q0-58-41-99t-99-41q-59 0-99.5 41T342-480q0 58 40.5 99t99.5 41Zm-2-140Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_upcoming.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_upcoming.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (upcoming), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M160-120q-33 0-56.5-23.5T80-200v-200q0-33 23.5-56.5T160-480h200q0 50 35 85t85 35q50 0 85-35t35-85h200q33 0 56.5 23.5T880-400v200q0 33-23.5 56.5T800-120H160Zm0-80h640v-200H664q-25 55-74.5 87.5T480-280q-60 0-109.5-32.5T296-400H160v200Zm544-328-56-56 142-142 56 56-142 142Zm-448 0L114-670l56-56 142 142-56 56Zm184-112v-200h80v200h-80ZM160-200h640-640Z" />
+    </group>
+</vector>

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeShowcaseRoborazziTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeShowcaseRoborazziTest.kt
@@ -1,0 +1,193 @@
+package fr.forumhfr.redface2.core.ui.settings.shell
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onRoot
+import com.github.takahirom.roborazzi.captureRoboImage
+import fr.forumhfr.redface2.core.ui.R
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * #494 v2 — showcase Roborazzi (rendu JVM, sans device) du SHELL VERROUILLÉ du menu de configuration
+ * (direction figée 2026-06-15, Claude + Codex) : Search app bar (pill 56dp → app bar ~72dp) +
+ * racine « catégories d'abord » REGROUPÉE par familles (cercles tonals + sous-titres) + NavigationBar
+ * 80dp à 5 items. Icônes = vraies Material Symbols Outlined (`ic_ms_*`, plus de placeholder « tune »).
+ * Record-only (`roborazzi.test.record=true` forcé dans `core/ui/build.gradle.kts`) → PNG sous
+ * `core/ui/build/outputs/roborazzi/` ; gating CI à venir avec le plugin Roborazzi (AGP 9, #781) :
+ *
+ *     ./scripts/docker-dev.sh ./gradlew :core:ui:testDebugUnitTest \
+ *         --tests '*SettingsHomeShowcaseRoborazziTest*' --console=plain
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h900dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@OptIn(ExperimentalTestApi::class)
+class SettingsHomeShowcaseRoborazziTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Composable
+    private fun Shell() {
+        Column(Modifier.fillMaxSize()) {
+            SettingsHomeScreen(
+                groups = GROUPS,
+                searchPlaceholder = "Rechercher un réglage",
+                menuContentDescription = "Menu",
+                searchContentDescription = "Rechercher dans les réglages",
+                onMenuClick = {},
+                onSearchClick = {},
+                onCategoryClick = {},
+                modifier = Modifier.weight(1f),
+            )
+            ShellBottomBar()
+        }
+    }
+
+    @Composable
+    private fun ShellBottomBar() {
+        NavigationBar {
+            BOTTOM_ITEMS.forEach { (label, iconRes, selected) ->
+                NavigationBarItem(
+                    selected = selected,
+                    onClick = {},
+                    icon = { Icon(painterResource(iconRes), contentDescription = null) },
+                    label = { Text(label) },
+                )
+            }
+        }
+    }
+
+    @Test
+    fun settingsShellLight() {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                Surface(color = MaterialTheme.colorScheme.surface) { Shell() }
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage(
+            filePath = "build/outputs/roborazzi/settings_v2_shell_light.png",
+        )
+    }
+
+    @Test
+    fun settingsShellDark() {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = true, amoledTheme = false, dynamicColor = false) {
+                Surface(color = MaterialTheme.colorScheme.surface) { Shell() }
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage(
+            filePath = "build/outputs/roborazzi/settings_v2_shell_dark.png",
+        )
+    }
+
+    @Test
+    fun settingsShellAmoled() {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = true, amoledTheme = true, dynamicColor = false) {
+                Surface(color = MaterialTheme.colorScheme.surface) { Shell() }
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage(
+            filePath = "build/outputs/roborazzi/settings_v2_shell_amoled.png",
+        )
+    }
+
+    private companion object {
+        private fun cat(id: String, title: String, sub: String, icon: Int) =
+            SettingsCategoryUi(id, title, sub, icon)
+
+        val GROUPS = listOf(
+            SettingsCategoryGroup(
+                "appearance", "Apparence",
+                listOf(
+                    cat(
+                        "display", "Affichage", "Thème, AMOLED, densité, police",
+                        R.drawable.ic_ms_display_settings,
+                    ),
+                    cat(
+                        "flags", "Drapeaux", "Regroupement, masquer lus, auto-refresh",
+                        R.drawable.ic_ms_flag,
+                    ),
+                    cat(
+                        "topic", "Sujets et lecture", "Barre, sondages, navigation",
+                        R.drawable.ic_ms_article,
+                    ),
+                ),
+            ),
+            SettingsCategoryGroup(
+                "communication", "Communication",
+                listOf(
+                    cat(
+                        "mp", "Messages privés", "Badge de non-lus",
+                        R.drawable.ic_ms_mail,
+                    ),
+                    cat(
+                        "editing", "Édition et publication", "Confirmation avant envoi",
+                        R.drawable.ic_ms_edit_square,
+                    ),
+                ),
+            ),
+            SettingsCategoryGroup(
+                "content", "Contenu",
+                listOf(
+                    cat(
+                        "images", "Images et upload", "Hébergeur, Client-ID, insertion",
+                        R.drawable.ic_ms_add_photo_alternate,
+                    ),
+                    cat(
+                        "start", "Démarrage", "Écran ouvert au lancement",
+                        R.drawable.ic_ms_rocket_launch,
+                    ),
+                ),
+            ),
+            SettingsCategoryGroup(
+                "system", "Système",
+                listOf(
+                    cat(
+                        "network", "Réseau et cache", "Proxy, vider les caches",
+                        R.drawable.ic_ms_cached,
+                    ),
+                    cat(
+                        "account", "Compte et à propos", "Compte HFR, version, diagnostics",
+                        R.drawable.ic_ms_account_circle,
+                    ),
+                ),
+            ),
+            SettingsCategoryGroup(
+                "other", "Autres",
+                listOf(
+                    cat(
+                        "upcoming", "À venir", "Fonctionnalités planifiées",
+                        R.drawable.ic_ms_upcoming,
+                    ),
+                ),
+            ),
+        )
+        val BOTTOM_ITEMS = listOf(
+            Triple("Drapeaux", R.drawable.ic_ms_flag, false),
+            Triple("Forum", R.drawable.ic_ms_forum, false),
+            Triple("Recherche", R.drawable.ic_ms_search, false),
+            Triple("Messages", R.drawable.ic_ms_mail, false),
+            Triple("Réglages", R.drawable.ic_ms_settings, true),
+        )
+    }
+}


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaTriX)

## Quoi

Direction v2 du menu de configuration **verrouillée** (Claude + Codex, 2026-06-15) : architecture « catégories d'abord ». Cette PR pose les **primitives `:core:ui`** — **non encore câblées dans la navigation** (le câblage est la PR suivante).

- `RedfaceSearchAppBar` : pill **56 dp** (porte l'app bar à ~72 dp), hamburger gauche + slot avatar.
- `SettingsHomeScreen` : catégories **regroupées par familles** (`SettingsCategoryGroup`), lignes cercle tonal 40 dp + glyphe 24 dp + sous-titre + chevron, en-têtes de section sobres (`titleSmall`, espace plutôt que divider).
- **13 icônes Material Symbols Outlined** locales (`ic_ms_*`) — conversion viewBox `0 -960 960 960` via group `translateY=960`. Remplace le placeholder « tune » répété (caveat Codex sur le rendu groupé).
- Showcase **Roborazzi** du shell verrouillé (app bar + liste groupée + `NavigationBar` 80 dp à 5 items) en clair/sombre/AMOLED. Record-only ; gating CI quand le plugin Roborazzi supportera AGP 9 (#781).

## Cotes (consignes M3, Claude + Codex)

Pill 56 dp · app bar ~72 dp · ligne 2-lignes ~72 dp · conteneur leading 40 dp / glyphe 24 dp · `NavigationBar` 80 dp (3–5 destinations) · marges 16 dp · grille 8 dp.

## Hors périmètre (suivi)

Câblage dans la nav app-wide (bottom bar 5 items à icônes incl. **Réglages** comme 5ᵉ destination), recherche globale hoistée + résultats avec origine (`Affichage › Thème`), `NavDisplay` interne des sous-vues, microcopie, écran « À venir ». **Décision produit en attente** : Réglages = 5ᵉ destination de la barre du bas (vs accès actuel via le menu compte) — recoupe #396.

## Validation

`detektAll` + `:core:ui:lintDebug` + `:core:ui:testDebugUnitTest` verts en local. Rendus Roborazzi 3 thèmes vérifiés visuellement. Codex review passée.

Refs #494.
