### PR TITLE
feat(debug): dev-only overlay outlining component bounds (#445)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
@@ -49,4 +49,11 @@ class AppThemeViewModel @Inject constructor(
     val fontScale: StateFlow<FontScalePreference> =
         userPreferencesRepository.observeFontScale()
             .stateIn(viewModelScope, SharingStarted.Eagerly, FontScalePreference.M)
+
+    // #445 — debug bounds overlay toggle (dev channel only; the channel gate lives in RedfaceApp).
+    // No bootstrap mirror: it does not paint the pre-first-frame window, so the seed is the `false`
+    // default and DataStore resolves on the first Eagerly read.
+    val debugBoundsOverlay: StateFlow<Boolean> =
+        userPreferencesRepository.observeDebugBoundsOverlay()
+            .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 }

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -69,6 +69,7 @@ import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.ui.RedfaceTheme
 import fr.forumhfr.redface2.core.ui.account.RedfaceAccountMenu
+import fr.forumhfr.redface2.core.ui.debug.DebugBoundsOverlay
 import fr.forumhfr.redface2.core.ui.theme.ReadingDisplaySettings
 import fr.forumhfr.redface2.feature.auth.LoginScreen
 import fr.forumhfr.redface2.feature.editor.PostEditorMode
@@ -512,6 +513,9 @@ fun RedfaceApp(intent: Intent?) {
     // #287 — reading presets (density + font scale) resolved at the root and bundled for RedfaceTheme.
     val displayDensity by themeViewModel.displayDensity.collectAsStateWithLifecycle()
     val fontScale by themeViewModel.fontScale.collectAsStateWithLifecycle()
+    // #445 — debug bounds overlay preference (the dev-channel gate + render live in
+    // [DevDebugBoundsOverlay], emitted last so it paints over everything; off by default).
+    val debugBoundsOverlay by themeViewModel.debugBoundsOverlay.collectAsStateWithLifecycle()
     val darkTheme = when (themeMode) {
         ThemeMode.LIGHT -> false
         ThemeMode.DARK -> true
@@ -871,6 +875,24 @@ fun RedfaceApp(intent: Intent?) {
                 )
             }
         }
+
+        // #445 — debug bounds overlay, emitted LAST so it paints on top of every sibling (the nav
+        // scaffold + the profile sheet). The root content is Box-stacked by z-order = emission order,
+        // so no explicit wrapper is needed.
+        DevDebugBoundsOverlay(enabled = debugBoundsOverlay)
+    }
+}
+
+/**
+ * #445 — renders the [DebugBoundsOverlay] only when [enabled] AND the build is the DEV channel
+ * ([BuildConfig.FLAVOR]). Both gates live here (not in [RedfaceApp]) so the channel check can NEVER be
+ * bypassed and so [RedfaceApp] stays a single call site. Off the dev channel, or when the preference is
+ * off, the overlay composable is never composed — zero cost.
+ */
+@Composable
+private fun DevDebugBoundsOverlay(enabled: Boolean) {
+    if (enabled && BuildConfig.FLAVOR == DEV_CHANNEL) {
+        DebugBoundsOverlay()
     }
 }
 
@@ -897,6 +919,10 @@ private fun startReportEmail(
 }
 
 private const val REPORT_EMAIL: String = "xat@azora.fr"
+
+// #445 — the `channel` product flavor whose BuildConfig.FLAVOR gates the debug bounds overlay. Matches
+// the `dev` flavor name in app/build.gradle.kts; prod/beta never expose the overlay.
+private const val DEV_CHANNEL: String = "dev"
 
 /**
  * Ephemeral private-message navigation state, held in memory by the nav host and purged on every
@@ -1372,6 +1398,8 @@ private fun RedfaceNavHost(
                     },
                     onOpenDiagnostics = { backStack.add(DiagnosticsRoute) },
                     onOpenMpStorageInspector = { backStack.add(MpStorageInspectorRoute) },
+                    // #445 — expose the debug bounds overlay toggle on the dev channel only.
+                    debugOverlayAvailable = BuildConfig.FLAVOR == DEV_CHANNEL,
                     topBarActions = accountMenu,
                 )
             }

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModelTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModelTest.kt
@@ -52,6 +52,8 @@ class AppThemeViewModelTest {
             // #287 — eagerly collected by the VM; defaults are enough for this theme-focused test.
             every { observeDisplayDensity() } returns MutableStateFlow(DisplayDensity.COMFORT)
             every { observeFontScale() } returns MutableStateFlow(FontScalePreference.M)
+            // #445 — eagerly collected by the VM constructor; default off is enough here.
+            every { observeDebugBoundsOverlay() } returns MutableStateFlow(false)
         }
 
         val vm = AppThemeViewModel(
@@ -71,6 +73,8 @@ class AppThemeViewModelTest {
             every { observeAmoledEnabled() } returns MutableStateFlow(false)
             every { observeDisplayDensity() } returns MutableStateFlow(DisplayDensity.COMFORT)
             every { observeFontScale() } returns MutableStateFlow(FontScalePreference.M)
+            // #445 — eagerly collected by the VM constructor; default off is enough here.
+            every { observeDebugBoundsOverlay() } returns MutableStateFlow(false)
         }
 
         val vm = AppThemeViewModel(

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -474,6 +474,21 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeDebugBoundsOverlay(): Flow<Boolean> =
+        dataStore.data
+            // Default `false` (#445): the debug bounds overlay is opt-in and dev-channel only.
+            .map { prefs -> prefs[KEY_DEBUG_BOUNDS_OVERLAY] ?: false }
+            .distinctUntilChanged()
+            .catch { emit(false) }
+
+    override suspend fun setDebugBoundsOverlay(enabled: Boolean) {
+        persist {
+            dataStore.edit { prefs ->
+                prefs[KEY_DEBUG_BOUNDS_OVERLAY] = enabled
+            }
+        }
+    }
+
     /**
      * Reads [KEY_UPLOAD_PROVIDER] defensively: an unknown / corrupt stored value (older build with a
      * renamed enum, manual edit) falls back to [UploadProviderId.DIBERIE] instead of crashing on
@@ -631,5 +646,8 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         // (FontScalePreference.name), both defensively parsed. No bootstrap mirror (cf. observers).
         val KEY_DISPLAY_DENSITY = stringPreferencesKey("display_density")
         val KEY_FONT_SCALE = stringPreferencesKey("font_scale")
+
+        // #445 — debug bounds overlay toggle (default false; exposed on the dev channel only).
+        val KEY_DEBUG_BOUNDS_OVERLAY = booleanPreferencesKey("debug_bounds_overlay")
     }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -585,6 +585,27 @@ class DataStoreUserPreferencesRepositoryTest {
     }
 
     @Test
+    fun `observeDebugBoundsOverlay defaults to false then persists true and false`() = runTest(dispatcher) {
+        // #445 — the debug bounds overlay is opt-in (dev channel only); an empty store reports false.
+        repository.observeDebugBoundsOverlay().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setDebugBoundsOverlay(true)
+        repository.observeDebugBoundsOverlay().test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setDebugBoundsOverlay(false)
+        repository.observeDebugBoundsOverlay().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `saving disabled proxy removes optional fields from effective config`() = runTest(dispatcher) {
         repository.saveProxyConfig(
             ProxyConfig(

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -605,5 +605,9 @@ class TopicRepositoryImplTest {
         override fun observeFontScale(): Flow<FontScalePreference> = MutableStateFlow(FontScalePreference.M)
 
         override suspend fun setFontScale(scale: FontScalePreference) = Unit
+
+        override fun observeDebugBoundsOverlay(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setDebugBoundsOverlay(enabled: Boolean) = Unit
     }
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -286,4 +286,17 @@ interface UserPreferencesRepository {
 
     /** Persists [observeFontScale]. Default [FontScalePreference.M] until the first call. */
     suspend fun setFontScale(scale: FontScalePreference)
+
+    /**
+     * Debug bounds overlay (#445): when `true`, the app draws a full-screen overlay outlining the
+     * bounds of every laid-out component (walked from the Compose semantics tree) so a developer can
+     * eyeball layout/spacing while dogfooding. Default `false`. The toggle is exposed in Settings on
+     * the DEV channel ONLY (gated by the `:app` build flavor), and the overlay itself early-returns
+     * when disabled so it costs nothing in production. Observed at the app root
+     * ([fr.forumhfr.redface2.navigation.RedfaceApp]).
+     */
+    fun observeDebugBoundsOverlay(): Flow<Boolean>
+
+    /** Persists [observeDebugBoundsOverlay]. Default `false` until the first call. */
+    suspend fun setDebugBoundsOverlay(enabled: Boolean)
 }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/debug/DebugBoundsOverlay.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/debug/DebugBoundsOverlay.kt
@@ -1,0 +1,131 @@
+package fr.forumhfr.redface2.core.ui.debug
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.node.RootForTest
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.semantics.SemanticsNode
+
+/**
+ * #445 — full-screen debug overlay that outlines the bounds of every laid-out component, drawn ON TOP
+ * of the app content so a developer can eyeball layout/spacing while dogfooding. Exposed in Settings on
+ * the DEV channel only, default OFF.
+ *
+ * Bounds source: the Compose semantics tree. [LocalView] under an `AndroidComposeView` is a
+ * [RootForTest], whose `semanticsOwner.unmergedRootSemanticsNode` roots a walk where each node exposes
+ * `boundsInRoot` — already in this overlay's own coordinate space (the overlay fills the same root).
+ * The cast is guarded ([rememberDebugBounds] swallows a `ClassCastException` / a `@Preview` host) so a
+ * non-`RootForTest` view degrades to drawing nothing instead of crashing.
+ *
+ * The walk is re-sampled on a throttled ~8 Hz tick (not every frame) into a snapshot `State`, so the
+ * overlay does not re-walk the (potentially large) tree on each of the 60–120 fps content frames.
+ *
+ * Perf when disabled: this composable is gated by the caller (`if (enabled) DebugBoundsOverlay()`),
+ * so when the preference is off it is never composed and the tick loop never starts.
+ */
+@Composable
+fun DebugBoundsOverlay(modifier: Modifier = Modifier) {
+    val bounds = rememberDebugBounds()
+    // Fills the same root the bounds are measured against, so `boundsInRoot` maps 1:1 to draw
+    // coordinates. `Canvas` is a `Spacer`-backed drawing node with NO pointer handling, so it paints
+    // over the content without intercepting taps.
+    Canvas(modifier = modifier.fillMaxSize()) {
+        bounds.forEach { box ->
+            drawRect(
+                color = depthColor(box.depth),
+                topLeft = Offset(box.rect.left, box.rect.top),
+                size = Size(box.rect.width, box.rect.height),
+                style = STROKE,
+            )
+        }
+    }
+}
+
+/** A single outlined node: its [rect] (in root coordinates) and tree [depth] (drives the colour). */
+internal data class DebugBoundsBox(val rect: Rect, val depth: Int)
+
+/**
+ * Re-samples the semantics tree into a bounds snapshot on a throttled ~8 Hz tick. Held in a plain
+ * `State` so the [Canvas] repaints only when the snapshot is replaced (≈ every [TICK_INTERVAL_NANOS]),
+ * not on every content frame. The root view is resolved once; the cast is guarded so a host that is
+ * not a [RootForTest] (e.g. a `@Preview`) yields an empty list rather than throwing.
+ */
+@OptIn(InternalComposeUiApi::class)
+@Composable
+private fun rememberDebugBounds(): List<DebugBoundsBox> {
+    val view = LocalView.current
+    var snapshot by remember { mutableStateOf(emptyList<DebugBoundsBox>()) }
+    LaunchedEffect(view) {
+        var lastTickNanos = 0L
+        while (true) {
+            val now = withFrameNanos { it }
+            if (now - lastTickNanos >= TICK_INTERVAL_NANOS) {
+                lastTickNanos = now
+                snapshot = sampleBounds(view as? RootForTest)
+            }
+        }
+    }
+    return snapshot
+}
+
+/**
+ * Walks the semantics tree from the root (depth-first, iterative to avoid recursion-depth limits) and
+ * collects each node's `boundsInRoot`. Returns an empty list when [root] is null (non-`RootForTest`
+ * host) or when accessing the tree throws (defensive: the semantics owner is an internal surface).
+ */
+@OptIn(InternalComposeUiApi::class)
+private fun sampleBounds(root: RootForTest?): List<DebugBoundsBox> {
+    // Unmerged root (#445 design): the unmerged tree keeps the individual layout/text/interactive
+    // nodes that a merged subtree would collapse into one accessibility node — that finer granularity
+    // is the whole point of a "outline every component" debug overlay.
+    val rootNode = root?.semanticsOwner?.unmergedRootSemanticsNode ?: return emptyList()
+    return runCatching { walkBounds(rootNode) }.getOrDefault(emptyList())
+}
+
+/** Iterative depth-first collection of every node's finite, non-empty `boundsInRoot`. */
+private fun walkBounds(rootNode: SemanticsNode): List<DebugBoundsBox> {
+    val out = ArrayList<DebugBoundsBox>()
+    val stack = ArrayDeque<Pair<SemanticsNode, Int>>()
+    stack.addLast(rootNode to 0)
+    while (stack.isNotEmpty()) {
+        val (node, depth) = stack.removeLast()
+        val rect = node.boundsInRoot
+        if (rect.width > 0f && rect.height > 0f && rect.isFinite) {
+            out.add(DebugBoundsBox(rect, depth))
+        }
+        node.children.forEach { child -> stack.addLast(child to depth + 1) }
+    }
+    return out
+}
+
+/** Cycles a small palette by tree depth so nested components stay visually distinguishable. */
+private fun depthColor(depth: Int): Color = DEPTH_PALETTE[depth % DEPTH_PALETTE.size]
+
+private val STROKE = Stroke(width = 2f)
+
+// Semi-transparent so the underlying content stays readable through the outlines.
+private val DEPTH_PALETTE = listOf(
+    Color(0x88E53935), // red
+    Color(0x881E88E5), // blue
+    Color(0x8843A047), // green
+    Color(0x88FB8C00), // orange
+    Color(0x888E24AA), // purple
+    Color(0x8800ACC1), // cyan
+)
+
+// ~8 Hz refresh: 125 ms between re-walks of the tree (1_000 ms / 8).
+private const val TICK_INTERVAL_NANOS = 125_000_000L

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -2026,6 +2026,10 @@ class PostEditorViewModelTest {
         override fun observeFontScale(): Flow<FontScalePreference> = MutableStateFlow(FontScalePreference.M)
 
         override suspend fun setFontScale(scale: FontScalePreference) = Unit
+
+        override fun observeDebugBoundsOverlay(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setDebugBoundsOverlay(enabled: Boolean) = Unit
     }
 
     /**

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1423,6 +1423,10 @@ class TopicFormViewModelTest {
         override fun observeFontScale(): Flow<FontScalePreference> = MutableStateFlow(FontScalePreference.M)
 
         override suspend fun setFontScale(scale: FontScalePreference) = Unit
+
+        override fun observeDebugBoundsOverlay(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setDebugBoundsOverlay(enabled: Boolean) = Unit
     }
 
     /** #405 — in-memory fake [EditorDraftStore], same shape as the one in `PostEditorViewModelTest`. */

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1676,5 +1676,9 @@ class FlagsViewModelTest {
         override fun observeFontScale(): Flow<FontScalePreference> = MutableStateFlow(FontScalePreference.M)
 
         override suspend fun setFontScale(scale: FontScalePreference) = Unit
+
+        override fun observeDebugBoundsOverlay(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setDebugBoundsOverlay(enabled: Boolean) = Unit
     }
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsMaintenanceScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsMaintenanceScreen.kt
@@ -44,6 +44,10 @@ fun SettingsMaintenanceScreen(
     onOpenDiagnostics: () -> Unit,
     onOpenMpStorageInspector: () -> Unit,
     modifier: Modifier = Modifier,
+    // #445 — debug bounds overlay row visibility. `:feature:settings` does not own the `:app`
+    // BuildConfig, so the dev-channel gate is computed in `:app` and passed in (same approach as the
+    // version surfaced on the About screen). Defaults to false so a non-dev caller never shows it.
+    debugOverlayAvailable: Boolean = false,
     topBarActions: @Composable (() -> Unit)? = null,
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
@@ -122,6 +126,12 @@ fun SettingsMaintenanceScreen(
             }
 
             IgnoreTopicCacheRow(state = state, onIntent = viewModel::submit)
+
+            // #445 — debug bounds overlay. Dev-channel only: the row is composed solely when the
+            // `:app` flavor gate ([debugOverlayAvailable]) is true, so prod/beta never see it.
+            if (debugOverlayAvailable) {
+                DebugBoundsOverlayRow(state = state, onIntent = viewModel::submit)
+            }
 
             HorizontalDivider()
             RedfaceSettingsListItem(
@@ -221,6 +231,48 @@ private fun IgnoreTopicCacheRow(
     }
     if (state.ignoreTopicCacheError) {
         PreferencePersistError(R.string.settings_ignore_topic_cache_persist_failed)
+    }
+}
+
+/**
+ * #445 — « Surligner les bounds des composants » switch (dev channel only). Mirrors [IgnoreTopicCacheRow]
+ * exactly (title + description + gated Switch + inline persist error). The dev-channel gate lives at the
+ * call site ([SettingsMaintenanceScreen]'s `debugOverlayAvailable`), so this row is simply not composed
+ * off dev.
+ */
+@Composable
+private fun DebugBoundsOverlayRow(
+    state: SettingsState,
+    onIntent: (SettingsIntent) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_debug_bounds_overlay_title),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = stringResource(R.string.settings_debug_bounds_overlay_description),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Switch(
+            checked = state.debugBoundsOverlay,
+            enabled = state.canToggleDebugBoundsOverlay,
+            onCheckedChange = { onIntent(SettingsIntent.DebugBoundsOverlayChanged(it)) },
+        )
+    }
+    if (state.debugBoundsOverlayError) {
+        PreferencePersistError(R.string.settings_debug_bounds_overlay_persist_failed)
     }
 }
 

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -41,6 +41,13 @@ data class SettingsState(
      * later and overwrite the optimistic flip with a stale snapshot. Never surfaced in the UI.
      */
     val ignoreTopicCacheTouchedLocally: Boolean = false,
+    // #445 — debug bounds overlay toggle (dev-channel only; the channel gate is in the screen, which
+    // hides the row off dev). Same optimistic-flip + startup-race-guard machinery as ignoreTopicCache.
+    // Default false (the overlay is opt-in even on dev).
+    val debugBoundsOverlay: Boolean = false,
+    val isUpdatingDebugBoundsOverlay: Boolean = false,
+    val debugBoundsOverlayError: Boolean = false,
+    val debugBoundsOverlayTouchedLocally: Boolean = false,
     // Drapeaux view preferences (#179 follow-up). Same optimistic-flip + startup-race-guard
     // machinery as ignoreTopicCache: the field is the displayed value, `isUpdating*` gates the
     // switch while DataStore writes, `*Error` surfaces a persist failure, and `*TouchedLocally`
@@ -172,6 +179,10 @@ data class SettingsState(
     val canToggleIgnoreTopicCache: Boolean
         get() = !isUpdatingIgnoreTopicCache
 
+    // #445 — the debug bounds overlay toggle is gated only by its own in-flight write.
+    val canToggleDebugBoundsOverlay: Boolean
+        get() = !isUpdatingDebugBoundsOverlay
+
     val canToggleFlagsGroupByCategory: Boolean
         get() = !isUpdatingFlagsGroupByCategory
 
@@ -286,6 +297,10 @@ sealed interface SettingsIntent {
     // ViewModel applies it optimistically, then reverts on DataStore failure so the UI never
     // shows a value that doesn't match what's persisted.
     data class IgnoreTopicCacheChanged(val enabled: Boolean) : SettingsIntent
+
+    // #445 — debug bounds overlay toggle (dev only). Same optimistic-flip contract: the boolean is
+    // the desired post-flip state.
+    data class DebugBoundsOverlayChanged(val enabled: Boolean) : SettingsIntent
 
     // Drapeaux view preferences (#179 follow-up). Same optimistic-flip contract as
     // IgnoreTopicCacheChanged: the boolean is the desired post-flip state.

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -53,6 +53,11 @@ class SettingsViewModel @Inject constructor(
             apply = { state, value -> state.copy(ignoreTopicCache = value) },
         )
         hydratePreference(
+            read = { userPreferencesRepository.observeDebugBoundsOverlay().first() },
+            isLocked = { it.debugBoundsOverlayTouchedLocally || it.isUpdatingDebugBoundsOverlay },
+            apply = { state, value -> state.copy(debugBoundsOverlay = value) },
+        )
+        hydratePreference(
             read = { userPreferencesRepository.observeFlagsGroupByCategory().first() },
             isLocked = { it.flagsGroupByCategoryTouchedLocally || it.isUpdatingFlagsGroupByCategory },
             apply = { state, value -> state.copy(flagsGroupByCategory = value) },
@@ -198,6 +203,7 @@ class SettingsViewModel @Inject constructor(
                 _state.update { it.copy(showClearImageCacheConfirm = false) }
             SettingsIntent.ClearImageCacheConfirmed -> clearImageCache()
             is SettingsIntent.IgnoreTopicCacheChanged -> updateIgnoreTopicCache(intent.enabled)
+            is SettingsIntent.DebugBoundsOverlayChanged -> updateDebugBoundsOverlay(intent.enabled)
             is SettingsIntent.FlagsGroupByCategoryChanged -> updateFlagsGroupByCategory(intent.enabled)
             is SettingsIntent.FlagsHideReadCategoriesChanged -> updateFlagsHideReadCategories(intent.enabled)
             is SettingsIntent.FlagsPerTabOverrideChanged -> updateFlagsPerTabOverride(intent.enabled)
@@ -357,6 +363,35 @@ class SettingsViewModel @Inject constructor(
                     }
                 }
         }
+    }
+
+    // #445 — debug bounds overlay (dev only). Plain boolean, so it reuses the shared optimistic-flip
+    // helper rather than the bespoke shape, like the flags toggles.
+    private fun updateDebugBoundsOverlay(desired: Boolean) {
+        val previous = _state.value.debugBoundsOverlay
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    debugBoundsOverlay = desired,
+                    isUpdatingDebugBoundsOverlay = true,
+                    debugBoundsOverlayError = false,
+                    debugBoundsOverlayTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(debugBoundsOverlay = desired, isUpdatingDebugBoundsOverlay = false)
+                } else {
+                    state.copy(
+                        debugBoundsOverlay = previous,
+                        isUpdatingDebugBoundsOverlay = false,
+                        debugBoundsOverlayError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setDebugBoundsOverlay,
+        )
     }
 
     private fun updateFlagsGroupByCategory(desired: Boolean) {

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -213,6 +213,12 @@
     <string name="settings_ignore_topic_cache_description">Force le retéléchargement et le reparse des pages de topic. Utile après un changement de parser/rendu. Désactive le prefetch topic pour éviter de remplir Room inutilement.</string>
     <string name="settings_ignore_topic_cache_persist_failed">Impossible de mémoriser le réglage « Ignorer le cache topic ». Réessayez.</string>
 
+    <!-- #445 — Overlay de debug qui surligne les bounds des composants. Réglage dev uniquement
+         (la ligne n'est affichée que sur le canal dev), désactivé par défaut. -->
+    <string name="settings_debug_bounds_overlay_title">Surligner les bounds des composants</string>
+    <string name="settings_debug_bounds_overlay_description">Dessine par-dessus l\'app un calque qui entoure les composants affichés (issus de l\'arbre sémantique Compose). Outil de debug du layout, canal dev uniquement.</string>
+    <string name="settings_debug_bounds_overlay_persist_failed">Impossible de mémoriser le réglage « Surligner les bounds des composants ». Réessayez.</string>
+
     <!-- #179 follow-up — Préférences d'affichage de l'écran Drapeaux. Persistées (DataStore) et
          observées en direct par l'écran Drapeaux : un changement ici se reflète sans refetch. -->
     <string name="settings_flags_title">Drapeaux</string>

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -1012,6 +1012,45 @@ class SettingsViewModelTest {
     }
 
     // ──────────────────────────────────────────────────────────────────────
+    // Debug bounds overlay (#445)
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `init hydrates debugBoundsOverlay from a persisted true`() = runTest {
+        // Default is false — only a persisted opt-in exercises the hydration path.
+        repository.emitDebugBoundsOverlay(true)
+
+        val viewModel = newViewModel()
+
+        assertTrue(viewModel.state.value.debugBoundsOverlay)
+        assertFalse(viewModel.state.value.debugBoundsOverlayError)
+    }
+
+    @Test
+    fun `DebugBoundsOverlayChanged persists the flip`() = runTest {
+        val viewModel = newViewModel()
+        assertFalse("overlay is off by default", viewModel.state.value.debugBoundsOverlay)
+
+        viewModel.submit(SettingsIntent.DebugBoundsOverlayChanged(true))
+
+        assertTrue(viewModel.state.value.debugBoundsOverlay)
+        assertFalse(viewModel.state.value.isUpdatingDebugBoundsOverlay)
+        assertEquals(1, repository.debugBoundsOverlaySetCalls)
+    }
+
+    @Test
+    fun `DebugBoundsOverlayChanged reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnDebugBoundsOverlaySet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.DebugBoundsOverlayChanged(true))
+
+        assertFalse("failed persist must revert to the previous value", viewModel.state.value.debugBoundsOverlay)
+        assertFalse(viewModel.state.value.isUpdatingDebugBoundsOverlay)
+        assertTrue(viewModel.state.value.debugBoundsOverlayError)
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
     // Confirm before posting (#312)
     // ──────────────────────────────────────────────────────────────────────
 
@@ -1679,6 +1718,25 @@ class SettingsViewModelTest {
 
         fun emitFlagsPerTabOverride(value: Boolean) {
             flagsPerTabOverride.value = value
+        }
+
+        // #445 — debug bounds overlay. Same optimistic-flip seam as topicSignatures so the Settings
+        // tests can assert hydration, the repo call, and the revert-on-failure path.
+        private val debugBoundsOverlay = MutableStateFlow(false)
+        var debugBoundsOverlaySetCalls: Int = 0
+            private set
+        var failOnDebugBoundsOverlaySet: Boolean = false
+
+        override fun observeDebugBoundsOverlay(): Flow<Boolean> = debugBoundsOverlay
+
+        override suspend fun setDebugBoundsOverlay(enabled: Boolean) {
+            debugBoundsOverlaySetCalls += 1
+            check(!failOnDebugBoundsOverlaySet) { "boom" }
+            debugBoundsOverlay.value = enabled
+        }
+
+        fun emitDebugBoundsOverlay(value: Boolean) {
+            debugBoundsOverlay.value = value
         }
     }
 

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -1434,4 +1434,8 @@ private class FakeUserPreferencesRepository(
     override fun observeFontScale(): Flow<FontScalePreference> = MutableStateFlow(FontScalePreference.M)
 
     override suspend fun setFontScale(scale: FontScalePreference) = Unit
+
+    override fun observeDebugBoundsOverlay(): Flow<Boolean> = MutableStateFlow(false)
+
+    override suspend fun setDebugBoundsOverlay(enabled: Boolean) = Unit
 }


### PR DESCRIPTION
> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

Implémente #445 : un overlay de debug qui surligne les bounds de chaque composant par-dessus l'app, pour inspecter layout/espacements **on-device sans Android Studio**.

## Approche
- **Source des bounds** : arbre sémantique Compose — `LocalView` → `RootForTest` → `semanticsOwner.unmergedRootSemanticsNode`, `boundsInRoot` par nœud (arbre *unmerged* comme spécifié dans l'issue → granularité fine). Walk DFS itératif, re-échantillonné sur un tick throttlé ~8 Hz dans un `State`, dessiné en rectangles stroke colorés par profondeur par un `Canvas` **non interactif** (ne capture aucun tap).
- **Gating canal dev** : `BuildConfig.FLAVOR == \"dev\"` garde **à la fois** le toggle Réglages **et** le rendu, côté `:app`. prod/beta ne peuvent ni l'exposer ni le rendre. Défaut **OFF** ; désactivé = jamais composé (coût nul, boucle de tick non démarrée).
- **API interne** (`RootForTest`/`semanticsOwner`) : `@OptIn(InternalComposeUiApi::class)` + cast défensif (`as?` + `runCatching`) → un host non-`RootForTest` (ex. `@Preview`) ne dessine rien au lieu de crasher.

## Surface
- pref `debug_bounds_overlay` (DataStore boolean, défaut false) sur le pattern `observeIgnoreTopicCache` ; toggle dans la page **Maintenance**.
- `core/ui/.../debug/DebugBoundsOverlay.kt` (nouveau) ; câblage racine `RedfaceApp` ; +6 fakes `UserPreferencesRepository` mis à jour.

## Validation (machine B, docker)
`detektAll`, `:app:assemble{Prod,Beta,Dev}Debug`, `:app:lint{Prod,Dev}Debug`, `test --rerun-tasks` → **BUILD SUCCESSFUL**. Revue Codex (review-only) : aucun bloquant ; gating prod/beta confirmé sûr ; findings « arbre unmerged » + « stub mockk `AppThemeViewModelTest` » corrigés.

## Caveat assumé (cf. issue)
L'arbre sémantique ne contient pas les `Box`/`Row`/`Column` purement layout — suffisant pour les bizarreries de spacing/empilement, pas une radiographie exhaustive. Dépendance `RootForTest` (API tooling) à réévaluer aux gros bumps Compose. Outil dev-only, trivialement révocable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)