### PR TITLE
perf(ui): reserved-box shimmer + crossfade for block images, anti-CLS (#249)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/ImageShimmer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/ImageShimmer.kt
@@ -1,0 +1,93 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import android.provider.Settings
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * #249 — animated shimmer painted INSIDE the already-reserved block-image box (see
+ * [PostMediaDisplayPolicy.reservedBlockImageHeight]) while the bitmap loads. A diagonal highlight band
+ * sweeps left→right over a tinted base, so the user reads "image en cours de chargement ici" without a
+ * spinner — and because the box is pre-sized to the final image, the crossfade reveal causes no bump.
+ *
+ * Allocation profile mirrors [fr.forumhfr.redface2.core.ui.pager.PageSwipe]: a single
+ * [Modifier.drawBehind] reads one animated progress float and rebuilds only a lightweight linear
+ * [Brush] per frame over the box width — no per-frame composable, no full-screen overdraw.
+ *
+ * Accessibility (#249 §4 "réduire les animations") : when [animated] is false (system animator scale
+ * 0, see [rememberAnimationsEnabled]) the band is parked at rest and the box shows a STATIC tint — no
+ * infinite animation, no crossfade upstream. The reveal is then instant.
+ */
+@Composable
+internal fun ImageShimmer(animated: Boolean, modifier: Modifier = Modifier) {
+    val base = MaterialTheme.colorScheme.surfaceContainerHighest
+    val highlight = MaterialTheme.colorScheme.surfaceContainerHigh
+    val shimmerColors = remember(base, highlight) { listOf(base, highlight, base) }
+
+    val progress = if (animated) {
+        val transition = rememberInfiniteTransition(label = "post_image_shimmer")
+        transition.animateFloat(
+            initialValue = 0f,
+            targetValue = 1f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = SHIMMER_PERIOD_MS, easing = LinearEasing),
+                repeatMode = RepeatMode.Restart,
+            ),
+            label = "post_image_shimmer_progress",
+        ).value
+    } else {
+        // Reduce-motion: park the band mid-box so the static tint blends base↔highlight, no harsh edge.
+        STATIC_PROGRESS
+    }
+
+    Box(
+        modifier = modifier
+            .drawBehind {
+                // Travel the band from off-left to off-right so the highlight enters and exits the box
+                // cleanly each period (width × 2 of travel keeps the diagonal visible throughout).
+                val travel = size.width * 2f
+                val start = -size.width + travel * progress
+                drawRect(
+                    brush = Brush.linearGradient(
+                        colors = shimmerColors,
+                        start = Offset(start, 0f),
+                        end = Offset(start + size.width, size.height),
+                    ),
+                )
+            },
+    )
+}
+
+/**
+ * #249 §4 — `true` unless the user disabled animations system-wide (Developer options / "Remove
+ * animations", or an accessibility profile setting `ANIMATOR_DURATION_SCALE` to 0). Reading the system
+ * setting (rather than the app's unwired `future_a11y_reduce_motion` row) honours the OS-level
+ * preference the same way Compose's own animations do. Defaults to enabled if the setting is absent.
+ */
+@Composable
+internal fun rememberAnimationsEnabled(): Boolean {
+    val resolver = LocalContext.current.contentResolver
+    return remember(resolver) {
+        val scale = Settings.Global.getFloat(resolver, Settings.Global.ANIMATOR_DURATION_SCALE, 1f)
+        scale != 0f
+    }
+}
+
+/** One full sweep period. ~1.1 s reads as "loading" without being distracting (dogfood-tunable). */
+private const val SHIMMER_PERIOD_MS = 1100
+
+private const val STATIC_PROGRESS = 0.5f

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
@@ -122,6 +122,30 @@ internal object PostMediaDisplayPolicy {
     }
 
     /**
+     * #249 — exact RESERVED height (dp) for a block `[img]`, computed BEFORE the bitmap arrives so the
+     * loading placeholder occupies the same vertical slot the loaded image will, hence zero layout
+     * shift (anti-CLS) when it crossfades in.
+     *
+     * Reuses the same measured intrinsic size the #175/#224 path already caches: at the block width
+     * [availableWidthDp] the image will render `availableWidthDp × (h/w)` tall (`ContentScale.Fit`,
+     * full width), so we reserve exactly that, clamped to the existing [blockImageMinHeight] /
+     * [blockImageMaxHeight] slot. A landscape shot narrower-than-tall and a portrait shot both land on
+     * their real height; only the rare clamp cases differ — exactly the bounds the loaded image already
+     * obeys, so no over-reserve vs the #175 sizing.
+     *
+     * [measured] is `null` for a not-yet-measured image (a standalone `PostBlock.Image` is not fed by
+     * the paragraph measure effect): callers then fall back to the legacy [blockImageMinHeight] slot.
+     */
+    fun reservedBlockImageHeight(measured: PixelSize?, availableWidthDp: Float): Dp? {
+        val size = measured?.takeIf { it.width > 0 && it.height > 0 }
+        if (size == null || availableWidthDp <= 0f) return null
+        val rawHeight = availableWidthDp * (size.height.toFloat() / size.width.toFloat())
+        return rawHeight
+            .coerceIn(blockImageMinHeight.value, blockImageMaxHeight.value)
+            .dp
+    }
+
+    /**
      * #416 — box for a DEAD smiley sprite (recorded as a fresh measurement failure). HFR's BBCode
      * engine turns ANY `:word:` into an `<img>` without checking existence, so an unknown code is
      * served as a 404 gif : web/RF1 then show the typed token at text size. The token replaces the

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -74,6 +75,7 @@ import coil3.compose.LocalPlatformContext
 import coil3.compose.SubcomposeAsyncImage
 import coil3.compose.SubcomposeAsyncImageContent
 import coil3.request.ImageRequest
+import coil3.request.crossfade
 import coil3.size.Precision
 import coil3.size.Scale
 import fr.forumhfr.redface2.core.ui.R
@@ -516,48 +518,84 @@ private fun ImageBlock(block: PostBlock.Image) = BlockImage(url = block.url, des
  *
  * Bounded so a 4000×3000 RAW screenshot can't blow up the post and destroy the scroll position.
  * SubcomposeAsyncImage exposes loading/error slots so the user gets visual feedback when an HFR image
- * host (rehost.diberie.com, super-h.fr, …) is offline rather than a silent empty Box. Phase 1 keeps the
- * loading + error layout minimal — no material-icons-extended dependency just for a placeholder glyph.
+ * host (rehost.diberie.com, super-h.fr, …) is offline rather than a silent empty Box.
+ *
+ * #249 — anti-CLS: instead of reserving the legacy `minHeight` slot (which then SNAPS to the bitmap's
+ * real height on arrival = a bump), reserve the EXACT final height from the measured intrinsic size
+ * (`width × h/w`, same #175/#224 cache) so the shimmer placeholder occupies the loaded image's slot and
+ * nothing below moves. The image then `crossfade`s in (Coil native) into the already-sized box. A
+ * not-yet-measured image (standalone `PostBlock.Image`, no paragraph measure effect) keeps the legacy
+ * min/max slot. Animations honour the system reduce-motion preference ([rememberAnimationsEnabled]).
  */
 @Composable
 private fun BlockImage(url: String, description: String?, linkUrl: String? = null) {
     val uriHandler = LocalUriHandler.current
     val openLabel = stringResource(R.string.post_image_open_link)
-    val containerModifier = Modifier
-        .fillMaxWidth()
-        .defaultMinSize(minHeight = PostMediaDisplayPolicy.blockImageMinHeight)
-        .heightIn(max = PostMediaDisplayPolicy.blockImageMaxHeight)
-        .clip(RoundedCornerShape(8.dp))
-        .background(MaterialTheme.colorScheme.surfaceContainerHighest)
-        .then(
-            if (linkUrl != null) {
-                // Role.Image (not Button): the element IS an image that opens its full version on tap;
-                // the localized onClickLabel carries the action for TalkBack ("Image, double-tap to …").
-                Modifier.clickable(role = Role.Image, onClickLabel = openLabel) {
-                    runCatching { uriHandler.openUri(linkUrl) }
-                }
-            } else {
-                Modifier
-            },
-        )
-    SubcomposeAsyncImage(
-        model = url,
-        contentDescription = description,
-        contentScale = ContentScale.Fit,
-        modifier = containerModifier,
-        loading = { ImageBlockLoading() },
-        error = { ImageBlockError(description) },
-        success = { SubcomposeAsyncImageContent() },
-    )
-}
+    val animationsEnabled = rememberAnimationsEnabled()
 
-@Composable
-private fun ImageBlockLoading() {
-    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-        Text(
-            text = stringResource(R.string.post_image_loading),
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+    // #249 — reserve the exact final box from the measured intrinsic size when known. The same cache the
+    // #175/#224 paragraph measure effect fills feeds promoted images; a standalone PostBlock.Image is
+    // unmeasured (null) and falls back to the legacy min/max slot below.
+    val sizeCache = LocalIntrinsicMediaSizeCache.current
+    val measured: IntSize? = sizeCache.get(url)
+
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val reservedHeight = PostMediaDisplayPolicy.reservedBlockImageHeight(
+            measured = measured?.let { PixelSize(it.width, it.height) },
+            availableWidthDp = maxWidth.value,
+        )
+        // Reserved box: an exact height when measured (anti-CLS), else the legacy min/max slot.
+        val sizeModifier = if (reservedHeight != null) {
+            Modifier.height(reservedHeight)
+        } else {
+            Modifier
+                .defaultMinSize(minHeight = PostMediaDisplayPolicy.blockImageMinHeight)
+                .heightIn(max = PostMediaDisplayPolicy.blockImageMaxHeight)
+        }
+        val containerModifier = Modifier
+            .fillMaxWidth()
+            .then(sizeModifier)
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+            .then(
+                if (linkUrl != null) {
+                    // Role.Image (not Button): the element IS an image that opens its full version on
+                    // tap; the localized onClickLabel carries the action for TalkBack.
+                    Modifier.clickable(role = Role.Image, onClickLabel = openLabel) {
+                        runCatching { uriHandler.openUri(linkUrl) }
+                    }
+                } else {
+                    Modifier
+                },
+            )
+        val context = LocalPlatformContext.current
+        val request = remember(url, animationsEnabled, context) {
+            ImageRequest.Builder(context)
+                .data(url)
+                // #249 — fondu natif Coil dans la box déjà dimensionnée → zéro saut. Désactivé quand le
+                // système demande de réduire les animations (apparition directe, §4 de l'issue).
+                .crossfade(animationsEnabled)
+                .build()
+        }
+        SubcomposeAsyncImage(
+            model = request,
+            contentDescription = description,
+            contentScale = ContentScale.Fit,
+            modifier = containerModifier,
+            loading = {
+                // Measured: fill the exact reserved box. Unmeasured (max-only constraint): a STABLE
+                // min-height placeholder — NOT fillMaxSize, which would balloon to the max slot and then
+                // collapse to the loaded intrinsic height (a visible shift, Codex review). The legacy
+                // min→intrinsic grow on load remains for these rare standalone images.
+                val shimmerModifier = if (reservedHeight != null) {
+                    Modifier.fillMaxSize()
+                } else {
+                    Modifier.fillMaxWidth().height(PostMediaDisplayPolicy.blockImageMinHeight)
+                }
+                ImageShimmer(animated = animationsEnabled, modifier = shimmerModifier)
+            },
+            error = { ImageBlockError(description) },
+            success = { SubcomposeAsyncImageContent() },
         )
     }
 }

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -10,7 +10,6 @@
     <string name="post_spoiler_show">(afficher)</string>
     <string name="post_spoiler_hide">(masquer)</string>
     <string name="post_inline_image_alt">[image]</string>
-    <string name="post_image_loading">Chargement…</string>
     <string name="post_image_error">Image indisponible</string>
     <string name="post_image_error_with_alt">Image indisponible — %1$s</string>
     <string name="post_image_open_link">Ouvrir l\'image</string>


### PR DESCRIPTION
Réserve la hauteur finale exacte (cache de taille intrinsèque #175/#224) avant l'arrivée du bitmap → zéro saut de layout ; shimmer animé dans la box réservée + crossfade Coil natif, tous deux respectant reduce-motion. Fix Codex : en non-mesuré (standalone), le shimmer prend une hauteur stable (min) au lieu de `fillMaxSize` (évite le ballon max→intrinsèque). N'altère pas le sizing #175. Build 4-flavor vert.

> Action par Claude Opus 4.8 (demandée par @XaTriX)