### PR TITLE
fix(topic): l'en-tête du post ne bouge plus à la sélection multi-quote (#476) [nuit, draft]

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1423,6 +1423,11 @@ internal fun TopicPostCard(
             } else {
                 Modifier
             }
+            // #476 — width of the avatar slot in the identity Row, used below to indent the
+            // pills under the pseudo (not under the avatar). minimumInteractiveComponentSize()
+            // inflates the clickable avatar to the 48dp touch target; otherwise it is the
+            // RedfaceUserAvatar default (40dp). Kept in sync with `avatarModifier` above.
+            val avatarSlotWidth = if (onOpenProfile != null) 48.dp else 40.dp
             val pseudoModifier = if (onOpenProfile != null) {
                 // No minimumInteractiveComponentSize() on the pseudo: it reserves a 48dp-tall box
                 // and centres the text inside it, which inflated the header Row and left the pseudo
@@ -1437,116 +1442,155 @@ internal fun TopicPostCard(
             } else {
                 Modifier
             }
-            Row(
+            // #476 — wrap the identity Row in a Column so the selection/citation pills can sit
+            // BELOW the identity line instead of inside it. Previously the pills lived in the
+            // pseudo+date Column, which the avatar and the « ⋯ » were CenterVertically-aligned
+            // against : toggling the multi-quote pill grew that Column and re-centred the avatar
+            // and the « ⋯ », so the identity line visibly shifted (dev feedback). Hoisting the
+            // pills out of that Column means a pill appearing/disappearing only grows the card
+            // downward, leaving the avatar/pseudo/⋯ line perfectly still. The header padding moves
+            // from the Row to this wrapper so the band geometry is unchanged.
+            Column(
                 modifier = Modifier
                     .fillMaxWidth()
                     // #287 — header band vertical padding tightens under the Compact preset.
                     .padding(horizontal = 12.dp, vertical = m.cardHeaderVertical),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                // Centre the avatar against the name+date block so the identity line reads as one
-                // tidy unit (the previous Top alignment + the inflated pseudo made the pseudo look
-                // vertically centred while the date dropped well below the avatar).
-                verticalAlignment = Alignment.CenterVertically,
+                verticalArrangement = Arrangement.spacedBy(2.dp),
             ) {
-                RedfaceUserAvatar(
-                    avatarUrl = post.avatarUrl,
-                    author = post.author,
-                    modifier = avatarModifier,
-                )
-                Column(
-                    // #362 — weight(1f) instead of fillMaxWidth so the menu button below gets its
-                    // slot at the right edge of the header; the pseudo keeps its own weight inside.
-                    modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    // Centre the avatar against the name+date block so the identity line reads as
+                    // one tidy unit (the previous Top alignment + the inflated pseudo made the
+                    // pseudo look vertically centred while the date dropped well below the avatar).
+                    // #476 — this Row now holds ONLY the stable pseudo+date block, so CenterVertically
+                    // can never be perturbed by the pills (which moved below this Row).
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
+                    RedfaceUserAvatar(
+                        avatarUrl = post.avatarUrl,
+                        author = post.author,
+                        modifier = avatarModifier,
+                    )
+                    Column(
+                        // #362 — weight(1f) instead of fillMaxWidth so the menu button beside it gets
+                        // its slot at the right edge of the header; the pseudo keeps its own weight.
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(2.dp),
                     ) {
-                        post.postIndex?.let { postIndex ->
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            post.postIndex?.let { postIndex ->
+                                Text(
+                                    text = stringResource(
+                                        R.string.topic_post_index_prefix,
+                                        postIndex,
+                                    ),
+                                    style = MaterialTheme.typography.titleSmall,
+                                    fontWeight = FontWeight.SemiBold,
+                                )
+                            }
                             Text(
-                                text = stringResource(R.string.topic_post_index_prefix, postIndex),
+                                text = post.author,
                                 style = MaterialTheme.typography.titleSmall,
                                 fontWeight = FontWeight.SemiBold,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                // Clickable on the pseudo only — the date stays inert.
+                                modifier = Modifier
+                                    .weight(weight = 1f, fill = false)
+                                    .then(pseudoModifier),
                             )
                         }
                         Text(
-                            text = post.author,
-                            style = MaterialTheme.typography.titleSmall,
-                            fontWeight = FontWeight.SemiBold,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            // Clickable on the pseudo only — the date stays inert.
-                            modifier = Modifier
-                                .weight(weight = 1f, fill = false)
-                                .then(pseudoModifier),
+                            text = post.date.asTopicDate(),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
+                    // #362 — per-post contextual menu trigger, flush right of the header. The post
+                    // number that used to trail the pseudo lives in the menu now. A text glyph, not
+                    // a Material icon (detekt ForbiddenImport blocks androidx.compose.material.*) —
+                    // same pattern as PageFab/ReplyFab. Sits in the identity Row (next to the
+                    // pseudo+date block) so its 48dp touch target never inflates the pseudo line
+                    // (cf. the pseudo minimumInteractiveComponentSize note above).
+                    val menuLabel = stringResource(R.string.topic_post_menu_action)
                     Text(
-                        text = post.date.asTopicDate(),
-                        style = MaterialTheme.typography.labelMedium,
+                        text = "⋯",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier
+                            .minimumInteractiveComponentSize()
+                            .clickable(
+                                onClick = onOpenMenu,
+                                role = Role.Button,
+                                onClickLabel = menuLabel,
+                            )
+                            .semantics { contentDescription = menuLabel },
                     )
-                    if (citedCount > 0) {
-                        // #239 — sober pill: how many posts of THIS page cite this one. Page-scoped
-                        // (cf. citationCountsByNumreponse); jumping to the citing posts is a follow-up.
-                        // `surface` container : the pill now lives on the secondaryContainer identity
-                        // band, where a secondaryContainer pill would be invisible.
-                        Surface(
-                            color = MaterialTheme.colorScheme.surface,
-                            shape = MaterialTheme.shapes.small,
-                        ) {
-                            Text(
-                                text = pluralStringResource(
-                                    R.plurals.topic_post_cited_count,
-                                    citedCount,
-                                    citedCount,
-                                ),
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
-                            )
+                }
+                // #476 — citation + multi-quote pills, hoisted OUT of the pseudo+date Column and
+                // placed below the identity Row, preserving the original « pills sit under the date,
+                // flush with the pseudo » look. The start padding reproduces where the pseudo column
+                // begins in the identity Row: the avatar slot width PLUS that Row's 12.dp
+                // avatar-to-name gap. (A leading Spacer + spacedBy would only add the 8.dp inter-pill
+                // gap, landing the pills 4.dp left of the pseudo.) Because they no longer share a
+                // Column with the avatar/⋯ vertical-centering, toggling the multi-quote pill only
+                // grows the card downward — the identity line never moves.
+                if (citedCount > 0 || multiQuoteSelected) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(start = avatarSlotWidth + 12.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        if (citedCount > 0) {
+                            // #239 — sober pill: how many posts of THIS page cite this one.
+                            // Page-scoped (cf. citationCountsByNumreponse); jumping to the citing
+                            // posts is a follow-up. `surface` container : the pill lives on the
+                            // secondaryContainer identity band, where a secondaryContainer pill
+                            // would be invisible.
+                            Surface(
+                                color = MaterialTheme.colorScheme.surface,
+                                shape = MaterialTheme.shapes.small,
+                            ) {
+                                Text(
+                                    text = pluralStringResource(
+                                        R.plurals.topic_post_cited_count,
+                                        citedCount,
+                                        citedCount,
+                                    ),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+                                )
+                            }
                         }
-                    }
-                    if (multiQuoteSelected) {
-                        // #436 — basket-membership pill, same shape family as the #239 pill above.
-                        // primaryContainer : distinct from the band (secondaryContainer) AND from a
-                        // highlighted band (tertiaryContainer), and it echoes the primary border so
-                        // the two marks read as one signal.
-                        Surface(
-                            color = MaterialTheme.colorScheme.primaryContainer,
-                            shape = MaterialTheme.shapes.small,
-                        ) {
-                            Text(
-                                text = stringResource(R.string.topic_post_multiquote_selected),
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onPrimaryContainer,
-                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
-                            )
+                        if (multiQuoteSelected) {
+                            // #436 — basket-membership pill, same shape family as the #239 pill.
+                            // primaryContainer : distinct from the band (secondaryContainer) AND
+                            // from a highlighted band (tertiaryContainer), and it echoes the primary
+                            // border so the two marks read as one signal.
+                            Surface(
+                                color = MaterialTheme.colorScheme.primaryContainer,
+                                shape = MaterialTheme.shapes.small,
+                            ) {
+                                Text(
+                                    text = stringResource(
+                                        R.string.topic_post_multiquote_selected,
+                                    ),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+                                )
+                            }
                         }
                     }
                 }
-                // #362 — per-post contextual menu trigger, flush right of the header. The post
-                // number that used to trail the pseudo lives in the menu now. A text glyph, not a
-                // Material icon (detekt ForbiddenImport blocks androidx.compose.material.*) — same
-                // pattern as PageFab/ReplyFab. Sits in the OUTER row (next to the whole
-                // avatar+name+date block) so its 48dp touch target never inflates the pseudo line
-                // (cf. the pseudo minimumInteractiveComponentSize note above).
-                val menuLabel = stringResource(R.string.topic_post_menu_action)
-                Text(
-                    text = "⋯",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier
-                        .minimumInteractiveComponentSize()
-                        .clickable(
-                            onClick = onOpenMenu,
-                            role = Role.Button,
-                            onClickLabel = menuLabel,
-                        )
-                        .semantics { contentDescription = menuLabel },
-                )
             }
         }
         Column(


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaTriX)

**Parcours de nuit 2026-06-15 → matin 2026-06-16. Draft : à arbitrer/merger au réveil, ne PAS merger automatiquement.**

Closes-#476 (mot-clé cassé volontairement — décision de merge au matin).

## Bug
Retour de **thibw** (DEV 2787559) : sélectionner un post pour la citation multiple (« + Citer », #436) décalait son avatar/pseudo. La pill « basket » de sélection (et la pill « cité N fois » #239) vivaient dans la Column pseudo+date, contre laquelle l'avatar et le « ⋯ » étaient centrés verticalement. Toggler la pill grandissait cette Column → avatar et ⋯ se re-centraient → la ligne d'identité sautait à chaque tap.

## Fix (option A — restructuration propre)
Les deux pills sont sorties de la Row d'identité vers une Column wrapper, placées **sous** la Row stable avatar+pseudo+date. La Row d'identité ne centre plus l'avatar que contre le bloc pseudo+date à hauteur fixe ; une pill qui apparaît/disparaît fait grandir la carte vers le bas sans jamais déplacer avatar/pseudo/⋯. Le padding de la bande passe de la Row au wrapper → géométrie de bande inchangée. Le `border` 2.dp (aussi piloté par la sélection) est peint, pas mesuré : il ne reflowait pas, gardé comme signal principal.

Alignement des pills sous le pseudo : `padding(start = avatarSlotWidth + 12.dp)` (largeur du slot avatar + le gap avatar→pseudo de 12.dp de la Row d'identité), pas un Spacer (qui, avec `spacedBy(8.dp)`, laissait les pills 4.dp trop à gauche — P3 Codex corrigé).

## Validation (machine B, Docker pin)
- `detektAll` ✅ · `:app:assembleDevDebug` ✅ · `:feature:topic:testDebugUnitTest` ✅
- Pas de test unitaire : layout Compose pur, aucun test ne monte le header (`TopicPostCardMultiQuoteTest` ne couvre que le footer « + Citer »/« ✓ Cité », inchangé → reste vert). L'invariant « le toggle ne déplace pas l'avatar » serait testable via Roborazzi/`getBoundsInRoot` mais aucun harnais de ce type n'existe ici.
- **À confirmer au device** (revue visuelle) : (1) alignement exact des pills sous le pseudo ; (2) cas combiné rare `citedCount>0` ET sélectionné → les 2 pills sont désormais **côte-à-côte** (Row, `spacedBy 8.dp`) alors qu'elles étaient empilées verticalement avant. Choix : chip-row horizontal, plus compact ; si l'empilement vertical est préféré pour ce cas, remplacer la Row des pills par une Column.

## Codex
1 finding P3 (alignement 4.dp) — **corrigé** dans ce PR. Aucun bloquant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
