### PR TITLE
feat(settings): recherche à plat + fil d'Ariane par résultat (#494 PR3)

### DIFF
--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
@@ -25,7 +24,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsListItem
-import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsSection
 import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsSearchTopBar
 import fr.forumhfr.redface2.core.ui.settings.shell.SettingsHomeScreen
 
@@ -182,17 +180,36 @@ internal fun SettingsRoot(
                     .fillMaxSize()
                     .padding(innerPadding),
             ) {
-                filtered.forEachIndexed { sectionIndex, section ->
-                    item(key = "section:${section.id}") {
-                        if (sectionIndex > 0) HorizontalDivider()
-                        RedfaceSettingsSection(section.title)
-                    }
-                    items(section.items, key = { "item:${it.id}" }) { item ->
-                        renderers[item.id]?.invoke()
-                    }
+                // #494 PR3 — résultats À PLAT : chaque résultat porte son origine (catégorie) en fil
+                // d'Ariane, et garde son contrôle éditable inline. Plus de regroupement par en-tête de
+                // section : l'origine vit sur chaque ligne (utile quand des résultats de catégories
+                // différentes se suivent).
+                val results = filtered.flatMap { section -> section.items.map { section.title to it } }
+                items(results, key = { "res:${it.second.id}" }) { (origin, item) ->
+                    SettingsSearchResult(origin = origin, render = renderers[item.id])
                 }
             }
         }
+    }
+}
+
+/**
+ * A flattened search result (#494 PR3) : the row's own editable control kept inline, preceded by a
+ * « fil d'Ariane » naming the [origin] category. Grouping by section header is dropped in search mode
+ * so each result self-describes — useful when results from different categories interleave. [render]
+ * is the catalogue renderer looked up by id; it is never expected to be null (every filtered item has
+ * a renderer), but it stays nullable so a stale id degrades to just the breadcrumb instead of crashing.
+ */
+@Composable
+private fun SettingsSearchResult(origin: String, render: (@Composable () -> Unit)?) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = origin,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 12.dp),
+        )
+        render?.invoke()
     }
 }
 


### PR DESCRIPTION
## Quoi

PR3 de la refonte du menu Réglages v2 (#494). En **mode recherche**, les résultats passent **à plat** : plus de regroupement par en-tête de section. Chaque résultat affiche désormais son **origine (catégorie) en fil d'Ariane** au-dessus de la ligne, et conserve son **contrôle éditable inline** (Switch / chevron).

Forme retenue par @XaTriX : « Fil d'Ariane par résultat + édition inline ».

## Pourquoi

Quand des résultats de catégories différentes se suivent (cas fréquent d'une recherche transverse), l'en-tête de section groupé devient ambigu : un toggle isolé ne dit plus d'où il vient. Le fil d'Ariane par ligne rend chaque résultat auto-descriptif.

## Détails

- `SettingsRoot` (mode recherche) : `filtered` est aplati en `(origine, item)`, rendu via un nouveau composable `SettingsSearchResult`.
- `SettingsSearchResult` : libellé d'origine (`labelMedium`, couleur `primary`) + le renderer du catalogue inline.
- Suppression de l'ancien rendu groupé (`RedfaceSettingsSection` + `HorizontalDivider`), imports orphelins retirés.
- Le filtre pur (`filterSettingsSections`) et les renderers Compose restent découplés (inchangé).

## Validation

- Build machine B : `detektAll :app:assembleDevDebug :app:lintDevDebug :feature:settings:testDebugUnitTest` → **BUILD SUCCESSFUL** (seuls warnings préexistants `hiltViewModel` deprecated).
- Revue Codex (gpt-5.5) sur le diff : 1 P0 (composable manquant) → corrigé dans le commit final.

> Action par Claude Opus 4.8 (demandée par @XaTriX)