### PR TITLE
chore(release): prep bêta 0.14.0 (bump versionName + changelog + whatsnew)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -38,6 +38,7 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 ### Fixed
 - **Drapeaux — recalage en haut** (#546) après le rafraîchissement auto à l'atterrissage : les sujets fraîchement remontés sont visibles sans scroller, le retour depuis un topic garde la position.
 - **Séparateur de signature** (#550) : la ligne web « --------------- » n'est plus rendue dans les signatures sous les posts.
+- **Couleurs de signature** (#553) : les signatures sont rendues dans la couleur neutre du thème ; les couleurs `[color]` de l'auteur (pensées pour le fond blanc web, illisibles sur le thème de l'app) sont ignorées.
 
 ### Perf
 - **Images de bloc** (#249) : encart réservé + shimmer + crossfade, anti-saut de mise en page (CLS).

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,37 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## v155 — `0.14.0` — 2026-06-17
+
+**Statut** : candidat bêta (à dispatcher) — destiné au track open testing + F-Droid `.beta`.
+**Commit** : promotion dev→main (cf. PR de promotion).
+**Contenu depuis la 0.13.0/v145** : dogfoodé sur le canal dev (v146 → v154).
+
+> `0.13.0` ayant déjà été shippé en bêta (v145), le `versionName` est bumpé en `0.14.0` (la garde CI refuse deux bêtas au même `versionName`). Le `versionCode` final est alloué au dispatch (registre de tags) ; le `v155` indiqué ici est le candidat et sera corrigé si d'autres builds dev s'intercalent avant la promotion.
+
+### Added
+- **Signatures des posts** (#330) : la signature de l'auteur s'affiche sous le message, derrière un réglage dédié.
+- **Avatar du compte connecté** (#479) dans la barre du haut des listes.
+- **Repli des longues citations** (#332) : les citations de premier niveau trop longues sont repliées avec un bouton afficher/masquer, désactivable dans les réglages.
+- **Barre d'actions des drapeaux** (#411) : masquée au défilement vers le bas, révélée vers le haut, et toujours visible en bas de page.
+
+### Changed
+- **Ligne de métadonnées des sujets unifiée** (#376) entre Drapeaux, Catégorie et Recherche.
+- **Boutons-icônes harmonisés** (#360) sur des vecteurs en trait, flèche retour plus épaisse.
+- **FAB « nouveau sujet »** (#482) réduit en icône seule au défilement.
+
+### Fixed
+- **Drapeaux — recalage en haut** (#546) après le rafraîchissement auto à l'atterrissage : les sujets fraîchement remontés sont visibles sans scroller, le retour depuis un topic garde la position.
+- **Séparateur de signature** (#550) : la ligne web « --------------- » n'est plus rendue dans les signatures sous les posts.
+
+### Perf
+- **Images de bloc** (#249) : encart réservé + shimmer + crossfade, anti-saut de mise en page (CLS).
+
+### Infra
+- **Overlay de debug** (#445, canal dev) : contours des composants Compose pour le diagnostic de layout.
+
+---
+
 ## v145 — `0.13.0` — 2026-06-16
 
 **Statut** : `open` (track open testing — canal beta, Play Edit committed) + F-Droid `.beta`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.13.0"
+        versionName = "0.14.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,13 +1,16 @@
-Redface 2 v0.13.0 — beta.
+Redface 2 v0.14.0 — beta.
 
 New:
-- Settings redesigned: dedicated tab, category-first navigation, search, smooth transitions.
-- Compact bottom bar, translucent search bar on scroll.
-- "edited" marker, steady post header on multi-quote, poll state kept across pages.
+- Post signatures shown beneath the message (dedicated setting).
+- Account avatar in the top bar.
+- Long quotes are collapsible.
+- Flags action bar hides on scroll.
+
+Improvements:
+- Unified topic info line, harmonized icon buttons, images without layout shift.
 
 Fixes:
-- Flags refresh on tab switch and on resume.
-- Unread MP badge that truly cuts the network when off.
-- Stray empty lines in posts, hardened image upload.
+- Flags scrolled back to top after refresh.
+- Signature separator "---" removed from rendering.
 
 Report bugs via the beta or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -11,6 +11,6 @@ Improvements:
 
 Fixes:
 - Flags scrolled back to top after refresh.
-- Signature separator "---" removed from rendering.
+- More readable signatures: author colours neutralised, "---" separator removed.
 
 Report bugs via the beta or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,13 +1,16 @@
-Redface 2 v0.13.0 — bêta.
+Redface 2 v0.14.0 — bêta.
 
 Nouveautés :
-- Réglages repensés : onglet dédié, navigation par catégories, recherche, transitions fluides.
-- Bottom bar compacte, recherche translucide au défilement.
-- Marqueur « édité », en-tête stable au multiquote, sondages conservés entre pages.
+- Signatures des posts affichées sous le message (réglage dédié).
+- Avatar du compte dans la barre du haut.
+- Longues citations repliables.
+- Barre d'actions des drapeaux masquée au défilement.
+
+Améliorations :
+- Infos des sujets unifiées, boutons-icônes harmonisés, images sans saut de page.
 
 Correctifs :
-- Drapeaux rafraîchis au changement d'onglet et à la reprise.
-- Badge MP non-lus qui coupe vraiment le réseau.
-- Lignes vides parasites, upload d'images durci.
+- Drapeaux recalés en haut après le rafraîchissement.
+- Séparateur de signature « --- » retiré du rendu.
 
 Signalez les bugs via la bêta ou GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,16 +1,16 @@
 Redface 2 v0.14.0 — bêta.
 
 Nouveautés :
-- Signatures des posts affichées sous le message (réglage dédié).
+- Signatures affichées sous le message (réglage dédié).
 - Avatar du compte dans la barre du haut.
 - Longues citations repliables.
-- Barre d'actions des drapeaux masquée au défilement.
+- Barre d'actions drapeaux masquée au scroll.
 
 Améliorations :
-- Infos des sujets unifiées, boutons-icônes harmonisés, images sans saut de page.
+- Infos des sujets unifiées, icônes harmonisées, images sans à-coup.
 
 Correctifs :
 - Drapeaux recalés en haut après le rafraîchissement.
-- Séparateur de signature « --- » retiré du rendu.
+- Signatures plus lisibles : couleurs auteur neutralisées, séparateur « --- » retiré.
 
 Signalez les bugs via la bêta ou GitHub.


### PR DESCRIPTION
**Brouillon — NE PAS MERGER avant la validation du dev v154.** Prep pour la promotion bêta 0.14.0 (préparée à l'avance à la demande de @XaTriX).

## Contenu

- `app/build.gradle.kts` : `versionName` 0.13.0 → **0.14.0** (la garde CI refuse deux bêtas au même `versionName` ; 0.13.0 déjà shippé en bêta = v145).
- `app/CHANGELOG.md` : entrée **v155 — 0.14.0** (candidat ; le `versionCode` est alloué au dispatch, à corriger si d'autres builds dev s'intercalent).
- `app/src/main/play/whatsnew/{fr-FR,en-US}` : notes Play 0.14.0 (494 / 434 caractères, sous la limite Play de 500).

## Charge 0.14.0 (depuis la bêta 0.13.0/v145, dogfoodé dev v146→v154)

#330 signatures sous les posts · #479 avatar du compte · #332 repli des longues citations · #411 barre d'actions drapeaux (masquage au scroll + bas de page) · #376 ligne méta unifiée · #360 boutons-icônes harmonisés · #482 FAB nouveau sujet en icône · #546 recalage drapeaux en haut · #550 séparateur de signature retiré · #249 images anti-CLS · #445 overlay debug (dev).

## Procédure de promotion (au GO, après validation)

1. Marquer ready + merger cette PR sur dev.
2. Sync main→dev si divergence (piège #454).
3. Promotion dev→main (no-ff).
4. Dispatch `release.yml` channel=beta → AAB track open testing + F-Droid `.beta`.
5. Mettre à jour le statut de l'entrée changelog + annonce HFR.

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)