### PR TITLE
fix(upload): durcissement providers Imgur + repository (#474) [nuit, draft]

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/DefaultUploadRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/DefaultUploadRepository.kt
@@ -85,16 +85,21 @@ private fun UploadedImage.toEntity(userId: String, uploadedAt: Instant): Uploade
         expiresAt = expiresAt,
     )
 
-private fun UploadedImageEntity.toRecord(): UploadedImageRecord =
-    UploadedImageRecord(
-        // Defensive read: an unknown stored provider name (downgrade / manual edit) degrades to the
-        // DIBERIE default instead of crashing valueOf — the row stays listable.
-        provider = runCatching { UploadProviderId.valueOf(provider) }
-            .getOrDefault(UploadProviderId.DIBERIE),
+private fun UploadedImageEntity.toRecord(): UploadedImageRecord {
+    // Defensive read (#474): an unknown stored provider name (downgrade, manual DB edit, or a future
+    // provider written by a newer build) must NOT crash valueOf nor be dropped — the trace stays
+    // listable so the user still sees the image. The enum has no "unknown" member, so we degrade the
+    // provider to the safe DIBERIE default AND force `deleteHandle = null`: with no known provider we
+    // cannot route a deletion correctly, so deletion is disabled (canDelete=false) rather than
+    // mis-sent to the wrong host. A recognised provider keeps its real handle untouched.
+    val knownProvider = runCatching { UploadProviderId.valueOf(provider) }.getOrNull()
+    return UploadedImageRecord(
+        provider = knownProvider ?: UploadProviderId.DIBERIE,
         picId = picId,
         imageUrl = imageUrl,
         thumbnailUrl = thumbnailUrl,
-        deleteHandle = deleteHandle,
+        deleteHandle = if (knownProvider != null) deleteHandle else null,
         uploadedAt = uploadedAt,
         expiresAt = expiresAt,
     )
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/ImgurDtos.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/ImgurDtos.kt
@@ -2,6 +2,10 @@ package fr.forumhfr.redface2.core.data.upload
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 
 /**
  * Response envelope of `POST https://api.imgur.com/3/image` (#459). The imgur API wraps every
@@ -11,7 +15,10 @@ import kotlinx.serialization.Serializable
 @Serializable
 internal data class ImgurEnvelope(
     @SerialName("data") val data: ImgurData? = null,
-    @SerialName("success") val success: Boolean = false,
+    // Nullable so the three states are distinct (#474): `true` = success, `false` = explicit
+    // application-level refusal (→ Server), `null` = field omitted (hand-built fixtures), in which
+    // case the outcome is decided by the HTTP code and the presence of `data.link`.
+    @SerialName("success") val success: Boolean? = null,
     @SerialName("status") val status: Int = 0,
 )
 
@@ -20,4 +27,23 @@ internal data class ImgurData(
     @SerialName("link") val link: String? = null,
     @SerialName("deletehash") val deleteHash: String? = null,
     @SerialName("type") val type: String? = null,
+    // On a `success:false` envelope imgur returns the failure reason here (#474). imgur uses BOTH
+    // shapes depending on the error: a plain string OR a `{code,message,type,...}` object. Modelled
+    // as a raw JsonElement so neither shape fails the whole envelope decode — a `String?` field
+    // would throw on the object form, leaving `envelope == null` and masking a 2xx `success:false`
+    // refusal as Malformed instead of the typed Server path (Codex review #474). Read it through
+    // [errorMessage]. `null`/absent simply means « no detail to surface » and the status carries.
+    @SerialName("error") val error: JsonElement? = null,
 )
+
+/**
+ * Human-readable message extracted from [ImgurData.error], which imgur returns as either a plain
+ * string or a `{code,message,...}` object (#474). Returns the string itself, the object's
+ * `message`, or `null` when there is no usable detail — the HTTP/application status carries then.
+ */
+internal val ImgurData.errorMessage: String?
+    get() = when (val raw = error) {
+        is JsonPrimitive -> raw.contentOrNull
+        is JsonObject -> (raw["message"] as? JsonPrimitive)?.contentOrNull
+        else -> null
+    }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/ImgurProvider.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/ImgurProvider.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.core.data.upload
 
 import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.ImageUpload
 import fr.forumhfr.redface2.core.domain.upload.UploadException
 import fr.forumhfr.redface2.core.domain.upload.UploadProvider
@@ -9,9 +10,9 @@ import fr.forumhfr.redface2.core.domain.upload.UploadedImage
 import fr.forumhfr.redface2.core.network.qualifiers.UploadClient
 import javax.inject.Inject
 import javax.inject.Named
-import javax.inject.Provider
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
@@ -25,9 +26,12 @@ import okhttp3.RequestBody.Companion.toRequestBody
  * Client-ID (option B, never committed — pasted in Settings). Deletion is GUARANTEED through
  * `DELETE /3/image/{deletehash}`.
  *
- * The Client-ID is injected as a [Provider] so each call re-reads the current preference value: the
- * provider is a [Singleton] but the Client-ID can be set / changed after the graph is built. Imgur
- * uploads are only offered by the selector when a non-empty Client-ID is configured.
+ * The Client-ID is read from [UserPreferencesRepository] on each call so the current preference
+ * value is honoured: the provider is a [Singleton] but the Client-ID can be set / changed after the
+ * graph is built. Imgur uploads are only offered by the selector when a non-empty Client-ID is
+ * configured; [upload] still guards a blank value with [UploadException.Configuration] (#474). The
+ * read is a suspending `observeImgurClientId().first()` collected inside `withContext(ioDispatcher)`
+ * — no `runBlocking` bridge (#474).
  *
  * All network work runs on [ioDispatcher] (project rule for OkHttp calls).
  *
@@ -38,7 +42,7 @@ import okhttp3.RequestBody.Companion.toRequestBody
 internal class ImgurProvider @Inject constructor(
     @param:UploadClient private val client: OkHttpClient,
     @param:UploadJson private val json: Json,
-    @param:ImgurClientId private val clientId: Provider<String>,
+    private val userPreferencesRepository: UserPreferencesRepository,
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     @param:Named(IMGUR_BASE_URL) private val baseUrl: String,
 ) : UploadProvider {
@@ -46,6 +50,20 @@ internal class ImgurProvider @Inject constructor(
     override val id = UploadProviderId.IMGUR
 
     override suspend fun upload(image: ImageUpload): UploadedImage = withContext(ioDispatcher) {
+        // Fail fast on misconfiguration: a blank Client-ID would otherwise produce an opaque imgur
+        // 400/403 only after a wasted round-trip (#474). Surface it as a typed config error instead.
+        // Suspending read of the current preference — no runBlocking (#474).
+        val resolvedClientId = userPreferencesRepository.observeImgurClientId().first()
+        if (resolvedClientId.isBlank()) {
+            throw UploadException.Configuration("imgur Client-ID is not configured")
+        }
+        // Reject an over-limit STILL image locally, before any POST: imgur would refuse it anyway
+        // (#474). Animated GIFs are exempt — imgur allows them up to 200 MB, so the 20 MB still-image
+        // cap must not block a large-but-valid GIF; the reader's MAX_READ_BYTES ceiling already bounds
+        // every payload, well under imgur's GIF limit (#474, Codex review).
+        if (image.mimeType != GIF_MIME && image.bytes.size > MAX_BYTES) {
+            throw UploadException.TooLarge(MAX_BYTES)
+        }
         val body = MultipartBody.Builder()
             .setType(MultipartBody.FORM)
             .addFormDataPart(
@@ -56,16 +74,29 @@ internal class ImgurProvider @Inject constructor(
             .build()
         val request = Request.Builder()
             .url("$baseUrl/3/image")
-            .header("Authorization", "Client-ID ${clientId.get()}")
+            .header("Authorization", "Client-ID $resolvedClientId")
             .post(body)
             .build()
         val response = runCatching { client.newCall(request).execute() }
             .getOrElse { throw UploadException.Network(it) }
         response.use { resp ->
-            if (!resp.isSuccessful) throw UploadException.Server(resp.code, id)
-            val envelope = runCatching { json.decodeFromString<ImgurEnvelope>(resp.body.string()) }
-                .getOrElse { throw UploadException.Malformed(id, it) }
-            val data = envelope.data ?: throw UploadException.Malformed(id)
+            // Best-effort body read: a truncated / timed-out body must NOT leak a raw IOException
+            // past the UploadException contract (#474, Codex review). A null body is fine — a non-2xx
+            // still reports its HTTP status below, and a 2xx with no parseable body falls to Malformed.
+            val raw = runCatching { resp.body.string() }.getOrNull()
+            val envelope = raw?.let { runCatching { json.decodeFromString<ImgurEnvelope>(it) }.getOrNull() }
+            // A `success:false` envelope is an application-level refusal even on a 2xx transport:
+            // map it to Server with the host's `data.error` when present (#474), instead of
+            // stumbling into a generic Malformed on the missing `link`. Prefer the envelope's
+            // application-level `status` (e.g. 400) over the transport code, which is often 200 on
+            // such a refusal — falling back to the HTTP code when imgur omits it (Codex review #474).
+            if (envelope?.success == false) {
+                val status = envelope.status.takeIf { it != 0 } ?: resp.code
+                throw UploadException.Server(status, id, envelope.data?.errorMessage)
+            }
+            if (!resp.isSuccessful) throw UploadException.Server(resp.code, id, envelope?.data?.errorMessage)
+            val data = (envelope ?: throw UploadException.Malformed(id)).data
+                ?: throw UploadException.Malformed(id)
             UploadedImage(
                 provider = id,
                 imageUrl = data.link ?: throw UploadException.Malformed(id),
@@ -73,17 +104,21 @@ internal class ImgurProvider @Inject constructor(
                 // imgur exposes size variants via URL suffixes, but the v1 contract does not derive
                 // them — the editor's reduced mode falls back to the full link for imgur.
                 resizedUrl = null,
-                deleteHandle = data.deleteHash,
+                // imgur's deletion contract requires a deletehash; a blank/absent one means deletion
+                // is impossible, so surface `null` (canDelete=false) rather than an empty handle that
+                // would later DELETE /3/image/ (no id) and falsely promise a removal (#474).
+                deleteHandle = data.deleteHash?.takeIf { it.isNotBlank() },
                 expiresAt = null,
             )
         }
     }
 
     override suspend fun delete(deleteHandle: String): Boolean = withContext(ioDispatcher) {
-        // Guaranteed deletion (#459): DELETE /3/image/{deletehash}.
+        // Guaranteed deletion (#459): DELETE /3/image/{deletehash}. Suspending Client-ID read (#474).
+        val resolvedClientId = userPreferencesRepository.observeImgurClientId().first()
         val request = Request.Builder()
             .url("$baseUrl/3/image/$deleteHandle")
-            .header("Authorization", "Client-ID ${clientId.get()}")
+            .header("Authorization", "Client-ID $resolvedClientId")
             .delete()
             .build()
         runCatching { client.newCall(request).execute().use { it.isSuccessful } }.getOrDefault(false)
@@ -94,5 +129,19 @@ internal class ImgurProvider @Inject constructor(
         const val IMGUR_BASE_URL = "imgur_base_url"
         const val DEFAULT_BASE_URL = "https://api.imgur.com"
         private const val DEFAULT_FILENAME = "upload"
+
+        /**
+         * Per-image size cap enforced locally before any POST (#474). imgur documents a 20 MB limit
+         * for non-animated images (animated GIFs go up to 200 MB) — see the imgur API upload docs /
+         * help centre « What files can I upload? ». The documented figure is decimal MB, so the cap
+         * is 20_000_000 bytes, NOT 20 MiB (20*1024*1024 = 20_971_520) — the binary value would let a
+         * file between 20_000_001 and 20_971_520 bytes slip past this guard only to be refused by
+         * imgur. Decimal is the conservative side for a client-side reject (Codex review #474).
+         * Applies to STILL images only — [GIF_MIME] is exempt (imgur GIF limit is 200 MB).
+         */
+        const val MAX_BYTES = 20_000_000L
+
+        /** imgur accepts animated GIFs up to 200 MB, so the still-image [MAX_BYTES] guard skips them. */
+        const val GIF_MIME = "image/gif"
     }
 }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/UploadModule.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/UploadModule.kt
@@ -6,8 +6,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
-import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
-import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.ImageUploadReader
 import fr.forumhfr.redface2.core.domain.upload.UploadProvider
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
@@ -15,9 +13,6 @@ import fr.forumhfr.redface2.core.domain.upload.UploadRepository
 import javax.inject.Named
 import javax.inject.Qualifier
 import javax.inject.Singleton
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 
 /**
@@ -27,14 +22,6 @@ import kotlinx.serialization.json.Json
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 internal annotation class UploadJson
-
-/**
- * The user's imgur Client-ID (#459, option B). Injected as a `javax.inject.Provider<String>` into
- * [ImgurProvider] so each upload re-reads the current preference value. Empty when not configured.
- */
-@Qualifier
-@Retention(AnnotationRetention.BINARY)
-internal annotation class ImgurClientId
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -85,19 +72,8 @@ internal object UploadModule {
     @Suppress("FunctionOnlyReturningConstant")
     fun provideImgurBaseUrl(): String = ImgurProvider.DEFAULT_BASE_URL
 
-    /**
-     * Reads the user's imgur Client-ID from the preference (option B). Synchronous — invoked via a
-     * `javax.inject.Provider` on each upload, off the main thread inside the provider's
-     * `withContext(ioDispatcher)`. Empty string when the user has not configured imgur (the
-     * selector then hides IMGUR). Same synchronous-bridge pattern as
-     * `UserPreferencesRepository.readProxyConfigForNetworkBootstrap`.
-     */
-    @Provides
-    @ImgurClientId
-    fun provideImgurClientId(
-        userPreferencesRepository: UserPreferencesRepository,
-        @IoDispatcher ioDispatcher: CoroutineDispatcher,
-    ): String = runBlocking(ioDispatcher) {
-        userPreferencesRepository.observeImgurClientId().first()
-    }
+    // #474 — the imgur Client-ID is no longer bridged through a runBlocking @Provides. ImgurProvider
+    // now reads `UserPreferencesRepository.observeImgurClientId().first()` directly inside its
+    // suspending `withContext(ioDispatcher)`, so the preference is collected without blocking a
+    // thread and the value is still re-read on every upload/delete.
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/upload/DefaultUploadRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/upload/DefaultUploadRepositoryTest.kt
@@ -84,7 +84,10 @@ class DefaultUploadRepositoryTest {
     }
 
     @Test
-    fun `observeUploads maps entities to records, defaulting an unknown provider to DIBERIE`() = runTest {
+    fun `observeUploads preserves an unknown-provider row but disables its deletion`() = runTest {
+        // #474 — a row whose stored provider matches no enum value (downgrade, manual edit, future
+        // provider) must be PRESERVED (still listable) and NON-DELETABLE (canDelete=false) without
+        // throwing: with no known provider a deletion cannot be routed to the right host.
         io.mockk.every { dao.observeForUser("alice") } returns MutableStateFlow(
             listOf(
                 entity(provider = "IMGUR", picId = "A"),
@@ -94,10 +97,14 @@ class DefaultUploadRepositoryTest {
 
         val records = repository().observeUploads("ALICE").first()
 
+        assertEquals("the unknown-provider row must not be dropped", 2, records.size)
         assertEquals(UploadProviderId.IMGUR, records[0].provider)
-        // Unknown stored provider degrades to DIBERIE instead of crashing valueOf.
+        assertTrue("a known-provider record with a handle can be deleted", records[0].canDelete)
+        // Unknown stored provider degrades to the safe DIBERIE default instead of crashing valueOf,
+        // but its delete handle is dropped so it can never be mis-routed to the wrong host.
         assertEquals(UploadProviderId.DIBERIE, records[1].provider)
-        assertTrue("a record with a handle can be deleted", records[0].canDelete)
+        assertFalse("an unknown-provider row must be non-deletable", records[1].canDelete)
+        assertEquals("the unknown row stays listable (URL preserved)", "https://host/B", records[1].imageUrl)
     }
 
     @Test

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/upload/ImgurProviderTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/upload/ImgurProviderTest.kt
@@ -1,17 +1,22 @@
 package fr.forumhfr.redface2.core.data.upload
 
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.ImageUpload
 import fr.forumhfr.redface2.core.domain.upload.UploadException
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
-import javax.inject.Provider
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -26,13 +31,19 @@ class ImgurProviderTest {
     private lateinit var server: MockWebServer
     private lateinit var provider: ImgurProvider
 
+    // The Client-ID preference, read by the provider on each call via observeImgurClientId().first().
+    private val clientIdFlow = MutableStateFlow(TEST_CLIENT_ID)
+    private val prefs = mockk<UserPreferencesRepository> {
+        every { observeImgurClientId() } returns clientIdFlow
+    }
+
     @Before
     fun setUp() {
         server = MockWebServer().apply { start() }
         provider = ImgurProvider(
             client = OkHttpClient(),
             json = Json { ignoreUnknownKeys = true; explicitNulls = false },
-            clientId = Provider { TEST_CLIENT_ID },
+            userPreferencesRepository = prefs,
             ioDispatcher = UnconfinedTestDispatcher(),
             baseUrl = server.url("/").toString().trimEnd('/'),
         )
@@ -103,12 +114,61 @@ class ImgurProviderTest {
     }
 
     @Test
-    fun `upload maps a missing data envelope to UploadException Malformed`() = runTest {
+    fun `upload maps a success-false envelope to Server with the HTTP code and the data error`() = runTest {
+        // #474 — imgur signals an application-level refusal with `success:false` even on a 2xx
+        // transport (HTTP 200 here). It must map to Server (carrying the host's data.error) rather
+        // than stumbling into a generic Malformed on the now-absent `link`. The reported code must
+        // be the envelope's application-level `status` (400), NOT the 200 transport code (Codex #474).
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"data":{"error":"File is over the size limit"},"success":false,"status":400}"""),
+        )
+
+        val error = runCatching { provider.upload(sampleImage()) }.exceptionOrNull()
+
+        assertTrue("success:false must be Server, not Malformed", error is UploadException.Server)
+        error as UploadException.Server
+        assertEquals("the envelope status must win over the 200 transport code", 400, error.code)
+        assertEquals(UploadProviderId.IMGUR, error.providerId)
+        assertEquals("File is over the size limit", error.errorMessage)
+    }
+
+    @Test
+    fun `upload maps a success-false envelope without a data error to Server with a null message`() = runTest {
+        // No `data.error` provided — still Server (not Malformed), with a null message; the HTTP code
+        // carries the meaning. Mirrors the old fixture that used to expect Malformed here (#474).
         server.enqueue(MockResponse().setResponseCode(200).setBody("""{"success":false,"status":400}"""))
 
         val error = runCatching { provider.upload(sampleImage()) }.exceptionOrNull()
 
-        assertTrue(error is UploadException.Malformed)
+        assertTrue(error is UploadException.Server)
+        error as UploadException.Server
+        assertEquals("the envelope status must win over the 200 transport code", 400, error.code)
+        assertNull(error.errorMessage)
+    }
+
+    @Test
+    fun `upload maps a success-false envelope with an OBJECT data error to Server`() = runTest {
+        // #474 (Codex review) — imgur also returns `data.error` as a {code,message,...} OBJECT, not
+        // only a string. A String? field would fail the whole envelope decode on this shape, leaving
+        // envelope == null and mis-reporting the refusal as Malformed. The JsonElement model keeps the
+        // envelope decodable: this must still be Server, with the object's `message` surfaced.
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """{"data":{"error":{"code":1003,"message":"File type invalid"}},""" +
+                        """"success":false,"status":400}""",
+                ),
+        )
+
+        val error = runCatching { provider.upload(sampleImage()) }.exceptionOrNull()
+
+        assertTrue("an object-form data.error must still be Server, not Malformed", error is UploadException.Server)
+        error as UploadException.Server
+        assertEquals(400, error.code)
+        assertEquals("File type invalid", error.errorMessage)
     }
 
     @Test
@@ -137,6 +197,104 @@ class ImgurProviderTest {
         server.enqueue(MockResponse().setResponseCode(404))
 
         assertEquals(false, provider.delete("DELHASH"))
+    }
+
+    @Test
+    fun `upload returns a null delete handle when the response omits the deletehash`() = runTest {
+        // #474 — without a deletehash imgur cannot delete the image; surfacing an empty/absent handle
+        // as null disables the delete affordance instead of falsely promising a removal.
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody("""{"data":{"link":"https://i/x.png"},"success":true}"""),
+        )
+
+        val result = provider.upload(sampleImage())
+
+        assertEquals("https://i/x.png", result.imageUrl)
+        assertNull("a missing deletehash must yield a null handle (canDelete=false)", result.deleteHandle)
+    }
+
+    @Test
+    fun `upload returns a null delete handle when the deletehash is blank`() = runTest {
+        // A blank deletehash is as useless as an absent one — must not survive as an empty handle.
+        server.enqueue(
+            MockResponse().setResponseCode(200)
+                .setBody("""{"data":{"link":"https://i/x.png","deletehash":"  "},"success":true}"""),
+        )
+
+        val result = provider.upload(sampleImage())
+
+        assertNull(result.deleteHandle)
+    }
+
+    @Test
+    fun `upload rejects an oversized image with TooLarge without hitting the network`() = runTest {
+        // #474 — the per-host MAX_BYTES guard fires locally, before any POST is enqueued.
+        val tooBig = ImageUpload(
+            bytes = ByteArray((ImgurProvider.MAX_BYTES + 1).toInt()),
+            mimeType = "image/jpeg",
+            displayName = "big.jpg",
+        )
+
+        val error = runCatching { provider.upload(tooBig) }.exceptionOrNull()
+
+        assertTrue(error is UploadException.TooLarge)
+        assertEquals(ImgurProvider.MAX_BYTES, (error as UploadException.TooLarge).maxBytes)
+        assertEquals("no POST may be sent for an over-limit image", 0, server.requestCount)
+    }
+
+    @Test
+    fun `upload keeps a typed Server error when a non-2xx response body read fails`() = runTest {
+        // #474 (Codex review) — a truncated / cut response body must NOT leak a raw IOException past
+        // the UploadException contract, and a known non-2xx status must survive an unreadable body.
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(500)
+                .setBody("part")
+                .setSocketPolicy(SocketPolicy.DISCONNECT_DURING_RESPONSE_BODY),
+        )
+
+        val error = runCatching { provider.upload(sampleImage()) }.exceptionOrNull()
+
+        assertTrue("a body-read failure must stay a typed UploadException", error is UploadException)
+        assertTrue("a non-2xx must remain Server even if the body is unreadable", error is UploadException.Server)
+        assertEquals(500, (error as UploadException.Server).code)
+    }
+
+    @Test
+    fun `upload does NOT apply the still-image cap to a GIF above MAX_BYTES`() = runTest {
+        // #474 (Codex review) — imgur allows animated GIFs up to 200 MB, so a GIF past the 20 MB
+        // still-image cap must NOT be rejected locally; it is uploaded (the reader bounds the size).
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """{"data":{"link":"https://i.imgur.com/g.gif","deletehash":"DH"},""" +
+                        """"success":true,"status":200}""",
+                ),
+        )
+        val bigGif = ImageUpload(
+            bytes = ByteArray((ImgurProvider.MAX_BYTES + 1).toInt()),
+            mimeType = "image/gif",
+            displayName = "anim.gif",
+        )
+
+        val result = runCatching { provider.upload(bigGif) }
+
+        assertTrue("a large GIF must not be rejected by the still-image cap", result.isSuccess)
+        assertEquals("https://i.imgur.com/g.gif", result.getOrThrow().imageUrl)
+        assertEquals("the GIF must actually be POSTed, not locally rejected", 1, server.requestCount)
+    }
+
+    @Test
+    fun `upload raises a typed Configuration error when the Client-ID is blank, before any network`() = runTest {
+        // #474 — a blank Client-ID must fail with a typed config error locally, not an opaque imgur
+        // 400/403 after a wasted round-trip.
+        clientIdFlow.value = "   "
+
+        val error = runCatching { provider.upload(sampleImage()) }.exceptionOrNull()
+
+        assertTrue("blank Client-ID must be a Configuration error", error is UploadException.Configuration)
+        assertEquals("no POST may be sent when the Client-ID is blank", 0, server.requestCount)
     }
 
     private fun sampleImage(): ImageUpload = ImageUpload(

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/upload/UploadException.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/upload/UploadException.kt
@@ -17,9 +17,20 @@ sealed class UploadException(message: String, cause: Throwable? = null) : Except
     /** The picked image MIME type is not accepted by the provider. */
     class UnsupportedType(val mimeType: String?) : UploadException("Unsupported image type: $mimeType")
 
-    /** The host answered with a non-2xx HTTP status. [code] is the status, [providerId] the host. */
-    class Server(val code: Int, val providerId: UploadProviderId) :
-        UploadException("HTTP $code ($providerId)")
+    /**
+     * The host refused the upload at the protocol level. [code] is the HTTP status, [providerId] the
+     * host. [errorMessage] is the host-supplied reason when one was parsed (imgur surfaces it in the
+     * `data.error` field of a `success:false` envelope, #474) — `null` when the host gave none. It is
+     * an OPTIONAL, retro-compatible addition: existing call sites that only read [code]/[providerId]
+     * keep compiling unchanged.
+     */
+    class Server(
+        val code: Int,
+        val providerId: UploadProviderId,
+        val errorMessage: String? = null,
+    ) : UploadException(
+        if (errorMessage != null) "HTTP $code ($providerId): $errorMessage" else "HTTP $code ($providerId)",
+    )
 
     /** The host answered 2xx but the body could not be parsed into the expected shape. */
     class Malformed(val providerId: UploadProviderId, cause: Throwable? = null) :
@@ -27,4 +38,13 @@ sealed class UploadException(message: String, cause: Throwable? = null) : Except
 
     /** The exchange never produced an HTTP response (airplane mode, DNS, timeout). */
     class Network(cause: Throwable) : UploadException("Network unavailable", cause)
+
+    /**
+     * The provider is mis-configured and the upload cannot even be attempted (#474) — e.g. the
+     * imgur Client-ID preference is empty/blank. Raised LOCALLY, before any network call, so the
+     * user gets an actionable « configure the host » message instead of an opaque HTTP 400/403.
+     * [detail] is a short, non-secret explanation safe to log/surface. Distinct from [Server], which
+     * means the host was reached and refused.
+     */
+    class Configuration(val detail: String) : UploadException("Upload provider misconfigured: $detail")
 }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -537,6 +537,7 @@ private fun UploadError.bannerText(): String = when (this) {
         stringResource(R.string.editor_upload_error_server, providerId.displayName(), code)
     is UploadError.Malformed ->
         stringResource(R.string.editor_upload_error_malformed, providerId.displayName())
+    UploadError.Configuration -> stringResource(R.string.editor_upload_error_configuration)
     UploadError.Network -> stringResource(R.string.editor_upload_error_network)
 }
 

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
@@ -189,6 +189,10 @@ sealed interface UploadError {
     /** The host answered 2xx but the body could not be parsed into the expected shape (#474). */
     data class Malformed(val providerId: UploadProviderId) : UploadError
 
+    /** The upload provider is not configured (e.g. a blank Imgur Client-ID): the user must set it
+     * up in Settings, not retry — so the banner points at configuration, not connectivity (#474). */
+    data object Configuration : UploadError
+
     /** No network / DNS / timeout — also covers an unreadable picked Uri (mapped to Network). */
     data object Network : UploadError
 }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -525,6 +525,8 @@ class PostEditorViewModel @AssistedInject constructor(
             // (Server) vs. an unreadable host response (Malformed), instead of one vague message.
             is UploadException.Server -> UploadError.Server(code = error.code, providerId = error.providerId)
             is UploadException.Malformed -> UploadError.Malformed(providerId = error.providerId)
+            // #474 — a config error (blank Imgur Client-ID) must point at Settings, not connectivity.
+            is UploadException.Configuration -> UploadError.Configuration
             is UploadException.Network -> UploadError.Network
             else -> UploadError.Network
         }

--- a/feature/editor/src/main/res/values/strings.xml
+++ b/feature/editor/src/main/res/values/strings.xml
@@ -49,6 +49,7 @@
     <string name="editor_upload_error_unsupported_type">Type d\'image non accepté par l\'hébergeur.</string>
     <string name="editor_upload_error_server">L\'hébergeur %1$s a refusé l\'image (HTTP %2$d). Réessayez ou changez d\'hébergeur dans les réglages.</string>
     <string name="editor_upload_error_malformed">Réponse illisible de l\'hébergeur %1$s. Réessayez ou changez d\'hébergeur dans les réglages.</string>
+    <string name="editor_upload_error_configuration">Hébergeur d\'images non configuré. Renseignez le Client-ID dans les réglages avant d\'envoyer une image.</string>
     <string name="editor_upload_error_network">Erreur réseau pendant l\'upload. Vérifiez votre connexion et réessayez.</string>
     <!-- Upload multi-images — compteur de progression « n/N » affiché pendant l\'envoi du lot. -->
     <string name="editor_upload_progress">Envoi %1$d/%2$d…</string>


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaTriX)

**Parcours de nuit 2026-06-15 → matin 2026-06-16. Draft : à arbitrer/merger au réveil, ne PAS merger automatiquement.** ✅ Codex convergé (0 finding après 5 tours).

Closes-#474 (mot-clé cassé volontairement).

Durcissement des findings LOW (Codex + multi-flavor) des fondations d'upload (#459 PR1 / #473), avant l'exposition de l'upload dans l'éditeur (PR2) où ces chemins d'erreur deviennent visibles. Upload **pas encore exposé en prod** → faible risque.

## ImgurProvider
- **deletehash requis** : absent/blank → `deleteHandle=null` (`canDelete=false`), plus de chaîne vide trompeuse.
- **Garde de taille avant POST** : images STILL > 20 000 000 o (cap **décimal**, limite Imgur documentée — le binaire 20 MiB serait trop permissif) → `TooLarge` local. **GIF exemptés** (Imgur 200 Mo ; le plafond du reader borne déjà), un gros GIF valide n'est pas bloqué.
- **`success:false` → `Server`** avec le **status applicatif de l'enveloppe** (ex. 400) plutôt que le code transport (souvent 200 sur un refus) + message `data.error` quand présent (au lieu de `Malformed`).
- **Lecture du corps best-effort** : un corps tronqué/timeout ne fuit plus d'`IOException` brute ; un non-2xx garde son `Server(code)` typé même si le corps est illisible.
- **Client-ID vide** → `UploadException.Configuration` typée avant tout réseau.

## DefaultUploadRepository
- **Provider Room inconnu préservé** (listé, suppression désactivée) au lieu de crash/drop silencieux.
- **`runBlocking` supprimé** : Client-ID lu via `observeImgurClientId().first()` dans `withContext(ioDispatcher)` (injecté dans `ImgurProvider`) — pont `UploadModule` retiré.

## DTO / domaine
- `ImgurData.error` en **`JsonElement`** (Imgur renvoie string OU objet `{code,message,…}`) : un `String?` faisait échouer tout le decode sur la forme objet → enveloppe null → refus masqué en `Malformed`. Extraction défensive via `ImgurData.errorMessage`.
- `UploadException.Configuration(detail)` ajoutée ; `Server` +`errorMessage` optionnel (rétro-compatible) ; `ImgurEnvelope.success` nullable (distinguer false explicite vs omis).

## Éditeur (pour surfacer les nouvelles erreurs typées)
- `UploadError.Configuration` + string de bandeau dédiée pointant vers les réglages (Client-ID) au lieu du message réseau générique « vérifiez la connexion ».

## Validation (machine B, Docker pin)
- `detektAll` ✅ · `:app:assembleDevDebug` ✅ · `:core:data:testDebugUnitTest` ✅ · `:feature:editor:testDebugUnitTest` ✅ · `:feature:editor:lintDebug` ✅
- **Codex : convergé, 0 finding** après 5 tours (status applicatif, JsonElement, cap décimal, exemption GIF, corps best-effort tous corrigés).
- Tests ajoutés/étendus (écrits ET exécutés sur B) : deletehash null, cap STILL, exemption GIF, success:false string + objet (status enveloppe), échec lecture corps → Server typé, Client-ID vide, provider inconnu préservé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
