### PR TITLE
fix(flags): auto-refresh au changement d'onglet + à la reprise (#501) [nuit, draft, À REPRENDRE]

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/flags/DefaultFlagRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/flags/DefaultFlagRepository.kt
@@ -22,6 +22,9 @@ import java.util.EnumMap
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.channels.BufferOverflow
@@ -81,6 +84,11 @@ class DefaultFlagRepository @Inject constructor(
 
     private val cachedSuccesses: MutableMap<FlagType, FlagsResult.Success> = EnumMap(FlagType::class.java)
 
+    // Bumped by [clearSessionCache] on logout / account switch, read+written under the cachedSuccesses
+    // lock. A fetch that began before a switch must not write its result into the (type-keyed)
+    // singleton cache afterwards (#501 Codex P1) — it compares this generation at write time.
+    private var sessionGeneration = 0
+
     /**
      * One refresh-trigger per [FlagType] so a refresh on one tab does not re-fetch the
      * other two. Replay = 0 because [observe] emits its own cached-or-initial result;
@@ -94,6 +102,26 @@ class DefaultFlagRepository @Inject constructor(
                 onBufferOverflow = BufferOverflow.DROP_OLDEST,
             )
         }
+
+    /**
+     * #501 (Codex review) — in-flight fetch coordinator, one [Deferred] per [FlagType]. observe()'s
+     * initial fetch (first subscription with no fresh cache) and an explicit refresh() can fire for
+     * the SAME tab at the same instant (the screen's auto-refresh lands as the list first subscribes),
+     * each otherwise running the full per-category REST fan-out. Sharing one in-flight Deferred
+     * collapses concurrent calls into a single fan-out; a completed fetch is cleared, so a LATER
+     * refresh still triggers a fresh one. Launched in an app-scoped CoroutineScope (this is a
+     * @Singleton, so the scope lives for the process) so cancelling one caller — e.g. observe() torn
+     * down by a flatMapLatest tab switch — never cancels the fetch a concurrent refresh still awaits.
+     */
+    private val fetchScope = CoroutineScope(SupervisorJob() + ioDispatcher)
+
+    /** Identifies an in-flight fetch by BOTH type and user — never share a fetch across accounts. */
+    private data class FetchKey(val type: FlagType, val userId: String)
+
+    // Keyed by (type, userId), NOT type alone: a fetch started for one account must never be awaited
+    // by another after a logout / account switch, and [clearSessionCache] cancels stragglers so they
+    // cannot repopulate the singleton success cache with the previous account's data (#501 Codex P1).
+    private val inFlightFetches: MutableMap<FetchKey, Deferred<FlagsResult>> = mutableMapOf()
 
     override fun observe(type: FlagType): Flow<FlagsResult> = flow {
         val cached = synchronized(cachedSuccesses) { cachedSuccesses[type] }
@@ -109,7 +137,7 @@ class DefaultFlagRepository @Inject constructor(
                     synchronized(cachedSuccesses) { cachedSuccesses[type] = diskCached.result }
                     emit(diskCached.result)
                     if (!diskCached.isFresh) {
-                        when (val refreshed = fetch(type = type, userId = userId)) {
+                        when (val refreshed = fetchDeduplicated(type = type, userId = userId)) {
                             is FlagsResult.Success -> emit(refreshed)
                             is FlagsResult.Failure -> Log.w(
                                 LOG_TAG,
@@ -121,7 +149,7 @@ class DefaultFlagRepository @Inject constructor(
                     }
                 } else {
                     emit(FlagsResult.Loading)
-                    emit(fetch(type = type, userId = userId))
+                    emit(fetchDeduplicated(type = type, userId = userId))
                 }
             }
         }
@@ -136,13 +164,24 @@ class DefaultFlagRepository @Inject constructor(
             if (userId == null) {
                 notAuthenticatedFailure()
             } else {
-                fetch(type = type, userId = userId)
+                fetchDeduplicated(type = type, userId = userId)
             },
         )
     }
 
     override fun clearSessionCache() {
-        synchronized(cachedSuccesses) { cachedSuccesses.clear() }
+        // Bump the generation under the same lock as the write guard: a fetch in flight across this
+        // point will see a changed generation and skip its cache write (#501 Codex P1).
+        synchronized(cachedSuccesses) {
+            cachedSuccesses.clear()
+            sessionGeneration++
+        }
+        // Cancel any fetch still in flight from the previous session so it stops early instead of
+        // running the full fan-out for an account that just logged out / switched.
+        synchronized(inFlightFetches) {
+            inFlightFetches.values.forEach { it.cancel() }
+            inFlightFetches.clear()
+        }
     }
 
     /**
@@ -225,8 +264,31 @@ class DefaultFlagRepository @Inject constructor(
         }
     }
 
+    /**
+     * Runs [fetch] for [type] unless an identical fetch is already in flight, in which case the
+     * concurrent caller awaits the same result instead of launching a second per-category fan-out
+     * (#501, Codex review). [fetch] folds every failure into [FlagsResult.Failure] and never throws,
+     * so the shared [Deferred] always completes with a result (no exception to propagate on await).
+     */
+    private suspend fun fetchDeduplicated(type: FlagType, userId: String): FlagsResult {
+        val key = FetchKey(type = type, userId = userId)
+        val deferred = synchronized(inFlightFetches) {
+            inFlightFetches[key]?.takeIf { it.isActive }
+                ?: fetchScope.async { fetch(type = type, userId = userId) }.also { started ->
+                    inFlightFetches[key] = started
+                    started.invokeOnCompletion {
+                        synchronized(inFlightFetches) {
+                            if (inFlightFetches[key] === started) inFlightFetches.remove(key)
+                        }
+                    }
+                }
+        }
+        return deferred.await()
+    }
+
     private suspend fun fetch(type: FlagType, userId: String): FlagsResult = withContext(ioDispatcher) {
-        runCatching {
+        val startGeneration = synchronized(cachedSuccesses) { sessionGeneration }
+        val result = runCatching {
             val cats = loadCategories()
             val bucket = type.toBucket()
             // `coroutineScope` (fail-all) is intentional over `supervisorScope` (best-effort).
@@ -249,15 +311,26 @@ class DefaultFlagRepository @Inject constructor(
         }.fold(
             onSuccess = { flags ->
                 persistFlags(userId = userId, type = type, flags = flags)
-                FlagsResult.Success(flags).also { result ->
-                    synchronized(cachedSuccesses) { cachedSuccesses[type] = result }
-                }
+                FlagsResult.Success(flags)
             },
             onFailure = { throwable ->
                 Log.w(LOG_TAG, "Flags REST fetch failed for $type", throwable)
                 FlagsResult.Failure(throwable)
             },
         )
+        // Cache the success ONLY if it still belongs to the active session (#501 Codex P1). observe()
+        // serves this type-keyed singleton cache BEFORE resolving the current user, so a stale write
+        // would hand the next account the previous account's flags. Two guards cover every ordering of
+        // a logout / account switch vs. this fetch: the user must still be the one we fetched for (a
+        // fetch launched for a now-stale account, racing the switch, is dropped), AND no
+        // clearSessionCache must have bumped the generation since this fetch began (a switch DURING the
+        // fetch). The disk cache (persistFlags) is already userId-scoped, so it keeps each account's data.
+        if (result is FlagsResult.Success && currentUserId() == userId) {
+            synchronized(cachedSuccesses) {
+                if (sessionGeneration == startGeneration) cachedSuccesses[type] = result
+            }
+        }
+        result
     }
 
     private suspend fun persistFlags(userId: String, type: FlagType, flags: List<Flag>) {

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/flags/DefaultFlagRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/flags/DefaultFlagRepositoryTest.kt
@@ -25,9 +25,13 @@ import java.io.IOException
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
@@ -89,6 +93,104 @@ class DefaultFlagRepositoryTest {
                 type = FlagType.CYAN,
                 rows = match { rows -> rows.size == 1 && rows.single().topicId == 35395 },
             )
+        }
+    }
+
+    @Test
+    fun `observe and refresh fired together share a single REST fan-out - 501`() = runTest {
+        // #501 (Codex review) — observe()'s initial fetch and a concurrent refresh() for the SAME tab
+        // must collapse into ONE per-category fan-out, not two. The gate keeps the first fetch in
+        // flight while the second caller arrives, so a missing in-flight dedup would call cat 23 twice.
+        val gate = CompletableDeferred<Unit>()
+        val apiClient = mockk<HfrApiClient>()
+        coEvery {
+            apiClient.getCategoryFlagTopics(
+                cat = 13,
+                bucket = HfrRestFlagBucket.PARTICIPATED,
+                page = any(),
+                resultsPerPage = any(),
+                useAuth = true,
+            )
+        } returns EMPTY_PAGE
+        coEvery {
+            apiClient.getCategoryFlagTopics(
+                cat = 23,
+                bucket = HfrRestFlagBucket.PARTICIPATED,
+                page = any(),
+                resultsPerPage = any(),
+                useAuth = true,
+            )
+        } coAnswers {
+            gate.await()
+            capturedParticipatedFixture
+        }
+        val repo = buildRepository(apiClient, stubForumRepository(sampleCategories))
+
+        // Sequence the two callers so they genuinely overlap: observe() first reaches the gated fetch
+        // (registering the in-flight Deferred), THEN refresh() runs and must find + await that same
+        // Deferred rather than starting a second fan-out. Only then release the gate.
+        val observeJob = launch { repo.observe(FlagType.CYAN).first { it is FlagsResult.Success } }
+        runCurrent()
+        val refreshJob = launch { repo.refresh(FlagType.CYAN) }
+        runCurrent()
+        gate.complete(Unit)
+        observeJob.join()
+        refreshJob.join()
+
+        // A single fan-out: the gated category was hit exactly once despite the two concurrent callers.
+        coVerify(exactly = 1) {
+            apiClient.getCategoryFlagTopics(
+                cat = 23,
+                bucket = HfrRestFlagBucket.PARTICIPATED,
+                page = any(),
+                resultsPerPage = any(),
+                useAuth = true,
+            )
+        }
+    }
+
+    @Test
+    fun `clearSessionCache keeps an in-flight fetch from caching across a session change - 501 P1`() = runTest {
+        // #501 (Codex review P1) — a fetch in flight when the account logs out / switches must not
+        // repopulate the type-keyed singleton cache, which observe() serves before resolving the
+        // current user (else the next account would receive the previous account's flags).
+        val gate = CompletableDeferred<Unit>()
+        val apiClient = mockk<HfrApiClient>()
+        coEvery {
+            apiClient.getCategoryFlagTopics(
+                cat = 13,
+                bucket = HfrRestFlagBucket.PARTICIPATED,
+                page = any(),
+                resultsPerPage = any(),
+                useAuth = true,
+            )
+        } returns EMPTY_PAGE
+        coEvery {
+            apiClient.getCategoryFlagTopics(
+                cat = 23,
+                bucket = HfrRestFlagBucket.PARTICIPATED,
+                page = any(),
+                resultsPerPage = any(),
+                useAuth = true,
+            )
+        } coAnswers {
+            gate.await()
+            capturedParticipatedFixture
+        }
+        val repo = buildRepository(apiClient, stubForumRepository(sampleCategories))
+
+        val inFlight = launch { repo.observe(FlagType.CYAN).first { it is FlagsResult.Success } }
+        runCurrent() // the fetch is now in flight, awaiting the gate
+        repo.clearSessionCache() // logout / account switch while the fetch is running
+        gate.complete(Unit)
+        inFlight.join()
+
+        // A fresh observe must RE-FETCH (Loading first) rather than serve the interrupted fetch's
+        // success from the singleton cache.
+        repo.observe(FlagType.CYAN).test {
+            assertEquals(FlagsResult.Loading, awaitItem())
+            assertTrue(awaitItem() is FlagsResult.Success)
+            cancelAndIgnoreRemainingEvents()
         }
     }
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -61,6 +61,8 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.domain.error.classifyHfrError
@@ -158,12 +160,23 @@ fun FlagsRoute(
         onFallback = { viewModel.selectTab(FlagTab.Cyan) },
     )
 
-    // #378 — auto-refresh on landing. LaunchedEffect(Unit) re-fires every time this screen
-    // (re)enters the composition: app open, back from a topic, return from another bottom tab —
-    // exactly the two requested triggers plus the tab round-trip that motivated #384. The
-    // ViewModel gates it (preference opt-out, auth, real tab, in-flight refresh, 15 s throttle)
-    // and reuses the pull-to-refresh indicator as the visual cue.
-    LaunchedEffect(Unit) {
+    // #378 — auto-refresh on landing. Keyed on [selectedTab] (not Unit) so it re-fires both when
+    // this screen (re)enters the composition — app open, back from a topic, return from another
+    // bottom tab — AND when the user switches flag tab WITHOUT leaving the screen (#501: a tab
+    // change kept FlagsRoute composed, so a Unit key never re-fired and the new tab showed stale
+    // data). The ViewModel snapshots the tab at call time and gates the call (preference opt-out,
+    // auth, real tab, in-flight refresh, 15 s throttle), so a rapid tab burst is absorbed by the
+    // throttle and reuses the pull-to-refresh indicator as the visual cue.
+    LaunchedEffect(selectedTab) {
+        viewModel.maybeAutoRefresh()
+    }
+
+    // #501 — also refresh when the app returns to the foreground. A warm resume (home → reopen
+    // without process death) does NOT leave/re-enter the composition, so the LaunchedEffect above
+    // never re-fired on relaunch. ON_RESUME covers exactly that case; the ViewModel's throttle and
+    // in-flight guard make a resume that lands right after another trigger a no-op (no double
+    // fan-out — the post-suspension recheck in maybeAutoRefresh is concurrency-safe).
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
         viewModel.maybeAutoRefresh()
     }
 


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaTriX)

**Parcours de nuit 2026-06-15 → matin 2026-06-16. Draft : à arbitrer/merger au réveil, ne PAS merger automatiquement.** 🟠 **À REPRENDRE** (1 P2 Codex à trancher avant merge — voir plus bas).

Closes-#501 (mot-clé cassé volontairement).

## Bug
L'auto-refresh des drapeaux ne se déclenchait que via `LaunchedEffect(Unit)`, qui re-fire seulement quand `FlagsRoute` (re)entre en composition : cold start, retour d'un topic, retour d'un autre onglet du bas. Il NE se déclenchait PAS :
- au **changement d'onglet drapeaux** (FlagsRoute reste composé → clé `Unit` jamais re-déclenchée) ;
- à la **reprise de l'app** depuis l'arrière-plan (un resume « tiède » ne quitte/ré-entre pas la composition).

## Fix (UI, `FlagsRoute.kt`)
1. **Clé `selectedTab`** au lieu de `Unit` sur l'effet de landing : re-fire aussi au changement d'onglet (rafraîchit l'onglet fraîchement sélectionné). Superset du comportement actuel (cold start / retour topic / retour onglet bas inchangés, bypass `onFlagOpened` préservé).
2. **`LifecycleEventEffect(ON_RESUME)`** : couvre la reprise depuis l'arrière-plan.

Les deux délèguent à `maybeAutoRefresh` (inchangé) : throttle global 15 s (absorbe les rafales — le throttle reste **global** car l'issue demande explicitement « ne pas re-fetch en rafale » ; basculer en throttle par-onglet est une option d'arbitrage), et recheck post-suspension concurrency-safe (deux triggers simultanés → un seul refresh).

## ⚠️ Arbitrage demandé — finding Codex (P2)
**Double fan-out au 1er affichage d'un onglet non encore chargé.** Le contrat `FlagRepository.observe(type)` fait un `fetch(type)` réseau (un GET par catégorie) à la 1re souscription sans cache frais. Mon `LaunchedEffect(selectedTab)` appelle aussi `maybeAutoRefresh` → `refresh(type)` → un 2e `fetch(type)` concurrent. `fetch()` n'a **aucun** dédoublonnage in-flight (vérifié), et `_isRefreshing` ne garde que les refresh explicites, pas le fetch initial de `observe`. → 2 fan-out concurrents pour le même type.

Portée réelle :
- Survient au **1er affichage de chaque onglet** (pas de cache mémoire). Après ça, `cachedSuccesses[type]` persiste entre les changements d'onglet → `observe` ressert le cache (pas de fetch) → seul `maybeAutoRefresh` fetch (throttlé). Cas re-visite = OK (= le fix voulu).
- Un **double cold-start préexistant** (observe(Cyan) + ancien `LaunchedEffect(Unit)`→refresh) existait DÉJÀ avant ce PR sur l'onglet initial — non introduit ici. Mon changement étend ce double aux **1res sélections d'autres onglets**.
- Fonctionnellement inoffensif (GETs idempotents, même cache écrit) mais **gaspilleur** — contraire à l'esprit anti-rafale de l'issue.

**Options de remède (à trancher au matin) :**
- **(A recommandée)** Dédup in-flight au niveau repository : un `Deferred<FlagsResult>` partagé par type (ou Mutex+cache d'in-flight) pour que `observe`-initial et `refresh` concurrents collapse sur un seul fan-out. **Corrige AUSSI le double cold-start préexistant.** Touche le cœur de `fetch()` + cancellation/scope (flatMapLatest annule `observe` au switch) → nécessite un scope injecté + tests `DefaultFlagRepositoryTest` → délicat, non fait en nuit autonome.
- **(B)** Gater le trigger tab-change pour ne PAS fire au 1er affichage (laisser `observe` fetch) et fire seulement en re-visite — mais l'état « déjà-vu » doit survivre à la ré-entrée de composition (retour topic), donc hoist dans le VM, stateful.
- **(C)** Ship seulement le trigger `ON_RESUME` (propre, sans double) et différer le trigger tab-change jusqu'à (A).

Reco : **(A)** — le seul remède qui rend le tab-change refresh propre ET supprime le gaspillage cold-start préexistant.

## Validation (machine B, Docker pin)
- `detektAll` ✅ · `:app:assembleDevDebug` ✅ · `:feature:flags:testDebugUnitTest` ✅
- Pas de test unitaire sur le câblage d'effets (Compose) ; `maybeAutoRefresh` (VM) inchangé donc ses tests restent verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
