### PR TITLE
fix(parser): lignes vides `&nbsp;` orphelines entre paragraphes (#466)

### DIFF
--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
@@ -41,6 +41,14 @@ class PostContentParser {
         val blocks = mutableListOf<PostBlock>()
         val paragraph = mutableListOf<PostInline>()
 
+        // #466 (Codex review) — true ONLY while [paragraph]'s tail is the inline body of a CLOSED
+        // inline-only <p> with nothing appended after it, kept buffered so a FOLLOWING <p> can still
+        // merge with it. Any other sibling closes the merge window: an inline-classified <ul> or a
+        // block flushes the buffered <p> as its own paragraph (the sibling is not appended to it),
+        // and a top-level <br> appends its LineBreak but clears this flag (the extended buffer is no
+        // longer a pristine <p> body, so the next <p> must not merge with it).
+        var pendingParagraph = false
+
         fun flushParagraph() {
             // #333 — trim breaks and blank fragments at the paragraph EDGES only: breaks adjacent
             // to a block boundary (quote, image, end of post) duplicate the renderer's inter-block
@@ -53,6 +61,7 @@ class PostContentParser {
                 blocks += PostBlock.Paragraph(cleaned)
             }
             paragraph.clear()
+            pendingParagraph = false
         }
 
         // #466 — count of orphan `&nbsp;` (U+00A0) carried by the last top-level whitespace-only
@@ -75,6 +84,12 @@ class PostContentParser {
                 NodeKind.LINE_BREAK -> {
                     paragraph += PostInline.LineBreak
                     pendingNbsp = 0
+                    // A top-level <br> appended after a buffered closed <p> EXTENDS the running
+                    // paragraph, so the buffer is no longer a pristine inline-only <p> body: a
+                    // FOLLOWING <p> must NOT merge with it (`<p>A</p><br>&nbsp;&nbsp;<p>B</p>` stays
+                    // two blocks, matching legacy — the break is a non-<p> sibling that closes the
+                    // merge window, #466 Codex review). The break itself stays for web parity (#280).
+                    pendingParagraph = false
                 }
 
                 NodeKind.QUOTE -> {
@@ -110,12 +125,31 @@ class PostContentParser {
                 NodeKind.BLANK_TEXT -> pendingNbsp = orphanNbspCount(node as TextNode)
 
                 NodeKind.INLINE -> {
+                    if (pendingParagraph) {
+                        // A buffered closed <p> followed by a non-<p> inline sibling (HFR emits
+                        // `</p>&nbsp;<ul>…`): close the <p> as its own paragraph and drop the lone
+                        // separator — do NOT run the list/inline content into it (#466 Codex review).
+                        flushParagraph()
+                        pendingNbsp = 0
+                    } else if (pendingNbsp > 0) {
+                        // A pending `&nbsp;` between two plain inline siblings is genuine word spacing,
+                        // not a paragraph separator: keep it so `<a>one</a>&nbsp;<a>two</a>` reads
+                        // "one two", not "onetwo" (#466 Codex review).
+                        paragraph += PostInline.Text(" ")
+                        pendingNbsp = 0
+                    }
                     paragraph += parseInline(node)
-                    pendingNbsp = 0
                 }
 
                 NodeKind.PARAGRAPH_CONTAINER -> {
-                    parseParagraphContainer(node as Element, blocks, paragraph, pendingNbsp, ::flushParagraph)
+                    pendingParagraph = parseParagraphContainer(
+                        element = node as Element,
+                        blocks = blocks,
+                        paragraph = paragraph,
+                        pendingNbsp = pendingNbsp,
+                        pendingParagraph = pendingParagraph,
+                        flushParagraph = ::flushParagraph,
+                    )
                     pendingNbsp = 0
                 }
             }
@@ -148,21 +182,35 @@ class PostContentParser {
      * A `<p>` that does carry a nested block keeps the legacy path: flush, then sub-parse so the
      * inner block surfaces.
      */
+    @Suppress("LongParameterList") // shares parseBlocks' mutable state (blocks/paragraph) + the merge
+    // inputs (pendingNbsp/pendingParagraph) and its flush closure; a wrapper object would only hide it.
     private fun parseParagraphContainer(
         element: Element,
         blocks: MutableList<PostBlock>,
         paragraph: MutableList<PostInline>,
         pendingNbsp: Int,
+        pendingParagraph: Boolean,
         flushParagraph: () -> Unit,
-    ) {
+    ): Boolean {
         val children = element.childNodes()
         if (children.any { isBlockNode(it) }) {
+            // Legacy path: a <p> carrying a nested block is flushed + sub-parsed, leaving nothing
+            // buffered to merge with — return false so the caller does not treat it as a pending <p>.
             flushParagraph()
             blocks += parseBlocks(children)
-            return
+            return false
         }
-        val mergeable = pendingNbsp >= 2 && paragraph.any { it.isNonBlank() }
+        // Only fold the `&nbsp;` separator into empty lines when the buffer is genuinely the body of
+        // a PREVIOUS inline-only <p> ([pendingParagraph]) — NOT arbitrary buffered inline content.
+        // `<strong>A</strong>&nbsp;&nbsp;<p>B</p>` must stay two blocks, not merge (#466 Codex review).
+        val mergeable = pendingNbsp >= 2 && pendingParagraph && paragraph.any { it.isNonBlank() }
         if (mergeable) {
+            // #466 (Codex review) — drop a trailing border <br> on the first paragraph so its edge
+            // break does not pile onto the separator breaks below (the legacy sub-parse edge-trimmed
+            // it via flushParagraph). Only the separator + the paragraphs' INTERIOR breaks remain.
+            while (paragraph.isNotEmpty() && paragraph.last().isBlankOrBreak()) {
+                paragraph.removeAt(paragraph.lastIndex)
+            }
             repeat(pendingNbsp) { paragraph += PostInline.LineBreak }
         } else {
             // Close the previous paragraph as its own block, then accumulate this <p>'s inline
@@ -171,14 +219,22 @@ class PostContentParser {
         }
         // Accumulate the <p> body inline, honouring the same per-node classification as the block
         // path: a nested <br> stays a LineBreak and an ignored node (e.g. a `clear: both` spacer
-        // div) is dropped, so the merged paragraph matches what the legacy sub-parse produced.
-        children.forEach { child ->
-            when (classifyNode(child)) {
-                NodeKind.IGNORE -> Unit
-                NodeKind.LINE_BREAK -> paragraph += PostInline.LineBreak
-                else -> paragraph += parseInline(child)
+        // div) is dropped. EDGE-trim leading/trailing breaks (#466 Codex review): the real fixture
+        // has `<p><br />Pour…`, whose leading border <br> would otherwise render an extra empty line
+        // — only INTERIOR breaks (the author's line structure) survive, matching flushParagraph #333.
+        val merged = buildList {
+            children.forEach { child ->
+                when (classifyNode(child)) {
+                    NodeKind.IGNORE -> Unit
+                    NodeKind.LINE_BREAK -> add(PostInline.LineBreak)
+                    else -> addAll(parseInline(child))
+                }
             }
-        }
+        }.dropWhile { it.isBlankOrBreak() }.dropLastWhile { it.isBlankOrBreak() }
+        paragraph += merged
+        // The buffer now holds this inline-only <p>'s body: a following <p> may still merge with it,
+        // so report it as pending (the caller closes it if the next sibling is not a <p>).
+        return true
     }
 
     /** #466 — a top-level text node made solely of whitespace carries its U+00A0 (`&nbsp;`) count. */

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
@@ -36,6 +36,7 @@ class PostContentParser {
         blocks = listOf(PostBlock.Paragraph(listOf(PostInline.Text(DELETED_PLACEHOLDER)))),
     )
 
+    @Suppress("CyclomaticComplexMethod")
     private fun parseBlocks(nodes: List<Node>): List<PostBlock> {
         val blocks = mutableListOf<PostBlock>()
         val paragraph = mutableListOf<PostInline>()
@@ -54,6 +55,14 @@ class PostContentParser {
             paragraph.clear()
         }
 
+        // #466 — count of orphan `&nbsp;` (U+00A0) carried by the last top-level whitespace-only
+        // text node, kept pending until we know what follows it. HFR always emits at LEAST one
+        // `&nbsp;` between two sibling <p> (the structural paragraph separator, ~all pages), and
+        // an EXTRA `&nbsp;` for each blank line the author typed in between. So a run of N drives
+        // (N - 1) rendered empty lines ; a lone separator (N == 1) keeps the current behaviour
+        // (two distinct Paragraph blocks). See `parseParagraphContainer`.
+        var pendingNbsp = 0
+
         nodes.forEach { node ->
             when (classifyNode(node)) {
                 NodeKind.IGNORE -> Unit
@@ -63,38 +72,51 @@ class PostContentParser {
                 // renderer's 8dp inter-block gap replaced the natural line height between every
                 // line (#280). A top-level break is now an inline LineBreak INSIDE the running
                 // paragraph — web parity: N consecutive breaks render N newlines.
-                NodeKind.LINE_BREAK -> paragraph += PostInline.LineBreak
+                NodeKind.LINE_BREAK -> {
+                    paragraph += PostInline.LineBreak
+                    pendingNbsp = 0
+                }
 
                 NodeKind.QUOTE -> {
                     flushParagraph()
+                    pendingNbsp = 0
                     parseQuote(node as Element)?.let(blocks::add)
                 }
 
                 NodeKind.SPOILER -> {
                     flushParagraph()
+                    pendingNbsp = 0
                     parseSpoiler(node as Element)?.let(blocks::add)
                 }
 
                 NodeKind.IMAGE_BLOCK -> {
                     flushParagraph()
+                    pendingNbsp = 0
                     parseImageBlock(node as Element)?.let(blocks::add)
                 }
 
                 NodeKind.FIXED_BLOCK -> {
                     flushParagraph()
+                    pendingNbsp = 0
                     parseFixedBlock(node as Element)?.let(blocks::add)
                 }
 
                 NodeKind.CODE_BLOCK -> {
                     flushParagraph()
+                    pendingNbsp = 0
                     parseCodeBlock(node as Element)?.let(blocks::add)
                 }
 
-                NodeKind.INLINE -> paragraph += parseInline(node)
+                NodeKind.BLANK_TEXT -> pendingNbsp = orphanNbspCount(node as TextNode)
+
+                NodeKind.INLINE -> {
+                    paragraph += parseInline(node)
+                    pendingNbsp = 0
+                }
 
                 NodeKind.PARAGRAPH_CONTAINER -> {
-                    flushParagraph()
-                    blocks += parseBlocks((node as Element).childNodes())
+                    parseParagraphContainer(node as Element, blocks, paragraph, pendingNbsp, ::flushParagraph)
+                    pendingNbsp = 0
                 }
             }
         }
@@ -103,8 +125,76 @@ class PostContentParser {
         return blocks
     }
 
+    /**
+     * #466 — folds the orphan `&nbsp;` run separating two `<p>` into rendered empty lines.
+     *
+     * HFR encodes a deliberate blank line BETWEEN two paragraphs as an EXTRA `&nbsp;` in the
+     * orphan text node separating the two `<p>` (the very first `&nbsp;` is the structural
+     * separator HFR always emits between any two sibling `<p>`). The parser used to swallow that
+     * whitespace and emit each `<p>` as its own Paragraph block, losing the empty lines (the
+     * "lignes sautées" bug, suite of #333/#280 — the earlier fix only covered the
+     * `<br />&nbsp;<br />` shape, not the `</p>&nbsp;…&nbsp;<p>` one).
+     *
+     * An inline-only `<p>` (HFR never nests a block table/container directly inside a `<p>`,
+     * verified across the fixtures) is accumulated into the running paragraph buffer rather than
+     * sub-parsed, so the NEXT `<p>` can decide to merge with it:
+     *  - when at least one EXTRA `&nbsp;` is pending (run ≥ 2) and the running paragraph already
+     *    holds real content, the boundary is kept inside ONE paragraph as [pendingNbsp] LineBreaks
+     *    — one for the paragraph boundary itself plus (pendingNbsp - 1) for the authored empty
+     *    lines. They sit strictly between two text runs, so the #333 edge-trim never touches them.
+     *  - otherwise (lone `&nbsp;` separator, or an empty running paragraph) the running paragraph
+     *    is flushed first, so two ordinary paragraphs stay two distinct Paragraph blocks as before.
+     *
+     * A `<p>` that does carry a nested block keeps the legacy path: flush, then sub-parse so the
+     * inner block surfaces.
+     */
+    private fun parseParagraphContainer(
+        element: Element,
+        blocks: MutableList<PostBlock>,
+        paragraph: MutableList<PostInline>,
+        pendingNbsp: Int,
+        flushParagraph: () -> Unit,
+    ) {
+        val children = element.childNodes()
+        if (children.any { isBlockNode(it) }) {
+            flushParagraph()
+            blocks += parseBlocks(children)
+            return
+        }
+        val mergeable = pendingNbsp >= 2 && paragraph.any { it.isNonBlank() }
+        if (mergeable) {
+            repeat(pendingNbsp) { paragraph += PostInline.LineBreak }
+        } else {
+            // Close the previous paragraph as its own block, then accumulate this <p>'s inline
+            // content into the now-empty buffer so a following <p> can still merge with it (#466).
+            flushParagraph()
+        }
+        // Accumulate the <p> body inline, honouring the same per-node classification as the block
+        // path: a nested <br> stays a LineBreak and an ignored node (e.g. a `clear: both` spacer
+        // div) is dropped, so the merged paragraph matches what the legacy sub-parse produced.
+        children.forEach { child ->
+            when (classifyNode(child)) {
+                NodeKind.IGNORE -> Unit
+                NodeKind.LINE_BREAK -> paragraph += PostInline.LineBreak
+                else -> paragraph += parseInline(child)
+            }
+        }
+    }
+
+    /** #466 — a top-level text node made solely of whitespace carries its U+00A0 (`&nbsp;`) count. */
+    private fun orphanNbspCount(node: TextNode): Int =
+        node.wholeText.count { it == NBSP }
+
+    /** #466 — true when [node] would be parsed as a block (so a `<p>` wrapping it can't be merged). */
+    private fun isBlockNode(node: Node): Boolean = when (classifyNode(node)) {
+        NodeKind.QUOTE, NodeKind.SPOILER, NodeKind.IMAGE_BLOCK,
+        NodeKind.FIXED_BLOCK, NodeKind.CODE_BLOCK, NodeKind.PARAGRAPH_CONTAINER -> true
+
+        else -> false
+    }
+
     private fun classifyNode(node: Node): NodeKind {
-        val element = (node as? Element) ?: return if (node is TextNode) NodeKind.INLINE else NodeKind.IGNORE
+        val element = (node as? Element) ?: return classifyNonElement(node)
         return when (element.tagName()) {
             "br" -> NodeKind.LINE_BREAK
             "div" -> classifyDiv(element)
@@ -117,6 +207,17 @@ class PostContentParser {
             "table" -> classifyTable(element)
             else -> NodeKind.INLINE
         }
+    }
+
+    private fun classifyNonElement(node: Node): NodeKind = when {
+        node !is TextNode -> NodeKind.IGNORE
+        // #466 — a whitespace-only text node carrying at least one `&nbsp;` (U+00A0) is HFR's
+        // inter-paragraph separator, possibly inflated with one extra `&nbsp;` per authored empty
+        // line. It is BLANK_TEXT so parseBlocks can fold the run into rendered line breaks instead
+        // of swallowing it. A whitespace text node WITHOUT `&nbsp;` stays INLINE: it is genuine
+        // word spacing inside a paragraph and must survive between two text runs.
+        node.wholeText.isBlank() && node.wholeText.any { it == NBSP } -> NodeKind.BLANK_TEXT
+        else -> NodeKind.INLINE
     }
 
     private fun classifyDiv(element: Element): NodeKind {
@@ -486,11 +587,18 @@ class PostContentParser {
         FIXED_BLOCK,
         CODE_BLOCK,
         INLINE,
+
+        /** #466 — a whitespace-only orphan text node carrying `&nbsp;` separators. */
+        BLANK_TEXT,
         PARAGRAPH_CONTAINER,
     }
 
     private companion object {
         const val DELETED_PLACEHOLDER = "[Message supprimé]"
+
+        // #466 — non-breaking space (U+00A0). HFR encodes inter-paragraph blank lines as runs of
+        // `&nbsp;` between sibling <p>; Jsoup keeps them as this literal char until normalizeText.
+        const val NBSP = '\u00A0'
 
         val WHITESPACE_REGEX = Regex("\\s+")
         val HEX_REGEX = Regex("[0-9a-fA-F]+")

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
@@ -403,6 +403,117 @@ class PostContentParserTest {
     }
 
     @Test
+    fun `orphan nbsp runs between paragraphs survive as empty lines (real fixture)`() {
+        // #466 — suite of #333/#280. HFR encodes a deliberate blank line BETWEEN two paragraphs
+        // not as `<br /><br />` (the shape #423 already handled) but as an EXTRA `&nbsp;` inside
+        // the orphan text node separating two sibling <p>. Real witness on the single-page topic
+        // (post #9762063, captured fixture): `…C'est normal.</p>&nbsp;&nbsp;&nbsp;<p><br />Pour
+        // trouver une solution…</p>` — 3 `&nbsp;` between the two paragraphs. The parser used to
+        // swallow that whitespace and emit two separate Paragraph blocks, losing the blank lines.
+        val topic = pageParser.parse(fixture("topic_page_single.html"))
+
+        // Anchor on the UNIQUE authored second line "Pour trouver une solution". There are two
+        // "C'est normal." occurrences in the fixture and only the second precedes the triple-nbsp
+        // run, so anchoring on "C'est normal." picks the wrong (single-separator) paragraph. After
+        // the fix, the second <p> folds INTO the preceding paragraph, so the paragraph holding
+        // "Pour trouver une solution" also holds "C'est normal.", with the blank lines as LineBreaks.
+        val paragraph = topic.posts
+            .flatMap { it.content.allBlocks() }
+            .filterIsInstance<PostBlock.Paragraph>()
+            .firstOrNull { block ->
+                block.inlines.filterIsInstance<PostInline.Text>()
+                    .any { it.value.contains("Pour trouver une solution") }
+            }
+
+        assertNotNull("fixture should contain the folded paragraph", paragraph)
+        assertTrue(
+            "the line before the orphan-nbsp run must merge into the same paragraph, " +
+                "got=${paragraph!!.inlines}",
+            paragraph.inlines.filterIsInstance<PostInline.Text>()
+                .any { it.value.contains("C'est normal.") },
+        )
+        // The triple `&nbsp;` run folds into blank lines (>= 2 LineBreaks) between the two authored
+        // lines; the exact count for a bare run is pinned by the synthetic test below. A lone
+        // `&nbsp;` separator never folds, so >= 2 here proves the multi-nbsp blank lines survived.
+        val breaksBetween = run {
+            val inlines = paragraph.inlines
+            val from = inlines.indexOfLast {
+                it is PostInline.Text && it.value.contains("C'est normal.")
+            }
+            val to = inlines.indexOfFirst {
+                it is PostInline.Text && it.value.contains("Pour trouver une solution")
+            }
+            inlines.subList(from + 1, to).count { it is PostInline.LineBreak }
+        }
+        assertTrue(
+            "the triple orphan &nbsp; run must yield at least 2 LineBreaks between the lines, " +
+                "got=$breaksBetween",
+            breaksBetween >= 2,
+        )
+    }
+
+    @Test
+    fun `single orphan nbsp between paragraphs stays two separate blocks`() {
+        // #466 guard — a LONE `&nbsp;` between two <p> is HFR's normal paragraph separator (it is
+        // present between ~every pair of sibling <p>), NOT an authored blank line. Folding it in
+        // would add a spurious empty line to virtually every multi-paragraph post, so the parser
+        // must keep two distinct Paragraph blocks in that case (legacy behaviour preserved).
+        //
+        // NOTE: this HTML input is DERIVED FROM THE ISSUE #466 encoding (`</p>&nbsp;<p>`), not a
+        // raw hfr-mcp capture — it isolates the single-separator boundary so the fix can be pinned
+        // without depending on a fixture that happens to contain exactly two adjacent <p>. The
+        // real `</p>&nbsp;&nbsp;&nbsp;<p>` multi-run case is covered by the fixture test above.
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            "<div id=\"para1\"><p>premier paragraphe</p>&nbsp;<p>second paragraphe</p></div>",
+        )
+
+        val result = parser.parse(element)
+
+        val paragraphs = result.ast.blocks.filterIsInstance<PostBlock.Paragraph>()
+        assertEquals(
+            "a lone &nbsp; separator must keep two distinct Paragraph blocks, got=${result.ast.blocks}",
+            2,
+            paragraphs.size,
+        )
+        assertEquals("premier paragraphe", (paragraphs[0].inlines.single() as PostInline.Text).value)
+        assertEquals("second paragraphe", (paragraphs[1].inlines.single() as PostInline.Text).value)
+    }
+
+    @Test
+    fun `multiple orphan nbsp between paragraphs fold into one paragraph with empty lines`() {
+        // #466 — focused boundary check on the EXACT encoding documented in the issue:
+        // `<p>A</p>&nbsp;&nbsp;&nbsp;<p>B</p>` (3 orphan `&nbsp;`). DERIVED FROM THE ISSUE #466
+        // encoding, not a raw hfr-mcp capture (the real multi-run shape is also pinned by the
+        // `topic_page_single.html` fixture test above). A run of 3 ⇒ one paragraph boundary +
+        // two authored empty lines, kept as 3 LineBreaks inside ONE paragraph.
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            "<div id=\"para1\"><p>A</p>&nbsp;&nbsp;&nbsp;<p>B</p></div>",
+        )
+
+        val result = parser.parse(element)
+
+        val paragraphs = result.ast.blocks.filterIsInstance<PostBlock.Paragraph>()
+        assertEquals(
+            "the two paragraphs separated by a >=2 nbsp run must merge into ONE block, got=${result.ast.blocks}",
+            1,
+            paragraphs.size,
+        )
+        assertEquals(
+            "3 orphan &nbsp; fold into 3 LineBreaks between A and B (1 boundary + 2 empty lines)",
+            listOf(
+                PostInline.Text("A"),
+                PostInline.LineBreak,
+                PostInline.LineBreak,
+                PostInline.LineBreak,
+                PostInline.Text("B"),
+            ),
+            paragraphs.single().inlines,
+        )
+    }
+
+    @Test
     fun `breaks adjacent to block boundaries never leak to paragraph edges`() {
         // #333 — edge-trim invariant over real pages. The fixtures carry both directions:
         // `a écrit :</a></b><br /><br /><p>…` (leading, quote header, topic_page_single) and

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
@@ -445,10 +445,150 @@ class PostContentParserTest {
             }
             inlines.subList(from + 1, to).count { it is PostInline.LineBreak }
         }
-        assertTrue(
-            "the triple orphan &nbsp; run must yield at least 2 LineBreaks between the lines, " +
+        // EXACTLY 3: the triple `&nbsp;` run yields 3 separator breaks (1 boundary + 2 empty lines).
+        // The second <p> opens with a border `<br />` (`<p><br />Pour…`) which must be edge-trimmed
+        // (#466 Codex review) — were it kept it would push this to 4 and render a spurious 3rd empty
+        // line. Pinning the exact count guards that border-break trim on the real fixture.
+        assertEquals(
+            "the triple orphan &nbsp; run must yield EXACTLY 3 LineBreaks (border <br> trimmed), " +
                 "got=$breaksBetween",
-            breaksBetween >= 2,
+            3,
+            breaksBetween,
+        )
+    }
+
+    @Test
+    fun `orphan nbsp between two inline nodes stays word spacing not a separator - 466 codex`() {
+        // #466 (Codex review) — a `&nbsp;` whitespace text node is HFR's inter-<p> separator ONLY
+        // when a <p> follows it. Between two inline siblings it is genuine word spacing; the parser
+        // used to drop it, concatenating `<strong>A</strong>&nbsp;<strong>B</strong>` with no space.
+        // DERIVED FROM THE issue/Codex example, not a raw hfr-mcp capture.
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            "<div id=\"para1\"><strong>A</strong>&nbsp;<strong>B</strong></div>",
+        )
+
+        val result = parser.parse(element)
+
+        val inlines = result.ast.blocks.filterIsInstance<PostBlock.Paragraph>().single().inlines
+        assertTrue(
+            "the &nbsp; between two inline nodes must survive as a spacing Text, got=$inlines",
+            inlines.any { it is PostInline.Text && it.value == " " },
+        )
+    }
+
+    @Test
+    fun `merging paragraphs trims border breaks but keeps separator breaks - 466 codex`() {
+        // #466 (Codex review) — when two <p> merge over a >=2 `&nbsp;` run, a trailing `<br>` on the
+        // first <p> and a leading `<br>` on the second are BORDER breaks (the legacy sub-parse
+        // edge-trimmed them via flushParagraph). Only the separator breaks (here 2) plus any INTERIOR
+        // break survive. DERIVED FROM the issue #466 encoding, not a raw hfr-mcp capture.
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            "<div id=\"para1\"><p>A<br /></p>&nbsp;&nbsp;<p><br />B</p></div>",
+        )
+
+        val result = parser.parse(element)
+
+        val paragraphs = result.ast.blocks.filterIsInstance<PostBlock.Paragraph>()
+        assertEquals(
+            "the two paragraphs must merge into ONE block, got=${result.ast.blocks}",
+            1,
+            paragraphs.size,
+        )
+        assertEquals(
+            "2 orphan &nbsp; ⇒ 2 separator LineBreaks; the border <br>s of both <p> are trimmed",
+            listOf(
+                PostInline.Text("A"),
+                PostInline.LineBreak,
+                PostInline.LineBreak,
+                PostInline.Text("B"),
+            ),
+            paragraphs.single().inlines,
+        )
+    }
+
+    @Test
+    fun `lone nbsp between a paragraph and an inline-classified list keeps them separate - 466 codex`() {
+        // #466 (Codex review) — HFR emits `</p>&nbsp;<ul>…` where <ul> is classified INLINE. The
+        // buffered inline-only <p> must be CLOSED at its boundary, NOT have the list content run into
+        // it. DERIVED FROM the Codex example, not a raw hfr-mcp capture.
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            "<div id=\"para1\"><p>intro</p>&nbsp;<ul><li>item</li></ul></div>",
+        )
+
+        val result = parser.parse(element)
+
+        val paragraphs = result.ast.blocks.filterIsInstance<PostBlock.Paragraph>()
+        assertEquals(
+            "the <p> and the following inline-classified <ul> must stay two blocks, got=${result.ast.blocks}",
+            2,
+            paragraphs.size,
+        )
+        assertTrue(
+            "first block keeps the paragraph text",
+            paragraphs[0].inlines.filterIsInstance<PostInline.Text>().any { it.value.contains("intro") },
+        )
+        assertTrue(
+            "second block holds the list text, not merged into the paragraph",
+            paragraphs[1].inlines.filterIsInstance<PostInline.Text>().any { it.value.contains("item") },
+        )
+    }
+
+    @Test
+    fun `multi nbsp after inline content before a paragraph does not fold - 466 codex`() {
+        // #466 (Codex review) — a >=2 `&nbsp;` run folds into empty lines ONLY between two <p>. After
+        // arbitrary buffered inline content (`<strong>A</strong>&nbsp;&nbsp;<p>B</p>`) it must NOT
+        // merge: the two stay distinct blocks. DERIVED FROM the Codex example.
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            "<div id=\"para1\"><strong>A</strong>&nbsp;&nbsp;<p>B</p></div>",
+        )
+
+        val result = parser.parse(element)
+
+        val paragraphs = result.ast.blocks.filterIsInstance<PostBlock.Paragraph>()
+        assertEquals(
+            "inline content + multi-nbsp + <p> must stay two blocks, got=${result.ast.blocks}",
+            2,
+            paragraphs.size,
+        )
+        assertEquals(
+            "the second <p> stays its own block, not merged with the inline content",
+            listOf(PostInline.Text("B")),
+            paragraphs[1].inlines,
+        )
+    }
+
+    @Test
+    fun `top-level break between two paragraphs closes the merge window - 466 codex`() {
+        // #466 (Codex review, round 3) — a top-level <br> between a buffered closed <p> and a later
+        // <p> EXTENDS the running paragraph, so the buffer is no longer a pristine <p> body and the
+        // >=2 `&nbsp;` run must NOT fold the two <p> into one block (`<p>A</p><br>&nbsp;&nbsp;<p>B</p>`
+        // stays two blocks, matching legacy). DERIVED FROM the Codex example, not a raw hfr-mcp capture.
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            "<div id=\"para1\"><p>A</p><br />&nbsp;&nbsp;<p>B</p></div>",
+        )
+
+        val result = parser.parse(element)
+
+        val paragraphs = result.ast.blocks.filterIsInstance<PostBlock.Paragraph>()
+        assertEquals(
+            "the intervening top-level <br> must keep the two <p> as separate blocks, got=${result.ast.blocks}",
+            2,
+            paragraphs.size,
+        )
+        assertEquals(
+            "first block holds A with its border break trimmed",
+            listOf(PostInline.Text("A")),
+            paragraphs[0].inlines,
+        )
+        assertEquals(
+            "second block holds B, not merged with A",
+            listOf(PostInline.Text("B")),
+            paragraphs[1].inlines,
         )
     }
 


### PR DESCRIPTION
**Night run 2026-06-15 — PR draft, à arbitrer.** Closes-#466 (mot-clé cassé exprès tant que non mergé).

## Cause
HFR encode une ligne vide volontaire entre deux `<p>` via des `&nbsp;` orphelins dans le nœud texte top-level (`</p>&nbsp;…&nbsp;<p>`), **pas** en `<br><br>` (déjà géré #423/#333/#280). L'ancien parser jetait ce run comme blanc insignifiant → lignes vides perdues + 2 `Paragraph` séparés.

## Fix
Modèle `PostContent` gelé (sérialisé Room) → réutilise `PostInline.LineBreak` (#333). `NodeKind.BLANK_TEXT` (run whitespace-only avec ≥1 `&nbsp;`) ; un `<p>` inline-only est accumulé dans le paragraphe courant ; si `pendingNbsp ≥ 2` + contenu réel → fusion en un `Paragraph` avec `LineBreak`s. Un `&nbsp;` unique reste 2 blocs.

## ⚠️ Décision produit à trancher (arbitrage matin)
**N `&nbsp;` → N-1 lignes vides** (pas 1:1). Le 1er `&nbsp;` est le séparateur structurel universel entre `<p>` (présent partout, même entre paragraphes ordinaires) ; un mapping 1:1 ajouterait une ligne vide parasite à ~tout post multi-paragraphe. À confirmer visuellement sur device.

## Tests (verts sur B : `:core:parser:test`)
- Fixture **réelle** `topic_page_single.html` (run triple-nbsp, réancré sur le texte unique « Pour trouver une solution » — l'agent avait d'abord ancré sur « C'est normal. » présent 2× → faux positif, corrigé).
- 2 synthétiques : inputs **dérivés de l'encodage #466** (pas une capture hfr-mcp), signalés en commentaire.

> Action par Claude Opus 4.8 (demandée par @XaTriX)