### PR TITLE
feat(ui): fold long top-level quotes with a show/hide toggle (#332)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -104,6 +104,68 @@ internal const val MAX_VISIBLE_QUOTE_DEPTH = 3
 internal fun isCollapsedQuoteDepth(depth: Int): Boolean = depth >= MAX_VISIBLE_QUOTE_DEPTH
 
 /**
+ * Issue #332 — character budget above which a TOP-LEVEL `[quote]`/`[quotemsg]` block renders
+ * folded to a one-line header by default ("longues citations… repliées sur une ligne, dépliables
+ * au clic puis repliables"), mirroring the long-quote behaviour of the existing HFR userscript.
+ *
+ * 280 ≈ a few lines of body text: a one- or two-sentence citation (the common "je cite la phrase à
+ * laquelle je réponds" case) stays expanded so the reader never has to tap for a short quote, while
+ * a wall-of-text citation folds away by default and can be opened on demand.
+ *
+ * This is ORTHOGONAL to [MAX_VISIBLE_QUOTE_DEPTH] / [isCollapsedQuoteDepth] (issue #3/#82 — collapse
+ * by NESTING depth, not length): the length fold only applies at depth 0 (see [isLongQuote]) so the
+ * two never compete on the same block.
+ */
+internal const val LONG_QUOTE_CHAR_THRESHOLD = 280
+
+/**
+ * Total length of the visible text carried by a [PostContent] (paragraph text + nested quote text,
+ * line breaks counted as one char, plus one separator per block boundary since consecutive blocks
+ * render on their own lines). Pure so the long-quote rule is pinned in a JVM test without entering
+ * Compose; smiley tokens and image alt-text are deliberately ignored — they are not "reading length"
+ * and a smiley-heavy line should not force a fold. A nested spoiler contributes nothing: its body is
+ * hidden behind its own toggle by default, so it adds no visible reading length to the fold decision
+ * (else a short quote wrapping a long spoiler would fold before the spoiler toggle even shows).
+ */
+internal fun quoteVisibleTextLength(content: PostContent): Int {
+    if (content.blocks.isEmpty()) return 0
+    // +1 per block boundary: consecutive paragraphs/blocks render on separate lines, so a quote made
+    // of many short blocks accumulates the visible breaks between them (Codex review).
+    return content.blocks.sumOf(::blockVisibleTextLength) + (content.blocks.size - 1)
+}
+
+private fun blockVisibleTextLength(block: PostBlock): Int = when (block) {
+    is PostBlock.Paragraph -> block.inlines.sumOf(::inlineVisibleTextLength)
+    is PostBlock.Quote -> quoteVisibleTextLength(block.content)
+    is PostBlock.Spoiler -> 0
+    is PostBlock.Fixed -> block.text.length
+    is PostBlock.CodeBlock -> block.text.length
+    is PostBlock.Image -> 0
+}
+
+private fun inlineVisibleTextLength(inline: PostInline): Int = when (inline) {
+    is PostInline.Text -> inline.value.length
+    PostInline.LineBreak -> 1
+    is PostInline.Strong -> inline.children.sumOf(::inlineVisibleTextLength)
+    is PostInline.Emphasis -> inline.children.sumOf(::inlineVisibleTextLength)
+    is PostInline.Underline -> inline.children.sumOf(::inlineVisibleTextLength)
+    is PostInline.Strike -> inline.children.sumOf(::inlineVisibleTextLength)
+    is PostInline.Color -> inline.children.sumOf(::inlineVisibleTextLength)
+    is PostInline.Link -> inline.children.sumOf(::inlineVisibleTextLength)
+    is PostInline.InlineImage -> 0
+    is PostInline.Smiley -> 0
+}
+
+/**
+ * Issue #332 — true when a quote must fold to a one-line header by default because it is "long".
+ * Restricted to [quoteDepth] == 0: a nested quote is already governed by the depth rule
+ * ([isCollapsedQuoteDepth]) and the parent fold, so folding it again by length would stack two
+ * different toggles on the same sub-tree. Pure decision, pinned in [PostRendererQuoteDepthTest].
+ */
+internal fun isLongQuote(block: PostBlock.Quote, quoteDepth: Int): Boolean =
+    quoteDepth == 0 && quoteVisibleTextLength(block.content) > LONG_QUOTE_CHAR_THRESHOLD
+
+/**
  * Which themed accent the [QuoteFrame] left bar uses. Issue #252 — a **bare** `[quote]` (typed by
  * hand, no author) is the user formatting their own text, not citing a sourced post, so it must read
  * differently from a real HFR citation (`[quotemsg=]`, author set) and from a nested citation:
@@ -320,21 +382,73 @@ private fun QuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
         CollapsedQuoteBlock(block, quoteDepth)
         return
     }
+    if (isLongQuote(block, quoteDepth)) {
+        FoldableQuoteBlock(block, quoteDepth)
+        return
+    }
     QuoteFrame(quoteDepth = quoteDepth, isBareQuote = isBareQuote(block)) {
-        Text(
-            // #252 — a bare quote still gets a "Citation" header (no author), mirroring the
-            // "Citation de X" header of a sourced citation, so the framed block always reads
-            // as a quotation and not as a stray indented paragraph.
-            text = block.author
-                ?.let { stringResource(R.string.post_quote_author, it) }
-                ?: stringResource(R.string.post_quote_bare),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        QuoteHeader(block)
         PostBlocksRenderer(
             blocks = block.content.blocks,
             quoteDepth = quoteDepth + 1,
         )
+    }
+}
+
+/**
+ * #252 — the "Citation de X" / "Citation" header shown above every framed quote so the block always
+ * reads as a quotation, not a stray indented paragraph. A bare quote (no author) falls back to the
+ * generic "Citation" label. Extracted so the expanded, depth-collapsed and long-fold variants share
+ * one source of truth for the header text.
+ */
+@Composable
+private fun QuoteHeader(block: PostBlock.Quote) {
+    Text(
+        text = block.author
+            ?.let { stringResource(R.string.post_quote_author, it) }
+            ?: stringResource(R.string.post_quote_bare),
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+/**
+ * Issue #332 — a "long" top-level citation (`isLongQuote`) folds to a single header line by default,
+ * dépliable au clic puis repliable. Mirrors the [SpoilerBlock] interaction (a `rememberSaveable`
+ * boolean + a clickable header carrying an "Afficher"/"Masquer" affordance) and reuses [QuoteFrame]
+ * so the accent bar, surface and bare-quote palette stay identical to a normal quote. Unlike
+ * [CollapsedQuoteBlock] (issue #3 depth fold, which resets depth to 0 on reveal) this fold keeps the
+ * real [quoteDepth] when expanded so a long quote that also nests deeply still hits the depth rule.
+ */
+@Composable
+private fun FoldableQuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
+    var expanded by rememberSaveable(block) { mutableStateOf(false) }
+    QuoteFrame(
+        quoteDepth = quoteDepth,
+        isBareQuote = isBareQuote(block),
+        modifier = Modifier.clickable { expanded = !expanded },
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            QuoteHeader(block)
+            Text(
+                text = if (expanded) {
+                    stringResource(R.string.post_quote_hide)
+                } else {
+                    stringResource(R.string.post_quote_show)
+                },
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+        if (expanded) {
+            PostBlocksRenderer(
+                blocks = block.content.blocks,
+                quoteDepth = quoteDepth + 1,
+            )
+        }
     }
 }
 
@@ -444,14 +558,8 @@ private fun CollapsedQuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
             )
         }
         if (revealed) {
-            Text(
-                // #252 — same "Citation"/"Citation de X" header rule as the expanded QuoteBlock.
-                text = block.author
-                    ?.let { stringResource(R.string.post_quote_author, it) }
-                    ?: stringResource(R.string.post_quote_bare),
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            // #252 — same "Citation"/"Citation de X" header rule as the expanded QuoteBlock.
+            QuoteHeader(block)
             PostBlocksRenderer(
                 blocks = block.content.blocks,
                 quoteDepth = 0,

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteDepthTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteDepthTest.kt
@@ -2,6 +2,8 @@ package fr.forumhfr.redface2.core.ui.post
 
 import fr.forumhfr.redface2.core.model.PostBlock
 import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.model.PostInline
+import fr.forumhfr.redface2.core.model.SmileyKind
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -95,5 +97,120 @@ class PostRendererQuoteDepthTest {
         assertEquals(QuoteAccentRole.SOURCED_ODD, quoteAccentRole(quoteDepth = 1, isBareQuote = false))
         assertEquals(QuoteAccentRole.SOURCED_EVEN, quoteAccentRole(quoteDepth = 2, isBareQuote = false))
         assertEquals(QuoteAccentRole.SOURCED_ODD, quoteAccentRole(quoteDepth = 3, isBareQuote = false))
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Issue #332 — long top-level quotes fold to one line by default (distinct from the #3 depth fold).
+    // The reveal/re-collapse interaction lives in the @Composable FoldableQuoteBlock; here we pin the
+    // pure decision (isLongQuote) and its length measure (quoteVisibleTextLength).
+    // ---------------------------------------------------------------------------------------------
+
+    private fun quoteOf(text: String, depthContent: PostContent? = null) = PostBlock.Quote(
+        author = "Lt Ripley",
+        numreponse = 1,
+        page = 1,
+        content = depthContent ?: PostContent(
+            blocks = listOf(PostBlock.Paragraph(inlines = listOf(PostInline.Text(text)))),
+        ),
+    )
+
+    @Test
+    fun `a short top-level quote stays expanded`() {
+        // The common "je cite la phrase à laquelle je réponds" case must never force a tap.
+        assertFalse(isLongQuote(quoteOf("Court extrait d'une phrase."), quoteDepth = 0))
+    }
+
+    @Test
+    fun `a long top-level quote folds by default`() {
+        val longText = "Mur de texte. ".repeat(40) // ~560 chars, well over the 280 budget
+        assertTrue(isLongQuote(quoteOf(longText), quoteDepth = 0))
+    }
+
+    @Test
+    fun `a long quote is never length-folded when nested`() {
+        // Nested quotes are governed by the depth rule + the parent fold; length-folding them too
+        // would stack two toggles on the same sub-tree, so isLongQuote is depth-0-only.
+        val longText = "Mur de texte. ".repeat(40)
+        assertFalse(isLongQuote(quoteOf(longText), quoteDepth = 1))
+        assertFalse(isLongQuote(quoteOf(longText), quoteDepth = 2))
+    }
+
+    @Test
+    fun `the fold threshold value stays at the documented budget`() {
+        assertEquals(
+            "Bumping LONG_QUOTE_CHAR_THRESHOLD changes which citations fold by default — keep it a " +
+                "deliberate review step.",
+            280,
+            LONG_QUOTE_CHAR_THRESHOLD,
+        )
+    }
+
+    @Test
+    fun `quoteVisibleTextLength counts text and line breaks across nested blocks`() {
+        val content = PostContent(
+            blocks = listOf(
+                PostBlock.Paragraph(
+                    inlines = listOf(
+                        PostInline.Text("abc"), // 3
+                        PostInline.LineBreak, // 1
+                        PostInline.Strong(listOf(PostInline.Text("de"))), // 2
+                    ),
+                ),
+                PostBlock.Quote(
+                    author = null,
+                    numreponse = null,
+                    page = null,
+                    content = PostContent(
+                        blocks = listOf(
+                            PostBlock.Paragraph(inlines = listOf(PostInline.Text("fghi"))), // 4
+                        ),
+                    ),
+                ),
+            ),
+        )
+        // 3 + 1 + 2 (paragraph) + 4 (nested quote) + 1 (separator between the 2 top-level blocks).
+        assertEquals(3 + 1 + 2 + 4 + 1, quoteVisibleTextLength(content))
+    }
+
+    @Test
+    fun `quoteVisibleTextLength excludes the hidden spoiler body`() {
+        // A short quote wrapping a long spoiler must NOT fold: the spoiler body is hidden behind its
+        // own toggle, so it adds no visible reading length (Codex review).
+        val longSpoiler = "x".repeat(LONG_QUOTE_CHAR_THRESHOLD + 50)
+        val content = PostContent(
+            blocks = listOf(
+                PostBlock.Paragraph(inlines = listOf(PostInline.Text("ab"))), // 2
+                PostBlock.Spoiler(
+                    label = null,
+                    content = PostContent(
+                        blocks = listOf(
+                            PostBlock.Paragraph(inlines = listOf(PostInline.Text(longSpoiler))),
+                        ),
+                    ),
+                ), // 0 — hidden body excluded
+            ),
+        )
+        // 2 (paragraph) + 0 (spoiler) + 1 (block boundary) = 3, far under the fold threshold.
+        assertEquals(3, quoteVisibleTextLength(content))
+    }
+
+    @Test
+    fun `quoteVisibleTextLength ignores smileys and inline images`() {
+        // A smiley-heavy or image-heavy short citation is not "long reading" and must not fold.
+        val content = PostContent(
+            blocks = listOf(
+                PostBlock.Paragraph(
+                    inlines = listOf(
+                        PostInline.Smiley(
+                            kind = SmileyKind.Builtin(":lol:"),
+                            imageUrl = "https://forum-images.hardware.fr/images/perso/x.gif",
+                        ),
+                        PostInline.InlineImage(url = "https://example.com/x.png", description = null),
+                        PostInline.Text("ok"), // only this counts → 2
+                    ),
+                ),
+            ),
+        )
+        assertEquals(2, quoteVisibleTextLength(content))
     }
 }

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteRoborazziTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteRoborazziTest.kt
@@ -142,6 +142,33 @@ class PostRendererQuoteRoborazziTest {
         )
     }
 
+    /**
+     * Issue #332 — a "long" top-level citation folds to a single header line by default ("longues
+     * citations repliées sur une ligne, dépliables au clic puis repliables"). This captures the
+     * default *folded* state: the framed quote shows only its "Citation de X" header + the
+     * "(afficher)" affordance, and the wall-of-text body is hidden until tapped.
+     */
+    @Test
+    fun postRendererLongQuoteFoldedLight() {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                Surface(color = MaterialTheme.colorScheme.surface) {
+                    Box(
+                        modifier = Modifier
+                            .width(360.dp)
+                            .background(MaterialTheme.colorScheme.surface)
+                            .padding(16.dp),
+                    ) {
+                        PostRenderer(content = longQuoteContent())
+                    }
+                }
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage(
+            filePath = "build/outputs/roborazzi/post_renderer_long_quote_folded_light.png",
+        )
+    }
+
     @androidx.compose.runtime.Composable
     private fun AmoledHost(content: @androidx.compose.runtime.Composable () -> Unit) {
         RedfaceTheme(
@@ -227,6 +254,33 @@ class PostRendererQuoteRoborazziTest {
                     blocks = listOf(paragraph("Granfondo : épreuve cyclosportive de longue distance.")),
                 ),
             ),
+        ),
+    )
+
+    private fun longQuoteContent(): PostContent = PostContent(
+        blocks = listOf(
+            paragraph("Je réponds à un très long pavé :"),
+            PostBlock.Quote(
+                author = "XaTriX",
+                numreponse = 74749781,
+                page = 8270,
+                content = PostContent(
+                    blocks = listOf(
+                        paragraph(
+                            "Voilà un mur de texte volontairement très long pour dépasser le " +
+                                "seuil de repli automatique des citations (issue #332). " +
+                                "On répète quelques phrases afin de simuler une citation " +
+                                "interminable qu'un lecteur préfère replier par défaut puis " +
+                                "déplier au clic si le contexte l'intéresse vraiment.",
+                        ),
+                        paragraph(
+                            "Deuxième paragraphe tout aussi bavard, histoire de bien franchir " +
+                                "le budget de caractères et de rendre le repli pertinent.",
+                        ),
+                    ),
+                ),
+            ),
+            paragraph("Bref, replié par défaut c'est plus lisible."),
         ),
     )
 


### PR DESCRIPTION
Les longues citations top-level (>280 caractères visibles) se replient à leur en-tête par défaut, dépliables au tap (re-repliables), comme les spoilers. Citations courtes restées dépliées ; fold de profondeur (#3/#82) inchangé et orthogonal. État pur UI (rememberSaveable), pas de modif AST.

Fixes Codex : le corps des spoilers n'est pas compté (sinon une citation courte avec un long spoiler se replierait à tort), et un séparateur inter-blocs est ajouté (citation multi-lignes courtes). Tests purs + Roborazzi. Build vert (detekt + core:ui tests + assemble).

> Action par Claude Opus 4.8 (demandée par @XaTriX)