### PR TITLE
fix(parser): strip the HFR signature separator from rendered signatures (#550)

### DIFF
--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
@@ -37,17 +37,37 @@ class PostContentParser {
     /**
      * #330 — extracts the author signature trailer (`<span class="signature">`, a descendant of
      * the `div[id^=para]` content element, after the post body and any `div.edited` marker) into
-     * the same AST as the body so it renders with the shared `PostRenderer`. HFR opens every
-     * signature with a horizontal-rule-ish dashes line and a trailing `clear: both` spacer div
-     * (both stripped by [parseBlocks]'s edge-trim / IGNORE rules), so an EMPTY signature
-     * (`<span class="signature"></span>`, or one carrying only decoration) yields no real block
-     * and is reported as `null` — same "no noise" contract as a never-edited [editedAt].
+     * the same AST as the body so it renders with the shared `PostRenderer`.
+     *
+     * HFR opens every signature span with a literal separator « --------------- » (a dashes-only
+     * text node, then a `<br>`) before the author's real signature, and closes it with a trailing
+     * `clear: both` spacer div. The spacer edge-trims away, but the dashes are a NON-blank text node
+     * so [parseBlocks]' edge-trim never drops them (they leaked as the first signature line, web
+     * separator chrome the app must not show — XaaT). The leading separator node is therefore removed
+     * explicitly before parsing; its following `<br>` then becomes a leading break and edge-trims
+     * away too. A signature that is ONLY the separator + decoration yields no real block and is
+     * reported as `null` — same "no noise" contract as a never-edited [editedAt].
      */
     private fun parseSignature(contentElement: Element): PostContent? {
-        val span = contentElement.selectFirst(HfrSelectors.POST_SIGNATURE) ?: return null
-        val blocks = parseBlocks(span.clone().childNodes())
+        val span = contentElement.selectFirst(HfrSelectors.POST_SIGNATURE)?.clone() ?: return null
+        // Match HFR's exact separator shape — a leading dashes-only text node IMMEDIATELY followed by
+        // the `<br>` it always emits — before removing it. Requiring the `<br>` sibling keeps the
+        // strip precise to the server chrome and guards a (hypothetical) real signature that merely
+        // opens with dashes (Codex review): on raw HFR the user's content always sits AFTER this pair.
+        (span.childNodes().firstOrNull() as? TextNode)
+            ?.takeIf { it.wholeText.isHfrSignatureSeparator() && it.nextSibling().isLineBreakElement() }
+            ?.remove()
+        val blocks = parseBlocks(span.childNodes())
         return blocks.takeIf { it.isNotEmpty() }?.let { PostContent(blocks = it) }
     }
+
+    /** HFR's server-inserted signature separator: a run of dashes only (after trimming whitespace). */
+    private fun String.isHfrSignatureSeparator(): Boolean {
+        val trimmed = trim { it.isWhitespace() || it == NBSP }
+        return trimmed.length >= MIN_SIGNATURE_SEPARATOR_DASHES && trimmed.all { it == '-' }
+    }
+
+    private fun Node?.isLineBreakElement(): Boolean = (this as? Element)?.tagName() == "br"
 
     private fun deletedFallbackAst(): PostContent = PostContent(
         blocks = listOf(PostBlock.Paragraph(listOf(PostInline.Text(DELETED_PLACEHOLDER)))),
@@ -672,6 +692,11 @@ class PostContentParser {
         // #466 — non-breaking space (U+00A0). HFR encodes inter-paragraph blank lines as runs of
         // `&nbsp;` between sibling <p>; Jsoup keeps them as this literal char until normalizeText.
         const val NBSP = '\u00A0'
+
+        // #330 follow-up \u2014 minimum dashes for a text node to count as HFR's signature separator
+        // \u00AB --------------- \u00BB (server-inserted before every signature). 3+ avoids treating a stray
+        // \u00AB -- \u00BB in real signature content as the separator.
+        const val MIN_SIGNATURE_SEPARATOR_DASHES = 3
 
         val WHITESPACE_REGEX = Regex("\\s+")
         val HEX_REGEX = Regex("[0-9a-fA-F]+")

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
@@ -217,6 +217,12 @@ class PostContentParserTest {
             "signature content must be parsed, got=$signatureText",
             signatureText.contains("Ma signature avec un"),
         )
+        // The HFR « --------------- » separator that opens every signature span is server chrome,
+        // not content — it must be stripped, never rendered as the first signature line (XaaT).
+        assertFalse(
+            "the HFR signature separator must not leak into the signature, got=$signatureText",
+            signatureText.contains("---"),
+        )
         // Inline formatting inside the signature survives (shared parseBlocks pipeline).
         assertTrue(
             "signature inline formatting must survive",
@@ -246,18 +252,20 @@ class PostContentParserTest {
     }
 
     @Test
-    fun `signature span with only decoration edge-trims to null`() {
-        // The dashes line + the trailing `clear: both` spacer are HFR boilerplate; a signature
-        // carrying nothing else must report null (no empty subdued block under the post).
+    fun `signature span with only the separator and decoration edge-trims to null`() {
+        // The « --------------- » separator line + the trailing `clear: both` spacer are HFR
+        // boilerplate; a signature carrying nothing else must report null (no empty subdued block
+        // under the post). Real-shape fixture: the separator dashes text node, a <br>, the spacer.
         val html = """
             <div id="para1980664236"><p>Corps.<div style="clear: both;"> </div></p>
-            <br /><span class="signature"><br /><div style="clear: both;"> </div></span></div>
+            <br /><span class="signature"> ---------------
+            <br /><div style="clear: both;"> </div></span></div>
         """.trimIndent()
         val contentElement = Jsoup.parse(html).selectFirst("div[id^=para]")
 
         val parsed = PostContentParser().parse(contentElement)
 
-        assertEquals("a decoration-only signature must report null", null, parsed.signature)
+        assertEquals("a separator-only signature must report null", null, parsed.signature)
     }
 
     @Test


### PR DESCRIPTION
## Problème (#550, suivi de #330)

HFR ouvre chaque `<span class="signature">` par un séparateur littéral « --------------- » (un nœud texte de tirets suivi du `<br>` qu'il émet toujours) avant la vraie signature de l'auteur. C'est le séparateur **web** entre le post et la signature — du chrome serveur, pas du contenu — et un nœud texte non-blanc, donc l'edge-trim de `parseBlocks` ne le retirait pas : il fuyait comme première ligne de la signature rendue dans l'app.

## Correctif

`parseSignature` retire ce nœud séparateur de tête quand il correspond à la forme exacte HFR : **un nœud texte de tirets uniquement (≥3), immédiatement suivi d'un `<br>`**. La signature rendue commence alors au vrai texte, et une signature réduite au seul séparateur retombe correctement à `null`. Exiger le `<br>` frère garde le strip précis au chrome serveur et évite de toucher un (hypothétique) vrai contenu ouvrant sur des tirets — sur HFR brut le contenu utilisateur est toujours **après** cette paire (revue Codex).

## Tests

- Le test #330 existant vérifie désormais aussi que le séparateur ne fuit PAS dans la signature.
- Le test « signature réduite à la décoration » utilise la forme réelle (tirets + `<br>` + spacer) et confirme le `null`.

## Validation locale (machine B injoignable)

`detektAll` + `:core:parser:test` + `:app:assembleDevDebug` (`--rerun-tasks`) → BUILD SUCCESSFUL. Revue Codex sur le diff : fix correct, durcissement `<br>` appliqué.

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)