### PR TITLE
fix(flags): recall the list to the top after a landing auto-refresh (#546)

### DIFF
--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -50,6 +50,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -140,6 +141,31 @@ fun FlagsRoute(
         tabUnreadFilter = tabUnreadFilter,
         listState = flagsListState,
     )
+
+    // #546 — recall the list to the top after a LANDING auto-refresh (app open / tab switch /
+    // resume): the refresh prepends freshly-surfaced flags and a held scroll position would leave
+    // them off-screen (« faut scroller vers le haut », tinc/Lt Ripley). Driven by a one-shot
+    // ViewModel signal (consumed once handled) rather than a replayable counter, so a rotation /
+    // route recreation does not replay a stale scroll. Return-from-topic refreshes never raise it.
+    val recallListToTop by viewModel.recallListToTop.collectAsStateWithLifecycle()
+    LaunchedEffect(recallListToTop) {
+        if (recallListToTop) {
+            // requestScrollToItem (not scrollToItem) pins index 0 on the next remeasure ignoring the
+            // key-based position restoration — without that, when the refresh prepends freshly-
+            // surfaced flags the old top row stays anchored and the new rows sit above the viewport
+            // (the original #546 bug). But the request is honoured per-remeasure and is NOT durable:
+            // the refreshed list can land a frame later (repository SharedFlow → combine/flatMapLatest
+            // defers the final emission), and a remeasure that ran first on the old list would consume
+            // the request before the prepend. So re-assert it across a few frames — the top then wins
+            // whichever frame the new list lands on. Bounded so a no-change landing still disarms the
+            // signal (no replay on rotation/recreation). Codex review #546.
+            repeat(RECALL_TO_TOP_FRAMES) {
+                flagsListState.requestScrollToItem(0)
+                withFrameNanos { }
+            }
+            viewModel.consumeRecallListToTop()
+        }
+    }
 
     // #309 — display-settings bottom sheet. Opened from the header « Affichage » action; the trigger
     // is only offered when there is a real list to configure (authenticated AND a real FlagType tab,
@@ -773,6 +799,13 @@ private fun FilterFlipScrollResetEffect(
         }
     }
 }
+
+// #546 — number of consecutive frames over which the « recall to top » scroll is re-asserted after a
+// landing auto-refresh. requestScrollToItem is per-remeasure and not durable, while the refreshed list
+// can land a frame or two after the signal (repository SharedFlow → combine/flatMapLatest), so a small
+// window covers the prepend whichever frame it arrives on. Three is generous for an in-memory emission
+// and the loop always terminates, so the one-shot signal is always consumed (no rotation replay).
+private const val RECALL_TO_TOP_FRAMES = 3
 
 // LazyColumn contentType tags (#179 compose-perf): one reuse pool per structurally distinct slot
 // kind so Compose recycles like-for-like across the header→row→header alternation of the grouped

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -382,6 +382,24 @@ class FlagsViewModel @Inject constructor(
     val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
 
     /**
+     * #546 — one-shot signal raised when a LANDING auto-refresh commits (app open, tab switch,
+     * resume) so the screen can recall the list to the top. An auto-refresh prepends freshly-surfaced
+     * flags; a held [androidx.compose.foundation.lazy.LazyListState] would otherwise leave those new
+     * top rows scrolled off-screen, the « faut scroller vers le haut » beta report (tinc, Lt Ripley).
+     * A return-from-topic refresh is deliberately EXCLUDED so the reader keeps their place in the list
+     * they were browsing.
+     *
+     * Modelled as a **consumable** boolean (set on the landing refresh, reset by
+     * [consumeRecallListToTop] once the screen has scrolled), exactly like [removeFlagEvent] — NOT a
+     * replayable counter. A counter's latest value re-arms a brand-new collector, so a rotation or a
+     * route recreation would replay the last scroll-to-top with no fresh refresh behind it (Codex
+     * review #546); a consumed `false` is inert on re-subscription, and an un-consumed `true` survives
+     * the recreation as a genuine still-pending scroll.
+     */
+    private val _recallListToTop = MutableStateFlow(false)
+    val recallListToTop: StateFlow<Boolean> = _recallListToTop.asStateFlow()
+
+    /**
      * Tab selection. Re-tapping [FlagTab.Cyan] while it is **already** selected toggles its
      * « non-lus uniquement » filter (show / hide the already-read participated topics) — the « +lus »
      * shortcut, inline replacement for the former « Cyans lus » FilterChip. Selecting Cyan from
@@ -442,6 +460,11 @@ class FlagsViewModel @Inject constructor(
     /** Consume the one-shot removal event after the snackbar has been shown. */
     fun consumeRemoveFlagEvent() {
         _removeFlagEvent.value = null
+    }
+
+    /** Consume the one-shot « recall to top » signal once the screen has scrolled (#546). */
+    fun consumeRecallListToTop() {
+        _recallListToTop.value = false
     }
 
     /**
@@ -588,6 +611,11 @@ class FlagsViewModel @Inject constructor(
             _isRefreshing.value = true
             try {
                 flagRepository.refresh(type)
+                // #546 — a genuine landing / tab-switch / resume refresh: recall the list to the top
+                // so the freshly prepended flags are visible. A return-from-topic refresh keeps the
+                // reader's current position (it is not a fresh landing). One-shot signal, consumed by
+                // the screen — see [recallListToTop].
+                if (!returningFromTopic) _recallListToTop.value = true
             } finally {
                 _isRefreshing.value = false
             }

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1156,6 +1156,37 @@ class FlagsViewModelTest {
     }
 
     @Test
+    fun `maybeAutoRefresh recalls the list to the top on a landing refresh (#546)`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)
+        val vm = viewModel(auth, flags, FakeForumRepository())
+
+        vm.maybeAutoRefresh()
+        assertTrue(vm.recallListToTop.value)
+
+        // One-shot: consuming it disarms the signal so a recomposition / rotation cannot replay the
+        // scroll with no fresh refresh behind it (Codex review #546).
+        vm.consumeRecallListToTop()
+        assertFalse(vm.recallListToTop.value)
+    }
+
+    @Test
+    fun `a return-from-topic auto-refresh does not recall the list to the top (#546)`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)
+        val clock = SteppingClock(Instant.parse("2026-06-11T12:00:00Z"))
+        val vm = FlagsViewModel(auth, flags, FakeForumRepository(), FakeUserPreferencesRepository(), clock)
+
+        vm.maybeAutoRefresh() // landing refresh → raises the signal
+        vm.consumeRecallListToTop() // screen scrolled and consumed it
+        vm.onFlagOpened() // user opens a topic…
+        vm.maybeAutoRefresh() // …and returns (throttle bypassed): refreshes but must NOT re-raise
+
+        assertEquals(2, flags.refreshCalls.size)
+        assertFalse(vm.recallListToTop.value)
+    }
+
+    @Test
     fun `maybeAutoRefresh honours the Settings opt-out`() = runTest {
         val flags = FakeFlagRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)


### PR DESCRIPTION
## Problème (#546)

Retour bêta dev (tinc, Lt Ripley) : après un atterrissage (ouverture de l'app, changement d'onglet, retour au premier plan), l'auto-refresh #378 remonte des drapeaux fraîchement actualisés en tête de liste, mais la `LazyListState` conservée laissait ces nouvelles lignes hors écran — « faut scroller vers le haut » pour les voir.

## Correctif

La liste est recalée en haut sur un refresh d'**atterrissage**. Un refresh **retour-de-topic** est exclu (`returningFromTopic`) — le lecteur garde sa place dans la liste qu'il parcourait.

## Mécanique (refonte post-revue Codex)

- **Signal one-shot consommable** `recallListToTop: StateFlow<Boolean>` + `consumeRecallListToTop()`, sur le modèle de `removeFlagEvent` déjà présent dans le ViewModel — **pas** un compteur replayable. Un compteur rejouait sa dernière valeur à chaque nouveau collecteur → une rotation / recréation de route rescrollait sans refresh derrière. Un `false` consommé est inerte à la re-souscription.
- **`requestScrollToItem(0)`** (et non `scrollToItem(0)`) : ignore la restauration de position par clé qui, sinon, ré-ancre l'ancienne tête de liste quand les nouveaux drapeaux se préfixent (= le bug d'origine). La requête étant honorée par-remeasure et **non durable**, elle est **ré-assertée sur quelques frames** car la nouvelle liste peut arriver une frame après le signal (repository `SharedFlow` → `combine`/`flatMapLatest`). Boucle bornée → le signal est toujours consommé (pas de replay sur rotation).

## Tests

- `maybeAutoRefresh recalls the list to the top on a landing refresh (#546)` : signal levé après un atterrissage, puis désarmé après `consume`.
- `a return-from-topic auto-refresh does not recall the list to the top (#546)` : un retour-de-topic refresh ne ré-arme pas le signal.

## Validation locale (machine B injoignable)

`detektAll` + `:app:assembleProdDebug` + `:app:assembleDevDebug` + `:app:lintDevDebug` + `:feature:flags:testDebugUnitTest` (`--rerun-tasks`) → BUILD SUCCESSFUL. Code 100 % partagé entre flavors (seul `applicationId`/label diffère). Revue Codex sur le diff final : finding #1 (replay) et #2 (course émission) résolus.

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)