### PR TITLE
fix(ui): signatures rendues en couleur neutre du thème, couleurs auteur ignorées (#553)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -80,6 +80,7 @@ import coil3.size.Precision
 import coil3.size.Scale
 import fr.forumhfr.redface2.core.ui.R
 import fr.forumhfr.redface2.core.ui.theme.LocalFoldLongQuotes
+import fr.forumhfr.redface2.core.ui.theme.LocalIgnoreInlineColors
 import fr.forumhfr.redface2.core.model.PostBlock
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.PostInline
@@ -256,10 +257,12 @@ private fun ParagraphBlock(inlines: List<PostInline>) {
         )
     }
     val imageAlt = stringResource(R.string.post_inline_image_alt)
+    // #553 — signatures provide LocalIgnoreInlineColors = true so author `[color]` is dropped.
+    val ignoreColors = LocalIgnoreInlineColors.current
     // The AnnotatedString is INVARIANT — it carries only the U+FFFC markers + IDs (via MediaCounter),
     // never a size — so it is never rebuilt when a measurement lands (#175 stability pivot).
-    val annotated = remember(inlines, linkStyles, imageAlt) {
-        buildInlineText(inlines, linkStyles, imageAlt)
+    val annotated = remember(inlines, linkStyles, imageAlt, ignoreColors) {
+        buildInlineText(inlines, linkStyles, imageAlt, ignoreColors)
     }
     val hasMedia = remember(inlines) { hasInlineMedia(inlines) }
 
@@ -894,9 +897,13 @@ internal fun buildInlineText(
     inlines: List<PostInline>,
     linkStyles: TextLinkStyles,
     imageAlt: String,
+    // #553 — when true, the author's inline `[color]` styling is dropped (used for signatures, whose
+    // web-tuned colours read as garish/illegible on the app theme). Text falls back to the caller's
+    // colour. Default false: post bodies keep author colours.
+    ignoreColors: Boolean = false,
 ): AnnotatedString = buildAnnotatedString {
     val media = MediaCounter()
-    appendInlines(inlines, linkStyles, media, imageAlt)
+    appendInlines(inlines, linkStyles, media, imageAlt, ignoreColors)
 }
 
 private fun AnnotatedString.Builder.appendInlines(
@@ -904,8 +911,9 @@ private fun AnnotatedString.Builder.appendInlines(
     linkStyles: TextLinkStyles,
     media: MediaCounter,
     imageAlt: String,
+    ignoreColors: Boolean,
 ) {
-    inlines.forEach { inline -> appendInline(inline, linkStyles, media, imageAlt) }
+    inlines.forEach { inline -> appendInline(inline, linkStyles, media, imageAlt, ignoreColors) }
 }
 
 @Suppress("CyclomaticComplexMethod")
@@ -914,32 +922,39 @@ private fun AnnotatedString.Builder.appendInline(
     linkStyles: TextLinkStyles,
     media: MediaCounter,
     imageAlt: String,
+    ignoreColors: Boolean,
 ) {
     when (inline) {
         is PostInline.Text -> append(inline.value)
         PostInline.LineBreak -> append('\n')
         is PostInline.Strong -> withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
-            appendInlines(inline.children, linkStyles, media, imageAlt)
+            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors)
         }
 
         is PostInline.Emphasis -> withStyle(SpanStyle(fontStyle = FontStyle.Italic)) {
-            appendInlines(inline.children, linkStyles, media, imageAlt)
+            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors)
         }
 
         is PostInline.Underline -> withStyle(SpanStyle(textDecoration = TextDecoration.Underline)) {
-            appendInlines(inline.children, linkStyles, media, imageAlt)
+            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors)
         }
 
         is PostInline.Strike -> withStyle(SpanStyle(textDecoration = TextDecoration.LineThrough)) {
-            appendInlines(inline.children, linkStyles, media, imageAlt)
+            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors)
         }
 
-        is PostInline.Color -> withStyle(SpanStyle(color = parseColor(inline.colorHex))) {
-            appendInlines(inline.children, linkStyles, media, imageAlt)
+        // #553 — drop the author colour when asked (signatures): render the children plain so they
+        // inherit the caller's neutral colour instead of the web-tuned, often-illegible author hue.
+        is PostInline.Color -> if (ignoreColors) {
+            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors)
+        } else {
+            withStyle(SpanStyle(color = parseColor(inline.colorHex))) {
+                appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors)
+            }
         }
 
         is PostInline.Link -> withLink(LinkAnnotation.Url(inline.url, linkStyles)) {
-            appendInlines(inline.children, linkStyles, media, imageAlt)
+            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors)
         }
 
         is PostInline.InlineImage -> appendInlineContent(media.nextImage(), inline.description ?: imageAlt)

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/DisplayMetrics.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/DisplayMetrics.kt
@@ -70,3 +70,12 @@ val LocalDisplayMetrics = staticCompositionLocalOf { DisplayMetrics.Comfort }
  * resolved value from [ReadingDisplaySettings.foldLongQuotes].
  */
 val LocalFoldLongQuotes = staticCompositionLocalOf { true }
+
+/**
+ * Project CompositionLocal asking the post renderer to IGNORE the author's inline `[color]` styling
+ * for the subtree it wraps (#553). HFR signatures embed colours chosen for the white web background;
+ * rendered as-is on the app theme (especially dark) they read as unreadable/garish, so the signature
+ * render site provides `true` and the text falls back to the theme's neutral colour. Defaults to
+ * `false` (post bodies keep author colours). `staticCompositionLocalOf`: flips rarely, scoped reads.
+ */
+val LocalIgnoreInlineColors = staticCompositionLocalOf { false }

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineTest.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.core.ui.post
 
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.unit.sp
@@ -104,6 +105,54 @@ class PostRendererInlineTest {
                 annotated.inlineContentIds(),
             )
         }
+    }
+
+    @Test
+    fun `buildInlineText drops the author color span when ignoreColors is set (#553)`() {
+        val inlines = listOf(
+            PostInline.Color(
+                colorHex = "#FF0000",
+                children = listOf(PostInline.Text("rouge")),
+            ),
+        )
+
+        // Default (post bodies): the author colour is applied as a span.
+        val colored = buildInlineText(inlines, emptyLinkStyles, imageAlt = "img")
+        assertTrue(
+            "by default the author color is applied",
+            colored.spanStyles.any { it.item.color != Color.Unspecified },
+        )
+
+        // Signatures (#553): ignoreColors drops the author colour; the text survives and falls back
+        // to the caller's neutral colour (no specified-colour span left).
+        val neutral = buildInlineText(inlines, emptyLinkStyles, imageAlt = "img", ignoreColors = true)
+        assertEquals("the text content is preserved", "rouge", neutral.text)
+        assertFalse(
+            "with ignoreColors the author color span is dropped (#553 signatures)",
+            neutral.spanStyles.any { it.item.color != Color.Unspecified },
+        )
+
+        // Media nested inside an ignored colour still emits its placeholder: ignoreColors only drops
+        // the colour span, never the recursion, so the MediaCounter symmetry (AnnotatedString IDs ==
+        // inline-content map keys) holds (Codex review #553).
+        val withMedia = listOf(
+            PostInline.Color(
+                colorHex = "#00FF00",
+                children = listOf(
+                    PostInline.Text("vert "),
+                    PostInline.Smiley(
+                        kind = SmileyKind.Perso("rofl"),
+                        imageUrl = "https://forum-images.hardware.fr/images/perso/rofl.gif",
+                    ),
+                ),
+            ),
+        )
+        val neutralMedia = buildInlineText(withMedia, emptyLinkStyles, imageAlt = "img", ignoreColors = true)
+        assertEquals(
+            "media inside an ignored colour keeps its placeholder (MediaCounter symmetry)",
+            collectInlineMedia(withMedia).keys,
+            neutralMedia.inlineContentIds(),
+        )
     }
 
     @Test

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -91,6 +92,7 @@ import fr.forumhfr.redface2.core.ui.list.LazyListScrollbar
 import fr.forumhfr.redface2.core.ui.pager.pageSwipeEdgeHint
 import fr.forumhfr.redface2.core.ui.post.PostRenderer
 import fr.forumhfr.redface2.core.ui.theme.LocalDisplayMetrics
+import fr.forumhfr.redface2.core.ui.theme.LocalIgnoreInlineColors
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -1705,10 +1707,16 @@ internal fun TopicPostCard(
             post.signature?.let { signature ->
                 if (showSignature) {
                     HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-                    PostRenderer(
-                        content = signature,
-                        modifier = Modifier.alpha(SIGNATURE_ALPHA),
-                    )
+                    // #553 — drop the author's web-tuned `[color]` in the signature: on the app theme
+                    // (especially dark) those colours read as garish/illegible. The signature then
+                    // renders in the neutral subdued body colour (the reduced alpha keeps it
+                    // subordinate). Post bodies are unaffected (they don't provide this local).
+                    CompositionLocalProvider(LocalIgnoreInlineColors provides true) {
+                        PostRenderer(
+                            content = signature,
+                            modifier = Modifier.alpha(SIGNATURE_ALPHA),
+                        )
+                    }
                 }
             }
             if (onQuote != null || onEdit != null || onToggleMultiQuote != null) {


### PR DESCRIPTION
## Problème (#553, suivi de #330)

Remonté par djull sur le topic DEV : les signatures de posts sont « dégueulasses » / illisibles. Cause : le rendu gardait les couleurs `[color]` choisies par l'auteur (pensées pour le fond blanc du web HFR), qui virent au moche/illisible sur le thème de l'app, surtout en sombre.

## Correctif

Nouveau CompositionLocal **`LocalIgnoreInlineColors`** (défaut `false`, dans `DisplayMetrics.kt` à côté de `LocalFoldLongQuotes`). Le site de rendu de signature (`TopicScreen`) le fournit à `true` ; `PostRenderer` threade un flag `ignoreColors` jusqu'à `appendInline`, qui sur `PostInline.Color` **saute le `SpanStyle(color)`** et rend les enfants dans la couleur neutre héritée (la signature garde son `alpha` subdued). Les corps de posts ne fournissent pas le local → couleurs auteur **intactes**.

Symétrie `MediaCounter` préservée : seul le `withStyle(color)` est sauté, jamais la récursion (les smileys/images d'une couleur ignorée gardent leurs placeholders).

## Tests

`PostRendererInlineTest` : couleur appliquée par défaut, supprimée avec `ignoreColors = true` (texte préservé), + média imbriqué dans une couleur ignorée garde son placeholder (symétrie MediaCounter).

## Validation locale (machine B injoignable)

`detektAll` + `:app:assembleDevDebug` + `:core:ui:testDebugUnitTest` (`--rerun-tasks`) → BUILD SUCCESSFUL. Revue Codex sur le diff : aucun problème (threading complet, clé `remember` OK, pas de régression corps de posts, symétrie préservée).

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX ; bug remonté par djull sur le topic DEV)

🤖 Generated with [Claude Code](https://claude.com/claude-code)