### PR TITLE
fix(topic): persistance pli/dépli sondage entre pages (#465) [nuit, draft]

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -630,6 +630,14 @@ fun RedfaceApp(intent: Intent?) {
         // time (selecting in another topic resets it — quoting is a single-topic act). Plain
         // remember: losing it on process death just means re-selecting, like the markers above.
         var multiQuoteBasket by remember { mutableStateOf<MultiQuoteBasket?>(null) }
+        // #465 — per-topic MANUAL poll-expansion choice, keyed by (cat, post) (one poll per topic),
+        // twin of topicTitleCache / topicScrollAnchorCache: a page change replaces the TopicRoute
+        // (new nav entry → new ViewModel), so a `rememberSaveable` toggle inside the poll card was
+        // re-seeded to the global default on every page. Hoisted above NavDisplay so collapsing /
+        // expanding a poll survives navigation between the topic's pages. Absence of a key = follow
+        // the `topicPollsExpanded` default; the toggle records the manual choice here. RAM/session
+        // only, never serialized into a route.
+        var topicPollExpansionCache by remember { mutableStateOf(emptyMap<TopicPollKey, Boolean>()) }
 
         LaunchedEffect(authState) {
             when (authState) {
@@ -742,6 +750,15 @@ fun RedfaceApp(intent: Intent?) {
                             multiQuoteBasket = multiQuoteBasket.toggled(cat, post, numreponse)
                         },
                         onClear = { multiQuoteBasket = null },
+                    ),
+                    topicPollNavState = TopicPollNavState(
+                        expansions = topicPollExpansionCache,
+                        onExpansionChanged = { cat, post, expanded ->
+                            topicPollExpansionCache = topicPollExpansionCache.withPollExpansion(
+                                TopicPollKey(cat, post),
+                                expanded,
+                            )
+                        },
                     ),
                     onOpenProfile = { userId, pseudo, avatarUrl ->
                         // Review feedback I3: capture the **origin** tab so that
@@ -901,6 +918,21 @@ private data class MultiQuoteNavState(
 )
 
 /**
+ * #465 — per-topic poll-expansion bundle threaded into [RedfaceNavHost], same shape and survival
+ * rationale as the other hoisted-state bundles ([TopicScrollNavState], [TopicTitleNavState]): a page
+ * change replaces the TopicRoute entry, so any expansion state owned by the topic screen would die
+ * with it. The `var` backing [expansions] lives in [RedfaceApp]. A `null` lookup (no entry for the
+ * topic) means « follow the global default »; [onExpansionChanged] records the user's manual toggle.
+ *
+ * @property expansions the manual collapse/expand choice per topic the user has toggled.
+ * @property onExpansionChanged records a topic's manual poll choice when the card is tapped.
+ */
+private data class TopicPollNavState(
+    val expansions: Map<TopicPollKey, Boolean>,
+    val onExpansionChanged: (cat: Int, post: Int, expanded: Boolean) -> Unit,
+)
+
+/**
  * #291 — multi-quote selection, hoisted to RedfaceApp (same survival rationale as
  * [TopicScrollNavState]: a page change replaces the TopicRoute entry, so any state owned by the
  * topic screen dies with it). [numreponses] keeps SELECTION ORDER — the quotes are concatenated
@@ -981,6 +1013,8 @@ private fun RedfaceNavHost(
     topicScrollNavState: TopicScrollNavState,
     // #291 — multi-quote basket, same hoisting rationale (survives the per-page entry swap).
     multiQuoteNavState: MultiQuoteNavState,
+    // #465 — per-topic poll-expansion cache, same hoisting rationale (survives the per-page swap).
+    topicPollNavState: TopicPollNavState,
     onOpenProfile: (userId: Int, pseudo: String, avatarUrl: String?) -> Unit = { _, _, _ -> },
 ) {
     NavDisplay(
@@ -1458,6 +1492,15 @@ private fun RedfaceNavHost(
                         .orEmpty(),
                     onToggleMultiQuote = { numreponse ->
                         multiQuoteNavState.onToggle(route.cat, route.post, numreponse)
+                    },
+                    // #465 — the topic's saved manual poll choice (null = follow the global
+                    // default), and the callback recording a tap on the poll card. Hoisted to
+                    // :app so it survives the per-page TopicRoute swap, keyed by (cat, post).
+                    pollManualExpanded = topicPollNavState.expansions[
+                        TopicPollKey(route.cat, route.post),
+                    ],
+                    onPollExpansionChanged = { expanded ->
+                        topicPollNavState.onExpansionChanged(route.cat, route.post, expanded)
                     },
                     onMultiQuote = { subcat, page ->
                         // #291 — quote flavour of reply with the EXTRA numreponses riding the

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/TopicPollKey.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/TopicPollKey.kt
@@ -1,0 +1,43 @@
+package fr.forumhfr.redface2.navigation
+
+/**
+ * #465 — composite cache key for the per-topic poll-expansion cache. HFR exposes at most ONE poll
+ * per topic, so a topic-level key is enough — no need for a per-page or per-poll component. Same
+ * `(cat, post)` rationale as [TopicTitleKey] / `MultiQuoteBasket`: a topic id is unique only per HFR
+ * category, so keying by `post` alone could leak a manual choice across two categories that happen
+ * to share the same id.
+ */
+internal data class TopicPollKey(val cat: Int, val post: Int)
+
+// Upper bound on the per-topic poll-expansion cache, mirroring TOPIC_TITLE_CACHE_MAX / the scroll
+// anchor cap. A long reading session opens many topics with polls; the cap keeps the map from
+// growing unbounded for the app's lifetime. Eviction is least-recently-WRITTEN (like the scroll
+// anchors): dropping an old manual choice just lets that topic fall back to the global default,
+// which is harmless.
+internal const val TOPIC_POLL_EXPANSION_CACHE_MAX = 128
+
+/**
+ * #465 — records the user's MANUAL poll-expansion choice for [key] (`true` = revealed, `false` =
+ * collapsed), evicting the oldest entries past [TOPIC_POLL_EXPANSION_CACHE_MAX]. Twin of
+ * [withScrollAnchor]: an update to an existing key is remove-then-reinsert so the entry moves to the
+ * tail (least-recently-written eviction), and an unchanged value short-circuits to the same instance
+ * so a redundant toggle never reallocates the map nor recomposes `RedfaceApp`.
+ *
+ * Only topics the user has manually toggled appear here; absence of a key means « follow the global
+ * `topicPollsExpanded` default ». The map survives the per-page TopicRoute entry swap because it is
+ * hoisted into `RedfaceApp` (above `NavDisplay`), exactly like the title / scroll-anchor caches — so
+ * collapsing or expanding a poll persists across page navigation within the same topic. In-memory
+ * only (session-scoped), reset naturally when the app process dies.
+ */
+internal fun Map<TopicPollKey, Boolean>.withPollExpansion(
+    key: TopicPollKey,
+    expanded: Boolean,
+): Map<TopicPollKey, Boolean> {
+    if (this[key] == expanded) return this
+    val updated = (if (containsKey(key)) this - key else this) + (key to expanded)
+    return if (updated.size > TOPIC_POLL_EXPANSION_CACHE_MAX) {
+        updated.entries.drop(updated.size - TOPIC_POLL_EXPANSION_CACHE_MAX).associate { it.toPair() }
+    } else {
+        updated
+    }
+}

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/TopicPollExpansionTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/TopicPollExpansionTest.kt
@@ -1,0 +1,106 @@
+package fr.forumhfr.redface2.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #465 — covers the per-topic poll-expansion cache helper that makes a manual collapse/expand
+ * survive page navigation within a topic. Twin of [TopicScrollCacheTest] / [TopicTitleCacheTest]:
+ * a pure function over an immutable map, unit-testable without Compose.
+ */
+class TopicPollExpansionTest {
+
+    private fun key(cat: Int, post: Int) = TopicPollKey(cat, post)
+
+    @Test
+    fun `withPollExpansion inserts a new manual choice`() {
+        val cache = emptyMap<TopicPollKey, Boolean>().withPollExpansion(key(1, 10), expanded = false)
+
+        assertEquals(false, cache[key(1, 10)])
+    }
+
+    @Test
+    fun `absent topic returns null so the screen follows the global default`() {
+        val cache = emptyMap<TopicPollKey, Boolean>().withPollExpansion(key(1, 10), expanded = true)
+
+        // A topic the user never toggled has no entry: the lookup is null, and TopicScreen falls
+        // back to TopicUiState.pollsExpandedDefault (the #456 setting).
+        assertNull(cache[key(2, 20)])
+    }
+
+    @Test
+    fun `withPollExpansion keys by (cat, post) so other topics and categories do not collide`() {
+        val cache = emptyMap<TopicPollKey, Boolean>()
+            .withPollExpansion(key(1, 10), expanded = false)
+            .withPollExpansion(key(1, 11), expanded = true)
+            .withPollExpansion(key(2, 10), expanded = true)
+
+        assertEquals(false, cache[key(1, 10)])
+        assertEquals(true, cache[key(1, 11)])
+        assertEquals(true, cache[key(2, 10)])
+        assertEquals(3, cache.size)
+    }
+
+    @Test
+    fun `withPollExpansion flips the value when the user toggles again`() {
+        // The core #465 scenario: default expanded → user collapses on page N → the collapse must
+        // persist (a later toggle expands it again). One entry per topic, last write wins.
+        val cache = emptyMap<TopicPollKey, Boolean>()
+            .withPollExpansion(key(1, 10), expanded = false)
+            .withPollExpansion(key(1, 10), expanded = true)
+
+        assertEquals(true, cache[key(1, 10)])
+        assertEquals(1, cache.size)
+    }
+
+    @Test
+    fun `withPollExpansion returns the same instance when unchanged (no recomposition)`() {
+        val cache = emptyMap<TopicPollKey, Boolean>().withPollExpansion(key(1, 10), expanded = true)
+
+        val again = cache.withPollExpansion(key(1, 10), expanded = true)
+
+        assertSame("an unchanged choice must not allocate a new map", cache, again)
+    }
+
+    @Test
+    fun `withPollExpansion evicts the oldest entries past the cap`() {
+        var cache = emptyMap<TopicPollKey, Boolean>()
+        repeat(TOPIC_POLL_EXPANSION_CACHE_MAX + 10) { i ->
+            cache = cache.withPollExpansion(key(0, i), expanded = i % 2 == 0)
+        }
+
+        assertEquals(TOPIC_POLL_EXPANSION_CACHE_MAX, cache.size)
+        assertTrue(
+            "the 10 oldest insertions are evicted",
+            (0 until 10).none { cache.containsKey(key(0, it)) },
+        )
+        assertTrue(
+            "the newest insertion is kept",
+            cache.containsKey(key(0, TOPIC_POLL_EXPANSION_CACHE_MAX + 9)),
+        )
+    }
+
+    @Test
+    fun `withPollExpansion refreshes the eviction rank when an existing key is updated`() {
+        // Same LRU-by-write contract as withScrollAnchor: re-toggling a topic must move it to the
+        // tail, so a topic toggled early but still actively read is not the first evicted.
+        var cache = emptyMap<TopicPollKey, Boolean>()
+            .withPollExpansion(key(9, 99), expanded = false)
+        repeat(TOPIC_POLL_EXPANSION_CACHE_MAX - 1) { i ->
+            cache = cache.withPollExpansion(key(0, i), expanded = true)
+        }
+
+        // Cache exactly full; updating the oldest key must re-rank it to most recent…
+        cache = cache.withPollExpansion(key(9, 99), expanded = true)
+        // …so the next insertion evicts the oldest filler key, not the just-updated one.
+        cache = cache.withPollExpansion(key(0, 9999), expanded = false)
+
+        assertEquals(TOPIC_POLL_EXPANSION_CACHE_MAX, cache.size)
+        assertEquals(true, cache[key(9, 99)])
+        assertFalse("the oldest filler entry is the one evicted", cache.containsKey(key(0, 0)))
+    }
+}

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -218,6 +218,19 @@ fun TopicScreen(
      * topic's `(subcat, page)` like [onReply].
      */
     onMultiQuote: (subcat: Int, page: Int) -> Unit = { _, _ -> },
+    /**
+     * #465 — the user's MANUAL poll-expansion choice for THIS topic, owned by `:app` so it survives
+     * the per-page TopicRoute swap (like the multi-quote basket / scroll anchors). `null` means « no
+     * manual choice yet — follow the [TopicUiState.pollsExpandedDefault] setting »; `true` / `false`
+     * mean the user explicitly expanded / collapsed the poll. The screen only renders it.
+     */
+    pollManualExpanded: Boolean? = null,
+    /**
+     * #465 — records a tap on the poll card (the resulting revealed state), so `:app` caches the
+     * manual choice per `(cat, post)`. The next page of the same topic reads it back through
+     * [pollManualExpanded], keeping the poll collapsed / expanded across page navigation.
+     */
+    onPollExpansionChanged: (Boolean) -> Unit = {},
 ) {
     val viewModel = hiltViewModel<TopicViewModel, TopicViewModel.Factory>(
         creationCallback = { factory -> factory.create(request) },
@@ -372,6 +385,8 @@ fun TopicScreen(
         multiQuoteSelection = multiQuoteSelection,
         onToggleMultiQuote = onToggleMultiQuote,
         onMultiQuote = onMultiQuote,
+        pollManualExpanded = pollManualExpanded,
+        onPollExpansionChanged = onPollExpansionChanged,
     )
 
     // #292 — confirmation before the (irreversible, no-undo) deletion. Only « Supprimer » sends the
@@ -601,6 +616,10 @@ internal fun TopicContent(
     multiQuoteSelection: List<Int> = emptyList(),
     onToggleMultiQuote: (numreponse: Int) -> Unit = {},
     onMultiQuote: (subcat: Int, page: Int) -> Unit = { _, _ -> },
+    // #465 — the topic's manual poll choice (owned by :app, null = follow the global default) +
+    // the callback recording a tap on the poll card. Threaded to the header card's poll.
+    pollManualExpanded: Boolean? = null,
+    onPollExpansionChanged: (Boolean) -> Unit = {},
 ) {
     // #285 — the topic title and #284 — the page counter live in a persistent top app bar so they
     // stay visible while the user scrolls (the in-card title/caption scrolls away). When the page
@@ -777,6 +796,8 @@ internal fun TopicContent(
                                 listState = listState,
                                 multiQuoteSelection = multiQuoteSelection,
                                 onToggleMultiQuote = onToggleMultiQuote,
+                                pollManualExpanded = pollManualExpanded,
+                                onPollExpansionChanged = onPollExpansionChanged,
                             )
                             LazyListScrollbar(
                                 listState = listState,
@@ -808,6 +829,10 @@ private fun TopicLoadedContent(
     // #291 — selection state + toggle for the post menu's multi-quote entry.
     multiQuoteSelection: List<Int> = emptyList(),
     onToggleMultiQuote: (numreponse: Int) -> Unit = {},
+    // #465 — the topic's manual poll choice (owned by :app, null = follow the global default) + the
+    // callback recording a tap on the poll card. Threaded down to the header card's poll.
+    pollManualExpanded: Boolean? = null,
+    onPollExpansionChanged: (Boolean) -> Unit = {},
 ) {
     val highlight = state.request.scrollTo
     // #239 — how many posts of THIS page cite each post, computed once per loaded post list. Drives
@@ -934,6 +959,8 @@ private fun TopicLoadedContent(
                 onReply = onReply,
                 onEditFirstPost = editFirstPostAction,
                 onOpenPage = onOpenPage,
+                pollManualExpanded = pollManualExpanded,
+                onPollExpansionChanged = onPollExpansionChanged,
             )
         }
         items(
@@ -1082,12 +1109,17 @@ private fun EndOfTopicFooter() {
 }
 
 @Composable
+@Suppress("LongParameterList") // state-hoisted Composable : each param has a distinct call-site.
 private fun TopicHeaderCard(
     topic: Topic,
     state: TopicUiState,
     onReply: (subcat: Int, page: Int) -> Unit,
     onEditFirstPost: (() -> Unit)?,
     onOpenPage: (Int) -> Unit,
+    // #465 — manual poll choice (null = follow the global default) + its toggle callback, both
+    // owned by :app so the expand/collapse choice survives the per-page TopicRoute swap.
+    pollManualExpanded: Boolean? = null,
+    onPollExpansionChanged: (Boolean) -> Unit = {},
 ) {
     Card {
         Column(
@@ -1126,7 +1158,12 @@ private fun TopicHeaderCard(
                 onOpenPage = onOpenPage,
             )
             topic.poll?.let { poll ->
-                TopicPollCard(poll, expandedDefault = state.pollsExpandedDefault)
+                TopicPollCard(
+                    poll = poll,
+                    expandedDefault = state.pollsExpandedDefault,
+                    manualExpanded = pollManualExpanded,
+                    onExpansionChanged = onPollExpansionChanged,
+                )
             }
             Button(
                 onClick = { onReply(topic.subcat, topic.page) },
@@ -1253,16 +1290,23 @@ private fun TopicPageJumpField(
 }
 
 @Composable
-private fun TopicPollCard(poll: Poll, expandedDefault: Boolean) {
-    // #456 — the preference seeds the initial state only; the tap toggle stays per-topic and
-    // survives rotation (rememberSaveable). Keyed on the poll AND the seed so the card follows
-    // a Settings change without restart (the saved value wins otherwise).
-    var revealed by rememberSaveable(poll, expandedDefault) { mutableStateOf(expandedDefault) }
+private fun TopicPollCard(
+    poll: Poll,
+    expandedDefault: Boolean,
+    // #465 — the user's manual choice for this topic's poll, hoisted to :app so it survives the
+    // per-page TopicRoute swap. `null` = no manual choice yet → follow [expandedDefault] (#456).
+    manualExpanded: Boolean?,
+    onExpansionChanged: (Boolean) -> Unit,
+) {
+    // #456 — the preference seeds the initial state; #465 — once the user taps, the manual choice
+    // (owned by :app, keyed by topic) wins and survives navigation between the topic's pages. The
+    // card is fully controlled: it never holds the revealed state itself, it only reports a toggle.
+    val revealed = manualExpanded ?: expandedDefault
     Card(
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
         ),
-        modifier = Modifier.clickable { revealed = !revealed },
+        modifier = Modifier.clickable { onExpansionChanged(!revealed) },
     ) {
         Column(
             modifier = Modifier


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaTriX)

**Parcours de nuit 2026-06-15 → matin 2026-06-16. Draft : à arbitrer/merger au réveil, ne PAS merger automatiquement.**

Closes-#465 (mot-clé cassé volontairement — décision de merge au matin).

## Problème
Le pli/dépli d'un sondage vivait dans `TopicPollCard` via `rememberSaveable(poll, expandedDefault)`. Un changement de page remplace le `TopicRoute` en place (#282) → nouvelle nav entry → nouveau `TopicViewModel` **et** un `rememberSaveable` neuf, donc la carte se re-seedait sur le réglage global à chaque page. Le geste manuel ne survivait pas au swipe.

## Fix
État hissé dans `RedfaceApp` (jumeau de `topicTitleCache` / `topicScrollAnchorCache` / `MultiQuoteBasket`), keyé `TopicPollKey(cat, post)` (un seul sondage par topic ; un id de topic n'est unique que par catégorie). `TopicPollCard` devient **entièrement contrôlée** : `revealed = manualExpanded ?: expandedDefault`, le tap remonte `onExpansionChanged(!revealed)`. Absence de clé = suit le défaut global `topicPollsExpanded` (#456). Map RAM/session, éviction least-recently-written au-delà de 128 entrées.

La proposition littérale de l'issue (hisser dans `TopicViewModel` keyé `topicId`) **ne corrigerait pas** le bug : le VM est recréé à chaque page par `TopicRoute`, donc il ne survit pas non plus au swap.

## Validation (machine B, Docker pin)
- `detektAll` ✅ · `:app:assembleDevDebug` ✅ · `:app:testDevDebugUnitTest` ✅ (dont 7 cas `TopicPollExpansionTest`) · `:feature:topic:testDebugUnitTest` ✅
- Tests écrits ET exécutés.

## ⚠️ Arbitrage demandé — finding Codex (P2)
Codex relève une **régression rotation** : l'ancien `rememberSaveable` survivait à une recréation d'Activity (rotation, changement de thème/config) ; le cache hissé en `remember` nu est reconstruit vide → le sondage retombe sur le défaut global après rotation.

**C'est un arbitrage, pas un bug net** :
- Le pattern choisi est **identique aux 3 caches de session jumeaux** (`multiQuoteBasket`, `topicTitleCache`, `topicScrollAnchorCache`) — tous en `remember` nu, tous perdus à la rotation. La cohérence est ici respectée.
- Mais le sondage, lui, *survivait* à la rotation avant ce PR (via `rememberSaveable` dans la carte). C'est donc une régression réelle sur cet axe précis.

**Options :**
- **(A)** Rendre `topicPollExpansionCache` saveable (`rememberSaveable` + `listSaver` aplati `[cat, post, expanded, …]`, ~15 l.) → zéro régression rotation, mais **incohérent** avec les 3 caches frères (pourquoi seul le sondage serait saveable ?).
- **(B)** Garder `remember` nu (état actuel du PR) → cohérent avec les frères, régression rotation mineure acceptée (un sondage plié se ré-ouvre après rotation, comme la position de scroll/titre se reperdent).

Reco : **(A)** si on considère que « le sondage survivait à la rotation, on ne régresse pas » prime ; sinon **(B)** + ouvrir une issue « rendre les caches de session saveable » traitant les 4 d'un coup (décision d'archi à trancher ensemble, cf. AGENTS.md « plusieurs options viables → avis humain »).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
