### PR TITLE
test(flags): garde-fou dernier posteur (#331) — pas de bug de code

### DIFF
--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/flags/RestFlagMappersTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/flags/RestFlagMappersTest.kt
@@ -6,6 +6,7 @@ import fr.forumhfr.redface2.core.model.FlagType
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -54,6 +55,31 @@ class RestFlagMappersTest {
         assertEquals("XaTriX", flag.firstPostAuthor)
         assertEquals("qwazer", flag.lastReplyAuthor)
         assertEquals("2026-05-01 17:07", flag.lastReplyAt)
+    }
+
+    @Test
+    fun `last poster is links last_author, never the topic author - regression 331`() {
+        // #331 (@tinc, HFR #2786280): « mes sujets » showed an incorrect last poster.
+        // The real cat23 participated fixture has DISTINCT people on the two author slots —
+        // creator XaTriX vs last poster qwazer — so a swap (mapping lastReplyAuthor to
+        // links.author by mistake) would flip this assertion. The flag list must surface the
+        // REST `links.last_author.title` (last poster), not `links.author.title` (creator).
+        val envelope = json.decodeFromString<RestListEnvelope<RestTopic>>(
+            fixture("rest_cat23_participated.json"),
+        )
+
+        val flag = RestFlagMappers.toFlags(
+            envelope = envelope,
+            type = FlagType.CYAN,
+            fallbackCat = 23,
+        ).single()
+
+        assertEquals("qwazer", flag.lastReplyAuthor)
+        assertNotEquals(
+            "last poster must not be the topic creator (the #331 confusion)",
+            flag.firstPostAuthor,
+            flag.lastReplyAuthor,
+        )
     }
 
     @Test


### PR DESCRIPTION
**Night run — PR draft.** Re #331 (pas de mot-clé closing : à NE PAS fermer sans confirmation device).

## Conclusion : aucun bug de code
Chaîne du dernier posteur tracée et **correcte** : `links.last_author` (DTO) → `RestFlagMappers.lastReplyAuthor` → Room (round-trip symétrique) → UI `flagRowMetadata`, distincte de `firstPostAuthor` (`links.author`). Prouvé sur la fixture réelle `rest_cat23_participated.json` (`author=XaTriX` ≠ `last_author=qwazer`). Le scrape HTML de listing a été retiré en Phase 1D-1 (#110) → **pas de `TopicListParser` à corriger**.

Le symptôme rapporté = **staleness de cache** (déjà diagnostiqué dans les commentaires de l'issue ; fix auto-refresh #378/#421 livré dev v118 → bêta 0.10.0). L'issue doit rester ouverte jusqu'à **confirmation device** post-refresh.

## Apport
Test de régression `last poster is links last_author, never the topic author` sur fixture réelle → garde-fou contre un futur recâblage sur `links.author` (seule cause-racine « parsing » possible).

> Action par Claude Opus 4.8 (demandée par @XaTriX)