### PR TITLE
feat(topic): render post signatures beneath posts, behind a toggle (#330)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -317,6 +317,21 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeTopicSignatures(): Flow<Boolean> =
+        dataStore.data
+            // Default `false` (#330): signatures are noisy; opt-in so the feed stays compact.
+            .map { prefs -> prefs[KEY_TOPIC_SIGNATURES] ?: false }
+            .distinctUntilChanged()
+            .catch { emit(false) }
+
+    override suspend fun setTopicSignatures(enabled: Boolean) {
+        persist {
+            dataStore.edit { prefs ->
+                prefs[KEY_TOPIC_SIGNATURES] = enabled
+            }
+        }
+    }
+
     override fun observeStartScreen(): Flow<StartScreenPreference> =
         dataStore.data
             .map(::readStartScreen)
@@ -596,6 +611,9 @@ class DataStoreUserPreferencesRepository @Inject constructor(
 
         // #456 — polls expanded by default in topic reading (default false = collapsed).
         val KEY_TOPIC_POLLS_EXPANDED = booleanPreferencesKey("topic_polls_expanded")
+
+        // #330 — render author signatures beneath posts (default false = hidden, signatures are noisy).
+        val KEY_TOPIC_SIGNATURES = booleanPreferencesKey("topic_signatures")
 
         // #458 — cold-start tab (StartScreenChoice.name, defensively parsed) + optional Forum
         // category id (absent unless screen == FORUM and a category was picked).

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicMappers.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicMappers.kt
@@ -100,6 +100,7 @@ internal object TopicMappers {
         quoteRef = quoteRef,
         profileId = profileId,
         editedAt = editedAt,
+        signature = signature,
     )
 
     private fun PostEntity.toDomain(): Post = Post(
@@ -115,6 +116,7 @@ internal object TopicMappers {
         quoteRef = quoteRef,
         profileId = profileId,
         editedAt = editedAt,
+        signature = signature,
     )
 
     /**

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -573,6 +573,10 @@ class TopicRepositoryImplTest {
 
         override suspend fun setTopicPollsExpanded(enabled: Boolean) = Unit
 
+        override fun observeTopicSignatures(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setTopicSignatures(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/core/database/schemas/fr.forumhfr.redface2.core.database.RedfaceDatabase/14.json
+++ b/core/database/schemas/fr.forumhfr.redface2.core.database.RedfaceDatabase/14.json
@@ -1,0 +1,541 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 14,
+    "identityHash": "9ab3e3cc16fead190e136b6c9f2bfb7b",
+    "entities": [
+      {
+        "tableName": "topic_pages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cat` INTEGER NOT NULL, `post` INTEGER NOT NULL, `page` INTEGER NOT NULL, `title` TEXT NOT NULL, `totalPages` INTEGER NOT NULL, `isFirstPostOwner` INTEGER NOT NULL, `pollJson` TEXT, `numreponses` TEXT NOT NULL, `fetchedAt` INTEGER NOT NULL, `authMode` TEXT NOT NULL, `subcat` INTEGER NOT NULL, `canReply` INTEGER NOT NULL, PRIMARY KEY(`cat`, `post`, `page`))",
+        "fields": [
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "post",
+            "columnName": "post",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPages",
+            "columnName": "totalPages",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFirstPostOwner",
+            "columnName": "isFirstPostOwner",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pollJson",
+            "columnName": "pollJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "numreponses",
+            "columnName": "numreponses",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authMode",
+            "columnName": "authMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subcat",
+            "columnName": "subcat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canReply",
+            "columnName": "canReply",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cat",
+            "post",
+            "page"
+          ]
+        }
+      },
+      {
+        "tableName": "posts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cat` INTEGER NOT NULL, `numreponse` INTEGER NOT NULL, `post` INTEGER NOT NULL, `author` TEXT NOT NULL, `date` INTEGER NOT NULL, `content` TEXT NOT NULL, `avatarUrl` TEXT, `isEditable` INTEGER NOT NULL, `isOwnPost` INTEGER NOT NULL, `quotedAuthors` TEXT NOT NULL, `postIndex` INTEGER, `fetchedAt` INTEGER NOT NULL, `authMode` TEXT NOT NULL, `quoteRef` INTEGER, `profileId` INTEGER, `editedAt` INTEGER, `signature` TEXT, PRIMARY KEY(`cat`, `numreponse`))",
+        "fields": [
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numreponse",
+            "columnName": "numreponse",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "post",
+            "columnName": "post",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isEditable",
+            "columnName": "isEditable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOwnPost",
+            "columnName": "isOwnPost",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quotedAuthors",
+            "columnName": "quotedAuthors",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postIndex",
+            "columnName": "postIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authMode",
+            "columnName": "authMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quoteRef",
+            "columnName": "quoteRef",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "editedAt",
+            "columnName": "editedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "signature",
+            "columnName": "signature",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cat",
+            "numreponse"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_posts_cat_post",
+            "unique": false,
+            "columnNames": [
+              "cat",
+              "post"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_posts_cat_post` ON `${TABLE_NAME}` (`cat`, `post`)"
+          }
+        ]
+      },
+      {
+        "tableName": "flag_topics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `type` TEXT NOT NULL, `cat` INTEGER NOT NULL, `subcat` INTEGER, `topicId` INTEGER NOT NULL, `title` TEXT NOT NULL, `totalPages` INTEGER NOT NULL, `replyCount` INTEGER NOT NULL, `isFavorite` INTEGER NOT NULL DEFAULT 0, `hasUnread` INTEGER NOT NULL, `lastReadPage` INTEGER NOT NULL, `lastPostReadId` INTEGER, `firstPostAuthor` TEXT NOT NULL, `lastReplyAuthor` TEXT NOT NULL, `lastReplyAt` TEXT NOT NULL, `fetchedAt` INTEGER NOT NULL, `authMode` TEXT NOT NULL, PRIMARY KEY(`userId`, `type`, `cat`, `topicId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subcat",
+            "columnName": "subcat",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "topicId",
+            "columnName": "topicId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPages",
+            "columnName": "totalPages",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "replyCount",
+            "columnName": "replyCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hasUnread",
+            "columnName": "hasUnread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadPage",
+            "columnName": "lastReadPage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPostReadId",
+            "columnName": "lastPostReadId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "firstPostAuthor",
+            "columnName": "firstPostAuthor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReplyAuthor",
+            "columnName": "lastReplyAuthor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReplyAt",
+            "columnName": "lastReplyAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authMode",
+            "columnName": "authMode",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "type",
+            "cat",
+            "topicId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_flag_topics_userId_type",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_flag_topics_userId_type` ON `${TABLE_NAME}` (`userId`, `type`)"
+          },
+          {
+            "name": "index_flag_topics_userId_fetchedAt",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "fetchedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_flag_topics_userId_fetchedAt` ON `${TABLE_NAME}` (`userId`, `fetchedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "mp_read_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `threadId` INTEGER NOT NULL, `page` INTEGER NOT NULL, PRIMARY KEY(`userId`, `threadId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "threadId",
+            "columnName": "threadId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "threadId"
+          ]
+        }
+      },
+      {
+        "tableName": "editor_drafts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`draftKey` TEXT NOT NULL, `ownerId` TEXT NOT NULL, `body` TEXT NOT NULL, `subject` TEXT, `recipients` TEXT, `updatedAt` INTEGER NOT NULL, `isPrivate` INTEGER NOT NULL, PRIMARY KEY(`draftKey`))",
+        "fields": [
+          {
+            "fieldPath": "draftKey",
+            "columnName": "draftKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subject",
+            "columnName": "subject",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "recipients",
+            "columnName": "recipients",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrivate",
+            "columnName": "isPrivate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "draftKey"
+          ]
+        }
+      },
+      {
+        "tableName": "uploaded_images",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `provider` TEXT NOT NULL, `picId` TEXT NOT NULL, `imageUrl` TEXT NOT NULL, `thumbnailUrl` TEXT, `deleteHandle` TEXT, `uploadedAt` INTEGER NOT NULL, `expiresAt` INTEGER, PRIMARY KEY(`userId`, `provider`, `picId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "picId",
+            "columnName": "picId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deleteHandle",
+            "columnName": "deleteHandle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "uploadedAt",
+            "columnName": "uploadedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "provider",
+            "picId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_uploaded_images_userId_uploadedAt",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "uploadedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_uploaded_images_userId_uploadedAt` ON `${TABLE_NAME}` (`userId`, `uploadedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "mp_storage_locations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `threadId` INTEGER NOT NULL, `numreponse` INTEGER NOT NULL, PRIMARY KEY(`userId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "threadId",
+            "columnName": "threadId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numreponse",
+            "columnName": "numreponse",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9ab3e3cc16fead190e136b6c9f2bfb7b')"
+    ]
+  }
+}

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/RedfaceDatabase.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/RedfaceDatabase.kt
@@ -28,7 +28,7 @@ import fr.forumhfr.redface2.core.database.entities.UploadedImageEntity
         UploadedImageEntity::class,
         MpStorageLocationEntity::class,
     ],
-    version = 13,
+    version = 14,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/converters/Converters.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/converters/Converters.kt
@@ -54,6 +54,21 @@ internal object Converters {
     fun postContentFromJson(value: String): PostContent =
         PostContentSerializer.decode(value)
 
+    /**
+     * #330 — nullable variant for `posts.signature`. A `null` AST (the common case: most posts
+     * carry no signature) maps to a SQL `NULL` rather than an encoded empty document, so the
+     * column stays sparse and `cursor.isNull(...)` reads true for signature-less rows.
+     */
+    @TypeConverter
+    @JvmStatic
+    fun nullablePostContentToJson(value: PostContent?): String? =
+        value?.let(PostContentSerializer::encode)
+
+    @TypeConverter
+    @JvmStatic
+    fun nullablePostContentFromJson(value: String?): PostContent? =
+        value?.let(PostContentSerializer::decode)
+
     @TypeConverter
     @JvmStatic
     fun fetchModeToString(value: FetchMode): String = value.name

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/di/DatabaseModule.kt
@@ -17,6 +17,7 @@ import fr.forumhfr.redface2.core.database.dao.UploadedImageDao
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_10_11
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_11_12
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_12_13
+import fr.forumhfr.redface2.core.database.migrations.MIGRATION_13_14
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_1_2
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_2_3
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_3_4
@@ -53,6 +54,7 @@ object DatabaseModule {
             MIGRATION_10_11,
             MIGRATION_11_12,
             MIGRATION_12_13,
+            MIGRATION_13_14,
         )
         .build()
 

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/entities/PostEntity.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/entities/PostEntity.kt
@@ -77,4 +77,14 @@ data class PostEntity(
      *   whose `div.edited` only holds the « Message cité N fois » citation link.
      */
     val editedAt: Instant? = null,
+    /**
+     * #330 — the author signature AST (`<span class="signature">`), persisted as JSON via the
+     * nullable [Converters.nullablePostContentToJson] converter so the « Afficher les signatures »
+     * reading preference is a pure render-time switch (no refetch when toggled). Persisted in
+     * Room v14 (`MIGRATION_13_14`). Nullable on disk:
+     *
+     * - pre-v14 rows backfill to `NULL` (recovered on the next live fetch);
+     * - most posts legitimately carry no signature.
+     */
+    val signature: PostContent? = null,
 )

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/migrations/Migrations.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/migrations/Migrations.kt
@@ -372,3 +372,24 @@ val MIGRATION_12_13: Migration = object : Migration(12, 13) {
         )
     }
 }
+
+/**
+ * v13 → v14 (#330):
+ *
+ * Adds `signature` to `posts`. Stores the author's signature block (the HFR
+ * `<span class="signature">` trailer) as JSON in the same `PostContent` AST shape as `content`,
+ * so the « Afficher les signatures » reading preference is a pure render-time switch — toggling
+ * it never triggers a refetch.
+ *
+ * Nullable `TEXT` on disk because:
+ * - pre-v14 rows backfill to `NULL` (the next live fetch sets the real value);
+ * - most posts legitimately carry no signature.
+ *
+ * Pure DDL, no row rewrite — posts are short-lived cache and the next fetch overwrites every row
+ * with a parsed (possibly null) signature.
+ */
+val MIGRATION_13_14: Migration = object : Migration(13, 14) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE posts ADD COLUMN signature TEXT")
+    }
+}

--- a/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/migrations/MigrationTest.kt
+++ b/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/migrations/MigrationTest.kt
@@ -26,8 +26,9 @@ import org.robolectric.annotation.Config
  * in v8), `MIGRATION_8_9` (#384 follow-up added `FlagTopic.isFavorite` in v9),
  * `MIGRATION_9_10` (#430 added the `mp_read_positions` table in v10),
  * `MIGRATION_10_11` (#405 added the `editor_drafts` table in v11),
- * `MIGRATION_11_12` (#459 added the `uploaded_images` table in v12) and
- * `MIGRATION_12_13` (#6/ADR-014 added the `mp_storage_locations` table in v13).
+ * `MIGRATION_11_12` (#459 added the `uploaded_images` table in v12),
+ * `MIGRATION_12_13` (#6/ADR-014 added the `mp_storage_locations` table in v13) and
+ * `MIGRATION_13_14` (#330 added `Post.signature` in v14).
  * Without these tests a typo (missing column, wrong index name, wrong default)
  * would only crash on a real upgrade-in-place install, where the diagnostic loop is
  * days long. The tests take seconds.
@@ -125,6 +126,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -268,6 +270,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -371,6 +374,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -446,6 +450,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -517,6 +522,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -579,6 +585,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -655,6 +662,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -718,6 +726,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -771,6 +780,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -828,6 +838,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -890,6 +901,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -952,6 +964,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -966,6 +979,74 @@ class MigrationTest {
                 assertTrue("the migrated table must accept and return a row", cursor.moveToFirst())
                 assertEquals(9100200, cursor.getInt(0))
                 assertEquals(1980664234, cursor.getInt(1))
+            }
+        } finally {
+            migrated.close()
+        }
+    }
+
+    /**
+     * #330 — v13 → v14 adds nullable `signature` to `posts`.
+     *
+     * Verifies:
+     * 1. The migration runs cleanly against the v13 fixture and matches the exported v14 schema.
+     * 2. Pre-existing post rows survive the migration.
+     * 3. The new column defaults to NULL on old rows (recovered on the next live fetch).
+     */
+    @Test
+    fun migrate_13_to_14_adds_nullable_signature_to_posts() {
+        val dbName = "migration_13_14_test"
+
+        // 1. Create a v13 database and insert a posts row that pre-dates `signature`.
+        helper.createDatabase(dbName, 13).apply {
+            execSQL(
+                """INSERT INTO topic_pages (cat, post, page, title, totalPages, isFirstPostOwner,
+                   numreponses, fetchedAt, authMode, subcat, canReply)
+                   VALUES (23, 35395, 1, 'v13 cached topic', 10, 0, '[]', 1000, 'AUTHENTICATED', 550, 1)""",
+            )
+            execSQL(
+                """INSERT INTO posts (cat, numreponse, post, author, date, content, avatarUrl,
+                   isEditable, isOwnPost, quotedAuthors, postIndex, fetchedAt, authMode, quoteRef,
+                   profileId, editedAt)
+                   VALUES (23, 100, 35395, 'XaTriX', 1000,
+                   '{"blocks":[]}', NULL, 0, 0, '[]', 1, 1000, 'AUTHENTICATED', NULL, NULL, NULL)""",
+            )
+            close()
+        }
+
+        // 2. Run MIGRATION_13_14 and validate against the v14 schema.
+        helper.runMigrationsAndValidate(dbName, 14, true, MIGRATION_13_14).close()
+
+        // 3. Open the production Room database (which chains every migration).
+        val migrated = Room.databaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            RedfaceDatabase::class.java,
+            dbName,
+        )
+            .allowMainThreadQueries()
+            .addMigrations(
+                MIGRATION_1_2,
+                MIGRATION_2_3,
+                MIGRATION_3_4,
+                MIGRATION_4_5,
+                MIGRATION_5_6,
+                MIGRATION_6_7,
+                MIGRATION_7_8,
+                MIGRATION_8_9,
+                MIGRATION_9_10,
+                MIGRATION_10_11,
+                MIGRATION_11_12,
+                MIGRATION_12_13,
+                MIGRATION_13_14,
+            )
+            .build()
+
+        try {
+            migrated.openHelper.readableDatabase.query(
+                "SELECT signature FROM posts WHERE cat = 23 AND numreponse = 100",
+            ).use { cursor ->
+                assertTrue("pre-v14 post row must survive MIGRATION_13_14", cursor.moveToFirst())
+                assertTrue("signature must be NULL for pre-v14 rows", cursor.isNull(0))
             }
         } finally {
             migrated.close()

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -201,6 +201,18 @@ interface UserPreferencesRepository {
     suspend fun setTopicPollsExpanded(enabled: Boolean)
 
     /**
+     * #330 — whether each post's author signature (`<span class="signature">`, web parity) is
+     * rendered beneath the post body, in a subdued style separated by a divider. Default `false`:
+     * signatures are noisy and most readers scroll past them, so they are opt-in. Toggling is a
+     * pure render-time switch (the signature is always parsed and cached, no refetch). Observed by
+     * `:feature:topic`, toggled in Settings.
+     */
+    fun observeTopicSignatures(): Flow<Boolean>
+
+    /** Persists [observeTopicSignatures]. Default `false` until the first call. */
+    suspend fun setTopicSignatures(enabled: Boolean)
+
+    /**
      * #458 — which top-level tab (and optional Forum category) a cold start opens on. Default
      * [StartScreenChoice.FLAGS] (historical behaviour). The navigation reads the SYNCHRONOUS
      * [StartScreenBootstrapStore] mirror at cold start; this flow is the source of truth and

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/Post.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/Post.kt
@@ -56,4 +56,20 @@ data class Post(
      * marker; pre-v8 rows backfill to `NULL` and recover on the next live fetch.
      */
     val editedAt: Instant? = null,
+    /**
+     * #330 — the author's signature block (the HFR `<span class="signature">`
+     * trailer rendered under the post body on the web), parsed into the same
+     * [PostContent] AST as [content] so it can be rendered with the shared
+     * `PostRenderer`. `null` when the post has no signature (most posts) — the
+     * span is absent or empty.
+     *
+     * Gated for DISPLAY behind the `topic_signatures` reading preference (default
+     * OFF, signatures are noisy); the field is always parsed and persisted so the
+     * toggle is a pure render-time switch with no refetch.
+     *
+     * Persisted in Room v14 (cf. `MIGRATION_13_14`) so a cache hit keeps the
+     * signature without a network round-trip. Pre-v14 rows backfill to `NULL`
+     * and recover the real value on the next live fetch.
+     */
+    val signature: PostContent? = null,
 )

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
@@ -15,6 +15,7 @@ class PostContentParser {
             return ParsedPostContent(
                 quotedAuthors = emptyList(),
                 ast = deletedFallbackAst(),
+                signature = null,
             )
         }
 
@@ -29,7 +30,23 @@ class PostContentParser {
         return ParsedPostContent(
             quotedAuthors = quotedAuthors,
             ast = ast,
+            signature = parseSignature(contentElement),
         )
+    }
+
+    /**
+     * #330 — extracts the author signature trailer (`<span class="signature">`, a descendant of
+     * the `div[id^=para]` content element, after the post body and any `div.edited` marker) into
+     * the same AST as the body so it renders with the shared `PostRenderer`. HFR opens every
+     * signature with a horizontal-rule-ish dashes line and a trailing `clear: both` spacer div
+     * (both stripped by [parseBlocks]'s edge-trim / IGNORE rules), so an EMPTY signature
+     * (`<span class="signature"></span>`, or one carrying only decoration) yields no real block
+     * and is reported as `null` — same "no noise" contract as a never-edited [editedAt].
+     */
+    private fun parseSignature(contentElement: Element): PostContent? {
+        val span = contentElement.selectFirst(HfrSelectors.POST_SIGNATURE) ?: return null
+        val blocks = parseBlocks(span.clone().childNodes())
+        return blocks.takeIf { it.isNotEmpty() }?.let { PostContent(blocks = it) }
     }
 
     private fun deletedFallbackAst(): PostContent = PostContent(
@@ -709,4 +726,9 @@ internal fun sanitizeImageHref(rawSrc: String): String? =
 data class ParsedPostContent(
     val quotedAuthors: List<String>,
     val ast: PostContent,
+    /**
+     * #330 — the author signature AST (`<span class="signature">`), or `null` when the post has
+     * no signature (the span is absent, or holds only decoration that edge-trims to nothing).
+     */
+    val signature: PostContent? = null,
 )

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostsParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostsParser.kt
@@ -82,6 +82,9 @@ class PostsParser(
             quoteRef = parseQuoteRef(postTable),
             profileId = parseProfileId(postTable),
             editedAt = parseEditedAt(postTable),
+            // #330 — parsed from the same content element as `content` (the signature span is a
+            // descendant of `div[id^=para]`, stripped from the body but surfaced here).
+            signature = content.signature,
         )
     }
 

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
@@ -195,6 +195,72 @@ class PostContentParserTest {
     }
 
     @Test
+    fun `signature span surfaces as a separate signature AST and is stripped from the body`() {
+        // #330 — HFR appends the author signature as a <span class="signature"> trailer inside
+        // the post content div, after the body and any div.edited marker. It is parsed into its
+        // own AST (rendered subdued, web parity) and removed from the body content.
+        val html = """
+            <div id="para1980664234"><p>Le corps du message.<div style="clear: both;"> </div></p>
+            <div class="edited"><br />Message édité par alice le 16-03-2016&nbsp;à&nbsp;14:35:19</div>
+            <br /><span class="signature"> ---------------
+            <br />Ma signature avec un <b>mot</b> en gras.<br /><div style="clear: both;"> </div></span></div>
+        """.trimIndent()
+        val contentElement = Jsoup.parse(html).selectFirst("div[id^=para]")
+
+        val parsed = PostContentParser().parse(contentElement)
+
+        val signature = requireNotNull(parsed.signature) { "the signature span must surface" }
+        val signatureText = signature.allInlines()
+            .filterIsInstance<PostInline.Text>()
+            .joinToString(" ") { it.value }
+        assertTrue(
+            "signature content must be parsed, got=$signatureText",
+            signatureText.contains("Ma signature avec un"),
+        )
+        // Inline formatting inside the signature survives (shared parseBlocks pipeline).
+        assertTrue(
+            "signature inline formatting must survive",
+            signature.allInlines().any { it is PostInline.Strong },
+        )
+        // The signature text must NOT leak into the body AST.
+        val bodyText = parsed.ast.allInlines()
+            .filterIsInstance<PostInline.Text>()
+            .joinToString(" ") { it.value }
+        assertTrue("body must keep its own text, got=$bodyText", bodyText.contains("Le corps du message"))
+        assertFalse(
+            "signature must not leak into the body, got=$bodyText",
+            bodyText.contains("Ma signature avec un"),
+        )
+    }
+
+    @Test
+    fun `post without a signature span yields a null signature`() {
+        val html = """
+            <div id="para1980664235"><p>Un message sans signature.<div style="clear: both;"> </div></p></div>
+        """.trimIndent()
+        val contentElement = Jsoup.parse(html).selectFirst("div[id^=para]")
+
+        val parsed = PostContentParser().parse(contentElement)
+
+        assertEquals("a post without a signature span must report null", null, parsed.signature)
+    }
+
+    @Test
+    fun `signature span with only decoration edge-trims to null`() {
+        // The dashes line + the trailing `clear: both` spacer are HFR boilerplate; a signature
+        // carrying nothing else must report null (no empty subdued block under the post).
+        val html = """
+            <div id="para1980664236"><p>Corps.<div style="clear: both;"> </div></p>
+            <br /><span class="signature"><br /><div style="clear: both;"> </div></span></div>
+        """.trimIndent()
+        val contentElement = Jsoup.parse(html).selectFirst("div[id^=para]")
+
+        val parsed = PostContentParser().parse(contentElement)
+
+        assertEquals("a decoration-only signature must report null", null, parsed.signature)
+    }
+
+    @Test
     fun `a quote whose quoted content embeds a spoiler stays a Quote`() {
         // #393 — post t2787065 (topic RF2-DEV page 6, the live repro) : XaTriX cites a post
         // shaped "Test / [spoiler]caca rose[/spoiler] / Suite". The container div used to be

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/TopicPageParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/TopicPageParserTest.kt
@@ -803,6 +803,23 @@ class TopicPageParserTest {
         )
     }
 
+    @Test
+    fun `parses author signatures into Post signature when present`() {
+        // #330 — the single-page fixture carries posts with a <span class="signature"> trailer.
+        // The parser surfaces each one as Post.signature (its own AST) without leaking it into the
+        // body content. Posts with no signature span keep Post.signature == null.
+        val topic = parser.parse(fixture("topic_page_single.html"))
+
+        val withSignature = topic.posts.filter { it.signature != null }
+        assertTrue("the single-page fixture should expose at least one author signature", withSignature.isNotEmpty())
+        withSignature.forEach { post ->
+            assertTrue(
+                "parsed signature #${post.numreponse} should hold at least one block",
+                post.signature!!.blocks.isNotEmpty(),
+            )
+        }
+    }
+
     private fun fixture(name: String): String {
         return requireNotNull(javaClass.getResource("/fixtures/$name")) {
             "Fixture not found: $name"

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -1990,6 +1990,10 @@ class PostEditorViewModelTest {
 
         override suspend fun setTopicPollsExpanded(enabled: Boolean) = Unit
 
+        override fun observeTopicSignatures(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setTopicSignatures(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1390,6 +1390,10 @@ class TopicFormViewModelTest {
 
         override suspend fun setTopicPollsExpanded(enabled: Boolean) = Unit
 
+        override fun observeTopicSignatures(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setTopicSignatures(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1614,6 +1614,10 @@ class FlagsViewModelTest {
 
         override suspend fun setTopicPollsExpanded(enabled: Boolean) = Unit
 
+        override fun observeTopicSignatures(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setTopicSignatures(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -510,6 +510,16 @@ internal fun buildSettingsCatalogue(
                     .takeIf { state.topicPollsExpandedError },
                 onCheckedChange = { onIntent(SettingsIntent.TopicPollsExpandedChanged(it)) },
             ),
+            toggleRow(
+                id = "topic_signatures",
+                title = stringResource(R.string.settings_topic_signatures_title),
+                description = stringResource(R.string.settings_topic_signatures_description),
+                checked = state.topicSignatures,
+                enabled = state.canToggleTopicSignatures,
+                errorRes = R.string.settings_topic_signatures_persist_failed
+                    .takeIf { state.topicSignaturesError },
+                onCheckedChange = { onIntent(SettingsIntent.TopicSignaturesChanged(it)) },
+            ),
             futureRow(
                 id = "future_restore_read_position",
                 title = stringResource(R.string.settings_future_restore_read_position),

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -99,6 +99,12 @@ data class SettingsState(
     val isUpdatingTopicPollsExpanded: Boolean = false,
     val topicPollsExpandedError: Boolean = false,
     val topicPollsExpandedTouchedLocally: Boolean = false,
+    // #330 — afficher les signatures sous les posts. Même machinerie optimistic-flip + garde de
+    // course au démarrage. Default FALSE (masquées) : les signatures sont bruyantes, donc opt-in.
+    val topicSignatures: Boolean = false,
+    val isUpdatingTopicSignatures: Boolean = false,
+    val topicSignaturesError: Boolean = false,
+    val topicSignaturesTouchedLocally: Boolean = false,
     // Publishing preferences (#312). Same optimistic-flip + startup-race-guard machinery:
     // `confirmBeforePosting` is the displayed value, `isUpdating*` gates the switch while DataStore
     // writes, `*Error` surfaces a persist failure, `*TouchedLocally` forbids a late `init` hydration
@@ -199,6 +205,10 @@ data class SettingsState(
     // #456 — the polls toggle is gated only by its own write.
     val canToggleTopicPollsExpanded: Boolean
         get() = !isUpdatingTopicPollsExpanded
+
+    // #330 — the signatures toggle is gated only by its own write.
+    val canToggleTopicSignatures: Boolean
+        get() = !isUpdatingTopicSignatures
 
     // #312 — the confirm-before-posting toggle is gated only by its own write.
     val canToggleConfirmBeforePosting: Boolean
@@ -303,6 +313,9 @@ sealed interface SettingsIntent {
 
     /** #456 — sondages dépliés par défaut dans la lecture de sujet. */
     data class TopicPollsExpandedChanged(val enabled: Boolean) : SettingsIntent
+
+    /** #330 — afficher les signatures des auteurs sous les posts. */
+    data class TopicSignaturesChanged(val enabled: Boolean) : SettingsIntent
 
     // #312 — confirm-before-posting toggle. Optimistic-flip contract, like the flags toggles:
     // the boolean is the desired post-flip state.

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -98,6 +98,11 @@ class SettingsViewModel @Inject constructor(
             apply = { state, value -> state.copy(topicPollsExpanded = value) },
         )
         hydratePreference(
+            read = { userPreferencesRepository.observeTopicSignatures().first() },
+            isLocked = { it.topicSignaturesTouchedLocally || it.isUpdatingTopicSignatures },
+            apply = { state, value -> state.copy(topicSignatures = value) },
+        )
+        hydratePreference(
             read = { userPreferencesRepository.observeConfirmBeforePosting().first() },
             isLocked = { it.confirmBeforePostingTouchedLocally || it.isUpdatingConfirmBeforePosting },
             apply = { state, value -> state.copy(confirmBeforePosting = value) },
@@ -202,6 +207,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.TopicPageFabsChanged -> updateTopicPageFabs(intent.enabled)
             is SettingsIntent.MpUnreadBadgeChanged -> updateMpUnreadBadge(intent.enabled)
             is SettingsIntent.TopicPollsExpandedChanged -> updateTopicPollsExpanded(intent.enabled)
+            is SettingsIntent.TopicSignaturesChanged -> updateTopicSignatures(intent.enabled)
             is SettingsIntent.ShowDtSectionChanged -> updateShowDtSection(intent.enabled)
             is SettingsIntent.ConfirmBeforePostingChanged -> updateConfirmBeforePosting(intent.enabled)
             is SettingsIntent.FlagsAutoRefreshChanged -> updateFlagsAutoRefresh(intent.enabled)
@@ -705,6 +711,33 @@ class SettingsViewModel @Inject constructor(
                 }
             },
             persist = userPreferencesRepository::setTopicPollsExpanded,
+        )
+    }
+
+    private fun updateTopicSignatures(desired: Boolean) {
+        val previous = _state.value.topicSignatures
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    topicSignatures = desired,
+                    isUpdatingTopicSignatures = true,
+                    topicSignaturesError = false,
+                    topicSignaturesTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(topicSignatures = desired, isUpdatingTopicSignatures = false)
+                } else {
+                    state.copy(
+                        topicSignatures = previous,
+                        isUpdatingTopicSignatures = false,
+                        topicSignaturesError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setTopicSignatures,
         )
     }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -284,6 +284,11 @@
     <string name="settings_topic_polls_expanded_description">Sondages dépliés en haut des sujets ; sinon une ligne repliée.</string>
     <string name="settings_topic_polls_expanded_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
 
+    <!-- #330 — Lecture. Afficher la signature de l'auteur sous chaque post (parité web). -->
+    <string name="settings_topic_signatures_title">Afficher les signatures</string>
+    <string name="settings_topic_signatures_description">Signature de l\'auteur sous chaque post, en plus discret.</string>
+    <string name="settings_topic_signatures_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
+
     <!-- #312 — Publication. Confirmation avant chaque envoi (réponse/édition de message, sujet,
          message privé) ; persisté en DataStore et lu en direct par les éditeurs.
          `settings_future_submit_confirm` (catalogue vitrine #288) renommé selon la convention des

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -973,6 +973,45 @@ class SettingsViewModelTest {
     }
 
     // ──────────────────────────────────────────────────────────────────────
+    // Author signatures (#330)
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `init hydrates topicSignatures from a persisted true`() = runTest {
+        // Default is false — only a persisted opt-in exercises the hydration path.
+        repository.emitTopicSignatures(true)
+
+        val viewModel = newViewModel()
+
+        assertTrue(viewModel.state.value.topicSignatures)
+        assertFalse(viewModel.state.value.topicSignaturesError)
+    }
+
+    @Test
+    fun `TopicSignaturesChanged persists the flip`() = runTest {
+        val viewModel = newViewModel()
+        assertFalse("signatures are hidden by default", viewModel.state.value.topicSignatures)
+
+        viewModel.submit(SettingsIntent.TopicSignaturesChanged(true))
+
+        assertTrue(viewModel.state.value.topicSignatures)
+        assertFalse(viewModel.state.value.isUpdatingTopicSignatures)
+        assertEquals(1, repository.topicSignaturesSetCalls)
+    }
+
+    @Test
+    fun `TopicSignaturesChanged reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnTopicSignaturesSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.TopicSignaturesChanged(true))
+
+        assertFalse("failed persist must revert to the previous value", viewModel.state.value.topicSignatures)
+        assertFalse(viewModel.state.value.isUpdatingTopicSignatures)
+        assertTrue(viewModel.state.value.topicSignaturesError)
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
     // Confirm before posting (#312)
     // ──────────────────────────────────────────────────────────────────────
 
@@ -1478,6 +1517,24 @@ class SettingsViewModelTest {
 
         fun emitTopicPollsExpanded(value: Boolean) {
             topicPollsExpanded.value = value
+        }
+
+        // #330 — afficher les signatures. Même seam optimistic-flip que topicPollsExpanded.
+        private val topicSignatures = MutableStateFlow(false)
+        var topicSignaturesSetCalls: Int = 0
+            private set
+        var failOnTopicSignaturesSet: Boolean = false
+
+        override fun observeTopicSignatures(): Flow<Boolean> = topicSignatures
+
+        override suspend fun setTopicSignatures(enabled: Boolean) {
+            topicSignaturesSetCalls += 1
+            check(!failOnTopicSignaturesSet) { "boom" }
+            topicSignatures.value = enabled
+        }
+
+        fun emitTopicSignatures(value: Boolean) {
+            topicSignatures.value = value
         }
 
         // #458 — start screen lives on its own StartScreenSettingsViewModel; this fake only

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -1006,6 +1007,9 @@ private fun TopicLoadedContent(
                 post = post,
                 highlighted = highlight == post.numreponse,
                 citedCount = citationCounts[post.numreponse] ?: 0,
+                // #330 — render the author signature beneath the body when the reading preference
+                // is on (the signature is always parsed/cached on the Post; this is render-only).
+                showSignature = state.showSignatures,
                 onQuote = quoteAction,
                 onEdit = editAction,
                 onOpenProfile = profileAction,
@@ -1381,6 +1385,12 @@ internal fun TopicPostCard(
      * #239 — number of posts on the current page that cite this one. 0 hides the badge.
      */
     citedCount: Int,
+    /**
+     * #330 — when `true` (the « Afficher les signatures » reading preference is on), the author's
+     * signature ([Post.signature]) is rendered beneath the body, separated by a divider, in a
+     * subdued style. No-op when the post has no signature. Default `false`.
+     */
+    showSignature: Boolean = false,
     onQuote: (() -> Unit)?,
     onEdit: (() -> Unit)?,
     /**
@@ -1675,6 +1685,19 @@ internal fun TopicPostCard(
         ) {
             // #281 — topic posts are selectable/copyable (opt-in; default is OFF in PostRenderer).
             PostRenderer(content = post.content, selectable = true)
+            // #330 — the author signature (web parity), gated by the reading preference. Rendered
+            // with the shared PostRenderer (the signature is BBCode/HTML like the body) but in a
+            // subdued style: a divider separates it from the body and a reduced alpha makes it
+            // subordinate to the post content. No-op when the post carries no signature.
+            post.signature?.let { signature ->
+                if (showSignature) {
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                    PostRenderer(
+                        content = signature,
+                        modifier = Modifier.alpha(SIGNATURE_ALPHA),
+                    )
+                }
+            }
             if (onQuote != null || onEdit != null || onToggleMultiQuote != null) {
                 // Actions row at the bottom of the post card, sober TextButtons
                 // so they stay subordinate to the post content. « Modifier »
@@ -1747,6 +1770,11 @@ internal fun TopicPostCard(
         }
     }
 }
+
+// #330 — the author signature renders subordinate to the post body: a reduced opacity keeps it
+// visually secondary (it shares the body's typography, so colour-only dimming via alpha is the
+// least invasive subdued treatment without recolouring PostRenderer's internals).
+private const val SIGNATURE_ALPHA = 0.7f
 
 private val topicDateFormatter = DateTimeFormatter
     .ofPattern("dd/MM/yyyy HH:mm:ss", Locale.FRANCE)

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -46,6 +46,13 @@ data class TopicUiState(
      */
     val pollsExpandedDefault: Boolean = false,
     /**
+     * #330 — mirrors `UserPreferencesRepository.observeTopicSignatures()`. When `true`, each post
+     * card renders the author's signature (`Post.signature`) beneath the body, in a subdued style
+     * separated by a divider. Default `false`: signatures are noisy and opt-in. Flips on the first
+     * preference emission; the field is always parsed/cached so toggling never refetches.
+     */
+    val showSignatures: Boolean = false,
+    /**
      * #335 — `true` while a manual pull-to-refresh of the current page is in flight. Drives the
      * Material3 `PullToRefreshBox` spinner. Set on the `Refresh` intent, cleared in the refresh
      * coroutine's `finally` (so a cancellation — e.g. a delete starting mid-refresh — never leaves

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -122,6 +122,13 @@ class TopicViewModel @AssistedInject constructor(
                 _state.update { it.copy(pollsExpandedDefault = expanded) }
             }
             .launchIn(viewModelScope)
+        // #330 — mirror the signatures preference so the post cards can show/hide the author
+        // signature without a refetch (it is always parsed and cached on the Post).
+        userPreferencesRepository.observeTopicSignatures()
+            .onEach { show ->
+                _state.update { it.copy(showSignatures = show) }
+            }
+            .launchIn(viewModelScope)
     }
 
     fun send(intent: TopicIntent) {

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -471,6 +471,25 @@ class TopicViewModelTest {
     }
 
     @Test
+    fun `state showSignatures reflects the user preference (#330)`() = runTest {
+        val hidden = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            userPreferencesRepository = FakeUserPreferencesRepository(topicSignatures = false),
+        )
+        assertEquals(false, hidden.state.value.showSignatures)
+
+        val shown = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            userPreferencesRepository = FakeUserPreferencesRepository(topicSignatures = true),
+        )
+        assertEquals(true, shown.state.value.showSignatures)
+    }
+
+    @Test
     fun `DeletePost success emits PostDeleted and force-refreshes the current page (#292)`() = runTest {
         // Page 2 so the editable post 777 is NOT the first post (the FP lives on page 1 and is
         // excluded from deletion). Editable + authenticated + canReply → the VM gate lets it through.
@@ -1304,15 +1323,16 @@ private class FakeStreamingTopicRepository(
 
 /**
  * No-op preferences fake for the topic ViewModel tests. Only [observeTopicTopBarAutoHide]
- * (build 89 follow-up), [observeTopicPageFabs] (#383) and [observeTopicPollsExpanded] (#456)
- * are read by [TopicViewModel] — everything else returns the DataStore default so the fake
- * stays a thin stand-in. The three relevant values are constructor-injectable so tests can
- * assert they reach state.
+ * (build 89 follow-up), [observeTopicPageFabs] (#383), [observeTopicPollsExpanded] (#456) and
+ * [observeTopicSignatures] (#330) are read by [TopicViewModel] — everything else returns the
+ * DataStore default so the fake stays a thin stand-in. The relevant values are
+ * constructor-injectable so tests can assert they reach state.
  */
 private class FakeUserPreferencesRepository(
     private val topicTopBarAutoHide: Boolean = false,
     private val topicPageFabs: Boolean = true,
     private val topicPollsExpanded: Boolean = false,
+    private val topicSignatures: Boolean = false,
 ) : UserPreferencesRepository {
     override fun observeProxyConfig(): Flow<ProxyConfig> = MutableStateFlow(ProxyConfig())
 
@@ -1381,6 +1401,10 @@ private class FakeUserPreferencesRepository(
     override fun observeTopicPollsExpanded(): Flow<Boolean> = MutableStateFlow(topicPollsExpanded)
 
     override suspend fun setTopicPollsExpanded(enabled: Boolean) = Unit
+
+    override fun observeTopicSignatures(): Flow<Boolean> = MutableStateFlow(topicSignatures)
+
+    override suspend fun setTopicSignatures(enabled: Boolean) = Unit
 
     override fun observeStartScreen(): Flow<StartScreenPreference> =
         MutableStateFlow(StartScreenPreference())


### PR DESCRIPTION
Affiche la signature des posts sous le corps, derrière un nouveau réglage **défaut OFF**. Parse la signature HFR dans l'AST `PostContent` (avant elle n'était que strippée), persistée (migration Room v13→v14, champ nullable), rendue en style atténué (divider + alpha). Toggle = pur render-time (toujours parsée/cachée, pas de refetch). Threads MP non concernés.

Validation : build 4-flavor vert (detekt + assemble Prod/Beta/Dev + lint + tests, dont `MigrationTest migrate_13_to_14` + schéma `14.json` régénéré par ksp) ; Codex review-only **RAS / mergeable** (migration nullable correcte, mapping symétrique, rendu no-op si null/OFF).

> Action par Claude Opus 4.8 (demandée par @XaTriX)