### PR TITLE
feat(ui): search app bar translucide au scroll + scrim (#494)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/RedfaceSearchAppBar.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/RedfaceSearchAppBar.kt
@@ -25,6 +25,9 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.ui.R
 
+/** Opacité du conteneur de la barre au scroll : translucide pour laisser deviner le contenu dessous. */
+private const val SEARCH_BAR_ELEVATED_ALPHA = 0.94f
+
 /**
  * #494 v2 — Search app bar (docked search bar M3) du shell de configuration : icône menu (hamburger,
  * rôle à définir) · champ de recherche cliquable · avatar de compte. Custom STABLE (Surface + Row +
@@ -52,9 +55,13 @@ fun RedfaceSearchAppBar(
     elevated: Boolean = false,
     avatar: @Composable () -> Unit = { DefaultAvatarPlaceholder() },
 ) {
+    // Au scroll, le conteneur passe à surfaceContainer LÉGÈREMENT translucide : on devine le contenu
+    // qui glisse derrière (l'effet « voir le texte passer dessous »), sans nuire à la lisibilité — le
+    // pill de recherche, lui, reste opaque (surfaceContainerHigh). Au repos : surface opaque (rien
+    // dessous). Pas de flou (non-standard M3, fragile en Compose) : translucidité + scrim (cf. shell).
     val containerColor by animateColorAsState(
         targetValue = if (elevated) {
-            MaterialTheme.colorScheme.surfaceContainer
+            MaterialTheme.colorScheme.surfaceContainer.copy(alpha = SEARCH_BAR_ELEVATED_ALPHA)
         } else {
             MaterialTheme.colorScheme.surface
         },

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeScreen.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeScreen.kt
@@ -1,12 +1,15 @@
 package fr.forumhfr.redface2.core.ui.settings.shell
 
 import androidx.annotation.DrawableRes
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -27,10 +30,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.ui.R
 
@@ -136,6 +142,21 @@ fun SettingsHomeScreen(
                 )
             }
         }
+        // Scrim : juste sous la barre, un court dégradé surfaceContainer → transparent qui fond le
+        // contenu émergeant de dessous la barre (pas de coupure nette). N'apparaît qu'à l'élévation.
+        val scrimAlpha by animateFloatAsState(
+            targetValue = if (barElevated) 1f else 0f,
+            label = "searchBarScrim",
+        )
+        val scrimTop = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = scrimAlpha)
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .fillMaxWidth()
+                .offset { IntOffset(0, barHeightPx) }
+                .height(24.dp)
+                .background(Brush.verticalGradient(listOf(scrimTop, Color.Transparent))),
+        )
     }
 }
 


### PR DESCRIPTION
## Quoi

Rend **visible** l'effet « contenu sous la search app bar » (retour @XaTriX : le fond opaque livré en build 140 cachait le contenu qui passait pourtant déjà derrière). Idiome M3, **pas de flou** (techniquement fragile en Compose + non-standard) :

- **`RedfaceSearchAppBar`** : au scroll (`elevated`), le conteneur passe à `surfaceContainer` **légèrement translucide** (alpha 0.94) → on devine le contenu qui glisse derrière. Le **pill de recherche reste opaque** (lisibilité). Au repos : `surface` opaque.
- **`SettingsHomeScreen`** : court **scrim** (dégradé `surfaceContainer`→transparent, 24 dp) juste sous la barre, animé avec l'élévation → fond le contenu émergeant de dessous la barre (plus de coupure nette).

## Choix de conception (Claude + Codex gpt-5.5)
- **Flou frosted glass écarté** : `Modifier.blur`/`RenderEffect` floutent le composant, pas l'arrière-plan ; flouter le contenu derrière une `LazyColumn` qui scrolle = fragile + coûteux + fallback API 29-30 divergent.
- **Barre extensible/collapsante** (Large/Medium TopAppBar, « cadre qui s'agrandit ») tracée en **#516** pour exploration/tests ultérieurs.

## Validation
- Machine B : `detektAll :app:assembleDevDebug :core:ui:lintDebug :core:ui:testDebugUnitTest` → **BUILD SUCCESSFUL**.
- Revue Codex : aucun problème de correction.
- ⚠️ Effet dynamique (au scroll) non visible sur frame Roborazzi statique ; se constate sur le build dev.

> Action par Claude Opus 4.8 (demandée par @XaTriX)