### PR TITLE
fix(topic): re-evaluate bottom-actions visibility on scrollability change (#411)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1850,16 +1850,26 @@ private fun rememberBottomActionsVisible(listState: LazyListState): Boolean {
     LaunchedEffect(listState) {
         var prevIndex = listState.firstVisibleItemIndex
         var prevOffset = listState.firstVisibleItemScrollOffset
-        // snapshotFlow only emits on a REAL position change, so a recomposition / async layout shift
-        // with an identical first-visible item+offset never re-reveals the cluster (Codex review): the
-        // last decision is simply held. A list that cannot scroll stays visible.
-        snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
-            .collect { (index, offset) ->
+        // snapshotFlow keys on the first-visible item+offset AND canScrollForward, so a recomposition /
+        // async layout shift with an identical position never re-reveals the cluster (the last decision
+        // is held) — BUT a change in SCROLLABILITY with an unchanged position (e.g. the list shrinks so
+        // the current position becomes the end without a scroll) still re-fires the collect and re-
+        // evaluates the « visible at the end » rule. Keying on position alone left that case stale until
+        // the next real scroll (multi-agent review finding, scored >65). A list that cannot scroll stays
+        // visible.
+        snapshotFlow {
+            Triple(
+                listState.firstVisibleItemIndex,
+                listState.firstVisibleItemScrollOffset,
+                listState.canScrollForward,
+            )
+        }
+            .collect { (index, offset, canScrollForward) ->
                 visible = when {
                     // At the end of the list (or a short, non-scrollable page) always show: the user is
                     // on the last post and most likely wants to reply, so they should not have to scroll
                     // up to reveal the cluster (#411 beta feedback, tinc t2788220).
-                    !listState.canScrollForward -> true
+                    !canScrollForward -> true
                     index != prevIndex -> index < prevIndex
                     offset != prevOffset -> offset < prevOffset
                     // No real movement (incl. snapshotFlow's initial emission): hold the last decision


### PR DESCRIPTION
## Finding (revue multi-agents bêta 0.14.0, scoré >65)

`rememberBottomActionsVisible` (#411) keyait son `snapshotFlow` sur `firstVisibleItemIndex`+`offset` uniquement, alors que la règle « toujours visible en fin de liste » lit `listState.canScrollForward` dans le `collect`. Si la scrollabilité changeait SANS changement de position — ex. la liste rétrécit et la position courante devient la fin sans scroll — le `collect` ne se ré-exécutait pas et le cluster restait caché jusqu'au prochain scroll réel.

## Correctif

`snapshotFlow` keyé aussi sur `canScrollForward` (Triple) → la règle de fin de liste se réévalue quand la scrollabilité change. Le `else -> visible` (hold sans mouvement) et le comportement scroll-up/scroll-down normal sont inchangés.

## Validation locale

`detektAll` + `:app:assembleDevDebug` + `:feature:topic:testDebugUnitTest` → BUILD SUCCESSFUL. Revue Codex sur le diff : aucun problème (pas de flicker/boucle, `when` cohérent).

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX ; finding de la revue multi-agents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)