### PR TITLE
fix(forum): collapse the new-topic FAB to icon-only on scroll (#482)

### DIFF
--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
@@ -14,8 +14,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -35,7 +37,9 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -79,6 +83,16 @@ fun ForumCategoryScreen(
     )
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
+    // #482 — hoisted so the FAB can collapse to icon-only once the listing is scrolled
+    // (Azgor: the extended FAB is "presque envahissant"). Shared with the LazyColumn below.
+    val listState = rememberLazyListState()
+    // Expanded only while resting at the very top; any scroll shrinks it out of the way.
+    val fabExpanded by remember {
+        derivedStateOf {
+            listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
+        }
+    }
+
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         containerColor = MaterialTheme.colorScheme.surface,
@@ -86,6 +100,7 @@ fun ForumCategoryScreen(
             if (state.canCreateTopic) {
                 ExtendedFloatingActionButton(
                     onClick = { onCreateTopic(state.cat, state.selectedSubcat) },
+                    expanded = fabExpanded,
                     text = { Text(text = stringResource(R.string.category_create_topic)) },
                     icon = { Text(text = "+") },
                 )
@@ -142,6 +157,7 @@ fun ForumCategoryScreen(
             ) {
                 TopicsBody(
                     state = activeTopics,
+                    listState = listState,
                     filteredTopics = state.filteredTopics,
                     searchQuery = state.searchQuery,
                     onOpenTopic = onOpenTopic,
@@ -282,6 +298,7 @@ private fun SubcategoryChips(
 @Composable
 private fun TopicsBody(
     state: TopicsUiState,
+    listState: LazyListState,
     filteredTopics: List<TopicSummary>,
     searchQuery: String,
     onOpenTopic: (TopicSummary) -> Unit,
@@ -333,7 +350,7 @@ private fun TopicsBody(
             // The PagerRow always shows the underlying `state.page` total — a search
             // filter only narrows the visible rows in the current page; switching
             // page or subcat is what actually re-fetches.
-            LazyColumn(modifier = Modifier.fillMaxWidth()) {
+            LazyColumn(state = listState, modifier = Modifier.fillMaxWidth()) {
                 if (filteredTopics.isEmpty()) {
                     item { TopicsEmpty(searchQuery = searchQuery) }
                 } else {


### PR DESCRIPTION
Le FAB étendu « Nouveau sujet » paraissait envahissant (retour Azgor). Label visible au repos (découvrable), repli en `+` compact au scroll via un `derivedStateOf` sur le LazyListState hoisté. Build 4-flavor vert.

> Action par Claude Opus 4.8 (demandée par @XaTriX)