### PR TITLE
fix(ui): consume only the BOTTOM nav-bar inset under bottom-bar layouts (#529)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -35,8 +35,10 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
@@ -203,7 +205,10 @@ private fun navSuiteContentInsetModifier(
     navLayoutType == NavigationSuiteType.ShortNavigationBarCompact ||
     navLayoutType == NavigationSuiteType.NavigationBar
 ) {
-    Modifier.consumeWindowInsets(navigationBarInsets)
+    // BOTTOM edge only : a side navigation bar (landscape / compact multi-window with 3-button
+    // nav) reports a horizontal navigationBars inset too — consuming the whole thing would zero the
+    // screens' horizontal `.navigationBarsPadding()` and run content under the side bar (Codex review).
+    Modifier.consumeWindowInsets(navigationBarInsets.only(WindowInsetsSides.Bottom))
 } else {
     Modifier
 }


### PR DESCRIPTION
Raffinement de #530 (déjà shippé en app-v144 avec consume de l'inset entier).

`navSuiteContentInsetModifier` ne consomme plus que `only(WindowInsetsSides.Bottom)` : sous une bottom bar, une barre de navigation latérale (paysage / multi-fenêtre compact en nav 3-boutons) rapporte aussi un inset horizontal `navigationBars` ; consommer l'inset entier annulait le `.navigationBarsPadding()` horizontal des écrans → contenu sous la barre latérale (relevé par Codex).

Validation : build 4-flavor vert (detekt + assemble Prod/Beta/Dev + lint prod/dev + tests) ; Codex review 0 finding.

> Action par Claude Opus 4.8 (demandée par @XaTriX)