### PR TITLE
feat(topic): marqueur « édité » visible près de la date (#483) [nuit, draft]

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1548,11 +1548,33 @@ internal fun TopicPostCard(
                                     .then(pseudoModifier),
                             )
                         }
-                        Text(
-                            text = post.date.asTopicDate(),
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
+                        // #483 — the date line carries a compact « · édité » marker when the post was
+                        // edited (beta feedback Azgor). The exact edit time stays in the « … » menu
+                        // (PostMenuSheet « Édité le … »). On the date line, INSIDE the pseudo+date
+                        // Column but OUTSIDE the pseudo Row, so it never reflows the avatar nor breaks
+                        // the pseudo ellipsis — and it composes with #476's stable header (pills hoisted
+                        // below this Row) since the date block never grows the identity line sideways.
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            Text(
+                                text = post.date.asTopicDate(),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            if (post.editedAt != null) {
+                                val editedLabel = stringResource(R.string.topic_post_edited_inline)
+                                Text(
+                                    // « · » is a decorative separator — TalkBack reads the
+                                    // contentDescription (« édité »), so the dot is never vocalised.
+                                    text = "· $editedLabel",
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.semantics { contentDescription = editedLabel },
+                                )
+                            }
+                        }
                     }
                     // #362 — per-post contextual menu trigger, flush right of the header. The post
                     // number that used to trail the pseudo lives in the menu now. A text glyph, not

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -40,6 +40,9 @@
     <string name="topic_post_menu_no_browser">Aucun navigateur disponible</string>
     <string name="topic_post_menu_report_soon">Alerter (à venir)</string>
     <string name="topic_post_menu_edited">Édité le %1$s</string>
+    <!-- #483 — compact inline marker next to the post date when the post was edited; the full
+         « Édité le … » timestamp stays in the post menu (R.string.topic_post_menu_edited). -->
+    <string name="topic_post_edited_inline">édité</string>
     <plurals name="topic_post_menu_cited_on_page">
         <item quantity="one">Cité %1$d fois sur cette page</item>
         <item quantity="other">Cité %1$d fois sur cette page</item>


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaTriX)

**Parcours de nuit 2026-06-15 → matin 2026-06-16. Draft : à arbitrer/merger au réveil, ne PAS merger automatiquement.**

Closes-#483 (mot-clé cassé volontairement — décision de merge au matin).

## Feature
Retour d'**Azgor** (bêta 0.10.0) : aucune indication visible qu'un post est édité — l'info ne vivait que dans le menu « ⋯ ». Ce PR affiche un marqueur sobre **« · édité »** sur la ligne de date du post quand `post.editedAt != null`, **en plus** de l'entrée du menu (conservée intacte, « Édité le … »).

- Donnée existante (`Post.editedAt`, déjà parsé du `div.edited`) — aucun nouveau parsing.
- Marqueur sur la ligne de date (sa propre Row), **hors de la Row du pseudo** : ne grandit pas la ligne pseudo, ne décale pas l'avatar (cf. historique reflow en-tête #476).
- TalkBack : `contentDescription = "édité"` pour ne pas vocaliser le séparateur « · ».
- Nouvelle string `topic_post_edited_inline` (« édité »), distincte de `topic_post_menu_edited` (« Édité le %1$s ») car formats différents. FR uniquement (aucune autre locale dans le projet).

## Choix de design (à confirmer)
Marqueur **mot seul « · édité »** accolé à la date (l'horodatage précis reste dans le menu), plutôt qu'une pill/badge (jugé trop lourd, redondant avec les pills #239/#436). Alternative possible si XaTriX préfère : afficher la date d'édition courte inline (« édité le DD/MM »). À trancher au device.

## Validation (machine B, Docker pin)
- `detektAll` ✅ · `:app:assembleDevDebug` ✅ · `:feature:topic:testDebugUnitTest` ✅ · `:feature:topic:lintDebug` ✅
- Codex review : 0 finding.
- Pas de test unitaire (marqueur visuel, layout Compose) ; `TopicPostCardMultiQuoteTest` non impacté.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
