### PR TITLE
feat(nav): Réglages = 5e onglet de la barre du bas + icônes Material Symbols (#494)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
@@ -38,6 +39,7 @@ import androidx.core.net.toUri
 import androidx.core.view.WindowCompat
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.Icon
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
@@ -52,6 +54,7 @@ import androidx.navigation3.scene.Scene
 import androidx.navigation3.ui.NavDisplay
 import fr.forumhfr.redface2.BuildConfig
 import fr.forumhfr.redface2.R
+import fr.forumhfr.redface2.core.ui.R as CoreUiR
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
@@ -337,12 +340,14 @@ data class ProfileFullRoute(
 
 internal enum class TopLevelDestination(
     val labelRes: Int,
+    val iconRes: Int,
     val rootRoute: RedfaceNavKey,
 ) {
-    Flags(R.string.nav_flags, FlagsListRoute),
-    Forum(R.string.nav_forum, ForumRoute),
-    Search(R.string.nav_search, SearchRoute),
-    Messages(R.string.nav_messages, MessagesRoute),
+    Flags(R.string.nav_flags, CoreUiR.drawable.ic_ms_flag, FlagsListRoute),
+    Forum(R.string.nav_forum, CoreUiR.drawable.ic_ms_forum, ForumRoute),
+    Search(R.string.nav_search, CoreUiR.drawable.ic_ms_search, SearchRoute),
+    Messages(R.string.nav_messages, CoreUiR.drawable.ic_ms_mail, MessagesRoute),
+    Settings(R.string.nav_settings, CoreUiR.drawable.ic_ms_settings, SettingsRoute),
 }
 
 /** #458 — maps the persisted cold-start choice onto the navigation's own destination enum. */
@@ -363,9 +368,11 @@ private const val MAX_BADGE_COUNT = 9
  */
 @Composable
 private fun TopLevelDestinationIcon(destination: TopLevelDestination, mpUnreadCount: Int?) {
-    val glyph = stringResource(destination.labelRes).first().toString()
+    val icon: @Composable () -> Unit = {
+        Icon(painter = painterResource(destination.iconRes), contentDescription = null)
+    }
     if (destination != TopLevelDestination.Messages || mpUnreadCount == null) {
-        Text(text = glyph)
+        icon()
         return
     }
     BadgedBox(
@@ -381,7 +388,7 @@ private fun TopLevelDestinationIcon(destination: TopLevelDestination, mpUnreadCo
             }
         },
     ) {
-        Text(text = glyph)
+        icon()
     }
 }
 
@@ -501,6 +508,9 @@ fun RedfaceApp(intent: Intent?) {
         val forumBackStack = rememberNavBackStack(*forumInitialStack)
         val searchBackStack = rememberNavBackStack(SearchRoute)
         val messagesBackStack = rememberNavBackStack(MessagesRoute)
+        // #494 v2 — Réglages est désormais une destination top-level à part entière (5e onglet),
+        // avec sa propre pile (sa racine = SettingsRoute), au lieu d'être poussé sur l'onglet actif.
+        val settingsBackStack = rememberNavBackStack(SettingsRoute)
 
         var currentDestination by rememberSaveable {
             mutableStateOf(startScreen.screen.toTopLevelDestination())
@@ -515,12 +525,19 @@ fun RedfaceApp(intent: Intent?) {
             mutableStateOf<ProfileSheetRequest?>(null)
         }
 
-        val backStacks = remember(flagsBackStack, forumBackStack, searchBackStack, messagesBackStack) {
+        val backStacks = remember(
+            flagsBackStack,
+            forumBackStack,
+            searchBackStack,
+            messagesBackStack,
+            settingsBackStack,
+        ) {
             mapOf(
                 TopLevelDestination.Flags to flagsBackStack,
                 TopLevelDestination.Forum to forumBackStack,
                 TopLevelDestination.Search to searchBackStack,
                 TopLevelDestination.Messages to messagesBackStack,
+                TopLevelDestination.Settings to settingsBackStack,
             )
         }
 
@@ -653,7 +670,6 @@ fun RedfaceApp(intent: Intent?) {
                         versionCode = BuildConfig.VERSION_CODE,
                         onLogin = { activeBackStack.add(LoginRoute) },
                         onLogout = accountViewModel::logout,
-                        onOpenSettings = { openSettingsIdempotently(activeBackStack) },
                         onOpenDiagnostics = { activeBackStack.add(DiagnosticsRoute) },
                         onReportContent = {
                             startReportEmail(context, reportEmailSubject, reportNoEmailClient)
@@ -924,26 +940,6 @@ internal fun Map<TopicTitleKey, String>.withTitle(key: TopicTitleKey, title: Str
     }
 }
 
-/**
- * Opens the settings root idempotently. The account menu is shown ON the settings screen and its
- * sub-pages too, so tapping « Paramètres » there must land back on the existing [SettingsRoute]
- * (popping any sub-pages stacked above it) rather than push a duplicate that Back then has to unwind
- * (#494 Codex P3). When no [SettingsRoute] is in [backStack] (we are elsewhere), a fresh one is pushed.
- *
- * Kept top-level (not inlined in the account-menu lambda) so its branches don't inflate RedfaceApp's
- * cyclomatic complexity.
- */
-private fun openSettingsIdempotently(backStack: NavBackStack<NavKey>) {
-    val existing = backStack.indexOfLast { it is SettingsRoute }
-    if (existing >= 0) {
-        while (backStack.lastIndex > existing) {
-            backStack.removeAt(backStack.lastIndex)
-        }
-    } else {
-        backStack.add(SettingsRoute)
-    }
-}
-
 @Composable
 @Suppress("CyclomaticComplexMethod", "LongParameterList") // One entry per top-level route + per-screen
 // navigation callbacks ; splitting the host would just push the same `when` shape one level deeper
@@ -1192,11 +1188,8 @@ private fun RedfaceNavHost(
             }
             entry<SettingsRoute> {
                 SettingsScreen(
-                    onBack = {
-                        if (backStack.size > 1) {
-                            backStack.removeAt(backStack.lastIndex)
-                        }
-                    },
+                    // #494 v2 — racine de l'onglet Réglages (jamais empilée) : pas de flèche retour morte.
+                    onBack = null,
                     onOpenProxy = { backStack.add(SettingsProxyRoute) },
                     onOpenMaintenance = { backStack.add(SettingsMaintenanceRoute) },
                     onOpenDisplay = { backStack.add(SettingsDisplayRoute) },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,8 @@
     <string name="nav_forum">Forum</string>
     <string name="nav_search">Recherche</string>
     <string name="nav_messages">Messages</string>
+    <!-- #494 v2 — Réglages devient la 5e destination de la barre du bas (retiré du menu compte). -->
+    <string name="nav_settings">Réglages</string>
     <!-- #313 — badge MP non lus sur l'item Messages ; au-delà de 9 le badge plafonne. -->
     <string name="nav_messages_badge_overflow">9+</string>
 </resources>

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/account/RedfaceAccountMenu.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/account/RedfaceAccountMenu.kt
@@ -52,7 +52,6 @@ fun RedfaceAccountMenu(
     versionCode: Int,
     onLogin: () -> Unit,
     onLogout: () -> Unit,
-    onOpenSettings: () -> Unit,
     onOpenDiagnostics: () -> Unit,
     onReportContent: () -> Unit,
     modifier: Modifier = Modifier,
@@ -91,13 +90,7 @@ fun RedfaceAccountMenu(
                 )
             }
 
-            DropdownMenuItem(
-                text = { Text(stringResource(R.string.account_menu_settings)) },
-                onClick = {
-                    expanded = false
-                    onOpenSettings()
-                },
-            )
+            // #494 v2 — « Réglages » a quitté ce menu : c'est désormais la 5e destination de la barre du bas.
             DropdownMenuItem(
                 text = { Text(stringResource(R.string.account_menu_diagnostics)) },
                 onClick = {

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/RedfaceSettingsSearchTopBar.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/RedfaceSettingsSearchTopBar.kt
@@ -50,7 +50,7 @@ fun RedfaceSettingsSearchTopBar(
     query: String,
     onQueryChange: (String) -> Unit,
     onSearchActiveChange: (Boolean) -> Unit,
-    onBack: () -> Unit,
+    onBack: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
     actions: @Composable RowScope.() -> Unit = {},
 ) {
@@ -58,18 +58,18 @@ fun RedfaceSettingsSearchTopBar(
     TopAppBar(
         modifier = modifier,
         navigationIcon = {
-            val backLabel = if (searchActive) {
-                labels.closeSearchContentDescription
-            } else {
-                labels.backContentDescription
-            }
-            IconButton(
-                onClick = { if (searchActive) onSearchActiveChange(false) else onBack() },
-                modifier = Modifier.semantics { contentDescription = backLabel },
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_arrow_back),
-                    contentDescription = null,
+            // Search active → the icon CLOSES the search. Otherwise it's a back affordance, shown only
+            // when [onBack] is provided : a top-level/root use (Réglages onglet, #494 v2) passes null so
+            // no dead back button appears (Codex P2).
+            if (searchActive) {
+                NavigationIconButton(
+                    label = labels.closeSearchContentDescription,
+                    onClick = { onSearchActiveChange(false) },
+                )
+            } else if (onBack != null) {
+                NavigationIconButton(
+                    label = labels.backContentDescription,
+                    onClick = onBack,
                 )
             }
         },
@@ -128,6 +128,20 @@ fun RedfaceSettingsSearchTopBar(
             }
         },
     )
+}
+
+/** Bouton de navigation (flèche retour / fermer la recherche) partagé par le top bar de réglages. */
+@Composable
+private fun NavigationIconButton(label: String, onClick: () -> Unit) {
+    IconButton(
+        onClick = onClick,
+        modifier = Modifier.semantics { contentDescription = label },
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_arrow_back),
+            contentDescription = null,
+        )
+    }
 }
 
 /**

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -50,7 +50,7 @@ import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsSearchTopBar
 @Composable
 @Suppress("LongParameterList") // state-hoisted Composable: 5 sub-page nav callbacks + back + 2 VMs, each distinct.
 fun SettingsScreen(
-    onBack: () -> Unit,
+    onBack: (() -> Unit)? = null,
     onOpenProxy: () -> Unit,
     onOpenMaintenance: () -> Unit,
     onOpenDisplay: () -> Unit,
@@ -89,7 +89,7 @@ internal fun SettingsCatalogue(
     onIntent: (SettingsIntent) -> Unit,
     startScreenState: StartScreenSettingsState,
     onStartScreenIntent: (StartScreenSettingsIntent) -> Unit,
-    onBack: () -> Unit,
+    onBack: (() -> Unit)? = null,
     onOpenProxy: () -> Unit,
     onOpenMaintenance: () -> Unit,
     onOpenDisplay: () -> Unit,


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaTriX)

## Quoi (PR1/3 du câblage shell réglages v2)

Barre du bas **à 5 onglets à icônes** ; **Réglages devient la 5ᵉ destination** (et quitte le menu compte). Décisions validées par XaTriX (direction v2, 2026-06-15).

- `TopLevelDestination` : ajout de `Settings` (5ᵉ entrée) + champ `iconRes`.
- Icônes de la barre : remplacement des **pastilles-lettres** D/F/R/M par les **Material Symbols Outlined** (`ic_ms_flag/forum/search/mail/settings`) — le badge MP non-lus sur « Messages » est conservé.
- `Settings` a sa **propre pile** (`settingsBackStack`, racine `SettingsRoute`) au lieu d'être poussé sur l'onglet actif → `openSettingsIdempotently` supprimé.
- `RedfaceAccountMenu` : l'entrée « Réglages » est retirée (param `onOpenSettings` supprimé) ; Réglages s'atteint maintenant par l'onglet.
- String `nav_settings` = « Réglages ».
- **Flèche retour morte corrigée** (Codex P2) : `RedfaceSettingsSearchTopBar.onBack` / `SettingsScreen.onBack` deviennent nullable ; à la racine de l'onglet Réglages (jamais empilée) on passe `null` → pas de flèche morte, mais la flèche « fermer la recherche » reste affichée en mode recherche. Les sous-pages (scaffold distinct) gardent leur retour.

## Hors périmètre (suivi immédiat)

- **PR2** : remplace la racine du tab Réglages (écran v1 `SettingsScreen`) par la **racine groupée** (`SettingsHomeScreen`, hamburger + Search app bar) livrée en #510, + câble les sous-vues par catégorie.
- **PR3** : recherche globale hoistée (résultats avec origine `Affichage › Thème`).
- Pas de release dev avant PR2 (cohérence visuelle).

## Validation

`detektAll` + `:app:assembleDevDebug` + `:app:lintDevDebug` + `:core:ui:testDebugUnitTest` verts en local. Aperçu visuel de la barre 5 onglets : showcase `settings_v2_shell_*` (#510).

Refs #494, #396.
