### PR TITLE
feat(settings): racine « catégories d'abord » + sous-vues par catégorie (#494)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -84,6 +84,7 @@ import fr.forumhfr.redface2.feature.profile.ProfileViewModel
 import fr.forumhfr.redface2.feature.search.SearchScreen
 import fr.forumhfr.redface2.feature.settings.MyImagesScreen
 import fr.forumhfr.redface2.feature.settings.SettingsAccountAboutScreen
+import fr.forumhfr.redface2.feature.settings.SettingsCategoryDetailScreen
 import fr.forumhfr.redface2.feature.settings.SettingsDisplayScreen
 import fr.forumhfr.redface2.feature.settings.SettingsImagesScreen
 import fr.forumhfr.redface2.feature.settings.SettingsMaintenanceScreen
@@ -306,6 +307,10 @@ data object SettingsImagesRoute : RedfaceNavKey
 
 @Serializable
 data object SettingsAccountAboutRoute : RedfaceNavKey
+
+/** #494 v2 — détail générique d'une catégorie de réglages (cf. SettingsCategoryDetailScreen). */
+@Serializable
+data class SettingsCategoryRoute(val categoryId: String) : RedfaceNavKey
 
 /**
  * Phase 2 finish (#208) — full profile page route.
@@ -1188,8 +1193,24 @@ private fun RedfaceNavHost(
             }
             entry<SettingsRoute> {
                 SettingsScreen(
-                    // #494 v2 — racine de l'onglet Réglages (jamais empilée) : pas de flèche retour morte.
-                    onBack = null,
+                    onOpenProxy = { backStack.add(SettingsProxyRoute) },
+                    onOpenMaintenance = { backStack.add(SettingsMaintenanceRoute) },
+                    onOpenDisplay = { backStack.add(SettingsDisplayRoute) },
+                    onOpenImages = { backStack.add(SettingsImagesRoute) },
+                    onOpenAccountAbout = { backStack.add(SettingsAccountAboutRoute) },
+                    // #494 v2 — catégories sans sous-page dédiée → détail générique.
+                    onOpenCategory = { categoryId -> backStack.add(SettingsCategoryRoute(categoryId)) },
+                    topBarActions = accountMenu,
+                )
+            }
+            entry<SettingsCategoryRoute> { key ->
+                SettingsCategoryDetailScreen(
+                    categoryId = key.categoryId,
+                    onBack = {
+                        if (backStack.size > 1) {
+                            backStack.removeAt(backStack.lastIndex)
+                        }
+                    },
                     onOpenProxy = { backStack.add(SettingsProxyRoute) },
                     onOpenMaintenance = { backStack.add(SettingsMaintenanceRoute) },
                     onOpenDisplay = { backStack.add(SettingsDisplayRoute) },

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/RedfaceSearchAppBar.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/RedfaceSearchAppBar.kt
@@ -38,7 +38,7 @@ fun RedfaceSearchAppBar(
     placeholder: String,
     menuContentDescription: String,
     searchContentDescription: String,
-    onMenuClick: () -> Unit,
+    onMenuClick: (() -> Unit)? = null,
     onSearchClick: () -> Unit,
     modifier: Modifier = Modifier,
     avatar: @Composable () -> Unit = { DefaultAvatarPlaceholder() },
@@ -52,8 +52,11 @@ fun RedfaceSearchAppBar(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {
+            // Hamburger gardé par décision produit (#494 v2), rôle à définir : désactivé tant qu'aucune
+            // action n'est câblée → présent visuellement mais pas de bouton mort (a11y : annoncé désactivé).
             IconButton(
-                onClick = onMenuClick,
+                onClick = onMenuClick ?: {},
+                enabled = onMenuClick != null,
                 modifier = Modifier.semantics { contentDescription = menuContentDescription },
             ) {
                 Icon(painter = painterResource(R.drawable.ic_ms_menu), contentDescription = null)

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeScreen.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeScreen.kt
@@ -62,23 +62,36 @@ fun SettingsHomeScreen(
     searchPlaceholder: String,
     menuContentDescription: String,
     searchContentDescription: String,
-    onMenuClick: () -> Unit,
+    onMenuClick: (() -> Unit)? = null,
     onSearchClick: () -> Unit,
     onCategoryClick: (String) -> Unit,
     modifier: Modifier = Modifier,
+    accountSlot: (@Composable () -> Unit)? = null,
 ) {
     Column(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.surface),
     ) {
-        RedfaceSearchAppBar(
-            placeholder = searchPlaceholder,
-            menuContentDescription = menuContentDescription,
-            searchContentDescription = searchContentDescription,
-            onMenuClick = onMenuClick,
-            onSearchClick = onSearchClick,
-        )
+        // Le slot compte (menu compte app-wide) remplace l'avatar placeholder quand le host le fournit.
+        if (accountSlot != null) {
+            RedfaceSearchAppBar(
+                placeholder = searchPlaceholder,
+                menuContentDescription = menuContentDescription,
+                searchContentDescription = searchContentDescription,
+                onMenuClick = onMenuClick,
+                onSearchClick = onSearchClick,
+                avatar = accountSlot,
+            )
+        } else {
+            RedfaceSearchAppBar(
+                placeholder = searchPlaceholder,
+                menuContentDescription = menuContentDescription,
+                searchContentDescription = searchContentDescription,
+                onMenuClick = onMenuClick,
+                onSearchClick = onSearchClick,
+            )
+        }
         LazyColumn(modifier = Modifier.fillMaxWidth()) {
             groups.forEachIndexed { index, group ->
                 item(key = "header_${group.id}") {

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeShowcaseRoborazziTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeShowcaseRoborazziTest.kt
@@ -52,7 +52,7 @@ class SettingsHomeShowcaseRoborazziTest {
                 searchPlaceholder = "Rechercher un réglage",
                 menuContentDescription = "Menu",
                 searchContentDescription = "Rechercher dans les réglages",
-                onMenuClick = {},
+                onMenuClick = null,
                 onSearchClick = {},
                 onCategoryClick = {},
                 modifier = Modifier.weight(1f),

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsCategories.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsCategories.kt
@@ -1,0 +1,144 @@
+package fr.forumhfr.redface2.feature.settings
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import fr.forumhfr.redface2.core.ui.settings.shell.SettingsCategoryGroup
+import fr.forumhfr.redface2.core.ui.settings.shell.SettingsCategoryUi
+import fr.forumhfr.redface2.core.ui.R as CoreUiR
+
+/**
+ * #494 v2 — modèle de la racine « catégories d'abord » : 10 catégories regroupées en 5 familles.
+ * Les titres de catégorie réutilisent les titres de section existants ; sous-titres et familles sont
+ * propres à la racine v2. Le routage (catégorie → sous-page dédiée ou détail générique) et le mapping
+ * catégorie → section(s) du catalogue vivent ici pour rester testables et hors du composant racine.
+ */
+
+@Composable
+internal fun rememberSettingsCategoryGroups(): List<SettingsCategoryGroup> = listOf(
+    SettingsCategoryGroup(
+        id = "appearance",
+        title = stringResource(R.string.settings_family_appearance),
+        categories = listOf(
+            category(
+                "display", R.string.settings_section_display,
+                R.string.settings_category_subtitle_display,
+                CoreUiR.drawable.ic_ms_display_settings,
+            ),
+            category(
+                "flags", R.string.settings_section_flags,
+                R.string.settings_category_subtitle_flags,
+                CoreUiR.drawable.ic_ms_flag,
+            ),
+            category(
+                "topic", R.string.settings_section_topic,
+                R.string.settings_category_subtitle_topic,
+                CoreUiR.drawable.ic_ms_article,
+            ),
+        ),
+    ),
+    SettingsCategoryGroup(
+        id = "communication",
+        title = stringResource(R.string.settings_family_communication),
+        categories = listOf(
+            category(
+                "mp", R.string.settings_section_mp,
+                R.string.settings_category_subtitle_mp,
+                CoreUiR.drawable.ic_ms_mail,
+            ),
+            category(
+                "editing", R.string.settings_section_editing,
+                R.string.settings_category_subtitle_editing,
+                CoreUiR.drawable.ic_ms_edit_square,
+            ),
+        ),
+    ),
+    SettingsCategoryGroup(
+        id = "content",
+        title = stringResource(R.string.settings_family_content),
+        categories = listOf(
+            category(
+                "images", R.string.settings_section_images,
+                R.string.settings_category_subtitle_images,
+                CoreUiR.drawable.ic_ms_add_photo_alternate,
+            ),
+            category(
+                "start", R.string.settings_section_start,
+                R.string.settings_category_subtitle_start,
+                CoreUiR.drawable.ic_ms_rocket_launch,
+            ),
+        ),
+    ),
+    SettingsCategoryGroup(
+        id = "system",
+        title = stringResource(R.string.settings_family_system),
+        categories = listOf(
+            category(
+                "network", R.string.settings_section_network,
+                R.string.settings_category_subtitle_network,
+                CoreUiR.drawable.ic_ms_cached,
+            ),
+            category(
+                "account", R.string.settings_section_hfr_account,
+                R.string.settings_category_subtitle_account,
+                CoreUiR.drawable.ic_ms_account_circle,
+            ),
+        ),
+    ),
+    SettingsCategoryGroup(
+        id = "other",
+        title = stringResource(R.string.settings_family_other),
+        categories = listOf(
+            category(
+                "upcoming", R.string.settings_category_upcoming_title,
+                R.string.settings_category_subtitle_upcoming,
+                CoreUiR.drawable.ic_ms_upcoming,
+            ),
+        ),
+    ),
+)
+
+@Composable
+private fun category(id: String, titleRes: Int, subtitleRes: Int, iconRes: Int): SettingsCategoryUi =
+    SettingsCategoryUi(
+        id = id,
+        title = stringResource(titleRes),
+        subtitle = stringResource(subtitleRes),
+        iconRes = iconRes,
+    )
+
+/**
+ * Routage d'un tap sur une catégorie de la racine : les catégories adossées à une sous-page dédiée
+ * existante y mènent directement (pas de double saut) ; les autres ouvrent un détail générique.
+ */
+internal fun routeSettingsCategory(
+    id: String,
+    onOpenDisplay: () -> Unit,
+    onOpenImages: () -> Unit,
+    onOpenAccountAbout: () -> Unit,
+    onOpenCategory: (String) -> Unit,
+) {
+    when (id) {
+        "display" -> onOpenDisplay()
+        "images" -> onOpenImages()
+        "account" -> onOpenAccountAbout()
+        else -> onOpenCategory(id)
+    }
+}
+
+/** Les sections du catalogue rendues par le détail générique d'une catégorie. */
+internal fun sectionIdsForCategory(categoryId: String): List<String> = when (categoryId) {
+    "upcoming" -> listOf("notifications", "accessibility", "extensions")
+    else -> listOf(categoryId)
+}
+
+/** Titre du détail générique d'une catégorie (réutilise les titres de section quand ils existent). */
+internal fun categoryTitleRes(categoryId: String): Int = when (categoryId) {
+    "network" -> R.string.settings_section_network
+    "start" -> R.string.settings_section_start
+    "flags" -> R.string.settings_section_flags
+    "topic" -> R.string.settings_section_topic
+    "editing" -> R.string.settings_section_editing
+    "mp" -> R.string.settings_section_mp
+    "upcoming" -> R.string.settings_category_upcoming_title
+    else -> R.string.settings_title
+}

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsCategoryDetailScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsCategoryDetailScreen.kt
@@ -1,0 +1,80 @@
+package fr.forumhfr.redface2.feature.settings
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsSection
+
+/**
+ * #494 v2 — détail générique d'une catégorie de la racine « catégories d'abord ». Rend la/les
+ * section(s) du catalogue associée(s) à [categoryId] (cf. [sectionIdsForCategory]) en réutilisant
+ * [buildSettingsCatalogue] : mêmes renderers et même câblage MVI que la recherche. Scaffold à barre
+ * simple avec retour. Les catégories adossées à une sous-page dédiée (Affichage, Images, Compte) ne
+ * passent PAS par ici — elles ouvrent directement leur écran (cf. [routeSettingsCategory]).
+ */
+@Composable
+@Suppress("LongParameterList") // détail : id + back + 5 nav-rows de sous-pages + 2 VMs + slots.
+fun SettingsCategoryDetailScreen(
+    categoryId: String,
+    onBack: () -> Unit,
+    onOpenProxy: () -> Unit,
+    onOpenMaintenance: () -> Unit,
+    onOpenDisplay: () -> Unit,
+    onOpenImages: () -> Unit,
+    onOpenAccountAbout: () -> Unit,
+    modifier: Modifier = Modifier,
+    topBarActions: @Composable (() -> Unit)? = null,
+    viewModel: SettingsViewModel = hiltViewModel(),
+    startScreenViewModel: StartScreenSettingsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val startScreenState by startScreenViewModel.state.collectAsStateWithLifecycle()
+    val sections = buildSettingsCatalogue(
+        state = state,
+        onIntent = viewModel::submit,
+        startScreenState = startScreenState,
+        onStartScreenIntent = startScreenViewModel::submit,
+        onOpenProxy = onOpenProxy,
+        onOpenMaintenance = onOpenMaintenance,
+        onOpenDisplay = onOpenDisplay,
+        onOpenImages = onOpenImages,
+        onOpenAccountAbout = onOpenAccountAbout,
+    )
+    val wanted = sectionIdsForCategory(categoryId)
+    val shown = sections.filter { it.id in wanted }
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            SettingsSubPageTopBar(
+                title = stringResource(categoryTitleRes(categoryId)),
+                onBack = onBack,
+                topBarActions = topBarActions,
+            )
+        },
+    ) { innerPadding ->
+        LazyColumn(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+            shown.forEachIndexed { index, section ->
+                // En-tête de section seulement quand plusieurs sections cohabitent (catégorie « À venir »).
+                if (shown.size > 1) {
+                    item(key = "section:${section.id}") {
+                        if (index > 0) HorizontalDivider()
+                        RedfaceSettingsSection(section.title)
+                    }
+                }
+                items(section.items, key = { "item:${it.searchable.id}" }) { row ->
+                    row.render()
+                }
+            }
+        }
+    }
+}

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsListItem
 import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsSection
 import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsSearchTopBar
+import fr.forumhfr.redface2.core.ui.settings.shell.SettingsHomeScreen
 
 /**
  * #494 — root of the redesigned settings catalogue.
@@ -48,14 +49,14 @@ import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsSearchTopBar
  * [startScreenViewModel] (#458 « Démarrage ») — both `hiltViewModel()` in the same `ViewModelStore`.
  */
 @Composable
-@Suppress("LongParameterList") // state-hoisted Composable: 5 sub-page nav callbacks + back + 2 VMs, each distinct.
+@Suppress("LongParameterList") // racine v2 : 5 sous-pages + onOpenCategory + 2 VMs + slots, chacun distinct.
 fun SettingsScreen(
-    onBack: (() -> Unit)? = null,
     onOpenProxy: () -> Unit,
     onOpenMaintenance: () -> Unit,
     onOpenDisplay: () -> Unit,
     onOpenImages: () -> Unit,
     onOpenAccountAbout: () -> Unit,
+    onOpenCategory: (String) -> Unit,
     modifier: Modifier = Modifier,
     topBarActions: @Composable (() -> Unit)? = null,
     viewModel: SettingsViewModel = hiltViewModel(),
@@ -63,17 +64,17 @@ fun SettingsScreen(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val startScreenState by startScreenViewModel.state.collectAsStateWithLifecycle()
-    SettingsCatalogue(
+    SettingsRoot(
         state = state,
         onIntent = viewModel::submit,
         startScreenState = startScreenState,
         onStartScreenIntent = startScreenViewModel::submit,
-        onBack = onBack,
         onOpenProxy = onOpenProxy,
         onOpenMaintenance = onOpenMaintenance,
         onOpenDisplay = onOpenDisplay,
         onOpenImages = onOpenImages,
         onOpenAccountAbout = onOpenAccountAbout,
+        onOpenCategory = onOpenCategory,
         modifier = modifier,
         topBarActions = topBarActions,
     )
@@ -84,17 +85,17 @@ fun SettingsScreen(
 // stateless catalogue body so it stays previewable/testable without Hilt.
 @Suppress("LongParameterList", "LongMethod", "CyclomaticComplexMethod")
 @Composable
-internal fun SettingsCatalogue(
+internal fun SettingsRoot(
     state: SettingsState,
     onIntent: (SettingsIntent) -> Unit,
     startScreenState: StartScreenSettingsState,
     onStartScreenIntent: (StartScreenSettingsIntent) -> Unit,
-    onBack: (() -> Unit)? = null,
     onOpenProxy: () -> Unit,
     onOpenMaintenance: () -> Unit,
     onOpenDisplay: () -> Unit,
     onOpenImages: () -> Unit,
     onOpenAccountAbout: () -> Unit,
+    onOpenCategory: (String) -> Unit,
     modifier: Modifier = Modifier,
     topBarActions: @Composable (() -> Unit)? = null,
 ) {
@@ -106,6 +107,25 @@ internal fun SettingsCatalogue(
     BackHandler(enabled = searchActive) {
         searchActive = false
         query = ""
+    }
+
+    // #494 v2 — idle : racine « catégories d'abord » (catégories regroupées en familles). Le pill de
+    // recherche bascule en mode recherche qui réutilise le filtre/renderers du catalogue (ci-dessous).
+    if (!searchActive) {
+        SettingsHomeScreen(
+            groups = rememberSettingsCategoryGroups(),
+            searchPlaceholder = stringResource(R.string.settings_search_placeholder),
+            menuContentDescription = stringResource(R.string.settings_menu_content_description),
+            searchContentDescription = stringResource(R.string.settings_search_open),
+            onMenuClick = null, // hamburger gardé mais désactivé : rôle à définir (#494 v2)
+            onSearchClick = { searchActive = true },
+            onCategoryClick = { id ->
+                routeSettingsCategory(id, onOpenDisplay, onOpenImages, onOpenAccountAbout, onOpenCategory)
+            },
+            modifier = modifier,
+            accountSlot = topBarActions,
+        )
+        return
     }
 
     // The renderable catalogue: each row carries its search metadata AND its Compose renderer. The
@@ -138,7 +158,6 @@ internal fun SettingsCatalogue(
                     searchActive = active
                     if (!active) query = ""
                 },
-                onBack = onBack,
                 actions = { topBarActions?.invoke() },
             )
         },
@@ -200,7 +219,7 @@ internal data class SettingsCatalogueSection(
  */
 @Suppress("LongMethod", "LongParameterList")
 @Composable
-private fun buildSettingsCatalogue(
+internal fun buildSettingsCatalogue(
     state: SettingsState,
     onIntent: (SettingsIntent) -> Unit,
     startScreenState: StartScreenSettingsState,

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -40,6 +40,25 @@
     <string name="settings_search_placeholder">Rechercher un réglage…</string>
     <string name="settings_search_empty">Aucun réglage ne correspond à votre recherche.</string>
 
+    <!-- #494 v2 — racine « catégories d'abord » : familles, sous-titres de catégories, a11y, écran « À venir ». -->
+    <string name="settings_menu_content_description">Menu</string>
+    <string name="settings_category_upcoming_title">À venir</string>
+    <string name="settings_family_appearance">Apparence</string>
+    <string name="settings_family_communication">Communication</string>
+    <string name="settings_family_content">Contenu</string>
+    <string name="settings_family_system">Système</string>
+    <string name="settings_family_other">Autres</string>
+    <string name="settings_category_subtitle_display">Thème, AMOLED, densité, police</string>
+    <string name="settings_category_subtitle_flags">Regroupement, masquer lus, auto-refresh</string>
+    <string name="settings_category_subtitle_topic">Barre, sondages, navigation</string>
+    <string name="settings_category_subtitle_mp">Badge de non-lus</string>
+    <string name="settings_category_subtitle_editing">Confirmation avant envoi</string>
+    <string name="settings_category_subtitle_images">Hébergeur, Client-ID, insertion</string>
+    <string name="settings_category_subtitle_start">Écran ouvert au lancement</string>
+    <string name="settings_category_subtitle_network">Proxy, vider les caches</string>
+    <string name="settings_category_subtitle_account">Compte HFR, version, diagnostics</string>
+    <string name="settings_category_subtitle_upcoming">Fonctionnalités planifiées</string>
+
     <!-- #494 — lignes de navigation de la racine vers les sous-pages, et titres des sous-pages. -->
     <string name="settings_nav_proxy">Proxy</string>
     <string name="settings_nav_proxy_description">Router les requêtes HFR via votre proxy.</string>

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsCategoriesTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsCategoriesTest.kt
@@ -1,0 +1,77 @@
+package fr.forumhfr.redface2.feature.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #494 v2 — contrat de routage de la racine « catégories d'abord » : les catégories adossées à une
+ * sous-page dédiée y mènent directement, les autres ouvrent le détail générique ; le mapping
+ * catégorie → section(s) du catalogue est figé (notamment « À venir » qui agrège 3 sections futures).
+ */
+class SettingsCategoriesTest {
+
+    private class Spy {
+        var display = 0
+        var images = 0
+        var accountAbout = 0
+        var category: String? = null
+
+        fun route(id: String) = routeSettingsCategory(
+            id = id,
+            onOpenDisplay = { display++ },
+            onOpenImages = { images++ },
+            onOpenAccountAbout = { accountAbout++ },
+            onOpenCategory = { category = it },
+        )
+    }
+
+    @Test
+    fun `dedicated categories route straight to their sub-page`() {
+        with(Spy()) {
+            route("display")
+            assertEquals(1, display)
+            assertNull(category)
+        }
+        with(Spy()) {
+            route("images")
+            assertEquals(1, images)
+            assertNull(category)
+        }
+        with(Spy()) {
+            route("account")
+            assertEquals(1, accountAbout)
+            assertNull(category)
+        }
+    }
+
+    @Test
+    fun `other categories open the generic detail with their id`() {
+        for (id in listOf("flags", "topic", "mp", "editing", "start", "network", "upcoming")) {
+            with(Spy()) {
+                route(id)
+                assertEquals(id, category)
+                assertEquals(0, display + images + accountAbout)
+            }
+        }
+    }
+
+    @Test
+    fun `upcoming aggregates the three future sections`() {
+        assertEquals(listOf("notifications", "accessibility", "extensions"), sectionIdsForCategory("upcoming"))
+    }
+
+    @Test
+    fun `a regular category maps to its own section id`() {
+        assertEquals(listOf("flags"), sectionIdsForCategory("flags"))
+        assertEquals(listOf("network"), sectionIdsForCategory("network"))
+    }
+
+    @Test
+    fun `every category title resolves to a non-zero resource`() {
+        for (id in listOf("network", "start", "flags", "topic", "editing", "mp", "upcoming")) {
+            assertTrue("title res for $id", categoryTitleRes(id) != 0)
+        }
+    }
+}


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaTriX)

## Quoi (PR2/3 du câblage shell réglages v2)

La **racine de l'onglet Réglages** passe du monolithe scrollé à la racine **« catégories d'abord »** (#510) câblée pour de vrai.

- `SettingsScreen` devient bi-mode :
  - **idle** → `SettingsHomeScreen` (#510) : 10 catégories regroupées en 5 familles (Apparence / Communication / Contenu / Système / Autres), cercles tonals + sous-titres + vraies icônes Material Symbols. Le menu compte vit dans le slot avatar de la Search app bar (nouveau `accountSlot` exposé par `SettingsHomeScreen`).
  - **recherche** → le pill ouvre la recherche existante (`filterSettingsSections` + renderers du catalogue, déjà en place) → pas d'affordance morte.
- **Sous-vues par catégorie** :
  - Catégories adossées à une sous-page dédiée existante → directes (Affichage→Display, Images→Images, Compte→Compte/À propos).
  - Autres (Drapeaux, Sujet, MP, Édition, Démarrage, Réseau&cache, À venir) → `SettingsCategoryDetailScreen` générique qui rend la/les section(s) du catalogue (réutilise `buildSettingsCatalogue` : mêmes renderers et câblage MVI). « À venir » agrège Notifications + Accessibilité + Extensions.
- Nouvelle route `SettingsCategoryRoute(categoryId)` + entrée nav. `SettingsScreen.onBack` supprimé (racine d'onglet).
- 17 strings (familles, sous-titres, a11y, titre « À venir ») ; titres de catégorie réutilisent les titres de section existants.
- Test pur `SettingsCategoriesTest` : contrat de routage + mapping catégorie→section(s).

## Hors périmètre

- **PR3** : recherche globale polie (résultats avec origine « Affichage › Thème »). Ici la recherche réutilise le filtre existant (à plat).
- Rôle du hamburger (laissé en place, no-op) — à définir plus tard.

## Validation

`detektAll` + `:app:assembleDevDebug` + `:app:lintDevDebug` + `:feature:settings:testDebugUnitTest` + `:core:ui:testDebugUnitTest` verts en local. Aperçu visuel de la racine : showcase `settings_v2_shell_*` (#510).

Refs #494, #288.
