### PR TITLE
fix(mp): badge non-lus — opt-out coupe le réseau (#452) + refresh à la lecture (#453)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/MpUnreadBadgeViewModel.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/MpUnreadBadgeViewModel.kt
@@ -6,9 +6,13 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.messages.MessagesRepository
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import javax.inject.Inject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
 /**
@@ -21,27 +25,47 @@ import kotlinx.coroutines.flow.stateIn
  * the page-1 inbox piggyback (free, fires when the user opens the Messages tab or comes back from
  * a conversation), and the explicit [onAppForegrounded] tick below.
  *
+ * #452 — the opt-out must cut the NETWORK, not just the display. The preference is the OUTER flow
+ * (`flatMapLatest`) : while the badge is disabled the upstream `observeUnreadMpCount` is NOT
+ * collected, so its auth-flip fetch / foreground ticks / piggyback chain never run — flipping the
+ * setting off tears the fetch chain down, flipping it on re-subscribes (and re-fetches). A
+ * foreground tick or thread-read signal raised while disabled is inert : it only enqueues onto the
+ * uncollected count flow, so no fetch happens.
+ *
  * `WhileSubscribed` (not Eagerly) : the only consumer is the navigation bar — when nothing shows
  * it, nothing should hold the upstream fetch chain alive.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class MpUnreadBadgeViewModel @Inject constructor(
     private val messagesRepository: MessagesRepository,
     userPreferencesRepository: UserPreferencesRepository,
 ) : ViewModel() {
 
+    private val badgeEnabled = userPreferencesRepository.observeMpUnreadBadge()
+        .distinctUntilChanged()
+
     val unreadCount: StateFlow<Int?> =
-        combine(
-            userPreferencesRepository.observeMpUnreadBadge(),
-            messagesRepository.observeUnreadMpCount(),
-        ) { enabled, count ->
-            count?.takeIf { enabled && it > 0 }
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), null)
+        badgeEnabled
+            .flatMapLatest { enabled ->
+                if (enabled) {
+                    messagesRepository.observeUnreadMpCount().map { count -> count?.takeIf { it > 0 } }
+                } else {
+                    // Disabled : emit nothing-to-show AND do not collect the network flow at all.
+                    flowOf(null)
+                }
+            }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), null)
 
     /**
      * `ON_START` hook (app brought back to the foreground) : MPs received while backgrounded
      * must surface without waiting for a tab visit. The FIRST start is skipped — the cold-start
      * fetch already runs when the auth state resolves, a tick there would only double the call.
+     *
+     * #452 — the tick is INERT while the badge is disabled : `requestUnreadRefresh` only enqueues
+     * onto the count flow, which `flatMapLatest` above does not collect when the preference is off,
+     * so no fetch runs. No extra gate needed here — the disabled state is enforced upstream by not
+     * subscribing to the network flow at all.
      */
     fun onAppForegrounded() {
         if (firstStart) {
@@ -49,6 +73,16 @@ class MpUnreadBadgeViewModel @Inject constructor(
             return
         }
         messagesRepository.requestUnreadRefresh()
+    }
+
+    /**
+     * #453 — a private-message conversation was opened/read. Optimistically decrements the badge
+     * count so reading the LAST unread conversation clears the badge immediately, without waiting
+     * for the next page-1 fetch. Inert while the badge is disabled (#452) for the same reason as
+     * [onAppForegrounded] : the count flow is not collected, so the signal serves no collector.
+     */
+    fun onThreadRead(threadId: Int) {
+        messagesRepository.markThreadRead(threadId)
     }
 
     private var firstStart = true

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -601,6 +601,12 @@ fun RedfaceApp(intent: Intent?) {
         // Purged on every auth transition, exactly like readPrivateMessageThreadIds, so private
         // metadata never outlives the session / account.
         var multiRecipientThreadIds by remember { mutableStateOf(emptySet<Int>()) }
+        // #453 (Codex review) — threads that were UNREAD when opened from the inbox. The badge
+        // decrement on first read must fire ONLY for these: opening an already-read conversation has
+        // nothing to subtract. In-memory only and purged on auth transition, like the sets above —
+        // it is private metadata (it reveals a conversation carried an unread message) and must never
+        // outlive the session, hence it stays OUT of the opaque PrivateMessageThreadRoute.
+        var unreadOnOpenThreadIds by remember { mutableStateOf(emptySet<Int>()) }
         // #301 follow-up — bumped when the new-conversation composer pops back after a successful
         // send. The MP list collects the signal and refreshes itself so the created conversation
         // appears at the top (its thread id is unknown — the bddpost success response of a new MP
@@ -637,6 +643,7 @@ fun RedfaceApp(intent: Intent?) {
                 AuthState.Anonymous -> {
                     readPrivateMessageThreadIds = emptySet()
                     multiRecipientThreadIds = emptySet()
+                    unreadOnOpenThreadIds = emptySet()
                     privateMessageSentSignal = null
                     // #291 — a write intention armed under another session must not survive the
                     // transition (Codex review: stale « Citer N » after logout/login).
@@ -646,6 +653,7 @@ fun RedfaceApp(intent: Intent?) {
                 is AuthState.Authenticated -> {
                     readPrivateMessageThreadIds = emptySet()
                     multiRecipientThreadIds = emptySet()
+                    unreadOnOpenThreadIds = emptySet()
                     privateMessageSentSignal = null
                     multiQuoteBasket = null
                     resetStack(messagesBackStack, MessagesRoute, MessagesRoute)
@@ -709,17 +717,24 @@ fun RedfaceApp(intent: Intent?) {
                         readThreadIds = readPrivateMessageThreadIds,
                         multiRecipientThreadIds = multiRecipientThreadIds,
                         onThreadLoaded = { threadId ->
-                            // #453 — only the FIRST time this thread is marked read decrements the
-                            // badge ; re-opening an already-read conversation must not subtract
-                            // again (the repository also guards against double-decrement, but
-                            // skipping the redundant signal keeps the intent local to the nav).
-                            if (threadId !in readPrivateMessageThreadIds) {
+                            // #453 (Codex review) — decrement the badge ONLY when the conversation was
+                            // unread when opened AND this is its first read of the session (predicate
+                            // extracted to keep this composable under detekt's complexity threshold).
+                            val decrement = shouldDecrementUnreadBadge(
+                                threadId = threadId,
+                                unreadOnOpen = unreadOnOpenThreadIds,
+                                alreadyRead = readPrivateMessageThreadIds,
+                            )
+                            if (decrement) {
                                 mpBadgeViewModel.onThreadRead(threadId)
                             }
                             readPrivateMessageThreadIds = readPrivateMessageThreadIds + threadId
                         },
                         onThreadOpenedAsMulti = { threadId ->
                             multiRecipientThreadIds = multiRecipientThreadIds + threadId
+                        },
+                        onThreadOpenedUnread = { threadId ->
+                            unreadOnOpenThreadIds = unreadOnOpenThreadIds + threadId
                         },
                         sentSignal = privateMessageSentSignal,
                         onConversationSent = {
@@ -840,17 +855,33 @@ private const val REPORT_EMAIL: String = "xat@azora.fr"
  *   page shows a single other author.
  * @property onThreadLoaded marks a thread read once its first page has successfully loaded.
  * @property onThreadOpenedAsMulti records that a thread was opened from a multi-recipient row.
+ * @property onThreadOpenedUnread records that a thread was UNREAD when opened, so [onThreadLoaded]
+ *   knows it may decrement the unread badge (an already-read conversation must not, #453).
  */
 private data class PrivateMessageNavState(
     val readThreadIds: Set<Int>,
     val multiRecipientThreadIds: Set<Int>,
     val onThreadLoaded: (Int) -> Unit,
     val onThreadOpenedAsMulti: (Int) -> Unit,
+    val onThreadOpenedUnread: (Int) -> Unit = {},
     /** #301 follow-up — last successful new-conversation send ; the MP list refreshes on change. */
     val sentSignal: Long? = null,
     /** #301 follow-up — bumps [sentSignal] when the composer reports a successful send. */
     val onConversationSent: () -> Unit = {},
 )
+
+/**
+ * #453 (Codex review) — the unread badge decrements on a thread's first read of the session ONLY
+ * when that thread was actually unread when opened ([unreadOnOpen]). Opening an already-read
+ * conversation subtracts nothing, and re-opening one ([alreadyRead]) must not subtract twice.
+ * Extracted from [onThreadLoaded] so the boolean connective stays out of RedfaceApp's cyclomatic
+ * complexity budget.
+ */
+private fun shouldDecrementUnreadBadge(
+    threadId: Int,
+    unreadOnOpen: Set<Int>,
+    alreadyRead: Set<Int>,
+): Boolean = threadId in unreadOnOpen && threadId !in alreadyRead
 
 /**
  * Bug fix (build 89) — per-topic title cache plumbed into [RedfaceNavHost]. A topic page change
@@ -1126,10 +1157,15 @@ private fun RedfaceNavHost(
             entry<MessagesRoute> {
                 MessagesScreen(
                     readThreadIds = privateMessageNavState.readThreadIds,
-                    onOpenThread = { threadId, isMultiRecipient, openAtPage ->
+                    onOpenThread = { threadId, isMultiRecipient, openAtPage, wasUnread ->
                         // Record the multi-recipient hint in memory only; the route stays opaque.
                         if (isMultiRecipient) {
                             privateMessageNavState.onThreadOpenedAsMulti(threadId)
+                        }
+                        // #453 (Codex review) — remember the unread-on-open state so the badge only
+                        // decrements for a conversation that actually had something unread.
+                        if (wasUnread) {
+                            privateMessageNavState.onThreadOpenedUnread(threadId)
                         }
                         backStack.add(
                             PrivateMessageThreadRoute(

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -709,6 +709,13 @@ fun RedfaceApp(intent: Intent?) {
                         readThreadIds = readPrivateMessageThreadIds,
                         multiRecipientThreadIds = multiRecipientThreadIds,
                         onThreadLoaded = { threadId ->
+                            // #453 — only the FIRST time this thread is marked read decrements the
+                            // badge ; re-opening an already-read conversation must not subtract
+                            // again (the repository also guards against double-decrement, but
+                            // skipping the redundant signal keeps the intent local to the nav).
+                            if (threadId !in readPrivateMessageThreadIds) {
+                                mpBadgeViewModel.onThreadRead(threadId)
+                            }
                             readPrivateMessageThreadIds = readPrivateMessageThreadIds + threadId
                         },
                         onThreadOpenedAsMulti = { threadId ->

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/MpUnreadBadgeViewModelTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/MpUnreadBadgeViewModelTest.kt
@@ -113,4 +113,69 @@ class MpUnreadBadgeViewModelTest {
         vm.onAppForegrounded()
         verify(exactly = 2) { repository.requestUnreadRefresh() }
     }
+
+    /**
+     * #452 — the opt-out must cut the NETWORK, not just the display. While the badge preference is
+     * off, the ViewModel must NOT collect (nor even invoke) the count flow that drives the
+     * authenticated page-1 fetch ; the badge stays null.
+     */
+    @Test
+    fun `the count flow is not collected while the badge is disabled (#452)`() = runTest {
+        val repository = mockk<MessagesRepository>(relaxed = true)
+        val vm = viewModel(
+            counts = flowOf(7),
+            badgeEnabled = flowOf(false),
+            messagesRepository = repository,
+        )
+
+        vm.unreadCount.test {
+            assertNull(expectMostRecentItem())
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+        // The network-backed count flow is never even asked for : no fetch chain is kept alive.
+        verify(exactly = 0) { repository.observeUnreadMpCount() }
+    }
+
+    /**
+     * #452 — flipping the badge ON must (re)subscribe to the count flow, flipping it OFF must drop
+     * the subscription. Asserted via the call count of `observeUnreadMpCount` across a live toggle.
+     */
+    @Test
+    fun `toggling the badge subscribes and unsubscribes the count flow (#452)`() = runTest {
+        val enabled = MutableStateFlow(false)
+        val repository = mockk<MessagesRepository>(relaxed = true) {
+            every { observeUnreadMpCount() } returns flowOf(4)
+        }
+        val vm = viewModel(counts = flowOf(4), badgeEnabled = enabled, messagesRepository = repository)
+
+        vm.unreadCount.test {
+            assertNull(expectMostRecentItem())
+            verify(exactly = 0) { repository.observeUnreadMpCount() }
+
+            enabled.value = true
+            assertEquals(4, awaitItem())
+            verify(exactly = 1) { repository.observeUnreadMpCount() }
+
+            enabled.value = false
+            assertNull(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    /**
+     * #453 — reading a conversation forwards an optimistic-decrement signal to the repository
+     * (which owns the count) so the badge clears the moment the last unread MP is opened.
+     */
+    @Test
+    fun `onThreadRead forwards the read signal to the repository (#453)`() = runTest {
+        val repository = mockk<MessagesRepository>(relaxed = true) {
+            every { observeUnreadMpCount() } returns flowOf(1)
+        }
+        val vm = viewModel(counts = flowOf(1), messagesRepository = repository)
+
+        vm.onThreadRead(threadId = 99)
+
+        verify(exactly = 1) { repository.markThreadRead(threadId = 99) }
+    }
 }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepository.kt
@@ -103,9 +103,12 @@ class DefaultMessagesRepository @Inject constructor(
             },
         )
         // The initial fetch is its own first emission so reads marked before any refresh still
-        // decrement it (otherwise the cold-start count would be a non-resettable baseline).
+        // decrement it (otherwise the cold-start count would be a non-resettable baseline). It is
+        // tagged `isInitial` so that, if a page-1 piggyback or a refresh tick wins the race to be the
+        // first count, the late-landing cold-start is dropped rather than resetting the local reads
+        // accumulated meanwhile (Codex review, #453).
         return merge(
-            flow { emit(NetworkCount(fetchUnreadCount())) },
+            flow { emit(NetworkCount(fetchUnreadCount(), isInitial = true)) },
             networkCounts,
             markThreadReadEvents.map { ReadThread(it) },
         )
@@ -182,8 +185,11 @@ class DefaultMessagesRepository @Inject constructor(
     /** #453 — events folded by the unread-count [scan]. */
     private sealed interface UnreadEvent
 
-    /** A fresh, authoritative count from the network (resets local read-decrements). */
-    private data class NetworkCount(val count: Int?) : UnreadEvent
+    /**
+     * A count from the network. [isInitial] marks the one-shot cold-start fetch (vs a refresh tick /
+     * page-1 piggyback) so a late-landing cold-start cannot reset reads another count already baselined.
+     */
+    private data class NetworkCount(val count: Int?, val isInitial: Boolean = false) : UnreadEvent
 
     /** A conversation was read in-app (decrements the displayed count by one, once). */
     private data class ReadThread(val threadId: Int) : UnreadEvent
@@ -202,19 +208,19 @@ class DefaultMessagesRepository @Inject constructor(
             get() = baseCount?.let { (it - readThreadIds.size).coerceAtLeast(0) }
 
         fun applyEvent(event: UnreadEvent): LocalUnread = when (event) {
-            // The FIRST network count is the cold-start fetch, kicked off at collection time before
-            // any in-session read can commit. A read that races it (the user opens an unread MP while
-            // the initial fetch is still in flight) must NOT be discarded — HFR has no server-side
-            // read flag (#361), so the initial count cannot reflect that read anyway. Keep the local
-            // decrement set and only adopt the count (#453, Codex review). EVERY LATER network count
-            // is a deliberate refresh (foreground tick / page-1 piggyback) and stays authoritative:
-            // it resets the set so the displayed count reconciles with the server truth.
-            is NetworkCount ->
-                if (hasNetworkCount) {
-                    LocalUnread(baseCount = event.count, readThreadIds = emptySet(), hasNetworkCount = true)
-                } else {
-                    copy(baseCount = event.count, hasNetworkCount = true)
-                }
+            is NetworkCount -> when {
+                // The FIRST count to arrive (whichever source wins the cold-start race) adopts its
+                // value but KEEPS the local reads accumulated meanwhile : a read that raced the very
+                // first fetch must not be discarded — HFR has no server-side read flag (#361), so that
+                // count can't reflect it anyway (#453, Codex review).
+                !hasNetworkCount -> copy(baseCount = event.count, hasNetworkCount = true)
+                // A late-landing cold-start fetch (a piggyback / refresh tick already baselined first)
+                // is stale and must NOT reset the reads marked since : drop it (Codex review, #453).
+                event.isInitial -> this
+                // A genuine later refresh (foreground tick / page-1 piggyback) is authoritative : it
+                // resets the local decrements so the displayed count reconciles with the server truth.
+                else -> LocalUnread(baseCount = event.count, readThreadIds = emptySet(), hasNetworkCount = true)
+            }
             is ReadThread -> copy(readThreadIds = readThreadIds + event.threadId)
         }
     }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepository.kt
@@ -16,12 +16,15 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.withContext
@@ -62,30 +65,65 @@ class DefaultMessagesRepository @Inject constructor(
     private val unreadRefreshTicks = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     private val inboxDerivedUnread = MutableSharedFlow<Pair<String, Int>>(extraBufferCapacity = 1)
 
+    // #453 — optimistic local decrement. Reading the LAST unread conversation left the badge
+    // stale until the next page-1 fetch (foreground / tab visit), because the count only ever
+    // came from the network. A thread-read signal decrements the displayed count locally — zero
+    // network, and consistent with the inbox row that already forces `hasUnread=false` for a read
+    // thread (MessagesScreen). HFR has no server-side read flag (#361), so the server count would
+    // not change just from reading anyway ; the next real page-1 fetch reconciles. Threads read
+    // since the last network count are tracked so re-opening one never double-decrements, and a
+    // fresh fetch clears the set (its count is authoritative). tryEmit + buffer: the signal may
+    // fire with no collector (badge disabled, #452) and must never suspend.
+    private val markThreadReadEvents = MutableSharedFlow<Int>(extraBufferCapacity = 8)
+
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun observeUnreadMpCount(): Flow<Int?> = authRepository.observeAuthState()
         .transformLatest { state ->
             when (state) {
                 AuthState.Anonymous -> emit(null)
-                is AuthState.Authenticated -> {
-                    emit(fetchUnreadCount())
-                    emitAll(
-                        merge(
-                            unreadRefreshTicks.map { fetchUnreadCount() },
-                            inboxDerivedUnread.mapNotNull { (pseudo, count) ->
-                                // Drop emissions sealed for another session (account switch
-                                // while the page-1 fetch was in flight).
-                                if (pseudo == state.pseudo) count else null
-                            },
-                        ),
-                    )
-                }
+                is AuthState.Authenticated -> emitAll(authenticatedUnreadCount(state))
             }
         }
+        .distinctUntilChanged()
         .flowOn(ioDispatcher)
+
+    /**
+     * Stream of unread counts for an authenticated [session] : the first fetch, then every network
+     * refresh (foreground tick / page-1 piggyback), with #453 local read-decrements applied on top.
+     * Each fresh network count is authoritative and resets the local decrements
+     * ([LocalUnread.applyEvent] on a [NetworkCount]).
+     */
+    private fun authenticatedUnreadCount(session: AuthState.Authenticated): Flow<Int?> {
+        val networkCounts = merge(
+            unreadRefreshTicks.map { NetworkCount(fetchUnreadCount()) },
+            inboxDerivedUnread.mapNotNull { (pseudo, count) ->
+                // Drop emissions sealed for another session (account switch while the page-1
+                // fetch was in flight).
+                if (pseudo == session.pseudo) NetworkCount(count) else null
+            },
+        )
+        // The initial fetch is its own first emission so reads marked before any refresh still
+        // decrement it (otherwise the cold-start count would be a non-resettable baseline).
+        return merge(
+            flow { emit(NetworkCount(fetchUnreadCount())) },
+            networkCounts,
+            markThreadReadEvents.map { ReadThread(it) },
+        )
+            .scan(LocalUnread()) { acc, event -> acc.applyEvent(event) }
+            // Drop the seed (no network count seen yet) ; emit every resolved state afterwards,
+            // including a `null` from a failed fetch (the contract surfaces failures as null).
+            .mapNotNull { folded ->
+                if (folded.hasNetworkCount) Displayed(folded.displayedCount) else null
+            }
+            .map { it.value }
+    }
 
     override fun requestUnreadRefresh() {
         unreadRefreshTicks.tryEmit(Unit)
+    }
+
+    override fun markThreadRead(threadId: Int) {
+        markThreadReadEvents.tryEmit(threadId)
     }
 
     private suspend fun fetchUnreadCount(): Int? = withContext(ioDispatcher) {
@@ -140,6 +178,38 @@ class DefaultMessagesRepository @Inject constructor(
             fallbackCorrespondent = fallbackCorrespondent,
         )
     }
+
+    /** #453 — events folded by the unread-count [scan]. */
+    private sealed interface UnreadEvent
+
+    /** A fresh, authoritative count from the network (resets local read-decrements). */
+    private data class NetworkCount(val count: Int?) : UnreadEvent
+
+    /** A conversation was read in-app (decrements the displayed count by one, once). */
+    private data class ReadThread(val threadId: Int) : UnreadEvent
+
+    /**
+     * #453 — fold state over [UnreadEvent]s. [baseCount] is the last network count ; [readThreadIds]
+     * are the threads read since that count arrived. [displayedCount] subtracts them (clamped at 0).
+     * [hasNetworkCount] tells the seed (no count yet) apart from a resolved `null` (failed fetch).
+     */
+    private data class LocalUnread(
+        val baseCount: Int? = null,
+        val readThreadIds: Set<Int> = emptySet(),
+        val hasNetworkCount: Boolean = false,
+    ) {
+        val displayedCount: Int?
+            get() = baseCount?.let { (it - readThreadIds.size).coerceAtLeast(0) }
+
+        fun applyEvent(event: UnreadEvent): LocalUnread = when (event) {
+            // A fresh network count is authoritative : reset the local read-decrement set.
+            is NetworkCount -> LocalUnread(baseCount = event.count, readThreadIds = emptySet(), hasNetworkCount = true)
+            is ReadThread -> copy(readThreadIds = readThreadIds + event.threadId)
+        }
+    }
+
+    /** Wraps a resolved (possibly `null`) displayed count so [mapNotNull] only drops the scan seed. */
+    private data class Displayed(val value: Int?)
 
     private companion object {
         const val LOG_TAG = "MessagesRepository"

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepository.kt
@@ -202,8 +202,19 @@ class DefaultMessagesRepository @Inject constructor(
             get() = baseCount?.let { (it - readThreadIds.size).coerceAtLeast(0) }
 
         fun applyEvent(event: UnreadEvent): LocalUnread = when (event) {
-            // A fresh network count is authoritative : reset the local read-decrement set.
-            is NetworkCount -> LocalUnread(baseCount = event.count, readThreadIds = emptySet(), hasNetworkCount = true)
+            // The FIRST network count is the cold-start fetch, kicked off at collection time before
+            // any in-session read can commit. A read that races it (the user opens an unread MP while
+            // the initial fetch is still in flight) must NOT be discarded — HFR has no server-side
+            // read flag (#361), so the initial count cannot reflect that read anyway. Keep the local
+            // decrement set and only adopt the count (#453, Codex review). EVERY LATER network count
+            // is a deliberate refresh (foreground tick / page-1 piggyback) and stays authoritative:
+            // it resets the set so the displayed count reconciles with the server truth.
+            is NetworkCount ->
+                if (hasNetworkCount) {
+                    LocalUnread(baseCount = event.count, readThreadIds = emptySet(), hasNetworkCount = true)
+                } else {
+                    copy(baseCount = event.count, hasNetworkCount = true)
+                }
             is ReadThread -> copy(readThreadIds = readThreadIds + event.threadId)
         }
     }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepositoryTest.kt
@@ -16,6 +16,7 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import java.io.IOException
 import java.time.Instant
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -322,6 +323,40 @@ class DefaultMessagesRepositoryTest {
             // is the source of truth ; the optimistic subtraction was only a stop-gap).
             repo.requestUnreadRefresh()
             assertEquals(3, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `a read racing the cold-start fetch is preserved by the initial count (#453 codex)`() = runTest {
+        // Codex review — at cold start the user may open an unread MP before the very first
+        // `fetchUnreadCount()` resolves. The initial network count must NOT discard that read (HFR
+        // has no server-side read flag, so the count can't reflect it anyway), otherwise the badge
+        // would snap back to the pre-read total. Here the cold-start fetch is held on a gate, the
+        // read lands first, then the fetch resolves : 3 - 1 must be displayed, not a reset to 3.
+        val hfrClient = mockk<HfrClient>()
+        val gate = CompletableDeferred<Unit>()
+        coEvery { hfrClient.getPrivateMessageListPage(page = 1) } coAnswers {
+            gate.await()
+            FAKE_HTML
+        }
+        val parser = mockk<PrivateMessageListParser>()
+        coEvery { parser.countUnread(FAKE_HTML) } returns 3
+
+        val (repo, authStates) = buildRepository(hfrClient = hfrClient, parser = parser)
+
+        repo.observeUnreadMpCount().test {
+            authStates.emit(AuthState.Authenticated("xaat"))
+            // The cold-start fetch is suspended on the gate ; the read races ahead of it.
+            repo.markThreadRead(threadId = 11)
+            // Now the initial fetch resolves : it adopts the count but keeps the racing read.
+            gate.complete(Unit)
+
+            assertEquals(
+                "the initial count must subtract the read that raced it, not reset to the raw total",
+                2,
+                awaitItem(),
+            )
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepositoryTest.kt
@@ -256,6 +256,91 @@ class DefaultMessagesRepositoryTest {
     }
 
     @Test
+    fun `markThreadRead decrements the observed count and clears it on the last unread (#453)`() = runTest {
+        val hfrClient = mockk<HfrClient>()
+        coEvery { hfrClient.getPrivateMessageListPage(page = 1) } returns FAKE_HTML
+        val parser = mockk<PrivateMessageListParser>()
+        coEvery { parser.countUnread(FAKE_HTML) } returns 1
+
+        val (repo, authStates) = buildRepository(hfrClient = hfrClient, parser = parser)
+
+        repo.observeUnreadMpCount().test {
+            authStates.emit(AuthState.Authenticated("xaat"))
+            assertEquals(1, awaitItem())
+
+            // Reading the LAST unread conversation must clear the badge immediately (#453), with no
+            // second network fetch (the count came from page 1 only once).
+            repo.markThreadRead(threadId = 42)
+
+            assertEquals(0, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        coVerify(exactly = 1) { hfrClient.getPrivateMessageListPage(page = 1) }
+    }
+
+    @Test
+    fun `markThreadRead twice on the same thread decrements only once (#453)`() = runTest {
+        val hfrClient = mockk<HfrClient>()
+        coEvery { hfrClient.getPrivateMessageListPage(page = 1) } returns FAKE_HTML
+        val parser = mockk<PrivateMessageListParser>()
+        coEvery { parser.countUnread(FAKE_HTML) } returns 2
+
+        val (repo, authStates) = buildRepository(hfrClient = hfrClient, parser = parser)
+
+        repo.observeUnreadMpCount().test {
+            authStates.emit(AuthState.Authenticated("xaat"))
+            assertEquals(2, awaitItem())
+
+            repo.markThreadRead(threadId = 7)
+            assertEquals(1, awaitItem())
+
+            // Re-opening the same conversation must NOT subtract again (idempotent per thread until
+            // the next authoritative network count).
+            repo.markThreadRead(threadId = 7)
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `a fresh network count resets the local read-decrements (#453)`() = runTest {
+        val hfrClient = mockk<HfrClient>()
+        coEvery { hfrClient.getPrivateMessageListPage(page = 1) } returns FAKE_HTML
+        val parser = mockk<PrivateMessageListParser>()
+        coEvery { parser.countUnread(FAKE_HTML) } returnsMany listOf(1, 3)
+
+        val (repo, authStates) = buildRepository(hfrClient = hfrClient, parser = parser)
+
+        repo.observeUnreadMpCount().test {
+            authStates.emit(AuthState.Authenticated("xaat"))
+            assertEquals(1, awaitItem())
+
+            repo.markThreadRead(threadId = 1)
+            assertEquals(0, awaitItem())
+
+            // A real refresh is authoritative : it supersedes the local decrement (the server count
+            // is the source of truth ; the optimistic subtraction was only a stop-gap).
+            repo.requestUnreadRefresh()
+            assertEquals(3, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `markThreadRead is inert while anonymous (#453)`() = runTest {
+        val (repo, authStates) = buildRepository()
+
+        repo.observeUnreadMpCount().test {
+            authStates.emit(AuthState.Anonymous)
+            assertNull(awaitItem())
+
+            repo.markThreadRead(threadId = 5)
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `getPrivateMessageList fetches the requested page and returns the parsed inbox`() = runTest {
         val hfrClient = mockk<HfrClient>()
         coEvery { hfrClient.getPrivateMessageListPage(page = 2) } returns FAKE_HTML

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/messages/MessagesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/messages/MessagesRepository.kt
@@ -35,6 +35,20 @@ interface MessagesRepository {
     fun requestUnreadRefresh()
 
     /**
+     * #453 — signals that conversation [threadId] was read in-app. Optimistically decrements the
+     * observed unread count by one (clamped at zero), so reading the LAST unread conversation
+     * clears the badge immediately instead of waiting for the next page-1 fetch. Fire-and-forget,
+     * non-suspending (safe from a navigation callback) ; no-op while anonymous or while nobody
+     * collects [observeUnreadMpCount].
+     *
+     * Local-only by design (zero network) : HFR has no server-side read flag (#361), so a read does
+     * not change the server count — the decrement mirrors the inbox row that already marks the
+     * conversation read locally, and the next real page-1 fetch reconciles. Marking the same thread
+     * twice between two network refreshes decrements only once.
+     */
+    fun markThreadRead(threadId: Int)
+
+    /**
      * Fetches one page of the private-message inbox (`forum1.php?cat=prive`). Throws on
      * network / session errors (e.g. [fr.forumhfr.redface2.core.domain.auth.SessionExpiredException]);
      * the caller maps the failure to its UI state.

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessagesScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessagesScreen.kt
@@ -62,7 +62,10 @@ fun MessagesScreen(
     // opaque — it never persists this private metadata in the back stack). openAtPage is the
     // conversation's last page read from the inbox (#430, web parity: the inbox "Pages" cell
     // links the last page) — a bare page number is not private metadata.
-    onOpenThread: (threadId: Int, isMultiRecipient: Boolean, openAtPage: Int) -> Unit,
+    // wasUnread is the row's unread state at open-time (#453) : the nav host decrements the unread
+    // badge only for a conversation that was actually unread. Not private metadata persisted in any
+    // route — a transient signal consumed by the ephemeral nav state.
+    onOpenThread: (threadId: Int, isMultiRecipient: Boolean, openAtPage: Int, wasUnread: Boolean) -> Unit,
     readThreadIds: Set<Int> = emptySet(),
     topBarActions: @Composable (() -> Unit)? = null,
     // #301 follow-up — opens the new-conversation composer. Null hides the button.
@@ -184,6 +187,9 @@ fun MessagesScreen(
                                 conversation.threadId,
                                 conversation.isMultiRecipient,
                                 conversation.lastPage,
+                                // effectiveConversation already folds the local read override, so a
+                                // re-opened (now read) row correctly reports wasUnread = false (#453).
+                                conversation.hasUnread,
                             )
                         },
                     )


### PR DESCRIPTION
**Night run — PR draft.** Closes-#452, closes-#453 (mots-clés cassés tant que non mergé).

## Cause commune
`MpUnreadBadgeViewModel.unreadCount` = `combine(observeMpUnreadBadge(), observeUnreadMpCount())`. `combine` collecte **toujours** ses 2 sources → le fetch réseau (GET page-1 auth) tournait **badge masqué** (#452), et le compteur venait **uniquement** du réseau donc lire le dernier MP ne le rafraîchissait pas (#453).

## #452 — l'opt-out coupe le réseau
`combine` → `flatMapLatest` gaté sur la préférence (flow externe). Badge off → `flowOf(null)`, `observeUnreadMpCount()` n'est **jamais collecté ni appelé** → la chaîne fetch ne tourne pas. Flip on → resouscription + re-fetch.

## #453 — refresh à la lecture (décrément local)
`markThreadRead(threadId)` (repo + interface domaine) sur un `SharedFlow` ; `observeUnreadMpCount()` applique un `scan` : compteur réseau autoritaire, lecture = −1 (clamp 0), **dédup par thread**. `RedfaceNavigation.onThreadLoaded` → `onThreadRead` à la 1ʳᵉ lecture.

**Choix : décrément LOCAL optimiste, pas de re-fetch.** Cohérent avec #452 (re-fetcher par conversation irait à l'encontre) et le contrat MP « pas de drapeau serveur » (#361) ; le prochain fetch page-1 réel réconcilie. *À valider produit : si on veut un alignement serveur strict, basculer vers un refresh réseau — mais contradictoire avec #452.*

## Validation (B vert)
`:app:assembleDevDebug :core:data:testDebugUnitTest :app:testDevDebugUnitTest` → BUILD SUCCESSFUL, nouveaux tests exécutés. Codex review à suivre en commentaire.

> Action par Claude Opus 4.8 (demandée par @XaTriX)