### PR TITLE
fix(topic): keep bottom action cluster visible at the end of the list (#411)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1832,8 +1832,9 @@ private fun DeletePostConfirmDialog(
  * #411 — drives the bottom-action cluster's show-on-scroll-up visibility, derived READ-ONLY from
  * [listState] (it never drives scrolling, so the anchor/restore #307 and the swipe #282 stay
  * untouched). Hides while the list scrolls DOWN, reveals on the first UPWARD scroll — the M3 idiom,
- * matching the collapsible top bar. A list that cannot scroll (a short, one-screen topic) stays
- * visible, so a page with nothing below never hides its actions.
+ * matching the collapsible top bar. It also stays visible at the END of the list (and on a short,
+ * one-screen topic): reaching the last post is exactly when the reader wants to reply, so the cluster
+ * must be there without scrolling back up (#411 beta feedback).
  */
 @Composable
 private fun rememberBottomActionsVisible(listState: LazyListState): Boolean {
@@ -1847,7 +1848,10 @@ private fun rememberBottomActionsVisible(listState: LazyListState): Boolean {
         snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
             .collect { (index, offset) ->
                 visible = when {
-                    !listState.canScrollForward && !listState.canScrollBackward -> true
+                    // At the end of the list (or a short, non-scrollable page) always show: the user is
+                    // on the last post and most likely wants to reply, so they should not have to scroll
+                    // up to reveal the cluster (#411 beta feedback, tinc t2788220).
+                    !listState.canScrollForward -> true
                     index != prevIndex -> index < prevIndex
                     offset != prevOffset -> offset < prevOffset
                     // No real movement (incl. snapshotFlow's initial emission): hold the last decision


### PR DESCRIPTION
> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

Correctif du retour bêta sur #411 (tinc [t2788220](https://forum.hardware.fr/hfr/gsmgpspda/redface-dev-sujet_35421_20.htm#t2788220), styx42, Lt Ripley) : le cluster de boutons (Répondre/pages) « show-on-scroll-up » restait caché une fois descendu au **dernier post** — pile quand on veut répondre — obligeant à remonter pour le révéler.

## Fix
Le cluster est désormais **toujours affiché quand la liste ne peut plus défiler vers le bas** (`!listState.canScrollForward`). Cette seule condition **englobe** l'ancienne garde « page courte » (`!canScrollForward && !canScrollBackward`). Comportement inchangé ailleurs : se cache en descendant au milieu d'une page, réapparaît à tout défilement vers le haut. Toujours lecture seule du `listState` (n'affecte ni ancrage #307 ni swipe #282).

## Validation
4-flavor + `lint{Prod,Dev}Debug` + `detektAll` + `test` → **BUILD SUCCESSFUL** (docker local ; machine B injoignable au moment du build, validation faite en local sur la même image `android-sdk:36`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)