### PR TITLE
feat(ui): bottom bar courte (~64dp) + contenu sous la search app bar (#494)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -164,6 +164,24 @@ private fun NavKey?.hidesNavigationSuite(): Boolean =
     this is PostEditorRoute || this is TopicFormRoute || this is PrivateMessageReplyRoute ||
         this is PrivateMessageComposeRoute
 
+/**
+ * #494 — type de barre de navigation à passer au [NavigationSuiteScaffold]. Sur téléphone l'adaptatif
+ * renvoie `NavigationBar` (80dp) ; on lui substitue `ShortNavigationBarCompact` (M3 Expressive, ~64dp,
+ * icône au-dessus du label, labels conservés, cible tactile ≥48dp). Les autres formes (rail/drawer sur
+ * largeur medium/expanded) restent telles quelles ; la navigation est masquée (`None`) sur les routes
+ * plein écran (éditeur, #624). Pure (l'`adaptiveType` composable est résolu côté appelant) + extraite
+ * pour garder la complexité cyclomatique de `RedfaceApp` sous le seuil.
+ */
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+private fun resolveNavLayoutType(
+    hidesNavigationSuite: Boolean,
+    adaptiveType: NavigationSuiteType,
+): NavigationSuiteType = when {
+    hidesNavigationSuite -> NavigationSuiteType.None
+    adaptiveType == NavigationSuiteType.NavigationBar -> NavigationSuiteType.ShortNavigationBarCompact
+    else -> adaptiveType
+}
+
 @Serializable
 data class CategoryRoute(
     val cat: Int,
@@ -641,11 +659,8 @@ fun RedfaceApp(intent: Intent?) {
         // routes makes the editor full-screen: its submit bar then sits at the window bottom and the IME
         // inset lands exactly on the keyboard. Bonus UX: no tab switching mid-compose (would drop the draft).
         val topRoute = backStacks.getValue(currentDestination).lastOrNull()
-        val navLayoutType = if (topRoute.hidesNavigationSuite()) {
-            NavigationSuiteType.None
-        } else {
-            NavigationSuiteScaffoldDefaults.calculateFromAdaptiveInfo(currentWindowAdaptiveInfo())
-        }
+        val adaptiveType = NavigationSuiteScaffoldDefaults.calculateFromAdaptiveInfo(currentWindowAdaptiveInfo())
+        val navLayoutType = resolveNavLayoutType(topRoute.hidesNavigationSuite(), adaptiveType)
 
         NavigationSuiteScaffold(
             layoutType = navLayoutType,

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/RedfaceSettingsSearchTopBar.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/RedfaceSettingsSearchTopBar.kt
@@ -12,6 +12,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -40,10 +42,14 @@ import fr.forumhfr.redface2.core.ui.R
  *
  * Icons use local vector drawables from `:core:ui` rendered with the material3 [Icon] (material-icons
  * are forbidden project-wide); a11y labels live on the [IconButton]s, the glyphs are decorative.
+ *
+ * [scrollBehavior] branche l'effet « contenu sous la barre » (idiome M3) : avec un
+ * `pinnedScrollBehavior` câblé côté écran (Scaffold `nestedScroll`), la barre prend la teinte
+ * `scrolledContainerColor` (`surfaceContainer`) dès que la liste de résultats défile dessous.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-@Suppress("LongParameterList") // Top-bar API: search state + the two back/query callbacks + slots.
+@Suppress("LongParameterList") // Top-bar API: search state + the two back/query callbacks + scroll + slots.
 fun RedfaceSettingsSearchTopBar(
     labels: RedfaceSettingsSearchTopBarLabels,
     searchActive: Boolean,
@@ -52,11 +58,16 @@ fun RedfaceSettingsSearchTopBar(
     onSearchActiveChange: (Boolean) -> Unit,
     onBack: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
+    scrollBehavior: TopAppBarScrollBehavior? = null,
     actions: @Composable RowScope.() -> Unit = {},
 ) {
     val focusManager = LocalFocusManager.current
     TopAppBar(
         modifier = modifier,
+        scrollBehavior = scrollBehavior,
+        colors = TopAppBarDefaults.topAppBarColors(
+            scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
+        ),
         navigationIcon = {
             // Search active → the icon CLOSES the search. Otherwise it's a back affordance, shown only
             // when [onBack] is provided : a top-level/root use (Réglages onglet, #494 v2) passes null so

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/RedfaceSearchAppBar.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/RedfaceSearchAppBar.kt
@@ -1,5 +1,7 @@
 package fr.forumhfr.redface2.core.ui.settings.shell
 
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -14,6 +16,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -31,9 +34,14 @@ import fr.forumhfr.redface2.core.ui.R
  *
  * Edge-to-edge : la barre applique `statusBarsPadding()` pour se loger sous la status bar transparente.
  * Le pill ouvre la recherche ([onSearchClick]) ; le filtrage/résultats vivent au niveau du shell.
+ *
+ * [elevated] pilote l'effet « contenu sous la barre » (idiome M3) : au repos la barre est `surface`
+ * (continue avec le contenu) ; quand du contenu scrolle DESSOUS, elle prend la teinte `surfaceContainer`
+ * + une ombre fine. Le shell la superpose à la liste (Box + `contentPadding` haut) et passe
+ * `elevated = listState.canScrollBackward`. Transition tonale animée (pas de flou : non-standard M3).
  */
 @Composable
-@Suppress("LongParameterList") // Top-bar API : placeholder + 2 a11y labels + 2 callbacks + slot avatar.
+@Suppress("LongParameterList") // Top-bar API : placeholder + 2 a11y labels + 2 callbacks + elevated + avatar.
 fun RedfaceSearchAppBar(
     placeholder: String,
     menuContentDescription: String,
@@ -41,9 +49,26 @@ fun RedfaceSearchAppBar(
     onMenuClick: (() -> Unit)? = null,
     onSearchClick: () -> Unit,
     modifier: Modifier = Modifier,
+    elevated: Boolean = false,
     avatar: @Composable () -> Unit = { DefaultAvatarPlaceholder() },
 ) {
-    Surface(modifier = modifier.fillMaxWidth(), color = MaterialTheme.colorScheme.surface) {
+    val containerColor by animateColorAsState(
+        targetValue = if (elevated) {
+            MaterialTheme.colorScheme.surfaceContainer
+        } else {
+            MaterialTheme.colorScheme.surface
+        },
+        label = "searchAppBarContainer",
+    )
+    val shadowElevation by animateDpAsState(
+        targetValue = if (elevated) 3.dp else 0.dp,
+        label = "searchAppBarShadow",
+    )
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = containerColor,
+        shadowElevation = shadowElevation,
+    ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeScreen.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeScreen.kt
@@ -4,13 +4,14 @@ import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
@@ -19,8 +20,15 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
@@ -68,31 +76,26 @@ fun SettingsHomeScreen(
     modifier: Modifier = Modifier,
     accountSlot: (@Composable () -> Unit)? = null,
 ) {
-    Column(
+    val listState = rememberLazyListState()
+    // « Contenu sous la barre » (edge-to-edge) : la barre est SUPERPOSÉE à la liste (Box, pas Column),
+    // donc le contenu glisse derrière elle. Elle s'élève (teinte surfaceContainer) dès que la liste a
+    // défilé — canScrollBackward passe true au 1er pixel sous la barre.
+    val barElevated by remember { derivedStateOf { listState.canScrollBackward } }
+    // Hauteur réelle de la barre (status bar + pill + paddings), mesurée au runtime et reportée en
+    // contentPadding haut : le 1er item démarre VISIBLE juste sous la barre, puis passe DERRIÈRE elle.
+    var barHeightPx by remember { mutableIntStateOf(0) }
+    val density = LocalDensity.current
+
+    Box(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.surface),
     ) {
-        // Le slot compte (menu compte app-wide) remplace l'avatar placeholder quand le host le fournit.
-        if (accountSlot != null) {
-            RedfaceSearchAppBar(
-                placeholder = searchPlaceholder,
-                menuContentDescription = menuContentDescription,
-                searchContentDescription = searchContentDescription,
-                onMenuClick = onMenuClick,
-                onSearchClick = onSearchClick,
-                avatar = accountSlot,
-            )
-        } else {
-            RedfaceSearchAppBar(
-                placeholder = searchPlaceholder,
-                menuContentDescription = menuContentDescription,
-                searchContentDescription = searchContentDescription,
-                onMenuClick = onMenuClick,
-                onSearchClick = onSearchClick,
-            )
-        }
-        LazyColumn(modifier = Modifier.fillMaxWidth()) {
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(top = with(density) { barHeightPx.toDp() }),
+        ) {
             groups.forEachIndexed { index, group ->
                 item(key = "header_${group.id}") {
                     SettingsSectionHeader(title = group.title, first = index == 0)
@@ -103,6 +106,34 @@ fun SettingsHomeScreen(
                         onClick = { onCategoryClick(category.id) },
                     )
                 }
+            }
+        }
+        // Barre superposée en haut. Le slot compte (menu app-wide) remplace l'avatar placeholder quand
+        // le host le fournit. onSizeChanged alimente le contentPadding de la liste ci-dessus.
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .onSizeChanged { barHeightPx = it.height },
+        ) {
+            if (accountSlot != null) {
+                RedfaceSearchAppBar(
+                    placeholder = searchPlaceholder,
+                    menuContentDescription = menuContentDescription,
+                    searchContentDescription = searchContentDescription,
+                    onMenuClick = onMenuClick,
+                    onSearchClick = onSearchClick,
+                    elevated = barElevated,
+                    avatar = accountSlot,
+                )
+            } else {
+                RedfaceSearchAppBar(
+                    placeholder = searchPlaceholder,
+                    menuContentDescription = menuContentDescription,
+                    searchContentDescription = searchContentDescription,
+                    onMenuClick = onMenuClick,
+                    onSearchClick = onSearchClick,
+                    elevated = barElevated,
+                )
             }
         }
     }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -8,10 +8,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -19,6 +21,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -81,6 +84,7 @@ fun SettingsScreen(
 // 12 navigation/intent callbacks + state make the explicit surface; grouping them behind an object
 // would hide the call site. The two VMs are observed in [SettingsScreen]; this content is the
 // stateless catalogue body so it stays previewable/testable without Hilt.
+@OptIn(ExperimentalMaterial3Api::class)
 @Suppress("LongParameterList", "LongMethod", "CyclomaticComplexMethod")
 @Composable
 internal fun SettingsRoot(
@@ -144,8 +148,14 @@ internal fun SettingsRoot(
         .associate { it.searchable.id to it.render }
     val filtered = filterSettingsSections(sections.map { it.toSearchable() }, query)
 
+    // #494 — effet « résultats sous la barre » (idiome M3) : pinnedScrollBehavior + nestedScroll sur le
+    // Scaffold → la barre prend sa teinte surfaceContainer quand la liste de résultats défile dessous.
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+
     Scaffold(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             RedfaceSettingsSearchTopBar(
                 labels = rememberSettingsSearchTopBarLabels(),
@@ -156,6 +166,7 @@ internal fun SettingsRoot(
                     searchActive = active
                     if (!active) query = ""
                 },
+                scrollBehavior = scrollBehavior,
                 actions = { topBarActions?.invoke() },
             )
         },


### PR DESCRIPTION
## Quoi

Deux retours produit (@XaTriX) sur le shell réglages v2 :

### 1. Bottom bar plus basse
Substitue `NavigationBar` (80dp) par `NavigationSuiteType.ShortNavigationBarCompact` (M3 Expressive, **~64dp**, icône au-dessus du label, **labels conservés**, cible tactile ≥48dp) quand l'adaptatif renvoie une barre basse. Rail/drawer gardés sur largeur medium/expanded, `None` sur les routes plein écran (éditeur).

> **« Réduire par 2 » (→40dp) écarté** : passe sous le plancher tactile a11y de 48dp. Reco convergente Claude + Codex (gpt-5.5) : 64dp est le max réaliste conforme M3 en gardant les labels. ~20% de gain, pas « moitié ».

### 2. Contenu sous la search app bar (edge-to-edge)
Edge-to-edge était déjà activé mais le contenu ne passait pas **sous** les barres (empilées). Effet M3 **tonal au scroll** (pas de flou, non-standard) :
- **Racine réglages** : `RedfaceSearchAppBar` superposée à la liste (`Box`, plus `Column`) ; la liste défile **derrière**, hauteur de barre mesurée → `contentPadding` haut ; la barre prend `surfaceContainer` + ombre fine dès que ça scrolle (`elevated = listState.canScrollBackward`).
- **Résultats de recherche** : `TopAppBar` + `pinnedScrollBehavior` (`nestedScroll` sur le `Scaffold`) → `scrolledContainerColor = surfaceContainer`.

## Notes techniques
- `ShortNavigationBarCompact` ne requiert que l'opt-in `ExperimentalMaterial3AdaptiveApi` (le marqueur `ExperimentalMaterial3ExpressiveApi` est `internal` dans le BOM 2026.05.01).
- `resolveNavLayoutType` extraite (pure) pour garder la complexité cyclomatique de `RedfaceApp` sous le seuil detekt (15).

## Validation
- Machine B : `detektAll :app:assembleDevDebug :app:lintDevDebug :core:ui:lintDebug :feature:settings:lintDebug :core:ui:testDebugUnitTest :feature:settings:testDebugUnitTest` → **BUILD SUCCESSFUL** (seuls warnings préexistants `hiltViewModel`).
- Revue Codex (gpt-5.5) : aucun problème de correction.
- Rendu Roborazzi du shell : layout overlay OK (effet tonal/barre courte visibles en dynamique, pas sur frame statique).
- ⚠️ Vérif device non faite (S10e non connecté) : la barre 64dp + tonal au scroll se constatent sur le build dev.

> Action par Claude Opus 4.8 (demandée par @XaTriX)