### PR TITLE
feat(settings): catalogue « À venir » exhaustif + microcopie épurée (#494)

### DIFF
--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsCategories.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsCategories.kt
@@ -7,7 +7,7 @@ import fr.forumhfr.redface2.core.ui.settings.shell.SettingsCategoryUi
 import fr.forumhfr.redface2.core.ui.R as CoreUiR
 
 /**
- * #494 v2 — modèle de la racine « catégories d'abord » : 10 catégories regroupées en 5 familles.
+ * #494 v2 — modèle de la racine « catégories d'abord » : 12 catégories regroupées en 5 familles.
  * Les titres de catégorie réutilisent les titres de section existants ; sous-titres et familles sont
  * propres à la racine v2. Le routage (catégorie → sous-page dédiée ou détail générique) et le mapping
  * catégorie → section(s) du catalogue vivent ici pour rester testables et hors du composant racine.
@@ -84,14 +84,26 @@ internal fun rememberSettingsCategoryGroups(): List<SettingsCategoryGroup> = lis
             ),
         ),
     ),
+    // #494 — « À venir » éclatée en 3 vraies catégories (décision produit XaTriX 2026-06-15) : chacune
+    // pointe sur sa propre section future du catalogue (cf. [sectionIdsForCategory]).
     SettingsCategoryGroup(
-        id = "other",
-        title = stringResource(R.string.settings_family_other),
+        id = "upcoming",
+        title = stringResource(R.string.settings_family_upcoming),
         categories = listOf(
             category(
-                "upcoming", R.string.settings_category_upcoming_title,
-                R.string.settings_category_subtitle_upcoming,
+                "notifications", R.string.settings_section_notifications,
+                R.string.settings_category_subtitle_notifications,
                 CoreUiR.drawable.ic_ms_upcoming,
+            ),
+            category(
+                "accessibility", R.string.settings_section_accessibility,
+                R.string.settings_category_subtitle_accessibility,
+                CoreUiR.drawable.ic_ms_settings,
+            ),
+            category(
+                "extensions", R.string.settings_section_extensions,
+                R.string.settings_category_subtitle_extensions,
+                CoreUiR.drawable.ic_ms_article,
             ),
         ),
     ),
@@ -125,11 +137,12 @@ internal fun routeSettingsCategory(
     }
 }
 
-/** Les sections du catalogue rendues par le détail générique d'une catégorie. */
-internal fun sectionIdsForCategory(categoryId: String): List<String> = when (categoryId) {
-    "upcoming" -> listOf("notifications", "accessibility", "extensions")
-    else -> listOf(categoryId)
-}
+/**
+ * Les sections du catalogue rendues par le détail générique d'une catégorie. Chaque catégorie (y compris
+ * les 3 catégories « à venir » Notifications/Accessibilité/Extensions, désormais distinctes) pointe sur
+ * la section homonyme du catalogue ; l'identité id-catégorie == id-section suffit.
+ */
+internal fun sectionIdsForCategory(categoryId: String): List<String> = listOf(categoryId)
 
 /** Titre du détail générique d'une catégorie (réutilise les titres de section quand ils existent). */
 internal fun categoryTitleRes(categoryId: String): Int = when (categoryId) {
@@ -139,6 +152,8 @@ internal fun categoryTitleRes(categoryId: String): Int = when (categoryId) {
     "topic" -> R.string.settings_section_topic
     "editing" -> R.string.settings_section_editing
     "mp" -> R.string.settings_section_mp
-    "upcoming" -> R.string.settings_category_upcoming_title
+    "notifications" -> R.string.settings_section_notifications
+    "accessibility" -> R.string.settings_section_accessibility
+    "extensions" -> R.string.settings_section_extensions
     else -> R.string.settings_title
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -8,9 +8,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -296,6 +298,26 @@ internal fun buildSettingsCatalogue(
                 },
                 onClick = onOpenMaintenance,
             ),
+            futureRow(
+                id = "future_prefetch_wifi_only",
+                title = stringResource(R.string.settings_future_prefetch_wifi_only),
+            ),
+            futureRow(
+                id = "future_data_saver",
+                title = stringResource(R.string.settings_future_data_saver),
+            ),
+            futureRow(
+                id = "future_image_cache_size",
+                title = stringResource(R.string.settings_future_image_cache_size),
+            ),
+            futureRow(
+                id = "future_clear_cache_on_start",
+                title = stringResource(R.string.settings_future_clear_cache_on_start),
+            ),
+            futureRow(
+                id = "future_offline_mode",
+                title = stringResource(R.string.settings_future_offline_mode),
+            ),
         ),
     ),
     // Démarrage (rendered inline — category picker, not a sub-page).
@@ -311,6 +333,10 @@ internal fun buildSettingsCatalogue(
                     keywords = listOf("démarrage", "écran", "onglet", "lancement", "catégorie"),
                 ),
                 render = { StartScreenPreferencesCard(state = startScreenState, onIntent = onStartScreenIntent) },
+            ),
+            futureRow(
+                id = "future_resume_last_topic",
+                title = stringResource(R.string.settings_future_resume_last_topic),
             ),
         ),
     ),
@@ -346,6 +372,34 @@ internal fun buildSettingsCatalogue(
                     stringResource(R.string.settings_display_font_scale_large),
                 ),
                 onClick = onOpenDisplay,
+            ),
+            futureRow(
+                id = "future_material_you",
+                title = stringResource(R.string.settings_future_material_you),
+            ),
+            futureRow(
+                id = "future_ui_colors",
+                title = stringResource(R.string.settings_future_ui_colors),
+            ),
+            futureRow(
+                id = "future_classic_theme",
+                title = stringResource(R.string.settings_future_classic_theme),
+            ),
+            futureRow(
+                id = "future_amoled_auto_night",
+                title = stringResource(R.string.settings_future_amoled_auto_night),
+            ),
+            futureRow(
+                id = "future_smiley_size",
+                title = stringResource(R.string.settings_future_smiley_size),
+            ),
+            futureRow(
+                id = "future_show_avatars",
+                title = stringResource(R.string.settings_future_show_avatars),
+            ),
+            futureRow(
+                id = "future_show_signatures",
+                title = stringResource(R.string.settings_future_show_signatures),
             ),
         ),
     ),
@@ -404,6 +458,22 @@ internal fun buildSettingsCatalogue(
                     .takeIf { state.flagsAutoRefreshError },
                 onCheckedChange = { onIntent(SettingsIntent.FlagsAutoRefreshChanged(it)) },
             ),
+            futureRow(
+                id = "future_flags_sort",
+                title = stringResource(R.string.settings_future_flags_sort),
+            ),
+            futureRow(
+                id = "future_flags_on_listing",
+                title = stringResource(R.string.settings_future_flags_on_listing),
+            ),
+            futureRow(
+                id = "future_flags_mark_read_on_scroll",
+                title = stringResource(R.string.settings_future_flags_mark_read_on_scroll),
+            ),
+            futureRow(
+                id = "future_flags_by_subcategory",
+                title = stringResource(R.string.settings_future_flags_by_subcategory),
+            ),
         ),
     ),
     // Sujet et lecture (inline toggles).
@@ -440,6 +510,34 @@ internal fun buildSettingsCatalogue(
                     .takeIf { state.topicPollsExpandedError },
                 onCheckedChange = { onIntent(SettingsIntent.TopicPollsExpandedChanged(it)) },
             ),
+            futureRow(
+                id = "future_restore_read_position",
+                title = stringResource(R.string.settings_future_restore_read_position),
+            ),
+            futureRow(
+                id = "future_swipe_page",
+                title = stringResource(R.string.settings_future_swipe_page),
+            ),
+            futureRow(
+                id = "future_collapse_quotes",
+                title = stringResource(R.string.settings_future_collapse_quotes),
+            ),
+            futureRow(
+                id = "future_prefetch",
+                title = stringResource(R.string.settings_future_prefetch),
+            ),
+            futureRow(
+                id = "future_open_external_in_app",
+                title = stringResource(R.string.settings_future_open_external_in_app),
+            ),
+            futureRow(
+                id = "future_autoplay_animations",
+                title = stringResource(R.string.settings_future_autoplay_animations),
+            ),
+            futureRow(
+                id = "future_fullscreen_reading",
+                title = stringResource(R.string.settings_future_fullscreen_reading),
+            ),
         ),
     ),
     // Édition et publication (inline toggle).
@@ -456,6 +554,26 @@ internal fun buildSettingsCatalogue(
                 errorRes = R.string.settings_confirm_before_posting_persist_failed
                     .takeIf { state.confirmBeforePostingError },
                 onCheckedChange = { onIntent(SettingsIntent.ConfirmBeforePostingChanged(it)) },
+            ),
+            futureRow(
+                id = "future_auto_signature",
+                title = stringResource(R.string.settings_future_auto_signature),
+            ),
+            futureRow(
+                id = "future_auto_drafts",
+                title = stringResource(R.string.settings_future_auto_drafts),
+            ),
+            futureRow(
+                id = "future_recent_smileys",
+                title = stringResource(R.string.settings_future_recent_smileys),
+            ),
+            futureRow(
+                id = "future_spell_check",
+                title = stringResource(R.string.settings_future_spell_check),
+            ),
+            futureRow(
+                id = "future_custom_bbcode_toolbar",
+                title = stringResource(R.string.settings_future_custom_bbcode_toolbar),
             ),
         ),
     ),
@@ -488,6 +606,18 @@ internal fun buildSettingsCatalogue(
                 ),
                 onClick = onOpenImages,
             ),
+            futureRow(
+                id = "future_compress_upload",
+                title = stringResource(R.string.settings_future_compress_upload),
+            ),
+            futureRow(
+                id = "future_strip_exif",
+                title = stringResource(R.string.settings_future_strip_exif),
+            ),
+            futureRow(
+                id = "future_upload_wifi_only",
+                title = stringResource(R.string.settings_future_upload_wifi_only),
+            ),
         ),
     ),
     // Messages privés (inline toggle).
@@ -503,6 +633,18 @@ internal fun buildSettingsCatalogue(
                 enabled = state.canToggleMpUnreadBadge,
                 errorRes = R.string.settings_mp_unread_badge_persist_failed.takeIf { state.mpUnreadBadgeError },
                 onCheckedChange = { onIntent(SettingsIntent.MpUnreadBadgeChanged(it)) },
+            ),
+            futureRow(
+                id = "future_mp_push",
+                title = stringResource(R.string.settings_future_mp_push),
+            ),
+            futureRow(
+                id = "future_mp_preview",
+                title = stringResource(R.string.settings_future_mp_preview),
+            ),
+            futureRow(
+                id = "future_mp_read_receipt",
+                title = stringResource(R.string.settings_future_mp_read_receipt),
             ),
         ),
     ),
@@ -527,42 +669,110 @@ internal fun buildSettingsCatalogue(
                 ),
                 onClick = onOpenAccountAbout,
             ),
+            futureRow(
+                id = "future_hfr_profile_settings",
+                title = stringResource(R.string.settings_future_hfr_profile_settings),
+            ),
+            futureRow(
+                id = "future_multi_account",
+                title = stringResource(R.string.settings_future_multi_account),
+            ),
+            futureRow(
+                id = "future_auto_logout",
+                title = stringResource(R.string.settings_future_auto_logout),
+            ),
         ),
     ),
-    // Notifications (future, disabled — searchable).
+    // Notifications (future category, all rows disabled — searchable). Draft §10.
     SettingsCatalogueSection(
         id = "notifications",
         title = stringResource(R.string.settings_section_notifications),
         items = listOf(
             futureRow(
-                id = "future_notifications",
-                title = stringResource(R.string.settings_future_notifications),
+                id = "future_notif_push",
+                title = stringResource(R.string.settings_future_notif_push),
+            ),
+            futureRow(
+                id = "future_notif_mp",
+                title = stringResource(R.string.settings_future_notif_mp),
+            ),
+            futureRow(
+                id = "future_notif_mentions",
+                title = stringResource(R.string.settings_future_notif_mentions),
+            ),
+            futureRow(
+                id = "future_notif_polling",
+                title = stringResource(R.string.settings_future_notif_polling),
+            ),
+            futureRow(
+                id = "future_notif_dnd",
+                title = stringResource(R.string.settings_future_notif_dnd),
+            ),
+            futureRow(
+                id = "future_notif_sound_vibration",
+                title = stringResource(R.string.settings_future_notif_sound_vibration),
             ),
         ),
     ),
-    // Accessibilité (future, disabled — searchable).
+    // Accessibilité (future category, all rows disabled — searchable). Draft §11.
     SettingsCatalogueSection(
         id = "accessibility",
         title = stringResource(R.string.settings_section_accessibility),
         items = listOf(
             futureRow(
-                id = "future_timezone",
-                title = stringResource(R.string.settings_future_timezone),
+                id = "future_a11y_force_system_text",
+                title = stringResource(R.string.settings_future_a11y_force_system_text),
             ),
             futureRow(
-                id = "future_multilang",
-                title = stringResource(R.string.settings_future_multilang),
+                id = "future_a11y_high_contrast",
+                title = stringResource(R.string.settings_future_a11y_high_contrast),
+            ),
+            futureRow(
+                id = "future_a11y_reduce_motion",
+                title = stringResource(R.string.settings_future_a11y_reduce_motion),
+            ),
+            futureRow(
+                id = "future_a11y_timezone",
+                title = stringResource(R.string.settings_future_a11y_timezone),
+            ),
+            futureRow(
+                id = "future_a11y_language",
+                title = stringResource(R.string.settings_future_a11y_language),
             ),
         ),
     ),
-    // Extensions et filtrage (future, disabled — searchable).
+    // Extensions et filtrage (future category, all rows disabled — searchable). Draft §12.
     SettingsCatalogueSection(
         id = "extensions",
         title = stringResource(R.string.settings_section_extensions),
         items = listOf(
             futureRow(
-                id = "future_extensions",
-                title = stringResource(R.string.settings_future_extensions),
+                id = "future_ext_ignore_list",
+                title = stringResource(R.string.settings_future_ext_ignore_list),
+            ),
+            futureRow(
+                id = "future_ext_keyword_filters",
+                title = stringResource(R.string.settings_future_ext_keyword_filters),
+            ),
+            futureRow(
+                id = "future_ext_blacklist",
+                title = stringResource(R.string.settings_future_ext_blacklist),
+            ),
+            futureRow(
+                id = "future_ext_color_tag",
+                title = stringResource(R.string.settings_future_ext_color_tag),
+            ),
+            futureRow(
+                id = "future_ext_qualitay",
+                title = stringResource(R.string.settings_future_ext_qualitay),
+            ),
+            futureRow(
+                id = "future_ext_redflag",
+                title = stringResource(R.string.settings_future_ext_redflag),
+            ),
+            futureRow(
+                id = "future_ext_community",
+                title = stringResource(R.string.settings_future_ext_community),
             ),
         ),
     ),
@@ -617,13 +827,40 @@ private fun toggleRow(
     },
 )
 
-/** A planned (not-yet-shipped) row: disabled but still searchable (`enabled = false`). */
+/**
+ * A planned (not-yet-shipped) row: disabled but still searchable (`enabled = false`), carrying a small
+ * « À venir » badge in its trailing slot to make the planned status explicit (cf. [FutureBadge]).
+ */
 private fun futureRow(
     id: String,
     title: String,
 ): SettingsCatalogueRow = SettingsCatalogueRow(
     searchable = SettingsSearchableItem(id = id, title = title, enabled = false),
     render = {
-        RedfaceSettingsListItem(title = title, enabled = false)
+        RedfaceSettingsListItem(
+            title = title,
+            enabled = false,
+            trailingContent = { FutureBadge() },
+        )
     },
 )
+
+/**
+ * The « À venir » pill shown in the trailing slot of a [futureRow]: a sober tonal `Surface` (rounded,
+ * `secondaryContainer`) wrapping a `labelSmall` label. Signals the planned status without competing
+ * with the disabled (greyed) row text.
+ */
+@Composable
+private fun FutureBadge() {
+    Surface(
+        shape = RoundedCornerShape(8.dp),
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+    ) {
+        Text(
+            text = stringResource(R.string.settings_future_badge),
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+        )
+    }
+}

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <!-- #313 — carte « Messages privés » : badge MP non lus. -->
     <string name="settings_mp_title">Notifications</string>
     <string name="settings_mp_unread_badge_title">Badge de MP non lus</string>
-    <string name="settings_mp_unread_badge_description">Affiche le nombre de conversations non lues sur l\'onglet Messages. Actualisé à l\'ouverture de l\'app et à chaque visite de la liste.</string>
+    <string name="settings_mp_unread_badge_description">Nombre de conversations non lues sur l\'onglet Messages.</string>
     <string name="settings_mp_unread_badge_persist_failed">Impossible d\'enregistrer ce réglage pour le moment.</string>
     <string name="settings_section_hfr_account">Compte HFR</string>
     <string name="settings_section_notifications">Notifications</string>
@@ -42,12 +42,10 @@
 
     <!-- #494 v2 — racine « catégories d'abord » : familles, sous-titres de catégories, a11y, écran « À venir ». -->
     <string name="settings_menu_content_description">Menu</string>
-    <string name="settings_category_upcoming_title">À venir</string>
     <string name="settings_family_appearance">Apparence</string>
     <string name="settings_family_communication">Communication</string>
     <string name="settings_family_content">Contenu</string>
     <string name="settings_family_system">Système</string>
-    <string name="settings_family_other">Autres</string>
     <string name="settings_category_subtitle_display">Thème, AMOLED, densité, police</string>
     <string name="settings_category_subtitle_flags">Regroupement, masquer lus, auto-refresh</string>
     <string name="settings_category_subtitle_topic">Barre, sondages, navigation</string>
@@ -57,7 +55,13 @@
     <string name="settings_category_subtitle_start">Écran ouvert au lancement</string>
     <string name="settings_category_subtitle_network">Proxy, vider les caches</string>
     <string name="settings_category_subtitle_account">Compte HFR, version, diagnostics</string>
-    <string name="settings_category_subtitle_upcoming">Fonctionnalités planifiées</string>
+    <!-- #494 — famille « À venir » : 3 catégories distinctes (Notifications, Accessibilité, Extensions). -->
+    <string name="settings_family_upcoming">À venir</string>
+    <string name="settings_category_subtitle_notifications">Push, MP, relève, Ne pas déranger</string>
+    <string name="settings_category_subtitle_accessibility">Contraste, animations, langue</string>
+    <string name="settings_category_subtitle_extensions">Ignorés, filtres, Blacklist, Qualitay</string>
+    <!-- #494 — badge texte affiché en trailing des lignes « à venir » (désactivées mais cherchables). -->
+    <string name="settings_future_badge">À venir</string>
 
     <!-- #494 — lignes de navigation de la racine vers les sous-pages, et titres des sous-pages. -->
     <string name="settings_nav_proxy">Proxy</string>
@@ -90,14 +94,75 @@
     <string name="settings_future_classic_theme">Thème HFR Classique</string>
     <string name="settings_future_flags_on_listing">Poser les drapeaux en listant une catégorie</string>
     <string name="settings_future_prefetch">Préchargement de la page suivante</string>
-    <string name="settings_future_signature">Signature automatique et notification e-mail</string>
-    <string name="settings_future_mp_notifications">Notifications et badge de MP non lus</string>
     <string name="settings_future_data_saver">Mode économie de données</string>
+    <!-- Toujours utilisée par SettingsAccountAboutScreen (sous-page Compte). -->
     <string name="settings_future_hfr_profile">Avatars, signatures, messages par page</string>
-    <string name="settings_future_notifications">Relève configurable, filtres, mode Ne pas déranger</string>
-    <string name="settings_future_timezone">Fuseau horaire d’affichage</string>
-    <string name="settings_future_multilang">Multilingue</string>
-    <string name="settings_future_extensions">Blacklist, Color Tag, ignore-list, Qualitay, Redflag</string>
+
+    <!-- #494 — catalogue exhaustif des options à venir (toggles désactivés mais cherchables).
+         Une string par option du draft drafts/claude-settings-catalogue-v2-options.md. -->
+    <!-- §1 Affichage -->
+    <string name="settings_future_amoled_auto_night">AMOLED automatique la nuit</string>
+    <string name="settings_future_smiley_size">Taille des smileys</string>
+    <string name="settings_future_show_avatars">Afficher les avatars dans les sujets</string>
+    <string name="settings_future_show_signatures">Afficher les signatures</string>
+    <!-- §2 Drapeaux -->
+    <string name="settings_future_flags_sort">Tri des drapeaux</string>
+    <string name="settings_future_flags_mark_read_on_scroll">Marquer lu au survol / défilement</string>
+    <string name="settings_future_flags_by_subcategory">Drapeaux par sous-catégorie</string>
+    <!-- §3 Sujet et lecture -->
+    <string name="settings_future_restore_read_position">Restaurer la position de lecture</string>
+    <string name="settings_future_swipe_page">Changer de page au glissement</string>
+    <string name="settings_future_collapse_quotes">Replier les longues citations</string>
+    <string name="settings_future_open_external_in_app">Ouvrir les liens externes dans l\'app</string>
+    <string name="settings_future_autoplay_animations">Lecture auto des images animées</string>
+    <string name="settings_future_fullscreen_reading">Plein écran en lecture</string>
+    <!-- §4 Messages privés -->
+    <string name="settings_future_mp_push">Notifications de MP</string>
+    <string name="settings_future_mp_preview">Aperçu du message dans la liste</string>
+    <string name="settings_future_mp_read_receipt">Accusé de lecture</string>
+    <!-- §5 Édition et publication -->
+    <string name="settings_future_auto_signature">Signature automatique</string>
+    <string name="settings_future_auto_drafts">Brouillons automatiques</string>
+    <string name="settings_future_recent_smileys">Smileys récents / favoris</string>
+    <string name="settings_future_spell_check">Correcteur orthographique</string>
+    <string name="settings_future_custom_bbcode_toolbar">Barre d\'outils BBCode personnalisable</string>
+    <!-- §6 Images et upload -->
+    <string name="settings_future_compress_upload">Compression avant upload</string>
+    <string name="settings_future_strip_exif">Supprimer les métadonnées (EXIF)</string>
+    <string name="settings_future_upload_wifi_only">Upload uniquement en Wi-Fi</string>
+    <!-- §7 Démarrage -->
+    <string name="settings_future_resume_last_topic">Reprendre le dernier sujet ouvert</string>
+    <!-- §8 Réseau et cache -->
+    <string name="settings_future_prefetch_wifi_only">Préchargement Wi-Fi uniquement</string>
+    <string name="settings_future_image_cache_size">Taille max du cache images</string>
+    <string name="settings_future_clear_cache_on_start">Vider le cache au démarrage</string>
+    <string name="settings_future_offline_mode">Mode hors-ligne</string>
+    <!-- §9 Compte et à propos -->
+    <string name="settings_future_hfr_profile_settings">Réglages du profil HFR</string>
+    <string name="settings_future_multi_account">Multi-comptes</string>
+    <string name="settings_future_auto_logout">Déconnexion automatique</string>
+    <!-- §10 Notifications -->
+    <string name="settings_future_notif_push">Notifications push</string>
+    <string name="settings_future_notif_mp">Notifications de MP</string>
+    <string name="settings_future_notif_mentions">Citations et mentions</string>
+    <string name="settings_future_notif_polling">Relève configurable</string>
+    <string name="settings_future_notif_dnd">Mode Ne pas déranger</string>
+    <string name="settings_future_notif_sound_vibration">Son et vibration</string>
+    <!-- §11 Accessibilité -->
+    <string name="settings_future_a11y_force_system_text">Forcer la taille du texte système</string>
+    <string name="settings_future_a11y_high_contrast">Contraste élevé</string>
+    <string name="settings_future_a11y_reduce_motion">Réduire les animations</string>
+    <string name="settings_future_a11y_timezone">Fuseau horaire d\'affichage</string>
+    <string name="settings_future_a11y_language">Langue de l\'interface</string>
+    <!-- §12 Extensions et filtrage -->
+    <string name="settings_future_ext_ignore_list">Liste d\'ignorés</string>
+    <string name="settings_future_ext_keyword_filters">Filtres par mots-clés</string>
+    <string name="settings_future_ext_blacklist">Blacklist</string>
+    <string name="settings_future_ext_color_tag">Color Tag</string>
+    <string name="settings_future_ext_qualitay">Qualitay</string>
+    <string name="settings_future_ext_redflag">Redflag</string>
+    <string name="settings_future_ext_community">Extensions communautaires</string>
+
     <string name="settings_proxy_title">Proxy utilisateur</string>
     <string name="settings_proxy_intro">Route les requêtes HFR via votre proxy. Le changement peut nécessiter un redémarrage de l’app.</string>
     <string name="settings_proxy_enabled">Activer le proxy</string>
@@ -152,28 +217,28 @@
          observées en direct par l'écran Drapeaux : un changement ici se reflète sans refetch. -->
     <string name="settings_flags_title">Drapeaux</string>
     <string name="settings_flags_group_by_category_title">Grouper par catégorie</string>
-    <string name="settings_flags_group_by_category_description">Affiche les drapeaux regroupés par catégorie de forum, avec un en-tête par catégorie. Désactivé : une liste à plat triée par dernière réponse (comme avant).</string>
+    <string name="settings_flags_group_by_category_description">En-tête par catégorie ; sinon liste à plat.</string>
     <string name="settings_flags_group_by_category_persist_failed">Impossible de mémoriser l\'affichage des drapeaux. Réessayez.</string>
     <string name="settings_flags_hide_read_categories_title">Masquer les catégories sans non-lu</string>
-    <string name="settings_flags_hide_read_categories_description">Cache les catégories qui n\'ont aucun message non lu. Les cyans déjà lus restent accessibles en activant « +lus » sur l\'onglet Mes sujets. Sans effet en vue à plat.</string>
+    <string name="settings_flags_hide_read_categories_description">Cache les catégories sans message non lu. Sans effet en vue à plat.</string>
     <string name="settings_flags_hide_read_categories_persist_failed">Impossible de mémoriser le filtre des catégories. Réessayez.</string>
 
     <!-- #309 — Réglages d'affichage différents par type de drapeau (onglet). Quand activé, les deux
          réglages ci-dessus servent de valeurs par défaut et chaque onglet (Mes sujets / Lu / Favoris)
          garde son propre affichage, ajustable depuis le menu d'affichage de l'écran Drapeaux. -->
     <string name="settings_flags_per_tab_override_title">Réglages différents par onglet</string>
-    <string name="settings_flags_per_tab_override_description">Chaque onglet (Mes sujets, Lu, Favoris) garde son propre affichage. Les réglages ci-dessus deviennent les valeurs par défaut ; ajustez chaque onglet depuis le menu d\'affichage de l\'écran Drapeaux.</string>
+    <string name="settings_flags_per_tab_override_description">Chaque onglet (Mes sujets, Lu, Favoris) garde son propre affichage ; les réglages ci-dessus servent de valeurs par défaut.</string>
     <string name="settings_flags_per_tab_override_persist_failed">Impossible de mémoriser le réglage par onglet. Réessayez.</string>
 
     <!-- Onglet « DT » opt-in dans l'écran Drapeaux (placeholder, synchro MPStorage à venir, #6). -->
     <string name="settings_flags_show_dt_section_title">Section DT</string>
-    <string name="settings_flags_show_dt_section_description">Affiche un onglet « DT » dans l\'écran Drapeaux. Le contenu (discussions suivies avec drapeaux synchronisés via MPStorage) arrivera dans une prochaine version.</string>
+    <string name="settings_flags_show_dt_section_description">Affiche un onglet « DT » dans l\'écran Drapeaux (contenu à venir).</string>
     <string name="settings_flags_show_dt_section_persist_failed">Impossible de mémoriser la section DT. Réessayez.</string>
 
     <!-- #378 — auto-refresh des listes de drapeaux à l'arrivée sur l'écran (ouverture de l'app,
          retour d'un sujet). Activé par défaut ; ce réglage est l'opt-out. -->
     <string name="settings_flags_auto_refresh_title">Actualisation automatique</string>
-    <string name="settings_flags_auto_refresh_description">Rafraîchit la liste des drapeaux à l\'ouverture de l\'app et au retour d\'un sujet. L\'indicateur de rafraîchissement signale l\'actualisation en cours.</string>
+    <string name="settings_flags_auto_refresh_description">Rafraîchit la liste à l\'ouverture de l\'app et au retour d\'un sujet.</string>
     <string name="settings_flags_auto_refresh_persist_failed">Impossible de mémoriser l\'actualisation automatique. Réessayez.</string>
 
     <!-- #286 — Thème. Sélecteur Clair/Système/Sombre (Système = suit l'OS) + thème AMOLED (vrai
@@ -206,17 +271,17 @@
          en défilant vers le bas pour libérer de la place ; persisté en DataStore et appliqué en direct. -->
     <string name="settings_topic_title">Lecture des sujets</string>
     <string name="settings_topic_topbar_auto_hide_title">Masquer la barre en défilant</string>
-    <string name="settings_topic_topbar_auto_hide_description">La barre du haut (titre du sujet et numéro de page) disparaît quand vous faites défiler vers le bas et réapparaît dès que vous remontez.</string>
+    <string name="settings_topic_topbar_auto_hide_description">La barre du haut disparaît en défilant vers le bas, réapparaît en remontant.</string>
     <string name="settings_topic_topbar_auto_hide_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
 
     <!-- #383 — Boutons flottants ‹/› de changement de page (#283). Le swipe (#282) couvre déjà le
          changement de page ; ce réglage est l'opt-out demandé en bêta. « Répondre » reste affiché. -->
     <string name="settings_topic_page_fabs_title">Boutons de changement de page</string>
-    <string name="settings_topic_page_fabs_description">Affiche les boutons flottants ‹ et › en bas du sujet. Désactivez-les si vous changez de page au glissement ; le bouton Répondre reste affiché.</string>
+    <string name="settings_topic_page_fabs_description">Boutons flottants ‹ et › en bas du sujet ; le bouton Répondre reste affiché.</string>
     <string name="settings_topic_page_fabs_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
     <!-- #456 — sondages dépliés par défaut dans la lecture de sujet. -->
     <string name="settings_topic_polls_expanded_title">Déplier les sondages</string>
-    <string name="settings_topic_polls_expanded_description">Affiche les sondages dépliés en haut des sujets. Désactivé : une ligne « Sondage » repliée, à déplier d\'un appui.</string>
+    <string name="settings_topic_polls_expanded_description">Sondages dépliés en haut des sujets ; sinon une ligne repliée.</string>
     <string name="settings_topic_polls_expanded_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
 
     <!-- #312 — Publication. Confirmation avant chaque envoi (réponse/édition de message, sujet,
@@ -225,7 +290,7 @@
          toggles actifs. -->
     <string name="settings_editing_title">Publication</string>
     <string name="settings_confirm_before_posting_title">Confirmation avant publication</string>
-    <string name="settings_confirm_before_posting_description">Demande une confirmation avant d\'envoyer une réponse, un sujet ou un message privé.</string>
+    <string name="settings_confirm_before_posting_description">Avant chaque réponse, sujet ou MP envoyé.</string>
     <string name="settings_confirm_before_posting_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
 
     <!-- #459 PR3 — entrée vers l'écran « Mes images uploadées » depuis le catalogue de réglages. -->

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsCategoriesTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsCategoriesTest.kt
@@ -8,7 +8,9 @@ import org.junit.Test
 /**
  * #494 v2 — contrat de routage de la racine « catégories d'abord » : les catégories adossées à une
  * sous-page dédiée y mènent directement, les autres ouvrent le détail générique ; le mapping
- * catégorie → section(s) du catalogue est figé (notamment « À venir » qui agrège 3 sections futures).
+ * catégorie → section du catalogue est l'identité (id-catégorie == id-section). Les 3 catégories « à
+ * venir » (Notifications/Accessibilité/Extensions) sont désormais distinctes, plus une « À venir »
+ * fourre-tout.
  */
 class SettingsCategoriesTest {
 
@@ -48,7 +50,11 @@ class SettingsCategoriesTest {
 
     @Test
     fun `other categories open the generic detail with their id`() {
-        for (id in listOf("flags", "topic", "mp", "editing", "start", "network", "upcoming")) {
+        val generic = listOf(
+            "flags", "topic", "mp", "editing", "start", "network",
+            "notifications", "accessibility", "extensions",
+        )
+        for (id in generic) {
             with(Spy()) {
                 route(id)
                 assertEquals(id, category)
@@ -58,8 +64,10 @@ class SettingsCategoriesTest {
     }
 
     @Test
-    fun `upcoming aggregates the three future sections`() {
-        assertEquals(listOf("notifications", "accessibility", "extensions"), sectionIdsForCategory("upcoming"))
+    fun `the three future categories map to their own homonymous section`() {
+        assertEquals(listOf("notifications"), sectionIdsForCategory("notifications"))
+        assertEquals(listOf("accessibility"), sectionIdsForCategory("accessibility"))
+        assertEquals(listOf("extensions"), sectionIdsForCategory("extensions"))
     }
 
     @Test
@@ -70,7 +78,11 @@ class SettingsCategoriesTest {
 
     @Test
     fun `every category title resolves to a non-zero resource`() {
-        for (id in listOf("network", "start", "flags", "topic", "editing", "mp", "upcoming")) {
+        val ids = listOf(
+            "network", "start", "flags", "topic", "editing", "mp",
+            "notifications", "accessibility", "extensions",
+        )
+        for (id in ids) {
             assertTrue("title res for $id", categoryTitleRes(id) != 0)
         }
     }


### PR DESCRIPTION
## Quoi

Refonte de la **liste d'options** des réglages (#494), d'après le draft validé par @XaTriX et 3 arbitrages produit.

### Options « À venir » exhaustives
**56 options planifiées** ajoutées en **toggle désactivé** (grisé, mais **cherchables** `enabled=false`), couvrant toutes les évolutions plausibles, réparties dans leurs sections : Affichage (7), Drapeaux (4), Sujet/lecture (7), MP (3), Édition (5), Images (3), Démarrage (1), Réseau (5), Compte (3), Notifications (6), Accessibilité (5), Extensions (7).

### 3 arbitrages (tranchés par @XaTriX)
1. **Notifications / Accessibilité / Extensions = 3 vraies catégories** à la racine (famille « À venir »), au lieu d'une catégorie fourre-tout. `sectionIdsForCategory` simplifié en identité, `categoryTitleRes` + test alignés.
2. **Badge texte « À venir »** (`FutureBadge` : `Surface` tonale arrondie + `labelSmall`) en trailing des lignes désactivées.
3. **Tout en toggle désactivé** (uniforme, même les futurs « choix »).

### Microcopie épurée
Descriptions des toggles raccourcies/clarifiées ; les `keywords` de recherche des nav rows sont **préservés** (pas de régression de recherche).

## Limite connue (suivi à part)
Les options « À venir » des catégories adossées à une **sous-page dédiée** (Affichage / Images / Compte) restent **cherchables** mais ne s'affichent **pas** en naviguant ces sous-pages (elles ont leur propre UI, hors catalogue générique). Les 43 autres (catégories à détail générique) s'affichent bien. Un suivi ajoutera les « À venir » dans ces 3 sous-pages.

## Validation
- Machine B : `detektAll :app:assembleDevDebug :app:lintDevDebug :feature:settings:lintDebug :core:ui:testDebugUnitTest :feature:settings:testDebugUnitTest` → **BUILD SUCCESSFUL**.
- Revue Codex (gpt-5.5) : aucun problème de correction.
- Rendu Roborazzi de la racine OK (12 catégories, microcopie raccourcie).
- Implémentation initiale par agent dédié (code-only), relue + validée + buildée par l'orchestrateur.

> Action par Claude Opus 4.8 (demandée par @XaTriX)