### PR TITLE
feat(ui): unify topic-row metadata across flags/category/search (#376)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
@@ -92,33 +91,13 @@ fun FlagItem(
                 fontWeight = if (flag.hasUnread) FontWeight.SemiBold else FontWeight.Normal,
                 maxLines = 2,
             )
-            if (metadata.start.isNotEmpty() || metadata.end.isNotEmpty()) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = metadata.start,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        // #325 — only the START segment may truncate; the end-aligned
-                        // timestamp keeps its intrinsic width (weight measures this text
-                        // in the remaining space).
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f),
-                    )
-                    if (metadata.end.isNotEmpty()) {
-                        Text(
-                            text = metadata.end,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
-                            modifier = Modifier.padding(start = 8.dp),
-                        )
-                    }
-                }
-            }
+            // #376 — shared two-segment metadata line (start truncatable + date pinned right),
+            // common to the drapeaux / catégorie / recherche lists.
+            TopicMetadataLine(
+                metadata = metadata,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagMetadata.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagMetadata.kt
@@ -1,9 +1,74 @@
 package fr.forumhfr.redface2.core.ui
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+
 /**
- * Footer line of a [FlagItem] row, split in two segments (#325 follow-up). [start] is the
- * only segment allowed to truncate (ellipsis); [end] — typically the last-reply
- * timestamp — keeps its intrinsic width, pinned to the row's end. Either side may be
- * empty. Bundled as one value so callers stay under the detekt parameter-count threshold.
+ * Footer line of a topic row, split in two segments (#325, generalised to all three topic
+ * lists in #376). [start] is the only segment allowed to truncate (ellipsis); [end] —
+ * typically the last-reply timestamp — keeps its intrinsic width, pinned to the row's end.
+ * Either side may be empty. Bundled as one value so callers stay under the detekt
+ * parameter-count threshold.
  */
 data class FlagMetadata(val start: String = "", val end: String = "")
+
+/**
+ * #376 — shared two-segment metadata line for every topic-list row (drapeaux, catégorie,
+ * recherche). Extracted from [FlagItem] so the three lists render the SAME template:
+ *
+ *  - [FlagMetadata.start] (e.g. `auteur · p.X/Y`) takes the remaining width and ellipsises;
+ *  - [FlagMetadata.end] (the last-reply timestamp) keeps its intrinsic width, end-aligned,
+ *    and is NEVER truncated — the date survives on narrow screens, the left segment clips
+ *    first (dogfooding feedback on v102, where the date was last in a single string and was
+ *    the part being cut off).
+ *
+ * Renders nothing when both segments are blank. [style] / [color] are passed in so each list
+ * keeps its own typography role (drapeaux/catégorie use `labelSmall`, recherche uses
+ * `bodySmall`) and its own highlight tint — only the LAYOUT is harmonised, not the chrome.
+ */
+@Composable
+fun TopicMetadataLine(
+    metadata: FlagMetadata,
+    modifier: Modifier = Modifier,
+    style: TextStyle = LocalTextStyle.current,
+    color: Color = MaterialTheme.colorScheme.onSurfaceVariant,
+) {
+    if (metadata.start.isEmpty() && metadata.end.isEmpty()) return
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Start,
+    ) {
+        Text(
+            text = metadata.start,
+            style = style,
+            color = color,
+            maxLines = 1,
+            // Only the START segment may truncate; the end-aligned timestamp keeps its
+            // intrinsic width (weight measures this text in the remaining space).
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        if (metadata.end.isNotEmpty()) {
+            Text(
+                text = metadata.end,
+                style = style,
+                color = color,
+                maxLines = 1,
+                modifier = Modifier.padding(start = 8.dp),
+            )
+        }
+    }
+}

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
@@ -54,6 +54,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.SubCategory
 import fr.forumhfr.redface2.core.model.TopicSummary
+import fr.forumhfr.redface2.core.ui.FlagMetadata
+import fr.forumhfr.redface2.core.ui.TopicMetadataLine
 import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.formatLastReplyTimestamp
 import fr.forumhfr.redface2.core.ui.theme.FlagPalette
@@ -454,18 +456,21 @@ private fun TopicRow(
                 fontWeight = if (topic.hasUnread == true) FontWeight.SemiBold else FontWeight.Normal,
                 maxLines = 2,
             )
-            Text(
-                text = stringResource(
-                    R.string.category_topic_metadata,
-                    topic.author,
-                    topic.lastReplyAuthor,
-                    formatLastReplyTimestamp(topic.lastReplyAt),
-                    topic.replyCount,
-                    topic.totalPages,
+            // #376 — common two-segment metadata line: `par <auteur> · N rép. · N p.` (left,
+            // truncatable) + the last-reply timestamp pinned right and never truncated. Matches
+            // the drapeaux template; the search list uses the same TopicMetadataLine.
+            TopicMetadataLine(
+                metadata = FlagMetadata(
+                    start = stringResource(
+                        R.string.category_topic_metadata,
+                        topic.author,
+                        topic.replyCount,
+                        topic.totalPages,
+                    ),
+                    end = formatLastReplyTimestamp(topic.lastReplyAt),
                 ),
                 style = MaterialTheme.typography.labelSmall,
                 color = metadataColor,
-                maxLines = 1,
             )
             if (topic.isSticky || topic.isLocked) {
                 Text(

--- a/feature/forum/src/main/res/values/strings.xml
+++ b/feature/forum/src/main/res/values/strings.xml
@@ -12,7 +12,9 @@
     <string name="category_filter_all">Toutes</string>
     <string name="category_subcategories_error">Sous-catégories indisponibles</string>
     <string name="category_topics_error">Topics indisponibles</string>
-    <string name="category_topic_metadata">par %1$s · dernier %2$s · %3$s · %4$d réponses · %5$d pages</string>
+    <!-- #376 — segment gauche tronquable de la ligne de métadonnées (la date est alignée à
+         droite, jamais tronquée, cf. le gabarit commun des trois listes). -->
+    <string name="category_topic_metadata">par %1$s · %2$d rép. · %3$d p.</string>
     <!-- #206 — stateDescription a11y sur la ligne du topic fraîchement créé mise en évidence. -->
     <string name="category_topic_new_highlight">Sujet que vous venez de créer</string>
     <string name="category_badge_sticky">Épinglé</string>

--- a/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -54,6 +55,8 @@ import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.model.search.SearchPivotCategory
 import fr.forumhfr.redface2.core.model.search.SearchTextScope
 import fr.forumhfr.redface2.core.model.search.SearchTopicResult
+import fr.forumhfr.redface2.core.ui.FlagMetadata
+import fr.forumhfr.redface2.core.ui.TopicMetadataLine
 import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.formatLastReplyTimestamp
 
@@ -542,21 +545,23 @@ private fun SearchResultCard(result: SearchTopicResult, onClick: () -> Unit) {
                     overflow = TextOverflow.Ellipsis,
                 )
             }
-            Text(
-                text = stringResource(R.string.search_result_author, result.author),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Text(
-                text = stringResource(R.string.search_result_replies, result.replyCount, result.viewCount),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Text(
-                text = stringResource(
-                    R.string.search_result_last_reply,
-                    formatLastReplyTimestamp(result.lastReplyAt),
-                    result.lastReplyAuthor,
+            // #376 — common two-segment metadata line, shared with the drapeaux / catégorie
+            // lists: `par <auteur> · N rép. · N vues` (left, truncatable; search has no
+            // pagination so view count takes the page slot) + the last-reply timestamp pinned
+            // right and never truncated.
+            TopicMetadataLine(
+                metadata = FlagMetadata(
+                    start = stringResource(
+                        R.string.search_result_metadata,
+                        result.author,
+                        result.replyCount,
+                        pluralStringResource(
+                            R.plurals.search_result_views,
+                            result.viewCount,
+                            result.viewCount,
+                        ),
+                    ),
+                    end = formatLastReplyTimestamp(result.lastReplyAt),
                 ),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/feature/search/src/main/res/values/strings.xml
+++ b/feature/search/src/main/res/values/strings.xml
@@ -26,8 +26,14 @@
     <string name="search_pivot_hint">HFR affiche les topics d’une catégorie à la fois. Choisir une catégorie relance la même recherche dans ce périmètre.</string>
     <string name="search_result_location">dans %1$s</string>
     <string name="search_result_excerpt">Extrait : %1$s</string>
-    <string name="search_result_replies">%1$d réponses · %2$d vues</string>
-    <string name="search_result_author">par %1$s</string>
-    <string name="search_result_last_reply">Dernier message %1$s par %2$s</string>
+    <!-- #376 — segment gauche tronquable de la ligne de métadonnées commune aux trois listes
+         (la recherche n'expose pas de pagination, donc N pages est remplacé par N vues). La date
+         du dernier message est alignée à droite, jamais tronquée. -->
+    <string name="search_result_metadata">par %1$s · %2$d rép. · %3$s</string>
+    <!-- « vues » (vue complète, pas une abréviation) doit s'accorder : 1 vue / N vues. -->
+    <plurals name="search_result_views">
+        <item quantity="one">%d vue</item>
+        <item quantity="other">%d vues</item>
+    </plurals>
     <string name="search_result_locked">Verrouillé</string>
 </resources>


### PR DESCRIPTION
Gabarit commun des métadonnées de ligne : composable partagé `TopicMetadataLine` (:core:ui, repris de FlagItem) — segment gauche tronquable « auteur · … » + date à droite jamais tronquée — appliqué aux listes catégorie et recherche. Catégorie : « par X · N rép. · N p. » ; recherche : « par X · N rép. · N vue(s) » (pas de pagination). Drapeaux inchangés (délégation). Le « dernier posteur » est retiré des lignes catégorie/recherche pour coller au gabarit (champs modèle conservés) — à valider en dogfood.

Fix Codex : pluriel « vue(s) » via `plurals` (évite « 1 vues »). Build vert (detekt + lint prod/dev + tests search + assemble).

> Action par Claude Opus 4.8 (demandée par @XaTriX)