### PR TITLE
release: 0.13.0 — promotion dev → main (bêta)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,36 @@ permissions:
   contents: read
 
 jobs:
+  # Fan-out by task type (was a single `verify` job running every task in one invocation). Each
+  # entry runs on its own runner, so the four task groups parallelise PAST the 4-vCPU cap of a
+  # single runner. `setup-gradle` gives each entry its own incremental build cache (seeded on push
+  # to main/dev, read-only on PRs) so unchanged modules are not recompiled per job; the only
+  # duplication is recompiling the PR's *changed* modules in each entry — the build cache cannot be
+  # shared across jobs running concurrently.
+  #
+  # `:app` is flavored (#233 channels) so its variant tasks are flavored: the unqualified
+  # `lintDebug` / `:app:assembleDebug` no longer resolve for `:app`. Use the default `prod` flavor
+  # for the `:app` lint + APK; `lintDebug` / `test` / `testDebugUnitTest` still cover the
+  # (flavour-less) core/feature/jvm modules, and the unqualified `test` covers `:app`'s unit tests
+  # across variants (incl. the Konsist architecture test).
   verify:
-    name: Build, lint and test
+    name: ${{ matrix.task.name }}
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/cirruslabs/android-sdk:36@sha256:f9b3ea9ed2b5fc9522adae82c7b4622ab7aa54207ef532c8e615a347dca08f31
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        task:
+          - name: assemble
+            gradle: ":app:assembleProdDebug"
+          - name: test
+            gradle: "test testDebugUnitTest"
+          - name: lint
+            gradle: "lintDebug :app:lintProdDebug"
+          - name: detekt
+            gradle: "detektAll"
 
     steps:
       - name: Checkout
@@ -29,10 +53,24 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
 
-      - name: Verify
-        # `:app` now has product flavors (#233 channels) so its variant tasks are flavored:
-        # the unqualified `lintDebug` / `:app:assembleDebug` no longer resolve for `:app`. Use the
-        # default `prod` flavor for the `:app` lint + APK; `lintDebug`/`test`/`testDebugUnitTest`
-        # still cover the (flavour-less) core/feature/jvm modules, and the unqualified `test`
-        # covers `:app`'s unit tests across variants (incl. the Konsist architecture test).
-        run: ./gradlew detektAll lintDebug test testDebugUnitTest :app:lintProdDebug :app:assembleProdDebug
+      - name: ${{ matrix.task.name }}
+        run: ./gradlew ${{ matrix.task.gradle }}
+
+  # Single aggregate check whose name is the one `main`'s branch protection requires
+  # ("Build, lint and test"). Green iff every `verify` matrix entry succeeded, so the fan-out stays
+  # compatible with the existing required-status-check on `main` (dev→main promotion) without having
+  # to re-point branch protection at four separate contexts.
+  build-lint-and-test:
+    name: Build, lint and test
+    if: always()
+    needs: [verify]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Require all verify jobs to pass
+        run: |
+          result='${{ needs.verify.result }}'
+          echo "verify matrix result: $result"
+          if [ "$result" != "success" ]; then
+            echo "::error::One or more verify jobs did not succeed ($result)."
+            exit 1
+          fi

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,35 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## v145 — `0.13.0` — 2026-06-16
+
+**Statut** : `open` (track open testing — canal beta, Play Edit committed) + F-Droid `.beta`
+**Commit** : promotion dev→main (cf. PR de promotion)
+**Contenu depuis la 0.12.0/v136** : dogfoodé sur le canal dev (v137 → v144).
+
+> `0.12.0` ayant déjà été shippé en bêta (v136), le `versionName` est bumpé en `0.13.0` (la garde CI refuse deux bêtas au même `versionName`).
+
+### Added
+- **Refonte complète des Réglages** (#494) : Réglages devient un 5ᵉ onglet dédié de la barre du bas (icônes Material Symbols, #511), racine « catégories d'abord » avec sous-vues par catégorie (#512), recherche dans les réglages avec résultats à plat + fil d'Ariane (#514), catalogue « À venir » et microcopie épurée (#517).
+- **Transitions de navigation** (#513) : shared-axis X + fade-through entre onglets, geste de retour prédictif.
+- **Search app bar translucide** (#519, #515) : barre de recherche qui se fond au scroll, bottom bar plus compacte (~64 dp), contenu qui passe sous la barre.
+- **Marqueur « · édité »** (#483) inline sur la ligne de date d'un post édité.
+- **Persistance de l'état des sondages** (#465) : déplié/replié conservé en changeant de page dans un sujet.
+
+### Fixed
+- **Drapeaux — rafraîchissement auto** (#501) au changement d'onglet et à la reprise de l'app.
+- **Badge MP non-lus** (#452, #453) : l'option de désactivation coupe réellement le réseau ; rafraîchissement à la lecture.
+- **Lignes vides parasites** (#466) : paragraphes séparés par des `&nbsp;` orphelins correctement rendus.
+- **En-tête de post stable** (#476) quand on coche/décoche pour le multiquote.
+- **Upload d'images durci** (#474) : provider Imgur + repository, erreurs réseau mieux typées.
+- **Bande noire sous le contenu** au-dessus de la bottom bar (#529) supprimée (inset bottom-only).
+- **Écritures de préférences** (#507) déplacées sur un scope applicatif.
+
+### Infra
+- CI éclatée par type de tâche (#491), garde-fou de test drapeaux « dernier posteur = last_author » (#331), doc vivante des limitations connues (#419).
+
+---
+
 ## v136 — `0.12.0` — 2026-06-14
 
 **Statut** : `open` (track open testing — canal beta, Play Edit committed) + F-Droid `.beta`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.12.0"
+        versionName = "0.13.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/MpUnreadBadgeViewModel.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/MpUnreadBadgeViewModel.kt
@@ -6,9 +6,13 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.messages.MessagesRepository
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import javax.inject.Inject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
 /**
@@ -21,27 +25,47 @@ import kotlinx.coroutines.flow.stateIn
  * the page-1 inbox piggyback (free, fires when the user opens the Messages tab or comes back from
  * a conversation), and the explicit [onAppForegrounded] tick below.
  *
+ * #452 — the opt-out must cut the NETWORK, not just the display. The preference is the OUTER flow
+ * (`flatMapLatest`) : while the badge is disabled the upstream `observeUnreadMpCount` is NOT
+ * collected, so its auth-flip fetch / foreground ticks / piggyback chain never run — flipping the
+ * setting off tears the fetch chain down, flipping it on re-subscribes (and re-fetches). A
+ * foreground tick or thread-read signal raised while disabled is inert : it only enqueues onto the
+ * uncollected count flow, so no fetch happens.
+ *
  * `WhileSubscribed` (not Eagerly) : the only consumer is the navigation bar — when nothing shows
  * it, nothing should hold the upstream fetch chain alive.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class MpUnreadBadgeViewModel @Inject constructor(
     private val messagesRepository: MessagesRepository,
     userPreferencesRepository: UserPreferencesRepository,
 ) : ViewModel() {
 
+    private val badgeEnabled = userPreferencesRepository.observeMpUnreadBadge()
+        .distinctUntilChanged()
+
     val unreadCount: StateFlow<Int?> =
-        combine(
-            userPreferencesRepository.observeMpUnreadBadge(),
-            messagesRepository.observeUnreadMpCount(),
-        ) { enabled, count ->
-            count?.takeIf { enabled && it > 0 }
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), null)
+        badgeEnabled
+            .flatMapLatest { enabled ->
+                if (enabled) {
+                    messagesRepository.observeUnreadMpCount().map { count -> count?.takeIf { it > 0 } }
+                } else {
+                    // Disabled : emit nothing-to-show AND do not collect the network flow at all.
+                    flowOf(null)
+                }
+            }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), null)
 
     /**
      * `ON_START` hook (app brought back to the foreground) : MPs received while backgrounded
      * must surface without waiting for a tab visit. The FIRST start is skipped — the cold-start
      * fetch already runs when the auth state resolves, a tick there would only double the call.
+     *
+     * #452 — the tick is INERT while the badge is disabled : `requestUnreadRefresh` only enqueues
+     * onto the count flow, which `flatMapLatest` above does not collect when the preference is off,
+     * so no fetch runs. No extra gate needed here — the disabled state is enforced upstream by not
+     * subscribing to the network flow at all.
      */
     fun onAppForegrounded() {
         if (firstStart) {
@@ -49,6 +73,16 @@ class MpUnreadBadgeViewModel @Inject constructor(
             return
         }
         messagesRepository.requestUnreadRefresh()
+    }
+
+    /**
+     * #453 — a private-message conversation was opened/read. Optimistically decrements the badge
+     * count so reading the LAST unread conversation clears the badge immediately, without waiting
+     * for the next page-1 fetch. Inert while the badge is disabled (#452) for the same reason as
+     * [onAppForegrounded] : the count flow is not collected, so the signal serves no collector.
+     */
+    fun onThreadRead(threadId: Int) {
+        messagesRepository.markThreadRead(threadId)
     }
 
     private var firstStart = true

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
@@ -38,6 +39,7 @@ import androidx.core.net.toUri
 import androidx.core.view.WindowCompat
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.Icon
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
@@ -52,6 +54,7 @@ import androidx.navigation3.scene.Scene
 import androidx.navigation3.ui.NavDisplay
 import fr.forumhfr.redface2.BuildConfig
 import fr.forumhfr.redface2.R
+import fr.forumhfr.redface2.core.ui.R as CoreUiR
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
@@ -337,12 +340,14 @@ data class ProfileFullRoute(
 
 internal enum class TopLevelDestination(
     val labelRes: Int,
+    val iconRes: Int,
     val rootRoute: RedfaceNavKey,
 ) {
-    Flags(R.string.nav_flags, FlagsListRoute),
-    Forum(R.string.nav_forum, ForumRoute),
-    Search(R.string.nav_search, SearchRoute),
-    Messages(R.string.nav_messages, MessagesRoute),
+    Flags(R.string.nav_flags, CoreUiR.drawable.ic_ms_flag, FlagsListRoute),
+    Forum(R.string.nav_forum, CoreUiR.drawable.ic_ms_forum, ForumRoute),
+    Search(R.string.nav_search, CoreUiR.drawable.ic_ms_search, SearchRoute),
+    Messages(R.string.nav_messages, CoreUiR.drawable.ic_ms_mail, MessagesRoute),
+    Settings(R.string.nav_settings, CoreUiR.drawable.ic_ms_settings, SettingsRoute),
 }
 
 /** #458 — maps the persisted cold-start choice onto the navigation's own destination enum. */
@@ -363,9 +368,11 @@ private const val MAX_BADGE_COUNT = 9
  */
 @Composable
 private fun TopLevelDestinationIcon(destination: TopLevelDestination, mpUnreadCount: Int?) {
-    val glyph = stringResource(destination.labelRes).first().toString()
+    val icon: @Composable () -> Unit = {
+        Icon(painter = painterResource(destination.iconRes), contentDescription = null)
+    }
     if (destination != TopLevelDestination.Messages || mpUnreadCount == null) {
-        Text(text = glyph)
+        icon()
         return
     }
     BadgedBox(
@@ -381,7 +388,7 @@ private fun TopLevelDestinationIcon(destination: TopLevelDestination, mpUnreadCo
             }
         },
     ) {
-        Text(text = glyph)
+        icon()
     }
 }
 
@@ -501,6 +508,9 @@ fun RedfaceApp(intent: Intent?) {
         val forumBackStack = rememberNavBackStack(*forumInitialStack)
         val searchBackStack = rememberNavBackStack(SearchRoute)
         val messagesBackStack = rememberNavBackStack(MessagesRoute)
+        // #494 v2 — Réglages est désormais une destination top-level à part entière (5e onglet),
+        // avec sa propre pile (sa racine = SettingsRoute), au lieu d'être poussé sur l'onglet actif.
+        val settingsBackStack = rememberNavBackStack(SettingsRoute)
 
         var currentDestination by rememberSaveable {
             mutableStateOf(startScreen.screen.toTopLevelDestination())
@@ -515,12 +525,19 @@ fun RedfaceApp(intent: Intent?) {
             mutableStateOf<ProfileSheetRequest?>(null)
         }
 
-        val backStacks = remember(flagsBackStack, forumBackStack, searchBackStack, messagesBackStack) {
+        val backStacks = remember(
+            flagsBackStack,
+            forumBackStack,
+            searchBackStack,
+            messagesBackStack,
+            settingsBackStack,
+        ) {
             mapOf(
                 TopLevelDestination.Flags to flagsBackStack,
                 TopLevelDestination.Forum to forumBackStack,
                 TopLevelDestination.Search to searchBackStack,
                 TopLevelDestination.Messages to messagesBackStack,
+                TopLevelDestination.Settings to settingsBackStack,
             )
         }
 
@@ -653,7 +670,6 @@ fun RedfaceApp(intent: Intent?) {
                         versionCode = BuildConfig.VERSION_CODE,
                         onLogin = { activeBackStack.add(LoginRoute) },
                         onLogout = accountViewModel::logout,
-                        onOpenSettings = { openSettingsIdempotently(activeBackStack) },
                         onOpenDiagnostics = { activeBackStack.add(DiagnosticsRoute) },
                         onReportContent = {
                             startReportEmail(context, reportEmailSubject, reportNoEmailClient)
@@ -924,26 +940,6 @@ internal fun Map<TopicTitleKey, String>.withTitle(key: TopicTitleKey, title: Str
     }
 }
 
-/**
- * Opens the settings root idempotently. The account menu is shown ON the settings screen and its
- * sub-pages too, so tapping « Paramètres » there must land back on the existing [SettingsRoute]
- * (popping any sub-pages stacked above it) rather than push a duplicate that Back then has to unwind
- * (#494 Codex P3). When no [SettingsRoute] is in [backStack] (we are elsewhere), a fresh one is pushed.
- *
- * Kept top-level (not inlined in the account-menu lambda) so its branches don't inflate RedfaceApp's
- * cyclomatic complexity.
- */
-private fun openSettingsIdempotently(backStack: NavBackStack<NavKey>) {
-    val existing = backStack.indexOfLast { it is SettingsRoute }
-    if (existing >= 0) {
-        while (backStack.lastIndex > existing) {
-            backStack.removeAt(backStack.lastIndex)
-        }
-    } else {
-        backStack.add(SettingsRoute)
-    }
-}
-
 @Composable
 @Suppress("CyclomaticComplexMethod", "LongParameterList") // One entry per top-level route + per-screen
 // navigation callbacks ; splitting the host would just push the same `when` shape one level deeper
@@ -1192,11 +1188,8 @@ private fun RedfaceNavHost(
             }
             entry<SettingsRoute> {
                 SettingsScreen(
-                    onBack = {
-                        if (backStack.size > 1) {
-                            backStack.removeAt(backStack.lastIndex)
-                        }
-                    },
+                    // #494 v2 — racine de l'onglet Réglages (jamais empilée) : pas de flèche retour morte.
+                    onBack = null,
                     onOpenProxy = { backStack.add(SettingsProxyRoute) },
                     onOpenMaintenance = { backStack.add(SettingsMaintenanceRoute) },
                     onOpenDisplay = { backStack.add(SettingsDisplayRoute) },

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -164,6 +164,24 @@ private fun NavKey?.hidesNavigationSuite(): Boolean =
     this is PostEditorRoute || this is TopicFormRoute || this is PrivateMessageReplyRoute ||
         this is PrivateMessageComposeRoute
 
+/**
+ * #494 — type de barre de navigation à passer au [NavigationSuiteScaffold]. Sur téléphone l'adaptatif
+ * renvoie `NavigationBar` (80dp) ; on lui substitue `ShortNavigationBarCompact` (M3 Expressive, ~64dp,
+ * icône au-dessus du label, labels conservés, cible tactile ≥48dp). Les autres formes (rail/drawer sur
+ * largeur medium/expanded) restent telles quelles ; la navigation est masquée (`None`) sur les routes
+ * plein écran (éditeur, #624). Pure (l'`adaptiveType` composable est résolu côté appelant) + extraite
+ * pour garder la complexité cyclomatique de `RedfaceApp` sous le seuil.
+ */
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+private fun resolveNavLayoutType(
+    hidesNavigationSuite: Boolean,
+    adaptiveType: NavigationSuiteType,
+): NavigationSuiteType = when {
+    hidesNavigationSuite -> NavigationSuiteType.None
+    adaptiveType == NavigationSuiteType.NavigationBar -> NavigationSuiteType.ShortNavigationBarCompact
+    else -> adaptiveType
+}
+
 @Serializable
 data class CategoryRoute(
     val cat: Int,
@@ -641,11 +659,8 @@ fun RedfaceApp(intent: Intent?) {
         // routes makes the editor full-screen: its submit bar then sits at the window bottom and the IME
         // inset lands exactly on the keyboard. Bonus UX: no tab switching mid-compose (would drop the draft).
         val topRoute = backStacks.getValue(currentDestination).lastOrNull()
-        val navLayoutType = if (topRoute.hidesNavigationSuite()) {
-            NavigationSuiteType.None
-        } else {
-            NavigationSuiteScaffoldDefaults.calculateFromAdaptiveInfo(currentWindowAdaptiveInfo())
-        }
+        val adaptiveType = NavigationSuiteScaffoldDefaults.calculateFromAdaptiveInfo(currentWindowAdaptiveInfo())
+        val navLayoutType = resolveNavLayoutType(topRoute.hidesNavigationSuite(), adaptiveType)
 
         NavigationSuiteScaffold(
             layoutType = navLayoutType,

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -35,8 +35,10 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
@@ -203,7 +205,10 @@ private fun navSuiteContentInsetModifier(
     navLayoutType == NavigationSuiteType.ShortNavigationBarCompact ||
     navLayoutType == NavigationSuiteType.NavigationBar
 ) {
-    Modifier.consumeWindowInsets(navigationBarInsets)
+    // BOTTOM edge only : a side navigation bar (landscape / compact multi-window with 3-button
+    // nav) reports a horizontal navigationBars inset too — consuming the whole thing would zero the
+    // screens' horizontal `.navigationBarsPadding()` and run content under the side bar (Codex review).
+    Modifier.consumeWindowInsets(navigationBarInsets.only(WindowInsetsSides.Bottom))
 } else {
     Modifier
 }

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -80,6 +80,11 @@ import fr.forumhfr.redface2.feature.profile.ProfileRoute
 import fr.forumhfr.redface2.feature.profile.ProfileViewModel
 import fr.forumhfr.redface2.feature.search.SearchScreen
 import fr.forumhfr.redface2.feature.settings.MyImagesScreen
+import fr.forumhfr.redface2.feature.settings.SettingsAccountAboutScreen
+import fr.forumhfr.redface2.feature.settings.SettingsDisplayScreen
+import fr.forumhfr.redface2.feature.settings.SettingsImagesScreen
+import fr.forumhfr.redface2.feature.settings.SettingsMaintenanceScreen
+import fr.forumhfr.redface2.feature.settings.SettingsProxyScreen
 import fr.forumhfr.redface2.feature.settings.SettingsScreen
 import fr.forumhfr.redface2.feature.topic.TopicRequest
 import fr.forumhfr.redface2.feature.topic.TopicScreen
@@ -278,6 +283,26 @@ data object MyImagesRoute : RedfaceNavKey
  */
 @Serializable
 data object MpStorageInspectorRoute : RedfaceNavKey
+
+/**
+ * #494 — settings sub-pages reached from the redesigned catalogue. Each is a distinct nav entry (a
+ * distinct `ViewModelStore`), so each binds its own `SettingsViewModel`; DataStore is the single
+ * source of truth so the instances stay consistent. Opaque routes, no params.
+ */
+@Serializable
+data object SettingsProxyRoute : RedfaceNavKey
+
+@Serializable
+data object SettingsMaintenanceRoute : RedfaceNavKey
+
+@Serializable
+data object SettingsDisplayRoute : RedfaceNavKey
+
+@Serializable
+data object SettingsImagesRoute : RedfaceNavKey
+
+@Serializable
+data object SettingsAccountAboutRoute : RedfaceNavKey
 
 /**
  * Phase 2 finish (#208) — full profile page route.
@@ -628,7 +653,7 @@ fun RedfaceApp(intent: Intent?) {
                         versionCode = BuildConfig.VERSION_CODE,
                         onLogin = { activeBackStack.add(LoginRoute) },
                         onLogout = accountViewModel::logout,
-                        onOpenSettings = { activeBackStack.add(SettingsRoute) },
+                        onOpenSettings = { openSettingsIdempotently(activeBackStack) },
                         onOpenDiagnostics = { activeBackStack.add(DiagnosticsRoute) },
                         onReportContent = {
                             startReportEmail(context, reportEmailSubject, reportNoEmailClient)
@@ -638,6 +663,9 @@ fun RedfaceApp(intent: Intent?) {
                 RedfaceNavHost(
                     backStack = activeBackStack,
                     accountMenu = accountMenu,
+                    onReportContent = {
+                        startReportEmail(context, reportEmailSubject, reportNoEmailClient)
+                    },
                     privateMessageNavState = PrivateMessageNavState(
                         readThreadIds = readPrivateMessageThreadIds,
                         multiRecipientThreadIds = multiRecipientThreadIds,
@@ -896,6 +924,26 @@ internal fun Map<TopicTitleKey, String>.withTitle(key: TopicTitleKey, title: Str
     }
 }
 
+/**
+ * Opens the settings root idempotently. The account menu is shown ON the settings screen and its
+ * sub-pages too, so tapping « Paramètres » there must land back on the existing [SettingsRoute]
+ * (popping any sub-pages stacked above it) rather than push a duplicate that Back then has to unwind
+ * (#494 Codex P3). When no [SettingsRoute] is in [backStack] (we are elsewhere), a fresh one is pushed.
+ *
+ * Kept top-level (not inlined in the account-menu lambda) so its branches don't inflate RedfaceApp's
+ * cyclomatic complexity.
+ */
+private fun openSettingsIdempotently(backStack: NavBackStack<NavKey>) {
+    val existing = backStack.indexOfLast { it is SettingsRoute }
+    if (existing >= 0) {
+        while (backStack.lastIndex > existing) {
+            backStack.removeAt(backStack.lastIndex)
+        }
+    } else {
+        backStack.add(SettingsRoute)
+    }
+}
+
 @Composable
 @Suppress("CyclomaticComplexMethod", "LongParameterList") // One entry per top-level route + per-screen
 // navigation callbacks ; splitting the host would just push the same `when` shape one level deeper
@@ -903,6 +951,9 @@ internal fun Map<TopicTitleKey, String>.withTitle(key: TopicTitleKey, title: Str
 private fun RedfaceNavHost(
     backStack: NavBackStack<NavKey>,
     accountMenu: @Composable () -> Unit,
+    // #494 — the « Signaler un contenu » row of the settings Account/About sub-page reuses the same
+    // report-email flow as the account menu (which owns `context` + the report strings).
+    onReportContent: () -> Unit,
     privateMessageNavState: PrivateMessageNavState,
     // Bug fix (build 89) — per-topic title cache threaded down from RedfaceApp (where the `var` lives
     // so it survives entry recreation across page changes). Bundled to keep the param count in check.
@@ -1141,8 +1192,74 @@ private fun RedfaceNavHost(
             }
             entry<SettingsRoute> {
                 SettingsScreen(
-                    onOpenMyImages = { backStack.add(MyImagesRoute) },
+                    onBack = {
+                        if (backStack.size > 1) {
+                            backStack.removeAt(backStack.lastIndex)
+                        }
+                    },
+                    onOpenProxy = { backStack.add(SettingsProxyRoute) },
+                    onOpenMaintenance = { backStack.add(SettingsMaintenanceRoute) },
+                    onOpenDisplay = { backStack.add(SettingsDisplayRoute) },
+                    onOpenImages = { backStack.add(SettingsImagesRoute) },
+                    onOpenAccountAbout = { backStack.add(SettingsAccountAboutRoute) },
+                    topBarActions = accountMenu,
+                )
+            }
+            entry<SettingsProxyRoute> {
+                SettingsProxyScreen(
+                    onBack = {
+                        if (backStack.size > 1) {
+                            backStack.removeAt(backStack.lastIndex)
+                        }
+                    },
+                    topBarActions = accountMenu,
+                )
+            }
+            entry<SettingsMaintenanceRoute> {
+                SettingsMaintenanceScreen(
+                    onBack = {
+                        if (backStack.size > 1) {
+                            backStack.removeAt(backStack.lastIndex)
+                        }
+                    },
+                    onOpenDiagnostics = { backStack.add(DiagnosticsRoute) },
                     onOpenMpStorageInspector = { backStack.add(MpStorageInspectorRoute) },
+                    topBarActions = accountMenu,
+                )
+            }
+            entry<SettingsDisplayRoute> {
+                SettingsDisplayScreen(
+                    onBack = {
+                        if (backStack.size > 1) {
+                            backStack.removeAt(backStack.lastIndex)
+                        }
+                    },
+                    topBarActions = accountMenu,
+                )
+            }
+            entry<SettingsImagesRoute> {
+                SettingsImagesScreen(
+                    onBack = {
+                        if (backStack.size > 1) {
+                            backStack.removeAt(backStack.lastIndex)
+                        }
+                    },
+                    onOpenMyImages = { backStack.add(MyImagesRoute) },
+                    topBarActions = accountMenu,
+                )
+            }
+            entry<SettingsAccountAboutRoute> {
+                SettingsAccountAboutScreen(
+                    onBack = {
+                        if (backStack.size > 1) {
+                            backStack.removeAt(backStack.lastIndex)
+                        }
+                    },
+                    versionName = BuildConfig.VERSION_NAME,
+                    versionCode = BuildConfig.VERSION_CODE,
+                    onOpenDiagnostics = { backStack.add(DiagnosticsRoute) },
+                    onReportContent = onReportContent,
+                    topBarActions = accountMenu,
                 )
             }
             entry<MyImagesRoute> {

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -84,6 +84,7 @@ import fr.forumhfr.redface2.feature.profile.ProfileViewModel
 import fr.forumhfr.redface2.feature.search.SearchScreen
 import fr.forumhfr.redface2.feature.settings.MyImagesScreen
 import fr.forumhfr.redface2.feature.settings.SettingsAccountAboutScreen
+import fr.forumhfr.redface2.feature.settings.SettingsCategoryDetailScreen
 import fr.forumhfr.redface2.feature.settings.SettingsDisplayScreen
 import fr.forumhfr.redface2.feature.settings.SettingsImagesScreen
 import fr.forumhfr.redface2.feature.settings.SettingsMaintenanceScreen
@@ -306,6 +307,10 @@ data object SettingsImagesRoute : RedfaceNavKey
 
 @Serializable
 data object SettingsAccountAboutRoute : RedfaceNavKey
+
+/** #494 v2 — détail générique d'une catégorie de réglages (cf. SettingsCategoryDetailScreen). */
+@Serializable
+data class SettingsCategoryRoute(val categoryId: String) : RedfaceNavKey
 
 /**
  * Phase 2 finish (#208) — full profile page route.
@@ -1188,8 +1193,24 @@ private fun RedfaceNavHost(
             }
             entry<SettingsRoute> {
                 SettingsScreen(
-                    // #494 v2 — racine de l'onglet Réglages (jamais empilée) : pas de flèche retour morte.
-                    onBack = null,
+                    onOpenProxy = { backStack.add(SettingsProxyRoute) },
+                    onOpenMaintenance = { backStack.add(SettingsMaintenanceRoute) },
+                    onOpenDisplay = { backStack.add(SettingsDisplayRoute) },
+                    onOpenImages = { backStack.add(SettingsImagesRoute) },
+                    onOpenAccountAbout = { backStack.add(SettingsAccountAboutRoute) },
+                    // #494 v2 — catégories sans sous-page dédiée → détail générique.
+                    onOpenCategory = { categoryId -> backStack.add(SettingsCategoryRoute(categoryId)) },
+                    topBarActions = accountMenu,
+                )
+            }
+            entry<SettingsCategoryRoute> { key ->
+                SettingsCategoryDetailScreen(
+                    categoryId = key.categoryId,
+                    onBack = {
+                        if (backStack.size > 1) {
+                            backStack.removeAt(backStack.lastIndex)
+                        }
+                    },
                     onOpenProxy = { backStack.add(SettingsProxyRoute) },
                     onOpenMaintenance = { backStack.add(SettingsMaintenanceRoute) },
                     onOpenDisplay = { backStack.add(SettingsDisplayRoute) },

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -28,11 +28,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
@@ -180,6 +184,28 @@ private fun resolveNavLayoutType(
     hidesNavigationSuite -> NavigationSuiteType.None
     adaptiveType == NavigationSuiteType.NavigationBar -> NavigationSuiteType.ShortNavigationBarCompact
     else -> adaptiveType
+}
+
+/**
+ * #529 — modifier appliqué au CONTENU du [NavigationSuiteScaffold]. Quand la suite est une barre du
+ * BAS (téléphone), cette barre possède déjà `WindowInsets.navigationBars` : on consomme l'inset pour
+ * le sous-arbre de contenu, de sorte que les `.navigationBarsPadding()` des écrans (toujours requis
+ * pour les dispositions rail/drawer, où la suite est sur le côté et laisse l'inset bas) se résolvent
+ * à 0 sous une barre du bas, au lieu de laisser une bande sombre de la couleur `Surface` au-dessus de
+ * la barre (le « vide noir »). Le type custom `ShortNavigationBarCompact` ne consomme pas cet inset
+ * pour le contenu côté scaffold, d'où la bande. Extrait (la branche reste hors de `RedfaceApp`).
+ */
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+private fun navSuiteContentInsetModifier(
+    navLayoutType: NavigationSuiteType,
+    navigationBarInsets: WindowInsets,
+): Modifier = if (
+    navLayoutType == NavigationSuiteType.ShortNavigationBarCompact ||
+    navLayoutType == NavigationSuiteType.NavigationBar
+) {
+    Modifier.consumeWindowInsets(navigationBarInsets)
+} else {
+    Modifier
 }
 
 @Serializable
@@ -661,6 +687,9 @@ fun RedfaceApp(intent: Intent?) {
         val topRoute = backStacks.getValue(currentDestination).lastOrNull()
         val adaptiveType = NavigationSuiteScaffoldDefaults.calculateFromAdaptiveInfo(currentWindowAdaptiveInfo())
         val navLayoutType = resolveNavLayoutType(topRoute.hidesNavigationSuite(), adaptiveType)
+        // #529 — consume the bottom nav-bar inset for the content only under a bottom-bar layout
+        // (see navSuiteContentInsetModifier). Read in composable scope, branch lives in the helper.
+        val contentInsetModifier = navSuiteContentInsetModifier(navLayoutType, WindowInsets.navigationBars)
 
         NavigationSuiteScaffold(
             layoutType = navLayoutType,
@@ -684,7 +713,8 @@ fun RedfaceApp(intent: Intent?) {
             // (listings keep their 16/24 dp content padding, readers compensate explicitly),
             // so the nav host no longer steals 8 dp/side from every screen. The Surface is kept
             // for the theme background/elevation; only its horizontal padding was removed.
-            Surface {
+            // #529 — consumes the bottom nav-bar inset under a bottom-bar layout (no-op otherwise).
+            Surface(modifier = contentInsetModifier) {
                 val activeBackStack = backStacks.getValue(currentDestination)
                 val accountMenu: @Composable () -> Unit = {
                     RedfaceAccountMenu(

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -627,6 +627,12 @@ fun RedfaceApp(intent: Intent?) {
         // Purged on every auth transition, exactly like readPrivateMessageThreadIds, so private
         // metadata never outlives the session / account.
         var multiRecipientThreadIds by remember { mutableStateOf(emptySet<Int>()) }
+        // #453 (Codex review) — threads that were UNREAD when opened from the inbox. The badge
+        // decrement on first read must fire ONLY for these: opening an already-read conversation has
+        // nothing to subtract. In-memory only and purged on auth transition, like the sets above —
+        // it is private metadata (it reveals a conversation carried an unread message) and must never
+        // outlive the session, hence it stays OUT of the opaque PrivateMessageThreadRoute.
+        var unreadOnOpenThreadIds by remember { mutableStateOf(emptySet<Int>()) }
         // #301 follow-up — bumped when the new-conversation composer pops back after a successful
         // send. The MP list collects the signal and refreshes itself so the created conversation
         // appears at the top (its thread id is unknown — the bddpost success response of a new MP
@@ -663,6 +669,7 @@ fun RedfaceApp(intent: Intent?) {
                 AuthState.Anonymous -> {
                     readPrivateMessageThreadIds = emptySet()
                     multiRecipientThreadIds = emptySet()
+                    unreadOnOpenThreadIds = emptySet()
                     privateMessageSentSignal = null
                     // #291 — a write intention armed under another session must not survive the
                     // transition (Codex review: stale « Citer N » after logout/login).
@@ -672,6 +679,7 @@ fun RedfaceApp(intent: Intent?) {
                 is AuthState.Authenticated -> {
                     readPrivateMessageThreadIds = emptySet()
                     multiRecipientThreadIds = emptySet()
+                    unreadOnOpenThreadIds = emptySet()
                     privateMessageSentSignal = null
                     multiQuoteBasket = null
                     resetStack(messagesBackStack, MessagesRoute, MessagesRoute)
@@ -739,10 +747,24 @@ fun RedfaceApp(intent: Intent?) {
                         readThreadIds = readPrivateMessageThreadIds,
                         multiRecipientThreadIds = multiRecipientThreadIds,
                         onThreadLoaded = { threadId ->
+                            // #453 (Codex review) — decrement the badge ONLY when the conversation was
+                            // unread when opened AND this is its first read of the session (predicate
+                            // extracted to keep this composable under detekt's complexity threshold).
+                            val decrement = shouldDecrementUnreadBadge(
+                                threadId = threadId,
+                                unreadOnOpen = unreadOnOpenThreadIds,
+                                alreadyRead = readPrivateMessageThreadIds,
+                            )
+                            if (decrement) {
+                                mpBadgeViewModel.onThreadRead(threadId)
+                            }
                             readPrivateMessageThreadIds = readPrivateMessageThreadIds + threadId
                         },
                         onThreadOpenedAsMulti = { threadId ->
                             multiRecipientThreadIds = multiRecipientThreadIds + threadId
+                        },
+                        onThreadOpenedUnread = { threadId ->
+                            unreadOnOpenThreadIds = unreadOnOpenThreadIds + threadId
                         },
                         sentSignal = privateMessageSentSignal,
                         onConversationSent = {
@@ -863,17 +885,33 @@ private const val REPORT_EMAIL: String = "xat@azora.fr"
  *   page shows a single other author.
  * @property onThreadLoaded marks a thread read once its first page has successfully loaded.
  * @property onThreadOpenedAsMulti records that a thread was opened from a multi-recipient row.
+ * @property onThreadOpenedUnread records that a thread was UNREAD when opened, so [onThreadLoaded]
+ *   knows it may decrement the unread badge (an already-read conversation must not, #453).
  */
 private data class PrivateMessageNavState(
     val readThreadIds: Set<Int>,
     val multiRecipientThreadIds: Set<Int>,
     val onThreadLoaded: (Int) -> Unit,
     val onThreadOpenedAsMulti: (Int) -> Unit,
+    val onThreadOpenedUnread: (Int) -> Unit = {},
     /** #301 follow-up — last successful new-conversation send ; the MP list refreshes on change. */
     val sentSignal: Long? = null,
     /** #301 follow-up — bumps [sentSignal] when the composer reports a successful send. */
     val onConversationSent: () -> Unit = {},
 )
+
+/**
+ * #453 (Codex review) — the unread badge decrements on a thread's first read of the session ONLY
+ * when that thread was actually unread when opened ([unreadOnOpen]). Opening an already-read
+ * conversation subtracts nothing, and re-opening one ([alreadyRead]) must not subtract twice.
+ * Extracted from [onThreadLoaded] so the boolean connective stays out of RedfaceApp's cyclomatic
+ * complexity budget.
+ */
+private fun shouldDecrementUnreadBadge(
+    threadId: Int,
+    unreadOnOpen: Set<Int>,
+    alreadyRead: Set<Int>,
+): Boolean = threadId in unreadOnOpen && threadId !in alreadyRead
 
 /**
  * Bug fix (build 89) — per-topic title cache plumbed into [RedfaceNavHost]. A topic page change
@@ -1149,10 +1187,15 @@ private fun RedfaceNavHost(
             entry<MessagesRoute> {
                 MessagesScreen(
                     readThreadIds = privateMessageNavState.readThreadIds,
-                    onOpenThread = { threadId, isMultiRecipient, openAtPage ->
+                    onOpenThread = { threadId, isMultiRecipient, openAtPage, wasUnread ->
                         // Record the multi-recipient hint in memory only; the route stays opaque.
                         if (isMultiRecipient) {
                             privateMessageNavState.onThreadOpenedAsMulti(threadId)
+                        }
+                        // #453 (Codex review) — remember the unread-on-open state so the badge only
+                        // decrements for a conversation that actually had something unread.
+                        if (wasUnread) {
+                            privateMessageNavState.onThreadOpenedUnread(threadId)
                         }
                         backStack.add(
                             PrivateMessageThreadRoute(

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -10,9 +10,12 @@ import android.widget.Toast
 import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -972,15 +975,16 @@ private fun RedfaceNavHost(
                 backStack.removeAt(backStack.lastIndex)
             }
         },
-        // #282 — a topic page change (swipe) replaces the top TopicRoute with the same route at a new
-        // page; our gesture already slides the outgoing page off-screen, so the default 700 ms NavDisplay
-        // cross-fade is redundant AND keeps the incoming entry below RESUMED for its whole duration —
-        // exactly the window the swipe is gated off. Making the FORWARD topic→topic transition instant
-        // collapses that dead-zone to ~one frame. The pop direction ALWAYS cross-fades: a page change is
-        // always a forward in-place replace (never a pop), so a genuine back-pop never goes instant even
-        // if two TopicRoute entries ever coexist. Every other transition keeps nav3's default cross-fade.
-        transitionSpec = { navContentTransform(initialState, targetState) },
-        popTransitionSpec = { navCrossfade() },
+        // Transitions (Claude + Codex, remplace le crossfade 700 ms global) : shared-axis X léger pour le
+        // drill-down (forward/back), fade-through court pour un changement d'onglet, instantané pour le
+        // swipe topic→topic (#282 : le geste glisse déjà la page sortante ; un crossfade garderait l'entrée
+        // entrante sous RESUMED toute la durée — pile la fenêtre où le swipe est gaté). Le sens vient du
+        // spec appelé (transitionSpec = forward/replace, popTransitionSpec = pop). Changer d'onglet remplace
+        // le backStack → ça passe par transitionSpec : on le détecte par le changement de racine de pile
+        // (chaque onglet a une racine distincte) pour ne pas hériter du slide de drill-down.
+        transitionSpec = { navForwardTransform(initialState, targetState) },
+        popTransitionSpec = { navPopTransform(initialState, targetState) },
+        predictivePopTransitionSpec = { navPopTransform(initialState, targetState) },
         entryDecorators = listOf(
             rememberSaveableStateHolderNavEntryDecorator(),
             rememberViewModelStoreNavEntryDecorator(),
@@ -1762,12 +1766,36 @@ private tailrec fun Context.findActivity(): Activity? = when (this) {
     else -> null
 }
 
-/** Default NavDisplay cross-fade duration, mirroring nav3 1.1.1 `defaultTransitionSpec` (700 ms). */
-private const val NAV_CROSSFADE_MILLIS = 700
+// #494 — paramètres de transition (Claude + Codex). MotionScheme M3 absent en stable 1.4.x (1.5.0-alpha)
+// → easings « emphasized » locaux. Slide LÉGER (1/4 de largeur) pour ne pas singer le swipe topic.
+private val EmphasizedDecelerate = CubicBezierEasing(0.05f, 0.7f, 0.1f, 1f)
+private val EmphasizedAccelerate = CubicBezierEasing(0.3f, 0f, 0.8f, 0.15f)
+private const val DRILL_MS = 320
+private const val DRILL_FADE_IN_MS = 150
+private const val DRILL_FADE_OUT_MS = 90
+private const val TAB_FADE_IN_MS = 140
+private const val TAB_FADE_OUT_MS = 80
+private const val SLIDE_DIVISOR = 4
 
-/** nav3 1.1.1 default transition: a 700 ms cross-fade (mirrors androidx `defaultTransitionSpec`). */
-private fun navCrossfade(): ContentTransform =
-    fadeIn(tween(NAV_CROSSFADE_MILLIS)) togetherWith fadeOut(tween(NAV_CROSSFADE_MILLIS))
+private fun navInstant(): ContentTransform = EnterTransition.None togetherWith ExitTransition.None
+
+/** Shared-axis X, sens AVANT : l'entrant glisse depuis la droite, le sortant part vers la gauche. */
+private fun navSharedAxisXForward(): ContentTransform =
+    (slideInHorizontally(tween(DRILL_MS, easing = EmphasizedDecelerate)) { it / SLIDE_DIVISOR } +
+        fadeIn(tween(DRILL_FADE_IN_MS, delayMillis = 30))) togetherWith
+        (slideOutHorizontally(tween(DRILL_MS, easing = EmphasizedAccelerate)) { -it / SLIDE_DIVISOR } +
+            fadeOut(tween(DRILL_FADE_OUT_MS)))
+
+/** Shared-axis X, sens ARRIÈRE : l'entrant glisse depuis la gauche, le sortant part vers la droite. */
+private fun navSharedAxisXBack(): ContentTransform =
+    (slideInHorizontally(tween(DRILL_MS, easing = EmphasizedDecelerate)) { -it / SLIDE_DIVISOR } +
+        fadeIn(tween(DRILL_FADE_IN_MS, delayMillis = 30))) togetherWith
+        (slideOutHorizontally(tween(DRILL_MS, easing = EmphasizedAccelerate)) { it / SLIDE_DIVISOR } +
+            fadeOut(tween(DRILL_FADE_OUT_MS)))
+
+/** Fade-through court entre onglets (contenus sans relation spatiale → pas de slide). */
+private fun navTabFadeThrough(): ContentTransform =
+    fadeIn(tween(TAB_FADE_IN_MS, delayMillis = 30)) togetherWith fadeOut(tween(TAB_FADE_OUT_MS))
 
 /**
  * Marks a [TopicRoute] NavEntry so [isTopicScene] can recognise a topic scene without relying on the
@@ -1790,15 +1818,38 @@ private fun Scene<NavKey>.isTopicScene(): Boolean =
     isTopicSceneMetadata(entries.lastOrNull()?.metadata)
 
 /**
- * Forward ContentTransform for a NavDisplay transition: instant for a topic→topic FORWARD transition
- * (the swipe page change is an in-place backStack replace — always forward, never a pop — collapsing
- * the dead-zone, see #282), nav3's default 700 ms cross-fade otherwise. Only used for the forward
- * direction; the pop direction always uses [navCrossfade]. A deep-link reset that swaps one topic for
- * another while already in a topic would also be instant here, which is benign.
+ * Pure : une navigation AVANT est un drill-down (push) — par opposition à un changement d'onglet ou un
+ * remplacement de pile — ssi la pile cible est exactement la pile source AVEC une entrée empilée au
+ * sommet. On compare les piles ENTIÈRES (par `contentKey`), pas seulement le sommet : deux onglets
+ * peuvent partager une même valeur de route (ex. `CategoryRoute(cat=23)` présent dans Drapeaux ET dans
+ * Forums), et ne comparer que le dernier `contentKey` ferait passer un changement d'onglet pour un push
+ * (slide au lieu de fade-through). On ne peut PAS s'appuyer sur une « racine » via `entries.first` : dans
+ * le `SinglePaneScene` de nav3 `entries` ne contient que l'entrée visible (le sommet) ; la pile complète
+ * se reconstruit par `previousEntries + entries`. [sourceStack] = pile source complète (bas→haut),
+ * [targetParentStack] = pile cible privée de son sommet (ce vers quoi elle se dépilerait). Drill-down
+ * ssi les deux coïncident et sont non vides — exact à toute profondeur.
  */
-private fun navContentTransform(from: Scene<NavKey>, to: Scene<NavKey>): ContentTransform =
-    if (from.isTopicScene() && to.isTopicScene()) {
-        EnterTransition.None togetherWith ExitTransition.None
-    } else {
-        navCrossfade()
-    }
+internal fun isForwardDrillDown(sourceStack: List<Any?>, targetParentStack: List<Any?>): Boolean =
+    targetParentStack.isNotEmpty() && targetParentStack == sourceStack
+
+/** True quand passer de [this] à [to] est un drill-down (cf. [isForwardDrillDown]). */
+private fun Scene<NavKey>.isForwardDrillDownTo(to: Scene<NavKey>): Boolean =
+    isForwardDrillDown(
+        sourceStack = (previousEntries + entries).map { it.contentKey },
+        targetParentStack = to.previousEntries.map { it.contentKey },
+    )
+
+/**
+ * Transition AVANT (push/replace non-pop) : instantané pour le swipe topic→topic (#282), shared-axis X
+ * avant pour un drill-down (push intra-onglet, toute profondeur), fade-through sinon (changement
+ * d'onglet ou remplacement de pile — contenus sans relation spatiale parent/enfant).
+ */
+private fun navForwardTransform(from: Scene<NavKey>, to: Scene<NavKey>): ContentTransform = when {
+    from.isTopicScene() && to.isTopicScene() -> navInstant()
+    from.isForwardDrillDownTo(to) -> navSharedAxisXForward()
+    else -> navTabFadeThrough()
+}
+
+/** Transition ARRIÈRE (pop / retour prédictif) : instantané topic→topic, sinon shared-axis X arrière. */
+private fun navPopTransform(from: Scene<NavKey>, to: Scene<NavKey>): ContentTransform =
+    if (from.isTopicScene() && to.isTopicScene()) navInstant() else navSharedAxisXBack()

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -662,6 +662,14 @@ fun RedfaceApp(intent: Intent?) {
         // time (selecting in another topic resets it — quoting is a single-topic act). Plain
         // remember: losing it on process death just means re-selecting, like the markers above.
         var multiQuoteBasket by remember { mutableStateOf<MultiQuoteBasket?>(null) }
+        // #465 — per-topic MANUAL poll-expansion choice, keyed by (cat, post) (one poll per topic),
+        // twin of topicTitleCache / topicScrollAnchorCache: a page change replaces the TopicRoute
+        // (new nav entry → new ViewModel), so a `rememberSaveable` toggle inside the poll card was
+        // re-seeded to the global default on every page. Hoisted above NavDisplay so collapsing /
+        // expanding a poll survives navigation between the topic's pages. Absence of a key = follow
+        // the `topicPollsExpanded` default; the toggle records the manual choice here. RAM/session
+        // only, never serialized into a route.
+        var topicPollExpansionCache by remember { mutableStateOf(emptyMap<TopicPollKey, Boolean>()) }
 
         LaunchedEffect(authState) {
             when (authState) {
@@ -794,6 +802,15 @@ fun RedfaceApp(intent: Intent?) {
                             multiQuoteBasket = multiQuoteBasket.toggled(cat, post, numreponse)
                         },
                         onClear = { multiQuoteBasket = null },
+                    ),
+                    topicPollNavState = TopicPollNavState(
+                        expansions = topicPollExpansionCache,
+                        onExpansionChanged = { cat, post, expanded ->
+                            topicPollExpansionCache = topicPollExpansionCache.withPollExpansion(
+                                TopicPollKey(cat, post),
+                                expanded,
+                            )
+                        },
                     ),
                     onOpenProfile = { userId, pseudo, avatarUrl ->
                         // Review feedback I3: capture the **origin** tab so that
@@ -969,6 +986,21 @@ private data class MultiQuoteNavState(
 )
 
 /**
+ * #465 — per-topic poll-expansion bundle threaded into [RedfaceNavHost], same shape and survival
+ * rationale as the other hoisted-state bundles ([TopicScrollNavState], [TopicTitleNavState]): a page
+ * change replaces the TopicRoute entry, so any expansion state owned by the topic screen would die
+ * with it. The `var` backing [expansions] lives in [RedfaceApp]. A `null` lookup (no entry for the
+ * topic) means « follow the global default »; [onExpansionChanged] records the user's manual toggle.
+ *
+ * @property expansions the manual collapse/expand choice per topic the user has toggled.
+ * @property onExpansionChanged records a topic's manual poll choice when the card is tapped.
+ */
+private data class TopicPollNavState(
+    val expansions: Map<TopicPollKey, Boolean>,
+    val onExpansionChanged: (cat: Int, post: Int, expanded: Boolean) -> Unit,
+)
+
+/**
  * #291 — multi-quote selection, hoisted to RedfaceApp (same survival rationale as
  * [TopicScrollNavState]: a page change replaces the TopicRoute entry, so any state owned by the
  * topic screen dies with it). [numreponses] keeps SELECTION ORDER — the quotes are concatenated
@@ -1049,6 +1081,8 @@ private fun RedfaceNavHost(
     topicScrollNavState: TopicScrollNavState,
     // #291 — multi-quote basket, same hoisting rationale (survives the per-page entry swap).
     multiQuoteNavState: MultiQuoteNavState,
+    // #465 — per-topic poll-expansion cache, same hoisting rationale (survives the per-page swap).
+    topicPollNavState: TopicPollNavState,
     onOpenProfile: (userId: Int, pseudo: String, avatarUrl: String?) -> Unit = { _, _, _ -> },
 ) {
     NavDisplay(
@@ -1531,6 +1565,15 @@ private fun RedfaceNavHost(
                         .orEmpty(),
                     onToggleMultiQuote = { numreponse ->
                         multiQuoteNavState.onToggle(route.cat, route.post, numreponse)
+                    },
+                    // #465 — the topic's saved manual poll choice (null = follow the global
+                    // default), and the callback recording a tap on the poll card. Hoisted to
+                    // :app so it survives the per-page TopicRoute swap, keyed by (cat, post).
+                    pollManualExpanded = topicPollNavState.expansions[
+                        TopicPollKey(route.cat, route.post),
+                    ],
+                    onPollExpansionChanged = { expanded ->
+                        topicPollNavState.onExpansionChanged(route.cat, route.post, expanded)
                     },
                     onMultiQuote = { subcat, page ->
                         // #291 — quote flavour of reply with the EXTRA numreponses riding the

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/TopicPollKey.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/TopicPollKey.kt
@@ -1,0 +1,43 @@
+package fr.forumhfr.redface2.navigation
+
+/**
+ * #465 — composite cache key for the per-topic poll-expansion cache. HFR exposes at most ONE poll
+ * per topic, so a topic-level key is enough — no need for a per-page or per-poll component. Same
+ * `(cat, post)` rationale as [TopicTitleKey] / `MultiQuoteBasket`: a topic id is unique only per HFR
+ * category, so keying by `post` alone could leak a manual choice across two categories that happen
+ * to share the same id.
+ */
+internal data class TopicPollKey(val cat: Int, val post: Int)
+
+// Upper bound on the per-topic poll-expansion cache, mirroring TOPIC_TITLE_CACHE_MAX / the scroll
+// anchor cap. A long reading session opens many topics with polls; the cap keeps the map from
+// growing unbounded for the app's lifetime. Eviction is least-recently-WRITTEN (like the scroll
+// anchors): dropping an old manual choice just lets that topic fall back to the global default,
+// which is harmless.
+internal const val TOPIC_POLL_EXPANSION_CACHE_MAX = 128
+
+/**
+ * #465 — records the user's MANUAL poll-expansion choice for [key] (`true` = revealed, `false` =
+ * collapsed), evicting the oldest entries past [TOPIC_POLL_EXPANSION_CACHE_MAX]. Twin of
+ * [withScrollAnchor]: an update to an existing key is remove-then-reinsert so the entry moves to the
+ * tail (least-recently-written eviction), and an unchanged value short-circuits to the same instance
+ * so a redundant toggle never reallocates the map nor recomposes `RedfaceApp`.
+ *
+ * Only topics the user has manually toggled appear here; absence of a key means « follow the global
+ * `topicPollsExpanded` default ». The map survives the per-page TopicRoute entry swap because it is
+ * hoisted into `RedfaceApp` (above `NavDisplay`), exactly like the title / scroll-anchor caches — so
+ * collapsing or expanding a poll persists across page navigation within the same topic. In-memory
+ * only (session-scoped), reset naturally when the app process dies.
+ */
+internal fun Map<TopicPollKey, Boolean>.withPollExpansion(
+    key: TopicPollKey,
+    expanded: Boolean,
+): Map<TopicPollKey, Boolean> {
+    if (this[key] == expanded) return this
+    val updated = (if (containsKey(key)) this - key else this) + (key to expanded)
+    return if (updated.size > TOPIC_POLL_EXPANSION_CACHE_MAX) {
+        updated.entries.drop(updated.size - TOPIC_POLL_EXPANSION_CACHE_MAX).associate { it.toPair() }
+    } else {
+        updated
+    }
+}

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,10 +1,13 @@
-Redface 2 v0.12.0 — beta.
+Redface 2 v0.13.0 — beta.
 
 New:
-- Editor: insert images at reduced or full size (your choice in Settings), line break between images of a multi-upload, "Upload" button always visible.
-- (DT) Cross-app MP storage inspector for DT users (Settings → DT section).
+- Settings redesigned: dedicated tab, category-first navigation, search, smooth transitions.
+- Compact bottom bar, translucent search bar on scroll.
+- "edited" marker, steady post header on multi-quote, poll state kept across pages.
 
-Fix:
-- MP list pagination beyond page 2.
+Fixes:
+- Flags refresh on tab switch and on resume.
+- Unread MP badge that truly cuts the network when off.
+- Stray empty lines in posts, hardened image upload.
 
 Report bugs via the beta or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,10 +1,13 @@
-Redface 2 v0.12.0 — bêta.
+Redface 2 v0.13.0 — bêta.
 
 Nouveautés :
-- Éditeur : insertion d'image en taille réduite ou pleine taille (au choix dans les Réglages), saut de ligne entre les images d'un envoi multiple, bouton « Uploader » toujours visible.
-- (DT) Inspecteur du stockage MP cross-app pour les utilisateurs DT (Réglages → section DT).
+- Réglages repensés : onglet dédié, navigation par catégories, recherche, transitions fluides.
+- Bottom bar compacte, recherche translucide au défilement.
+- Marqueur « édité », en-tête stable au multiquote, sondages conservés entre pages.
 
-Correctif :
-- Pagination des MP au-delà de la page 2.
+Correctifs :
+- Drapeaux rafraîchis au changement d'onglet et à la reprise.
+- Badge MP non-lus qui coupe vraiment le réseau.
+- Lignes vides parasites, upload d'images durci.
 
 Signalez les bugs via la bêta ou GitHub.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,8 @@
     <string name="nav_forum">Forum</string>
     <string name="nav_search">Recherche</string>
     <string name="nav_messages">Messages</string>
+    <!-- #494 v2 — Réglages devient la 5e destination de la barre du bas (retiré du menu compte). -->
+    <string name="nav_settings">Réglages</string>
     <!-- #313 — badge MP non lus sur l'item Messages ; au-delà de 9 le badge plafonne. -->
     <string name="nav_messages_badge_overflow">9+</string>
 </resources>

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/MpUnreadBadgeViewModelTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/MpUnreadBadgeViewModelTest.kt
@@ -113,4 +113,69 @@ class MpUnreadBadgeViewModelTest {
         vm.onAppForegrounded()
         verify(exactly = 2) { repository.requestUnreadRefresh() }
     }
+
+    /**
+     * #452 — the opt-out must cut the NETWORK, not just the display. While the badge preference is
+     * off, the ViewModel must NOT collect (nor even invoke) the count flow that drives the
+     * authenticated page-1 fetch ; the badge stays null.
+     */
+    @Test
+    fun `the count flow is not collected while the badge is disabled (#452)`() = runTest {
+        val repository = mockk<MessagesRepository>(relaxed = true)
+        val vm = viewModel(
+            counts = flowOf(7),
+            badgeEnabled = flowOf(false),
+            messagesRepository = repository,
+        )
+
+        vm.unreadCount.test {
+            assertNull(expectMostRecentItem())
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+        // The network-backed count flow is never even asked for : no fetch chain is kept alive.
+        verify(exactly = 0) { repository.observeUnreadMpCount() }
+    }
+
+    /**
+     * #452 — flipping the badge ON must (re)subscribe to the count flow, flipping it OFF must drop
+     * the subscription. Asserted via the call count of `observeUnreadMpCount` across a live toggle.
+     */
+    @Test
+    fun `toggling the badge subscribes and unsubscribes the count flow (#452)`() = runTest {
+        val enabled = MutableStateFlow(false)
+        val repository = mockk<MessagesRepository>(relaxed = true) {
+            every { observeUnreadMpCount() } returns flowOf(4)
+        }
+        val vm = viewModel(counts = flowOf(4), badgeEnabled = enabled, messagesRepository = repository)
+
+        vm.unreadCount.test {
+            assertNull(expectMostRecentItem())
+            verify(exactly = 0) { repository.observeUnreadMpCount() }
+
+            enabled.value = true
+            assertEquals(4, awaitItem())
+            verify(exactly = 1) { repository.observeUnreadMpCount() }
+
+            enabled.value = false
+            assertNull(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    /**
+     * #453 — reading a conversation forwards an optimistic-decrement signal to the repository
+     * (which owns the count) so the badge clears the moment the last unread MP is opened.
+     */
+    @Test
+    fun `onThreadRead forwards the read signal to the repository (#453)`() = runTest {
+        val repository = mockk<MessagesRepository>(relaxed = true) {
+            every { observeUnreadMpCount() } returns flowOf(1)
+        }
+        val vm = viewModel(counts = flowOf(1), messagesRepository = repository)
+
+        vm.onThreadRead(threadId = 99)
+
+        verify(exactly = 1) { repository.markThreadRead(threadId = 99) }
+    }
 }

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/NavTransitionTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/NavTransitionTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 /**
  * Pins the topic-scene marker contract used by the instant `TopicRoute → TopicRoute` NavDisplay
  * transition (#282). The transition reads this marker off a scene's top NavEntry metadata; if the
- * lookup silently returned the wrong answer the page-change would degrade to the 700 ms cross-fade
+ * lookup silently returned the wrong answer the page-change would degrade to the shared-axis X slide
  * (re-introducing the swipe dead-zone) without any crash. These cover the lookup + the edge cases
  * (empty `entries` surfaces as a null metadata map).
  */
@@ -37,5 +37,51 @@ class NavTransitionTest {
     @Test
     fun `unrelated metadata keys are not a topic scene`() {
         assertFalse(isTopicSceneMetadata(mapOf("some.other.key" to true)))
+    }
+
+    // --- isForwardDrillDown (#494 transitions) ---------------------------------------------------
+    // A forward navigation is a drill-down (shared-axis X) iff the target stack is exactly the source
+    // stack + one pushed top. We compare WHOLE stacks (the target minus its top vs the full source),
+    // not just the last key: two tabs can share a route value (CategoryRoute(cat=23) lives in both
+    // Drapeaux and Forums), and a last-key-only check would slide a tab switch. Using entries.first()
+    // as a "root" also fails — nav3's SinglePaneScene exposes only the visible top in entries.
+
+    @Test
+    fun `target parent stack equal to source stack is a drill-down`() {
+        // Forums [Forum, Category] -> [Forum, Category, Topic] : target-minus-top == source.
+        assertTrue(
+            isForwardDrillDown(
+                sourceStack = listOf("Forum", "Category"),
+                targetParentStack = listOf("Forum", "Category"),
+            ),
+        )
+    }
+
+    @Test
+    fun `depth-1 drill-down is a drill-down`() {
+        assertTrue(isForwardDrillDown(sourceStack = listOf("Flags"), targetParentStack = listOf("Flags")))
+    }
+
+    @Test
+    fun `empty target parent stack (tab root) is not a drill-down`() {
+        // Switching to a tab sitting at its root: target-minus-top is empty -> tab switch.
+        assertFalse(isForwardDrillDown(sourceStack = listOf("Flags"), targetParentStack = emptyList()))
+    }
+
+    @Test
+    fun `cross-tab navigation with a shared route value is not a drill-down`() {
+        // Codex P3: Flags top = Category(23) ; Forum tab = [Forum, Category(23), Topic]. The last keys
+        // match (both Category(23)) but the full stacks differ -> must stay a tab switch (fade-through).
+        assertFalse(
+            isForwardDrillDown(
+                sourceStack = listOf("FlagsList", "Category23"),
+                targetParentStack = listOf("Forum", "Category23"),
+            ),
+        )
+    }
+
+    @Test
+    fun `both stacks empty is not a drill-down`() {
+        assertFalse(isForwardDrillDown(sourceStack = emptyList(), targetParentStack = emptyList()))
     }
 }

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/TopicPollExpansionTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/TopicPollExpansionTest.kt
@@ -1,0 +1,106 @@
+package fr.forumhfr.redface2.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #465 — covers the per-topic poll-expansion cache helper that makes a manual collapse/expand
+ * survive page navigation within a topic. Twin of [TopicScrollCacheTest] / [TopicTitleCacheTest]:
+ * a pure function over an immutable map, unit-testable without Compose.
+ */
+class TopicPollExpansionTest {
+
+    private fun key(cat: Int, post: Int) = TopicPollKey(cat, post)
+
+    @Test
+    fun `withPollExpansion inserts a new manual choice`() {
+        val cache = emptyMap<TopicPollKey, Boolean>().withPollExpansion(key(1, 10), expanded = false)
+
+        assertEquals(false, cache[key(1, 10)])
+    }
+
+    @Test
+    fun `absent topic returns null so the screen follows the global default`() {
+        val cache = emptyMap<TopicPollKey, Boolean>().withPollExpansion(key(1, 10), expanded = true)
+
+        // A topic the user never toggled has no entry: the lookup is null, and TopicScreen falls
+        // back to TopicUiState.pollsExpandedDefault (the #456 setting).
+        assertNull(cache[key(2, 20)])
+    }
+
+    @Test
+    fun `withPollExpansion keys by (cat, post) so other topics and categories do not collide`() {
+        val cache = emptyMap<TopicPollKey, Boolean>()
+            .withPollExpansion(key(1, 10), expanded = false)
+            .withPollExpansion(key(1, 11), expanded = true)
+            .withPollExpansion(key(2, 10), expanded = true)
+
+        assertEquals(false, cache[key(1, 10)])
+        assertEquals(true, cache[key(1, 11)])
+        assertEquals(true, cache[key(2, 10)])
+        assertEquals(3, cache.size)
+    }
+
+    @Test
+    fun `withPollExpansion flips the value when the user toggles again`() {
+        // The core #465 scenario: default expanded → user collapses on page N → the collapse must
+        // persist (a later toggle expands it again). One entry per topic, last write wins.
+        val cache = emptyMap<TopicPollKey, Boolean>()
+            .withPollExpansion(key(1, 10), expanded = false)
+            .withPollExpansion(key(1, 10), expanded = true)
+
+        assertEquals(true, cache[key(1, 10)])
+        assertEquals(1, cache.size)
+    }
+
+    @Test
+    fun `withPollExpansion returns the same instance when unchanged (no recomposition)`() {
+        val cache = emptyMap<TopicPollKey, Boolean>().withPollExpansion(key(1, 10), expanded = true)
+
+        val again = cache.withPollExpansion(key(1, 10), expanded = true)
+
+        assertSame("an unchanged choice must not allocate a new map", cache, again)
+    }
+
+    @Test
+    fun `withPollExpansion evicts the oldest entries past the cap`() {
+        var cache = emptyMap<TopicPollKey, Boolean>()
+        repeat(TOPIC_POLL_EXPANSION_CACHE_MAX + 10) { i ->
+            cache = cache.withPollExpansion(key(0, i), expanded = i % 2 == 0)
+        }
+
+        assertEquals(TOPIC_POLL_EXPANSION_CACHE_MAX, cache.size)
+        assertTrue(
+            "the 10 oldest insertions are evicted",
+            (0 until 10).none { cache.containsKey(key(0, it)) },
+        )
+        assertTrue(
+            "the newest insertion is kept",
+            cache.containsKey(key(0, TOPIC_POLL_EXPANSION_CACHE_MAX + 9)),
+        )
+    }
+
+    @Test
+    fun `withPollExpansion refreshes the eviction rank when an existing key is updated`() {
+        // Same LRU-by-write contract as withScrollAnchor: re-toggling a topic must move it to the
+        // tail, so a topic toggled early but still actively read is not the first evicted.
+        var cache = emptyMap<TopicPollKey, Boolean>()
+            .withPollExpansion(key(9, 99), expanded = false)
+        repeat(TOPIC_POLL_EXPANSION_CACHE_MAX - 1) { i ->
+            cache = cache.withPollExpansion(key(0, i), expanded = true)
+        }
+
+        // Cache exactly full; updating the oldest key must re-rank it to most recent…
+        cache = cache.withPollExpansion(key(9, 99), expanded = true)
+        // …so the next insertion evicts the oldest filler key, not the just-updated one.
+        cache = cache.withPollExpansion(key(0, 9999), expanded = false)
+
+        assertEquals(TOPIC_POLL_EXPANSION_CACHE_MAX, cache.size)
+        assertEquals(true, cache[key(9, 99)])
+        assertFalse("the oldest filler entry is the one evicted", cache.containsKey(key(0, 0)))
+    }
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/di/PlatformBindingsModule.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/di/PlatformBindingsModule.kt
@@ -4,6 +4,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import fr.forumhfr.redface2.core.domain.coroutines.ApplicationScope
 import fr.forumhfr.redface2.core.domain.coroutines.DefaultDispatcher
 import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
 import fr.forumhfr.redface2.core.domain.coroutines.MainDispatcher
@@ -14,7 +15,9 @@ import fr.forumhfr.redface2.core.parser.messages.PrivateMessageThreadParser
 import java.time.Clock
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -37,6 +40,18 @@ object PlatformBindingsModule {
     @Singleton
     @MainDispatcher
     fun provideMainDispatcher(): CoroutineDispatcher = Dispatchers.Main.immediate
+
+    /**
+     * Process-lifetime scope for writes that must complete regardless of the caller's lifecycle
+     * (#507). `SupervisorJob` so one failed write never tears down the scope; on [IoDispatcher] since
+     * its only client today is DataStore commits. Never cancelled (it lives for the whole process).
+     */
+    @Provides
+    @Singleton
+    @ApplicationScope
+    fun provideApplicationScope(
+        @IoDispatcher ioDispatcher: CoroutineDispatcher,
+    ): CoroutineScope = CoroutineScope(SupervisorJob() + ioDispatcher)
 
     @Provides
     @Singleton

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/flags/DefaultFlagRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/flags/DefaultFlagRepository.kt
@@ -22,6 +22,9 @@ import java.util.EnumMap
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.channels.BufferOverflow
@@ -81,6 +84,11 @@ class DefaultFlagRepository @Inject constructor(
 
     private val cachedSuccesses: MutableMap<FlagType, FlagsResult.Success> = EnumMap(FlagType::class.java)
 
+    // Bumped by [clearSessionCache] on logout / account switch, read+written under the cachedSuccesses
+    // lock. A fetch that began before a switch must not write its result into the (type-keyed)
+    // singleton cache afterwards (#501 Codex P1) — it compares this generation at write time.
+    private var sessionGeneration = 0
+
     /**
      * One refresh-trigger per [FlagType] so a refresh on one tab does not re-fetch the
      * other two. Replay = 0 because [observe] emits its own cached-or-initial result;
@@ -94,6 +102,26 @@ class DefaultFlagRepository @Inject constructor(
                 onBufferOverflow = BufferOverflow.DROP_OLDEST,
             )
         }
+
+    /**
+     * #501 (Codex review) — in-flight fetch coordinator, one [Deferred] per [FlagType]. observe()'s
+     * initial fetch (first subscription with no fresh cache) and an explicit refresh() can fire for
+     * the SAME tab at the same instant (the screen's auto-refresh lands as the list first subscribes),
+     * each otherwise running the full per-category REST fan-out. Sharing one in-flight Deferred
+     * collapses concurrent calls into a single fan-out; a completed fetch is cleared, so a LATER
+     * refresh still triggers a fresh one. Launched in an app-scoped CoroutineScope (this is a
+     * @Singleton, so the scope lives for the process) so cancelling one caller — e.g. observe() torn
+     * down by a flatMapLatest tab switch — never cancels the fetch a concurrent refresh still awaits.
+     */
+    private val fetchScope = CoroutineScope(SupervisorJob() + ioDispatcher)
+
+    /** Identifies an in-flight fetch by BOTH type and user — never share a fetch across accounts. */
+    private data class FetchKey(val type: FlagType, val userId: String)
+
+    // Keyed by (type, userId), NOT type alone: a fetch started for one account must never be awaited
+    // by another after a logout / account switch, and [clearSessionCache] cancels stragglers so they
+    // cannot repopulate the singleton success cache with the previous account's data (#501 Codex P1).
+    private val inFlightFetches: MutableMap<FetchKey, Deferred<FlagsResult>> = mutableMapOf()
 
     override fun observe(type: FlagType): Flow<FlagsResult> = flow {
         val cached = synchronized(cachedSuccesses) { cachedSuccesses[type] }
@@ -109,7 +137,7 @@ class DefaultFlagRepository @Inject constructor(
                     synchronized(cachedSuccesses) { cachedSuccesses[type] = diskCached.result }
                     emit(diskCached.result)
                     if (!diskCached.isFresh) {
-                        when (val refreshed = fetch(type = type, userId = userId)) {
+                        when (val refreshed = fetchDeduplicated(type = type, userId = userId)) {
                             is FlagsResult.Success -> emit(refreshed)
                             is FlagsResult.Failure -> Log.w(
                                 LOG_TAG,
@@ -121,7 +149,7 @@ class DefaultFlagRepository @Inject constructor(
                     }
                 } else {
                     emit(FlagsResult.Loading)
-                    emit(fetch(type = type, userId = userId))
+                    emit(fetchDeduplicated(type = type, userId = userId))
                 }
             }
         }
@@ -136,13 +164,24 @@ class DefaultFlagRepository @Inject constructor(
             if (userId == null) {
                 notAuthenticatedFailure()
             } else {
-                fetch(type = type, userId = userId)
+                fetchDeduplicated(type = type, userId = userId)
             },
         )
     }
 
     override fun clearSessionCache() {
-        synchronized(cachedSuccesses) { cachedSuccesses.clear() }
+        // Bump the generation under the same lock as the write guard: a fetch in flight across this
+        // point will see a changed generation and skip its cache write (#501 Codex P1).
+        synchronized(cachedSuccesses) {
+            cachedSuccesses.clear()
+            sessionGeneration++
+        }
+        // Cancel any fetch still in flight from the previous session so it stops early instead of
+        // running the full fan-out for an account that just logged out / switched.
+        synchronized(inFlightFetches) {
+            inFlightFetches.values.forEach { it.cancel() }
+            inFlightFetches.clear()
+        }
     }
 
     /**
@@ -225,8 +264,31 @@ class DefaultFlagRepository @Inject constructor(
         }
     }
 
+    /**
+     * Runs [fetch] for [type] unless an identical fetch is already in flight, in which case the
+     * concurrent caller awaits the same result instead of launching a second per-category fan-out
+     * (#501, Codex review). [fetch] folds every failure into [FlagsResult.Failure] and never throws,
+     * so the shared [Deferred] always completes with a result (no exception to propagate on await).
+     */
+    private suspend fun fetchDeduplicated(type: FlagType, userId: String): FlagsResult {
+        val key = FetchKey(type = type, userId = userId)
+        val deferred = synchronized(inFlightFetches) {
+            inFlightFetches[key]?.takeIf { it.isActive }
+                ?: fetchScope.async { fetch(type = type, userId = userId) }.also { started ->
+                    inFlightFetches[key] = started
+                    started.invokeOnCompletion {
+                        synchronized(inFlightFetches) {
+                            if (inFlightFetches[key] === started) inFlightFetches.remove(key)
+                        }
+                    }
+                }
+        }
+        return deferred.await()
+    }
+
     private suspend fun fetch(type: FlagType, userId: String): FlagsResult = withContext(ioDispatcher) {
-        runCatching {
+        val startGeneration = synchronized(cachedSuccesses) { sessionGeneration }
+        val result = runCatching {
             val cats = loadCategories()
             val bucket = type.toBucket()
             // `coroutineScope` (fail-all) is intentional over `supervisorScope` (best-effort).
@@ -249,15 +311,26 @@ class DefaultFlagRepository @Inject constructor(
         }.fold(
             onSuccess = { flags ->
                 persistFlags(userId = userId, type = type, flags = flags)
-                FlagsResult.Success(flags).also { result ->
-                    synchronized(cachedSuccesses) { cachedSuccesses[type] = result }
-                }
+                FlagsResult.Success(flags)
             },
             onFailure = { throwable ->
                 Log.w(LOG_TAG, "Flags REST fetch failed for $type", throwable)
                 FlagsResult.Failure(throwable)
             },
         )
+        // Cache the success ONLY if it still belongs to the active session (#501 Codex P1). observe()
+        // serves this type-keyed singleton cache BEFORE resolving the current user, so a stale write
+        // would hand the next account the previous account's flags. Two guards cover every ordering of
+        // a logout / account switch vs. this fetch: the user must still be the one we fetched for (a
+        // fetch launched for a now-stale account, racing the switch, is dropped), AND no
+        // clearSessionCache must have bumped the generation since this fetch began (a switch DURING the
+        // fetch). The disk cache (persistFlags) is already userId-scoped, so it keeps each account's data.
+        if (result is FlagsResult.Success && currentUserId() == userId) {
+            synchronized(cachedSuccesses) {
+                if (sessionGeneration == startGeneration) cachedSuccesses[type] = result
+            }
+        }
+        result
     }
 
     private suspend fun persistFlags(userId: String, type: FlagType, flags: List<Flag>) {

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepository.kt
@@ -16,12 +16,15 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.withContext
@@ -62,30 +65,68 @@ class DefaultMessagesRepository @Inject constructor(
     private val unreadRefreshTicks = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     private val inboxDerivedUnread = MutableSharedFlow<Pair<String, Int>>(extraBufferCapacity = 1)
 
+    // #453 — optimistic local decrement. Reading the LAST unread conversation left the badge
+    // stale until the next page-1 fetch (foreground / tab visit), because the count only ever
+    // came from the network. A thread-read signal decrements the displayed count locally — zero
+    // network, and consistent with the inbox row that already forces `hasUnread=false` for a read
+    // thread (MessagesScreen). HFR has no server-side read flag (#361), so the server count would
+    // not change just from reading anyway ; the next real page-1 fetch reconciles. Threads read
+    // since the last network count are tracked so re-opening one never double-decrements, and a
+    // fresh fetch clears the set (its count is authoritative). tryEmit + buffer: the signal may
+    // fire with no collector (badge disabled, #452) and must never suspend.
+    private val markThreadReadEvents = MutableSharedFlow<Int>(extraBufferCapacity = 8)
+
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun observeUnreadMpCount(): Flow<Int?> = authRepository.observeAuthState()
         .transformLatest { state ->
             when (state) {
                 AuthState.Anonymous -> emit(null)
-                is AuthState.Authenticated -> {
-                    emit(fetchUnreadCount())
-                    emitAll(
-                        merge(
-                            unreadRefreshTicks.map { fetchUnreadCount() },
-                            inboxDerivedUnread.mapNotNull { (pseudo, count) ->
-                                // Drop emissions sealed for another session (account switch
-                                // while the page-1 fetch was in flight).
-                                if (pseudo == state.pseudo) count else null
-                            },
-                        ),
-                    )
-                }
+                is AuthState.Authenticated -> emitAll(authenticatedUnreadCount(state))
             }
         }
+        .distinctUntilChanged()
         .flowOn(ioDispatcher)
+
+    /**
+     * Stream of unread counts for an authenticated [session] : the first fetch, then every network
+     * refresh (foreground tick / page-1 piggyback), with #453 local read-decrements applied on top.
+     * Each fresh network count is authoritative and resets the local decrements
+     * ([LocalUnread.applyEvent] on a [NetworkCount]).
+     */
+    private fun authenticatedUnreadCount(session: AuthState.Authenticated): Flow<Int?> {
+        val networkCounts = merge(
+            unreadRefreshTicks.map { NetworkCount(fetchUnreadCount()) },
+            inboxDerivedUnread.mapNotNull { (pseudo, count) ->
+                // Drop emissions sealed for another session (account switch while the page-1
+                // fetch was in flight).
+                if (pseudo == session.pseudo) NetworkCount(count) else null
+            },
+        )
+        // The initial fetch is its own first emission so reads marked before any refresh still
+        // decrement it (otherwise the cold-start count would be a non-resettable baseline). It is
+        // tagged `isInitial` so that, if a page-1 piggyback or a refresh tick wins the race to be the
+        // first count, the late-landing cold-start is dropped rather than resetting the local reads
+        // accumulated meanwhile (Codex review, #453).
+        return merge(
+            flow { emit(NetworkCount(fetchUnreadCount(), isInitial = true)) },
+            networkCounts,
+            markThreadReadEvents.map { ReadThread(it) },
+        )
+            .scan(LocalUnread()) { acc, event -> acc.applyEvent(event) }
+            // Drop the seed (no network count seen yet) ; emit every resolved state afterwards,
+            // including a `null` from a failed fetch (the contract surfaces failures as null).
+            .mapNotNull { folded ->
+                if (folded.hasNetworkCount) Displayed(folded.displayedCount) else null
+            }
+            .map { it.value }
+    }
 
     override fun requestUnreadRefresh() {
         unreadRefreshTicks.tryEmit(Unit)
+    }
+
+    override fun markThreadRead(threadId: Int) {
+        markThreadReadEvents.tryEmit(threadId)
     }
 
     private suspend fun fetchUnreadCount(): Int? = withContext(ioDispatcher) {
@@ -140,6 +181,52 @@ class DefaultMessagesRepository @Inject constructor(
             fallbackCorrespondent = fallbackCorrespondent,
         )
     }
+
+    /** #453 — events folded by the unread-count [scan]. */
+    private sealed interface UnreadEvent
+
+    /**
+     * A count from the network. [isInitial] marks the one-shot cold-start fetch (vs a refresh tick /
+     * page-1 piggyback) so a late-landing cold-start cannot reset reads another count already baselined.
+     */
+    private data class NetworkCount(val count: Int?, val isInitial: Boolean = false) : UnreadEvent
+
+    /** A conversation was read in-app (decrements the displayed count by one, once). */
+    private data class ReadThread(val threadId: Int) : UnreadEvent
+
+    /**
+     * #453 — fold state over [UnreadEvent]s. [baseCount] is the last network count ; [readThreadIds]
+     * are the threads read since that count arrived. [displayedCount] subtracts them (clamped at 0).
+     * [hasNetworkCount] tells the seed (no count yet) apart from a resolved `null` (failed fetch).
+     */
+    private data class LocalUnread(
+        val baseCount: Int? = null,
+        val readThreadIds: Set<Int> = emptySet(),
+        val hasNetworkCount: Boolean = false,
+    ) {
+        val displayedCount: Int?
+            get() = baseCount?.let { (it - readThreadIds.size).coerceAtLeast(0) }
+
+        fun applyEvent(event: UnreadEvent): LocalUnread = when (event) {
+            is NetworkCount -> when {
+                // The FIRST count to arrive (whichever source wins the cold-start race) adopts its
+                // value but KEEPS the local reads accumulated meanwhile : a read that raced the very
+                // first fetch must not be discarded — HFR has no server-side read flag (#361), so that
+                // count can't reflect it anyway (#453, Codex review).
+                !hasNetworkCount -> copy(baseCount = event.count, hasNetworkCount = true)
+                // A late-landing cold-start fetch (a piggyback / refresh tick already baselined first)
+                // is stale and must NOT reset the reads marked since : drop it (Codex review, #453).
+                event.isInitial -> this
+                // A genuine later refresh (foreground tick / page-1 piggyback) is authoritative : it
+                // resets the local decrements so the displayed count reconciles with the server truth.
+                else -> LocalUnread(baseCount = event.count, readThreadIds = emptySet(), hasNetworkCount = true)
+            }
+            is ReadThread -> copy(readThreadIds = readThreadIds + event.threadId)
+        }
+    }
+
+    /** Wraps a resolved (possibly `null`) displayed count so [mapNotNull] only drops the scan seed. */
+    private data class Displayed(val value: Int?)
 
     private companion object {
         const val LOG_TAG = "MessagesRepository"

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
+import fr.forumhfr.redface2.core.domain.coroutines.ApplicationScope
 import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
@@ -23,6 +24,8 @@ import fr.forumhfr.redface2.core.model.FlagType
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -38,7 +41,25 @@ class DataStoreUserPreferencesRepository @Inject constructor(
     private val themeBootstrapStore: ThemeBootstrapStore,
     private val startScreenBootstrapStore: StartScreenBootstrapStore,
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    @param:ApplicationScope private val externalScope: CoroutineScope,
 ) : UserPreferencesRepository {
+
+    /**
+     * Runs a preference write on [externalScope] (process-lifetime) instead of the caller's job, then
+     * awaits it. A settings sub-page popped mid-write cancels the caller's `viewModelScope` — and thus
+     * this `await()` — but the `async` is parented to [externalScope], so the DataStore commit (and any
+     * bootstrap-mirror write in the same block) still completes and the change is not silently lost
+     * (#507). `await()` re-throws a write failure to the caller, preserving the ViewModels' optimistic
+     * rollback; if the caller is already gone, the failure is held in the (un-awaited) Deferred and the
+     * `SupervisorJob` keeps the scope alive for the next write.
+     *
+     * Use for DISCRETE writes (toggles, pickers, Save buttons). Do NOT use for write-on-keystroke
+     * setters that rely on caller cancellation to serialise (last-write-wins) — see [setImgurClientId],
+     * which deliberately stays on the caller's cancellable scope.
+     */
+    private suspend fun persist(block: suspend () -> Unit) {
+        externalScope.async { block() }.await()
+    }
 
     override fun observeProxyConfig(): Flow<ProxyConfig> =
         dataStore.data
@@ -47,7 +68,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
 
     override suspend fun saveProxyConfig(config: ProxyConfig) {
         val normalized = config.normalized()
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_PROXY_ENABLED] = normalized.enabled
                 prefs[KEY_PROXY_HOST] = normalized.host
@@ -70,7 +91,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(false) }
 
     override suspend fun setIgnoreTopicCache(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_IGNORE_TOPIC_CACHE] = enabled
             }
@@ -84,7 +105,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(true) }
 
     override suspend fun setFlagsGroupByCategory(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_FLAGS_GROUP_BY_CATEGORY] = enabled
             }
@@ -98,7 +119,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(false) }
 
     override suspend fun setFlagsHideReadCategories(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_FLAGS_HIDE_READ_CATEGORIES] = enabled
             }
@@ -112,7 +133,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(false) }
 
     override suspend fun setFlagsPerTabOverride(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_FLAGS_PER_TAB_OVERRIDE] = enabled
             }
@@ -132,7 +153,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(FlagsViewSettings(unreadOnly = defaultUnreadOnly(type))) }
 
     override suspend fun setFlagsGroupByCategoryForType(type: FlagType, enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[flagsGroupByCategoryKey(type)] = enabled
             }
@@ -140,7 +161,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
     }
 
     override suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[flagsHideReadCategoriesKey(type)] = enabled
             }
@@ -148,7 +169,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
     }
 
     override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[flagsUnreadOnlyKey(type)] = enabled
             }
@@ -172,7 +193,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(ThemeMode.SYSTEM) }
 
     override suspend fun setThemeMode(mode: ThemeMode) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_THEME_MODE] = mode.name
             }
@@ -195,7 +216,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(false) }
 
     override suspend fun setAmoledEnabled(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_AMOLED_ENABLED] = enabled
             }
@@ -211,7 +232,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(false) }
 
     override suspend fun setTopicTopBarAutoHide(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_TOPIC_TOPBAR_AUTO_HIDE] = enabled
             }
@@ -226,7 +247,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(false) }
 
     override suspend fun setConfirmBeforePosting(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_CONFIRM_BEFORE_POSTING] = enabled
             }
@@ -241,7 +262,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(false) }
 
     override suspend fun setShowDtSection(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_FLAGS_SHOW_DT_SECTION] = enabled
             }
@@ -257,7 +278,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(true) }
 
     override suspend fun setFlagsAutoRefresh(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_FLAGS_AUTO_REFRESH] = enabled
             }
@@ -273,7 +294,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(true) }
 
     override suspend fun setTopicPageFabs(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_TOPIC_PAGE_FABS] = enabled
             }
@@ -289,7 +310,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(false) }
 
     override suspend fun setTopicPollsExpanded(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_TOPIC_POLLS_EXPANDED] = enabled
             }
@@ -314,7 +335,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(StartScreenPreference()) }
 
     override suspend fun setStartScreen(preference: StartScreenPreference) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_START_SCREEN] = preference.screen.name
                 val catId = preference.forumCatId
@@ -349,7 +370,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(true) }
 
     override suspend fun setMpUnreadBadge(enabled: Boolean) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_MP_UNREAD_BADGE] = enabled
             }
@@ -364,7 +385,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(UploadProviderId.DIBERIE) }
 
     override suspend fun setUploadProvider(provider: UploadProviderId) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_UPLOAD_PROVIDER] = provider.name
             }
@@ -381,7 +402,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(DisplayDensity.COMFORT) }
 
     override suspend fun setDisplayDensity(density: DisplayDensity) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_DISPLAY_DENSITY] = density.name
             }
@@ -395,6 +416,11 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .distinctUntilChanged()
             .catch { emit("") }
 
+    // NOT routed through persist(): unlike the discrete toggles/pickers, the Client-ID is written on
+    // EVERY keystroke and SettingsViewModel cancels the previous in-flight write so only the latest text
+    // commits (last-write-wins, #459). Detaching it onto the application scope would let a cancelled
+    // older write survive and land after a newer one, stranding a stale value (#508 Codex review). Here
+    // cancellation IS the intended behaviour, so this write stays on the caller's (cancellable) scope.
     override suspend fun setImgurClientId(clientId: String) {
         withContext(ioDispatcher) {
             dataStore.edit { prefs ->
@@ -411,7 +437,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(EditorImageInsert.REDUCED) }
 
     override suspend fun setEditorImageInsert(mode: EditorImageInsert) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_EDITOR_IMAGE_INSERT] = mode.name
             }
@@ -426,7 +452,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             .catch { emit(FontScalePreference.M) }
 
     override suspend fun setFontScale(scale: FontScalePreference) {
-        withContext(ioDispatcher) {
+        persist {
             dataStore.edit { prefs ->
                 prefs[KEY_FONT_SCALE] = scale.name
             }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/DefaultUploadRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/DefaultUploadRepository.kt
@@ -85,16 +85,21 @@ private fun UploadedImage.toEntity(userId: String, uploadedAt: Instant): Uploade
         expiresAt = expiresAt,
     )
 
-private fun UploadedImageEntity.toRecord(): UploadedImageRecord =
-    UploadedImageRecord(
-        // Defensive read: an unknown stored provider name (downgrade / manual edit) degrades to the
-        // DIBERIE default instead of crashing valueOf — the row stays listable.
-        provider = runCatching { UploadProviderId.valueOf(provider) }
-            .getOrDefault(UploadProviderId.DIBERIE),
+private fun UploadedImageEntity.toRecord(): UploadedImageRecord {
+    // Defensive read (#474): an unknown stored provider name (downgrade, manual DB edit, or a future
+    // provider written by a newer build) must NOT crash valueOf nor be dropped — the trace stays
+    // listable so the user still sees the image. The enum has no "unknown" member, so we degrade the
+    // provider to the safe DIBERIE default AND force `deleteHandle = null`: with no known provider we
+    // cannot route a deletion correctly, so deletion is disabled (canDelete=false) rather than
+    // mis-sent to the wrong host. A recognised provider keeps its real handle untouched.
+    val knownProvider = runCatching { UploadProviderId.valueOf(provider) }.getOrNull()
+    return UploadedImageRecord(
+        provider = knownProvider ?: UploadProviderId.DIBERIE,
         picId = picId,
         imageUrl = imageUrl,
         thumbnailUrl = thumbnailUrl,
-        deleteHandle = deleteHandle,
+        deleteHandle = if (knownProvider != null) deleteHandle else null,
         uploadedAt = uploadedAt,
         expiresAt = expiresAt,
     )
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/ImgurDtos.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/ImgurDtos.kt
@@ -2,6 +2,10 @@ package fr.forumhfr.redface2.core.data.upload
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 
 /**
  * Response envelope of `POST https://api.imgur.com/3/image` (#459). The imgur API wraps every
@@ -11,7 +15,10 @@ import kotlinx.serialization.Serializable
 @Serializable
 internal data class ImgurEnvelope(
     @SerialName("data") val data: ImgurData? = null,
-    @SerialName("success") val success: Boolean = false,
+    // Nullable so the three states are distinct (#474): `true` = success, `false` = explicit
+    // application-level refusal (→ Server), `null` = field omitted (hand-built fixtures), in which
+    // case the outcome is decided by the HTTP code and the presence of `data.link`.
+    @SerialName("success") val success: Boolean? = null,
     @SerialName("status") val status: Int = 0,
 )
 
@@ -20,4 +27,23 @@ internal data class ImgurData(
     @SerialName("link") val link: String? = null,
     @SerialName("deletehash") val deleteHash: String? = null,
     @SerialName("type") val type: String? = null,
+    // On a `success:false` envelope imgur returns the failure reason here (#474). imgur uses BOTH
+    // shapes depending on the error: a plain string OR a `{code,message,type,...}` object. Modelled
+    // as a raw JsonElement so neither shape fails the whole envelope decode — a `String?` field
+    // would throw on the object form, leaving `envelope == null` and masking a 2xx `success:false`
+    // refusal as Malformed instead of the typed Server path (Codex review #474). Read it through
+    // [errorMessage]. `null`/absent simply means « no detail to surface » and the status carries.
+    @SerialName("error") val error: JsonElement? = null,
 )
+
+/**
+ * Human-readable message extracted from [ImgurData.error], which imgur returns as either a plain
+ * string or a `{code,message,...}` object (#474). Returns the string itself, the object's
+ * `message`, or `null` when there is no usable detail — the HTTP/application status carries then.
+ */
+internal val ImgurData.errorMessage: String?
+    get() = when (val raw = error) {
+        is JsonPrimitive -> raw.contentOrNull
+        is JsonObject -> (raw["message"] as? JsonPrimitive)?.contentOrNull
+        else -> null
+    }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/ImgurProvider.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/ImgurProvider.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.core.data.upload
 
 import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.ImageUpload
 import fr.forumhfr.redface2.core.domain.upload.UploadException
 import fr.forumhfr.redface2.core.domain.upload.UploadProvider
@@ -9,9 +10,9 @@ import fr.forumhfr.redface2.core.domain.upload.UploadedImage
 import fr.forumhfr.redface2.core.network.qualifiers.UploadClient
 import javax.inject.Inject
 import javax.inject.Named
-import javax.inject.Provider
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
@@ -25,9 +26,12 @@ import okhttp3.RequestBody.Companion.toRequestBody
  * Client-ID (option B, never committed — pasted in Settings). Deletion is GUARANTEED through
  * `DELETE /3/image/{deletehash}`.
  *
- * The Client-ID is injected as a [Provider] so each call re-reads the current preference value: the
- * provider is a [Singleton] but the Client-ID can be set / changed after the graph is built. Imgur
- * uploads are only offered by the selector when a non-empty Client-ID is configured.
+ * The Client-ID is read from [UserPreferencesRepository] on each call so the current preference
+ * value is honoured: the provider is a [Singleton] but the Client-ID can be set / changed after the
+ * graph is built. Imgur uploads are only offered by the selector when a non-empty Client-ID is
+ * configured; [upload] still guards a blank value with [UploadException.Configuration] (#474). The
+ * read is a suspending `observeImgurClientId().first()` collected inside `withContext(ioDispatcher)`
+ * — no `runBlocking` bridge (#474).
  *
  * All network work runs on [ioDispatcher] (project rule for OkHttp calls).
  *
@@ -38,7 +42,7 @@ import okhttp3.RequestBody.Companion.toRequestBody
 internal class ImgurProvider @Inject constructor(
     @param:UploadClient private val client: OkHttpClient,
     @param:UploadJson private val json: Json,
-    @param:ImgurClientId private val clientId: Provider<String>,
+    private val userPreferencesRepository: UserPreferencesRepository,
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     @param:Named(IMGUR_BASE_URL) private val baseUrl: String,
 ) : UploadProvider {
@@ -46,6 +50,20 @@ internal class ImgurProvider @Inject constructor(
     override val id = UploadProviderId.IMGUR
 
     override suspend fun upload(image: ImageUpload): UploadedImage = withContext(ioDispatcher) {
+        // Fail fast on misconfiguration: a blank Client-ID would otherwise produce an opaque imgur
+        // 400/403 only after a wasted round-trip (#474). Surface it as a typed config error instead.
+        // Suspending read of the current preference — no runBlocking (#474).
+        val resolvedClientId = userPreferencesRepository.observeImgurClientId().first()
+        if (resolvedClientId.isBlank()) {
+            throw UploadException.Configuration("imgur Client-ID is not configured")
+        }
+        // Reject an over-limit STILL image locally, before any POST: imgur would refuse it anyway
+        // (#474). Animated GIFs are exempt — imgur allows them up to 200 MB, so the 20 MB still-image
+        // cap must not block a large-but-valid GIF; the reader's MAX_READ_BYTES ceiling already bounds
+        // every payload, well under imgur's GIF limit (#474, Codex review).
+        if (image.mimeType != GIF_MIME && image.bytes.size > MAX_BYTES) {
+            throw UploadException.TooLarge(MAX_BYTES)
+        }
         val body = MultipartBody.Builder()
             .setType(MultipartBody.FORM)
             .addFormDataPart(
@@ -56,16 +74,29 @@ internal class ImgurProvider @Inject constructor(
             .build()
         val request = Request.Builder()
             .url("$baseUrl/3/image")
-            .header("Authorization", "Client-ID ${clientId.get()}")
+            .header("Authorization", "Client-ID $resolvedClientId")
             .post(body)
             .build()
         val response = runCatching { client.newCall(request).execute() }
             .getOrElse { throw UploadException.Network(it) }
         response.use { resp ->
-            if (!resp.isSuccessful) throw UploadException.Server(resp.code, id)
-            val envelope = runCatching { json.decodeFromString<ImgurEnvelope>(resp.body.string()) }
-                .getOrElse { throw UploadException.Malformed(id, it) }
-            val data = envelope.data ?: throw UploadException.Malformed(id)
+            // Best-effort body read: a truncated / timed-out body must NOT leak a raw IOException
+            // past the UploadException contract (#474, Codex review). A null body is fine — a non-2xx
+            // still reports its HTTP status below, and a 2xx with no parseable body falls to Malformed.
+            val raw = runCatching { resp.body.string() }.getOrNull()
+            val envelope = raw?.let { runCatching { json.decodeFromString<ImgurEnvelope>(it) }.getOrNull() }
+            // A `success:false` envelope is an application-level refusal even on a 2xx transport:
+            // map it to Server with the host's `data.error` when present (#474), instead of
+            // stumbling into a generic Malformed on the missing `link`. Prefer the envelope's
+            // application-level `status` (e.g. 400) over the transport code, which is often 200 on
+            // such a refusal — falling back to the HTTP code when imgur omits it (Codex review #474).
+            if (envelope?.success == false) {
+                val status = envelope.status.takeIf { it != 0 } ?: resp.code
+                throw UploadException.Server(status, id, envelope.data?.errorMessage)
+            }
+            if (!resp.isSuccessful) throw UploadException.Server(resp.code, id, envelope?.data?.errorMessage)
+            val data = (envelope ?: throw UploadException.Malformed(id)).data
+                ?: throw UploadException.Malformed(id)
             UploadedImage(
                 provider = id,
                 imageUrl = data.link ?: throw UploadException.Malformed(id),
@@ -73,17 +104,21 @@ internal class ImgurProvider @Inject constructor(
                 // imgur exposes size variants via URL suffixes, but the v1 contract does not derive
                 // them — the editor's reduced mode falls back to the full link for imgur.
                 resizedUrl = null,
-                deleteHandle = data.deleteHash,
+                // imgur's deletion contract requires a deletehash; a blank/absent one means deletion
+                // is impossible, so surface `null` (canDelete=false) rather than an empty handle that
+                // would later DELETE /3/image/ (no id) and falsely promise a removal (#474).
+                deleteHandle = data.deleteHash?.takeIf { it.isNotBlank() },
                 expiresAt = null,
             )
         }
     }
 
     override suspend fun delete(deleteHandle: String): Boolean = withContext(ioDispatcher) {
-        // Guaranteed deletion (#459): DELETE /3/image/{deletehash}.
+        // Guaranteed deletion (#459): DELETE /3/image/{deletehash}. Suspending Client-ID read (#474).
+        val resolvedClientId = userPreferencesRepository.observeImgurClientId().first()
         val request = Request.Builder()
             .url("$baseUrl/3/image/$deleteHandle")
-            .header("Authorization", "Client-ID ${clientId.get()}")
+            .header("Authorization", "Client-ID $resolvedClientId")
             .delete()
             .build()
         runCatching { client.newCall(request).execute().use { it.isSuccessful } }.getOrDefault(false)
@@ -94,5 +129,19 @@ internal class ImgurProvider @Inject constructor(
         const val IMGUR_BASE_URL = "imgur_base_url"
         const val DEFAULT_BASE_URL = "https://api.imgur.com"
         private const val DEFAULT_FILENAME = "upload"
+
+        /**
+         * Per-image size cap enforced locally before any POST (#474). imgur documents a 20 MB limit
+         * for non-animated images (animated GIFs go up to 200 MB) — see the imgur API upload docs /
+         * help centre « What files can I upload? ». The documented figure is decimal MB, so the cap
+         * is 20_000_000 bytes, NOT 20 MiB (20*1024*1024 = 20_971_520) — the binary value would let a
+         * file between 20_000_001 and 20_971_520 bytes slip past this guard only to be refused by
+         * imgur. Decimal is the conservative side for a client-side reject (Codex review #474).
+         * Applies to STILL images only — [GIF_MIME] is exempt (imgur GIF limit is 200 MB).
+         */
+        const val MAX_BYTES = 20_000_000L
+
+        /** imgur accepts animated GIFs up to 200 MB, so the still-image [MAX_BYTES] guard skips them. */
+        const val GIF_MIME = "image/gif"
     }
 }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/UploadModule.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/upload/UploadModule.kt
@@ -6,8 +6,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
-import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
-import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.ImageUploadReader
 import fr.forumhfr.redface2.core.domain.upload.UploadProvider
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
@@ -15,9 +13,6 @@ import fr.forumhfr.redface2.core.domain.upload.UploadRepository
 import javax.inject.Named
 import javax.inject.Qualifier
 import javax.inject.Singleton
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 
 /**
@@ -27,14 +22,6 @@ import kotlinx.serialization.json.Json
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 internal annotation class UploadJson
-
-/**
- * The user's imgur Client-ID (#459, option B). Injected as a `javax.inject.Provider<String>` into
- * [ImgurProvider] so each upload re-reads the current preference value. Empty when not configured.
- */
-@Qualifier
-@Retention(AnnotationRetention.BINARY)
-internal annotation class ImgurClientId
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -85,19 +72,8 @@ internal object UploadModule {
     @Suppress("FunctionOnlyReturningConstant")
     fun provideImgurBaseUrl(): String = ImgurProvider.DEFAULT_BASE_URL
 
-    /**
-     * Reads the user's imgur Client-ID from the preference (option B). Synchronous — invoked via a
-     * `javax.inject.Provider` on each upload, off the main thread inside the provider's
-     * `withContext(ioDispatcher)`. Empty string when the user has not configured imgur (the
-     * selector then hides IMGUR). Same synchronous-bridge pattern as
-     * `UserPreferencesRepository.readProxyConfigForNetworkBootstrap`.
-     */
-    @Provides
-    @ImgurClientId
-    fun provideImgurClientId(
-        userPreferencesRepository: UserPreferencesRepository,
-        @IoDispatcher ioDispatcher: CoroutineDispatcher,
-    ): String = runBlocking(ioDispatcher) {
-        userPreferencesRepository.observeImgurClientId().first()
-    }
+    // #474 — the imgur Client-ID is no longer bridged through a runBlocking @Provides. ImgurProvider
+    // now reads `UserPreferencesRepository.observeImgurClientId().first()` directly inside its
+    // suspending `withContext(ioDispatcher)`, so the preference is collected without blocking a
+    // thread and the value is still re-read on every upload/delete.
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/flags/DefaultFlagRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/flags/DefaultFlagRepositoryTest.kt
@@ -25,9 +25,13 @@ import java.io.IOException
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
@@ -89,6 +93,104 @@ class DefaultFlagRepositoryTest {
                 type = FlagType.CYAN,
                 rows = match { rows -> rows.size == 1 && rows.single().topicId == 35395 },
             )
+        }
+    }
+
+    @Test
+    fun `observe and refresh fired together share a single REST fan-out - 501`() = runTest {
+        // #501 (Codex review) — observe()'s initial fetch and a concurrent refresh() for the SAME tab
+        // must collapse into ONE per-category fan-out, not two. The gate keeps the first fetch in
+        // flight while the second caller arrives, so a missing in-flight dedup would call cat 23 twice.
+        val gate = CompletableDeferred<Unit>()
+        val apiClient = mockk<HfrApiClient>()
+        coEvery {
+            apiClient.getCategoryFlagTopics(
+                cat = 13,
+                bucket = HfrRestFlagBucket.PARTICIPATED,
+                page = any(),
+                resultsPerPage = any(),
+                useAuth = true,
+            )
+        } returns EMPTY_PAGE
+        coEvery {
+            apiClient.getCategoryFlagTopics(
+                cat = 23,
+                bucket = HfrRestFlagBucket.PARTICIPATED,
+                page = any(),
+                resultsPerPage = any(),
+                useAuth = true,
+            )
+        } coAnswers {
+            gate.await()
+            capturedParticipatedFixture
+        }
+        val repo = buildRepository(apiClient, stubForumRepository(sampleCategories))
+
+        // Sequence the two callers so they genuinely overlap: observe() first reaches the gated fetch
+        // (registering the in-flight Deferred), THEN refresh() runs and must find + await that same
+        // Deferred rather than starting a second fan-out. Only then release the gate.
+        val observeJob = launch { repo.observe(FlagType.CYAN).first { it is FlagsResult.Success } }
+        runCurrent()
+        val refreshJob = launch { repo.refresh(FlagType.CYAN) }
+        runCurrent()
+        gate.complete(Unit)
+        observeJob.join()
+        refreshJob.join()
+
+        // A single fan-out: the gated category was hit exactly once despite the two concurrent callers.
+        coVerify(exactly = 1) {
+            apiClient.getCategoryFlagTopics(
+                cat = 23,
+                bucket = HfrRestFlagBucket.PARTICIPATED,
+                page = any(),
+                resultsPerPage = any(),
+                useAuth = true,
+            )
+        }
+    }
+
+    @Test
+    fun `clearSessionCache keeps an in-flight fetch from caching across a session change - 501 P1`() = runTest {
+        // #501 (Codex review P1) — a fetch in flight when the account logs out / switches must not
+        // repopulate the type-keyed singleton cache, which observe() serves before resolving the
+        // current user (else the next account would receive the previous account's flags).
+        val gate = CompletableDeferred<Unit>()
+        val apiClient = mockk<HfrApiClient>()
+        coEvery {
+            apiClient.getCategoryFlagTopics(
+                cat = 13,
+                bucket = HfrRestFlagBucket.PARTICIPATED,
+                page = any(),
+                resultsPerPage = any(),
+                useAuth = true,
+            )
+        } returns EMPTY_PAGE
+        coEvery {
+            apiClient.getCategoryFlagTopics(
+                cat = 23,
+                bucket = HfrRestFlagBucket.PARTICIPATED,
+                page = any(),
+                resultsPerPage = any(),
+                useAuth = true,
+            )
+        } coAnswers {
+            gate.await()
+            capturedParticipatedFixture
+        }
+        val repo = buildRepository(apiClient, stubForumRepository(sampleCategories))
+
+        val inFlight = launch { repo.observe(FlagType.CYAN).first { it is FlagsResult.Success } }
+        runCurrent() // the fetch is now in flight, awaiting the gate
+        repo.clearSessionCache() // logout / account switch while the fetch is running
+        gate.complete(Unit)
+        inFlight.join()
+
+        // A fresh observe must RE-FETCH (Loading first) rather than serve the interrupted fetch's
+        // success from the singleton cache.
+        repo.observe(FlagType.CYAN).test {
+            assertEquals(FlagsResult.Loading, awaitItem())
+            assertTrue(awaitItem() is FlagsResult.Success)
+            cancelAndIgnoreRemainingEvents()
         }
     }
 

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/flags/RestFlagMappersTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/flags/RestFlagMappersTest.kt
@@ -6,6 +6,7 @@ import fr.forumhfr.redface2.core.model.FlagType
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -54,6 +55,31 @@ class RestFlagMappersTest {
         assertEquals("XaTriX", flag.firstPostAuthor)
         assertEquals("qwazer", flag.lastReplyAuthor)
         assertEquals("2026-05-01 17:07", flag.lastReplyAt)
+    }
+
+    @Test
+    fun `last poster is links last_author, never the topic author - regression 331`() {
+        // #331 (@tinc, HFR #2786280): « mes sujets » showed an incorrect last poster.
+        // The real cat23 participated fixture has DISTINCT people on the two author slots —
+        // creator XaTriX vs last poster qwazer — so a swap (mapping lastReplyAuthor to
+        // links.author by mistake) would flip this assertion. The flag list must surface the
+        // REST `links.last_author.title` (last poster), not `links.author.title` (creator).
+        val envelope = json.decodeFromString<RestListEnvelope<RestTopic>>(
+            fixture("rest_cat23_participated.json"),
+        )
+
+        val flag = RestFlagMappers.toFlags(
+            envelope = envelope,
+            type = FlagType.CYAN,
+            fallbackCat = 23,
+        ).single()
+
+        assertEquals("qwazer", flag.lastReplyAuthor)
+        assertNotEquals(
+            "last poster must not be the topic creator (the #331 confusion)",
+            flag.firstPostAuthor,
+            flag.lastReplyAuthor,
+        )
     }
 
     @Test

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/messages/DefaultMessagesRepositoryTest.kt
@@ -16,6 +16,7 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import java.io.IOException
 import java.time.Instant
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -251,6 +252,125 @@ class DefaultMessagesRepositoryTest {
             repo.requestUnreadRefresh()
 
             assertEquals(5, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `markThreadRead decrements the observed count and clears it on the last unread (#453)`() = runTest {
+        val hfrClient = mockk<HfrClient>()
+        coEvery { hfrClient.getPrivateMessageListPage(page = 1) } returns FAKE_HTML
+        val parser = mockk<PrivateMessageListParser>()
+        coEvery { parser.countUnread(FAKE_HTML) } returns 1
+
+        val (repo, authStates) = buildRepository(hfrClient = hfrClient, parser = parser)
+
+        repo.observeUnreadMpCount().test {
+            authStates.emit(AuthState.Authenticated("xaat"))
+            assertEquals(1, awaitItem())
+
+            // Reading the LAST unread conversation must clear the badge immediately (#453), with no
+            // second network fetch (the count came from page 1 only once).
+            repo.markThreadRead(threadId = 42)
+
+            assertEquals(0, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        coVerify(exactly = 1) { hfrClient.getPrivateMessageListPage(page = 1) }
+    }
+
+    @Test
+    fun `markThreadRead twice on the same thread decrements only once (#453)`() = runTest {
+        val hfrClient = mockk<HfrClient>()
+        coEvery { hfrClient.getPrivateMessageListPage(page = 1) } returns FAKE_HTML
+        val parser = mockk<PrivateMessageListParser>()
+        coEvery { parser.countUnread(FAKE_HTML) } returns 2
+
+        val (repo, authStates) = buildRepository(hfrClient = hfrClient, parser = parser)
+
+        repo.observeUnreadMpCount().test {
+            authStates.emit(AuthState.Authenticated("xaat"))
+            assertEquals(2, awaitItem())
+
+            repo.markThreadRead(threadId = 7)
+            assertEquals(1, awaitItem())
+
+            // Re-opening the same conversation must NOT subtract again (idempotent per thread until
+            // the next authoritative network count).
+            repo.markThreadRead(threadId = 7)
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `a fresh network count resets the local read-decrements (#453)`() = runTest {
+        val hfrClient = mockk<HfrClient>()
+        coEvery { hfrClient.getPrivateMessageListPage(page = 1) } returns FAKE_HTML
+        val parser = mockk<PrivateMessageListParser>()
+        coEvery { parser.countUnread(FAKE_HTML) } returnsMany listOf(1, 3)
+
+        val (repo, authStates) = buildRepository(hfrClient = hfrClient, parser = parser)
+
+        repo.observeUnreadMpCount().test {
+            authStates.emit(AuthState.Authenticated("xaat"))
+            assertEquals(1, awaitItem())
+
+            repo.markThreadRead(threadId = 1)
+            assertEquals(0, awaitItem())
+
+            // A real refresh is authoritative : it supersedes the local decrement (the server count
+            // is the source of truth ; the optimistic subtraction was only a stop-gap).
+            repo.requestUnreadRefresh()
+            assertEquals(3, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `a read racing the cold-start fetch is preserved by the initial count (#453 codex)`() = runTest {
+        // Codex review — at cold start the user may open an unread MP before the very first
+        // `fetchUnreadCount()` resolves. The initial network count must NOT discard that read (HFR
+        // has no server-side read flag, so the count can't reflect it anyway), otherwise the badge
+        // would snap back to the pre-read total. Here the cold-start fetch is held on a gate, the
+        // read lands first, then the fetch resolves : 3 - 1 must be displayed, not a reset to 3.
+        val hfrClient = mockk<HfrClient>()
+        val gate = CompletableDeferred<Unit>()
+        coEvery { hfrClient.getPrivateMessageListPage(page = 1) } coAnswers {
+            gate.await()
+            FAKE_HTML
+        }
+        val parser = mockk<PrivateMessageListParser>()
+        coEvery { parser.countUnread(FAKE_HTML) } returns 3
+
+        val (repo, authStates) = buildRepository(hfrClient = hfrClient, parser = parser)
+
+        repo.observeUnreadMpCount().test {
+            authStates.emit(AuthState.Authenticated("xaat"))
+            // The cold-start fetch is suspended on the gate ; the read races ahead of it.
+            repo.markThreadRead(threadId = 11)
+            // Now the initial fetch resolves : it adopts the count but keeps the racing read.
+            gate.complete(Unit)
+
+            assertEquals(
+                "the initial count must subtract the read that raced it, not reset to the raw total",
+                2,
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `markThreadRead is inert while anonymous (#453)`() = runTest {
+        val (repo, authStates) = buildRepository()
+
+        repo.observeUnreadMpCount().test {
+            authStates.emit(AuthState.Anonymous)
+            assertNull(awaitItem())
+
+            repo.markThreadRead(threadId = 5)
+            expectNoEvents()
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -18,8 +18,17 @@ import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import fr.forumhfr.redface2.core.model.FlagType
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -37,6 +46,7 @@ class DataStoreUserPreferencesRepositoryTest {
     private lateinit var dataStore: DataStore<Preferences>
     private lateinit var repository: DataStoreUserPreferencesRepository
     private val dispatcher = UnconfinedTestDispatcher()
+    private val externalScope = CoroutineScope(dispatcher + SupervisorJob())
 
     /** In-memory [ThemeBootstrapStore] — the SharedPreferences impl has its own Robolectric test. */
     private val themeBootstrapStore = object : ThemeBootstrapStore {
@@ -69,7 +79,46 @@ class DataStoreUserPreferencesRepositoryTest {
             themeBootstrapStore = themeBootstrapStore,
             startScreenBootstrapStore = startScreenBootstrapStore,
             ioDispatcher = dispatcher,
+            externalScope = externalScope,
         )
+    }
+
+    /**
+     * #507 — observable contract: a preference write whose initiating coroutine is cancelled (a
+     * settings sub-page popped right after a toggle, cancelling its `viewModelScope`) must still land,
+     * because the commit runs on the injected application scope, not the caller's. Built on a paused
+     * [StandardTestDispatcher] so the write is provably only *started* (dispatched onto the app scope,
+     * caller suspended at `await`) — not yet committed — when the caller is cancelled. Deterministic
+     * (no real time / threads): the assertion is the persisted value after the scheduler drains.
+     */
+    @Test
+    fun `setter write lands even when the initiating coroutine is cancelled`() = runTest {
+        val ioDispatcher = StandardTestDispatcher(testScheduler)
+        val dataStoreScope = CoroutineScope(ioDispatcher + Job())
+        val appScope = CoroutineScope(ioDispatcher + SupervisorJob())
+        val survivalStore = PreferenceDataStoreFactory.create(
+            scope = dataStoreScope,
+            produceFile = { tempFolder.newFile("survival.preferences_pb") },
+        )
+        val survivalRepository = DataStoreUserPreferencesRepository(
+            dataStore = survivalStore,
+            themeBootstrapStore = themeBootstrapStore,
+            startScreenBootstrapStore = startScreenBootstrapStore,
+            ioDispatcher = ioDispatcher,
+            externalScope = appScope,
+        )
+
+        // setFlagsAutoRefresh defaults to true; flip it to false from a cancellable caller scope.
+        val callerScope = CoroutineScope(ioDispatcher + Job())
+        callerScope.launch { survivalRepository.setFlagsAutoRefresh(false) }
+        runCurrent() // caller dispatched the write onto appScope, then suspended on await — not committed
+        callerScope.cancel() // the sub-page is popped before the commit completes
+        advanceUntilIdle() // appScope (not the cancelled caller) drives the commit to completion
+
+        assertFalse(survivalRepository.observeFlagsAutoRefresh().first())
+
+        appScope.cancel()
+        dataStoreScope.cancel()
     }
 
     @Test

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/upload/DefaultUploadRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/upload/DefaultUploadRepositoryTest.kt
@@ -84,7 +84,10 @@ class DefaultUploadRepositoryTest {
     }
 
     @Test
-    fun `observeUploads maps entities to records, defaulting an unknown provider to DIBERIE`() = runTest {
+    fun `observeUploads preserves an unknown-provider row but disables its deletion`() = runTest {
+        // #474 — a row whose stored provider matches no enum value (downgrade, manual edit, future
+        // provider) must be PRESERVED (still listable) and NON-DELETABLE (canDelete=false) without
+        // throwing: with no known provider a deletion cannot be routed to the right host.
         io.mockk.every { dao.observeForUser("alice") } returns MutableStateFlow(
             listOf(
                 entity(provider = "IMGUR", picId = "A"),
@@ -94,10 +97,14 @@ class DefaultUploadRepositoryTest {
 
         val records = repository().observeUploads("ALICE").first()
 
+        assertEquals("the unknown-provider row must not be dropped", 2, records.size)
         assertEquals(UploadProviderId.IMGUR, records[0].provider)
-        // Unknown stored provider degrades to DIBERIE instead of crashing valueOf.
+        assertTrue("a known-provider record with a handle can be deleted", records[0].canDelete)
+        // Unknown stored provider degrades to the safe DIBERIE default instead of crashing valueOf,
+        // but its delete handle is dropped so it can never be mis-routed to the wrong host.
         assertEquals(UploadProviderId.DIBERIE, records[1].provider)
-        assertTrue("a record with a handle can be deleted", records[0].canDelete)
+        assertFalse("an unknown-provider row must be non-deletable", records[1].canDelete)
+        assertEquals("the unknown row stays listable (URL preserved)", "https://host/B", records[1].imageUrl)
     }
 
     @Test

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/upload/ImgurProviderTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/upload/ImgurProviderTest.kt
@@ -1,17 +1,22 @@
 package fr.forumhfr.redface2.core.data.upload
 
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.ImageUpload
 import fr.forumhfr.redface2.core.domain.upload.UploadException
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
-import javax.inject.Provider
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -26,13 +31,19 @@ class ImgurProviderTest {
     private lateinit var server: MockWebServer
     private lateinit var provider: ImgurProvider
 
+    // The Client-ID preference, read by the provider on each call via observeImgurClientId().first().
+    private val clientIdFlow = MutableStateFlow(TEST_CLIENT_ID)
+    private val prefs = mockk<UserPreferencesRepository> {
+        every { observeImgurClientId() } returns clientIdFlow
+    }
+
     @Before
     fun setUp() {
         server = MockWebServer().apply { start() }
         provider = ImgurProvider(
             client = OkHttpClient(),
             json = Json { ignoreUnknownKeys = true; explicitNulls = false },
-            clientId = Provider { TEST_CLIENT_ID },
+            userPreferencesRepository = prefs,
             ioDispatcher = UnconfinedTestDispatcher(),
             baseUrl = server.url("/").toString().trimEnd('/'),
         )
@@ -103,12 +114,61 @@ class ImgurProviderTest {
     }
 
     @Test
-    fun `upload maps a missing data envelope to UploadException Malformed`() = runTest {
+    fun `upload maps a success-false envelope to Server with the HTTP code and the data error`() = runTest {
+        // #474 — imgur signals an application-level refusal with `success:false` even on a 2xx
+        // transport (HTTP 200 here). It must map to Server (carrying the host's data.error) rather
+        // than stumbling into a generic Malformed on the now-absent `link`. The reported code must
+        // be the envelope's application-level `status` (400), NOT the 200 transport code (Codex #474).
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"data":{"error":"File is over the size limit"},"success":false,"status":400}"""),
+        )
+
+        val error = runCatching { provider.upload(sampleImage()) }.exceptionOrNull()
+
+        assertTrue("success:false must be Server, not Malformed", error is UploadException.Server)
+        error as UploadException.Server
+        assertEquals("the envelope status must win over the 200 transport code", 400, error.code)
+        assertEquals(UploadProviderId.IMGUR, error.providerId)
+        assertEquals("File is over the size limit", error.errorMessage)
+    }
+
+    @Test
+    fun `upload maps a success-false envelope without a data error to Server with a null message`() = runTest {
+        // No `data.error` provided — still Server (not Malformed), with a null message; the HTTP code
+        // carries the meaning. Mirrors the old fixture that used to expect Malformed here (#474).
         server.enqueue(MockResponse().setResponseCode(200).setBody("""{"success":false,"status":400}"""))
 
         val error = runCatching { provider.upload(sampleImage()) }.exceptionOrNull()
 
-        assertTrue(error is UploadException.Malformed)
+        assertTrue(error is UploadException.Server)
+        error as UploadException.Server
+        assertEquals("the envelope status must win over the 200 transport code", 400, error.code)
+        assertNull(error.errorMessage)
+    }
+
+    @Test
+    fun `upload maps a success-false envelope with an OBJECT data error to Server`() = runTest {
+        // #474 (Codex review) — imgur also returns `data.error` as a {code,message,...} OBJECT, not
+        // only a string. A String? field would fail the whole envelope decode on this shape, leaving
+        // envelope == null and mis-reporting the refusal as Malformed. The JsonElement model keeps the
+        // envelope decodable: this must still be Server, with the object's `message` surfaced.
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """{"data":{"error":{"code":1003,"message":"File type invalid"}},""" +
+                        """"success":false,"status":400}""",
+                ),
+        )
+
+        val error = runCatching { provider.upload(sampleImage()) }.exceptionOrNull()
+
+        assertTrue("an object-form data.error must still be Server, not Malformed", error is UploadException.Server)
+        error as UploadException.Server
+        assertEquals(400, error.code)
+        assertEquals("File type invalid", error.errorMessage)
     }
 
     @Test
@@ -137,6 +197,104 @@ class ImgurProviderTest {
         server.enqueue(MockResponse().setResponseCode(404))
 
         assertEquals(false, provider.delete("DELHASH"))
+    }
+
+    @Test
+    fun `upload returns a null delete handle when the response omits the deletehash`() = runTest {
+        // #474 — without a deletehash imgur cannot delete the image; surfacing an empty/absent handle
+        // as null disables the delete affordance instead of falsely promising a removal.
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody("""{"data":{"link":"https://i/x.png"},"success":true}"""),
+        )
+
+        val result = provider.upload(sampleImage())
+
+        assertEquals("https://i/x.png", result.imageUrl)
+        assertNull("a missing deletehash must yield a null handle (canDelete=false)", result.deleteHandle)
+    }
+
+    @Test
+    fun `upload returns a null delete handle when the deletehash is blank`() = runTest {
+        // A blank deletehash is as useless as an absent one — must not survive as an empty handle.
+        server.enqueue(
+            MockResponse().setResponseCode(200)
+                .setBody("""{"data":{"link":"https://i/x.png","deletehash":"  "},"success":true}"""),
+        )
+
+        val result = provider.upload(sampleImage())
+
+        assertNull(result.deleteHandle)
+    }
+
+    @Test
+    fun `upload rejects an oversized image with TooLarge without hitting the network`() = runTest {
+        // #474 — the per-host MAX_BYTES guard fires locally, before any POST is enqueued.
+        val tooBig = ImageUpload(
+            bytes = ByteArray((ImgurProvider.MAX_BYTES + 1).toInt()),
+            mimeType = "image/jpeg",
+            displayName = "big.jpg",
+        )
+
+        val error = runCatching { provider.upload(tooBig) }.exceptionOrNull()
+
+        assertTrue(error is UploadException.TooLarge)
+        assertEquals(ImgurProvider.MAX_BYTES, (error as UploadException.TooLarge).maxBytes)
+        assertEquals("no POST may be sent for an over-limit image", 0, server.requestCount)
+    }
+
+    @Test
+    fun `upload keeps a typed Server error when a non-2xx response body read fails`() = runTest {
+        // #474 (Codex review) — a truncated / cut response body must NOT leak a raw IOException past
+        // the UploadException contract, and a known non-2xx status must survive an unreadable body.
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(500)
+                .setBody("part")
+                .setSocketPolicy(SocketPolicy.DISCONNECT_DURING_RESPONSE_BODY),
+        )
+
+        val error = runCatching { provider.upload(sampleImage()) }.exceptionOrNull()
+
+        assertTrue("a body-read failure must stay a typed UploadException", error is UploadException)
+        assertTrue("a non-2xx must remain Server even if the body is unreadable", error is UploadException.Server)
+        assertEquals(500, (error as UploadException.Server).code)
+    }
+
+    @Test
+    fun `upload does NOT apply the still-image cap to a GIF above MAX_BYTES`() = runTest {
+        // #474 (Codex review) — imgur allows animated GIFs up to 200 MB, so a GIF past the 20 MB
+        // still-image cap must NOT be rejected locally; it is uploaded (the reader bounds the size).
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """{"data":{"link":"https://i.imgur.com/g.gif","deletehash":"DH"},""" +
+                        """"success":true,"status":200}""",
+                ),
+        )
+        val bigGif = ImageUpload(
+            bytes = ByteArray((ImgurProvider.MAX_BYTES + 1).toInt()),
+            mimeType = "image/gif",
+            displayName = "anim.gif",
+        )
+
+        val result = runCatching { provider.upload(bigGif) }
+
+        assertTrue("a large GIF must not be rejected by the still-image cap", result.isSuccess)
+        assertEquals("https://i.imgur.com/g.gif", result.getOrThrow().imageUrl)
+        assertEquals("the GIF must actually be POSTed, not locally rejected", 1, server.requestCount)
+    }
+
+    @Test
+    fun `upload raises a typed Configuration error when the Client-ID is blank, before any network`() = runTest {
+        // #474 — a blank Client-ID must fail with a typed config error locally, not an opaque imgur
+        // 400/403 after a wasted round-trip.
+        clientIdFlow.value = "   "
+
+        val error = runCatching { provider.upload(sampleImage()) }.exceptionOrNull()
+
+        assertTrue("blank Client-ID must be a Configuration error", error is UploadException.Configuration)
+        assertEquals("no POST may be sent when the Client-ID is blank", 0, server.requestCount)
     }
 
     private fun sampleImage(): ImageUpload = ImageUpload(

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/coroutines/ApplicationScope.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/coroutines/ApplicationScope.kt
@@ -1,0 +1,13 @@
+package fr.forumhfr.redface2.core.domain.coroutines
+
+import javax.inject.Qualifier
+
+/**
+ * Qualifies the process-lifetime [kotlinx.coroutines.CoroutineScope] (a `SupervisorJob` on the IO
+ * dispatcher) used for writes that MUST outlive the component that triggered them — typically a
+ * DataStore commit started from a screen whose `viewModelScope` may be cancelled before the write
+ * lands (#507). Not for general background work: most coroutines should stay scoped to their owner.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ApplicationScope

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/messages/MessagesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/messages/MessagesRepository.kt
@@ -35,6 +35,20 @@ interface MessagesRepository {
     fun requestUnreadRefresh()
 
     /**
+     * #453 — signals that conversation [threadId] was read in-app. Optimistically decrements the
+     * observed unread count by one (clamped at zero), so reading the LAST unread conversation
+     * clears the badge immediately instead of waiting for the next page-1 fetch. Fire-and-forget,
+     * non-suspending (safe from a navigation callback) ; no-op while anonymous or while nobody
+     * collects [observeUnreadMpCount].
+     *
+     * Local-only by design (zero network) : HFR has no server-side read flag (#361), so a read does
+     * not change the server count — the decrement mirrors the inbox row that already marks the
+     * conversation read locally, and the next real page-1 fetch reconciles. Marking the same thread
+     * twice between two network refreshes decrements only once.
+     */
+    fun markThreadRead(threadId: Int)
+
+    /**
      * Fetches one page of the private-message inbox (`forum1.php?cat=prive`). Throws on
      * network / session errors (e.g. [fr.forumhfr.redface2.core.domain.auth.SessionExpiredException]);
      * the caller maps the failure to its UI state.

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/upload/UploadException.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/upload/UploadException.kt
@@ -17,9 +17,20 @@ sealed class UploadException(message: String, cause: Throwable? = null) : Except
     /** The picked image MIME type is not accepted by the provider. */
     class UnsupportedType(val mimeType: String?) : UploadException("Unsupported image type: $mimeType")
 
-    /** The host answered with a non-2xx HTTP status. [code] is the status, [providerId] the host. */
-    class Server(val code: Int, val providerId: UploadProviderId) :
-        UploadException("HTTP $code ($providerId)")
+    /**
+     * The host refused the upload at the protocol level. [code] is the HTTP status, [providerId] the
+     * host. [errorMessage] is the host-supplied reason when one was parsed (imgur surfaces it in the
+     * `data.error` field of a `success:false` envelope, #474) — `null` when the host gave none. It is
+     * an OPTIONAL, retro-compatible addition: existing call sites that only read [code]/[providerId]
+     * keep compiling unchanged.
+     */
+    class Server(
+        val code: Int,
+        val providerId: UploadProviderId,
+        val errorMessage: String? = null,
+    ) : UploadException(
+        if (errorMessage != null) "HTTP $code ($providerId): $errorMessage" else "HTTP $code ($providerId)",
+    )
 
     /** The host answered 2xx but the body could not be parsed into the expected shape. */
     class Malformed(val providerId: UploadProviderId, cause: Throwable? = null) :
@@ -27,4 +38,13 @@ sealed class UploadException(message: String, cause: Throwable? = null) : Except
 
     /** The exchange never produced an HTTP response (airplane mode, DNS, timeout). */
     class Network(cause: Throwable) : UploadException("Network unavailable", cause)
+
+    /**
+     * The provider is mis-configured and the upload cannot even be attempted (#474) — e.g. the
+     * imgur Client-ID preference is empty/blank. Raised LOCALLY, before any network call, so the
+     * user gets an actionable « configure the host » message instead of an opaque HTTP 400/403.
+     * [detail] is a short, non-secret explanation safe to log/surface. Distinct from [Server], which
+     * means the host was reached and refused.
+     */
+    class Configuration(val detail: String) : UploadException("Upload provider misconfigured: $detail")
 }

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
@@ -36,9 +36,18 @@ class PostContentParser {
         blocks = listOf(PostBlock.Paragraph(listOf(PostInline.Text(DELETED_PLACEHOLDER)))),
     )
 
+    @Suppress("CyclomaticComplexMethod")
     private fun parseBlocks(nodes: List<Node>): List<PostBlock> {
         val blocks = mutableListOf<PostBlock>()
         val paragraph = mutableListOf<PostInline>()
+
+        // #466 (Codex review) — true ONLY while [paragraph]'s tail is the inline body of a CLOSED
+        // inline-only <p> with nothing appended after it, kept buffered so a FOLLOWING <p> can still
+        // merge with it. Any other sibling closes the merge window: an inline-classified <ul> or a
+        // block flushes the buffered <p> as its own paragraph (the sibling is not appended to it),
+        // and a top-level <br> appends its LineBreak but clears this flag (the extended buffer is no
+        // longer a pristine <p> body, so the next <p> must not merge with it).
+        var pendingParagraph = false
 
         fun flushParagraph() {
             // #333 — trim breaks and blank fragments at the paragraph EDGES only: breaks adjacent
@@ -52,7 +61,16 @@ class PostContentParser {
                 blocks += PostBlock.Paragraph(cleaned)
             }
             paragraph.clear()
+            pendingParagraph = false
         }
+
+        // #466 — count of orphan `&nbsp;` (U+00A0) carried by the last top-level whitespace-only
+        // text node, kept pending until we know what follows it. HFR always emits at LEAST one
+        // `&nbsp;` between two sibling <p> (the structural paragraph separator, ~all pages), and
+        // an EXTRA `&nbsp;` for each blank line the author typed in between. So a run of N drives
+        // (N - 1) rendered empty lines ; a lone separator (N == 1) keeps the current behaviour
+        // (two distinct Paragraph blocks). See `parseParagraphContainer`.
+        var pendingNbsp = 0
 
         nodes.forEach { node ->
             when (classifyNode(node)) {
@@ -63,38 +81,76 @@ class PostContentParser {
                 // renderer's 8dp inter-block gap replaced the natural line height between every
                 // line (#280). A top-level break is now an inline LineBreak INSIDE the running
                 // paragraph — web parity: N consecutive breaks render N newlines.
-                NodeKind.LINE_BREAK -> paragraph += PostInline.LineBreak
+                NodeKind.LINE_BREAK -> {
+                    paragraph += PostInline.LineBreak
+                    pendingNbsp = 0
+                    // A top-level <br> appended after a buffered closed <p> EXTENDS the running
+                    // paragraph, so the buffer is no longer a pristine inline-only <p> body: a
+                    // FOLLOWING <p> must NOT merge with it (`<p>A</p><br>&nbsp;&nbsp;<p>B</p>` stays
+                    // two blocks, matching legacy — the break is a non-<p> sibling that closes the
+                    // merge window, #466 Codex review). The break itself stays for web parity (#280).
+                    pendingParagraph = false
+                }
 
                 NodeKind.QUOTE -> {
                     flushParagraph()
+                    pendingNbsp = 0
                     parseQuote(node as Element)?.let(blocks::add)
                 }
 
                 NodeKind.SPOILER -> {
                     flushParagraph()
+                    pendingNbsp = 0
                     parseSpoiler(node as Element)?.let(blocks::add)
                 }
 
                 NodeKind.IMAGE_BLOCK -> {
                     flushParagraph()
+                    pendingNbsp = 0
                     parseImageBlock(node as Element)?.let(blocks::add)
                 }
 
                 NodeKind.FIXED_BLOCK -> {
                     flushParagraph()
+                    pendingNbsp = 0
                     parseFixedBlock(node as Element)?.let(blocks::add)
                 }
 
                 NodeKind.CODE_BLOCK -> {
                     flushParagraph()
+                    pendingNbsp = 0
                     parseCodeBlock(node as Element)?.let(blocks::add)
                 }
 
-                NodeKind.INLINE -> paragraph += parseInline(node)
+                NodeKind.BLANK_TEXT -> pendingNbsp = orphanNbspCount(node as TextNode)
+
+                NodeKind.INLINE -> {
+                    if (pendingParagraph) {
+                        // A buffered closed <p> followed by a non-<p> inline sibling (HFR emits
+                        // `</p>&nbsp;<ul>…`): close the <p> as its own paragraph and drop the lone
+                        // separator — do NOT run the list/inline content into it (#466 Codex review).
+                        flushParagraph()
+                        pendingNbsp = 0
+                    } else if (pendingNbsp > 0) {
+                        // A pending `&nbsp;` between two plain inline siblings is genuine word spacing,
+                        // not a paragraph separator: keep it so `<a>one</a>&nbsp;<a>two</a>` reads
+                        // "one two", not "onetwo" (#466 Codex review).
+                        paragraph += PostInline.Text(" ")
+                        pendingNbsp = 0
+                    }
+                    paragraph += parseInline(node)
+                }
 
                 NodeKind.PARAGRAPH_CONTAINER -> {
-                    flushParagraph()
-                    blocks += parseBlocks((node as Element).childNodes())
+                    pendingParagraph = parseParagraphContainer(
+                        element = node as Element,
+                        blocks = blocks,
+                        paragraph = paragraph,
+                        pendingNbsp = pendingNbsp,
+                        pendingParagraph = pendingParagraph,
+                        flushParagraph = ::flushParagraph,
+                    )
+                    pendingNbsp = 0
                 }
             }
         }
@@ -103,8 +159,98 @@ class PostContentParser {
         return blocks
     }
 
+    /**
+     * #466 — folds the orphan `&nbsp;` run separating two `<p>` into rendered empty lines.
+     *
+     * HFR encodes a deliberate blank line BETWEEN two paragraphs as an EXTRA `&nbsp;` in the
+     * orphan text node separating the two `<p>` (the very first `&nbsp;` is the structural
+     * separator HFR always emits between any two sibling `<p>`). The parser used to swallow that
+     * whitespace and emit each `<p>` as its own Paragraph block, losing the empty lines (the
+     * "lignes sautées" bug, suite of #333/#280 — the earlier fix only covered the
+     * `<br />&nbsp;<br />` shape, not the `</p>&nbsp;…&nbsp;<p>` one).
+     *
+     * An inline-only `<p>` (HFR never nests a block table/container directly inside a `<p>`,
+     * verified across the fixtures) is accumulated into the running paragraph buffer rather than
+     * sub-parsed, so the NEXT `<p>` can decide to merge with it:
+     *  - when at least one EXTRA `&nbsp;` is pending (run ≥ 2) and the running paragraph already
+     *    holds real content, the boundary is kept inside ONE paragraph as [pendingNbsp] LineBreaks
+     *    — one for the paragraph boundary itself plus (pendingNbsp - 1) for the authored empty
+     *    lines. They sit strictly between two text runs, so the #333 edge-trim never touches them.
+     *  - otherwise (lone `&nbsp;` separator, or an empty running paragraph) the running paragraph
+     *    is flushed first, so two ordinary paragraphs stay two distinct Paragraph blocks as before.
+     *
+     * A `<p>` that does carry a nested block keeps the legacy path: flush, then sub-parse so the
+     * inner block surfaces.
+     */
+    @Suppress("LongParameterList") // shares parseBlocks' mutable state (blocks/paragraph) + the merge
+    // inputs (pendingNbsp/pendingParagraph) and its flush closure; a wrapper object would only hide it.
+    private fun parseParagraphContainer(
+        element: Element,
+        blocks: MutableList<PostBlock>,
+        paragraph: MutableList<PostInline>,
+        pendingNbsp: Int,
+        pendingParagraph: Boolean,
+        flushParagraph: () -> Unit,
+    ): Boolean {
+        val children = element.childNodes()
+        if (children.any { isBlockNode(it) }) {
+            // Legacy path: a <p> carrying a nested block is flushed + sub-parsed, leaving nothing
+            // buffered to merge with — return false so the caller does not treat it as a pending <p>.
+            flushParagraph()
+            blocks += parseBlocks(children)
+            return false
+        }
+        // Only fold the `&nbsp;` separator into empty lines when the buffer is genuinely the body of
+        // a PREVIOUS inline-only <p> ([pendingParagraph]) — NOT arbitrary buffered inline content.
+        // `<strong>A</strong>&nbsp;&nbsp;<p>B</p>` must stay two blocks, not merge (#466 Codex review).
+        val mergeable = pendingNbsp >= 2 && pendingParagraph && paragraph.any { it.isNonBlank() }
+        if (mergeable) {
+            // #466 (Codex review) — drop a trailing border <br> on the first paragraph so its edge
+            // break does not pile onto the separator breaks below (the legacy sub-parse edge-trimmed
+            // it via flushParagraph). Only the separator + the paragraphs' INTERIOR breaks remain.
+            while (paragraph.isNotEmpty() && paragraph.last().isBlankOrBreak()) {
+                paragraph.removeAt(paragraph.lastIndex)
+            }
+            repeat(pendingNbsp) { paragraph += PostInline.LineBreak }
+        } else {
+            // Close the previous paragraph as its own block, then accumulate this <p>'s inline
+            // content into the now-empty buffer so a following <p> can still merge with it (#466).
+            flushParagraph()
+        }
+        // Accumulate the <p> body inline, honouring the same per-node classification as the block
+        // path: a nested <br> stays a LineBreak and an ignored node (e.g. a `clear: both` spacer
+        // div) is dropped. EDGE-trim leading/trailing breaks (#466 Codex review): the real fixture
+        // has `<p><br />Pour…`, whose leading border <br> would otherwise render an extra empty line
+        // — only INTERIOR breaks (the author's line structure) survive, matching flushParagraph #333.
+        val merged = buildList {
+            children.forEach { child ->
+                when (classifyNode(child)) {
+                    NodeKind.IGNORE -> Unit
+                    NodeKind.LINE_BREAK -> add(PostInline.LineBreak)
+                    else -> addAll(parseInline(child))
+                }
+            }
+        }.dropWhile { it.isBlankOrBreak() }.dropLastWhile { it.isBlankOrBreak() }
+        paragraph += merged
+        // The buffer now holds this inline-only <p>'s body: a following <p> may still merge with it,
+        // so report it as pending (the caller closes it if the next sibling is not a <p>).
+        return true
+    }
+
+    /** #466 — a top-level text node made solely of whitespace carries its U+00A0 (`&nbsp;`) count. */
+    private fun orphanNbspCount(node: TextNode): Int =
+        node.wholeText.count { it == NBSP }
+
+    /** #466 — true when [node] would be parsed as a block (so a `<p>` wrapping it can't be merged). */
+    private fun isBlockNode(node: Node): Boolean = when (classifyNode(node)) {
+        NodeKind.QUOTE, NodeKind.SPOILER, NodeKind.IMAGE_BLOCK,
+        NodeKind.FIXED_BLOCK, NodeKind.CODE_BLOCK, NodeKind.PARAGRAPH_CONTAINER -> true
+
+        else -> false
+    }
+
     private fun classifyNode(node: Node): NodeKind {
-        val element = (node as? Element) ?: return if (node is TextNode) NodeKind.INLINE else NodeKind.IGNORE
+        val element = (node as? Element) ?: return classifyNonElement(node)
         return when (element.tagName()) {
             "br" -> NodeKind.LINE_BREAK
             "div" -> classifyDiv(element)
@@ -117,6 +263,17 @@ class PostContentParser {
             "table" -> classifyTable(element)
             else -> NodeKind.INLINE
         }
+    }
+
+    private fun classifyNonElement(node: Node): NodeKind = when {
+        node !is TextNode -> NodeKind.IGNORE
+        // #466 — a whitespace-only text node carrying at least one `&nbsp;` (U+00A0) is HFR's
+        // inter-paragraph separator, possibly inflated with one extra `&nbsp;` per authored empty
+        // line. It is BLANK_TEXT so parseBlocks can fold the run into rendered line breaks instead
+        // of swallowing it. A whitespace text node WITHOUT `&nbsp;` stays INLINE: it is genuine
+        // word spacing inside a paragraph and must survive between two text runs.
+        node.wholeText.isBlank() && node.wholeText.any { it == NBSP } -> NodeKind.BLANK_TEXT
+        else -> NodeKind.INLINE
     }
 
     private fun classifyDiv(element: Element): NodeKind {
@@ -486,11 +643,18 @@ class PostContentParser {
         FIXED_BLOCK,
         CODE_BLOCK,
         INLINE,
+
+        /** #466 — a whitespace-only orphan text node carrying `&nbsp;` separators. */
+        BLANK_TEXT,
         PARAGRAPH_CONTAINER,
     }
 
     private companion object {
         const val DELETED_PLACEHOLDER = "[Message supprimé]"
+
+        // #466 — non-breaking space (U+00A0). HFR encodes inter-paragraph blank lines as runs of
+        // `&nbsp;` between sibling <p>; Jsoup keeps them as this literal char until normalizeText.
+        const val NBSP = '\u00A0'
 
         val WHITESPACE_REGEX = Regex("\\s+")
         val HEX_REGEX = Regex("[0-9a-fA-F]+")

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
@@ -403,6 +403,257 @@ class PostContentParserTest {
     }
 
     @Test
+    fun `orphan nbsp runs between paragraphs survive as empty lines (real fixture)`() {
+        // #466 — suite of #333/#280. HFR encodes a deliberate blank line BETWEEN two paragraphs
+        // not as `<br /><br />` (the shape #423 already handled) but as an EXTRA `&nbsp;` inside
+        // the orphan text node separating two sibling <p>. Real witness on the single-page topic
+        // (post #9762063, captured fixture): `…C'est normal.</p>&nbsp;&nbsp;&nbsp;<p><br />Pour
+        // trouver une solution…</p>` — 3 `&nbsp;` between the two paragraphs. The parser used to
+        // swallow that whitespace and emit two separate Paragraph blocks, losing the blank lines.
+        val topic = pageParser.parse(fixture("topic_page_single.html"))
+
+        // Anchor on the UNIQUE authored second line "Pour trouver une solution". There are two
+        // "C'est normal." occurrences in the fixture and only the second precedes the triple-nbsp
+        // run, so anchoring on "C'est normal." picks the wrong (single-separator) paragraph. After
+        // the fix, the second <p> folds INTO the preceding paragraph, so the paragraph holding
+        // "Pour trouver une solution" also holds "C'est normal.", with the blank lines as LineBreaks.
+        val paragraph = topic.posts
+            .flatMap { it.content.allBlocks() }
+            .filterIsInstance<PostBlock.Paragraph>()
+            .firstOrNull { block ->
+                block.inlines.filterIsInstance<PostInline.Text>()
+                    .any { it.value.contains("Pour trouver une solution") }
+            }
+
+        assertNotNull("fixture should contain the folded paragraph", paragraph)
+        assertTrue(
+            "the line before the orphan-nbsp run must merge into the same paragraph, " +
+                "got=${paragraph!!.inlines}",
+            paragraph.inlines.filterIsInstance<PostInline.Text>()
+                .any { it.value.contains("C'est normal.") },
+        )
+        // The triple `&nbsp;` run folds into blank lines (>= 2 LineBreaks) between the two authored
+        // lines; the exact count for a bare run is pinned by the synthetic test below. A lone
+        // `&nbsp;` separator never folds, so >= 2 here proves the multi-nbsp blank lines survived.
+        val breaksBetween = run {
+            val inlines = paragraph.inlines
+            val from = inlines.indexOfLast {
+                it is PostInline.Text && it.value.contains("C'est normal.")
+            }
+            val to = inlines.indexOfFirst {
+                it is PostInline.Text && it.value.contains("Pour trouver une solution")
+            }
+            inlines.subList(from + 1, to).count { it is PostInline.LineBreak }
+        }
+        // EXACTLY 3: the triple `&nbsp;` run yields 3 separator breaks (1 boundary + 2 empty lines).
+        // The second <p> opens with a border `<br />` (`<p><br />Pour…`) which must be edge-trimmed
+        // (#466 Codex review) — were it kept it would push this to 4 and render a spurious 3rd empty
+        // line. Pinning the exact count guards that border-break trim on the real fixture.
+        assertEquals(
+            "the triple orphan &nbsp; run must yield EXACTLY 3 LineBreaks (border <br> trimmed), " +
+                "got=$breaksBetween",
+            3,
+            breaksBetween,
+        )
+    }
+
+    @Test
+    fun `orphan nbsp between two inline nodes stays word spacing not a separator - 466 codex`() {
+        // #466 (Codex review) — a `&nbsp;` whitespace text node is HFR's inter-<p> separator ONLY
+        // when a <p> follows it. Between two inline siblings it is genuine word spacing; the parser
+        // used to drop it, concatenating `<strong>A</strong>&nbsp;<strong>B</strong>` with no space.
+        // DERIVED FROM THE issue/Codex example, not a raw hfr-mcp capture.
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            "<div id=\"para1\"><strong>A</strong>&nbsp;<strong>B</strong></div>",
+        )
+
+        val result = parser.parse(element)
+
+        val inlines = result.ast.blocks.filterIsInstance<PostBlock.Paragraph>().single().inlines
+        assertTrue(
+            "the &nbsp; between two inline nodes must survive as a spacing Text, got=$inlines",
+            inlines.any { it is PostInline.Text && it.value == " " },
+        )
+    }
+
+    @Test
+    fun `merging paragraphs trims border breaks but keeps separator breaks - 466 codex`() {
+        // #466 (Codex review) — when two <p> merge over a >=2 `&nbsp;` run, a trailing `<br>` on the
+        // first <p> and a leading `<br>` on the second are BORDER breaks (the legacy sub-parse
+        // edge-trimmed them via flushParagraph). Only the separator breaks (here 2) plus any INTERIOR
+        // break survive. DERIVED FROM the issue #466 encoding, not a raw hfr-mcp capture.
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            "<div id=\"para1\"><p>A<br /></p>&nbsp;&nbsp;<p><br />B</p></div>",
+        )
+
+        val result = parser.parse(element)
+
+        val paragraphs = result.ast.blocks.filterIsInstance<PostBlock.Paragraph>()
+        assertEquals(
+            "the two paragraphs must merge into ONE block, got=${result.ast.blocks}",
+            1,
+            paragraphs.size,
+        )
+        assertEquals(
+            "2 orphan &nbsp; ⇒ 2 separator LineBreaks; the border <br>s of both <p> are trimmed",
+            listOf(
+                PostInline.Text("A"),
+                PostInline.LineBreak,
+                PostInline.LineBreak,
+                PostInline.Text("B"),
+            ),
+            paragraphs.single().inlines,
+        )
+    }
+
+    @Test
+    fun `lone nbsp between a paragraph and an inline-classified list keeps them separate - 466 codex`() {
+        // #466 (Codex review) — HFR emits `</p>&nbsp;<ul>…` where <ul> is classified INLINE. The
+        // buffered inline-only <p> must be CLOSED at its boundary, NOT have the list content run into
+        // it. DERIVED FROM the Codex example, not a raw hfr-mcp capture.
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            "<div id=\"para1\"><p>intro</p>&nbsp;<ul><li>item</li></ul></div>",
+        )
+
+        val result = parser.parse(element)
+
+        val paragraphs = result.ast.blocks.filterIsInstance<PostBlock.Paragraph>()
+        assertEquals(
+            "the <p> and the following inline-classified <ul> must stay two blocks, got=${result.ast.blocks}",
+            2,
+            paragraphs.size,
+        )
+        assertTrue(
+            "first block keeps the paragraph text",
+            paragraphs[0].inlines.filterIsInstance<PostInline.Text>().any { it.value.contains("intro") },
+        )
+        assertTrue(
+            "second block holds the list text, not merged into the paragraph",
+            paragraphs[1].inlines.filterIsInstance<PostInline.Text>().any { it.value.contains("item") },
+        )
+    }
+
+    @Test
+    fun `multi nbsp after inline content before a paragraph does not fold - 466 codex`() {
+        // #466 (Codex review) — a >=2 `&nbsp;` run folds into empty lines ONLY between two <p>. After
+        // arbitrary buffered inline content (`<strong>A</strong>&nbsp;&nbsp;<p>B</p>`) it must NOT
+        // merge: the two stay distinct blocks. DERIVED FROM the Codex example.
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            "<div id=\"para1\"><strong>A</strong>&nbsp;&nbsp;<p>B</p></div>",
+        )
+
+        val result = parser.parse(element)
+
+        val paragraphs = result.ast.blocks.filterIsInstance<PostBlock.Paragraph>()
+        assertEquals(
+            "inline content + multi-nbsp + <p> must stay two blocks, got=${result.ast.blocks}",
+            2,
+            paragraphs.size,
+        )
+        assertEquals(
+            "the second <p> stays its own block, not merged with the inline content",
+            listOf(PostInline.Text("B")),
+            paragraphs[1].inlines,
+        )
+    }
+
+    @Test
+    fun `top-level break between two paragraphs closes the merge window - 466 codex`() {
+        // #466 (Codex review, round 3) — a top-level <br> between a buffered closed <p> and a later
+        // <p> EXTENDS the running paragraph, so the buffer is no longer a pristine <p> body and the
+        // >=2 `&nbsp;` run must NOT fold the two <p> into one block (`<p>A</p><br>&nbsp;&nbsp;<p>B</p>`
+        // stays two blocks, matching legacy). DERIVED FROM the Codex example, not a raw hfr-mcp capture.
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            "<div id=\"para1\"><p>A</p><br />&nbsp;&nbsp;<p>B</p></div>",
+        )
+
+        val result = parser.parse(element)
+
+        val paragraphs = result.ast.blocks.filterIsInstance<PostBlock.Paragraph>()
+        assertEquals(
+            "the intervening top-level <br> must keep the two <p> as separate blocks, got=${result.ast.blocks}",
+            2,
+            paragraphs.size,
+        )
+        assertEquals(
+            "first block holds A with its border break trimmed",
+            listOf(PostInline.Text("A")),
+            paragraphs[0].inlines,
+        )
+        assertEquals(
+            "second block holds B, not merged with A",
+            listOf(PostInline.Text("B")),
+            paragraphs[1].inlines,
+        )
+    }
+
+    @Test
+    fun `single orphan nbsp between paragraphs stays two separate blocks`() {
+        // #466 guard — a LONE `&nbsp;` between two <p> is HFR's normal paragraph separator (it is
+        // present between ~every pair of sibling <p>), NOT an authored blank line. Folding it in
+        // would add a spurious empty line to virtually every multi-paragraph post, so the parser
+        // must keep two distinct Paragraph blocks in that case (legacy behaviour preserved).
+        //
+        // NOTE: this HTML input is DERIVED FROM THE ISSUE #466 encoding (`</p>&nbsp;<p>`), not a
+        // raw hfr-mcp capture — it isolates the single-separator boundary so the fix can be pinned
+        // without depending on a fixture that happens to contain exactly two adjacent <p>. The
+        // real `</p>&nbsp;&nbsp;&nbsp;<p>` multi-run case is covered by the fixture test above.
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            "<div id=\"para1\"><p>premier paragraphe</p>&nbsp;<p>second paragraphe</p></div>",
+        )
+
+        val result = parser.parse(element)
+
+        val paragraphs = result.ast.blocks.filterIsInstance<PostBlock.Paragraph>()
+        assertEquals(
+            "a lone &nbsp; separator must keep two distinct Paragraph blocks, got=${result.ast.blocks}",
+            2,
+            paragraphs.size,
+        )
+        assertEquals("premier paragraphe", (paragraphs[0].inlines.single() as PostInline.Text).value)
+        assertEquals("second paragraphe", (paragraphs[1].inlines.single() as PostInline.Text).value)
+    }
+
+    @Test
+    fun `multiple orphan nbsp between paragraphs fold into one paragraph with empty lines`() {
+        // #466 — focused boundary check on the EXACT encoding documented in the issue:
+        // `<p>A</p>&nbsp;&nbsp;&nbsp;<p>B</p>` (3 orphan `&nbsp;`). DERIVED FROM THE ISSUE #466
+        // encoding, not a raw hfr-mcp capture (the real multi-run shape is also pinned by the
+        // `topic_page_single.html` fixture test above). A run of 3 ⇒ one paragraph boundary +
+        // two authored empty lines, kept as 3 LineBreaks inside ONE paragraph.
+        val parser = PostContentParser()
+        val element = jsoupBody(
+            "<div id=\"para1\"><p>A</p>&nbsp;&nbsp;&nbsp;<p>B</p></div>",
+        )
+
+        val result = parser.parse(element)
+
+        val paragraphs = result.ast.blocks.filterIsInstance<PostBlock.Paragraph>()
+        assertEquals(
+            "the two paragraphs separated by a >=2 nbsp run must merge into ONE block, got=${result.ast.blocks}",
+            1,
+            paragraphs.size,
+        )
+        assertEquals(
+            "3 orphan &nbsp; fold into 3 LineBreaks between A and B (1 boundary + 2 empty lines)",
+            listOf(
+                PostInline.Text("A"),
+                PostInline.LineBreak,
+                PostInline.LineBreak,
+                PostInline.LineBreak,
+                PostInline.Text("B"),
+            ),
+            paragraphs.single().inlines,
+        )
+    }
+
+    @Test
     fun `breaks adjacent to block boundaries never leak to paragraph edges`() {
         // #333 — edge-trim invariant over real pages. The fixtures carry both directions:
         // `a écrit :</a></b><br /><br /><p>…` (leading, quote header, topic_page_single) and

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/account/RedfaceAccountMenu.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/account/RedfaceAccountMenu.kt
@@ -52,7 +52,6 @@ fun RedfaceAccountMenu(
     versionCode: Int,
     onLogin: () -> Unit,
     onLogout: () -> Unit,
-    onOpenSettings: () -> Unit,
     onOpenDiagnostics: () -> Unit,
     onReportContent: () -> Unit,
     modifier: Modifier = Modifier,
@@ -91,13 +90,7 @@ fun RedfaceAccountMenu(
                 )
             }
 
-            DropdownMenuItem(
-                text = { Text(stringResource(R.string.account_menu_settings)) },
-                onClick = {
-                    expanded = false
-                    onOpenSettings()
-                },
-            )
+            // #494 v2 — « Réglages » a quitté ce menu : c'est désormais la 5e destination de la barre du bas.
             DropdownMenuItem(
                 text = { Text(stringResource(R.string.account_menu_diagnostics)) },
                 onClick = {

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/RedfaceSettingsListItem.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/RedfaceSettingsListItem.kt
@@ -1,0 +1,130 @@
+package fr.forumhfr.redface2.core.ui.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+
+/**
+ * #494 — reusable Material 3 building blocks for the redesigned settings catalogue.
+ *
+ * These primitives keep `:feature:settings` (and any future settings host) free of bespoke row
+ * layouts: the screen composes [RedfaceSettingsSection] headers, [RedfaceSettingsListItem] rows
+ * (navigation, toggle, or plain) and [RedfaceSettingsChoiceGroup] segmented selectors, while the
+ * dividers between rows stay the caller's responsibility (M3 `HorizontalDivider`).
+ *
+ * Material 3 stable only — no `androidx.compose.material.*` / material-icons (forbidden project-wide).
+ */
+
+/**
+ * Section header for the settings catalogue (e.g. « Affichage », « Drapeaux »). Renders the [title]
+ * in the M3 `titleSmall` type and the `primary` colour, with the standard list inset padding so it
+ * lines up with the [RedfaceSettingsListItem] rows below it.
+ */
+@Composable
+fun RedfaceSettingsSection(
+    title: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 8.dp),
+    )
+}
+
+/**
+ * A single settings row, wrapping the Material 3 [ListItem].
+ *
+ * - [title] is the headline; [description] (optional) is the supporting line.
+ * - [leadingContent] / [trailingContent] are optional slots (e.g. a `Switch` trailing a toggle row,
+ *   or a chevron trailing a navigation row).
+ * - When [onClick] is non-null the whole row is clickable (gated by [enabled]); a `null` [onClick]
+ *   leaves the row inert so a toggle row can keep its `Switch` as the only interactive element.
+ * - When [enabled] is `false` the text is tinted `onSurfaceVariant` — the M3 idiom for an inactive
+ *   row, preferred over a blanket `Modifier.alpha`. Disabled rows are not clickable and still appear
+ *   in search (the caller decides searchability, not this primitive).
+ */
+@Composable
+@Suppress("LongParameterList") // Compose list-item API: optional defaulted slots, each a distinct surface.
+fun RedfaceSettingsListItem(
+    title: String,
+    modifier: Modifier = Modifier,
+    description: String? = null,
+    enabled: Boolean = true,
+    onClick: (() -> Unit)? = null,
+    leadingContent: (@Composable () -> Unit)? = null,
+    trailingContent: (@Composable () -> Unit)? = null,
+) {
+    val headlineColor = if (enabled) {
+        MaterialTheme.colorScheme.onSurface
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    val clickableModifier = if (onClick != null) {
+        Modifier.clickable(enabled = enabled, role = Role.Button, onClick = onClick)
+    } else {
+        Modifier
+    }
+    ListItem(
+        headlineContent = {
+            Text(text = title, color = headlineColor)
+        },
+        modifier = modifier
+            .fillMaxWidth()
+            .then(clickableModifier),
+        supportingContent = description?.let {
+            { Text(text = it, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+        },
+        leadingContent = leadingContent,
+        trailingContent = trailingContent,
+        colors = ListItemDefaults.colors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+    )
+}
+
+/**
+ * One option of a [RedfaceSettingsChoiceGroup]: the backing [value] (an enum, typically) and its
+ * localized [label].
+ */
+data class RedfaceSettingsChoice<T>(val value: T, val label: String)
+
+/**
+ * A text-only single-choice segmented selector, replicating the pattern used across the settings
+ * cards (theme, density, font scale, upload provider). [selected] is compared by equality against
+ * each [RedfaceSettingsChoice.value]; [onSelected] is called with the picked value. [enabled] gates
+ * every button at once (e.g. while a DataStore write is in flight).
+ */
+@Composable
+fun <T> RedfaceSettingsChoiceGroup(
+    options: List<RedfaceSettingsChoice<T>>,
+    selected: T,
+    onSelected: (T) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+) {
+    SingleChoiceSegmentedButtonRow(modifier = modifier.fillMaxWidth()) {
+        options.forEachIndexed { index, option ->
+            SegmentedButton(
+                selected = selected == option.value,
+                enabled = enabled,
+                onClick = { onSelected(option.value) },
+                shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
+            ) {
+                Text(option.label)
+            }
+        }
+    }
+}

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/RedfaceSettingsSearchTopBar.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/RedfaceSettingsSearchTopBar.kt
@@ -1,0 +1,145 @@
+package fr.forumhfr.redface2.core.ui.settings
+
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.ImeAction
+import fr.forumhfr.redface2.core.ui.R
+
+/**
+ * #494 — the settings shell top bar with an activable search field, built on the Material 3 stable
+ * [TopAppBar].
+ *
+ * - Normal mode: a back navigation icon (calls [onBack]), the [RedfaceSettingsSearchTopBarLabels.title],
+ *   a search action icon (calls `onSearchActiveChange(true)`), then the caller's [actions] slot.
+ * - Search mode: the navigation icon CLOSES the search (`onSearchActiveChange(false)`, it does NOT
+ *   pop the route), the title becomes a single-line [TextField] bound to [query] / [onQueryChange],
+ *   and a clear action (visible only when [query] is non-blank) empties the query.
+ *
+ * The two back paths are deliberately distinct: only the normal-mode back pops the route, so the
+ * search can always be dismissed without leaving the screen.
+ *
+ * Icons use local vector drawables from `:core:ui` rendered with the material3 [Icon] (material-icons
+ * are forbidden project-wide); a11y labels live on the [IconButton]s, the glyphs are decorative.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+@Suppress("LongParameterList") // Top-bar API: search state + the two back/query callbacks + slots.
+fun RedfaceSettingsSearchTopBar(
+    labels: RedfaceSettingsSearchTopBarLabels,
+    searchActive: Boolean,
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onSearchActiveChange: (Boolean) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    actions: @Composable RowScope.() -> Unit = {},
+) {
+    val focusManager = LocalFocusManager.current
+    TopAppBar(
+        modifier = modifier,
+        navigationIcon = {
+            val backLabel = if (searchActive) {
+                labels.closeSearchContentDescription
+            } else {
+                labels.backContentDescription
+            }
+            IconButton(
+                onClick = { if (searchActive) onSearchActiveChange(false) else onBack() },
+                modifier = Modifier.semantics { contentDescription = backLabel },
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_arrow_back),
+                    contentDescription = null,
+                )
+            }
+        },
+        title = {
+            if (searchActive) {
+                // Auto-focus + open the keyboard as soon as the search field enters composition
+                // (i.e. when search is activated): without this the field shows but stays unfocused.
+                val focusRequester = remember { FocusRequester() }
+                LaunchedEffect(Unit) { focusRequester.requestFocus() }
+                TextField(
+                    value = query,
+                    onValueChange = onQueryChange,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .focusRequester(focusRequester),
+                    singleLine = true,
+                    placeholder = { Text(labels.searchPlaceholder) },
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                    // Filtering is live; the IME "Search" action just dismisses the keyboard.
+                    keyboardActions = KeyboardActions(onSearch = { focusManager.clearFocus() }),
+                    colors = TextFieldDefaults.colors(
+                        focusedContainerColor = MaterialTheme.colorScheme.surface,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.surface,
+                    ),
+                )
+            } else {
+                Text(labels.title)
+            }
+        },
+        actions = {
+            if (searchActive) {
+                if (query.isNotEmpty()) {
+                    val clearLabel = labels.clearSearchContentDescription
+                    IconButton(
+                        onClick = { onQueryChange("") },
+                        modifier = Modifier.semantics { contentDescription = clearLabel },
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_close),
+                            contentDescription = null,
+                        )
+                    }
+                }
+            } else {
+                val openLabel = labels.openSearchContentDescription
+                IconButton(
+                    onClick = { onSearchActiveChange(true) },
+                    modifier = Modifier.semantics { contentDescription = openLabel },
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_search),
+                        contentDescription = null,
+                    )
+                }
+                actions()
+            }
+        },
+    )
+}
+
+/**
+ * #494 — localized labels for [RedfaceSettingsSearchTopBar]. Passed as plain `String`s (resolved
+ * via `stringResource` at the feature call site) so `:core:ui` carries no settings-specific strings
+ * and stays reusable.
+ */
+data class RedfaceSettingsSearchTopBarLabels(
+    val title: String,
+    val searchPlaceholder: String,
+    val backContentDescription: String,
+    val openSearchContentDescription: String,
+    val closeSearchContentDescription: String,
+    val clearSearchContentDescription: String,
+)

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/RedfaceSettingsSearchTopBar.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/RedfaceSettingsSearchTopBar.kt
@@ -50,7 +50,7 @@ fun RedfaceSettingsSearchTopBar(
     query: String,
     onQueryChange: (String) -> Unit,
     onSearchActiveChange: (Boolean) -> Unit,
-    onBack: () -> Unit,
+    onBack: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
     actions: @Composable RowScope.() -> Unit = {},
 ) {
@@ -58,18 +58,18 @@ fun RedfaceSettingsSearchTopBar(
     TopAppBar(
         modifier = modifier,
         navigationIcon = {
-            val backLabel = if (searchActive) {
-                labels.closeSearchContentDescription
-            } else {
-                labels.backContentDescription
-            }
-            IconButton(
-                onClick = { if (searchActive) onSearchActiveChange(false) else onBack() },
-                modifier = Modifier.semantics { contentDescription = backLabel },
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_arrow_back),
-                    contentDescription = null,
+            // Search active → the icon CLOSES the search. Otherwise it's a back affordance, shown only
+            // when [onBack] is provided : a top-level/root use (Réglages onglet, #494 v2) passes null so
+            // no dead back button appears (Codex P2).
+            if (searchActive) {
+                NavigationIconButton(
+                    label = labels.closeSearchContentDescription,
+                    onClick = { onSearchActiveChange(false) },
+                )
+            } else if (onBack != null) {
+                NavigationIconButton(
+                    label = labels.backContentDescription,
+                    onClick = onBack,
                 )
             }
         },
@@ -128,6 +128,20 @@ fun RedfaceSettingsSearchTopBar(
             }
         },
     )
+}
+
+/** Bouton de navigation (flèche retour / fermer la recherche) partagé par le top bar de réglages. */
+@Composable
+private fun NavigationIconButton(label: String, onClick: () -> Unit) {
+    IconButton(
+        onClick = onClick,
+        modifier = Modifier.semantics { contentDescription = label },
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_arrow_back),
+            contentDescription = null,
+        )
+    }
 }
 
 /**

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/RedfaceSettingsSearchTopBar.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/RedfaceSettingsSearchTopBar.kt
@@ -12,6 +12,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -40,10 +42,14 @@ import fr.forumhfr.redface2.core.ui.R
  *
  * Icons use local vector drawables from `:core:ui` rendered with the material3 [Icon] (material-icons
  * are forbidden project-wide); a11y labels live on the [IconButton]s, the glyphs are decorative.
+ *
+ * [scrollBehavior] branche l'effet « contenu sous la barre » (idiome M3) : avec un
+ * `pinnedScrollBehavior` câblé côté écran (Scaffold `nestedScroll`), la barre prend la teinte
+ * `scrolledContainerColor` (`surfaceContainer`) dès que la liste de résultats défile dessous.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-@Suppress("LongParameterList") // Top-bar API: search state + the two back/query callbacks + slots.
+@Suppress("LongParameterList") // Top-bar API: search state + the two back/query callbacks + scroll + slots.
 fun RedfaceSettingsSearchTopBar(
     labels: RedfaceSettingsSearchTopBarLabels,
     searchActive: Boolean,
@@ -52,11 +58,16 @@ fun RedfaceSettingsSearchTopBar(
     onSearchActiveChange: (Boolean) -> Unit,
     onBack: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
+    scrollBehavior: TopAppBarScrollBehavior? = null,
     actions: @Composable RowScope.() -> Unit = {},
 ) {
     val focusManager = LocalFocusManager.current
     TopAppBar(
         modifier = modifier,
+        scrollBehavior = scrollBehavior,
+        colors = TopAppBarDefaults.topAppBarColors(
+            scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
+        ),
         navigationIcon = {
             // Search active → the icon CLOSES the search. Otherwise it's a back affordance, shown only
             // when [onBack] is provided : a top-level/root use (Réglages onglet, #494 v2) passes null so

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/RedfaceSearchAppBar.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/RedfaceSearchAppBar.kt
@@ -38,7 +38,7 @@ fun RedfaceSearchAppBar(
     placeholder: String,
     menuContentDescription: String,
     searchContentDescription: String,
-    onMenuClick: () -> Unit,
+    onMenuClick: (() -> Unit)? = null,
     onSearchClick: () -> Unit,
     modifier: Modifier = Modifier,
     avatar: @Composable () -> Unit = { DefaultAvatarPlaceholder() },
@@ -52,8 +52,11 @@ fun RedfaceSearchAppBar(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {
+            // Hamburger gardé par décision produit (#494 v2), rôle à définir : désactivé tant qu'aucune
+            // action n'est câblée → présent visuellement mais pas de bouton mort (a11y : annoncé désactivé).
             IconButton(
-                onClick = onMenuClick,
+                onClick = onMenuClick ?: {},
+                enabled = onMenuClick != null,
                 modifier = Modifier.semantics { contentDescription = menuContentDescription },
             ) {
                 Icon(painter = painterResource(R.drawable.ic_ms_menu), contentDescription = null)

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/RedfaceSearchAppBar.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/RedfaceSearchAppBar.kt
@@ -1,0 +1,100 @@
+package fr.forumhfr.redface2.core.ui.settings.shell
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.ui.R
+
+/**
+ * #494 v2 — Search app bar (docked search bar M3) du shell de configuration : icône menu (hamburger,
+ * rôle à définir) · champ de recherche cliquable · avatar de compte. Custom STABLE (Surface + Row +
+ * pill cliquable), pas la `SearchBar`/`DockedSearchBar` `@ExperimentalMaterial3Api` : cette barre est
+ * le chrome PERMANENT de la zone réglages (et un pilote app-wide), on veut le contrôle total des
+ * insets edge-to-edge, du back et de l'IME sans opt-in expérimental.
+ *
+ * Edge-to-edge : la barre applique `statusBarsPadding()` pour se loger sous la status bar transparente.
+ * Le pill ouvre la recherche ([onSearchClick]) ; le filtrage/résultats vivent au niveau du shell.
+ */
+@Composable
+@Suppress("LongParameterList") // Top-bar API : placeholder + 2 a11y labels + 2 callbacks + slot avatar.
+fun RedfaceSearchAppBar(
+    placeholder: String,
+    menuContentDescription: String,
+    searchContentDescription: String,
+    onMenuClick: () -> Unit,
+    onSearchClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    avatar: @Composable () -> Unit = { DefaultAvatarPlaceholder() },
+) {
+    Surface(modifier = modifier.fillMaxWidth(), color = MaterialTheme.colorScheme.surface) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .statusBarsPadding()
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            IconButton(
+                onClick = onMenuClick,
+                modifier = Modifier.semantics { contentDescription = menuContentDescription },
+            ) {
+                Icon(painter = painterResource(R.drawable.ic_ms_menu), contentDescription = null)
+            }
+            Surface(
+                onClick = onSearchClick,
+                modifier = Modifier
+                    .weight(1f)
+                    .height(56.dp) // gabarit docked search bar M3 ; porte l'app bar à ~72dp (Claude+Codex)
+                    .semantics { contentDescription = searchContentDescription },
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_search),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = placeholder,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            avatar()
+        }
+    }
+}
+
+/** Avatar de compte par défaut (placeholder) — remplacé par l'avatar HFR réel quand connecté (#479). */
+@Composable
+private fun DefaultAvatarPlaceholder() {
+    Surface(
+        modifier = Modifier.size(40.dp),
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.primaryContainer,
+    ) {}
+}

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/RedfaceSearchAppBar.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/RedfaceSearchAppBar.kt
@@ -1,5 +1,7 @@
 package fr.forumhfr.redface2.core.ui.settings.shell
 
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -14,6 +16,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -31,9 +34,14 @@ import fr.forumhfr.redface2.core.ui.R
  *
  * Edge-to-edge : la barre applique `statusBarsPadding()` pour se loger sous la status bar transparente.
  * Le pill ouvre la recherche ([onSearchClick]) ; le filtrage/résultats vivent au niveau du shell.
+ *
+ * [elevated] pilote l'effet « contenu sous la barre » (idiome M3) : au repos la barre est `surface`
+ * (continue avec le contenu) ; quand du contenu scrolle DESSOUS, elle prend la teinte `surfaceContainer`
+ * + une ombre fine. Le shell la superpose à la liste (Box + `contentPadding` haut) et passe
+ * `elevated = listState.canScrollBackward`. Transition tonale animée (pas de flou : non-standard M3).
  */
 @Composable
-@Suppress("LongParameterList") // Top-bar API : placeholder + 2 a11y labels + 2 callbacks + slot avatar.
+@Suppress("LongParameterList") // Top-bar API : placeholder + 2 a11y labels + 2 callbacks + elevated + avatar.
 fun RedfaceSearchAppBar(
     placeholder: String,
     menuContentDescription: String,
@@ -41,9 +49,26 @@ fun RedfaceSearchAppBar(
     onMenuClick: (() -> Unit)? = null,
     onSearchClick: () -> Unit,
     modifier: Modifier = Modifier,
+    elevated: Boolean = false,
     avatar: @Composable () -> Unit = { DefaultAvatarPlaceholder() },
 ) {
-    Surface(modifier = modifier.fillMaxWidth(), color = MaterialTheme.colorScheme.surface) {
+    val containerColor by animateColorAsState(
+        targetValue = if (elevated) {
+            MaterialTheme.colorScheme.surfaceContainer
+        } else {
+            MaterialTheme.colorScheme.surface
+        },
+        label = "searchAppBarContainer",
+    )
+    val shadowElevation by animateDpAsState(
+        targetValue = if (elevated) 3.dp else 0.dp,
+        label = "searchAppBarShadow",
+    )
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = containerColor,
+        shadowElevation = shadowElevation,
+    ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/RedfaceSearchAppBar.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/RedfaceSearchAppBar.kt
@@ -25,6 +25,9 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.ui.R
 
+/** Opacité du conteneur de la barre au scroll : translucide pour laisser deviner le contenu dessous. */
+private const val SEARCH_BAR_ELEVATED_ALPHA = 0.94f
+
 /**
  * #494 v2 — Search app bar (docked search bar M3) du shell de configuration : icône menu (hamburger,
  * rôle à définir) · champ de recherche cliquable · avatar de compte. Custom STABLE (Surface + Row +
@@ -52,9 +55,13 @@ fun RedfaceSearchAppBar(
     elevated: Boolean = false,
     avatar: @Composable () -> Unit = { DefaultAvatarPlaceholder() },
 ) {
+    // Au scroll, le conteneur passe à surfaceContainer LÉGÈREMENT translucide : on devine le contenu
+    // qui glisse derrière (l'effet « voir le texte passer dessous »), sans nuire à la lisibilité — le
+    // pill de recherche, lui, reste opaque (surfaceContainerHigh). Au repos : surface opaque (rien
+    // dessous). Pas de flou (non-standard M3, fragile en Compose) : translucidité + scrim (cf. shell).
     val containerColor by animateColorAsState(
         targetValue = if (elevated) {
-            MaterialTheme.colorScheme.surfaceContainer
+            MaterialTheme.colorScheme.surfaceContainer.copy(alpha = SEARCH_BAR_ELEVATED_ALPHA)
         } else {
             MaterialTheme.colorScheme.surface
         },

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeScreen.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeScreen.kt
@@ -1,0 +1,154 @@
+package fr.forumhfr.redface2.core.ui.settings.shell
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.ui.R
+
+/**
+ * #494 v2 — une catégorie de la racine « catégories d'abord ». Identité visuelle : icône dans un
+ * conteneur tonal rond + titre + sous-titre optionnel + chevron. La racine n'expose QUE des catégories
+ * (aucun toggle/bouton inline) : chaque ligne ouvre une sous-vue de réglages.
+ */
+data class SettingsCategoryUi(
+    val id: String,
+    val title: String,
+    val subtitle: String?,
+    @param:DrawableRes val iconRes: Int,
+)
+
+/**
+ * #494 v2 — un groupe de catégories (famille) de la racine, avec un en-tête de section. Le regroupement
+ * (D4 léger) donne une carte mentale à la liste sans exposer de réglage inline. Le groupage est
+ * éditorial et fourni par la couche feature ; `:core:ui` ne fait que le rendre.
+ */
+data class SettingsCategoryGroup(
+    val id: String,
+    val title: String,
+    val categories: List<SettingsCategoryUi>,
+)
+
+/**
+ * #494 v2 — racine du menu de configuration (direction verrouillée 2026-06-15, Claude + Codex) :
+ * [RedfaceSearchAppBar] + liste de catégories REGROUPÉES par familles (D4 léger), chaque ligne en
+ * cercle tonal + sous-titre + chevron (D1). En-têtes de section sobres (espace blanc plutôt que
+ * separator). Stateless et Roborazzi-able sans nav/Hilt (groupes + callbacks hoistés).
+ */
+@Composable
+@Suppress("LongParameterList") // shell racine : data + placeholder + 2 a11y + 3 callbacks, tous distincts.
+fun SettingsHomeScreen(
+    groups: List<SettingsCategoryGroup>,
+    searchPlaceholder: String,
+    menuContentDescription: String,
+    searchContentDescription: String,
+    onMenuClick: () -> Unit,
+    onSearchClick: () -> Unit,
+    onCategoryClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface),
+    ) {
+        RedfaceSearchAppBar(
+            placeholder = searchPlaceholder,
+            menuContentDescription = menuContentDescription,
+            searchContentDescription = searchContentDescription,
+            onMenuClick = onMenuClick,
+            onSearchClick = onSearchClick,
+        )
+        LazyColumn(modifier = Modifier.fillMaxWidth()) {
+            groups.forEachIndexed { index, group ->
+                item(key = "header_${group.id}") {
+                    SettingsSectionHeader(title = group.title, first = index == 0)
+                }
+                items(group.categories, key = { it.id }) { category ->
+                    SettingsCategoryRow(
+                        category = category,
+                        onClick = { onCategoryClick(category.id) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * En-tête de section sobre : `titleSmall`, teinte primaire, padding start 16dp. Le premier en-tête
+ * (juste sous l'app bar) a un top réduit (16dp) ; les suivants respirent davantage (24dp) — gabarit
+ * M3 « espace plutôt que divider ».
+ */
+@Composable
+private fun SettingsSectionHeader(title: String, first: Boolean) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(
+            start = 16.dp,
+            end = 16.dp,
+            top = if (first) 16.dp else 24.dp,
+            bottom = 8.dp,
+        ),
+    )
+}
+
+@Composable
+private fun SettingsCategoryRow(
+    category: SettingsCategoryUi,
+    onClick: () -> Unit,
+) {
+    ListItem(
+        headlineContent = { Text(category.title) },
+        supportingContent = category.subtitle?.let { sub -> { Text(sub) } },
+        leadingContent = {
+            Surface(
+                modifier = Modifier.size(40.dp),
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.secondaryContainer,
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        painter = painterResource(category.iconRes),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.size(24.dp),
+                    )
+                }
+            }
+        },
+        trailingContent = {
+            Icon(
+                painter = painterResource(R.drawable.ic_chevron_right),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(role = Role.Button, onClick = onClick),
+        colors = ListItemDefaults.colors(containerColor = MaterialTheme.colorScheme.surface),
+    )
+}

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeScreen.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeScreen.kt
@@ -1,12 +1,15 @@
 package fr.forumhfr.redface2.core.ui.settings.shell
 
 import androidx.annotation.DrawableRes
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -27,10 +30,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.ui.R
 
@@ -136,6 +142,21 @@ fun SettingsHomeScreen(
                 )
             }
         }
+        // Scrim : juste sous la barre, un court dégradé surfaceContainer → transparent qui fond le
+        // contenu émergeant de dessous la barre (pas de coupure nette). N'apparaît qu'à l'élévation.
+        val scrimAlpha by animateFloatAsState(
+            targetValue = if (barElevated) 1f else 0f,
+            label = "searchBarScrim",
+        )
+        val scrimTop = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = scrimAlpha)
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .fillMaxWidth()
+                .offset { IntOffset(0, barHeightPx) }
+                .height(24.dp)
+                .background(Brush.verticalGradient(listOf(scrimTop, Color.Transparent))),
+        )
     }
 }
 

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeScreen.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeScreen.kt
@@ -4,13 +4,14 @@ import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
@@ -19,8 +20,15 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
@@ -68,31 +76,26 @@ fun SettingsHomeScreen(
     modifier: Modifier = Modifier,
     accountSlot: (@Composable () -> Unit)? = null,
 ) {
-    Column(
+    val listState = rememberLazyListState()
+    // « Contenu sous la barre » (edge-to-edge) : la barre est SUPERPOSÉE à la liste (Box, pas Column),
+    // donc le contenu glisse derrière elle. Elle s'élève (teinte surfaceContainer) dès que la liste a
+    // défilé — canScrollBackward passe true au 1er pixel sous la barre.
+    val barElevated by remember { derivedStateOf { listState.canScrollBackward } }
+    // Hauteur réelle de la barre (status bar + pill + paddings), mesurée au runtime et reportée en
+    // contentPadding haut : le 1er item démarre VISIBLE juste sous la barre, puis passe DERRIÈRE elle.
+    var barHeightPx by remember { mutableIntStateOf(0) }
+    val density = LocalDensity.current
+
+    Box(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.surface),
     ) {
-        // Le slot compte (menu compte app-wide) remplace l'avatar placeholder quand le host le fournit.
-        if (accountSlot != null) {
-            RedfaceSearchAppBar(
-                placeholder = searchPlaceholder,
-                menuContentDescription = menuContentDescription,
-                searchContentDescription = searchContentDescription,
-                onMenuClick = onMenuClick,
-                onSearchClick = onSearchClick,
-                avatar = accountSlot,
-            )
-        } else {
-            RedfaceSearchAppBar(
-                placeholder = searchPlaceholder,
-                menuContentDescription = menuContentDescription,
-                searchContentDescription = searchContentDescription,
-                onMenuClick = onMenuClick,
-                onSearchClick = onSearchClick,
-            )
-        }
-        LazyColumn(modifier = Modifier.fillMaxWidth()) {
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(top = with(density) { barHeightPx.toDp() }),
+        ) {
             groups.forEachIndexed { index, group ->
                 item(key = "header_${group.id}") {
                     SettingsSectionHeader(title = group.title, first = index == 0)
@@ -103,6 +106,34 @@ fun SettingsHomeScreen(
                         onClick = { onCategoryClick(category.id) },
                     )
                 }
+            }
+        }
+        // Barre superposée en haut. Le slot compte (menu app-wide) remplace l'avatar placeholder quand
+        // le host le fournit. onSizeChanged alimente le contentPadding de la liste ci-dessus.
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .onSizeChanged { barHeightPx = it.height },
+        ) {
+            if (accountSlot != null) {
+                RedfaceSearchAppBar(
+                    placeholder = searchPlaceholder,
+                    menuContentDescription = menuContentDescription,
+                    searchContentDescription = searchContentDescription,
+                    onMenuClick = onMenuClick,
+                    onSearchClick = onSearchClick,
+                    elevated = barElevated,
+                    avatar = accountSlot,
+                )
+            } else {
+                RedfaceSearchAppBar(
+                    placeholder = searchPlaceholder,
+                    menuContentDescription = menuContentDescription,
+                    searchContentDescription = searchContentDescription,
+                    onMenuClick = onMenuClick,
+                    onSearchClick = onSearchClick,
+                    elevated = barElevated,
+                )
             }
         }
     }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeScreen.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeScreen.kt
@@ -62,23 +62,36 @@ fun SettingsHomeScreen(
     searchPlaceholder: String,
     menuContentDescription: String,
     searchContentDescription: String,
-    onMenuClick: () -> Unit,
+    onMenuClick: (() -> Unit)? = null,
     onSearchClick: () -> Unit,
     onCategoryClick: (String) -> Unit,
     modifier: Modifier = Modifier,
+    accountSlot: (@Composable () -> Unit)? = null,
 ) {
     Column(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.surface),
     ) {
-        RedfaceSearchAppBar(
-            placeholder = searchPlaceholder,
-            menuContentDescription = menuContentDescription,
-            searchContentDescription = searchContentDescription,
-            onMenuClick = onMenuClick,
-            onSearchClick = onSearchClick,
-        )
+        // Le slot compte (menu compte app-wide) remplace l'avatar placeholder quand le host le fournit.
+        if (accountSlot != null) {
+            RedfaceSearchAppBar(
+                placeholder = searchPlaceholder,
+                menuContentDescription = menuContentDescription,
+                searchContentDescription = searchContentDescription,
+                onMenuClick = onMenuClick,
+                onSearchClick = onSearchClick,
+                avatar = accountSlot,
+            )
+        } else {
+            RedfaceSearchAppBar(
+                placeholder = searchPlaceholder,
+                menuContentDescription = menuContentDescription,
+                searchContentDescription = searchContentDescription,
+                onMenuClick = onMenuClick,
+                onSearchClick = onSearchClick,
+            )
+        }
         LazyColumn(modifier = Modifier.fillMaxWidth()) {
             groups.forEachIndexed { index, group ->
                 item(key = "header_${group.id}") {

--- a/core/ui/src/main/res/drawable/ic_chevron_right.xml
+++ b/core/ui/src/main/res/drawable/ic_chevron_right.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:autoMirrored="true">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M10,6L8.59,7.41 13.17,12l-4.58,4.59L10,18l6,-6z" />
+</vector>

--- a/core/ui/src/main/res/drawable/ic_close.xml
+++ b/core/ui/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z" />
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_account_circle.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_account_circle.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (account_circle), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M234-276q51-39 114-61.5T480-360q69 0 132 22.5T726-276q35-41 54.5-93T800-480q0-133-93.5-226.5T480-800q-133 0-226.5 93.5T160-480q0 59 19.5 111t54.5 93Zm246-164q-59 0-99.5-40.5T340-580q0-59 40.5-99.5T480-720q59 0 99.5 40.5T620-580q0 59-40.5 99.5T480-440Zm0 360q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q53 0 100-15.5t86-44.5q-39-29-86-44.5T480-280q-53 0-100 15.5T294-220q39 29 86 44.5T480-160Zm0-360q26 0 43-17t17-43q0-26-17-43t-43-17q-26 0-43 17t-17 43q0 26 17 43t43 17Zm0-60Zm0 360Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_add_photo_alternate.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_add_photo_alternate.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (add_photo_alternate), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h360v80H200v560h560v-360h80v360q0 33-23.5 56.5T760-120H200Zm480-480v-80h-80v-80h80v-80h80v80h80v80h-80v80h-80ZM240-280h480L570-480 450-320l-90-120-120 160Zm-40-480v560-560Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_article.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_article.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (article), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M280-280h280v-80H280v80Zm0-160h400v-80H280v80Zm0-160h400v-80H280v80Zm-80 480q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h560q33 0 56.5 23.5T840-760v560q0 33-23.5 56.5T760-120H200Zm0-80h560v-560H200v560Zm0-560v560-560Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_cached.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_cached.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (cached), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M482-160q-134 0-228-93t-94-227v-7l-64 64-56-56 160-160 160 160-56 56-64-64v7q0 100 70.5 170T482-240q26 0 51-6t49-18l60 60q-38 22-78 33t-82 11Zm278-161L600-481l56-56 64 64v-7q0-100-70.5-170T478-720q-26 0-51 6t-49 18l-60-60q38-22 78-33t82-11q134 0 228 93t94 227v7l64-64 56 56-160 160Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_display_settings.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_display_settings.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (display_settings), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M300-360h60v-160h-60v50h-60v60h60v50Zm100-50h320v-60H400v60Zm200-110h60v-50h60v-60h-60v-50h-60v160Zm-360-50h320v-60H240v60Zm80 450v-80H160q-33 0-56.5-23.5T80-280v-480q0-33 23.5-56.5T160-840h640q33 0 56.5 23.5T880-760v480q0 33-23.5 56.5T800-200H640v80H320ZM160-280h640v-480H160v480Zm0 0v-480 480Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_edit_square.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_edit_square.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (edit_square), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h357l-80 80H200v560h560v-278l80-80v358q0 33-23.5 56.5T760-120H200Zm280-360ZM360-360v-170l367-367q12-12 27-18t30-6q16 0 30.5 6t26.5 18l56 57q11 12 17 26.5t6 29.5q0 15-5.5 29.5T897-728L530-360H360Zm481-424-56-56 56 56ZM440-440h56l232-232-28-28-29-28-231 231v57Zm260-260-29-28 29 28 28 28-28-28Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_flag.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_flag.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (flag), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M200-120v-680h360l16 80h224v400H520l-16-80H280v280h-80Zm300-440Zm86 160h134v-240H510l-16-80H280v240h290l16 80Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_forum.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_forum.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (forum), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M280-240q-17 0-28.5-11.5T240-280v-80h520v-360h80q17 0 28.5 11.5T880-680v600L720-240H280ZM80-280v-560q0-17 11.5-28.5T120-880h520q17 0 28.5 11.5T680-840v360q0 17-11.5 28.5T640-440H240L80-280Zm520-240v-280H160v280h440Zm-440 0v-280 280Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_mail.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_mail.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (mail), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M160-160q-33 0-56.5-23.5T80-240v-480q0-33 23.5-56.5T160-800h640q33 0 56.5 23.5T880-720v480q0 33-23.5 56.5T800-160H160Zm320-280L160-640v400h640v-400L480-440Zm0-80 320-200H160l320 200ZM160-640v-80 480-400Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_menu.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_menu.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M3,18h18v-2H3v2zM3,13h18v-2H3v2zM3,6v2h18V6H3z" />
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_rocket_launch.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_rocket_launch.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (rocket_launch), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="m226-559 78 33q14-28 29-54t33-52l-56-11-84 84Zm142 83 114 113q42-16 90-49t90-75q70-70 109.5-155.5T806-800q-72-5-158 34.5T492-656q-42 42-75 90t-49 90Zm178-65q-23-23-23-56.5t23-56.5q23-23 57-23t57 23q23 23 23 56.5T660-541q-23 23-57 23t-57-23Zm19 321 84-84-11-56q-26 18-52 32.5T532-299l33 79Zm313-653q19 121-23.5 235.5T708-419l20 99q4 20-2 39t-20 33L538-80l-84-197-171-171-197-84 167-168q14-14 33.5-20t39.5-2l99 20q104-104 218-147t235-24ZM157-321q35-35 85.5-35.5T328-322q35 35 34.5 85.5T327-151q-25 25-83.5 43T82-76q14-103 32-161.5t43-83.5Zm57 56q-10 10-20 36.5T180-175q27-4 53.5-13.5T270-208q12-12 13-29t-11-29q-12-12-29-11.5T214-265Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_search.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_search.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (search), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M784-120 532-372q-30 24-69 38t-83 14q-109 0-184.5-75.5T120-580q0-109 75.5-184.5T380-840q109 0 184.5 75.5T640-580q0 44-14 83t-38 69l252 252-56 56ZM380-400q75 0 127.5-52.5T560-580q0-75-52.5-127.5T380-760q-75 0-127.5 52.5T200-580q0 75 52.5 127.5T380-400Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_settings.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_settings.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (settings), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="m370-80-16-128q-13-5-24.5-12T307-235l-119 50L78-375l103-78q-1-7-1-13.5v-27q0-6.5 1-13.5L78-585l110-190 119 50q11-8 23-15t24-12l16-128h220l16 128q13 5 24.5 12t22.5 15l119-50 110 190-103 78q1 7 1 13.5v27q0 6.5-2 13.5l103 78-110 190-118-50q-11 8-23 15t-24 12L590-80H370Zm70-80h79l14-106q31-8 57.5-23.5T639-327l99 41 39-68-86-65q5-14 7-29.5t2-31.5q0-16-2-31.5t-7-29.5l86-65-39-68-99 42q-22-23-48.5-38.5T533-694l-13-106h-79l-14 106q-31 8-57.5 23.5T321-633l-99-41-39 68 86 64q-5 15-7 30t-2 32q0 16 2 31t7 30l-86 65 39 68 99-42q22 23 48.5 38.5T427-266l13 106Zm42-180q58 0 99-41t41-99q0-58-41-99t-99-41q-59 0-99.5 41T342-480q0 58 40.5 99t99.5 41Zm-2-140Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_upcoming.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_upcoming.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #494 v2 — Material Symbols Outlined (upcoming), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M160-120q-33 0-56.5-23.5T80-200v-200q0-33 23.5-56.5T160-480h200q0 50 35 85t85 35q50 0 85-35t35-85h200q33 0 56.5 23.5T880-400v200q0 33-23.5 56.5T800-120H160Zm0-80h640v-200H664q-25 55-74.5 87.5T480-280q-60 0-109.5-32.5T296-400H160v200Zm544-328-56-56 142-142 56 56-142 142Zm-448 0L114-670l56-56 142 142-56 56Zm184-112v-200h80v200h-80ZM160-200h640-640Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_search.xml
+++ b/core/ui/src/main/res/drawable/ic_search.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z" />
+</vector>

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeShowcaseRoborazziTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeShowcaseRoborazziTest.kt
@@ -1,0 +1,193 @@
+package fr.forumhfr.redface2.core.ui.settings.shell
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onRoot
+import com.github.takahirom.roborazzi.captureRoboImage
+import fr.forumhfr.redface2.core.ui.R
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * #494 v2 — showcase Roborazzi (rendu JVM, sans device) du SHELL VERROUILLÉ du menu de configuration
+ * (direction figée 2026-06-15, Claude + Codex) : Search app bar (pill 56dp → app bar ~72dp) +
+ * racine « catégories d'abord » REGROUPÉE par familles (cercles tonals + sous-titres) + NavigationBar
+ * 80dp à 5 items. Icônes = vraies Material Symbols Outlined (`ic_ms_*`, plus de placeholder « tune »).
+ * Record-only (`roborazzi.test.record=true` forcé dans `core/ui/build.gradle.kts`) → PNG sous
+ * `core/ui/build/outputs/roborazzi/` ; gating CI à venir avec le plugin Roborazzi (AGP 9, #781) :
+ *
+ *     ./scripts/docker-dev.sh ./gradlew :core:ui:testDebugUnitTest \
+ *         --tests '*SettingsHomeShowcaseRoborazziTest*' --console=plain
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h900dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@OptIn(ExperimentalTestApi::class)
+class SettingsHomeShowcaseRoborazziTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Composable
+    private fun Shell() {
+        Column(Modifier.fillMaxSize()) {
+            SettingsHomeScreen(
+                groups = GROUPS,
+                searchPlaceholder = "Rechercher un réglage",
+                menuContentDescription = "Menu",
+                searchContentDescription = "Rechercher dans les réglages",
+                onMenuClick = {},
+                onSearchClick = {},
+                onCategoryClick = {},
+                modifier = Modifier.weight(1f),
+            )
+            ShellBottomBar()
+        }
+    }
+
+    @Composable
+    private fun ShellBottomBar() {
+        NavigationBar {
+            BOTTOM_ITEMS.forEach { (label, iconRes, selected) ->
+                NavigationBarItem(
+                    selected = selected,
+                    onClick = {},
+                    icon = { Icon(painterResource(iconRes), contentDescription = null) },
+                    label = { Text(label) },
+                )
+            }
+        }
+    }
+
+    @Test
+    fun settingsShellLight() {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                Surface(color = MaterialTheme.colorScheme.surface) { Shell() }
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage(
+            filePath = "build/outputs/roborazzi/settings_v2_shell_light.png",
+        )
+    }
+
+    @Test
+    fun settingsShellDark() {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = true, amoledTheme = false, dynamicColor = false) {
+                Surface(color = MaterialTheme.colorScheme.surface) { Shell() }
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage(
+            filePath = "build/outputs/roborazzi/settings_v2_shell_dark.png",
+        )
+    }
+
+    @Test
+    fun settingsShellAmoled() {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = true, amoledTheme = true, dynamicColor = false) {
+                Surface(color = MaterialTheme.colorScheme.surface) { Shell() }
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage(
+            filePath = "build/outputs/roborazzi/settings_v2_shell_amoled.png",
+        )
+    }
+
+    private companion object {
+        private fun cat(id: String, title: String, sub: String, icon: Int) =
+            SettingsCategoryUi(id, title, sub, icon)
+
+        val GROUPS = listOf(
+            SettingsCategoryGroup(
+                "appearance", "Apparence",
+                listOf(
+                    cat(
+                        "display", "Affichage", "Thème, AMOLED, densité, police",
+                        R.drawable.ic_ms_display_settings,
+                    ),
+                    cat(
+                        "flags", "Drapeaux", "Regroupement, masquer lus, auto-refresh",
+                        R.drawable.ic_ms_flag,
+                    ),
+                    cat(
+                        "topic", "Sujets et lecture", "Barre, sondages, navigation",
+                        R.drawable.ic_ms_article,
+                    ),
+                ),
+            ),
+            SettingsCategoryGroup(
+                "communication", "Communication",
+                listOf(
+                    cat(
+                        "mp", "Messages privés", "Badge de non-lus",
+                        R.drawable.ic_ms_mail,
+                    ),
+                    cat(
+                        "editing", "Édition et publication", "Confirmation avant envoi",
+                        R.drawable.ic_ms_edit_square,
+                    ),
+                ),
+            ),
+            SettingsCategoryGroup(
+                "content", "Contenu",
+                listOf(
+                    cat(
+                        "images", "Images et upload", "Hébergeur, Client-ID, insertion",
+                        R.drawable.ic_ms_add_photo_alternate,
+                    ),
+                    cat(
+                        "start", "Démarrage", "Écran ouvert au lancement",
+                        R.drawable.ic_ms_rocket_launch,
+                    ),
+                ),
+            ),
+            SettingsCategoryGroup(
+                "system", "Système",
+                listOf(
+                    cat(
+                        "network", "Réseau et cache", "Proxy, vider les caches",
+                        R.drawable.ic_ms_cached,
+                    ),
+                    cat(
+                        "account", "Compte et à propos", "Compte HFR, version, diagnostics",
+                        R.drawable.ic_ms_account_circle,
+                    ),
+                ),
+            ),
+            SettingsCategoryGroup(
+                "other", "Autres",
+                listOf(
+                    cat(
+                        "upcoming", "À venir", "Fonctionnalités planifiées",
+                        R.drawable.ic_ms_upcoming,
+                    ),
+                ),
+            ),
+        )
+        val BOTTOM_ITEMS = listOf(
+            Triple("Drapeaux", R.drawable.ic_ms_flag, false),
+            Triple("Forum", R.drawable.ic_ms_forum, false),
+            Triple("Recherche", R.drawable.ic_ms_search, false),
+            Triple("Messages", R.drawable.ic_ms_mail, false),
+            Triple("Réglages", R.drawable.ic_ms_settings, true),
+        )
+    }
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeShowcaseRoborazziTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/settings/shell/SettingsHomeShowcaseRoborazziTest.kt
@@ -52,7 +52,7 @@ class SettingsHomeShowcaseRoborazziTest {
                 searchPlaceholder = "Rechercher un réglage",
                 menuContentDescription = "Menu",
                 searchContentDescription = "Rechercher dans les réglages",
-                onMenuClick = {},
+                onMenuClick = null,
                 onSearchClick = {},
                 onCategoryClick = {},
                 modifier = Modifier.weight(1f),

--- a/docs/guides/known-issues.md
+++ b/docs/guides/known-issues.md
@@ -1,0 +1,47 @@
+---
+layout: default
+title: Limitations connues et compromis assumés
+parent: Guides
+nav_order: 9
+permalink: /guides/known-issues
+---
+
+# Limitations connues et compromis assumés
+
+Liste **vivante** des limitations connues de Redface 2 et des compromis **assumés** (choix délibérés, pas des bugs). Elle évite de re-diagnostiquer plusieurs fois les mêmes points et sert de référence pour les retours testeurs. Chaque entrée pointe vers l'issue de suivi quand il y en a une.
+
+> Convention : un point listé ici est un **comportement attendu** (compromis documenté) ou une **limite plateforme**, pas une régression. Les vrais bugs vivent dans les issues, pas ici.
+
+## Lecture et rendu
+
+- **Citations en mode connecté — pas de saut vers le post cité.** En authentifié, HFR sert l'en-tête de citation avec un lien dynamique `forum2.php?…&numreponse=M` au lieu du permalien statique `sujet_<post>_<page>.htm#tN`. Le parser extrait l'auteur de la citation mais laisse `page`/`numreponse` à `null` → le tap « aller au message cité » est inactif en mode connecté (il fonctionne en anonyme). Compromis Phase 2.
+- **Modèle de contenu de post gelé.** L'AST `PostContent` est sérialisé en base (Room) : ajouter un nouveau type de bloc/inline impose une migration. Les évolutions de rendu réutilisent les primitives existantes (ex. `LineBreak`) tant que possible.
+
+## Drapeaux et listes
+
+- **Fraîcheur du cache de drapeaux.** Le compteur de réponses et le dernier posteur affichés peuvent être périmés jusqu'au prochain rafraîchissement (cache REST + Room). Le rafraîchissement automatique (#378/#421) couvre le cas ; un écart résiduel relève de la fraîcheur, pas d'un mauvais mapping (cf. #331, #501).
+- **Drapeaux globaux tronqués par récence.** L'endpoint REST global tronque par récence ; le détail par catégorie est complet (cf. #251).
+
+## Messages privés
+
+- **Pas de drapeau lu/non-lu serveur.** HFR n'expose aucun état lu/non-lu serveur pour les MP : l'app s'appuie sur une heuristique (dot binaire par conversation). Le compteur de badge est donc une estimation côté client, recalculée à la lecture (cf. #313, #361).
+
+## Réglages
+
+- **Options « À venir » des sous-pages dédiées.** Les options planifiées (grisées) des catégories adossées à une sous-page propre — Affichage, Images, Compte — restent **cherchables** mais ne s'affichent pas en naviguant ces sous-pages (UI dédiée, hors catalogue générique). Les autres catégories les listent (cf. #494).
+- **Rôle du hamburger non défini.** L'icône hamburger de la barre de recherche des réglages est présente mais désactivée : son rôle (tiroir de navigation ?) est à définir (cf. #494).
+
+## Navigation et chrome
+
+- **Barre du bas ≈ 64 dp minimum.** La barre de navigation basse ne descend pas sous ~64 dp (`ShortNavigationBarCompact`) : aller plus bas violerait le plancher de cible tactile d'accessibilité (48 dp). Une réduction « de moitié » n'est pas possible proprement (cf. #515).
+- **Effet « contenu sous la barre » = tonal, pas de flou.** L'effet de profondeur sous la search app bar est une translucidité tonale + scrim (idiome Material 3), pas un vrai flou « frosted glass » (techniquement fragile en Compose, non standard M3). Une barre extensible/collapsante reste à explorer (cf. #516).
+- **Plein écran / barre système Android.** Masquer la barre de navigation système du bas (3 boutons) est un mode immersif : Android impose son **réaffichage transitoire** au swipe depuis le bas (on ne peut pas la supprimer définitivement). Le rendu exact varie en gestuel vs 3-boutons (cf. #518).
+
+## Réseau
+
+- **Prefetch non authentifié — volontaire.** Le préchargement utilise des requêtes non authentifiées, délibérément, pour **ne pas marquer les drapeaux comme lus** côté serveur.
+- **Deep links HFR — domaine non vérifiable.** Le domaine HFR n'est pas vérifiable côté Play Console ; les fragments d'URI (`#t<id>`) sont parsés dans `RedfaceApp` (Compose Navigation 3 ne gère pas les fragments nativement) (cf. #127).
+
+---
+
+*Page maintenue au fil de l'eau : ajouter ici tout compromis délibéré ou limite plateforme nouvellement constaté, avec un lien vers l'issue de suivi.*

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -537,6 +537,7 @@ private fun UploadError.bannerText(): String = when (this) {
         stringResource(R.string.editor_upload_error_server, providerId.displayName(), code)
     is UploadError.Malformed ->
         stringResource(R.string.editor_upload_error_malformed, providerId.displayName())
+    UploadError.Configuration -> stringResource(R.string.editor_upload_error_configuration)
     UploadError.Network -> stringResource(R.string.editor_upload_error_network)
 }
 

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
@@ -189,6 +189,10 @@ sealed interface UploadError {
     /** The host answered 2xx but the body could not be parsed into the expected shape (#474). */
     data class Malformed(val providerId: UploadProviderId) : UploadError
 
+    /** The upload provider is not configured (e.g. a blank Imgur Client-ID): the user must set it
+     * up in Settings, not retry — so the banner points at configuration, not connectivity (#474). */
+    data object Configuration : UploadError
+
     /** No network / DNS / timeout — also covers an unreadable picked Uri (mapped to Network). */
     data object Network : UploadError
 }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -525,6 +525,8 @@ class PostEditorViewModel @AssistedInject constructor(
             // (Server) vs. an unreadable host response (Malformed), instead of one vague message.
             is UploadException.Server -> UploadError.Server(code = error.code, providerId = error.providerId)
             is UploadException.Malformed -> UploadError.Malformed(providerId = error.providerId)
+            // #474 — a config error (blank Imgur Client-ID) must point at Settings, not connectivity.
+            is UploadException.Configuration -> UploadError.Configuration
             is UploadException.Network -> UploadError.Network
             else -> UploadError.Network
         }

--- a/feature/editor/src/main/res/values/strings.xml
+++ b/feature/editor/src/main/res/values/strings.xml
@@ -49,6 +49,7 @@
     <string name="editor_upload_error_unsupported_type">Type d\'image non accepté par l\'hébergeur.</string>
     <string name="editor_upload_error_server">L\'hébergeur %1$s a refusé l\'image (HTTP %2$d). Réessayez ou changez d\'hébergeur dans les réglages.</string>
     <string name="editor_upload_error_malformed">Réponse illisible de l\'hébergeur %1$s. Réessayez ou changez d\'hébergeur dans les réglages.</string>
+    <string name="editor_upload_error_configuration">Hébergeur d\'images non configuré. Renseignez le Client-ID dans les réglages avant d\'envoyer une image.</string>
     <string name="editor_upload_error_network">Erreur réseau pendant l\'upload. Vérifiez votre connexion et réessayez.</string>
     <!-- Upload multi-images — compteur de progression « n/N » affiché pendant l\'envoi du lot. -->
     <string name="editor_upload_progress">Envoi %1$d/%2$d…</string>

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -61,6 +61,8 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.domain.error.classifyHfrError
@@ -158,12 +160,23 @@ fun FlagsRoute(
         onFallback = { viewModel.selectTab(FlagTab.Cyan) },
     )
 
-    // #378 — auto-refresh on landing. LaunchedEffect(Unit) re-fires every time this screen
-    // (re)enters the composition: app open, back from a topic, return from another bottom tab —
-    // exactly the two requested triggers plus the tab round-trip that motivated #384. The
-    // ViewModel gates it (preference opt-out, auth, real tab, in-flight refresh, 15 s throttle)
-    // and reuses the pull-to-refresh indicator as the visual cue.
-    LaunchedEffect(Unit) {
+    // #378 — auto-refresh on landing. Keyed on [selectedTab] (not Unit) so it re-fires both when
+    // this screen (re)enters the composition — app open, back from a topic, return from another
+    // bottom tab — AND when the user switches flag tab WITHOUT leaving the screen (#501: a tab
+    // change kept FlagsRoute composed, so a Unit key never re-fired and the new tab showed stale
+    // data). The ViewModel snapshots the tab at call time and gates the call (preference opt-out,
+    // auth, real tab, in-flight refresh, 15 s throttle), so a rapid tab burst is absorbed by the
+    // throttle and reuses the pull-to-refresh indicator as the visual cue.
+    LaunchedEffect(selectedTab) {
+        viewModel.maybeAutoRefresh()
+    }
+
+    // #501 — also refresh when the app returns to the foreground. A warm resume (home → reopen
+    // without process death) does NOT leave/re-enter the composition, so the LaunchedEffect above
+    // never re-fired on relaunch. ON_RESUME covers exactly that case; the ViewModel's throttle and
+    // in-flight guard make a resume that lands right after another trigger a no-op (no double
+    // fan-out — the post-suspension recheck in maybeAutoRefresh is concurrency-safe).
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
         viewModel.maybeAutoRefresh()
     }
 

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessagesScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessagesScreen.kt
@@ -62,7 +62,10 @@ fun MessagesScreen(
     // opaque — it never persists this private metadata in the back stack). openAtPage is the
     // conversation's last page read from the inbox (#430, web parity: the inbox "Pages" cell
     // links the last page) — a bare page number is not private metadata.
-    onOpenThread: (threadId: Int, isMultiRecipient: Boolean, openAtPage: Int) -> Unit,
+    // wasUnread is the row's unread state at open-time (#453) : the nav host decrements the unread
+    // badge only for a conversation that was actually unread. Not private metadata persisted in any
+    // route — a transient signal consumed by the ephemeral nav state.
+    onOpenThread: (threadId: Int, isMultiRecipient: Boolean, openAtPage: Int, wasUnread: Boolean) -> Unit,
     readThreadIds: Set<Int> = emptySet(),
     topBarActions: @Composable (() -> Unit)? = null,
     // #301 follow-up — opens the new-conversation composer. Null hides the button.
@@ -184,6 +187,9 @@ fun MessagesScreen(
                                 conversation.threadId,
                                 conversation.isMultiRecipient,
                                 conversation.lastPage,
+                                // effectiveConversation already folds the local read override, so a
+                                // re-opened (now read) row correctly reports wasUnread = false (#453).
+                                conversation.hasUnread,
                             )
                         },
                     )

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -11,6 +11,9 @@ dependencies {
     implementation(project(":core:domain"))
     implementation(project(":core:ui"))
 
+    // #494 — BackHandler intercepts system/gesture back to close the settings search instead of
+    // popping the whole route (nav3 otherwise pops it).
+    implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.runtime.compose)

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsAccountAboutScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsAccountAboutScreen.kt
@@ -1,0 +1,91 @@
+package fr.forumhfr.redface2.feature.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsListItem
+import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsSection
+
+/**
+ * #494 — « Compte HFR et à propos » sub-page. Shows the HFR-account note, the planned (disabled)
+ * profile prefs, the app version, and rows to Diagnostics and the report-content flow. There is NO
+ * local login/logout: account actions stay in the global account menu surfaced via [topBarActions].
+ *
+ * The app version is passed in ([versionName] / [versionCode]) rather than read from `BuildConfig`,
+ * because `:feature:settings` does not own the app `BuildConfig` (it is `:app`'s) — the same approach
+ * as `RedfaceAccountMenu`, wired from `RedfaceNavigation`.
+ *
+ * This screen is stateless (no `SettingsViewModel`): nothing here reads or mutates a preference.
+ */
+@Composable
+@Suppress("LongParameterList") // state-hoisted Composable: each nav/version param has a distinct call-site.
+fun SettingsAccountAboutScreen(
+    onBack: () -> Unit,
+    versionName: String,
+    versionCode: Int,
+    onOpenDiagnostics: () -> Unit,
+    onReportContent: () -> Unit,
+    modifier: Modifier = Modifier,
+    topBarActions: @Composable (() -> Unit)? = null,
+) {
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            SettingsSubPageTopBar(
+                title = stringResource(R.string.settings_account_title),
+                onBack = onBack,
+                topBarActions = topBarActions,
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            RedfaceSettingsSection(stringResource(R.string.settings_section_hfr_account))
+            Text(
+                text = stringResource(R.string.settings_hfr_account_note),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+            )
+            // #311 — planned HFR-profile prefs, shown disabled (still searchable via the root catalogue).
+            RedfaceSettingsListItem(
+                title = stringResource(R.string.settings_future_hfr_profile),
+                enabled = false,
+            )
+
+            HorizontalDivider()
+            RedfaceSettingsSection(stringResource(R.string.settings_about_version))
+            Text(
+                text = stringResource(R.string.settings_about_version_value, versionName, versionCode),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+            )
+            RedfaceSettingsListItem(
+                title = stringResource(R.string.settings_about_diagnostics),
+                description = stringResource(R.string.settings_about_diagnostics_description),
+                onClick = onOpenDiagnostics,
+                trailingContent = { ChevronTrailing() },
+            )
+            RedfaceSettingsListItem(
+                title = stringResource(R.string.settings_about_report),
+                onClick = onReportContent,
+                trailingContent = { ChevronTrailing() },
+            )
+        }
+    }
+}

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsCategories.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsCategories.kt
@@ -7,7 +7,7 @@ import fr.forumhfr.redface2.core.ui.settings.shell.SettingsCategoryUi
 import fr.forumhfr.redface2.core.ui.R as CoreUiR
 
 /**
- * #494 v2 — modèle de la racine « catégories d'abord » : 10 catégories regroupées en 5 familles.
+ * #494 v2 — modèle de la racine « catégories d'abord » : 12 catégories regroupées en 5 familles.
  * Les titres de catégorie réutilisent les titres de section existants ; sous-titres et familles sont
  * propres à la racine v2. Le routage (catégorie → sous-page dédiée ou détail générique) et le mapping
  * catégorie → section(s) du catalogue vivent ici pour rester testables et hors du composant racine.
@@ -84,14 +84,26 @@ internal fun rememberSettingsCategoryGroups(): List<SettingsCategoryGroup> = lis
             ),
         ),
     ),
+    // #494 — « À venir » éclatée en 3 vraies catégories (décision produit XaTriX 2026-06-15) : chacune
+    // pointe sur sa propre section future du catalogue (cf. [sectionIdsForCategory]).
     SettingsCategoryGroup(
-        id = "other",
-        title = stringResource(R.string.settings_family_other),
+        id = "upcoming",
+        title = stringResource(R.string.settings_family_upcoming),
         categories = listOf(
             category(
-                "upcoming", R.string.settings_category_upcoming_title,
-                R.string.settings_category_subtitle_upcoming,
+                "notifications", R.string.settings_section_notifications,
+                R.string.settings_category_subtitle_notifications,
                 CoreUiR.drawable.ic_ms_upcoming,
+            ),
+            category(
+                "accessibility", R.string.settings_section_accessibility,
+                R.string.settings_category_subtitle_accessibility,
+                CoreUiR.drawable.ic_ms_settings,
+            ),
+            category(
+                "extensions", R.string.settings_section_extensions,
+                R.string.settings_category_subtitle_extensions,
+                CoreUiR.drawable.ic_ms_article,
             ),
         ),
     ),
@@ -125,11 +137,12 @@ internal fun routeSettingsCategory(
     }
 }
 
-/** Les sections du catalogue rendues par le détail générique d'une catégorie. */
-internal fun sectionIdsForCategory(categoryId: String): List<String> = when (categoryId) {
-    "upcoming" -> listOf("notifications", "accessibility", "extensions")
-    else -> listOf(categoryId)
-}
+/**
+ * Les sections du catalogue rendues par le détail générique d'une catégorie. Chaque catégorie (y compris
+ * les 3 catégories « à venir » Notifications/Accessibilité/Extensions, désormais distinctes) pointe sur
+ * la section homonyme du catalogue ; l'identité id-catégorie == id-section suffit.
+ */
+internal fun sectionIdsForCategory(categoryId: String): List<String> = listOf(categoryId)
 
 /** Titre du détail générique d'une catégorie (réutilise les titres de section quand ils existent). */
 internal fun categoryTitleRes(categoryId: String): Int = when (categoryId) {
@@ -139,6 +152,8 @@ internal fun categoryTitleRes(categoryId: String): Int = when (categoryId) {
     "topic" -> R.string.settings_section_topic
     "editing" -> R.string.settings_section_editing
     "mp" -> R.string.settings_section_mp
-    "upcoming" -> R.string.settings_category_upcoming_title
+    "notifications" -> R.string.settings_section_notifications
+    "accessibility" -> R.string.settings_section_accessibility
+    "extensions" -> R.string.settings_section_extensions
     else -> R.string.settings_title
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsCategories.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsCategories.kt
@@ -1,0 +1,144 @@
+package fr.forumhfr.redface2.feature.settings
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import fr.forumhfr.redface2.core.ui.settings.shell.SettingsCategoryGroup
+import fr.forumhfr.redface2.core.ui.settings.shell.SettingsCategoryUi
+import fr.forumhfr.redface2.core.ui.R as CoreUiR
+
+/**
+ * #494 v2 — modèle de la racine « catégories d'abord » : 10 catégories regroupées en 5 familles.
+ * Les titres de catégorie réutilisent les titres de section existants ; sous-titres et familles sont
+ * propres à la racine v2. Le routage (catégorie → sous-page dédiée ou détail générique) et le mapping
+ * catégorie → section(s) du catalogue vivent ici pour rester testables et hors du composant racine.
+ */
+
+@Composable
+internal fun rememberSettingsCategoryGroups(): List<SettingsCategoryGroup> = listOf(
+    SettingsCategoryGroup(
+        id = "appearance",
+        title = stringResource(R.string.settings_family_appearance),
+        categories = listOf(
+            category(
+                "display", R.string.settings_section_display,
+                R.string.settings_category_subtitle_display,
+                CoreUiR.drawable.ic_ms_display_settings,
+            ),
+            category(
+                "flags", R.string.settings_section_flags,
+                R.string.settings_category_subtitle_flags,
+                CoreUiR.drawable.ic_ms_flag,
+            ),
+            category(
+                "topic", R.string.settings_section_topic,
+                R.string.settings_category_subtitle_topic,
+                CoreUiR.drawable.ic_ms_article,
+            ),
+        ),
+    ),
+    SettingsCategoryGroup(
+        id = "communication",
+        title = stringResource(R.string.settings_family_communication),
+        categories = listOf(
+            category(
+                "mp", R.string.settings_section_mp,
+                R.string.settings_category_subtitle_mp,
+                CoreUiR.drawable.ic_ms_mail,
+            ),
+            category(
+                "editing", R.string.settings_section_editing,
+                R.string.settings_category_subtitle_editing,
+                CoreUiR.drawable.ic_ms_edit_square,
+            ),
+        ),
+    ),
+    SettingsCategoryGroup(
+        id = "content",
+        title = stringResource(R.string.settings_family_content),
+        categories = listOf(
+            category(
+                "images", R.string.settings_section_images,
+                R.string.settings_category_subtitle_images,
+                CoreUiR.drawable.ic_ms_add_photo_alternate,
+            ),
+            category(
+                "start", R.string.settings_section_start,
+                R.string.settings_category_subtitle_start,
+                CoreUiR.drawable.ic_ms_rocket_launch,
+            ),
+        ),
+    ),
+    SettingsCategoryGroup(
+        id = "system",
+        title = stringResource(R.string.settings_family_system),
+        categories = listOf(
+            category(
+                "network", R.string.settings_section_network,
+                R.string.settings_category_subtitle_network,
+                CoreUiR.drawable.ic_ms_cached,
+            ),
+            category(
+                "account", R.string.settings_section_hfr_account,
+                R.string.settings_category_subtitle_account,
+                CoreUiR.drawable.ic_ms_account_circle,
+            ),
+        ),
+    ),
+    SettingsCategoryGroup(
+        id = "other",
+        title = stringResource(R.string.settings_family_other),
+        categories = listOf(
+            category(
+                "upcoming", R.string.settings_category_upcoming_title,
+                R.string.settings_category_subtitle_upcoming,
+                CoreUiR.drawable.ic_ms_upcoming,
+            ),
+        ),
+    ),
+)
+
+@Composable
+private fun category(id: String, titleRes: Int, subtitleRes: Int, iconRes: Int): SettingsCategoryUi =
+    SettingsCategoryUi(
+        id = id,
+        title = stringResource(titleRes),
+        subtitle = stringResource(subtitleRes),
+        iconRes = iconRes,
+    )
+
+/**
+ * Routage d'un tap sur une catégorie de la racine : les catégories adossées à une sous-page dédiée
+ * existante y mènent directement (pas de double saut) ; les autres ouvrent un détail générique.
+ */
+internal fun routeSettingsCategory(
+    id: String,
+    onOpenDisplay: () -> Unit,
+    onOpenImages: () -> Unit,
+    onOpenAccountAbout: () -> Unit,
+    onOpenCategory: (String) -> Unit,
+) {
+    when (id) {
+        "display" -> onOpenDisplay()
+        "images" -> onOpenImages()
+        "account" -> onOpenAccountAbout()
+        else -> onOpenCategory(id)
+    }
+}
+
+/** Les sections du catalogue rendues par le détail générique d'une catégorie. */
+internal fun sectionIdsForCategory(categoryId: String): List<String> = when (categoryId) {
+    "upcoming" -> listOf("notifications", "accessibility", "extensions")
+    else -> listOf(categoryId)
+}
+
+/** Titre du détail générique d'une catégorie (réutilise les titres de section quand ils existent). */
+internal fun categoryTitleRes(categoryId: String): Int = when (categoryId) {
+    "network" -> R.string.settings_section_network
+    "start" -> R.string.settings_section_start
+    "flags" -> R.string.settings_section_flags
+    "topic" -> R.string.settings_section_topic
+    "editing" -> R.string.settings_section_editing
+    "mp" -> R.string.settings_section_mp
+    "upcoming" -> R.string.settings_category_upcoming_title
+    else -> R.string.settings_title
+}

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsCategoryDetailScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsCategoryDetailScreen.kt
@@ -1,0 +1,80 @@
+package fr.forumhfr.redface2.feature.settings
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsSection
+
+/**
+ * #494 v2 — détail générique d'une catégorie de la racine « catégories d'abord ». Rend la/les
+ * section(s) du catalogue associée(s) à [categoryId] (cf. [sectionIdsForCategory]) en réutilisant
+ * [buildSettingsCatalogue] : mêmes renderers et même câblage MVI que la recherche. Scaffold à barre
+ * simple avec retour. Les catégories adossées à une sous-page dédiée (Affichage, Images, Compte) ne
+ * passent PAS par ici — elles ouvrent directement leur écran (cf. [routeSettingsCategory]).
+ */
+@Composable
+@Suppress("LongParameterList") // détail : id + back + 5 nav-rows de sous-pages + 2 VMs + slots.
+fun SettingsCategoryDetailScreen(
+    categoryId: String,
+    onBack: () -> Unit,
+    onOpenProxy: () -> Unit,
+    onOpenMaintenance: () -> Unit,
+    onOpenDisplay: () -> Unit,
+    onOpenImages: () -> Unit,
+    onOpenAccountAbout: () -> Unit,
+    modifier: Modifier = Modifier,
+    topBarActions: @Composable (() -> Unit)? = null,
+    viewModel: SettingsViewModel = hiltViewModel(),
+    startScreenViewModel: StartScreenSettingsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val startScreenState by startScreenViewModel.state.collectAsStateWithLifecycle()
+    val sections = buildSettingsCatalogue(
+        state = state,
+        onIntent = viewModel::submit,
+        startScreenState = startScreenState,
+        onStartScreenIntent = startScreenViewModel::submit,
+        onOpenProxy = onOpenProxy,
+        onOpenMaintenance = onOpenMaintenance,
+        onOpenDisplay = onOpenDisplay,
+        onOpenImages = onOpenImages,
+        onOpenAccountAbout = onOpenAccountAbout,
+    )
+    val wanted = sectionIdsForCategory(categoryId)
+    val shown = sections.filter { it.id in wanted }
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            SettingsSubPageTopBar(
+                title = stringResource(categoryTitleRes(categoryId)),
+                onBack = onBack,
+                topBarActions = topBarActions,
+            )
+        },
+    ) { innerPadding ->
+        LazyColumn(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+            shown.forEachIndexed { index, section ->
+                // En-tête de section seulement quand plusieurs sections cohabitent (catégorie « À venir »).
+                if (shown.size > 1) {
+                    item(key = "section:${section.id}") {
+                        if (index > 0) HorizontalDivider()
+                        RedfaceSettingsSection(section.title)
+                    }
+                }
+                items(section.items, key = { "item:${it.searchable.id}" }) { row ->
+                    row.render()
+                }
+            }
+        }
+    }
+}

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsDisplayScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsDisplayScreen.kt
@@ -1,0 +1,182 @@
+package fr.forumhfr.redface2.feature.settings
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
+import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
+import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
+import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsChoice
+import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsChoiceGroup
+
+/**
+ * #494 — « Affichage » sub-page. Extracts the theme (#286: 3-way Clair / Système / Sombre + AMOLED,
+ * only meaningful when the effective theme is dark) and the reading presets (#287: density + font
+ * scale) from the former root catalogue, using the shared [RedfaceSettingsChoiceGroup]. Binds its
+ * own [SettingsViewModel] instance (DataStore source of truth — same trade-off as `SettingsProxyScreen`).
+ */
+@Composable
+fun SettingsDisplayScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    topBarActions: @Composable (() -> Unit)? = null,
+    viewModel: SettingsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    // The AMOLED toggle is only meaningful when the app will actually render dark — forced DARK, or
+    // SYSTEM while the OS is in dark mode. Computed here so the switch is disabled otherwise.
+    val effectiveDark = when (state.themeMode) {
+        ThemeMode.LIGHT -> false
+        ThemeMode.DARK -> true
+        ThemeMode.SYSTEM -> isSystemInDarkTheme()
+    }
+    val themeOptions = listOf(
+        RedfaceSettingsChoice(ThemeMode.LIGHT, stringResource(R.string.settings_theme_light)),
+        RedfaceSettingsChoice(ThemeMode.SYSTEM, stringResource(R.string.settings_theme_system)),
+        RedfaceSettingsChoice(ThemeMode.DARK, stringResource(R.string.settings_theme_dark)),
+    )
+    val densityOptions = listOf(
+        RedfaceSettingsChoice(DisplayDensity.COMFORT, stringResource(R.string.settings_display_density_comfort)),
+        RedfaceSettingsChoice(DisplayDensity.COMPACT, stringResource(R.string.settings_display_density_compact)),
+    )
+    val fontScaleOptions = listOf(
+        RedfaceSettingsChoice(FontScalePreference.S, stringResource(R.string.settings_display_font_scale_small)),
+        RedfaceSettingsChoice(FontScalePreference.M, stringResource(R.string.settings_display_font_scale_medium)),
+        RedfaceSettingsChoice(FontScalePreference.L, stringResource(R.string.settings_display_font_scale_large)),
+    )
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            SettingsSubPageTopBar(
+                title = stringResource(R.string.settings_nav_display),
+                onBack = onBack,
+                topBarActions = topBarActions,
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            // Theme (#286).
+            Text(
+                text = stringResource(R.string.settings_theme_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = stringResource(R.string.settings_theme_intro),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            RedfaceSettingsChoiceGroup(
+                options = themeOptions,
+                selected = state.themeMode,
+                onSelected = { viewModel.submit(SettingsIntent.ThemeModeChanged(it)) },
+                enabled = state.canChangeThemeMode,
+            )
+            if (state.themeModeError) {
+                PreferencePersistError(R.string.settings_theme_persist_failed)
+            }
+            DisplayToggleRow(
+                title = stringResource(R.string.settings_theme_amoled_title),
+                description = stringResource(R.string.settings_theme_amoled_description),
+                checked = state.amoledEnabled,
+                enabled = state.canToggleAmoled && effectiveDark,
+                onCheckedChange = { viewModel.submit(SettingsIntent.AmoledEnabledChanged(it)) },
+            )
+            if (state.amoledError) {
+                PreferencePersistError(R.string.settings_theme_amoled_persist_failed)
+            }
+
+            // Reading presets (#287).
+            Text(
+                text = stringResource(R.string.settings_display_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = stringResource(R.string.settings_display_density_intro),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            RedfaceSettingsChoiceGroup(
+                options = densityOptions,
+                selected = state.displayDensity,
+                onSelected = { viewModel.submit(SettingsIntent.DisplayDensityChanged(it)) },
+                enabled = state.canChangeDisplayDensity,
+            )
+            if (state.displayDensityError) {
+                PreferencePersistError(R.string.settings_display_density_persist_failed)
+            }
+            Text(
+                text = stringResource(R.string.settings_display_font_scale_intro),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            RedfaceSettingsChoiceGroup(
+                options = fontScaleOptions,
+                selected = state.fontScale,
+                onSelected = { viewModel.submit(SettingsIntent.FontScaleChanged(it)) },
+                enabled = state.canChangeFontScale,
+            )
+            if (state.fontScaleError) {
+                PreferencePersistError(R.string.settings_display_font_scale_persist_failed)
+            }
+        }
+    }
+}
+
+@Composable
+private fun DisplayToggleRow(
+    title: String,
+    description: String,
+    checked: Boolean,
+    enabled: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Switch(checked = checked, enabled = enabled, onCheckedChange = onCheckedChange)
+    }
+}

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsImagesScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsImagesScreen.kt
@@ -1,0 +1,136 @@
+package fr.forumhfr.redface2.feature.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
+import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
+import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsChoice
+import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsChoiceGroup
+import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsListItem
+
+/**
+ * #494 — « Images » sub-page. Extracts the upload provider selector (#459, with the imgur Client-ID
+ * field surfaced only for imgur), the image-insert mode and a navigation row to the « Mes images
+ * uploadées » screen. Binds its own [SettingsViewModel] instance (DataStore source of truth — same
+ * trade-off as `SettingsProxyScreen`).
+ */
+@Composable
+fun SettingsImagesScreen(
+    onBack: () -> Unit,
+    onOpenMyImages: () -> Unit,
+    modifier: Modifier = Modifier,
+    topBarActions: @Composable (() -> Unit)? = null,
+    viewModel: SettingsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val providerOptions = listOf(
+        RedfaceSettingsChoice(UploadProviderId.DIBERIE, stringResource(R.string.settings_upload_provider_diberie)),
+        RedfaceSettingsChoice(UploadProviderId.IMGUR, stringResource(R.string.settings_upload_provider_imgur)),
+    )
+    val imageInsertOptions = listOf(
+        RedfaceSettingsChoice(EditorImageInsert.FULL, stringResource(R.string.settings_image_insert_full)),
+        RedfaceSettingsChoice(EditorImageInsert.LINKED, stringResource(R.string.settings_image_insert_linked)),
+        RedfaceSettingsChoice(EditorImageInsert.REDUCED, stringResource(R.string.settings_image_insert_reduced)),
+    )
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            SettingsSubPageTopBar(
+                title = stringResource(R.string.settings_section_images),
+                onBack = onBack,
+                topBarActions = topBarActions,
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_upload_provider_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = stringResource(R.string.settings_upload_provider_intro),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            RedfaceSettingsChoiceGroup(
+                options = providerOptions,
+                selected = state.uploadProvider,
+                onSelected = { viewModel.submit(SettingsIntent.SetUploadProvider(it)) },
+                enabled = state.canChangeUploadProvider,
+            )
+            if (state.uploadProviderError) {
+                PreferencePersistError(R.string.settings_upload_provider_persist_failed)
+            }
+            // The Client-ID field is only meaningful for imgur (diberie needs no credentials).
+            if (state.uploadProvider == UploadProviderId.IMGUR) {
+                OutlinedTextField(
+                    value = state.imgurClientId,
+                    onValueChange = { viewModel.submit(SettingsIntent.SetImgurClientId(it)) },
+                    singleLine = true,
+                    label = { Text(stringResource(R.string.settings_upload_imgur_client_id_label)) },
+                    supportingText = {
+                        Text(stringResource(R.string.settings_upload_imgur_client_id_helper))
+                    },
+                    isError = state.imgurClientIdError,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                if (state.imgurClientIdError) {
+                    PreferencePersistError(R.string.settings_upload_imgur_client_id_persist_failed)
+                }
+            }
+            // #459 PR-images follow-up — how the editor wraps an inserted image.
+            Text(
+                text = stringResource(R.string.settings_image_insert_title),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = stringResource(R.string.settings_image_insert_intro),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            RedfaceSettingsChoiceGroup(
+                options = imageInsertOptions,
+                selected = state.editorImageInsert,
+                onSelected = { viewModel.submit(SettingsIntent.SetEditorImageInsert(it)) },
+                enabled = !state.isUpdatingEditorImageInsert,
+            )
+            if (state.editorImageInsertError) {
+                PreferencePersistError(R.string.settings_image_insert_persist_failed)
+            }
+
+            HorizontalDivider()
+            RedfaceSettingsListItem(
+                title = stringResource(R.string.settings_my_images_title),
+                description = stringResource(R.string.settings_my_images_description),
+                onClick = onOpenMyImages,
+                trailingContent = { ChevronTrailing() },
+            )
+        }
+    }
+}

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsMaintenanceScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsMaintenanceScreen.kt
@@ -1,0 +1,258 @@
+package fr.forumhfr.redface2.feature.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsListItem
+
+/**
+ * #494 — « Maintenance » sub-page. Extracts the cache actions (topics + #314 images), the
+ * « Ignorer le cache topic » toggle and the two confirm dialogs from the former root catalogue, and
+ * adds navigation rows to Diagnostics and (gated on [SettingsState.showDtSection]) the MPStorage
+ * inspector. Binds its own [SettingsViewModel] instance (DataStore is the source of truth — same
+ * trade-off documented on `SettingsProxyScreen`).
+ */
+@Composable
+@Suppress("LongParameterList") // state-hoisted Composable: each nav callback has a distinct call-site.
+fun SettingsMaintenanceScreen(
+    onBack: () -> Unit,
+    onOpenDiagnostics: () -> Unit,
+    onOpenMpStorageInspector: () -> Unit,
+    modifier: Modifier = Modifier,
+    topBarActions: @Composable (() -> Unit)? = null,
+    viewModel: SettingsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            SettingsSubPageTopBar(
+                title = stringResource(R.string.settings_maintenance_title),
+                onBack = onBack,
+                topBarActions = topBarActions,
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_clear_topic_cache_intro),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (state.isClearingTopicCache) {
+                MaintenanceProgress(R.string.settings_clear_topic_cache_in_progress)
+            }
+            when (state.topicCacheClearResult) {
+                TopicCacheClearResult.Success -> MaintenanceResult(
+                    messageRes = R.string.settings_clear_topic_cache_success,
+                    isError = false,
+                )
+                TopicCacheClearResult.Failure -> MaintenanceResult(
+                    messageRes = R.string.settings_clear_topic_cache_failure,
+                    isError = true,
+                )
+                null -> Unit
+            }
+            OutlinedButton(
+                enabled = state.canClearTopicCache,
+                onClick = { viewModel.submit(SettingsIntent.ClearTopicCacheClicked) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.settings_clear_topic_cache_button))
+            }
+
+            // #314 — « Vider le cache des images », same confirm → progress → inline-result flow.
+            Text(
+                text = stringResource(R.string.settings_clear_image_cache_intro),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (state.isClearingImageCache) {
+                MaintenanceProgress(R.string.settings_clear_image_cache_in_progress)
+            }
+            when (state.imageCacheClearResult) {
+                ImageCacheClearResult.Success -> MaintenanceResult(
+                    messageRes = R.string.settings_clear_image_cache_success,
+                    isError = false,
+                )
+                ImageCacheClearResult.Failure -> MaintenanceResult(
+                    messageRes = R.string.settings_clear_image_cache_failure,
+                    isError = true,
+                )
+                null -> Unit
+            }
+            OutlinedButton(
+                enabled = state.canClearImageCache,
+                onClick = { viewModel.submit(SettingsIntent.ClearImageCacheClicked) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.settings_clear_image_cache_button))
+            }
+
+            IgnoreTopicCacheRow(state = state, onIntent = viewModel::submit)
+
+            HorizontalDivider()
+            RedfaceSettingsListItem(
+                title = stringResource(R.string.settings_about_diagnostics),
+                description = stringResource(R.string.settings_about_diagnostics_description),
+                onClick = onOpenDiagnostics,
+                trailingContent = { ChevronTrailing() },
+            )
+            // #6 — read-only MPStorage inspector (debug). Gated on the DT section toggle.
+            if (state.showDtSection) {
+                RedfaceSettingsListItem(
+                    title = stringResource(R.string.settings_mpstorage_inspector_title),
+                    description = stringResource(R.string.settings_mpstorage_inspector_description),
+                    onClick = onOpenMpStorageInspector,
+                    trailingContent = { ChevronTrailing() },
+                )
+            }
+        }
+    }
+
+    if (state.showClearTopicCacheConfirm) {
+        MaintenanceConfirmDialog(
+            titleRes = R.string.settings_clear_topic_cache_confirm_title,
+            bodyRes = R.string.settings_clear_topic_cache_confirm_body,
+            actionRes = R.string.settings_clear_topic_cache_confirm_action,
+            cancelRes = R.string.settings_clear_topic_cache_confirm_cancel,
+            onConfirm = { viewModel.submit(SettingsIntent.ClearTopicCacheConfirmed) },
+            onDismiss = { viewModel.submit(SettingsIntent.ClearTopicCacheDismissed) },
+        )
+    }
+    if (state.showClearImageCacheConfirm) {
+        MaintenanceConfirmDialog(
+            titleRes = R.string.settings_clear_image_cache_confirm_title,
+            bodyRes = R.string.settings_clear_image_cache_confirm_body,
+            actionRes = R.string.settings_clear_image_cache_confirm_action,
+            cancelRes = R.string.settings_clear_image_cache_confirm_cancel,
+            onConfirm = { viewModel.submit(SettingsIntent.ClearImageCacheConfirmed) },
+            onDismiss = { viewModel.submit(SettingsIntent.ClearImageCacheDismissed) },
+        )
+    }
+}
+
+@Composable
+private fun MaintenanceProgress(messageRes: Int) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+        Text(
+            text = stringResource(messageRes),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun MaintenanceResult(messageRes: Int, isError: Boolean) {
+    Text(
+        text = stringResource(messageRes),
+        style = MaterialTheme.typography.bodyMedium,
+        color = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
+    )
+}
+
+@Composable
+private fun IgnoreTopicCacheRow(
+    state: SettingsState,
+    onIntent: (SettingsIntent) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_ignore_topic_cache_title),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = stringResource(R.string.settings_ignore_topic_cache_description),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Switch(
+            checked = state.ignoreTopicCache,
+            enabled = state.canToggleIgnoreTopicCache,
+            onCheckedChange = { onIntent(SettingsIntent.IgnoreTopicCacheChanged(it)) },
+        )
+    }
+    if (state.ignoreTopicCacheError) {
+        PreferencePersistError(R.string.settings_ignore_topic_cache_persist_failed)
+    }
+}
+
+@Composable
+@Suppress("LongParameterList") // generic confirm dialog: 4 string-res + 2 callbacks, all distinct.
+private fun MaintenanceConfirmDialog(
+    titleRes: Int,
+    bodyRes: Int,
+    actionRes: Int,
+    cancelRes: Int,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(titleRes)) },
+        text = { Text(stringResource(bodyRes)) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) { Text(stringResource(actionRes)) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(cancelRes)) }
+        },
+    )
+}
+
+/** Shared chevron trailing glyph for navigation rows (local drawable, material-icons forbidden). */
+@Composable
+internal fun ChevronTrailing() {
+    Icon(
+        painter = painterResource(fr.forumhfr.redface2.core.ui.R.drawable.ic_chevron_right),
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsProxyScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsProxyScreen.kt
@@ -1,0 +1,166 @@
+package fr.forumhfr.redface2.feature.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+/**
+ * #494 — « Proxy » sub-page. Extracts the proxy form verbatim from the former root catalogue (same
+ * intents, same errors, same Save gate). Each settings sub-page binds its own [SettingsViewModel]
+ * instance (a distinct nav entry = a distinct `ViewModelStore`), which is sound because DataStore is
+ * the single source of truth and every screen rehydrates from its `Flow` (same trade-off documented
+ * on `ProfileFullRoute`). This is the only settings screen with focusable text fields, so it KEEPS
+ * the sophisticated keyboard inset (ime ∪ navigationBars) that #624 relies on.
+ */
+@Composable
+fun SettingsProxyScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    topBarActions: @Composable (() -> Unit)? = null,
+    viewModel: SettingsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            SettingsSubPageTopBar(
+                title = stringResource(R.string.settings_proxy_title),
+                onBack = onBack,
+                topBarActions = topBarActions,
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                // Applied so the keyboard inset shrinks the scroll viewport: a focused proxy field
+                // then stays above the IME (cf. #624). union() keeps navBar clearance when closed.
+                .windowInsetsPadding(
+                    WindowInsets.navigationBars
+                        .union(WindowInsets.ime)
+                        .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom),
+                )
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_proxy_intro),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(R.string.settings_proxy_enabled),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Switch(
+                    checked = state.proxyEnabled,
+                    onCheckedChange = { viewModel.submit(SettingsIntent.ProxyEnabledChanged(it)) },
+                )
+            }
+            OutlinedTextField(
+                value = state.proxyHost,
+                onValueChange = { viewModel.submit(SettingsIntent.ProxyHostChanged(it)) },
+                enabled = state.proxyEnabled,
+                singleLine = true,
+                label = { Text(stringResource(R.string.settings_proxy_host)) },
+                modifier = Modifier.fillMaxWidth(),
+            )
+            OutlinedTextField(
+                value = state.proxyPort,
+                onValueChange = { viewModel.submit(SettingsIntent.ProxyPortChanged(it)) },
+                enabled = state.proxyEnabled,
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                label = { Text(stringResource(R.string.settings_proxy_port)) },
+                modifier = Modifier.fillMaxWidth(),
+            )
+            OutlinedTextField(
+                value = state.proxyUsername,
+                onValueChange = { viewModel.submit(SettingsIntent.ProxyUsernameChanged(it)) },
+                enabled = state.proxyEnabled,
+                singleLine = true,
+                label = { Text(stringResource(R.string.settings_proxy_username)) },
+                modifier = Modifier.fillMaxWidth(),
+            )
+            OutlinedTextField(
+                value = state.proxyPassword,
+                onValueChange = { viewModel.submit(SettingsIntent.ProxyPasswordChanged(it)) },
+                enabled = state.proxyEnabled,
+                singleLine = true,
+                visualTransformation = PasswordVisualTransformation(),
+                label = { Text(stringResource(R.string.settings_proxy_password)) },
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Text(
+                text = stringResource(R.string.settings_proxy_scope),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (state.error == SettingsError.InvalidProxy) {
+                Text(
+                    text = stringResource(R.string.settings_proxy_invalid),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+            if (state.error == SettingsError.PersistFailed) {
+                Text(
+                    text = stringResource(R.string.settings_proxy_persist_failed),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+            if (state.saved) {
+                Text(
+                    text = stringResource(R.string.settings_proxy_saved),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+            Button(
+                enabled = state.canSave,
+                onClick = { viewModel.submit(SettingsIntent.SaveProxyClicked) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.settings_proxy_save))
+            }
+        }
+    }
+}

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScaffolds.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScaffolds.kt
@@ -1,0 +1,70 @@
+package fr.forumhfr.redface2.feature.settings
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsSearchTopBarLabels
+
+/**
+ * #494 — resolves the localized labels for the settings shell search top bar from feature strings,
+ * keeping `:core:ui` free of settings-specific resources.
+ */
+@Composable
+internal fun rememberSettingsSearchTopBarLabels(): RedfaceSettingsSearchTopBarLabels =
+    RedfaceSettingsSearchTopBarLabels(
+        title = stringResource(R.string.settings_title),
+        searchPlaceholder = stringResource(R.string.settings_search_placeholder),
+        backContentDescription = stringResource(R.string.settings_back),
+        openSearchContentDescription = stringResource(R.string.settings_search_open),
+        closeSearchContentDescription = stringResource(R.string.settings_search_close),
+        clearSearchContentDescription = stringResource(R.string.settings_search_clear),
+    )
+
+/**
+ * #494 — plain Material 3 [TopAppBar] for the settings sub-pages (no search). A back navigation icon
+ * (local `ic_arrow_back` rendered with material3 [Icon] — material-icons are forbidden), the page
+ * [title], and the optional [topBarActions] slot (the global account menu, wired from navigation).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun SettingsSubPageTopBar(
+    title: String,
+    onBack: () -> Unit,
+    topBarActions: @Composable (() -> Unit)? = null,
+) {
+    val backLabel = stringResource(R.string.settings_back)
+    TopAppBar(
+        title = { Text(title) },
+        navigationIcon = {
+            IconButton(
+                onClick = onBack,
+                modifier = Modifier.semantics { contentDescription = backLabel },
+            ) {
+                Icon(
+                    painter = painterResource(fr.forumhfr.redface2.core.ui.R.drawable.ic_arrow_back),
+                    contentDescription = null,
+                )
+            }
+        },
+        actions = { topBarActions?.invoke() },
+    )
+}
+
+/** Inline persist-failure message for a settings row, shown below the row. */
+@Composable
+internal fun PreferencePersistError(messageRes: Int) {
+    Text(
+        text = stringResource(messageRes),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.error,
+    )
+}

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -8,9 +8,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -296,6 +298,26 @@ internal fun buildSettingsCatalogue(
                 },
                 onClick = onOpenMaintenance,
             ),
+            futureRow(
+                id = "future_prefetch_wifi_only",
+                title = stringResource(R.string.settings_future_prefetch_wifi_only),
+            ),
+            futureRow(
+                id = "future_data_saver",
+                title = stringResource(R.string.settings_future_data_saver),
+            ),
+            futureRow(
+                id = "future_image_cache_size",
+                title = stringResource(R.string.settings_future_image_cache_size),
+            ),
+            futureRow(
+                id = "future_clear_cache_on_start",
+                title = stringResource(R.string.settings_future_clear_cache_on_start),
+            ),
+            futureRow(
+                id = "future_offline_mode",
+                title = stringResource(R.string.settings_future_offline_mode),
+            ),
         ),
     ),
     // Démarrage (rendered inline — category picker, not a sub-page).
@@ -311,6 +333,10 @@ internal fun buildSettingsCatalogue(
                     keywords = listOf("démarrage", "écran", "onglet", "lancement", "catégorie"),
                 ),
                 render = { StartScreenPreferencesCard(state = startScreenState, onIntent = onStartScreenIntent) },
+            ),
+            futureRow(
+                id = "future_resume_last_topic",
+                title = stringResource(R.string.settings_future_resume_last_topic),
             ),
         ),
     ),
@@ -346,6 +372,34 @@ internal fun buildSettingsCatalogue(
                     stringResource(R.string.settings_display_font_scale_large),
                 ),
                 onClick = onOpenDisplay,
+            ),
+            futureRow(
+                id = "future_material_you",
+                title = stringResource(R.string.settings_future_material_you),
+            ),
+            futureRow(
+                id = "future_ui_colors",
+                title = stringResource(R.string.settings_future_ui_colors),
+            ),
+            futureRow(
+                id = "future_classic_theme",
+                title = stringResource(R.string.settings_future_classic_theme),
+            ),
+            futureRow(
+                id = "future_amoled_auto_night",
+                title = stringResource(R.string.settings_future_amoled_auto_night),
+            ),
+            futureRow(
+                id = "future_smiley_size",
+                title = stringResource(R.string.settings_future_smiley_size),
+            ),
+            futureRow(
+                id = "future_show_avatars",
+                title = stringResource(R.string.settings_future_show_avatars),
+            ),
+            futureRow(
+                id = "future_show_signatures",
+                title = stringResource(R.string.settings_future_show_signatures),
             ),
         ),
     ),
@@ -404,6 +458,22 @@ internal fun buildSettingsCatalogue(
                     .takeIf { state.flagsAutoRefreshError },
                 onCheckedChange = { onIntent(SettingsIntent.FlagsAutoRefreshChanged(it)) },
             ),
+            futureRow(
+                id = "future_flags_sort",
+                title = stringResource(R.string.settings_future_flags_sort),
+            ),
+            futureRow(
+                id = "future_flags_on_listing",
+                title = stringResource(R.string.settings_future_flags_on_listing),
+            ),
+            futureRow(
+                id = "future_flags_mark_read_on_scroll",
+                title = stringResource(R.string.settings_future_flags_mark_read_on_scroll),
+            ),
+            futureRow(
+                id = "future_flags_by_subcategory",
+                title = stringResource(R.string.settings_future_flags_by_subcategory),
+            ),
         ),
     ),
     // Sujet et lecture (inline toggles).
@@ -440,6 +510,34 @@ internal fun buildSettingsCatalogue(
                     .takeIf { state.topicPollsExpandedError },
                 onCheckedChange = { onIntent(SettingsIntent.TopicPollsExpandedChanged(it)) },
             ),
+            futureRow(
+                id = "future_restore_read_position",
+                title = stringResource(R.string.settings_future_restore_read_position),
+            ),
+            futureRow(
+                id = "future_swipe_page",
+                title = stringResource(R.string.settings_future_swipe_page),
+            ),
+            futureRow(
+                id = "future_collapse_quotes",
+                title = stringResource(R.string.settings_future_collapse_quotes),
+            ),
+            futureRow(
+                id = "future_prefetch",
+                title = stringResource(R.string.settings_future_prefetch),
+            ),
+            futureRow(
+                id = "future_open_external_in_app",
+                title = stringResource(R.string.settings_future_open_external_in_app),
+            ),
+            futureRow(
+                id = "future_autoplay_animations",
+                title = stringResource(R.string.settings_future_autoplay_animations),
+            ),
+            futureRow(
+                id = "future_fullscreen_reading",
+                title = stringResource(R.string.settings_future_fullscreen_reading),
+            ),
         ),
     ),
     // Édition et publication (inline toggle).
@@ -456,6 +554,26 @@ internal fun buildSettingsCatalogue(
                 errorRes = R.string.settings_confirm_before_posting_persist_failed
                     .takeIf { state.confirmBeforePostingError },
                 onCheckedChange = { onIntent(SettingsIntent.ConfirmBeforePostingChanged(it)) },
+            ),
+            futureRow(
+                id = "future_auto_signature",
+                title = stringResource(R.string.settings_future_auto_signature),
+            ),
+            futureRow(
+                id = "future_auto_drafts",
+                title = stringResource(R.string.settings_future_auto_drafts),
+            ),
+            futureRow(
+                id = "future_recent_smileys",
+                title = stringResource(R.string.settings_future_recent_smileys),
+            ),
+            futureRow(
+                id = "future_spell_check",
+                title = stringResource(R.string.settings_future_spell_check),
+            ),
+            futureRow(
+                id = "future_custom_bbcode_toolbar",
+                title = stringResource(R.string.settings_future_custom_bbcode_toolbar),
             ),
         ),
     ),
@@ -488,6 +606,18 @@ internal fun buildSettingsCatalogue(
                 ),
                 onClick = onOpenImages,
             ),
+            futureRow(
+                id = "future_compress_upload",
+                title = stringResource(R.string.settings_future_compress_upload),
+            ),
+            futureRow(
+                id = "future_strip_exif",
+                title = stringResource(R.string.settings_future_strip_exif),
+            ),
+            futureRow(
+                id = "future_upload_wifi_only",
+                title = stringResource(R.string.settings_future_upload_wifi_only),
+            ),
         ),
     ),
     // Messages privés (inline toggle).
@@ -503,6 +633,18 @@ internal fun buildSettingsCatalogue(
                 enabled = state.canToggleMpUnreadBadge,
                 errorRes = R.string.settings_mp_unread_badge_persist_failed.takeIf { state.mpUnreadBadgeError },
                 onCheckedChange = { onIntent(SettingsIntent.MpUnreadBadgeChanged(it)) },
+            ),
+            futureRow(
+                id = "future_mp_push",
+                title = stringResource(R.string.settings_future_mp_push),
+            ),
+            futureRow(
+                id = "future_mp_preview",
+                title = stringResource(R.string.settings_future_mp_preview),
+            ),
+            futureRow(
+                id = "future_mp_read_receipt",
+                title = stringResource(R.string.settings_future_mp_read_receipt),
             ),
         ),
     ),
@@ -527,42 +669,110 @@ internal fun buildSettingsCatalogue(
                 ),
                 onClick = onOpenAccountAbout,
             ),
+            futureRow(
+                id = "future_hfr_profile_settings",
+                title = stringResource(R.string.settings_future_hfr_profile_settings),
+            ),
+            futureRow(
+                id = "future_multi_account",
+                title = stringResource(R.string.settings_future_multi_account),
+            ),
+            futureRow(
+                id = "future_auto_logout",
+                title = stringResource(R.string.settings_future_auto_logout),
+            ),
         ),
     ),
-    // Notifications (future, disabled — searchable).
+    // Notifications (future category, all rows disabled — searchable). Draft §10.
     SettingsCatalogueSection(
         id = "notifications",
         title = stringResource(R.string.settings_section_notifications),
         items = listOf(
             futureRow(
-                id = "future_notifications",
-                title = stringResource(R.string.settings_future_notifications),
+                id = "future_notif_push",
+                title = stringResource(R.string.settings_future_notif_push),
+            ),
+            futureRow(
+                id = "future_notif_mp",
+                title = stringResource(R.string.settings_future_notif_mp),
+            ),
+            futureRow(
+                id = "future_notif_mentions",
+                title = stringResource(R.string.settings_future_notif_mentions),
+            ),
+            futureRow(
+                id = "future_notif_polling",
+                title = stringResource(R.string.settings_future_notif_polling),
+            ),
+            futureRow(
+                id = "future_notif_dnd",
+                title = stringResource(R.string.settings_future_notif_dnd),
+            ),
+            futureRow(
+                id = "future_notif_sound_vibration",
+                title = stringResource(R.string.settings_future_notif_sound_vibration),
             ),
         ),
     ),
-    // Accessibilité (future, disabled — searchable).
+    // Accessibilité (future category, all rows disabled — searchable). Draft §11.
     SettingsCatalogueSection(
         id = "accessibility",
         title = stringResource(R.string.settings_section_accessibility),
         items = listOf(
             futureRow(
-                id = "future_timezone",
-                title = stringResource(R.string.settings_future_timezone),
+                id = "future_a11y_force_system_text",
+                title = stringResource(R.string.settings_future_a11y_force_system_text),
             ),
             futureRow(
-                id = "future_multilang",
-                title = stringResource(R.string.settings_future_multilang),
+                id = "future_a11y_high_contrast",
+                title = stringResource(R.string.settings_future_a11y_high_contrast),
+            ),
+            futureRow(
+                id = "future_a11y_reduce_motion",
+                title = stringResource(R.string.settings_future_a11y_reduce_motion),
+            ),
+            futureRow(
+                id = "future_a11y_timezone",
+                title = stringResource(R.string.settings_future_a11y_timezone),
+            ),
+            futureRow(
+                id = "future_a11y_language",
+                title = stringResource(R.string.settings_future_a11y_language),
             ),
         ),
     ),
-    // Extensions et filtrage (future, disabled — searchable).
+    // Extensions et filtrage (future category, all rows disabled — searchable). Draft §12.
     SettingsCatalogueSection(
         id = "extensions",
         title = stringResource(R.string.settings_section_extensions),
         items = listOf(
             futureRow(
-                id = "future_extensions",
-                title = stringResource(R.string.settings_future_extensions),
+                id = "future_ext_ignore_list",
+                title = stringResource(R.string.settings_future_ext_ignore_list),
+            ),
+            futureRow(
+                id = "future_ext_keyword_filters",
+                title = stringResource(R.string.settings_future_ext_keyword_filters),
+            ),
+            futureRow(
+                id = "future_ext_blacklist",
+                title = stringResource(R.string.settings_future_ext_blacklist),
+            ),
+            futureRow(
+                id = "future_ext_color_tag",
+                title = stringResource(R.string.settings_future_ext_color_tag),
+            ),
+            futureRow(
+                id = "future_ext_qualitay",
+                title = stringResource(R.string.settings_future_ext_qualitay),
+            ),
+            futureRow(
+                id = "future_ext_redflag",
+                title = stringResource(R.string.settings_future_ext_redflag),
+            ),
+            futureRow(
+                id = "future_ext_community",
+                title = stringResource(R.string.settings_future_ext_community),
             ),
         ),
     ),
@@ -617,13 +827,40 @@ private fun toggleRow(
     },
 )
 
-/** A planned (not-yet-shipped) row: disabled but still searchable (`enabled = false`). */
+/**
+ * A planned (not-yet-shipped) row: disabled but still searchable (`enabled = false`), carrying a small
+ * « À venir » badge in its trailing slot to make the planned status explicit (cf. [FutureBadge]).
+ */
 private fun futureRow(
     id: String,
     title: String,
 ): SettingsCatalogueRow = SettingsCatalogueRow(
     searchable = SettingsSearchableItem(id = id, title = title, enabled = false),
     render = {
-        RedfaceSettingsListItem(title = title, enabled = false)
+        RedfaceSettingsListItem(
+            title = title,
+            enabled = false,
+            trailingContent = { FutureBadge() },
+        )
     },
 )
+
+/**
+ * The « À venir » pill shown in the trailing slot of a [futureRow]: a sober tonal `Surface` (rounded,
+ * `secondaryContainer`) wrapping a `labelSmall` label. Signals the planned status without competing
+ * with the disabled (greyed) row text.
+ */
+@Composable
+private fun FutureBadge() {
+    Surface(
+        shape = RoundedCornerShape(8.dp),
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+    ) {
+        Text(
+            text = stringResource(R.string.settings_future_badge),
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+        )
+    }
+}

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
@@ -25,7 +24,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsListItem
-import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsSection
 import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsSearchTopBar
 import fr.forumhfr.redface2.core.ui.settings.shell.SettingsHomeScreen
 
@@ -182,17 +180,36 @@ internal fun SettingsRoot(
                     .fillMaxSize()
                     .padding(innerPadding),
             ) {
-                filtered.forEachIndexed { sectionIndex, section ->
-                    item(key = "section:${section.id}") {
-                        if (sectionIndex > 0) HorizontalDivider()
-                        RedfaceSettingsSection(section.title)
-                    }
-                    items(section.items, key = { "item:${it.id}" }) { item ->
-                        renderers[item.id]?.invoke()
-                    }
+                // #494 PR3 — résultats À PLAT : chaque résultat porte son origine (catégorie) en fil
+                // d'Ariane, et garde son contrôle éditable inline. Plus de regroupement par en-tête de
+                // section : l'origine vit sur chaque ligne (utile quand des résultats de catégories
+                // différentes se suivent).
+                val results = filtered.flatMap { section -> section.items.map { section.title to it } }
+                items(results, key = { "res:${it.second.id}" }) { (origin, item) ->
+                    SettingsSearchResult(origin = origin, render = renderers[item.id])
                 }
             }
         }
+    }
+}
+
+/**
+ * A flattened search result (#494 PR3) : the row's own editable control kept inline, preceded by a
+ * « fil d'Ariane » naming the [origin] category. Grouping by section header is dropped in search mode
+ * so each result self-describes — useful when results from different categories interleave. [render]
+ * is the catalogue renderer looked up by id; it is never expected to be null (every filtered item has
+ * a renderer), but it stays nullable so a stale id degrades to just the breadcrumb instead of crashing.
+ */
+@Composable
+private fun SettingsSearchResult(origin: String, render: (@Composable () -> Unit)?) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = origin,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 12.dp),
+        )
+        render?.invoke()
     }
 }
 

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -50,7 +50,7 @@ import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsSearchTopBar
 @Composable
 @Suppress("LongParameterList") // state-hoisted Composable: 5 sub-page nav callbacks + back + 2 VMs, each distinct.
 fun SettingsScreen(
-    onBack: () -> Unit,
+    onBack: (() -> Unit)? = null,
     onOpenProxy: () -> Unit,
     onOpenMaintenance: () -> Unit,
     onOpenDisplay: () -> Unit,
@@ -89,7 +89,7 @@ internal fun SettingsCatalogue(
     onIntent: (SettingsIntent) -> Unit,
     startScreenState: StartScreenSettingsState,
     onStartScreenIntent: (StartScreenSettingsIntent) -> Unit,
-    onBack: () -> Unit,
+    onBack: (() -> Unit)? = null,
     onOpenProxy: () -> Unit,
     onOpenMaintenance: () -> Unit,
     onOpenDisplay: () -> Unit,

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsListItem
 import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsSection
 import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsSearchTopBar
+import fr.forumhfr.redface2.core.ui.settings.shell.SettingsHomeScreen
 
 /**
  * #494 — root of the redesigned settings catalogue.
@@ -48,14 +49,14 @@ import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsSearchTopBar
  * [startScreenViewModel] (#458 « Démarrage ») — both `hiltViewModel()` in the same `ViewModelStore`.
  */
 @Composable
-@Suppress("LongParameterList") // state-hoisted Composable: 5 sub-page nav callbacks + back + 2 VMs, each distinct.
+@Suppress("LongParameterList") // racine v2 : 5 sous-pages + onOpenCategory + 2 VMs + slots, chacun distinct.
 fun SettingsScreen(
-    onBack: (() -> Unit)? = null,
     onOpenProxy: () -> Unit,
     onOpenMaintenance: () -> Unit,
     onOpenDisplay: () -> Unit,
     onOpenImages: () -> Unit,
     onOpenAccountAbout: () -> Unit,
+    onOpenCategory: (String) -> Unit,
     modifier: Modifier = Modifier,
     topBarActions: @Composable (() -> Unit)? = null,
     viewModel: SettingsViewModel = hiltViewModel(),
@@ -63,17 +64,17 @@ fun SettingsScreen(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val startScreenState by startScreenViewModel.state.collectAsStateWithLifecycle()
-    SettingsCatalogue(
+    SettingsRoot(
         state = state,
         onIntent = viewModel::submit,
         startScreenState = startScreenState,
         onStartScreenIntent = startScreenViewModel::submit,
-        onBack = onBack,
         onOpenProxy = onOpenProxy,
         onOpenMaintenance = onOpenMaintenance,
         onOpenDisplay = onOpenDisplay,
         onOpenImages = onOpenImages,
         onOpenAccountAbout = onOpenAccountAbout,
+        onOpenCategory = onOpenCategory,
         modifier = modifier,
         topBarActions = topBarActions,
     )
@@ -84,17 +85,17 @@ fun SettingsScreen(
 // stateless catalogue body so it stays previewable/testable without Hilt.
 @Suppress("LongParameterList", "LongMethod", "CyclomaticComplexMethod")
 @Composable
-internal fun SettingsCatalogue(
+internal fun SettingsRoot(
     state: SettingsState,
     onIntent: (SettingsIntent) -> Unit,
     startScreenState: StartScreenSettingsState,
     onStartScreenIntent: (StartScreenSettingsIntent) -> Unit,
-    onBack: (() -> Unit)? = null,
     onOpenProxy: () -> Unit,
     onOpenMaintenance: () -> Unit,
     onOpenDisplay: () -> Unit,
     onOpenImages: () -> Unit,
     onOpenAccountAbout: () -> Unit,
+    onOpenCategory: (String) -> Unit,
     modifier: Modifier = Modifier,
     topBarActions: @Composable (() -> Unit)? = null,
 ) {
@@ -106,6 +107,25 @@ internal fun SettingsCatalogue(
     BackHandler(enabled = searchActive) {
         searchActive = false
         query = ""
+    }
+
+    // #494 v2 — idle : racine « catégories d'abord » (catégories regroupées en familles). Le pill de
+    // recherche bascule en mode recherche qui réutilise le filtre/renderers du catalogue (ci-dessous).
+    if (!searchActive) {
+        SettingsHomeScreen(
+            groups = rememberSettingsCategoryGroups(),
+            searchPlaceholder = stringResource(R.string.settings_search_placeholder),
+            menuContentDescription = stringResource(R.string.settings_menu_content_description),
+            searchContentDescription = stringResource(R.string.settings_search_open),
+            onMenuClick = null, // hamburger gardé mais désactivé : rôle à définir (#494 v2)
+            onSearchClick = { searchActive = true },
+            onCategoryClick = { id ->
+                routeSettingsCategory(id, onOpenDisplay, onOpenImages, onOpenAccountAbout, onOpenCategory)
+            },
+            modifier = modifier,
+            accountSlot = topBarActions,
+        )
+        return
     }
 
     // The renderable catalogue: each row carries its search metadata AND its Compose renderer. The
@@ -138,7 +158,6 @@ internal fun SettingsCatalogue(
                     searchActive = active
                     if (!active) query = ""
                 },
-                onBack = onBack,
                 actions = { topBarActions?.invoke() },
             )
         },
@@ -200,7 +219,7 @@ internal data class SettingsCatalogueSection(
  */
 @Suppress("LongMethod", "LongParameterList")
 @Composable
-private fun buildSettingsCatalogue(
+internal fun buildSettingsCatalogue(
     state: SettingsState,
     onIntent: (SettingsIntent) -> Unit,
     startScreenState: StartScreenSettingsState,

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -1,1183 +1,582 @@
 package fr.forumhfr.redface2.feature.settings
 
-import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Arrangement
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.ime
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.union
-import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
-import androidx.compose.material3.Surface
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
-import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
-import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
-import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
-import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
+import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsListItem
+import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsSection
+import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsSearchTopBar
 
+/**
+ * #494 — root of the redesigned settings catalogue.
+ *
+ * A `Scaffold` + [RedfaceSettingsSearchTopBar] + `LazyColumn`, replacing the former
+ * `Surface` / `verticalScroll` + stack of `Card`s. The catalogue is structured in sections; rows are
+ * either toggles (a trailing `Switch`, wired straight to [SettingsViewModel.submit]) or navigation
+ * rows (a trailing chevron, routing to a sub-page). The « Démarrage » block is rendered inline at the
+ * root (it is a category picker, not a sub-page). Heavy areas — Proxy, Maintenance, Affichage, Images,
+ * Compte/À propos — are sub-pages reached from navigation rows.
+ *
+ * Search is a local `rememberSaveable` state (no DataStore persistence): the catalogue is mapped to a
+ * pure [SettingsSearchableSection] list and filtered via [filterSettingsSections]. Each kept item is
+ * rendered by id from a `renderers` map, so the pure (testable) filter and the Compose rendering stay
+ * decoupled. Future (disabled) rows stay searchable; gated rows (e.g. the DT inspector while the DT
+ * section is off) are `visible = false` and excluded.
+ *
+ * Two distinct ViewModels coexist in this nav entry: [viewModel] (preferences) and
+ * [startScreenViewModel] (#458 « Démarrage ») — both `hiltViewModel()` in the same `ViewModelStore`.
+ */
 @Composable
+@Suppress("LongParameterList") // state-hoisted Composable: 5 sub-page nav callbacks + back + 2 VMs, each distinct.
 fun SettingsScreen(
+    onBack: () -> Unit,
+    onOpenProxy: () -> Unit,
+    onOpenMaintenance: () -> Unit,
+    onOpenDisplay: () -> Unit,
+    onOpenImages: () -> Unit,
+    onOpenAccountAbout: () -> Unit,
     modifier: Modifier = Modifier,
-    // #459 PR3 — navigates to the « Mes images uploadées » screen. Default no-op so previews and
-    // the multi-pane illustrative call sites stay valid ; wired from RedfaceApp.
-    onOpenMyImages: () -> Unit = {},
-    // #6 — navigates to the read-only MPStorage inspector (debug). Only surfaced when the DT section
-    // is enabled (gated below). Default no-op so previews / illustrative call sites stay valid.
-    onOpenMpStorageInspector: () -> Unit = {},
+    topBarActions: @Composable (() -> Unit)? = null,
     viewModel: SettingsViewModel = hiltViewModel(),
-    // #458 — the « Démarrage » section has its own ViewModel (cf. its KDoc).
     startScreenViewModel: StartScreenSettingsViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val startScreenState by startScreenViewModel.state.collectAsStateWithLifecycle()
-    SettingsContent(
+    SettingsCatalogue(
         state = state,
         onIntent = viewModel::submit,
-        modifier = modifier,
-        onOpenMyImages = onOpenMyImages,
-        onOpenMpStorageInspector = onOpenMpStorageInspector,
         startScreenState = startScreenState,
         onStartScreenIntent = startScreenViewModel::submit,
+        onBack = onBack,
+        onOpenProxy = onOpenProxy,
+        onOpenMaintenance = onOpenMaintenance,
+        onOpenDisplay = onOpenDisplay,
+        onOpenImages = onOpenImages,
+        onOpenAccountAbout = onOpenAccountAbout,
+        modifier = modifier,
+        topBarActions = topBarActions,
     )
 }
 
-// MVI screen content : state + intent + modifier + rappels de navigation/feature (#458 démarrage,
-// #459 « Mes images », #6 inspecteur MPStorage). 7 paramètres = la surface complète de l'écran ;
-// les regrouper derrière un objet masquerait le site d'appel sans gain réel.
-@Suppress("LongParameterList")
+// 12 navigation/intent callbacks + state make the explicit surface; grouping them behind an object
+// would hide the call site. The two VMs are observed in [SettingsScreen]; this content is the
+// stateless catalogue body so it stays previewable/testable without Hilt.
+@Suppress("LongParameterList", "LongMethod", "CyclomaticComplexMethod")
 @Composable
-internal fun SettingsContent(
+internal fun SettingsCatalogue(
     state: SettingsState,
     onIntent: (SettingsIntent) -> Unit,
+    startScreenState: StartScreenSettingsState,
+    onStartScreenIntent: (StartScreenSettingsIntent) -> Unit,
+    onBack: () -> Unit,
+    onOpenProxy: () -> Unit,
+    onOpenMaintenance: () -> Unit,
+    onOpenDisplay: () -> Unit,
+    onOpenImages: () -> Unit,
+    onOpenAccountAbout: () -> Unit,
     modifier: Modifier = Modifier,
-    onOpenMyImages: () -> Unit = {},
-    onOpenMpStorageInspector: () -> Unit = {},
-    startScreenState: StartScreenSettingsState = StartScreenSettingsState(),
-    onStartScreenIntent: (StartScreenSettingsIntent) -> Unit = {},
+    topBarActions: @Composable (() -> Unit)? = null,
 ) {
-    Surface(
+    var searchActive by rememberSaveable { mutableStateOf(false) }
+    var query by rememberSaveable { mutableStateOf("") }
+
+    // System/gesture back closes the active search (without popping the Settings route, which is what
+    // nav3 would otherwise do). Disabled when search is closed so normal back navigation proceeds.
+    BackHandler(enabled = searchActive) {
+        searchActive = false
+        query = ""
+    }
+
+    // The renderable catalogue: each row carries its search metadata AND its Compose renderer. The
+    // pure model fed to [filterSettingsSections] is derived from it (so the filter stays Android-free).
+    val sections = buildSettingsCatalogue(
+        state = state,
+        onIntent = onIntent,
+        startScreenState = startScreenState,
+        onStartScreenIntent = onStartScreenIntent,
+        onOpenProxy = onOpenProxy,
+        onOpenMaintenance = onOpenMaintenance,
+        onOpenDisplay = onOpenDisplay,
+        onOpenImages = onOpenImages,
+        onOpenAccountAbout = onOpenAccountAbout,
+    )
+    val renderers: Map<String, @Composable () -> Unit> = sections
+        .flatMap { it.items }
+        .associate { it.searchable.id to it.render }
+    val filtered = filterSettingsSections(sections.map { it.toSearchable() }, query)
+
+    Scaffold(
         modifier = modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.surface,
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .statusBarsPadding()
-                // Applied OUTSIDE verticalScroll so the keyboard inset shrinks the scroll viewport: a
-                // focused proxy field then stays above the IME (adjustNothing means the OEM no longer
-                // resizes the window for us, cf. #624). union() keeps navBar clearance when closed.
-                .windowInsetsPadding(
-                    WindowInsets.navigationBars
-                        .union(WindowInsets.ime)
-                        .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom),
+        topBar = {
+            RedfaceSettingsSearchTopBar(
+                labels = rememberSettingsSearchTopBarLabels(),
+                searchActive = searchActive,
+                query = query,
+                onQueryChange = { query = it },
+                onSearchActiveChange = { active ->
+                    searchActive = active
+                    if (!active) query = ""
+                },
+                onBack = onBack,
+                actions = { topBarActions?.invoke() },
+            )
+        },
+    ) { innerPadding ->
+        if (filtered.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(24.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = stringResource(R.string.settings_search_empty),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 24.dp, vertical = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.settings_title),
-                style = MaterialTheme.typography.headlineMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            // #288 — distinguish local (DataStore) preferences from HFR-account settings, and frame the
-            // screen as the full catalogue: shipped settings are interactive, planned ones are shown
-            // greyed with a phase/issue tag (a showcase of the roadmap, cf. the issue's design notes).
-            Text(
-                text = stringResource(R.string.settings_intro),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-
-            SettingsSectionHeader(stringResource(R.string.settings_section_network))
-            Card(modifier = Modifier.fillMaxWidth()) {
-                Column(
-                    modifier = Modifier.padding(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp),
-                ) {
-                    Text(
-                        text = stringResource(R.string.settings_proxy_title),
-                        style = MaterialTheme.typography.titleMedium,
-                        color = MaterialTheme.colorScheme.onSurface,
-                    )
-                    Text(
-                        text = stringResource(R.string.settings_proxy_intro),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = stringResource(R.string.settings_proxy_enabled),
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurface,
-                        )
-                        Switch(
-                            checked = state.proxyEnabled,
-                            onCheckedChange = { onIntent(SettingsIntent.ProxyEnabledChanged(it)) },
-                        )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+            ) {
+                filtered.forEachIndexed { sectionIndex, section ->
+                    item(key = "section:${section.id}") {
+                        if (sectionIndex > 0) HorizontalDivider()
+                        RedfaceSettingsSection(section.title)
                     }
-                    OutlinedTextField(
-                        value = state.proxyHost,
-                        onValueChange = { onIntent(SettingsIntent.ProxyHostChanged(it)) },
-                        enabled = state.proxyEnabled,
-                        singleLine = true,
-                        label = { Text(stringResource(R.string.settings_proxy_host)) },
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                    OutlinedTextField(
-                        value = state.proxyPort,
-                        onValueChange = { onIntent(SettingsIntent.ProxyPortChanged(it)) },
-                        enabled = state.proxyEnabled,
-                        singleLine = true,
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                        label = { Text(stringResource(R.string.settings_proxy_port)) },
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                    OutlinedTextField(
-                        value = state.proxyUsername,
-                        onValueChange = { onIntent(SettingsIntent.ProxyUsernameChanged(it)) },
-                        enabled = state.proxyEnabled,
-                        singleLine = true,
-                        label = { Text(stringResource(R.string.settings_proxy_username)) },
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                    OutlinedTextField(
-                        value = state.proxyPassword,
-                        onValueChange = { onIntent(SettingsIntent.ProxyPasswordChanged(it)) },
-                        enabled = state.proxyEnabled,
-                        singleLine = true,
-                        visualTransformation = PasswordVisualTransformation(),
-                        label = { Text(stringResource(R.string.settings_proxy_password)) },
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                    Text(
-                        text = stringResource(R.string.settings_proxy_scope),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    if (state.error == SettingsError.InvalidProxy) {
-                        Text(
-                            text = stringResource(R.string.settings_proxy_invalid),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.error,
-                        )
-                    }
-                    if (state.error == SettingsError.PersistFailed) {
-                        Text(
-                            text = stringResource(R.string.settings_proxy_persist_failed),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.error,
-                        )
-                    }
-                    if (state.saved) {
-                        Text(
-                            text = stringResource(R.string.settings_proxy_saved),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.primary,
-                        )
-                    }
-                    Button(
-                        enabled = state.canSave,
-                        onClick = { onIntent(SettingsIntent.SaveProxyClicked) },
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        Text(stringResource(R.string.settings_proxy_save))
+                    items(section.items, key = { "item:${it.id}" }) { item ->
+                        renderers[item.id]?.invoke()
                     }
                 }
             }
-
-            MaintenanceCard(
-                state = state,
-                onIntent = onIntent,
-            )
-            FutureSettingsCard(
-                items = listOf(
-                    R.string.settings_future_data_saver to issueTag(310),
-                ),
-            )
-
-            SettingsSectionHeader(stringResource(R.string.settings_section_start))
-            StartScreenPreferencesCard(
-                state = startScreenState,
-                onIntent = onStartScreenIntent,
-            )
-
-            SettingsSectionHeader(stringResource(R.string.settings_section_display))
-            ThemePreferencesCard(
-                state = state,
-                onIntent = onIntent,
-            )
-            DisplayPreferencesCard(
-                state = state,
-                onIntent = onIntent,
-            )
-            FutureSettingsCard(
-                items = listOf(
-                    R.string.settings_future_ui_colors to issueTag(296),
-                    R.string.settings_future_material_you to stringResource(R.string.settings_phase_future),
-                    R.string.settings_future_classic_theme to stringResource(R.string.settings_phase_future_far),
-                ),
-            )
-
-            SettingsSectionHeader(stringResource(R.string.settings_section_flags))
-            FlagsPreferencesCard(
-                state = state,
-                onIntent = onIntent,
-            )
-            FutureSettingsCard(
-                items = listOf(
-                    R.string.settings_future_flags_on_listing to issueTag(297),
-                ),
-            )
-
-            SettingsSectionHeader(stringResource(R.string.settings_section_topic))
-            TopicPreferencesCard(
-                state = state,
-                onIntent = onIntent,
-            )
-            FutureSettingsCard(
-                items = listOf(
-                    R.string.settings_future_prefetch to stringResource(R.string.settings_phase_future),
-                ),
-            )
-
-            SettingsSectionHeader(stringResource(R.string.settings_section_editing))
-            EditingPreferencesCard(
-                state = state,
-                onIntent = onIntent,
-            )
-            FutureSettingsCard(
-                items = listOf(
-                    R.string.settings_future_signature to stringResource(R.string.settings_phase_planned),
-                ),
-            )
-
-            SettingsSectionHeader(stringResource(R.string.settings_section_images))
-            UploadProviderPreferencesCard(
-                state = state,
-                onIntent = onIntent,
-            )
-            MyImagesCard(onOpenMyImages = onOpenMyImages)
-
-            SettingsSectionHeader(stringResource(R.string.settings_section_mp))
-            MessagesPreferencesCard(
-                state = state,
-                onIntent = onIntent,
-            )
-            // #6 — read-only MPStorage inspector (debug). Gated on the DT section toggle so it stays
-            // hidden from regular users and only power users who opted into DT features see it.
-            if (state.showDtSection) {
-                MpStorageInspectorCard(onOpen = onOpenMpStorageInspector)
-            }
-            FutureSettingsCard(
-                items = listOf(
-                    R.string.settings_future_mp_notifications to issueTag(313),
-                ),
-            )
-
-            SettingsSectionHeader(stringResource(R.string.settings_section_hfr_account))
-            Text(
-                text = stringResource(R.string.settings_hfr_account_note),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            FutureSettingsCard(
-                items = listOf(
-                    R.string.settings_future_hfr_profile to issueTag(311),
-                ),
-            )
-
-            SettingsSectionHeader(stringResource(R.string.settings_section_notifications))
-            FutureSettingsCard(
-                items = listOf(
-                    R.string.settings_future_notifications to stringResource(R.string.settings_phase_5),
-                ),
-            )
-
-            SettingsSectionHeader(stringResource(R.string.settings_section_accessibility))
-            FutureSettingsCard(
-                items = listOf(
-                    R.string.settings_future_timezone to stringResource(R.string.settings_phase_future),
-                    R.string.settings_future_multilang to stringResource(R.string.settings_phase_future),
-                ),
-            )
-
-            SettingsSectionHeader(stringResource(R.string.settings_section_extensions))
-            FutureSettingsCard(
-                items = listOf(
-                    R.string.settings_future_extensions to issueTag(7),
-                ),
-            )
-        }
-    }
-
-    if (state.showClearTopicCacheConfirm) {
-        ClearTopicCacheConfirmDialog(
-            onConfirm = { onIntent(SettingsIntent.ClearTopicCacheConfirmed) },
-            onDismiss = { onIntent(SettingsIntent.ClearTopicCacheDismissed) },
-        )
-    }
-    if (state.showClearImageCacheConfirm) {
-        ClearImageCacheConfirmDialog(
-            onConfirm = { onIntent(SettingsIntent.ClearImageCacheConfirmed) },
-            onDismiss = { onIntent(SettingsIntent.ClearImageCacheDismissed) },
-        )
-    }
-}
-
-/**
- * #288 — a section header that structures the catalogue by area (Affichage, Drapeaux, …).
- */
-@Composable
-private fun SettingsSectionHeader(title: String) {
-    Text(
-        text = title,
-        style = MaterialTheme.typography.titleSmall,
-        color = MaterialTheme.colorScheme.primary,
-        modifier = Modifier.padding(top = 8.dp),
-    )
-}
-
-/**
- * #288 — formats the tag pill for a planned setting backed by a GitHub issue (e.g. `#310`). The
- * issue number is a technical identifier, but the `#` prefix still goes through a string resource to
- * keep all displayed text localizable. Phase words ("À venir", "Phase 5", …) are passed directly.
- */
-@Composable
-private fun issueTag(number: Int): String = stringResource(R.string.settings_future_issue_tag, number)
-
-/**
- * #288 — a card grouping planned (not-yet-shipped) settings as non-interactive, greyed rows so the
- * screen shows the full roadmap "for free". Each [items] entry pairs a title string-res with a tag
- * (an issue reference via [issueTag], or a localized phase word resolved at the call site). Renders
- * nothing for an empty list so callers never produce a stray empty card.
- */
-@Composable
-private fun FutureSettingsCard(items: List<Pair<Int, String>>) {
-    if (items.isEmpty()) return
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            items.forEach { (titleRes, tag) ->
-                FutureSettingRow(title = stringResource(titleRes), tag = tag)
-            }
         }
     }
 }
 
-/**
- * One planned setting: title in the muted `onSurfaceVariant` colour (the M3 idiom for "not active",
- * preferred over a blanket `Modifier.alpha`) and a small tag pill. Non-interactive by design.
- */
-@Composable
-private fun FutureSettingRow(title: String, tag: String) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.weight(1f, fill = false),
-        )
-        Surface(
-            color = MaterialTheme.colorScheme.surfaceContainerHighest,
-            shape = MaterialTheme.shapes.small,
-        ) {
-            Text(
-                text = tag,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
-            )
-        }
-    }
+/** A catalogue row: its pure search metadata plus the Compose renderer that draws it. */
+internal data class SettingsCatalogueRow(
+    val searchable: SettingsSearchableItem,
+    val render: @Composable () -> Unit,
+)
+
+/** A catalogue section paired with its renderable rows. */
+internal data class SettingsCatalogueSection(
+    val id: String,
+    val title: String,
+    val items: List<SettingsCatalogueRow>,
+) {
+    fun toSearchable(): SettingsSearchableSection =
+        SettingsSearchableSection(id = id, title = title, items = items.map { it.searchable })
 }
 
 /**
- * Theme preferences (#286): a 3-way Clair / Système / Sombre selector (SYSTEM follows the OS),
- * plus an AMOLED true-black toggle that only applies when the effective theme is dark. Persisted via
- * DataStore; the selection is observed at the app root ([fr.forumhfr.redface2.navigation.RedfaceApp])
- * so a change here re-themes the whole app live.
+ * Builds the root catalogue from resolved strings + [state]. Keeps the search metadata and the
+ * renderer side by side so a row is described once. Toggle rows wire straight to [onIntent]; nav rows
+ * route to a sub-page.
  */
+@Suppress("LongMethod", "LongParameterList")
 @Composable
-private fun ThemePreferencesCard(
+private fun buildSettingsCatalogue(
     state: SettingsState,
     onIntent: (SettingsIntent) -> Unit,
-) {
-    // The AMOLED toggle is only meaningful when the app will actually render dark — forced DARK, or
-    // SYSTEM while the OS is in dark mode. Computed here so the switch is disabled otherwise.
-    val effectiveDark = when (state.themeMode) {
-        ThemeMode.LIGHT -> false
-        ThemeMode.DARK -> true
-        ThemeMode.SYSTEM -> isSystemInDarkTheme()
-    }
-    val options = listOf(
-        ThemeMode.LIGHT to stringResource(R.string.settings_theme_light),
-        ThemeMode.SYSTEM to stringResource(R.string.settings_theme_system),
-        ThemeMode.DARK to stringResource(R.string.settings_theme_dark),
-    )
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.settings_theme_title),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Text(
-                text = stringResource(R.string.settings_theme_intro),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                options.forEachIndexed { index, (mode, label) ->
-                    SegmentedButton(
-                        selected = state.themeMode == mode,
-                        enabled = state.canChangeThemeMode,
-                        onClick = { onIntent(SettingsIntent.ThemeModeChanged(mode)) },
-                        shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
-                    ) {
-                        Text(label)
-                    }
-                }
-            }
-            if (state.themeModeError) {
-                PreferencePersistError(R.string.settings_theme_persist_failed)
-            }
-            PreferenceSwitchRow(
-                title = stringResource(R.string.settings_theme_amoled_title),
-                description = stringResource(R.string.settings_theme_amoled_description),
-                checked = state.amoledEnabled,
-                enabled = state.canToggleAmoled && effectiveDark,
-                onCheckedChange = { onIntent(SettingsIntent.AmoledEnabledChanged(it)) },
-            )
-            if (state.amoledError) {
-                PreferencePersistError(R.string.settings_theme_amoled_persist_failed)
-            }
-        }
-    }
-}
-
-/**
- * Reading display presets (#287): a density preset (Confort / Compact, structural spacing) and a
- * reading font-size preset (S / M / L). Both are persisted via DataStore and observed at the app
- * root, so a change here re-themes the whole app live. Text-only segmented buttons (no Material
- * icons — the `androidx.compose.material.*` import is forbidden project-wide).
- */
-@Composable
-private fun DisplayPreferencesCard(
-    state: SettingsState,
-    onIntent: (SettingsIntent) -> Unit,
-) {
-    val densityOptions = listOf(
-        DisplayDensity.COMFORT to stringResource(R.string.settings_display_density_comfort),
-        DisplayDensity.COMPACT to stringResource(R.string.settings_display_density_compact),
-    )
-    val fontScaleOptions = listOf(
-        FontScalePreference.S to stringResource(R.string.settings_display_font_scale_small),
-        FontScalePreference.M to stringResource(R.string.settings_display_font_scale_medium),
-        FontScalePreference.L to stringResource(R.string.settings_display_font_scale_large),
-    )
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.settings_display_title),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Text(
-                text = stringResource(R.string.settings_display_density_intro),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                densityOptions.forEachIndexed { index, (density, label) ->
-                    SegmentedButton(
-                        selected = state.displayDensity == density,
-                        enabled = state.canChangeDisplayDensity,
-                        onClick = { onIntent(SettingsIntent.DisplayDensityChanged(density)) },
-                        shape = SegmentedButtonDefaults.itemShape(index = index, count = densityOptions.size),
-                    ) {
-                        Text(label)
-                    }
-                }
-            }
-            if (state.displayDensityError) {
-                PreferencePersistError(R.string.settings_display_density_persist_failed)
-            }
-            Text(
-                text = stringResource(R.string.settings_display_font_scale_intro),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                fontScaleOptions.forEachIndexed { index, (scale, label) ->
-                    SegmentedButton(
-                        selected = state.fontScale == scale,
-                        enabled = state.canChangeFontScale,
-                        onClick = { onIntent(SettingsIntent.FontScaleChanged(scale)) },
-                        shape = SegmentedButtonDefaults.itemShape(index = index, count = fontScaleOptions.size),
-                    ) {
-                        Text(label)
-                    }
-                }
-            }
-            if (state.fontScaleError) {
-                PreferencePersistError(R.string.settings_display_font_scale_persist_failed)
-            }
-        }
-    }
-}
-
-/**
- * Drapeaux display preferences (#179 follow-up): grouped-vs-flat layout and the « masquer les
- * catégories sans non-lu » filter. Persisted via DataStore and observed live by the Flags screen,
- * so a flip here re-renders the list without a refetch.
- */
-@Composable
-private fun FlagsPreferencesCard(
-    state: SettingsState,
-    onIntent: (SettingsIntent) -> Unit,
-) {
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.settings_flags_title),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            PreferenceSwitchRow(
+    startScreenState: StartScreenSettingsState,
+    onStartScreenIntent: (StartScreenSettingsIntent) -> Unit,
+    onOpenProxy: () -> Unit,
+    onOpenMaintenance: () -> Unit,
+    onOpenDisplay: () -> Unit,
+    onOpenImages: () -> Unit,
+    onOpenAccountAbout: () -> Unit,
+): List<SettingsCatalogueSection> = listOf(
+    // Réseau et cache.
+    SettingsCatalogueSection(
+        id = "network",
+        title = stringResource(R.string.settings_section_network),
+        items = listOf(
+            navRow(
+                id = "proxy",
+                title = stringResource(R.string.settings_nav_proxy),
+                description = stringResource(R.string.settings_nav_proxy_description),
+                // A nav row is opaque to search: it must carry the labels actually shown inside the
+                // sub-page (e.g. « Hôte »), or searching them hits the empty state (#494 Codex P2).
+                keywords = listOf(
+                    "proxy",
+                    "réseau",
+                    "host",
+                    "port",
+                    stringResource(R.string.settings_proxy_host),
+                    stringResource(R.string.settings_proxy_port),
+                    stringResource(R.string.settings_proxy_username),
+                    stringResource(R.string.settings_proxy_password),
+                ),
+                onClick = onOpenProxy,
+            ),
+            navRow(
+                id = "maintenance",
+                title = stringResource(R.string.settings_nav_maintenance),
+                description = stringResource(R.string.settings_nav_maintenance_description),
+                keywords = buildList {
+                    addAll(listOf("cache", "vider", "images", "topics", "diagnostic", "debug"))
+                    add(stringResource(R.string.settings_clear_topic_cache_button))
+                    add(stringResource(R.string.settings_clear_image_cache_button))
+                    add(stringResource(R.string.settings_ignore_topic_cache_title))
+                    // The MPStorage inspector only exists in this page when the DT section is on,
+                    // so only surface its label to search in that case (avoids a dead-end result).
+                    if (state.showDtSection) add(stringResource(R.string.settings_mpstorage_inspector_title))
+                },
+                onClick = onOpenMaintenance,
+            ),
+        ),
+    ),
+    // Démarrage (rendered inline — category picker, not a sub-page).
+    SettingsCatalogueSection(
+        id = "start",
+        title = stringResource(R.string.settings_section_start),
+        items = listOf(
+            SettingsCatalogueRow(
+                searchable = SettingsSearchableItem(
+                    id = "start_screen",
+                    title = stringResource(R.string.settings_start_screen_title),
+                    description = stringResource(R.string.settings_start_screen_intro),
+                    keywords = listOf("démarrage", "écran", "onglet", "lancement", "catégorie"),
+                ),
+                render = { StartScreenPreferencesCard(state = startScreenState, onIntent = onStartScreenIntent) },
+            ),
+        ),
+    ),
+    // Affichage (sub-page).
+    SettingsCatalogueSection(
+        id = "display",
+        title = stringResource(R.string.settings_section_display),
+        items = listOf(
+            navRow(
+                id = "display_nav",
+                title = stringResource(R.string.settings_nav_display),
+                description = stringResource(R.string.settings_nav_display_description),
+                keywords = listOf(
+                    "thème",
+                    "amoled",
+                    "sombre",
+                    "clair",
+                    "densité",
+                    "police",
+                    "taille",
+                    stringResource(R.string.settings_theme_title),
+                    stringResource(R.string.settings_theme_amoled_title),
+                    stringResource(R.string.settings_display_title),
+                    // Visible choice labels (theme / density / font scale) so e.g. « Système »,
+                    // « Confort », « Compact » route to this page instead of the empty state.
+                    stringResource(R.string.settings_theme_light),
+                    stringResource(R.string.settings_theme_system),
+                    stringResource(R.string.settings_theme_dark),
+                    stringResource(R.string.settings_display_density_comfort),
+                    stringResource(R.string.settings_display_density_compact),
+                    stringResource(R.string.settings_display_font_scale_small),
+                    stringResource(R.string.settings_display_font_scale_medium),
+                    stringResource(R.string.settings_display_font_scale_large),
+                ),
+                onClick = onOpenDisplay,
+            ),
+        ),
+    ),
+    // Drapeaux (inline toggles).
+    SettingsCatalogueSection(
+        id = "flags",
+        title = stringResource(R.string.settings_section_flags),
+        items = listOf(
+            toggleRow(
+                id = "flags_group_by_category",
                 title = stringResource(R.string.settings_flags_group_by_category_title),
                 description = stringResource(R.string.settings_flags_group_by_category_description),
                 checked = state.flagsGroupByCategory,
                 enabled = state.canToggleFlagsGroupByCategory,
+                errorRes = R.string.settings_flags_group_by_category_persist_failed
+                    .takeIf { state.flagsGroupByCategoryError },
                 onCheckedChange = { onIntent(SettingsIntent.FlagsGroupByCategoryChanged(it)) },
-            )
-            if (state.flagsGroupByCategoryError) {
-                PreferencePersistError(R.string.settings_flags_group_by_category_persist_failed)
-            }
-            PreferenceSwitchRow(
+            ),
+            toggleRow(
+                id = "flags_hide_read",
                 title = stringResource(R.string.settings_flags_hide_read_categories_title),
                 description = stringResource(R.string.settings_flags_hide_read_categories_description),
                 checked = state.flagsHideReadCategories,
                 enabled = state.canToggleFlagsHideReadCategories,
+                errorRes = R.string.settings_flags_hide_read_categories_persist_failed
+                    .takeIf { state.flagsHideReadCategoriesError },
                 onCheckedChange = { onIntent(SettingsIntent.FlagsHideReadCategoriesChanged(it)) },
-            )
-            if (state.flagsHideReadCategoriesError) {
-                PreferencePersistError(R.string.settings_flags_hide_read_categories_persist_failed)
-            }
-            PreferenceSwitchRow(
+            ),
+            toggleRow(
+                id = "flags_per_tab_override",
                 title = stringResource(R.string.settings_flags_per_tab_override_title),
                 description = stringResource(R.string.settings_flags_per_tab_override_description),
                 checked = state.flagsPerTabOverride,
                 enabled = state.canToggleFlagsPerTabOverride,
+                errorRes = R.string.settings_flags_per_tab_override_persist_failed
+                    .takeIf { state.flagsPerTabOverrideError },
                 onCheckedChange = { onIntent(SettingsIntent.FlagsPerTabOverrideChanged(it)) },
-            )
-            if (state.flagsPerTabOverrideError) {
-                PreferencePersistError(R.string.settings_flags_per_tab_override_persist_failed)
-            }
-            PreferenceSwitchRow(
+            ),
+            toggleRow(
+                id = "flags_show_dt_section",
                 title = stringResource(R.string.settings_flags_show_dt_section_title),
                 description = stringResource(R.string.settings_flags_show_dt_section_description),
                 checked = state.showDtSection,
                 enabled = state.canToggleShowDtSection,
+                errorRes = R.string.settings_flags_show_dt_section_persist_failed
+                    .takeIf { state.showDtSectionError },
                 onCheckedChange = { onIntent(SettingsIntent.ShowDtSectionChanged(it)) },
-            )
-            if (state.showDtSectionError) {
-                PreferencePersistError(R.string.settings_flags_show_dt_section_persist_failed)
-            }
-            // #378 — auto-refresh on landing (app open / back from a topic). Opt-OUT: default on.
-            PreferenceSwitchRow(
+            ),
+            toggleRow(
+                id = "flags_auto_refresh",
                 title = stringResource(R.string.settings_flags_auto_refresh_title),
                 description = stringResource(R.string.settings_flags_auto_refresh_description),
                 checked = state.flagsAutoRefresh,
                 enabled = state.canToggleFlagsAutoRefresh,
+                errorRes = R.string.settings_flags_auto_refresh_persist_failed
+                    .takeIf { state.flagsAutoRefreshError },
                 onCheckedChange = { onIntent(SettingsIntent.FlagsAutoRefreshChanged(it)) },
-            )
-            if (state.flagsAutoRefreshError) {
-                PreferencePersistError(R.string.settings_flags_auto_refresh_persist_failed)
-            }
-        }
-    }
-}
-
-/**
- * Topic reading preferences:
- *
- * - « masquer la barre du haut en défilant » (build 89 follow-up) — when on, the topic top app
- *   bar (title + page counter) collapses on scroll-down and snaps back on the first scroll-up
- *   (Material3 `enterAlways`), freeing reading space;
- * - « boutons de changement de page » (#383) — when off, the floating ‹/› mini-FABs (#283) are
- *   hidden for swipe-only readers; « Répondre » keeps its own gates and stays.
- *
- * Both persisted via DataStore and observed live by the topic screen, so a flip here applies
- * without reopening a topic.
- */
-@Composable
-private fun TopicPreferencesCard(
-    state: SettingsState,
-    onIntent: (SettingsIntent) -> Unit,
-) {
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.settings_topic_title),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            PreferenceSwitchRow(
+            ),
+        ),
+    ),
+    // Sujet et lecture (inline toggles).
+    SettingsCatalogueSection(
+        id = "topic",
+        title = stringResource(R.string.settings_section_topic),
+        items = listOf(
+            toggleRow(
+                id = "topic_topbar_auto_hide",
                 title = stringResource(R.string.settings_topic_topbar_auto_hide_title),
                 description = stringResource(R.string.settings_topic_topbar_auto_hide_description),
                 checked = state.topicTopBarAutoHide,
                 enabled = state.canToggleTopicTopBarAutoHide,
+                errorRes = R.string.settings_topic_topbar_auto_hide_persist_failed
+                    .takeIf { state.topicTopBarAutoHideError },
                 onCheckedChange = { onIntent(SettingsIntent.TopicTopBarAutoHideChanged(it)) },
-            )
-            if (state.topicTopBarAutoHideError) {
-                PreferencePersistError(R.string.settings_topic_topbar_auto_hide_persist_failed)
-            }
-            PreferenceSwitchRow(
+            ),
+            toggleRow(
+                id = "topic_page_fabs",
                 title = stringResource(R.string.settings_topic_page_fabs_title),
                 description = stringResource(R.string.settings_topic_page_fabs_description),
                 checked = state.topicPageFabs,
                 enabled = state.canToggleTopicPageFabs,
+                errorRes = R.string.settings_topic_page_fabs_persist_failed.takeIf { state.topicPageFabsError },
                 onCheckedChange = { onIntent(SettingsIntent.TopicPageFabsChanged(it)) },
-            )
-            if (state.topicPageFabsError) {
-                PreferencePersistError(R.string.settings_topic_page_fabs_persist_failed)
-            }
-            PreferenceSwitchRow(
+            ),
+            toggleRow(
+                id = "topic_polls_expanded",
                 title = stringResource(R.string.settings_topic_polls_expanded_title),
                 description = stringResource(R.string.settings_topic_polls_expanded_description),
                 checked = state.topicPollsExpanded,
                 enabled = state.canToggleTopicPollsExpanded,
+                errorRes = R.string.settings_topic_polls_expanded_persist_failed
+                    .takeIf { state.topicPollsExpandedError },
                 onCheckedChange = { onIntent(SettingsIntent.TopicPollsExpandedChanged(it)) },
-            )
-            if (state.topicPollsExpandedError) {
-                PreferencePersistError(R.string.settings_topic_polls_expanded_persist_failed)
-            }
-        }
-    }
-}
-
-/**
- * Publishing preferences (#312): the « Confirmation avant publication » toggle. When on, every
- * publish action (topic reply / post edit, new topic / first-post edit, private-message reply)
- * first shows a confirmation dialog. Persisted via DataStore and observed live by the editor
- * ViewModels, so a flip here applies without reopening an editor.
- */
-@Composable
-private fun MessagesPreferencesCard(
-    state: SettingsState,
-    onIntent: (SettingsIntent) -> Unit,
-) {
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.settings_mp_title),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            PreferenceSwitchRow(
-                title = stringResource(R.string.settings_mp_unread_badge_title),
-                description = stringResource(R.string.settings_mp_unread_badge_description),
-                checked = state.mpUnreadBadge,
-                enabled = state.canToggleMpUnreadBadge,
-                onCheckedChange = { onIntent(SettingsIntent.MpUnreadBadgeChanged(it)) },
-            )
-            if (state.mpUnreadBadgeError) {
-                PreferencePersistError(R.string.settings_mp_unread_badge_persist_failed)
-            }
-        }
-    }
-}
-
-/**
- * #459 PR3 — entry point to the « Mes images uploadées » screen. A short description plus a button
- * that navigates out of Settings (the screen itself is a standalone route, not a sub-form), mirroring
- * how the maintenance actions read but routing instead of mutating a preference.
- */
-@Composable
-private fun MyImagesCard(onOpenMyImages: () -> Unit) {
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.settings_my_images_title),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Text(
-                text = stringResource(R.string.settings_my_images_description),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            OutlinedButton(
-                onClick = onOpenMyImages,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Text(stringResource(R.string.settings_my_images_open))
-            }
-        }
-    }
-}
-
-/**
- * #6 — entry point to the read-only MPStorage inspector. Same shape as [MyImagesCard] (a routing
- * card, not a preference toggle). Only rendered when the DT section is enabled (see call site).
- */
-@Composable
-private fun MpStorageInspectorCard(onOpen: () -> Unit) {
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.settings_mpstorage_inspector_title),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Text(
-                text = stringResource(R.string.settings_mpstorage_inspector_description),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            OutlinedButton(
-                onClick = onOpen,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Text(stringResource(R.string.settings_mpstorage_inspector_open))
-            }
-        }
-    }
-}
-
-/**
- * #459 — « Hébergeur d'images » : choisit l'hébergeur des uploads de l'éditeur (diberie sans
- * compte, imgur avec un Client-ID que l'utilisateur colle). Le champ Client-ID n'apparaît que pour
- * imgur. Persisté en DataStore et lu par l'éditeur à chaque upload. Boutons segmentés en texte seul
- * (pas d'icônes Material — l'import `androidx.compose.material.*` est interdit dans le projet).
- */
-@Composable
-private fun UploadProviderPreferencesCard(
-    state: SettingsState,
-    onIntent: (SettingsIntent) -> Unit,
-) {
-    val options = listOf(
-        UploadProviderId.DIBERIE to stringResource(R.string.settings_upload_provider_diberie),
-        UploadProviderId.IMGUR to stringResource(R.string.settings_upload_provider_imgur),
-    )
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.settings_upload_provider_title),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Text(
-                text = stringResource(R.string.settings_upload_provider_intro),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                options.forEachIndexed { index, (provider, label) ->
-                    SegmentedButton(
-                        selected = state.uploadProvider == provider,
-                        enabled = state.canChangeUploadProvider,
-                        onClick = { onIntent(SettingsIntent.SetUploadProvider(provider)) },
-                        shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
-                    ) {
-                        Text(label)
-                    }
-                }
-            }
-            if (state.uploadProviderError) {
-                PreferencePersistError(R.string.settings_upload_provider_persist_failed)
-            }
-            // The Client-ID field is only meaningful for imgur (diberie needs no credentials).
-            if (state.uploadProvider == UploadProviderId.IMGUR) {
-                OutlinedTextField(
-                    value = state.imgurClientId,
-                    onValueChange = { onIntent(SettingsIntent.SetImgurClientId(it)) },
-                    singleLine = true,
-                    label = { Text(stringResource(R.string.settings_upload_imgur_client_id_label)) },
-                    supportingText = {
-                        Text(stringResource(R.string.settings_upload_imgur_client_id_helper))
-                    },
-                    isError = state.imgurClientIdError,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-                if (state.imgurClientIdError) {
-                    PreferencePersistError(R.string.settings_upload_imgur_client_id_persist_failed)
-                }
-            }
-            // #459 PR-images follow-up — how the editor wraps an inserted image (applies to uploads
-            // and pasted URLs). Reduced = the HFR "vignette cliquable" (default).
-            Text(
-                text = stringResource(R.string.settings_image_insert_title),
-                style = MaterialTheme.typography.titleSmall,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Text(
-                text = stringResource(R.string.settings_image_insert_intro),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            val imageInsertOptions = listOf(
-                EditorImageInsert.FULL to stringResource(R.string.settings_image_insert_full),
-                EditorImageInsert.LINKED to stringResource(R.string.settings_image_insert_linked),
-                EditorImageInsert.REDUCED to stringResource(R.string.settings_image_insert_reduced),
-            )
-            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                imageInsertOptions.forEachIndexed { index, (mode, label) ->
-                    SegmentedButton(
-                        selected = state.editorImageInsert == mode,
-                        enabled = !state.isUpdatingEditorImageInsert,
-                        onClick = { onIntent(SettingsIntent.SetEditorImageInsert(mode)) },
-                        shape = SegmentedButtonDefaults.itemShape(index = index, count = imageInsertOptions.size),
-                    ) {
-                        Text(label)
-                    }
-                }
-            }
-            if (state.editorImageInsertError) {
-                PreferencePersistError(R.string.settings_image_insert_persist_failed)
-            }
-        }
-    }
-}
-
-@Composable
-private fun EditingPreferencesCard(
-    state: SettingsState,
-    onIntent: (SettingsIntent) -> Unit,
-) {
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.settings_editing_title),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            PreferenceSwitchRow(
+            ),
+        ),
+    ),
+    // Édition et publication (inline toggle).
+    SettingsCatalogueSection(
+        id = "editing",
+        title = stringResource(R.string.settings_section_editing),
+        items = listOf(
+            toggleRow(
+                id = "confirm_before_posting",
                 title = stringResource(R.string.settings_confirm_before_posting_title),
                 description = stringResource(R.string.settings_confirm_before_posting_description),
                 checked = state.confirmBeforePosting,
                 enabled = state.canToggleConfirmBeforePosting,
+                errorRes = R.string.settings_confirm_before_posting_persist_failed
+                    .takeIf { state.confirmBeforePostingError },
                 onCheckedChange = { onIntent(SettingsIntent.ConfirmBeforePostingChanged(it)) },
-            )
-            if (state.confirmBeforePostingError) {
-                PreferencePersistError(R.string.settings_confirm_before_posting_persist_failed)
-            }
-        }
-    }
-}
+            ),
+        ),
+    ),
+    // Images (sub-page).
+    SettingsCatalogueSection(
+        id = "images",
+        title = stringResource(R.string.settings_section_images),
+        items = listOf(
+            navRow(
+                id = "images_nav",
+                title = stringResource(R.string.settings_nav_images),
+                description = stringResource(R.string.settings_nav_images_description),
+                keywords = listOf(
+                    "images",
+                    "hébergeur",
+                    "imgur",
+                    "diberie",
+                    "upload",
+                    "insertion",
+                    stringResource(R.string.settings_upload_provider_title),
+                    stringResource(R.string.settings_upload_provider_diberie),
+                    stringResource(R.string.settings_upload_provider_imgur),
+                    stringResource(R.string.settings_upload_imgur_client_id_label),
+                    stringResource(R.string.settings_image_insert_title),
+                    // Visible image-insert choice labels so they route here, not to the empty state.
+                    stringResource(R.string.settings_image_insert_full),
+                    stringResource(R.string.settings_image_insert_linked),
+                    stringResource(R.string.settings_image_insert_reduced),
+                    stringResource(R.string.settings_my_images_title),
+                ),
+                onClick = onOpenImages,
+            ),
+        ),
+    ),
+    // Messages privés (inline toggle).
+    SettingsCatalogueSection(
+        id = "mp",
+        title = stringResource(R.string.settings_section_mp),
+        items = listOf(
+            toggleRow(
+                id = "mp_unread_badge",
+                title = stringResource(R.string.settings_mp_unread_badge_title),
+                description = stringResource(R.string.settings_mp_unread_badge_description),
+                checked = state.mpUnreadBadge,
+                enabled = state.canToggleMpUnreadBadge,
+                errorRes = R.string.settings_mp_unread_badge_persist_failed.takeIf { state.mpUnreadBadgeError },
+                onCheckedChange = { onIntent(SettingsIntent.MpUnreadBadgeChanged(it)) },
+            ),
+        ),
+    ),
+    // Compte HFR (sub-page).
+    SettingsCatalogueSection(
+        id = "hfr_account",
+        title = stringResource(R.string.settings_section_hfr_account),
+        items = listOf(
+            navRow(
+                id = "account_nav",
+                title = stringResource(R.string.settings_nav_account),
+                description = stringResource(R.string.settings_nav_account_description),
+                keywords = listOf(
+                    "compte",
+                    "hfr",
+                    "profil",
+                    "version",
+                    "à propos",
+                    "diagnostic",
+                    stringResource(R.string.settings_about_diagnostics),
+                    stringResource(R.string.settings_about_report),
+                ),
+                onClick = onOpenAccountAbout,
+            ),
+        ),
+    ),
+    // Notifications (future, disabled — searchable).
+    SettingsCatalogueSection(
+        id = "notifications",
+        title = stringResource(R.string.settings_section_notifications),
+        items = listOf(
+            futureRow(
+                id = "future_notifications",
+                title = stringResource(R.string.settings_future_notifications),
+            ),
+        ),
+    ),
+    // Accessibilité (future, disabled — searchable).
+    SettingsCatalogueSection(
+        id = "accessibility",
+        title = stringResource(R.string.settings_section_accessibility),
+        items = listOf(
+            futureRow(
+                id = "future_timezone",
+                title = stringResource(R.string.settings_future_timezone),
+            ),
+            futureRow(
+                id = "future_multilang",
+                title = stringResource(R.string.settings_future_multilang),
+            ),
+        ),
+    ),
+    // Extensions et filtrage (future, disabled — searchable).
+    SettingsCatalogueSection(
+        id = "extensions",
+        title = stringResource(R.string.settings_section_extensions),
+        items = listOf(
+            futureRow(
+                id = "future_extensions",
+                title = stringResource(R.string.settings_future_extensions),
+            ),
+        ),
+    ),
+)
 
-/**
- * One label + description + Material 3 [Switch] row. Generic so the two Drapeaux preference rows
- * share the layout; the persist-failure message is rendered by the caller via
- * [PreferencePersistError] so this stays a layout-only composable.
- */
-@Composable
-private fun PreferenceSwitchRow(
+/** A navigation row (chevron trailing) — opaque to search via [keywords]. */
+private fun navRow(
+    id: String,
+    title: String,
+    description: String,
+    keywords: List<String>,
+    onClick: () -> Unit,
+): SettingsCatalogueRow = SettingsCatalogueRow(
+    searchable = SettingsSearchableItem(id = id, title = title, description = description, keywords = keywords),
+    render = {
+        RedfaceSettingsListItem(
+            title = title,
+            description = description,
+            onClick = onClick,
+            trailingContent = { ChevronTrailing() },
+        )
+    },
+)
+
+/** A toggle row (trailing `Switch`) with an optional inline persist-error message below it. */
+@Suppress("LongParameterList") // row descriptor: id + title/description + checked/enabled/error + callback.
+private fun toggleRow(
+    id: String,
     title: String,
     description: String,
     checked: Boolean,
     enabled: Boolean,
+    errorRes: Int?,
     onCheckedChange: (Boolean) -> Unit,
-) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Column(
-            modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(2.dp),
-        ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurface,
+): SettingsCatalogueRow = SettingsCatalogueRow(
+    searchable = SettingsSearchableItem(id = id, title = title, description = description),
+    render = {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            RedfaceSettingsListItem(
+                title = title,
+                description = description,
+                trailingContent = {
+                    Switch(checked = checked, enabled = enabled, onCheckedChange = onCheckedChange)
+                },
             )
-            Text(
-                text = description,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-        Switch(
-            checked = checked,
-            enabled = enabled,
-            onCheckedChange = onCheckedChange,
-        )
-    }
-}
-
-/** Inline persist-failure message for a [PreferenceSwitchRow], shown below the row. */
-@Composable
-internal fun PreferencePersistError(messageRes: Int) {
-    Text(
-        text = stringResource(messageRes),
-        style = MaterialTheme.typography.bodySmall,
-        color = MaterialTheme.colorScheme.error,
-    )
-}
-
-@Composable
-private fun MaintenanceCard(
-    state: SettingsState,
-    onIntent: (SettingsIntent) -> Unit,
-) {
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.settings_maintenance_title),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Text(
-                text = stringResource(R.string.settings_clear_topic_cache_intro),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            if (state.isClearingTopicCache) {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(18.dp),
-                        strokeWidth = 2.dp,
-                    )
-                    Text(
-                        text = stringResource(R.string.settings_clear_topic_cache_in_progress),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+            if (errorRes != null) {
+                Box(modifier = Modifier.padding(horizontal = 16.dp)) {
+                    PreferencePersistError(errorRes)
                 }
             }
-            when (state.topicCacheClearResult) {
-                TopicCacheClearResult.Success -> Text(
-                    text = stringResource(R.string.settings_clear_topic_cache_success),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-                TopicCacheClearResult.Failure -> Text(
-                    text = stringResource(R.string.settings_clear_topic_cache_failure),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error,
-                )
-                null -> Unit
-            }
-            OutlinedButton(
-                enabled = state.canClearTopicCache,
-                onClick = { onIntent(SettingsIntent.ClearTopicCacheClicked) },
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Text(stringResource(R.string.settings_clear_topic_cache_button))
-            }
-
-            // #314 — « Vider le cache des images », same confirm → progress → inline-result
-            // flow as the topic clear above, on its own dedicated state fields.
-            Text(
-                text = stringResource(R.string.settings_clear_image_cache_intro),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            if (state.isClearingImageCache) {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(18.dp),
-                        strokeWidth = 2.dp,
-                    )
-                    Text(
-                        text = stringResource(R.string.settings_clear_image_cache_in_progress),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-            when (state.imageCacheClearResult) {
-                ImageCacheClearResult.Success -> Text(
-                    text = stringResource(R.string.settings_clear_image_cache_success),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-                ImageCacheClearResult.Failure -> Text(
-                    text = stringResource(R.string.settings_clear_image_cache_failure),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error,
-                )
-                null -> Unit
-            }
-            OutlinedButton(
-                enabled = state.canClearImageCache,
-                onClick = { onIntent(SettingsIntent.ClearImageCacheClicked) },
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Text(stringResource(R.string.settings_clear_image_cache_button))
-            }
-
-            IgnoreTopicCacheRow(
-                state = state,
-                onIntent = onIntent,
-            )
         }
-    }
-}
+    },
+)
 
-@Composable
-private fun IgnoreTopicCacheRow(
-    state: SettingsState,
-    onIntent: (SettingsIntent) -> Unit,
-) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Column(
-            modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(2.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.settings_ignore_topic_cache_title),
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Text(
-                text = stringResource(R.string.settings_ignore_topic_cache_description),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-        Switch(
-            checked = state.ignoreTopicCache,
-            enabled = state.canToggleIgnoreTopicCache,
-            onCheckedChange = { onIntent(SettingsIntent.IgnoreTopicCacheChanged(it)) },
-        )
-    }
-    if (state.ignoreTopicCacheError) {
-        Text(
-            text = stringResource(R.string.settings_ignore_topic_cache_persist_failed),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.error,
-        )
-    }
-}
-
-@Composable
-private fun ClearTopicCacheConfirmDialog(
-    onConfirm: () -> Unit,
-    onDismiss: () -> Unit,
-) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.settings_clear_topic_cache_confirm_title)) },
-        text = { Text(stringResource(R.string.settings_clear_topic_cache_confirm_body)) },
-        confirmButton = {
-            TextButton(onClick = onConfirm) {
-                Text(stringResource(R.string.settings_clear_topic_cache_confirm_action))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.settings_clear_topic_cache_confirm_cancel))
-            }
-        },
-    )
-}
-
-@Composable
-private fun ClearImageCacheConfirmDialog(
-    onConfirm: () -> Unit,
-    onDismiss: () -> Unit,
-) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.settings_clear_image_cache_confirm_title)) },
-        text = { Text(stringResource(R.string.settings_clear_image_cache_confirm_body)) },
-        confirmButton = {
-            TextButton(onClick = onConfirm) {
-                Text(stringResource(R.string.settings_clear_image_cache_confirm_action))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.settings_clear_image_cache_confirm_cancel))
-            }
-        },
-    )
-}
+/** A planned (not-yet-shipped) row: disabled but still searchable (`enabled = false`). */
+private fun futureRow(
+    id: String,
+    title: String,
+): SettingsCatalogueRow = SettingsCatalogueRow(
+    searchable = SettingsSearchableItem(id = id, title = title, enabled = false),
+    render = {
+        RedfaceSettingsListItem(title = title, enabled = false)
+    },
+)

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -8,10 +8,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -19,6 +21,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -81,6 +84,7 @@ fun SettingsScreen(
 // 12 navigation/intent callbacks + state make the explicit surface; grouping them behind an object
 // would hide the call site. The two VMs are observed in [SettingsScreen]; this content is the
 // stateless catalogue body so it stays previewable/testable without Hilt.
+@OptIn(ExperimentalMaterial3Api::class)
 @Suppress("LongParameterList", "LongMethod", "CyclomaticComplexMethod")
 @Composable
 internal fun SettingsRoot(
@@ -144,8 +148,14 @@ internal fun SettingsRoot(
         .associate { it.searchable.id to it.render }
     val filtered = filterSettingsSections(sections.map { it.toSearchable() }, query)
 
+    // #494 — effet « résultats sous la barre » (idiome M3) : pinnedScrollBehavior + nestedScroll sur le
+    // Scaffold → la barre prend sa teinte surfaceContainer quand la liste de résultats défile dessous.
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+
     Scaffold(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             RedfaceSettingsSearchTopBar(
                 labels = rememberSettingsSearchTopBarLabels(),
@@ -156,6 +166,7 @@ internal fun SettingsRoot(
                     searchActive = active
                     if (!active) query = ""
                 },
+                scrollBehavior = scrollBehavior,
                 actions = { topBarActions?.invoke() },
             )
         },

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsSearch.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsSearch.kt
@@ -1,0 +1,77 @@
+package fr.forumhfr.redface2.feature.settings
+
+import java.text.Normalizer
+
+/**
+ * #494 — pure, testable model of the settings catalogue for the activable search.
+ *
+ * This file is 100% Kotlin/JVM: it has NO `androidx`/`android` dependency (no `R`, no Compose, no
+ * `SettingsState`) so [filterSettingsSections] can be unit-tested without Robolectric. The mapping
+ * from `SettingsState` + resolved strings to a `List<SettingsSearchableSection>` is built at the
+ * `SettingsScreen` call site, not here.
+ */
+
+/** A catalogue section (e.g. « Affichage ») holding its searchable items. */
+internal data class SettingsSearchableSection(
+    val id: String,
+    val title: String,
+    val items: List<SettingsSearchableItem>,
+)
+
+/**
+ * A single searchable settings entry.
+ *
+ * - [keywords] are extra match terms not shown verbatim (synonyms, related issue topics).
+ * - [enabled] mirrors the row's interactivity. Disabled (future) rows STAY searchable.
+ * - [visible] gates the row entirely: an item with `visible = false` (e.g. a DT-only entry while the
+ *   DT section is off) is excluded from results even when it would match the query.
+ */
+internal data class SettingsSearchableItem(
+    val id: String,
+    val title: String,
+    val description: String? = null,
+    val keywords: List<String> = emptyList(),
+    val enabled: Boolean = true,
+    val visible: Boolean = true,
+)
+
+/**
+ * Filters [sections] against [query].
+ *
+ * - Items with `visible = false` are dropped first, always.
+ * - A blank [query] returns every section with its visible items (sections that have no visible item
+ *   are omitted).
+ * - Otherwise an item matches when the case- and accent-folded [query] is contained in the folded
+ *   title, description, or any keyword. `enabled = false` items remain matchable.
+ * - Sections left with no matching item are omitted.
+ *
+ * Folding replicates `ForumUiState.foldForSearch` (NFD + combining-marks removal + lowercase).
+ */
+internal fun filterSettingsSections(
+    sections: List<SettingsSearchableSection>,
+    query: String,
+): List<SettingsSearchableSection> {
+    val visibleSections = sections.map { section ->
+        section.copy(items = section.items.filter { it.visible })
+    }
+    if (query.isBlank()) {
+        return visibleSections.filter { it.items.isNotEmpty() }
+    }
+    val needle = query.foldForSearch()
+    return visibleSections.mapNotNull { section ->
+        val matches = section.items.filter { item -> item.matches(needle) }
+        if (matches.isEmpty()) null else section.copy(items = matches)
+    }
+}
+
+private fun SettingsSearchableItem.matches(needle: String): Boolean =
+    title.foldForSearch().contains(needle) ||
+        description?.foldForSearch()?.contains(needle) == true ||
+        keywords.any { it.foldForSearch().contains(needle) }
+
+private fun String.foldForSearch(): String =
+    Normalizer.normalize(this, Normalizer.Form.NFD)
+        .replace(COMBINING_MARKS, "")
+        .lowercase()
+
+private val COMBINING_MARKS = Regex("\\p{InCombiningDiacriticalMarks}+")

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/StartScreenPreferencesCard.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/StartScreenPreferencesCard.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Card
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
@@ -12,9 +11,6 @@ import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -25,12 +21,19 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
+import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsChoice
+import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsChoiceGroup
 
 /**
- * Settings card « Écran de démarrage » (#458): segmented choice of the cold-start tab, plus —
+ * Settings block « Écran de démarrage » (#458): segmented choice of the cold-start tab, plus —
  * for the Forum tab — an optional category picker (« Accueil du forum » = no pre-stacked
  * category). The selection applies on the NEXT launch (the intro line says so): the running
  * session is never teleported.
+ *
+ * #494 — the surrounding `Card` was dropped: the block now renders inline inside the settings
+ * `LazyColumn` (the « Démarrage » section stays at the root, it is not a sub-page). The 3-way
+ * selector uses the shared [RedfaceSettingsChoiceGroup]; the category picker keeps its bespoke
+ * `ExposedDropdownMenuBox` (not covered by the list primitives).
  */
 @Composable
 internal fun StartScreenPreferencesCard(
@@ -38,43 +41,32 @@ internal fun StartScreenPreferencesCard(
     onIntent: (StartScreenSettingsIntent) -> Unit,
 ) {
     val options = listOf(
-        StartScreenChoice.FLAGS to stringResource(R.string.settings_start_screen_flags),
-        StartScreenChoice.FORUM to stringResource(R.string.settings_start_screen_forum),
-        StartScreenChoice.MESSAGES to stringResource(R.string.settings_start_screen_messages),
+        RedfaceSettingsChoice(StartScreenChoice.FLAGS, stringResource(R.string.settings_start_screen_flags)),
+        RedfaceSettingsChoice(StartScreenChoice.FORUM, stringResource(R.string.settings_start_screen_forum)),
+        RedfaceSettingsChoice(StartScreenChoice.MESSAGES, stringResource(R.string.settings_start_screen_messages)),
     )
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.settings_start_screen_title),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Text(
-                text = stringResource(R.string.settings_start_screen_intro),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                options.forEachIndexed { index, (choice, label) ->
-                    SegmentedButton(
-                        selected = state.preference.screen == choice,
-                        enabled = state.canChange,
-                        onClick = { onIntent(StartScreenSettingsIntent.ScreenChanged(choice)) },
-                        shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
-                    ) {
-                        Text(label)
-                    }
-                }
-            }
-            if (state.preference.screen == StartScreenChoice.FORUM) {
-                StartForumCategoryPicker(state = state, onIntent = onIntent)
-            }
-            if (state.persistError) {
-                PreferencePersistError(R.string.settings_start_screen_persist_failed)
-            }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.settings_start_screen_intro),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        RedfaceSettingsChoiceGroup(
+            options = options,
+            selected = state.preference.screen,
+            onSelected = { onIntent(StartScreenSettingsIntent.ScreenChanged(it)) },
+            enabled = state.canChange,
+        )
+        if (state.preference.screen == StartScreenChoice.FORUM) {
+            StartForumCategoryPicker(state = state, onIntent = onIntent)
+        }
+        if (state.persistError) {
+            PreferencePersistError(R.string.settings_start_screen_persist_failed)
         }
     }
 }

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -40,6 +40,25 @@
     <string name="settings_search_placeholder">Rechercher un réglage…</string>
     <string name="settings_search_empty">Aucun réglage ne correspond à votre recherche.</string>
 
+    <!-- #494 v2 — racine « catégories d'abord » : familles, sous-titres de catégories, a11y, écran « À venir ». -->
+    <string name="settings_menu_content_description">Menu</string>
+    <string name="settings_category_upcoming_title">À venir</string>
+    <string name="settings_family_appearance">Apparence</string>
+    <string name="settings_family_communication">Communication</string>
+    <string name="settings_family_content">Contenu</string>
+    <string name="settings_family_system">Système</string>
+    <string name="settings_family_other">Autres</string>
+    <string name="settings_category_subtitle_display">Thème, AMOLED, densité, police</string>
+    <string name="settings_category_subtitle_flags">Regroupement, masquer lus, auto-refresh</string>
+    <string name="settings_category_subtitle_topic">Barre, sondages, navigation</string>
+    <string name="settings_category_subtitle_mp">Badge de non-lus</string>
+    <string name="settings_category_subtitle_editing">Confirmation avant envoi</string>
+    <string name="settings_category_subtitle_images">Hébergeur, Client-ID, insertion</string>
+    <string name="settings_category_subtitle_start">Écran ouvert au lancement</string>
+    <string name="settings_category_subtitle_network">Proxy, vider les caches</string>
+    <string name="settings_category_subtitle_account">Compte HFR, version, diagnostics</string>
+    <string name="settings_category_subtitle_upcoming">Fonctionnalités planifiées</string>
+
     <!-- #494 — lignes de navigation de la racine vers les sous-pages, et titres des sous-pages. -->
     <string name="settings_nav_proxy">Proxy</string>
     <string name="settings_nav_proxy_description">Router les requêtes HFR via votre proxy.</string>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -31,6 +31,35 @@
     <string name="settings_section_accessibility">Accessibilité</string>
     <string name="settings_section_extensions">Extensions et filtrage</string>
     <string name="settings_hfr_account_note">Ces réglages proviennent de votre profil HFR (editprofil.php) et arriveront plus tard.</string>
+
+    <!-- #494 — refonte du menu : barre supérieure avec recherche activable, sous-pages, état vide. -->
+    <string name="settings_back">Retour</string>
+    <string name="settings_search_open">Rechercher dans les réglages</string>
+    <string name="settings_search_close">Fermer la recherche</string>
+    <string name="settings_search_clear">Effacer la recherche</string>
+    <string name="settings_search_placeholder">Rechercher un réglage…</string>
+    <string name="settings_search_empty">Aucun réglage ne correspond à votre recherche.</string>
+
+    <!-- #494 — lignes de navigation de la racine vers les sous-pages, et titres des sous-pages. -->
+    <string name="settings_nav_proxy">Proxy</string>
+    <string name="settings_nav_proxy_description">Router les requêtes HFR via votre proxy.</string>
+    <string name="settings_nav_maintenance">Maintenance</string>
+    <string name="settings_nav_maintenance_description">Vider les caches, options de debug.</string>
+    <string name="settings_nav_display">Affichage</string>
+    <string name="settings_nav_display_description">Thème, AMOLED, densité et taille de police.</string>
+    <string name="settings_nav_images">Images</string>
+    <string name="settings_nav_images_description">Hébergeur d\'images, insertion, mes images uploadées.</string>
+    <string name="settings_nav_account">Compte HFR et à propos</string>
+    <string name="settings_nav_account_description">Réglages du compte HFR, version de l\'app, diagnostic.</string>
+
+    <!-- #494 — sous-page « Compte HFR et à propos » : version de l'app et raccourcis. -->
+    <string name="settings_account_title">Compte HFR et à propos</string>
+    <string name="settings_about_version">Version</string>
+    <string name="settings_about_version_value">%1$s (build %2$d)</string>
+    <string name="settings_about_diagnostics">Diagnostic</string>
+    <string name="settings_about_diagnostics_description">Informations techniques pour le support.</string>
+    <string name="settings_about_report">Signaler un contenu ou un problème</string>
+    <string name="settings_diagnostics_open">Ouvrir le diagnostic</string>
     <string name="settings_phase_future">À venir</string>
     <string name="settings_phase_future_far">Plus tard</string>
     <string name="settings_phase_planned">Planifié</string>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <!-- #313 — carte « Messages privés » : badge MP non lus. -->
     <string name="settings_mp_title">Notifications</string>
     <string name="settings_mp_unread_badge_title">Badge de MP non lus</string>
-    <string name="settings_mp_unread_badge_description">Affiche le nombre de conversations non lues sur l\'onglet Messages. Actualisé à l\'ouverture de l\'app et à chaque visite de la liste.</string>
+    <string name="settings_mp_unread_badge_description">Nombre de conversations non lues sur l\'onglet Messages.</string>
     <string name="settings_mp_unread_badge_persist_failed">Impossible d\'enregistrer ce réglage pour le moment.</string>
     <string name="settings_section_hfr_account">Compte HFR</string>
     <string name="settings_section_notifications">Notifications</string>
@@ -42,12 +42,10 @@
 
     <!-- #494 v2 — racine « catégories d'abord » : familles, sous-titres de catégories, a11y, écran « À venir ». -->
     <string name="settings_menu_content_description">Menu</string>
-    <string name="settings_category_upcoming_title">À venir</string>
     <string name="settings_family_appearance">Apparence</string>
     <string name="settings_family_communication">Communication</string>
     <string name="settings_family_content">Contenu</string>
     <string name="settings_family_system">Système</string>
-    <string name="settings_family_other">Autres</string>
     <string name="settings_category_subtitle_display">Thème, AMOLED, densité, police</string>
     <string name="settings_category_subtitle_flags">Regroupement, masquer lus, auto-refresh</string>
     <string name="settings_category_subtitle_topic">Barre, sondages, navigation</string>
@@ -57,7 +55,13 @@
     <string name="settings_category_subtitle_start">Écran ouvert au lancement</string>
     <string name="settings_category_subtitle_network">Proxy, vider les caches</string>
     <string name="settings_category_subtitle_account">Compte HFR, version, diagnostics</string>
-    <string name="settings_category_subtitle_upcoming">Fonctionnalités planifiées</string>
+    <!-- #494 — famille « À venir » : 3 catégories distinctes (Notifications, Accessibilité, Extensions). -->
+    <string name="settings_family_upcoming">À venir</string>
+    <string name="settings_category_subtitle_notifications">Push, MP, relève, Ne pas déranger</string>
+    <string name="settings_category_subtitle_accessibility">Contraste, animations, langue</string>
+    <string name="settings_category_subtitle_extensions">Ignorés, filtres, Blacklist, Qualitay</string>
+    <!-- #494 — badge texte affiché en trailing des lignes « à venir » (désactivées mais cherchables). -->
+    <string name="settings_future_badge">À venir</string>
 
     <!-- #494 — lignes de navigation de la racine vers les sous-pages, et titres des sous-pages. -->
     <string name="settings_nav_proxy">Proxy</string>
@@ -90,14 +94,75 @@
     <string name="settings_future_classic_theme">Thème HFR Classique</string>
     <string name="settings_future_flags_on_listing">Poser les drapeaux en listant une catégorie</string>
     <string name="settings_future_prefetch">Préchargement de la page suivante</string>
-    <string name="settings_future_signature">Signature automatique et notification e-mail</string>
-    <string name="settings_future_mp_notifications">Notifications et badge de MP non lus</string>
     <string name="settings_future_data_saver">Mode économie de données</string>
+    <!-- Toujours utilisée par SettingsAccountAboutScreen (sous-page Compte). -->
     <string name="settings_future_hfr_profile">Avatars, signatures, messages par page</string>
-    <string name="settings_future_notifications">Relève configurable, filtres, mode Ne pas déranger</string>
-    <string name="settings_future_timezone">Fuseau horaire d’affichage</string>
-    <string name="settings_future_multilang">Multilingue</string>
-    <string name="settings_future_extensions">Blacklist, Color Tag, ignore-list, Qualitay, Redflag</string>
+
+    <!-- #494 — catalogue exhaustif des options à venir (toggles désactivés mais cherchables).
+         Une string par option du draft drafts/claude-settings-catalogue-v2-options.md. -->
+    <!-- §1 Affichage -->
+    <string name="settings_future_amoled_auto_night">AMOLED automatique la nuit</string>
+    <string name="settings_future_smiley_size">Taille des smileys</string>
+    <string name="settings_future_show_avatars">Afficher les avatars dans les sujets</string>
+    <string name="settings_future_show_signatures">Afficher les signatures</string>
+    <!-- §2 Drapeaux -->
+    <string name="settings_future_flags_sort">Tri des drapeaux</string>
+    <string name="settings_future_flags_mark_read_on_scroll">Marquer lu au survol / défilement</string>
+    <string name="settings_future_flags_by_subcategory">Drapeaux par sous-catégorie</string>
+    <!-- §3 Sujet et lecture -->
+    <string name="settings_future_restore_read_position">Restaurer la position de lecture</string>
+    <string name="settings_future_swipe_page">Changer de page au glissement</string>
+    <string name="settings_future_collapse_quotes">Replier les longues citations</string>
+    <string name="settings_future_open_external_in_app">Ouvrir les liens externes dans l\'app</string>
+    <string name="settings_future_autoplay_animations">Lecture auto des images animées</string>
+    <string name="settings_future_fullscreen_reading">Plein écran en lecture</string>
+    <!-- §4 Messages privés -->
+    <string name="settings_future_mp_push">Notifications de MP</string>
+    <string name="settings_future_mp_preview">Aperçu du message dans la liste</string>
+    <string name="settings_future_mp_read_receipt">Accusé de lecture</string>
+    <!-- §5 Édition et publication -->
+    <string name="settings_future_auto_signature">Signature automatique</string>
+    <string name="settings_future_auto_drafts">Brouillons automatiques</string>
+    <string name="settings_future_recent_smileys">Smileys récents / favoris</string>
+    <string name="settings_future_spell_check">Correcteur orthographique</string>
+    <string name="settings_future_custom_bbcode_toolbar">Barre d\'outils BBCode personnalisable</string>
+    <!-- §6 Images et upload -->
+    <string name="settings_future_compress_upload">Compression avant upload</string>
+    <string name="settings_future_strip_exif">Supprimer les métadonnées (EXIF)</string>
+    <string name="settings_future_upload_wifi_only">Upload uniquement en Wi-Fi</string>
+    <!-- §7 Démarrage -->
+    <string name="settings_future_resume_last_topic">Reprendre le dernier sujet ouvert</string>
+    <!-- §8 Réseau et cache -->
+    <string name="settings_future_prefetch_wifi_only">Préchargement Wi-Fi uniquement</string>
+    <string name="settings_future_image_cache_size">Taille max du cache images</string>
+    <string name="settings_future_clear_cache_on_start">Vider le cache au démarrage</string>
+    <string name="settings_future_offline_mode">Mode hors-ligne</string>
+    <!-- §9 Compte et à propos -->
+    <string name="settings_future_hfr_profile_settings">Réglages du profil HFR</string>
+    <string name="settings_future_multi_account">Multi-comptes</string>
+    <string name="settings_future_auto_logout">Déconnexion automatique</string>
+    <!-- §10 Notifications -->
+    <string name="settings_future_notif_push">Notifications push</string>
+    <string name="settings_future_notif_mp">Notifications de MP</string>
+    <string name="settings_future_notif_mentions">Citations et mentions</string>
+    <string name="settings_future_notif_polling">Relève configurable</string>
+    <string name="settings_future_notif_dnd">Mode Ne pas déranger</string>
+    <string name="settings_future_notif_sound_vibration">Son et vibration</string>
+    <!-- §11 Accessibilité -->
+    <string name="settings_future_a11y_force_system_text">Forcer la taille du texte système</string>
+    <string name="settings_future_a11y_high_contrast">Contraste élevé</string>
+    <string name="settings_future_a11y_reduce_motion">Réduire les animations</string>
+    <string name="settings_future_a11y_timezone">Fuseau horaire d\'affichage</string>
+    <string name="settings_future_a11y_language">Langue de l\'interface</string>
+    <!-- §12 Extensions et filtrage -->
+    <string name="settings_future_ext_ignore_list">Liste d\'ignorés</string>
+    <string name="settings_future_ext_keyword_filters">Filtres par mots-clés</string>
+    <string name="settings_future_ext_blacklist">Blacklist</string>
+    <string name="settings_future_ext_color_tag">Color Tag</string>
+    <string name="settings_future_ext_qualitay">Qualitay</string>
+    <string name="settings_future_ext_redflag">Redflag</string>
+    <string name="settings_future_ext_community">Extensions communautaires</string>
+
     <string name="settings_proxy_title">Proxy utilisateur</string>
     <string name="settings_proxy_intro">Route les requêtes HFR via votre proxy. Le changement peut nécessiter un redémarrage de l’app.</string>
     <string name="settings_proxy_enabled">Activer le proxy</string>
@@ -152,28 +217,28 @@
          observées en direct par l'écran Drapeaux : un changement ici se reflète sans refetch. -->
     <string name="settings_flags_title">Drapeaux</string>
     <string name="settings_flags_group_by_category_title">Grouper par catégorie</string>
-    <string name="settings_flags_group_by_category_description">Affiche les drapeaux regroupés par catégorie de forum, avec un en-tête par catégorie. Désactivé : une liste à plat triée par dernière réponse (comme avant).</string>
+    <string name="settings_flags_group_by_category_description">En-tête par catégorie ; sinon liste à plat.</string>
     <string name="settings_flags_group_by_category_persist_failed">Impossible de mémoriser l\'affichage des drapeaux. Réessayez.</string>
     <string name="settings_flags_hide_read_categories_title">Masquer les catégories sans non-lu</string>
-    <string name="settings_flags_hide_read_categories_description">Cache les catégories qui n\'ont aucun message non lu. Les cyans déjà lus restent accessibles en activant « +lus » sur l\'onglet Mes sujets. Sans effet en vue à plat.</string>
+    <string name="settings_flags_hide_read_categories_description">Cache les catégories sans message non lu. Sans effet en vue à plat.</string>
     <string name="settings_flags_hide_read_categories_persist_failed">Impossible de mémoriser le filtre des catégories. Réessayez.</string>
 
     <!-- #309 — Réglages d'affichage différents par type de drapeau (onglet). Quand activé, les deux
          réglages ci-dessus servent de valeurs par défaut et chaque onglet (Mes sujets / Lu / Favoris)
          garde son propre affichage, ajustable depuis le menu d'affichage de l'écran Drapeaux. -->
     <string name="settings_flags_per_tab_override_title">Réglages différents par onglet</string>
-    <string name="settings_flags_per_tab_override_description">Chaque onglet (Mes sujets, Lu, Favoris) garde son propre affichage. Les réglages ci-dessus deviennent les valeurs par défaut ; ajustez chaque onglet depuis le menu d\'affichage de l\'écran Drapeaux.</string>
+    <string name="settings_flags_per_tab_override_description">Chaque onglet (Mes sujets, Lu, Favoris) garde son propre affichage ; les réglages ci-dessus servent de valeurs par défaut.</string>
     <string name="settings_flags_per_tab_override_persist_failed">Impossible de mémoriser le réglage par onglet. Réessayez.</string>
 
     <!-- Onglet « DT » opt-in dans l'écran Drapeaux (placeholder, synchro MPStorage à venir, #6). -->
     <string name="settings_flags_show_dt_section_title">Section DT</string>
-    <string name="settings_flags_show_dt_section_description">Affiche un onglet « DT » dans l\'écran Drapeaux. Le contenu (discussions suivies avec drapeaux synchronisés via MPStorage) arrivera dans une prochaine version.</string>
+    <string name="settings_flags_show_dt_section_description">Affiche un onglet « DT » dans l\'écran Drapeaux (contenu à venir).</string>
     <string name="settings_flags_show_dt_section_persist_failed">Impossible de mémoriser la section DT. Réessayez.</string>
 
     <!-- #378 — auto-refresh des listes de drapeaux à l'arrivée sur l'écran (ouverture de l'app,
          retour d'un sujet). Activé par défaut ; ce réglage est l'opt-out. -->
     <string name="settings_flags_auto_refresh_title">Actualisation automatique</string>
-    <string name="settings_flags_auto_refresh_description">Rafraîchit la liste des drapeaux à l\'ouverture de l\'app et au retour d\'un sujet. L\'indicateur de rafraîchissement signale l\'actualisation en cours.</string>
+    <string name="settings_flags_auto_refresh_description">Rafraîchit la liste à l\'ouverture de l\'app et au retour d\'un sujet.</string>
     <string name="settings_flags_auto_refresh_persist_failed">Impossible de mémoriser l\'actualisation automatique. Réessayez.</string>
 
     <!-- #286 — Thème. Sélecteur Clair/Système/Sombre (Système = suit l'OS) + thème AMOLED (vrai
@@ -206,17 +271,17 @@
          en défilant vers le bas pour libérer de la place ; persisté en DataStore et appliqué en direct. -->
     <string name="settings_topic_title">Lecture des sujets</string>
     <string name="settings_topic_topbar_auto_hide_title">Masquer la barre en défilant</string>
-    <string name="settings_topic_topbar_auto_hide_description">La barre du haut (titre du sujet et numéro de page) disparaît quand vous faites défiler vers le bas et réapparaît dès que vous remontez.</string>
+    <string name="settings_topic_topbar_auto_hide_description">La barre du haut disparaît en défilant vers le bas, réapparaît en remontant.</string>
     <string name="settings_topic_topbar_auto_hide_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
 
     <!-- #383 — Boutons flottants ‹/› de changement de page (#283). Le swipe (#282) couvre déjà le
          changement de page ; ce réglage est l'opt-out demandé en bêta. « Répondre » reste affiché. -->
     <string name="settings_topic_page_fabs_title">Boutons de changement de page</string>
-    <string name="settings_topic_page_fabs_description">Affiche les boutons flottants ‹ et › en bas du sujet. Désactivez-les si vous changez de page au glissement ; le bouton Répondre reste affiché.</string>
+    <string name="settings_topic_page_fabs_description">Boutons flottants ‹ et › en bas du sujet ; le bouton Répondre reste affiché.</string>
     <string name="settings_topic_page_fabs_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
     <!-- #456 — sondages dépliés par défaut dans la lecture de sujet. -->
     <string name="settings_topic_polls_expanded_title">Déplier les sondages</string>
-    <string name="settings_topic_polls_expanded_description">Affiche les sondages dépliés en haut des sujets. Désactivé : une ligne « Sondage » repliée, à déplier d\'un appui.</string>
+    <string name="settings_topic_polls_expanded_description">Sondages dépliés en haut des sujets ; sinon une ligne repliée.</string>
     <string name="settings_topic_polls_expanded_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
 
     <!-- #312 — Publication. Confirmation avant chaque envoi (réponse/édition de message, sujet,
@@ -225,7 +290,7 @@
          toggles actifs. -->
     <string name="settings_editing_title">Publication</string>
     <string name="settings_confirm_before_posting_title">Confirmation avant publication</string>
-    <string name="settings_confirm_before_posting_description">Demande une confirmation avant d\'envoyer une réponse, un sujet ou un message privé.</string>
+    <string name="settings_confirm_before_posting_description">Avant chaque réponse, sujet ou MP envoyé.</string>
     <string name="settings_confirm_before_posting_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
 
     <!-- #459 PR3 — entrée vers l'écran « Mes images uploadées » depuis le catalogue de réglages. -->

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsCategoriesTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsCategoriesTest.kt
@@ -1,0 +1,77 @@
+package fr.forumhfr.redface2.feature.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #494 v2 — contrat de routage de la racine « catégories d'abord » : les catégories adossées à une
+ * sous-page dédiée y mènent directement, les autres ouvrent le détail générique ; le mapping
+ * catégorie → section(s) du catalogue est figé (notamment « À venir » qui agrège 3 sections futures).
+ */
+class SettingsCategoriesTest {
+
+    private class Spy {
+        var display = 0
+        var images = 0
+        var accountAbout = 0
+        var category: String? = null
+
+        fun route(id: String) = routeSettingsCategory(
+            id = id,
+            onOpenDisplay = { display++ },
+            onOpenImages = { images++ },
+            onOpenAccountAbout = { accountAbout++ },
+            onOpenCategory = { category = it },
+        )
+    }
+
+    @Test
+    fun `dedicated categories route straight to their sub-page`() {
+        with(Spy()) {
+            route("display")
+            assertEquals(1, display)
+            assertNull(category)
+        }
+        with(Spy()) {
+            route("images")
+            assertEquals(1, images)
+            assertNull(category)
+        }
+        with(Spy()) {
+            route("account")
+            assertEquals(1, accountAbout)
+            assertNull(category)
+        }
+    }
+
+    @Test
+    fun `other categories open the generic detail with their id`() {
+        for (id in listOf("flags", "topic", "mp", "editing", "start", "network", "upcoming")) {
+            with(Spy()) {
+                route(id)
+                assertEquals(id, category)
+                assertEquals(0, display + images + accountAbout)
+            }
+        }
+    }
+
+    @Test
+    fun `upcoming aggregates the three future sections`() {
+        assertEquals(listOf("notifications", "accessibility", "extensions"), sectionIdsForCategory("upcoming"))
+    }
+
+    @Test
+    fun `a regular category maps to its own section id`() {
+        assertEquals(listOf("flags"), sectionIdsForCategory("flags"))
+        assertEquals(listOf("network"), sectionIdsForCategory("network"))
+    }
+
+    @Test
+    fun `every category title resolves to a non-zero resource`() {
+        for (id in listOf("network", "start", "flags", "topic", "editing", "mp", "upcoming")) {
+            assertTrue("title res for $id", categoryTitleRes(id) != 0)
+        }
+    }
+}

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsCategoriesTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsCategoriesTest.kt
@@ -8,7 +8,9 @@ import org.junit.Test
 /**
  * #494 v2 — contrat de routage de la racine « catégories d'abord » : les catégories adossées à une
  * sous-page dédiée y mènent directement, les autres ouvrent le détail générique ; le mapping
- * catégorie → section(s) du catalogue est figé (notamment « À venir » qui agrège 3 sections futures).
+ * catégorie → section du catalogue est l'identité (id-catégorie == id-section). Les 3 catégories « à
+ * venir » (Notifications/Accessibilité/Extensions) sont désormais distinctes, plus une « À venir »
+ * fourre-tout.
  */
 class SettingsCategoriesTest {
 
@@ -48,7 +50,11 @@ class SettingsCategoriesTest {
 
     @Test
     fun `other categories open the generic detail with their id`() {
-        for (id in listOf("flags", "topic", "mp", "editing", "start", "network", "upcoming")) {
+        val generic = listOf(
+            "flags", "topic", "mp", "editing", "start", "network",
+            "notifications", "accessibility", "extensions",
+        )
+        for (id in generic) {
             with(Spy()) {
                 route(id)
                 assertEquals(id, category)
@@ -58,8 +64,10 @@ class SettingsCategoriesTest {
     }
 
     @Test
-    fun `upcoming aggregates the three future sections`() {
-        assertEquals(listOf("notifications", "accessibility", "extensions"), sectionIdsForCategory("upcoming"))
+    fun `the three future categories map to their own homonymous section`() {
+        assertEquals(listOf("notifications"), sectionIdsForCategory("notifications"))
+        assertEquals(listOf("accessibility"), sectionIdsForCategory("accessibility"))
+        assertEquals(listOf("extensions"), sectionIdsForCategory("extensions"))
     }
 
     @Test
@@ -70,7 +78,11 @@ class SettingsCategoriesTest {
 
     @Test
     fun `every category title resolves to a non-zero resource`() {
-        for (id in listOf("network", "start", "flags", "topic", "editing", "mp", "upcoming")) {
+        val ids = listOf(
+            "network", "start", "flags", "topic", "editing", "mp",
+            "notifications", "accessibility", "extensions",
+        )
+        for (id in ids) {
             assertTrue("title res for $id", categoryTitleRes(id) != 0)
         }
     }

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsSearchTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsSearchTest.kt
@@ -1,0 +1,157 @@
+package fr.forumhfr.redface2.feature.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #494 — pure unit tests for [filterSettingsSections]. JUnit4 only, no Robolectric / Android
+ * resources: the filter is synchronous and Android-free by design.
+ */
+class SettingsSearchTest {
+
+    private fun sections() = listOf(
+        SettingsSearchableSection(
+            id = "display",
+            title = "Affichage",
+            items = listOf(
+                SettingsSearchableItem(
+                    id = "theme",
+                    title = "Thème",
+                    description = "Clair, Système ou Sombre",
+                    keywords = listOf("amoled", "couleur"),
+                ),
+                SettingsSearchableItem(
+                    id = "density",
+                    title = "Densité et police de lecture",
+                ),
+            ),
+        ),
+        SettingsSearchableSection(
+            id = "editing",
+            title = "Édition et publication",
+            items = listOf(
+                SettingsSearchableItem(
+                    id = "confirm",
+                    title = "Confirmation avant publication",
+                ),
+            ),
+        ),
+        SettingsSearchableSection(
+            id = "notifications",
+            title = "Notifications",
+            items = listOf(
+                // Planned (disabled) — must stay searchable.
+                SettingsSearchableItem(
+                    id = "future_notifications",
+                    title = "Relève configurable",
+                    enabled = false,
+                ),
+            ),
+        ),
+        // A navigation row whose target sub-page hosts controls only reachable by their displayed
+        // label (e.g. « Hôte » in Proxy). The row carries those labels as keywords so search routes
+        // to the sub-page instead of the empty state (#494 Codex P2).
+        SettingsSearchableSection(
+            id = "network",
+            title = "Réseau et cache",
+            items = listOf(
+                SettingsSearchableItem(
+                    id = "proxy",
+                    title = "Proxy",
+                    description = "Configurer un proxy HTTP",
+                    keywords = listOf("proxy", "Hôte", "Port"),
+                ),
+            ),
+        ),
+        SettingsSearchableSection(
+            id = "mp",
+            title = "Messages privés",
+            items = listOf(
+                // Gated off — must be excluded entirely.
+                SettingsSearchableItem(
+                    id = "dt_inspector",
+                    title = "Inspecteur MP storage",
+                    visible = false,
+                ),
+                SettingsSearchableItem(
+                    id = "mp_badge",
+                    title = "Badge de MP non lus",
+                ),
+            ),
+        ),
+    )
+
+    @Test
+    fun `blank query returns all sections with visible items`() {
+        val result = filterSettingsSections(sections(), "")
+        // The MP section keeps only its visible item; every other section is present.
+        assertEquals(listOf("display", "editing", "notifications", "network", "mp"), result.map { it.id })
+        val mp = result.first { it.id == "mp" }
+        assertEquals(listOf("mp_badge"), mp.items.map { it.id })
+    }
+
+    @Test
+    fun `matches on title`() {
+        val result = filterSettingsSections(sections(), "Thème")
+        assertEquals(listOf("display"), result.map { it.id })
+        assertEquals(listOf("theme"), result.first().items.map { it.id })
+    }
+
+    @Test
+    fun `matches on description`() {
+        val result = filterSettingsSections(sections(), "Sombre")
+        assertEquals(listOf("theme"), result.flatMap { it.items }.map { it.id })
+    }
+
+    @Test
+    fun `matches on keywords`() {
+        val result = filterSettingsSections(sections(), "couleur")
+        assertEquals(listOf("theme"), result.flatMap { it.items }.map { it.id })
+    }
+
+    @Test
+    fun `is accent insensitive`() {
+        // "systeme" (no accent) must match the "Clair, Système ou Sombre" description.
+        val result = filterSettingsSections(sections(), "systeme")
+        assertEquals(listOf("theme"), result.flatMap { it.items }.map { it.id })
+    }
+
+    @Test
+    fun `is case insensitive`() {
+        val result = filterSettingsSections(sections(), "THÈME")
+        assertEquals(listOf("theme"), result.flatMap { it.items }.map { it.id })
+    }
+
+    @Test
+    fun `omits sections emptied by the filter`() {
+        val result = filterSettingsSections(sections(), "Thème")
+        assertNull(result.firstOrNull { it.id == "editing" })
+        assertNull(result.firstOrNull { it.id == "notifications" })
+        assertNull(result.firstOrNull { it.id == "mp" })
+    }
+
+    @Test
+    fun `disabled future item stays searchable`() {
+        val result = filterSettingsSections(sections(), "Relève")
+        val items = result.flatMap { it.items }
+        assertEquals(listOf("future_notifications"), items.map { it.id })
+        assertTrue(items.all { !it.enabled })
+    }
+
+    @Test
+    fun `matches a sub-page label carried as a nav-row keyword`() {
+        // « Hôte » is only shown inside the Proxy sub-page; the nav row carries it as a keyword so
+        // searching it (accent-folded) routes to the network section instead of the empty state.
+        val result = filterSettingsSections(sections(), "hote")
+        assertEquals(listOf("network"), result.map { it.id })
+        assertEquals(listOf("proxy"), result.first().items.map { it.id })
+    }
+
+    @Test
+    fun `invisible item is excluded even when it matches`() {
+        val result = filterSettingsSections(sections(), "Inspecteur")
+        assertTrue(result.isEmpty())
+    }
+}

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -218,6 +218,19 @@ fun TopicScreen(
      * topic's `(subcat, page)` like [onReply].
      */
     onMultiQuote: (subcat: Int, page: Int) -> Unit = { _, _ -> },
+    /**
+     * #465 — the user's MANUAL poll-expansion choice for THIS topic, owned by `:app` so it survives
+     * the per-page TopicRoute swap (like the multi-quote basket / scroll anchors). `null` means « no
+     * manual choice yet — follow the [TopicUiState.pollsExpandedDefault] setting »; `true` / `false`
+     * mean the user explicitly expanded / collapsed the poll. The screen only renders it.
+     */
+    pollManualExpanded: Boolean? = null,
+    /**
+     * #465 — records a tap on the poll card (the resulting revealed state), so `:app` caches the
+     * manual choice per `(cat, post)`. The next page of the same topic reads it back through
+     * [pollManualExpanded], keeping the poll collapsed / expanded across page navigation.
+     */
+    onPollExpansionChanged: (Boolean) -> Unit = {},
 ) {
     val viewModel = hiltViewModel<TopicViewModel, TopicViewModel.Factory>(
         creationCallback = { factory -> factory.create(request) },
@@ -372,6 +385,8 @@ fun TopicScreen(
         multiQuoteSelection = multiQuoteSelection,
         onToggleMultiQuote = onToggleMultiQuote,
         onMultiQuote = onMultiQuote,
+        pollManualExpanded = pollManualExpanded,
+        onPollExpansionChanged = onPollExpansionChanged,
     )
 
     // #292 — confirmation before the (irreversible, no-undo) deletion. Only « Supprimer » sends the
@@ -601,6 +616,10 @@ internal fun TopicContent(
     multiQuoteSelection: List<Int> = emptyList(),
     onToggleMultiQuote: (numreponse: Int) -> Unit = {},
     onMultiQuote: (subcat: Int, page: Int) -> Unit = { _, _ -> },
+    // #465 — the topic's manual poll choice (owned by :app, null = follow the global default) +
+    // the callback recording a tap on the poll card. Threaded to the header card's poll.
+    pollManualExpanded: Boolean? = null,
+    onPollExpansionChanged: (Boolean) -> Unit = {},
 ) {
     // #285 — the topic title and #284 — the page counter live in a persistent top app bar so they
     // stay visible while the user scrolls (the in-card title/caption scrolls away). When the page
@@ -777,6 +796,8 @@ internal fun TopicContent(
                                 listState = listState,
                                 multiQuoteSelection = multiQuoteSelection,
                                 onToggleMultiQuote = onToggleMultiQuote,
+                                pollManualExpanded = pollManualExpanded,
+                                onPollExpansionChanged = onPollExpansionChanged,
                             )
                             LazyListScrollbar(
                                 listState = listState,
@@ -808,6 +829,10 @@ private fun TopicLoadedContent(
     // #291 — selection state + toggle for the post menu's multi-quote entry.
     multiQuoteSelection: List<Int> = emptyList(),
     onToggleMultiQuote: (numreponse: Int) -> Unit = {},
+    // #465 — the topic's manual poll choice (owned by :app, null = follow the global default) + the
+    // callback recording a tap on the poll card. Threaded down to the header card's poll.
+    pollManualExpanded: Boolean? = null,
+    onPollExpansionChanged: (Boolean) -> Unit = {},
 ) {
     val highlight = state.request.scrollTo
     // #239 — how many posts of THIS page cite each post, computed once per loaded post list. Drives
@@ -934,6 +959,8 @@ private fun TopicLoadedContent(
                 onReply = onReply,
                 onEditFirstPost = editFirstPostAction,
                 onOpenPage = onOpenPage,
+                pollManualExpanded = pollManualExpanded,
+                onPollExpansionChanged = onPollExpansionChanged,
             )
         }
         items(
@@ -1082,12 +1109,17 @@ private fun EndOfTopicFooter() {
 }
 
 @Composable
+@Suppress("LongParameterList") // state-hoisted Composable : each param has a distinct call-site.
 private fun TopicHeaderCard(
     topic: Topic,
     state: TopicUiState,
     onReply: (subcat: Int, page: Int) -> Unit,
     onEditFirstPost: (() -> Unit)?,
     onOpenPage: (Int) -> Unit,
+    // #465 — manual poll choice (null = follow the global default) + its toggle callback, both
+    // owned by :app so the expand/collapse choice survives the per-page TopicRoute swap.
+    pollManualExpanded: Boolean? = null,
+    onPollExpansionChanged: (Boolean) -> Unit = {},
 ) {
     Card {
         Column(
@@ -1126,7 +1158,12 @@ private fun TopicHeaderCard(
                 onOpenPage = onOpenPage,
             )
             topic.poll?.let { poll ->
-                TopicPollCard(poll, expandedDefault = state.pollsExpandedDefault)
+                TopicPollCard(
+                    poll = poll,
+                    expandedDefault = state.pollsExpandedDefault,
+                    manualExpanded = pollManualExpanded,
+                    onExpansionChanged = onPollExpansionChanged,
+                )
             }
             Button(
                 onClick = { onReply(topic.subcat, topic.page) },
@@ -1253,16 +1290,23 @@ private fun TopicPageJumpField(
 }
 
 @Composable
-private fun TopicPollCard(poll: Poll, expandedDefault: Boolean) {
-    // #456 — the preference seeds the initial state only; the tap toggle stays per-topic and
-    // survives rotation (rememberSaveable). Keyed on the poll AND the seed so the card follows
-    // a Settings change without restart (the saved value wins otherwise).
-    var revealed by rememberSaveable(poll, expandedDefault) { mutableStateOf(expandedDefault) }
+private fun TopicPollCard(
+    poll: Poll,
+    expandedDefault: Boolean,
+    // #465 — the user's manual choice for this topic's poll, hoisted to :app so it survives the
+    // per-page TopicRoute swap. `null` = no manual choice yet → follow [expandedDefault] (#456).
+    manualExpanded: Boolean?,
+    onExpansionChanged: (Boolean) -> Unit,
+) {
+    // #456 — the preference seeds the initial state; #465 — once the user taps, the manual choice
+    // (owned by :app, keyed by topic) wins and survives navigation between the topic's pages. The
+    // card is fully controlled: it never holds the revealed state itself, it only reports a toggle.
+    val revealed = manualExpanded ?: expandedDefault
     Card(
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
         ),
-        modifier = Modifier.clickable { revealed = !revealed },
+        modifier = Modifier.clickable { onExpansionChanged(!revealed) },
     ) {
         Column(
             modifier = Modifier

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1548,11 +1548,33 @@ internal fun TopicPostCard(
                                     .then(pseudoModifier),
                             )
                         }
-                        Text(
-                            text = post.date.asTopicDate(),
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
+                        // #483 — the date line carries a compact « · édité » marker when the post was
+                        // edited (beta feedback Azgor). The exact edit time stays in the « … » menu
+                        // (PostMenuSheet « Édité le … »). On the date line, INSIDE the pseudo+date
+                        // Column but OUTSIDE the pseudo Row, so it never reflows the avatar nor breaks
+                        // the pseudo ellipsis — and it composes with #476's stable header (pills hoisted
+                        // below this Row) since the date block never grows the identity line sideways.
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            Text(
+                                text = post.date.asTopicDate(),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            if (post.editedAt != null) {
+                                val editedLabel = stringResource(R.string.topic_post_edited_inline)
+                                Text(
+                                    // « · » is a decorative separator — TalkBack reads the
+                                    // contentDescription (« édité »), so the dot is never vocalised.
+                                    text = "· $editedLabel",
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.semantics { contentDescription = editedLabel },
+                                )
+                            }
+                        }
                     }
                     // #362 — per-post contextual menu trigger, flush right of the header. The post
                     // number that used to trail the pseudo lives in the menu now. A text glyph, not

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1467,6 +1467,11 @@ internal fun TopicPostCard(
             } else {
                 Modifier
             }
+            // #476 — width of the avatar slot in the identity Row, used below to indent the
+            // pills under the pseudo (not under the avatar). minimumInteractiveComponentSize()
+            // inflates the clickable avatar to the 48dp touch target; otherwise it is the
+            // RedfaceUserAvatar default (40dp). Kept in sync with `avatarModifier` above.
+            val avatarSlotWidth = if (onOpenProfile != null) 48.dp else 40.dp
             val pseudoModifier = if (onOpenProfile != null) {
                 // No minimumInteractiveComponentSize() on the pseudo: it reserves a 48dp-tall box
                 // and centres the text inside it, which inflated the header Row and left the pseudo
@@ -1481,116 +1486,155 @@ internal fun TopicPostCard(
             } else {
                 Modifier
             }
-            Row(
+            // #476 — wrap the identity Row in a Column so the selection/citation pills can sit
+            // BELOW the identity line instead of inside it. Previously the pills lived in the
+            // pseudo+date Column, which the avatar and the « ⋯ » were CenterVertically-aligned
+            // against : toggling the multi-quote pill grew that Column and re-centred the avatar
+            // and the « ⋯ », so the identity line visibly shifted (dev feedback). Hoisting the
+            // pills out of that Column means a pill appearing/disappearing only grows the card
+            // downward, leaving the avatar/pseudo/⋯ line perfectly still. The header padding moves
+            // from the Row to this wrapper so the band geometry is unchanged.
+            Column(
                 modifier = Modifier
                     .fillMaxWidth()
                     // #287 — header band vertical padding tightens under the Compact preset.
                     .padding(horizontal = 12.dp, vertical = m.cardHeaderVertical),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                // Centre the avatar against the name+date block so the identity line reads as one
-                // tidy unit (the previous Top alignment + the inflated pseudo made the pseudo look
-                // vertically centred while the date dropped well below the avatar).
-                verticalAlignment = Alignment.CenterVertically,
+                verticalArrangement = Arrangement.spacedBy(2.dp),
             ) {
-                RedfaceUserAvatar(
-                    avatarUrl = post.avatarUrl,
-                    author = post.author,
-                    modifier = avatarModifier,
-                )
-                Column(
-                    // #362 — weight(1f) instead of fillMaxWidth so the menu button below gets its
-                    // slot at the right edge of the header; the pseudo keeps its own weight inside.
-                    modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    // Centre the avatar against the name+date block so the identity line reads as
+                    // one tidy unit (the previous Top alignment + the inflated pseudo made the
+                    // pseudo look vertically centred while the date dropped well below the avatar).
+                    // #476 — this Row now holds ONLY the stable pseudo+date block, so CenterVertically
+                    // can never be perturbed by the pills (which moved below this Row).
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
+                    RedfaceUserAvatar(
+                        avatarUrl = post.avatarUrl,
+                        author = post.author,
+                        modifier = avatarModifier,
+                    )
+                    Column(
+                        // #362 — weight(1f) instead of fillMaxWidth so the menu button beside it gets
+                        // its slot at the right edge of the header; the pseudo keeps its own weight.
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(2.dp),
                     ) {
-                        post.postIndex?.let { postIndex ->
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            post.postIndex?.let { postIndex ->
+                                Text(
+                                    text = stringResource(
+                                        R.string.topic_post_index_prefix,
+                                        postIndex,
+                                    ),
+                                    style = MaterialTheme.typography.titleSmall,
+                                    fontWeight = FontWeight.SemiBold,
+                                )
+                            }
                             Text(
-                                text = stringResource(R.string.topic_post_index_prefix, postIndex),
+                                text = post.author,
                                 style = MaterialTheme.typography.titleSmall,
                                 fontWeight = FontWeight.SemiBold,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                // Clickable on the pseudo only — the date stays inert.
+                                modifier = Modifier
+                                    .weight(weight = 1f, fill = false)
+                                    .then(pseudoModifier),
                             )
                         }
                         Text(
-                            text = post.author,
-                            style = MaterialTheme.typography.titleSmall,
-                            fontWeight = FontWeight.SemiBold,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            // Clickable on the pseudo only — the date stays inert.
-                            modifier = Modifier
-                                .weight(weight = 1f, fill = false)
-                                .then(pseudoModifier),
+                            text = post.date.asTopicDate(),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
+                    // #362 — per-post contextual menu trigger, flush right of the header. The post
+                    // number that used to trail the pseudo lives in the menu now. A text glyph, not
+                    // a Material icon (detekt ForbiddenImport blocks androidx.compose.material.*) —
+                    // same pattern as PageFab/ReplyFab. Sits in the identity Row (next to the
+                    // pseudo+date block) so its 48dp touch target never inflates the pseudo line
+                    // (cf. the pseudo minimumInteractiveComponentSize note above).
+                    val menuLabel = stringResource(R.string.topic_post_menu_action)
                     Text(
-                        text = post.date.asTopicDate(),
-                        style = MaterialTheme.typography.labelMedium,
+                        text = "⋯",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier
+                            .minimumInteractiveComponentSize()
+                            .clickable(
+                                onClick = onOpenMenu,
+                                role = Role.Button,
+                                onClickLabel = menuLabel,
+                            )
+                            .semantics { contentDescription = menuLabel },
                     )
-                    if (citedCount > 0) {
-                        // #239 — sober pill: how many posts of THIS page cite this one. Page-scoped
-                        // (cf. citationCountsByNumreponse); jumping to the citing posts is a follow-up.
-                        // `surface` container : the pill now lives on the secondaryContainer identity
-                        // band, where a secondaryContainer pill would be invisible.
-                        Surface(
-                            color = MaterialTheme.colorScheme.surface,
-                            shape = MaterialTheme.shapes.small,
-                        ) {
-                            Text(
-                                text = pluralStringResource(
-                                    R.plurals.topic_post_cited_count,
-                                    citedCount,
-                                    citedCount,
-                                ),
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
-                            )
+                }
+                // #476 — citation + multi-quote pills, hoisted OUT of the pseudo+date Column and
+                // placed below the identity Row, preserving the original « pills sit under the date,
+                // flush with the pseudo » look. The start padding reproduces where the pseudo column
+                // begins in the identity Row: the avatar slot width PLUS that Row's 12.dp
+                // avatar-to-name gap. (A leading Spacer + spacedBy would only add the 8.dp inter-pill
+                // gap, landing the pills 4.dp left of the pseudo.) Because they no longer share a
+                // Column with the avatar/⋯ vertical-centering, toggling the multi-quote pill only
+                // grows the card downward — the identity line never moves.
+                if (citedCount > 0 || multiQuoteSelected) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(start = avatarSlotWidth + 12.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        if (citedCount > 0) {
+                            // #239 — sober pill: how many posts of THIS page cite this one.
+                            // Page-scoped (cf. citationCountsByNumreponse); jumping to the citing
+                            // posts is a follow-up. `surface` container : the pill lives on the
+                            // secondaryContainer identity band, where a secondaryContainer pill
+                            // would be invisible.
+                            Surface(
+                                color = MaterialTheme.colorScheme.surface,
+                                shape = MaterialTheme.shapes.small,
+                            ) {
+                                Text(
+                                    text = pluralStringResource(
+                                        R.plurals.topic_post_cited_count,
+                                        citedCount,
+                                        citedCount,
+                                    ),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+                                )
+                            }
                         }
-                    }
-                    if (multiQuoteSelected) {
-                        // #436 — basket-membership pill, same shape family as the #239 pill above.
-                        // primaryContainer : distinct from the band (secondaryContainer) AND from a
-                        // highlighted band (tertiaryContainer), and it echoes the primary border so
-                        // the two marks read as one signal.
-                        Surface(
-                            color = MaterialTheme.colorScheme.primaryContainer,
-                            shape = MaterialTheme.shapes.small,
-                        ) {
-                            Text(
-                                text = stringResource(R.string.topic_post_multiquote_selected),
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onPrimaryContainer,
-                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
-                            )
+                        if (multiQuoteSelected) {
+                            // #436 — basket-membership pill, same shape family as the #239 pill.
+                            // primaryContainer : distinct from the band (secondaryContainer) AND
+                            // from a highlighted band (tertiaryContainer), and it echoes the primary
+                            // border so the two marks read as one signal.
+                            Surface(
+                                color = MaterialTheme.colorScheme.primaryContainer,
+                                shape = MaterialTheme.shapes.small,
+                            ) {
+                                Text(
+                                    text = stringResource(
+                                        R.string.topic_post_multiquote_selected,
+                                    ),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+                                )
+                            }
                         }
                     }
                 }
-                // #362 — per-post contextual menu trigger, flush right of the header. The post
-                // number that used to trail the pseudo lives in the menu now. A text glyph, not a
-                // Material icon (detekt ForbiddenImport blocks androidx.compose.material.*) — same
-                // pattern as PageFab/ReplyFab. Sits in the OUTER row (next to the whole
-                // avatar+name+date block) so its 48dp touch target never inflates the pseudo line
-                // (cf. the pseudo minimumInteractiveComponentSize note above).
-                val menuLabel = stringResource(R.string.topic_post_menu_action)
-                Text(
-                    text = "⋯",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier
-                        .minimumInteractiveComponentSize()
-                        .clickable(
-                            onClick = onOpenMenu,
-                            role = Role.Button,
-                            onClickLabel = menuLabel,
-                        )
-                        .semantics { contentDescription = menuLabel },
-                )
             }
         }
         Column(

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -40,6 +40,9 @@
     <string name="topic_post_menu_no_browser">Aucun navigateur disponible</string>
     <string name="topic_post_menu_report_soon">Alerter (à venir)</string>
     <string name="topic_post_menu_edited">Édité le %1$s</string>
+    <!-- #483 — compact inline marker next to the post date when the post was edited; the full
+         « Édité le … » timestamp stays in the post menu (R.string.topic_post_menu_edited). -->
+    <string name="topic_post_edited_inline">édité</string>
     <plurals name="topic_post_menu_cited_on_page">
         <item quantity="one">Cité %1$d fois sur cette page</item>
         <item quantity="other">Cité %1$d fois sur cette page</item>


### PR DESCRIPTION
Promotion de `dev` vers `main` pour le ship **bêta 0.13.0** (v145).

Charge depuis la 0.12.0/v136 (dogfoodée sur le canal dev v137→v144) : refonte complète des Réglages (#494), transitions de navigation + retour prédictif, bottom bar compacte + search app bar translucide, marqueur édité, persistance des sondages, drapeaux auto-refresh, badge MP opt-out réseau, parser lignes vides, upload durci, inset bottom-only ; + infra (CI fan-out, garde-fou drapeaux, doc limitations).

Validation : build 4-flavor vert (detekt + assemble Prod/Beta/Dev + lint + tests), Codex #530 0 finding, reviews par-PR au merge. Merge **no-ff**.

> Action par Claude Opus 4.8 (demandée par @XaTriX)