### PR TITLE
feat(ui): setting to toggle long-quote folding (#332 follow-up)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
@@ -50,6 +50,13 @@ class AppThemeViewModel @Inject constructor(
         userPreferencesRepository.observeFontScale()
             .stateIn(viewModelScope, SharingStarted.Eagerly, FontScalePreference.M)
 
+    // #332 — « fold long quotes » reading preference, eagerly collected like the presets above.
+    // No bootstrap mirror (it does not paint the pre-first-frame window); the seed is the `true`
+    // default and DataStore resolves on the first Eagerly read.
+    val foldLongQuotes: StateFlow<Boolean> =
+        userPreferencesRepository.observeFoldLongQuotes()
+            .stateIn(viewModelScope, SharingStarted.Eagerly, true)
+
     // #445 — debug bounds overlay toggle (dev channel only; the channel gate lives in RedfaceApp).
     // No bootstrap mirror: it does not paint the pre-first-frame window, so the seed is the `false`
     // default and DataStore resolves on the first Eagerly read.

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -513,6 +513,8 @@ fun RedfaceApp(intent: Intent?) {
     // #287 — reading presets (density + font scale) resolved at the root and bundled for RedfaceTheme.
     val displayDensity by themeViewModel.displayDensity.collectAsStateWithLifecycle()
     val fontScale by themeViewModel.fontScale.collectAsStateWithLifecycle()
+    // #332 — « fold long quotes » reading preference, provided to the post renderer via RedfaceTheme.
+    val foldLongQuotes by themeViewModel.foldLongQuotes.collectAsStateWithLifecycle()
     // #445 — debug bounds overlay preference (the dev-channel gate + render live in
     // [DevDebugBoundsOverlay], emitted last so it paints over everything; off by default).
     val debugBoundsOverlay by themeViewModel.debugBoundsOverlay.collectAsStateWithLifecycle()
@@ -541,7 +543,11 @@ fun RedfaceApp(intent: Intent?) {
     RedfaceTheme(
         darkTheme = darkTheme,
         amoledTheme = amoledEnabled,
-        reading = ReadingDisplaySettings(density = displayDensity, fontScale = fontScale),
+        reading = ReadingDisplaySettings(
+            density = displayDensity,
+            fontScale = fontScale,
+            foldLongQuotes = foldLongQuotes,
+        ),
     ) {
         // #458 — cold-start screen, read synchronously from the bootstrap mirror and frozen for
         // the session. Only the INITIAL values below consume it: rememberSaveable and

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModelTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModelTest.kt
@@ -54,6 +54,8 @@ class AppThemeViewModelTest {
             every { observeFontScale() } returns MutableStateFlow(FontScalePreference.M)
             // #445 — eagerly collected by the VM constructor; default off is enough here.
             every { observeDebugBoundsOverlay() } returns MutableStateFlow(false)
+            // #332 — eagerly collected by the VM constructor; default on is enough here.
+            every { observeFoldLongQuotes() } returns MutableStateFlow(true)
         }
 
         val vm = AppThemeViewModel(
@@ -75,6 +77,8 @@ class AppThemeViewModelTest {
             every { observeFontScale() } returns MutableStateFlow(FontScalePreference.M)
             // #445 — eagerly collected by the VM constructor; default off is enough here.
             every { observeDebugBoundsOverlay() } returns MutableStateFlow(false)
+            // #332 — eagerly collected by the VM constructor; default on is enough here.
+            every { observeFoldLongQuotes() } returns MutableStateFlow(true)
         }
 
         val vm = AppThemeViewModel(

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -332,6 +332,22 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeFoldLongQuotes(): Flow<Boolean> =
+        dataStore.data
+            // Default `true` (#332): the long-quote fold is the historical behaviour; turning it
+            // off is the opt-out for readers who found the auto-fold « trop strict ».
+            .map { prefs -> prefs[KEY_FOLD_LONG_QUOTES] ?: true }
+            .distinctUntilChanged()
+            .catch { emit(true) }
+
+    override suspend fun setFoldLongQuotes(enabled: Boolean) {
+        persist {
+            dataStore.edit { prefs ->
+                prefs[KEY_FOLD_LONG_QUOTES] = enabled
+            }
+        }
+    }
+
     override fun observeStartScreen(): Flow<StartScreenPreference> =
         dataStore.data
             .map(::readStartScreen)
@@ -629,6 +645,9 @@ class DataStoreUserPreferencesRepository @Inject constructor(
 
         // #330 — render author signatures beneath posts (default false = hidden, signatures are noisy).
         val KEY_TOPIC_SIGNATURES = booleanPreferencesKey("topic_signatures")
+
+        // #332 — fold long top-level citations by default (default true = historical fold; opt-out).
+        val KEY_FOLD_LONG_QUOTES = booleanPreferencesKey("fold_long_quotes")
 
         // #458 — cold-start tab (StartScreenChoice.name, defensively parsed) + optional Forum
         // category id (absent unless screen == FORUM and a category was picked).

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -564,6 +564,27 @@ class DataStoreUserPreferencesRepositoryTest {
     }
 
     @Test
+    fun `observeFoldLongQuotes defaults to true then persists false and true`() = runTest(dispatcher) {
+        // #332 — the long-quote fold is the historical behaviour; disabling it is the opt-out.
+        repository.observeFoldLongQuotes().test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setFoldLongQuotes(false)
+        repository.observeFoldLongQuotes().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setFoldLongQuotes(true)
+        repository.observeFoldLongQuotes().test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `observeConfirmBeforePosting defaults to false then persists true and false`() = runTest(dispatcher) {
         // #312 — publishing stays one-tap by default; the guard is strictly opt-in.
         repository.observeConfirmBeforePosting().test {

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -577,6 +577,10 @@ class TopicRepositoryImplTest {
 
         override suspend fun setTopicSignatures(enabled: Boolean) = Unit
 
+        override fun observeFoldLongQuotes(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setFoldLongQuotes(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -213,6 +213,19 @@ interface UserPreferencesRepository {
     suspend fun setTopicSignatures(enabled: Boolean)
 
     /**
+     * #332 — whether a "long" top-level citation folds to a one-line header by default (the
+     * `isLongQuote` behaviour: a wall-of-text quote is collapsed and revealed on tap). Default
+     * `true` = the historical fold; `false` disables it entirely so a long quote always renders
+     * expanded inline like a short one (the beta feedback that the auto-fold is « trop strict »).
+     * Pure render-time switch (no refetch), provided to the post renderer through a CompositionLocal
+     * at the app root ([fr.forumhfr.redface2.navigation.RedfaceApp]) and mirrored in Settings.
+     */
+    fun observeFoldLongQuotes(): Flow<Boolean>
+
+    /** Persists [observeFoldLongQuotes]. Default `true` until the first call. */
+    suspend fun setFoldLongQuotes(enabled: Boolean)
+
+    /**
      * #458 — which top-level tab (and optional Forum category) a cold start opens on. Default
      * [StartScreenChoice.FLAGS] (historical behaviour). The navigation reads the SYNCHRONOUS
      * [StartScreenBootstrapStore] mirror at cold start; this flow is the source of truth and

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/RedfaceTheme.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/RedfaceTheme.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalContext
 import fr.forumhfr.redface2.core.ui.theme.DisplayMetrics
 import fr.forumhfr.redface2.core.ui.theme.LocalDisplayMetrics
+import fr.forumhfr.redface2.core.ui.theme.LocalFoldLongQuotes
 import fr.forumhfr.redface2.core.ui.theme.ReadingDisplaySettings
 import fr.forumhfr.redface2.core.ui.theme.RedfaceAmoledColorScheme
 import fr.forumhfr.redface2.core.ui.theme.RedfaceDarkColorScheme
@@ -39,6 +40,9 @@ fun RedfaceTheme(
 
     CompositionLocalProvider(
         LocalDisplayMetrics provides DisplayMetrics.of(reading.density),
+        // #332 — expose the « fold long quotes » preference to the post renderer (read via
+        // LocalFoldLongQuotes.current in QuoteBlock) so flipping the toggle re-renders posts.
+        LocalFoldLongQuotes provides reading.foldLongQuotes,
     ) {
         MaterialTheme(
             colorScheme = colorScheme,

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -79,6 +79,7 @@ import coil3.request.crossfade
 import coil3.size.Precision
 import coil3.size.Scale
 import fr.forumhfr.redface2.core.ui.R
+import fr.forumhfr.redface2.core.ui.theme.LocalFoldLongQuotes
 import fr.forumhfr.redface2.core.model.PostBlock
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.PostInline
@@ -382,7 +383,10 @@ private fun QuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
         CollapsedQuoteBlock(block, quoteDepth)
         return
     }
-    if (isLongQuote(block, quoteDepth)) {
+    // #332 — the long-quote fold is gated on the user preference (default ON = historical fold).
+    // When OFF we skip FoldableQuoteBlock entirely and fall through to the normal expanded render,
+    // exactly as if the quote were not "long". The depth fold above is unaffected.
+    if (LocalFoldLongQuotes.current && isLongQuote(block, quoteDepth)) {
         FoldableQuoteBlock(block, quoteDepth)
         return
     }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/DisplayMetrics.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/DisplayMetrics.kt
@@ -61,3 +61,12 @@ data class DisplayMetrics(
  * Defaults to [DisplayMetrics.Comfort] for previews / hosts that do not provide it.
  */
 val LocalDisplayMetrics = staticCompositionLocalOf { DisplayMetrics.Comfort }
+
+/**
+ * Project CompositionLocal carrying the #332 « fold long quotes » reading preference. Same
+ * `staticCompositionLocalOf` rationale as [LocalDisplayMetrics]: the value changes only when the
+ * user flips the toggle, so the subtree recomposes once on change. Defaults to `true` (the
+ * historical fold) for previews / hosts that do not provide it; `RedfaceTheme` provides the
+ * resolved value from [ReadingDisplaySettings.foldLongQuotes].
+ */
+val LocalFoldLongQuotes = staticCompositionLocalOf { true }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/ReadingDisplaySettings.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/ReadingDisplaySettings.kt
@@ -15,4 +15,7 @@ import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 data class ReadingDisplaySettings(
     val density: DisplayDensity = DisplayDensity.COMFORT,
     val fontScale: FontScalePreference = FontScalePreference.M,
+    // #332 — whether a long top-level citation folds to a one-line header by default. `true`
+    // (default) keeps the historical fold; `false` disables it so a long quote renders expanded.
+    val foldLongQuotes: Boolean = true,
 )

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -1994,6 +1994,10 @@ class PostEditorViewModelTest {
 
         override suspend fun setTopicSignatures(enabled: Boolean) = Unit
 
+        override fun observeFoldLongQuotes(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setFoldLongQuotes(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1394,6 +1394,10 @@ class TopicFormViewModelTest {
 
         override suspend fun setTopicSignatures(enabled: Boolean) = Unit
 
+        override fun observeFoldLongQuotes(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setFoldLongQuotes(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1618,6 +1618,10 @@ class FlagsViewModelTest {
 
         override suspend fun setTopicSignatures(enabled: Boolean) = Unit
 
+        override fun observeFoldLongQuotes(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setFoldLongQuotes(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -520,6 +520,17 @@ internal fun buildSettingsCatalogue(
                     .takeIf { state.topicSignaturesError },
                 onCheckedChange = { onIntent(SettingsIntent.TopicSignaturesChanged(it)) },
             ),
+            // #332 — replaces the former `future_collapse_quotes` placeholder, now shipped.
+            toggleRow(
+                id = "fold_long_quotes",
+                title = stringResource(R.string.settings_fold_long_quotes_title),
+                description = stringResource(R.string.settings_fold_long_quotes_description),
+                checked = state.foldLongQuotes,
+                enabled = state.canToggleFoldLongQuotes,
+                errorRes = R.string.settings_fold_long_quotes_persist_failed
+                    .takeIf { state.foldLongQuotesError },
+                onCheckedChange = { onIntent(SettingsIntent.FoldLongQuotesChanged(it)) },
+            ),
             futureRow(
                 id = "future_restore_read_position",
                 title = stringResource(R.string.settings_future_restore_read_position),
@@ -527,10 +538,6 @@ internal fun buildSettingsCatalogue(
             futureRow(
                 id = "future_swipe_page",
                 title = stringResource(R.string.settings_future_swipe_page),
-            ),
-            futureRow(
-                id = "future_collapse_quotes",
-                title = stringResource(R.string.settings_future_collapse_quotes),
             ),
             futureRow(
                 id = "future_prefetch",

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -112,6 +112,13 @@ data class SettingsState(
     val isUpdatingTopicSignatures: Boolean = false,
     val topicSignaturesError: Boolean = false,
     val topicSignaturesTouchedLocally: Boolean = false,
+    // #332 — replier les longues citations. Même machinerie optimistic-flip + garde de course au
+    // démarrage. Default TRUE (repli historique) : le toggle est l'opt-out demandé par le retour
+    // bêta « trop strict ».
+    val foldLongQuotes: Boolean = true,
+    val isUpdatingFoldLongQuotes: Boolean = false,
+    val foldLongQuotesError: Boolean = false,
+    val foldLongQuotesTouchedLocally: Boolean = false,
     // Publishing preferences (#312). Same optimistic-flip + startup-race-guard machinery:
     // `confirmBeforePosting` is the displayed value, `isUpdating*` gates the switch while DataStore
     // writes, `*Error` surfaces a persist failure, `*TouchedLocally` forbids a late `init` hydration
@@ -220,6 +227,10 @@ data class SettingsState(
     // #330 — the signatures toggle is gated only by its own write.
     val canToggleTopicSignatures: Boolean
         get() = !isUpdatingTopicSignatures
+
+    // #332 — the fold-long-quotes toggle is gated only by its own write.
+    val canToggleFoldLongQuotes: Boolean
+        get() = !isUpdatingFoldLongQuotes
 
     // #312 — the confirm-before-posting toggle is gated only by its own write.
     val canToggleConfirmBeforePosting: Boolean
@@ -331,6 +342,9 @@ sealed interface SettingsIntent {
 
     /** #330 — afficher les signatures des auteurs sous les posts. */
     data class TopicSignaturesChanged(val enabled: Boolean) : SettingsIntent
+
+    /** #332 — replier les longues citations sur une ligne. */
+    data class FoldLongQuotesChanged(val enabled: Boolean) : SettingsIntent
 
     // #312 — confirm-before-posting toggle. Optimistic-flip contract, like the flags toggles:
     // the boolean is the desired post-flip state.

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -108,6 +108,11 @@ class SettingsViewModel @Inject constructor(
             apply = { state, value -> state.copy(topicSignatures = value) },
         )
         hydratePreference(
+            read = { userPreferencesRepository.observeFoldLongQuotes().first() },
+            isLocked = { it.foldLongQuotesTouchedLocally || it.isUpdatingFoldLongQuotes },
+            apply = { state, value -> state.copy(foldLongQuotes = value) },
+        )
+        hydratePreference(
             read = { userPreferencesRepository.observeConfirmBeforePosting().first() },
             isLocked = { it.confirmBeforePostingTouchedLocally || it.isUpdatingConfirmBeforePosting },
             apply = { state, value -> state.copy(confirmBeforePosting = value) },
@@ -214,6 +219,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.MpUnreadBadgeChanged -> updateMpUnreadBadge(intent.enabled)
             is SettingsIntent.TopicPollsExpandedChanged -> updateTopicPollsExpanded(intent.enabled)
             is SettingsIntent.TopicSignaturesChanged -> updateTopicSignatures(intent.enabled)
+            is SettingsIntent.FoldLongQuotesChanged -> updateFoldLongQuotes(intent.enabled)
             is SettingsIntent.ShowDtSectionChanged -> updateShowDtSection(intent.enabled)
             is SettingsIntent.ConfirmBeforePostingChanged -> updateConfirmBeforePosting(intent.enabled)
             is SettingsIntent.FlagsAutoRefreshChanged -> updateFlagsAutoRefresh(intent.enabled)
@@ -773,6 +779,33 @@ class SettingsViewModel @Inject constructor(
                 }
             },
             persist = userPreferencesRepository::setTopicSignatures,
+        )
+    }
+
+    private fun updateFoldLongQuotes(desired: Boolean) {
+        val previous = _state.value.foldLongQuotes
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    foldLongQuotes = desired,
+                    isUpdatingFoldLongQuotes = true,
+                    foldLongQuotesError = false,
+                    foldLongQuotesTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(foldLongQuotes = desired, isUpdatingFoldLongQuotes = false)
+                } else {
+                    state.copy(
+                        foldLongQuotes = previous,
+                        isUpdatingFoldLongQuotes = false,
+                        foldLongQuotesError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setFoldLongQuotes,
         )
     }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -112,7 +112,6 @@
     <!-- §3 Sujet et lecture -->
     <string name="settings_future_restore_read_position">Restaurer la position de lecture</string>
     <string name="settings_future_swipe_page">Changer de page au glissement</string>
-    <string name="settings_future_collapse_quotes">Replier les longues citations</string>
     <string name="settings_future_open_external_in_app">Ouvrir les liens externes dans l\'app</string>
     <string name="settings_future_autoplay_animations">Lecture auto des images animées</string>
     <string name="settings_future_fullscreen_reading">Plein écran en lecture</string>
@@ -294,6 +293,11 @@
     <string name="settings_topic_signatures_title">Afficher les signatures</string>
     <string name="settings_topic_signatures_description">Signature de l\'auteur sous chaque post, en plus discret.</string>
     <string name="settings_topic_signatures_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
+
+    <!-- #332 — Lecture. Replier les longues citations sur une ligne (dépliables au clic). -->
+    <string name="settings_fold_long_quotes_title">Replier les longues citations</string>
+    <string name="settings_fold_long_quotes_description">Les longues citations sont repliées sur une ligne, dépliables au clic ; sinon elles restent affichées en entier.</string>
+    <string name="settings_fold_long_quotes_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
 
     <!-- #312 — Publication. Confirmation avant chaque envoi (réponse/édition de message, sujet,
          message privé) ; persisté en DataStore et lu en direct par les éditeurs.

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -1012,6 +1012,45 @@ class SettingsViewModelTest {
     }
 
     // ──────────────────────────────────────────────────────────────────────
+    // Fold long quotes (#332)
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `init hydrates foldLongQuotes from a persisted false`() = runTest {
+        // Default is true — only a persisted opt-OUT exercises the hydration path.
+        repository.emitFoldLongQuotes(false)
+
+        val viewModel = newViewModel()
+
+        assertFalse(viewModel.state.value.foldLongQuotes)
+        assertFalse(viewModel.state.value.foldLongQuotesError)
+    }
+
+    @Test
+    fun `FoldLongQuotesChanged persists the flip`() = runTest {
+        val viewModel = newViewModel()
+        assertTrue("long quotes fold by default", viewModel.state.value.foldLongQuotes)
+
+        viewModel.submit(SettingsIntent.FoldLongQuotesChanged(false))
+
+        assertFalse(viewModel.state.value.foldLongQuotes)
+        assertFalse(viewModel.state.value.isUpdatingFoldLongQuotes)
+        assertEquals(1, repository.foldLongQuotesSetCalls)
+    }
+
+    @Test
+    fun `FoldLongQuotesChanged reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnFoldLongQuotesSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.FoldLongQuotesChanged(false))
+
+        assertTrue("failed persist must revert to the previous value", viewModel.state.value.foldLongQuotes)
+        assertFalse(viewModel.state.value.isUpdatingFoldLongQuotes)
+        assertTrue(viewModel.state.value.foldLongQuotesError)
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
     // Debug bounds overlay (#445)
     // ──────────────────────────────────────────────────────────────────────
 
@@ -1574,6 +1613,24 @@ class SettingsViewModelTest {
 
         fun emitTopicSignatures(value: Boolean) {
             topicSignatures.value = value
+        }
+
+        // #332 — replier les longues citations. Même seam optimistic-flip ; default TRUE (repli).
+        private val foldLongQuotes = MutableStateFlow(true)
+        var foldLongQuotesSetCalls: Int = 0
+            private set
+        var failOnFoldLongQuotesSet: Boolean = false
+
+        override fun observeFoldLongQuotes(): Flow<Boolean> = foldLongQuotes
+
+        override suspend fun setFoldLongQuotes(enabled: Boolean) {
+            foldLongQuotesSetCalls += 1
+            check(!failOnFoldLongQuotesSet) { "boom" }
+            foldLongQuotes.value = enabled
+        }
+
+        fun emitFoldLongQuotes(value: Boolean) {
+            foldLongQuotes.value = value
         }
 
         // #458 — start screen lives on its own StartScreenSettingsViewModel; this fake only

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -1406,6 +1406,10 @@ private class FakeUserPreferencesRepository(
 
     override suspend fun setTopicSignatures(enabled: Boolean) = Unit
 
+    override fun observeFoldLongQuotes(): Flow<Boolean> = MutableStateFlow(true)
+
+    override suspend fun setFoldLongQuotes(enabled: Boolean) = Unit
+
     override fun observeStartScreen(): Flow<StartScreenPreference> =
         MutableStateFlow(StartScreenPreference())
 


### PR DESCRIPTION
> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

Suite aux retours bêta (**nicko** [t2788195](https://forum.hardware.fr/hfr/gsmgpspda/redface-dev-sujet_35421_19.htm#t2788195), **MisterDams** [t2788216](https://forum.hardware.fr/hfr/gsmgpspda/redface-dev-sujet_35421_19.htm#t2788216)) jugeant le repli auto des longues citations (#332) « trop strict / déclenché trop vite » : ajoute un **toggle utilisateur « Replier les longues citations »**, **défaut ON** (= comportement actuel), pour ceux qui préfèrent tout voir déplié.

## Câblage (calqué sur les presets de lecture existants)
pref `fold_long_quotes` (DataStore bool, défaut true) → `AppThemeViewModel` (Eagerly, seed true) → `RedfaceApp` → `ReadingDisplaySettings.foldLongQuotes` → `RedfaceTheme` provide `LocalFoldLongQuotes` → `PostRenderer.QuoteBlock` gate `LocalFoldLongQuotes.current && isLongQuote(...)`. OFF → rendu déplié normal ; le repli par **profondeur** (#3) n'est pas touché. Le toggle **remplace le placeholder `future_collapse_quotes`** des Réglages.

## Décision laissée ouverte
Le **seuil** par défaut (`LONG_QUOTE_CHAR_THRESHOLD = 280`) est **inchangé** ici — il est protégé par un test-garde « décision consciente ». Le « trop vite » mérite un arbitrage séparé : **remonter le seuil** et/ou **afficher les 3-4 premières lignes en teaser** (idée MisterDams) + cliquer le titre de citation pour aller au post d'origine. À trancher.

## Validation (machine B, docker)
`detektAll`, `:app:assemble{Prod,Beta,Dev}Debug`, `:app:lint{Prod,Dev}Debug`, `test --rerun-tasks` → **BUILD SUCCESSFUL**. Revue Codex : aucun bloquant/important (1 mineur accepté : flash de seed au cold-start pour les users OFF, même posture que density/fontScale, pas de mirror). Piège mockk `AppThemeViewModelTest` + 6 fakes mis à jour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)