### PR TITLE
feat(ui): unify icon-buttons on stroke vectors + thicker back arrow (#360)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/icon/RedfaceVectorIcon.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/icon/RedfaceVectorIcon.kt
@@ -1,0 +1,50 @@
+package fr.forumhfr.redface2.core.ui.icon
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Icône-bouton vectorielle unifiée (#360, ADR-015).
+ *
+ * Le projet **interdit `androidx.compose.material.*`** (détekt `ForbiddenImport`) : pas d'`Icons.*`
+ * Material. Les icônes sont donc des **vector drawables locaux** (`:core:ui/res/drawable`) tracés en
+ * *stroke* (`strokeWidth` 2.5, caps/joins ronds) pour un poids optique homogène — c'est ce composable
+ * qui matérialise la convention décidée pour la flèche retour et étendue aux chevrons de page et au
+ * crayon (cf. ADR-015).
+ *
+ * Un glyphe texte (`Text("←")`, `Text("✎")`…) dépendait de la police système, de la baseline et du
+ * font-scale : rendu incohérent selon l'appareil. Ce vector dimensionné en dp est indépendant de la
+ * police et optiquement centré par le conteneur (`IconButton` / `*FloatingActionButton`).
+ *
+ * L'icône est **décorative** : l'étiquette d'accessibilité reste portée par le conteneur cliquable
+ * (`contentDescription` sur l'`IconButton`/le FAB), donc [contentDescription] vaut `null` par défaut.
+ */
+@Composable
+fun RedfaceVectorIcon(
+    @DrawableRes resId: Int,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+    tint: Color = LocalContentColor.current,
+    size: Dp = RedfaceIconDefaults.Size,
+) {
+    Icon(
+        painter = painterResource(resId),
+        contentDescription = contentDescription,
+        modifier = modifier.size(size),
+        tint = tint,
+    )
+}
+
+/** Valeurs de référence de l'iconographie (#360, ADR-015). */
+object RedfaceIconDefaults {
+    /** Taille canonique des icônes-boutons, alignée sur la flèche retour des top bars. */
+    val Size: Dp = 24.dp
+}

--- a/core/ui/src/main/res/drawable/ic_arrow_back.xml
+++ b/core/ui/src/main/res/drawable/ic_arrow_back.xml
@@ -4,7 +4,13 @@
     android:viewportWidth="24"
     android:viewportHeight="24"
     android:autoMirrored="true">
+    <!-- #360 — tracé stroke unifié (ADR-015) : hampe + chevron en lignes, strokeWidth 2.5,
+         caps/joins ronds. Plus épais que l'ancien tracé fillColor (retour nicko « plus épaisse »),
+         et optiquement aligné avec ic_chevron_*/ic_edit. Tinté à l'usage. -->
     <path
-        android:fillColor="#FF000000"
-        android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8l8,8l1.41,-1.41L7.83,13H20v-2z" />
+        android:strokeColor="#FF000000"
+        android:strokeWidth="2.5"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M20,12 L4.5,12 M11.5,5 L4.5,12 L11.5,19" />
 </vector>

--- a/core/ui/src/main/res/drawable/ic_chevron_left.xml
+++ b/core/ui/src/main/res/drawable/ic_chevron_left.xml
@@ -4,13 +4,12 @@
     android:viewportWidth="24"
     android:viewportHeight="24"
     android:autoMirrored="true">
-    <!-- #360 — tracé stroke unifié (ADR-015) : chevron « › » en lignes, strokeWidth 2.5,
-         caps/joins ronds, même poids optique que ic_arrow_back/ic_chevron_left/ic_edit.
-         Tinté à l'usage. -->
+    <!-- #360 — tracé stroke unifié (ADR-015) : chevron « ‹ » en lignes, strokeWidth 2.5,
+         caps/joins ronds, miroir de ic_chevron_right, même poids optique que la famille. -->
     <path
         android:strokeColor="#FF000000"
         android:strokeWidth="2.5"
         android:strokeLineCap="round"
         android:strokeLineJoin="round"
-        android:pathData="M9,5 L16,12 L9,19" />
+        android:pathData="M15,5 L8,12 L15,19" />
 </vector>

--- a/core/ui/src/main/res/drawable/ic_edit.xml
+++ b/core/ui/src/main/res/drawable/ic_edit.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- #360 — tracé stroke unifié (ADR-015) : crayon « ✎ » en lignes, strokeWidth 2.5,
+         caps/joins ronds, même poids optique que ic_arrow_back/ic_chevron_*. Remplace le glyphe
+         texte ✎ des FAB « Répondre » (topic + thread MP). Tinté à l'usage. -->
+    <path
+        android:strokeColor="#FF000000"
+        android:strokeWidth="2.5"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M4,20 L4,16 L15,5 L19,9 L8,20 Z M13,7 L17,11" />
+</vector>

--- a/docs/adr/015-iconographie-boutons-icones.md
+++ b/docs/adr/015-iconographie-boutons-icones.md
@@ -1,0 +1,85 @@
+---
+title: ADR-015
+parent: ADRs
+grand_parent: Spécifications
+nav_order: 15
+permalink: /adr/015-iconographie-boutons-icones
+---
+
+# ADR-015 — Iconographie des boutons-icônes : vector drawables stroke locaux, pas de Material icons
+
+## Statut
+
+Accepté — 2026-06-16
+
+## Contexte
+
+Les boutons-icônes de l'app (flèche retour des top bars, chevrons de page « ‹ »/« › »,
+crayon « répondre ») étaient initialement des **glyphes texte** (`Text("←")`, `Text("✎")`…).
+Leur taille dépendait de la **police système, de la baseline et du font-scale** : rendu
+incohérent selon l'appareil, jamais aligné optiquement sur le titre voisin (cf. #355/#356/#357).
+
+La flèche retour a été corrigée la première (PR #357) en **vector drawable local
+(`ic_arrow_back.xml`) dimensionné en dp** et rendu via `material3 Icon`. Les autres
+boutons-icônes (chevrons `PageFab`, crayon `ReplyFab` topic + thread MP) souffraient encore
+du même défaut (#360).
+
+Contrainte structurante : `config/detekt/detekt.yml` interdit `androidx.compose.material.*`
+(règle `ForbiddenImport`) → **pas d'`Icons.*` Material** (ni widgets material1, ni
+material-icons). C'est précisément pourquoi la flèche est un vector dessiné à la main et non
+un `Icons.AutoMirrored.Filled.ArrowBack`.
+
+Retour communautaire (nicko) : la flèche vectorielle était jugée **trop fine** (« plus
+épaisse »). La passe d'uniformisation doit donc aussi corriger le **poids optique**, pas
+seulement le pattern.
+
+## Décision
+
+**Tous les boutons-icônes utilisent des vector drawables locaux (`:core:ui/res/drawable`),
+tracés en _stroke_, dimensionnés en dp, rendus via un primitive partagé.** Pas de Material
+icons.
+
+Convention de tracé (famille homogène) :
+- viewport `24×24` ;
+- tracé en **`strokeColor` / `strokeWidth="2.5"`** (pas de `fillColor`), `strokeLineCap` et
+  `strokeLineJoin` **`round`** ;
+- `android:autoMirrored="true"` pour les icônes directionnelles (flèche, chevrons) ;
+- `fillColor`/`strokeColor` neutre `#FF000000`, **tinté à l'usage** (`LocalContentColor`).
+
+Le `strokeWidth` 2.5 donne un trait **plus épais** que l'ancien `ic_arrow_back` en `fillColor`
+(retour nicko) et un poids identique d'une icône à l'autre.
+
+Primitive partagé : **`RedfaceVectorIcon`** (`:core:ui`, package `core.ui.icon`) encapsule
+`material3 Icon` + `painterResource` + la taille canonique (`RedfaceIconDefaults.Size = 24.dp`)
++ le contrat a11y (icône **décorative**, `contentDescription` porté par le conteneur cliquable
+`IconButton`/`*FloatingActionButton`). Tout nouveau bouton-icône passe par ce primitive.
+
+Drawables de la famille : `ic_arrow_back`, `ic_chevron_left`, `ic_chevron_right`, `ic_edit`
+(les `ic_ms_*` Material Symbols préexistants restent du `fillColor`, voir Conséquences).
+
+## Conséquences
+
+- un seul endroit définit taille en dp + a11y des boutons-icônes (`RedfaceVectorIcon`) ;
+- les écrans `topic` (flèche retour, `PageFab`, `ReplyFab`) et `messages` (flèche retour,
+  FAB répondre) consomment le primitive ; les chevrons `‹/›` et crayons `✎` ne sont plus des
+  glyphes texte ;
+- `ic_arrow_back` et `ic_chevron_right` passent de `fillColor` à `stroke` : leur rendu change
+  partout où ils servent (settings, recherche, profil, éditeur MP), mais reste un chevron /
+  une flèche, plus épais et cohérent — c'est l'effet recherché ;
+- coût : maintenir les drawables à la main (pas de dépendance `material-icons`, dont c'était
+  l'objectif de la règle detekt) ;
+- les icônes denses préexistantes (`ic_ms_*`, Material Symbols recadrés grille 960, p.ex.
+  `ic_ms_edit_square` du shell réglages #494) ne sont **pas** retracées en stroke : ce sont des
+  pictogrammes pleins, pas des boutons-icônes simples ; elles peuvent toujours passer par
+  `RedfaceVectorIcon` pour la taille/a11y.
+
+## Alternatives considérées
+
+- **Whitelister `androidx.compose.material.icons.*` dans `ForbiddenImport`** : donnerait
+  `Icons.*` standard, zéro drawable à maintenir, mais assouplit une règle posée volontairement
+  (éviter la dépendance `material-icons` et son poids) — rejeté, on garde la règle.
+- **Garder les glyphes texte mais forcer la taille en dp** (`Box` fixe / `fontSize` en sp) :
+  le tracé reste police-dépendant et le poids n'est pas maîtrisable — rejeté.
+- **`fillColor` (Material filled) plutôt que `stroke`** : c'était l'état initial de
+  `ic_arrow_back`, jugé trop fin par la communauté — le stroke à largeur explicite résout le
+  retour nicko et homogénéise le poids.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,3 +42,4 @@ Les numéros `004` à `007` sont volontairement laissés libres pour des décisi
 | [ADR-012]({{ site.baseurl }}/adr/012-credentials-proxy) | Credentials proxy : extension d'Option A |
 | [ADR-013]({{ site.baseurl }}/adr/013-mp-lecture-cache-prefetch) | Lecture MP : partage topic↔MP, cache à trois étages, prefetch borné |
 | [ADR-014]({{ site.baseurl }}/adr/014-mpstorage-v01-de-facto) | MPStorage : enveloppe v0.1 de facto, lecture d'abord, écriture différée |
+| [ADR-015]({{ site.baseurl }}/adr/015-iconographie-boutons-icones) | Iconographie des boutons-icônes : vector drawables stroke locaux, primitive `RedfaceVectorIcon` |

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
@@ -19,7 +18,6 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -39,7 +37,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -51,6 +48,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.model.Post
 import fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar
 import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
+import fr.forumhfr.redface2.core.ui.icon.RedfaceVectorIcon
 import fr.forumhfr.redface2.core.ui.list.LazyListScrollbar
 import fr.forumhfr.redface2.core.ui.pager.pageSwipeEdgeHint
 import fr.forumhfr.redface2.core.ui.post.PostRenderer
@@ -148,12 +146,11 @@ fun PrivateMessageThreadScreen(
                         onClick = onBack,
                         modifier = Modifier.semantics { contentDescription = backLabel },
                     ) {
-                        // dp-sized vector instead of a text « ← » glyph (font/baseline-dependent, cf.
-                        // Codex review). a11y label on the IconButton; the icon is decorative.
-                        Icon(
-                            painter = painterResource(fr.forumhfr.redface2.core.ui.R.drawable.ic_arrow_back),
-                            contentDescription = null,
-                            modifier = Modifier.size(24.dp),
+                        // #360 / ADR-015 — vector stroke unifié, dimensionné en dp (indépendant de la
+                        // police et de la baseline, contrairement au glyphe « ← »), via le primitive
+                        // partagé :core:ui. a11y label sur l'IconButton ; l'icône est décorative.
+                        RedfaceVectorIcon(
+                            resId = fr.forumhfr.redface2.core.ui.R.drawable.ic_arrow_back,
                         )
                     }
                 },
@@ -169,7 +166,12 @@ fun PrivateMessageThreadScreen(
                 val replyLabel = stringResource(R.string.messages_reply)
                 ExtendedFloatingActionButton(
                     text = { Text(replyLabel) },
-                    icon = { Text("✎") },
+                    // #360 / ADR-015 — crayon en vector stroke unifié via le primitive :core:ui,
+                    // à la place du glyphe « ✎ » (poids optique aligné sur la flèche retour / les
+                    // chevrons). Pas de Material icons (detekt ForbiddenImport).
+                    icon = {
+                        RedfaceVectorIcon(resId = fr.forumhfr.redface2.core.ui.R.drawable.ic_edit)
+                    },
                     onClick = { onReply(request.threadId, state.page) },
                 )
             }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.feature.topic
 
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -12,7 +13,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -28,7 +28,6 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -61,7 +60,6 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -82,6 +80,7 @@ import fr.forumhfr.redface2.core.model.Topic
 import fr.forumhfr.redface2.core.ui.RedfacePlaceholderScreen
 import fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar
 import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
+import fr.forumhfr.redface2.core.ui.icon.RedfaceVectorIcon
 import fr.forumhfr.redface2.core.ui.list.LazyListScrollbar
 import fr.forumhfr.redface2.core.ui.pager.pageSwipeEdgeHint
 import fr.forumhfr.redface2.core.ui.post.PostRenderer
@@ -677,15 +676,12 @@ internal fun TopicContent(
                         onClick = onBack,
                         modifier = Modifier.semantics { contentDescription = backLabel },
                     ) {
-                        // A text glyph used as an icon was unstable: its size depended on the system
-                        // font's `←` rendering, the baseline and the font-scale, never matching the
-                        // title cleanly (cf. Codex review). Use a dp-sized vector instead — optically
-                        // centred by the IconButton, font-independent. The a11y label stays on the
-                        // IconButton, so the icon itself is decorative (contentDescription = null).
-                        Icon(
-                            painter = painterResource(fr.forumhfr.redface2.core.ui.R.drawable.ic_arrow_back),
-                            contentDescription = null,
-                            modifier = Modifier.size(24.dp),
+                        // #360 / ADR-015 — vector stroke unifié, dimensionné en dp (indépendant de la
+                        // police et de la baseline, contrairement à l'ancien glyphe « ← »), via le
+                        // primitive partagé :core:ui. L'étiquette a11y reste sur l'IconButton, donc
+                        // l'icône est décorative (contentDescription = null par défaut).
+                        RedfaceVectorIcon(
+                            resId = fr.forumhfr.redface2.core.ui.R.drawable.ic_arrow_back,
                         )
                     }
                 },
@@ -1851,10 +1847,18 @@ private fun TopicBottomActions(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             if (showPrevious) {
-                PageFab(description = previousLabel, glyph = "‹", onClick = onPreviousPage)
+                PageFab(
+                    description = previousLabel,
+                    iconRes = fr.forumhfr.redface2.core.ui.R.drawable.ic_chevron_left,
+                    onClick = onPreviousPage,
+                )
             }
             if (showNext) {
-                PageFab(description = nextLabel, glyph = "›", onClick = onNextPage)
+                PageFab(
+                    description = nextLabel,
+                    iconRes = fr.forumhfr.redface2.core.ui.R.drawable.ic_chevron_right,
+                    onClick = onNextPage,
+                )
             }
             if (showMultiQuote) {
                 MultiQuoteFab(count = multiQuoteCount, onClick = onMultiQuote)
@@ -1883,31 +1887,32 @@ private fun MultiQuoteFab(count: Int, onClick: () -> Unit) {
 @Composable
 private fun PageFab(
     description: String,
-    glyph: String,
+    @DrawableRes iconRes: Int,
     onClick: () -> Unit,
 ) {
-    // No Material icons (detekt ForbiddenImport blocks androidx.compose.material.*): the glyph is a
-    // decorative Text and the real label rides on the FAB's `contentDescription` for TalkBack — same
-    // pattern as the top-bar back button.
+    // #360 / ADR-015 — chevron en vector stroke unifié (poids optique aligné sur la flèche retour),
+    // dimensionné en dp via le primitive partagé :core:ui plutôt qu'un glyphe « ‹ »/« › » dépendant
+    // de la police. Pas de Material icons (detekt ForbiddenImport). L'étiquette a11y reste sur le FAB,
+    // donc l'icône est décorative.
     SmallFloatingActionButton(
         onClick = onClick,
         modifier = Modifier.semantics { contentDescription = description },
     ) {
-        Text(glyph)
+        RedfaceVectorIcon(resId = iconRes)
     }
 }
 
 @Composable
 private fun ReplyFab(onClick: () -> Unit) {
-    // Same SmallFloatingActionButton footprint as the page FABs (user request): the « Répondre » label
-    // rides on contentDescription for TalkBack and the glyph is decorative (no Material icons — detekt
-    // ForbiddenImport blocks androidx.compose.material.*), mirroring PageFab and the top-bar back button.
+    // #360 / ADR-015 — crayon en vector stroke unifié (même poids optique que la flèche retour / les
+    // chevrons), via le primitive partagé :core:ui, à la place du glyphe « ✎ » dépendant de la police.
+    // Pas de Material icons (detekt ForbiddenImport). L'étiquette a11y reste sur le FAB.
     val replyLabel = stringResource(R.string.topic_fab_reply)
     SmallFloatingActionButton(
         onClick = onClick,
         modifier = Modifier.semantics { contentDescription = replyLabel },
     ) {
-        Text("✎")
+        RedfaceVectorIcon(resId = fr.forumhfr.redface2.core.ui.R.drawable.ic_edit)
     }
 }
 


### PR DESCRIPTION
Boutons-icônes (flèche retour, chevrons page, crayon) redessinés en vecteurs stroke 24dp d'un poids optique unique (plus épais, retour nicko), via une primitive partagée `:core:ui/RedfaceVectorIcon`. `ic_arrow_back`/`ic_chevron_right` passent fill→stroke (cohérent partout où ils servent — délta visuel large assumé, à valider en dogfood dev). ADR-015 documente la convention (pas de material-icons). Build 4-flavor vert ; Codex review-only RAS sur la primitive/a11y/drawables.

> Action par Claude Opus 4.8 (demandée par @XaTriX)