### PR TITLE
feat(account): show the connected user's avatar in the top-bar badge (#479)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppAccountViewModel.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppAccountViewModel.kt
@@ -5,11 +5,18 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.flags.FlagRepository
+import fr.forumhfr.redface2.core.domain.profile.ProfileRepository
 import fr.forumhfr.redface2.core.model.AuthState
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 /**
@@ -33,6 +40,7 @@ import kotlinx.coroutines.launch
 class AppAccountViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val flagRepository: FlagRepository,
+    private val profileRepository: ProfileRepository,
 ) : ViewModel() {
 
     val authState: StateFlow<AuthState?> = authRepository.observeAuthState()
@@ -41,6 +49,63 @@ class AppAccountViewModel @Inject constructor(
             started = SharingStarted.Eagerly,
             initialValue = null,
         )
+
+    /**
+     * #479 — avatar URL of the connected user, resolved per `userId` from the public profile so
+     * the top-bar account badge can show the real HFR avatar instead of the pseudo initial.
+     *
+     * Lives here (not in [AuthState]) so the auth model stays a pure session verdict: the avatar
+     * is a display enrichment fetched lazily, and a fetch failure / missing avatar simply leaves
+     * the map empty so [RedfaceAccountMenu] falls back to the initial. Keyed by `userId` and
+     * memoised across recompositions / tab switches (the ViewModel is a shared singleton per the
+     * nav host) so a tab change never refetches; a logout/login to another id falls through the
+     * cache miss and refetches.
+     */
+    private val avatarUrlByUserId = MutableStateFlow<Map<Int, String?>>(emptyMap())
+
+    /**
+     * Resolved avatar URL for the *currently* connected user, or `null` (anonymous, loading, or
+     * no avatar) — in which case the badge renders the pseudo initial. `combine` so it re-emits on
+     * BOTH inputs: a logout (auth → Anonymous) must drop the previous user's avatar even though the
+     * cache is untouched, and the lazily-filled cache must surface the avatar once the fetch lands.
+     */
+    val avatarUrl: StateFlow<String?> = combine(authState, avatarUrlByUserId) { auth, cache ->
+        (auth as? AuthState.Authenticated)?.userId?.let(cache::get)
+    }
+        .distinctUntilChanged()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = null,
+        )
+
+    init {
+        observeAvatarForConnectedUser()
+    }
+
+    private fun observeAvatarForConnectedUser() {
+        viewModelScope.launch {
+            authState
+                .map { (it as? AuthState.Authenticated)?.userId }
+                .distinctUntilChanged()
+                // collectLatest: a logout / account switch mid-fetch CANCELS the in-flight
+                // getProfile so a stale avatar can never be written back for the previous user
+                // after the auth state moved on (Codex review).
+                .collectLatest { userId ->
+                    if (userId != null && userId !in avatarUrlByUserId.value) {
+                        fetchAvatar(userId)
+                    }
+                }
+        }
+    }
+
+    private suspend fun fetchAvatar(userId: Int) {
+        // Anonymous fetch (ProfileRepository uses the unauthenticated client) so resolving our own
+        // avatar never marks drapeaux as read, matching the prefetch-non-authentifié rule. A
+        // failure stores `null` so we don't hammer the endpoint and the badge stays on the initial.
+        val avatar = profileRepository.getProfile(userId).getOrNull()?.avatarUrl
+        avatarUrlByUserId.update { it + (userId to avatar) }
+    }
 
     fun logout() {
         viewModelScope.launch {

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -613,6 +613,8 @@ fun RedfaceApp(intent: Intent?) {
         // every tab (Hilt hands back the same scoped instance for an identical owner).
         val accountViewModel: AppAccountViewModel = hiltViewModel()
         val authState by accountViewModel.authState.collectAsStateWithLifecycle()
+        // #479 — avatar of the connected user for the top-bar account badge (null → pseudo initial).
+        val accountAvatarUrl by accountViewModel.avatarUrl.collectAsStateWithLifecycle()
         // #313 — unread-MP badge on the « Messages » nav item. Same shared-instance logic as the
         // account ViewModel above. The ON_START hook refreshes the count when the app comes back
         // to the foreground (MPs received while backgrounded) ; the first start is skipped by the
@@ -748,6 +750,7 @@ fun RedfaceApp(intent: Intent?) {
                         onReportContent = {
                             startReportEmail(context, reportEmailSubject, reportNoEmailClient)
                         },
+                        avatarUrl = accountAvatarUrl,
                     )
                 }
                 RedfaceNavHost(

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppAccountViewModelTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppAccountViewModelTest.kt
@@ -4,8 +4,10 @@ import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.auth.LoginError
 import fr.forumhfr.redface2.core.domain.flags.FlagRepository
 import fr.forumhfr.redface2.core.domain.flags.FlagsResult
+import fr.forumhfr.redface2.core.domain.profile.ProfileRepository
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.FlagType
+import fr.forumhfr.redface2.core.model.UserProfile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -19,6 +21,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -59,7 +62,7 @@ class AppAccountViewModelTest {
     fun `logout clears the private flags cache exactly once before resetting auth state`() = runTest {
         val flags = FakeFlagRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = AppAccountViewModel(auth, flags)
+        val vm = AppAccountViewModel(auth, flags, FakeProfileRepository())
 
         val clearsBeforeLogout = flags.clearSessionCacheCallCount
 
@@ -82,7 +85,7 @@ class AppAccountViewModelTest {
     fun `authState mirrors the AuthRepository observation across login and logout transitions`() = runTest {
         val flags = FakeFlagRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = AppAccountViewModel(auth, flags)
+        val vm = AppAccountViewModel(auth, flags, FakeProfileRepository())
 
         // SharingStarted.Eagerly + initialValue = null. The first upstream emission lands
         // synchronously through Dispatchers.Main.immediate (= UnconfinedTestDispatcher in
@@ -95,6 +98,42 @@ class AppAccountViewModelTest {
         assertEquals(AuthState.Anonymous, vm.authState.value)
         auth.emit(AuthState.Authenticated("xaat"))
         assertEquals(AuthState.Authenticated("xaat"), vm.authState.value)
+    }
+
+    @Test
+    fun `avatarUrl resolves the connected user's avatar from the profile when a userId is present`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat", userId = 42), flagRepository = flags)
+        val profiles = FakeProfileRepository(avatarByUserId = mapOf(42 to "https://img/42.png"))
+
+        val vm = AppAccountViewModel(auth, flags, profiles)
+
+        assertEquals("https://img/42.png", vm.avatarUrl.value)
+        assertEquals("the avatar is fetched exactly once", 1, profiles.getProfileCallCount)
+    }
+
+    @Test
+    fun `avatarUrl stays null and does not fetch when the session carries no userId`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat", userId = null), flagRepository = flags)
+        val profiles = FakeProfileRepository()
+
+        val vm = AppAccountViewModel(auth, flags, profiles)
+
+        assertNull(vm.avatarUrl.value)
+        assertEquals("no userId → no profile fetch", 0, profiles.getProfileCallCount)
+    }
+
+    @Test
+    fun `avatarUrl falls back to null when the profile has no avatar`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat", userId = 42), flagRepository = flags)
+        // userId present but the profile resolves to no avatar (HFR rendered no img) → fall back.
+        val profiles = FakeProfileRepository(avatarByUserId = mapOf(42 to null))
+
+        val vm = AppAccountViewModel(auth, flags, profiles)
+
+        assertNull(vm.avatarUrl.value)
     }
 
     private class FakeAuthRepository(
@@ -150,6 +189,36 @@ class AppAccountViewModelTest {
         override suspend fun removeFlag(flag: fr.forumhfr.redface2.core.model.Flag): Result<Unit> {
             // Not exercised in these tests — included to satisfy the interface (#99).
             return Result.success(Unit)
+        }
+    }
+
+    /**
+     * #479 — fakes the profile fetch used to resolve the connected user's avatar. Records the
+     * call count so a test can assert the avatar is fetched once and never for a session without
+     * a userId. A userId absent from [avatarByUserId] resolves to a failed [Result].
+     */
+    private class FakeProfileRepository(
+        private val avatarByUserId: Map<Int, String?> = emptyMap(),
+    ) : ProfileRepository {
+        var getProfileCallCount: Int = 0
+            private set
+
+        override suspend fun getProfile(userId: Int): Result<UserProfile> {
+            getProfileCallCount += 1
+            if (userId !in avatarByUserId) {
+                return Result.failure(IllegalStateException("no profile for $userId"))
+            }
+            return Result.success(
+                UserProfile(
+                    userId = userId,
+                    pseudo = "xaat",
+                    avatarUrl = avatarByUserId.getValue(userId),
+                    registeredAt = null,
+                    postCount = null,
+                    location = null,
+                    signatureText = null,
+                ),
+            )
         }
     }
 }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/auth/DefaultAuthRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/auth/DefaultAuthRepository.kt
@@ -39,7 +39,17 @@ class DefaultAuthRepository @Inject constructor(
         .filterNotNull()
         .map { cookies ->
             val mdUser = cookies.firstOrNull { it.name == COOKIE_MD_USER && it.value.isNotBlank() }
-            if (mdUser != null) AuthState.Authenticated(decodePseudo(mdUser.value)) else AuthState.Anonymous
+            if (mdUser != null) {
+                // #479 — the numeric id (`md_id`) is captured here, at the same single point where the
+                // session pseudo is decoded, so every consumer (account badge avatar, …) can fetch the
+                // public profile by id without re-reading the cookie jar. Null-safe: a session without
+                // `md_id` (older cookie set) still authenticates — the avatar just falls back to the
+                // pseudo initial. The auth verdict depends ONLY on `md_user` (cf. AuthRemoteDataSource).
+                val userId = cookies.firstOrNull { it.name == COOKIE_MD_ID }?.value?.toIntOrNull()
+                AuthState.Authenticated(decodePseudo(mdUser.value), userId)
+            } else {
+                AuthState.Anonymous
+            }
         }
         .distinctUntilChanged()
 
@@ -69,6 +79,9 @@ class DefaultAuthRepository @Inject constructor(
 
     private companion object {
         const val COOKIE_MD_USER = "md_user"
+
+        /** HFR's numeric user-id cookie, set alongside `md_user`/`md_pass` on login (#479). */
+        const val COOKIE_MD_ID = "md_id"
 
         /**
          * #260 — HFR stores the pseudo in the `md_user` cookie form-urlencoded, so a pseudo with a

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/AuthState.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/AuthState.kt
@@ -3,5 +3,16 @@ package fr.forumhfr.redface2.core.model
 sealed interface AuthState {
     data object Anonymous : AuthState
 
-    data class Authenticated(val pseudo: String) : AuthState
+    /**
+     * @param pseudo the connected user's display pseudo (decoded from the `md_user` cookie).
+     * @param userId the connected user's numeric HFR id (from the `md_id` cookie), or `null`
+     *   when HFR did not set it (older sessions / partial cookie set). Used to fetch the
+     *   user's public profile — e.g. the avatar shown in the top-bar account badge (#479) —
+     *   keyed by `/hfr/profil-{userId}.htm`. Display-only: the auth verdict itself never
+     *   depends on it (only `md_user` proves the session, cf. `AuthRemoteDataSource.classify`).
+     */
+    data class Authenticated(
+        val pseudo: String,
+        val userId: Int? = null,
+    ) : AuthState
 }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/account/RedfaceAccountMenu.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/account/RedfaceAccountMenu.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.ui.R
+import fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar
 
 /**
  * Account / alpha-tools menu shown in the top-right of every main screen (#198).
@@ -55,12 +56,17 @@ fun RedfaceAccountMenu(
     onOpenDiagnostics: () -> Unit,
     onReportContent: () -> Unit,
     modifier: Modifier = Modifier,
+    // #479 — real HFR avatar of the connected user. Null (anonymous, loading, or no avatar set)
+    // falls back to the pseudo-initial badge. The host (RedfaceNavHost) resolves it from the
+    // connected user's profile via AppAccountViewModel.
+    avatarUrl: String? = null,
 ) {
     var expanded by remember { mutableStateOf(false) }
 
     Box(modifier = modifier) {
         AccountBadge(
             authState = authState,
+            avatarUrl = avatarUrl,
             onClick = { expanded = true },
         )
         DropdownMenu(
@@ -122,8 +128,22 @@ fun RedfaceAccountMenu(
 @Composable
 private fun AccountBadge(
     authState: AuthState?,
+    avatarUrl: String?,
     onClick: () -> Unit,
 ) {
+    // #479 — when the connected user has a resolved avatar, show it instead of the initial. The
+    // text-badge branch below is kept verbatim for anonymous / loading / no-avatar so the
+    // anti-flicker contract ("…" never "?") and the existing colour scheme are unchanged.
+    val authenticated = authState as? AuthState.Authenticated
+    if (authenticated != null && !avatarUrl.isNullOrBlank()) {
+        AvatarBadge(
+            avatarUrl = avatarUrl,
+            pseudo = authenticated.pseudo,
+            onClick = onClick,
+        )
+        return
+    }
+
     val label = when (authState) {
         null -> "…"
         AuthState.Anonymous -> "?"
@@ -169,6 +189,35 @@ private fun AccountBadge(
                 fontWeight = FontWeight.SemiBold,
             )
         }
+    }
+}
+
+@Composable
+private fun AvatarBadge(
+    avatarUrl: String,
+    pseudo: String,
+    onClick: () -> Unit,
+) {
+    // #479 — same interaction contract as the text [AccountBadge]: a clickable M3 `Surface`
+    // (ripple clipped to the rounded shape, `Role.Button` for TalkBack) with the 40dp visual and
+    // the explicit `minimumInteractiveComponentSize()` (BEFORE `.size`) expanding the touch
+    // target to 48dp. The Surface owns the "Ouvrir le menu compte" semantics
+    // (`mergeDescendants = true`) so the avatar's own "Avatar de <pseudo>" description does not
+    // leak as a second TalkBack node — the badge announces as the menu button, not the avatar.
+    val accessibilityLabel = stringResource(R.string.account_menu_open_description)
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(BADGE_CORNER_RADIUS),
+        modifier = Modifier
+            .minimumInteractiveComponentSize()
+            .size(BADGE_SIZE)
+            .semantics(mergeDescendants = true) { contentDescription = accessibilityLabel },
+    ) {
+        RedfaceUserAvatar(
+            avatarUrl = avatarUrl,
+            author = pseudo,
+            size = BADGE_SIZE,
+        )
     }
 }
 


### PR DESCRIPTION
Remplace l'initiale du pseudo par le vrai avatar HFR. `userId` exposé via le cookie `md_id` sur `AuthState.Authenticated`, avatar résolu via `ProfileRepository` (client anonyme → ne marque aucun drapeau lu), mémoïsé par userId. Fallback initiale si avatar inconnu. Fix Codex : `collectLatest` annule le fetch au logout/switch (pas de write avatar périmé). Build 4-flavor vert.

> Action par Claude Opus 4.8 (demandée par @XaTriX)