### PR TITLE
release: 0.14.0 — promotion dev → main (bêta)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,38 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## v155 — `0.14.0` — 2026-06-17
+
+**Statut** : candidat bêta (à dispatcher) — destiné au track open testing + F-Droid `.beta`.
+**Commit** : promotion dev→main (cf. PR de promotion).
+**Contenu depuis la 0.13.0/v145** : dogfoodé sur le canal dev (v146 → v154).
+
+> `0.13.0` ayant déjà été shippé en bêta (v145), le `versionName` est bumpé en `0.14.0` (la garde CI refuse deux bêtas au même `versionName`). Le `versionCode` final est alloué au dispatch (registre de tags) ; le `v155` indiqué ici est le candidat et sera corrigé si d'autres builds dev s'intercalent avant la promotion.
+
+### Added
+- **Signatures des posts** (#330) : la signature de l'auteur s'affiche sous le message, derrière un réglage dédié.
+- **Avatar du compte connecté** (#479) dans la barre du haut des listes.
+- **Repli des longues citations** (#332) : les citations de premier niveau trop longues sont repliées avec un bouton afficher/masquer, désactivable dans les réglages.
+- **Barre d'actions des drapeaux** (#411) : masquée au défilement vers le bas, révélée vers le haut, et toujours visible en bas de page.
+
+### Changed
+- **Ligne de métadonnées des sujets unifiée** (#376) entre Drapeaux, Catégorie et Recherche.
+- **Boutons-icônes harmonisés** (#360) sur des vecteurs en trait, flèche retour plus épaisse.
+- **FAB « nouveau sujet »** (#482) réduit en icône seule au défilement.
+
+### Fixed
+- **Drapeaux — recalage en haut** (#546) après le rafraîchissement auto à l'atterrissage : les sujets fraîchement remontés sont visibles sans scroller, le retour depuis un topic garde la position.
+- **Séparateur de signature** (#550) : la ligne web « --------------- » n'est plus rendue dans les signatures sous les posts.
+- **Couleurs de signature** (#553) : les signatures sont rendues dans la couleur neutre du thème ; les couleurs `[color]` de l'auteur (pensées pour le fond blanc web, illisibles sur le thème de l'app) sont ignorées.
+
+### Perf
+- **Images de bloc** (#249) : encart réservé + shimmer + crossfade, anti-saut de mise en page (CLS).
+
+### Infra
+- **Overlay de debug** (#445, canal dev) : contours des composants Compose pour le diagnostic de layout.
+
+---
+
 ## v145 — `0.13.0` — 2026-06-16
 
 **Statut** : `open` (track open testing — canal beta, Play Edit committed) + F-Droid `.beta`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.13.0"
+        versionName = "0.14.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppAccountViewModel.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppAccountViewModel.kt
@@ -5,11 +5,18 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.flags.FlagRepository
+import fr.forumhfr.redface2.core.domain.profile.ProfileRepository
 import fr.forumhfr.redface2.core.model.AuthState
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 /**
@@ -33,6 +40,7 @@ import kotlinx.coroutines.launch
 class AppAccountViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val flagRepository: FlagRepository,
+    private val profileRepository: ProfileRepository,
 ) : ViewModel() {
 
     val authState: StateFlow<AuthState?> = authRepository.observeAuthState()
@@ -41,6 +49,63 @@ class AppAccountViewModel @Inject constructor(
             started = SharingStarted.Eagerly,
             initialValue = null,
         )
+
+    /**
+     * #479 — avatar URL of the connected user, resolved per `userId` from the public profile so
+     * the top-bar account badge can show the real HFR avatar instead of the pseudo initial.
+     *
+     * Lives here (not in [AuthState]) so the auth model stays a pure session verdict: the avatar
+     * is a display enrichment fetched lazily, and a fetch failure / missing avatar simply leaves
+     * the map empty so [RedfaceAccountMenu] falls back to the initial. Keyed by `userId` and
+     * memoised across recompositions / tab switches (the ViewModel is a shared singleton per the
+     * nav host) so a tab change never refetches; a logout/login to another id falls through the
+     * cache miss and refetches.
+     */
+    private val avatarUrlByUserId = MutableStateFlow<Map<Int, String?>>(emptyMap())
+
+    /**
+     * Resolved avatar URL for the *currently* connected user, or `null` (anonymous, loading, or
+     * no avatar) — in which case the badge renders the pseudo initial. `combine` so it re-emits on
+     * BOTH inputs: a logout (auth → Anonymous) must drop the previous user's avatar even though the
+     * cache is untouched, and the lazily-filled cache must surface the avatar once the fetch lands.
+     */
+    val avatarUrl: StateFlow<String?> = combine(authState, avatarUrlByUserId) { auth, cache ->
+        (auth as? AuthState.Authenticated)?.userId?.let(cache::get)
+    }
+        .distinctUntilChanged()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = null,
+        )
+
+    init {
+        observeAvatarForConnectedUser()
+    }
+
+    private fun observeAvatarForConnectedUser() {
+        viewModelScope.launch {
+            authState
+                .map { (it as? AuthState.Authenticated)?.userId }
+                .distinctUntilChanged()
+                // collectLatest: a logout / account switch mid-fetch CANCELS the in-flight
+                // getProfile so a stale avatar can never be written back for the previous user
+                // after the auth state moved on (Codex review).
+                .collectLatest { userId ->
+                    if (userId != null && userId !in avatarUrlByUserId.value) {
+                        fetchAvatar(userId)
+                    }
+                }
+        }
+    }
+
+    private suspend fun fetchAvatar(userId: Int) {
+        // Anonymous fetch (ProfileRepository uses the unauthenticated client) so resolving our own
+        // avatar never marks drapeaux as read, matching the prefetch-non-authentifié rule. A
+        // failure stores `null` so we don't hammer the endpoint and the badge stays on the initial.
+        val avatar = profileRepository.getProfile(userId).getOrNull()?.avatarUrl
+        avatarUrlByUserId.update { it + (userId to avatar) }
+    }
 
     fun logout() {
         viewModelScope.launch {

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
@@ -49,4 +49,11 @@ class AppThemeViewModel @Inject constructor(
     val fontScale: StateFlow<FontScalePreference> =
         userPreferencesRepository.observeFontScale()
             .stateIn(viewModelScope, SharingStarted.Eagerly, FontScalePreference.M)
+
+    // #445 — debug bounds overlay toggle (dev channel only; the channel gate lives in RedfaceApp).
+    // No bootstrap mirror: it does not paint the pre-first-frame window, so the seed is the `false`
+    // default and DataStore resolves on the first Eagerly read.
+    val debugBoundsOverlay: StateFlow<Boolean> =
+        userPreferencesRepository.observeDebugBoundsOverlay()
+            .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 }

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
@@ -50,6 +50,13 @@ class AppThemeViewModel @Inject constructor(
         userPreferencesRepository.observeFontScale()
             .stateIn(viewModelScope, SharingStarted.Eagerly, FontScalePreference.M)
 
+    // #332 — « fold long quotes » reading preference, eagerly collected like the presets above.
+    // No bootstrap mirror (it does not paint the pre-first-frame window); the seed is the `true`
+    // default and DataStore resolves on the first Eagerly read.
+    val foldLongQuotes: StateFlow<Boolean> =
+        userPreferencesRepository.observeFoldLongQuotes()
+            .stateIn(viewModelScope, SharingStarted.Eagerly, true)
+
     // #445 — debug bounds overlay toggle (dev channel only; the channel gate lives in RedfaceApp).
     // No bootstrap mirror: it does not paint the pre-first-frame window, so the seed is the `false`
     // default and DataStore resolves on the first Eagerly read.

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -613,6 +613,8 @@ fun RedfaceApp(intent: Intent?) {
         // every tab (Hilt hands back the same scoped instance for an identical owner).
         val accountViewModel: AppAccountViewModel = hiltViewModel()
         val authState by accountViewModel.authState.collectAsStateWithLifecycle()
+        // #479 — avatar of the connected user for the top-bar account badge (null → pseudo initial).
+        val accountAvatarUrl by accountViewModel.avatarUrl.collectAsStateWithLifecycle()
         // #313 — unread-MP badge on the « Messages » nav item. Same shared-instance logic as the
         // account ViewModel above. The ON_START hook refreshes the count when the app comes back
         // to the foreground (MPs received while backgrounded) ; the first start is skipped by the
@@ -748,6 +750,7 @@ fun RedfaceApp(intent: Intent?) {
                         onReportContent = {
                             startReportEmail(context, reportEmailSubject, reportNoEmailClient)
                         },
+                        avatarUrl = accountAvatarUrl,
                     )
                 }
                 RedfaceNavHost(

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -69,6 +69,7 @@ import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.ui.RedfaceTheme
 import fr.forumhfr.redface2.core.ui.account.RedfaceAccountMenu
+import fr.forumhfr.redface2.core.ui.debug.DebugBoundsOverlay
 import fr.forumhfr.redface2.core.ui.theme.ReadingDisplaySettings
 import fr.forumhfr.redface2.feature.auth.LoginScreen
 import fr.forumhfr.redface2.feature.editor.PostEditorMode
@@ -512,6 +513,9 @@ fun RedfaceApp(intent: Intent?) {
     // #287 — reading presets (density + font scale) resolved at the root and bundled for RedfaceTheme.
     val displayDensity by themeViewModel.displayDensity.collectAsStateWithLifecycle()
     val fontScale by themeViewModel.fontScale.collectAsStateWithLifecycle()
+    // #445 — debug bounds overlay preference (the dev-channel gate + render live in
+    // [DevDebugBoundsOverlay], emitted last so it paints over everything; off by default).
+    val debugBoundsOverlay by themeViewModel.debugBoundsOverlay.collectAsStateWithLifecycle()
     val darkTheme = when (themeMode) {
         ThemeMode.LIGHT -> false
         ThemeMode.DARK -> true
@@ -871,6 +875,24 @@ fun RedfaceApp(intent: Intent?) {
                 )
             }
         }
+
+        // #445 — debug bounds overlay, emitted LAST so it paints on top of every sibling (the nav
+        // scaffold + the profile sheet). The root content is Box-stacked by z-order = emission order,
+        // so no explicit wrapper is needed.
+        DevDebugBoundsOverlay(enabled = debugBoundsOverlay)
+    }
+}
+
+/**
+ * #445 — renders the [DebugBoundsOverlay] only when [enabled] AND the build is the DEV channel
+ * ([BuildConfig.FLAVOR]). Both gates live here (not in [RedfaceApp]) so the channel check can NEVER be
+ * bypassed and so [RedfaceApp] stays a single call site. Off the dev channel, or when the preference is
+ * off, the overlay composable is never composed — zero cost.
+ */
+@Composable
+private fun DevDebugBoundsOverlay(enabled: Boolean) {
+    if (enabled && BuildConfig.FLAVOR == DEV_CHANNEL) {
+        DebugBoundsOverlay()
     }
 }
 
@@ -897,6 +919,10 @@ private fun startReportEmail(
 }
 
 private const val REPORT_EMAIL: String = "xat@azora.fr"
+
+// #445 — the `channel` product flavor whose BuildConfig.FLAVOR gates the debug bounds overlay. Matches
+// the `dev` flavor name in app/build.gradle.kts; prod/beta never expose the overlay.
+private const val DEV_CHANNEL: String = "dev"
 
 /**
  * Ephemeral private-message navigation state, held in memory by the nav host and purged on every
@@ -1372,6 +1398,8 @@ private fun RedfaceNavHost(
                     },
                     onOpenDiagnostics = { backStack.add(DiagnosticsRoute) },
                     onOpenMpStorageInspector = { backStack.add(MpStorageInspectorRoute) },
+                    // #445 — expose the debug bounds overlay toggle on the dev channel only.
+                    debugOverlayAvailable = BuildConfig.FLAVOR == DEV_CHANNEL,
                     topBarActions = accountMenu,
                 )
             }

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -513,6 +513,8 @@ fun RedfaceApp(intent: Intent?) {
     // #287 — reading presets (density + font scale) resolved at the root and bundled for RedfaceTheme.
     val displayDensity by themeViewModel.displayDensity.collectAsStateWithLifecycle()
     val fontScale by themeViewModel.fontScale.collectAsStateWithLifecycle()
+    // #332 — « fold long quotes » reading preference, provided to the post renderer via RedfaceTheme.
+    val foldLongQuotes by themeViewModel.foldLongQuotes.collectAsStateWithLifecycle()
     // #445 — debug bounds overlay preference (the dev-channel gate + render live in
     // [DevDebugBoundsOverlay], emitted last so it paints over everything; off by default).
     val debugBoundsOverlay by themeViewModel.debugBoundsOverlay.collectAsStateWithLifecycle()
@@ -541,7 +543,11 @@ fun RedfaceApp(intent: Intent?) {
     RedfaceTheme(
         darkTheme = darkTheme,
         amoledTheme = amoledEnabled,
-        reading = ReadingDisplaySettings(density = displayDensity, fontScale = fontScale),
+        reading = ReadingDisplaySettings(
+            density = displayDensity,
+            fontScale = fontScale,
+            foldLongQuotes = foldLongQuotes,
+        ),
     ) {
         // #458 — cold-start screen, read synchronously from the bootstrap mirror and frozen for
         // the session. Only the INITIAL values below consume it: rememberSaveable and

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,13 +1,16 @@
-Redface 2 v0.13.0 — beta.
+Redface 2 v0.14.0 — beta.
 
 New:
-- Settings redesigned: dedicated tab, category-first navigation, search, smooth transitions.
-- Compact bottom bar, translucent search bar on scroll.
-- "edited" marker, steady post header on multi-quote, poll state kept across pages.
+- Post signatures shown beneath the message (dedicated setting).
+- Account avatar in the top bar.
+- Long quotes are collapsible.
+- Flags action bar hides on scroll.
+
+Improvements:
+- Unified topic info line, harmonized icon buttons, images without layout shift.
 
 Fixes:
-- Flags refresh on tab switch and on resume.
-- Unread MP badge that truly cuts the network when off.
-- Stray empty lines in posts, hardened image upload.
+- Flags scrolled back to top after refresh.
+- More readable signatures: author colours neutralised, "---" separator removed.
 
 Report bugs via the beta or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,13 +1,16 @@
-Redface 2 v0.13.0 — bêta.
+Redface 2 v0.14.0 — bêta.
 
 Nouveautés :
-- Réglages repensés : onglet dédié, navigation par catégories, recherche, transitions fluides.
-- Bottom bar compacte, recherche translucide au défilement.
-- Marqueur « édité », en-tête stable au multiquote, sondages conservés entre pages.
+- Signatures affichées sous le message (réglage dédié).
+- Avatar du compte dans la barre du haut.
+- Longues citations repliables.
+- Barre d'actions drapeaux masquée au scroll.
+
+Améliorations :
+- Infos des sujets unifiées, icônes harmonisées, images sans à-coup.
 
 Correctifs :
-- Drapeaux rafraîchis au changement d'onglet et à la reprise.
-- Badge MP non-lus qui coupe vraiment le réseau.
-- Lignes vides parasites, upload d'images durci.
+- Drapeaux recalés en haut après le rafraîchissement.
+- Signatures plus lisibles : couleurs auteur neutralisées, séparateur « --- » retiré.
 
 Signalez les bugs via la bêta ou GitHub.

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppAccountViewModelTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppAccountViewModelTest.kt
@@ -4,8 +4,10 @@ import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.auth.LoginError
 import fr.forumhfr.redface2.core.domain.flags.FlagRepository
 import fr.forumhfr.redface2.core.domain.flags.FlagsResult
+import fr.forumhfr.redface2.core.domain.profile.ProfileRepository
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.FlagType
+import fr.forumhfr.redface2.core.model.UserProfile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -19,6 +21,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -59,7 +62,7 @@ class AppAccountViewModelTest {
     fun `logout clears the private flags cache exactly once before resetting auth state`() = runTest {
         val flags = FakeFlagRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = AppAccountViewModel(auth, flags)
+        val vm = AppAccountViewModel(auth, flags, FakeProfileRepository())
 
         val clearsBeforeLogout = flags.clearSessionCacheCallCount
 
@@ -82,7 +85,7 @@ class AppAccountViewModelTest {
     fun `authState mirrors the AuthRepository observation across login and logout transitions`() = runTest {
         val flags = FakeFlagRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = AppAccountViewModel(auth, flags)
+        val vm = AppAccountViewModel(auth, flags, FakeProfileRepository())
 
         // SharingStarted.Eagerly + initialValue = null. The first upstream emission lands
         // synchronously through Dispatchers.Main.immediate (= UnconfinedTestDispatcher in
@@ -95,6 +98,42 @@ class AppAccountViewModelTest {
         assertEquals(AuthState.Anonymous, vm.authState.value)
         auth.emit(AuthState.Authenticated("xaat"))
         assertEquals(AuthState.Authenticated("xaat"), vm.authState.value)
+    }
+
+    @Test
+    fun `avatarUrl resolves the connected user's avatar from the profile when a userId is present`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat", userId = 42), flagRepository = flags)
+        val profiles = FakeProfileRepository(avatarByUserId = mapOf(42 to "https://img/42.png"))
+
+        val vm = AppAccountViewModel(auth, flags, profiles)
+
+        assertEquals("https://img/42.png", vm.avatarUrl.value)
+        assertEquals("the avatar is fetched exactly once", 1, profiles.getProfileCallCount)
+    }
+
+    @Test
+    fun `avatarUrl stays null and does not fetch when the session carries no userId`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat", userId = null), flagRepository = flags)
+        val profiles = FakeProfileRepository()
+
+        val vm = AppAccountViewModel(auth, flags, profiles)
+
+        assertNull(vm.avatarUrl.value)
+        assertEquals("no userId → no profile fetch", 0, profiles.getProfileCallCount)
+    }
+
+    @Test
+    fun `avatarUrl falls back to null when the profile has no avatar`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat", userId = 42), flagRepository = flags)
+        // userId present but the profile resolves to no avatar (HFR rendered no img) → fall back.
+        val profiles = FakeProfileRepository(avatarByUserId = mapOf(42 to null))
+
+        val vm = AppAccountViewModel(auth, flags, profiles)
+
+        assertNull(vm.avatarUrl.value)
     }
 
     private class FakeAuthRepository(
@@ -150,6 +189,36 @@ class AppAccountViewModelTest {
         override suspend fun removeFlag(flag: fr.forumhfr.redface2.core.model.Flag): Result<Unit> {
             // Not exercised in these tests — included to satisfy the interface (#99).
             return Result.success(Unit)
+        }
+    }
+
+    /**
+     * #479 — fakes the profile fetch used to resolve the connected user's avatar. Records the
+     * call count so a test can assert the avatar is fetched once and never for a session without
+     * a userId. A userId absent from [avatarByUserId] resolves to a failed [Result].
+     */
+    private class FakeProfileRepository(
+        private val avatarByUserId: Map<Int, String?> = emptyMap(),
+    ) : ProfileRepository {
+        var getProfileCallCount: Int = 0
+            private set
+
+        override suspend fun getProfile(userId: Int): Result<UserProfile> {
+            getProfileCallCount += 1
+            if (userId !in avatarByUserId) {
+                return Result.failure(IllegalStateException("no profile for $userId"))
+            }
+            return Result.success(
+                UserProfile(
+                    userId = userId,
+                    pseudo = "xaat",
+                    avatarUrl = avatarByUserId.getValue(userId),
+                    registeredAt = null,
+                    postCount = null,
+                    location = null,
+                    signatureText = null,
+                ),
+            )
         }
     }
 }

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModelTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModelTest.kt
@@ -54,6 +54,8 @@ class AppThemeViewModelTest {
             every { observeFontScale() } returns MutableStateFlow(FontScalePreference.M)
             // #445 — eagerly collected by the VM constructor; default off is enough here.
             every { observeDebugBoundsOverlay() } returns MutableStateFlow(false)
+            // #332 — eagerly collected by the VM constructor; default on is enough here.
+            every { observeFoldLongQuotes() } returns MutableStateFlow(true)
         }
 
         val vm = AppThemeViewModel(
@@ -75,6 +77,8 @@ class AppThemeViewModelTest {
             every { observeFontScale() } returns MutableStateFlow(FontScalePreference.M)
             // #445 — eagerly collected by the VM constructor; default off is enough here.
             every { observeDebugBoundsOverlay() } returns MutableStateFlow(false)
+            // #332 — eagerly collected by the VM constructor; default on is enough here.
+            every { observeFoldLongQuotes() } returns MutableStateFlow(true)
         }
 
         val vm = AppThemeViewModel(

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModelTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModelTest.kt
@@ -52,6 +52,8 @@ class AppThemeViewModelTest {
             // #287 — eagerly collected by the VM; defaults are enough for this theme-focused test.
             every { observeDisplayDensity() } returns MutableStateFlow(DisplayDensity.COMFORT)
             every { observeFontScale() } returns MutableStateFlow(FontScalePreference.M)
+            // #445 — eagerly collected by the VM constructor; default off is enough here.
+            every { observeDebugBoundsOverlay() } returns MutableStateFlow(false)
         }
 
         val vm = AppThemeViewModel(
@@ -71,6 +73,8 @@ class AppThemeViewModelTest {
             every { observeAmoledEnabled() } returns MutableStateFlow(false)
             every { observeDisplayDensity() } returns MutableStateFlow(DisplayDensity.COMFORT)
             every { observeFontScale() } returns MutableStateFlow(FontScalePreference.M)
+            // #445 — eagerly collected by the VM constructor; default off is enough here.
+            every { observeDebugBoundsOverlay() } returns MutableStateFlow(false)
         }
 
         val vm = AppThemeViewModel(

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/auth/DefaultAuthRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/auth/DefaultAuthRepository.kt
@@ -39,7 +39,17 @@ class DefaultAuthRepository @Inject constructor(
         .filterNotNull()
         .map { cookies ->
             val mdUser = cookies.firstOrNull { it.name == COOKIE_MD_USER && it.value.isNotBlank() }
-            if (mdUser != null) AuthState.Authenticated(decodePseudo(mdUser.value)) else AuthState.Anonymous
+            if (mdUser != null) {
+                // #479 — the numeric id (`md_id`) is captured here, at the same single point where the
+                // session pseudo is decoded, so every consumer (account badge avatar, …) can fetch the
+                // public profile by id without re-reading the cookie jar. Null-safe: a session without
+                // `md_id` (older cookie set) still authenticates — the avatar just falls back to the
+                // pseudo initial. The auth verdict depends ONLY on `md_user` (cf. AuthRemoteDataSource).
+                val userId = cookies.firstOrNull { it.name == COOKIE_MD_ID }?.value?.toIntOrNull()
+                AuthState.Authenticated(decodePseudo(mdUser.value), userId)
+            } else {
+                AuthState.Anonymous
+            }
         }
         .distinctUntilChanged()
 
@@ -69,6 +79,9 @@ class DefaultAuthRepository @Inject constructor(
 
     private companion object {
         const val COOKIE_MD_USER = "md_user"
+
+        /** HFR's numeric user-id cookie, set alongside `md_user`/`md_pass` on login (#479). */
+        const val COOKIE_MD_ID = "md_id"
 
         /**
          * #260 — HFR stores the pseudo in the `md_user` cookie form-urlencoded, so a pseudo with a

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -474,6 +474,21 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeDebugBoundsOverlay(): Flow<Boolean> =
+        dataStore.data
+            // Default `false` (#445): the debug bounds overlay is opt-in and dev-channel only.
+            .map { prefs -> prefs[KEY_DEBUG_BOUNDS_OVERLAY] ?: false }
+            .distinctUntilChanged()
+            .catch { emit(false) }
+
+    override suspend fun setDebugBoundsOverlay(enabled: Boolean) {
+        persist {
+            dataStore.edit { prefs ->
+                prefs[KEY_DEBUG_BOUNDS_OVERLAY] = enabled
+            }
+        }
+    }
+
     /**
      * Reads [KEY_UPLOAD_PROVIDER] defensively: an unknown / corrupt stored value (older build with a
      * renamed enum, manual edit) falls back to [UploadProviderId.DIBERIE] instead of crashing on
@@ -631,5 +646,8 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         // (FontScalePreference.name), both defensively parsed. No bootstrap mirror (cf. observers).
         val KEY_DISPLAY_DENSITY = stringPreferencesKey("display_density")
         val KEY_FONT_SCALE = stringPreferencesKey("font_scale")
+
+        // #445 — debug bounds overlay toggle (default false; exposed on the dev channel only).
+        val KEY_DEBUG_BOUNDS_OVERLAY = booleanPreferencesKey("debug_bounds_overlay")
     }
 }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -317,6 +317,21 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeTopicSignatures(): Flow<Boolean> =
+        dataStore.data
+            // Default `false` (#330): signatures are noisy; opt-in so the feed stays compact.
+            .map { prefs -> prefs[KEY_TOPIC_SIGNATURES] ?: false }
+            .distinctUntilChanged()
+            .catch { emit(false) }
+
+    override suspend fun setTopicSignatures(enabled: Boolean) {
+        persist {
+            dataStore.edit { prefs ->
+                prefs[KEY_TOPIC_SIGNATURES] = enabled
+            }
+        }
+    }
+
     override fun observeStartScreen(): Flow<StartScreenPreference> =
         dataStore.data
             .map(::readStartScreen)
@@ -596,6 +611,9 @@ class DataStoreUserPreferencesRepository @Inject constructor(
 
         // #456 — polls expanded by default in topic reading (default false = collapsed).
         val KEY_TOPIC_POLLS_EXPANDED = booleanPreferencesKey("topic_polls_expanded")
+
+        // #330 — render author signatures beneath posts (default false = hidden, signatures are noisy).
+        val KEY_TOPIC_SIGNATURES = booleanPreferencesKey("topic_signatures")
 
         // #458 — cold-start tab (StartScreenChoice.name, defensively parsed) + optional Forum
         // category id (absent unless screen == FORUM and a category was picked).

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -332,6 +332,22 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeFoldLongQuotes(): Flow<Boolean> =
+        dataStore.data
+            // Default `true` (#332): the long-quote fold is the historical behaviour; turning it
+            // off is the opt-out for readers who found the auto-fold « trop strict ».
+            .map { prefs -> prefs[KEY_FOLD_LONG_QUOTES] ?: true }
+            .distinctUntilChanged()
+            .catch { emit(true) }
+
+    override suspend fun setFoldLongQuotes(enabled: Boolean) {
+        persist {
+            dataStore.edit { prefs ->
+                prefs[KEY_FOLD_LONG_QUOTES] = enabled
+            }
+        }
+    }
+
     override fun observeStartScreen(): Flow<StartScreenPreference> =
         dataStore.data
             .map(::readStartScreen)
@@ -629,6 +645,9 @@ class DataStoreUserPreferencesRepository @Inject constructor(
 
         // #330 — render author signatures beneath posts (default false = hidden, signatures are noisy).
         val KEY_TOPIC_SIGNATURES = booleanPreferencesKey("topic_signatures")
+
+        // #332 — fold long top-level citations by default (default true = historical fold; opt-out).
+        val KEY_FOLD_LONG_QUOTES = booleanPreferencesKey("fold_long_quotes")
 
         // #458 — cold-start tab (StartScreenChoice.name, defensively parsed) + optional Forum
         // category id (absent unless screen == FORUM and a category was picked).

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicMappers.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicMappers.kt
@@ -100,6 +100,7 @@ internal object TopicMappers {
         quoteRef = quoteRef,
         profileId = profileId,
         editedAt = editedAt,
+        signature = signature,
     )
 
     private fun PostEntity.toDomain(): Post = Post(
@@ -115,6 +116,7 @@ internal object TopicMappers {
         quoteRef = quoteRef,
         profileId = profileId,
         editedAt = editedAt,
+        signature = signature,
     )
 
     /**

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -564,6 +564,27 @@ class DataStoreUserPreferencesRepositoryTest {
     }
 
     @Test
+    fun `observeFoldLongQuotes defaults to true then persists false and true`() = runTest(dispatcher) {
+        // #332 — the long-quote fold is the historical behaviour; disabling it is the opt-out.
+        repository.observeFoldLongQuotes().test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setFoldLongQuotes(false)
+        repository.observeFoldLongQuotes().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setFoldLongQuotes(true)
+        repository.observeFoldLongQuotes().test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `observeConfirmBeforePosting defaults to false then persists true and false`() = runTest(dispatcher) {
         // #312 — publishing stays one-tap by default; the guard is strictly opt-in.
         repository.observeConfirmBeforePosting().test {

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -585,6 +585,27 @@ class DataStoreUserPreferencesRepositoryTest {
     }
 
     @Test
+    fun `observeDebugBoundsOverlay defaults to false then persists true and false`() = runTest(dispatcher) {
+        // #445 — the debug bounds overlay is opt-in (dev channel only); an empty store reports false.
+        repository.observeDebugBoundsOverlay().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setDebugBoundsOverlay(true)
+        repository.observeDebugBoundsOverlay().test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setDebugBoundsOverlay(false)
+        repository.observeDebugBoundsOverlay().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `saving disabled proxy removes optional fields from effective config`() = runTest(dispatcher) {
         repository.saveProxyConfig(
             ProxyConfig(

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -577,6 +577,10 @@ class TopicRepositoryImplTest {
 
         override suspend fun setTopicSignatures(enabled: Boolean) = Unit
 
+        override fun observeFoldLongQuotes(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setFoldLongQuotes(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -573,6 +573,10 @@ class TopicRepositoryImplTest {
 
         override suspend fun setTopicPollsExpanded(enabled: Boolean) = Unit
 
+        override fun observeTopicSignatures(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setTopicSignatures(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -605,5 +605,9 @@ class TopicRepositoryImplTest {
         override fun observeFontScale(): Flow<FontScalePreference> = MutableStateFlow(FontScalePreference.M)
 
         override suspend fun setFontScale(scale: FontScalePreference) = Unit
+
+        override fun observeDebugBoundsOverlay(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setDebugBoundsOverlay(enabled: Boolean) = Unit
     }
 }

--- a/core/database/schemas/fr.forumhfr.redface2.core.database.RedfaceDatabase/14.json
+++ b/core/database/schemas/fr.forumhfr.redface2.core.database.RedfaceDatabase/14.json
@@ -1,0 +1,541 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 14,
+    "identityHash": "9ab3e3cc16fead190e136b6c9f2bfb7b",
+    "entities": [
+      {
+        "tableName": "topic_pages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cat` INTEGER NOT NULL, `post` INTEGER NOT NULL, `page` INTEGER NOT NULL, `title` TEXT NOT NULL, `totalPages` INTEGER NOT NULL, `isFirstPostOwner` INTEGER NOT NULL, `pollJson` TEXT, `numreponses` TEXT NOT NULL, `fetchedAt` INTEGER NOT NULL, `authMode` TEXT NOT NULL, `subcat` INTEGER NOT NULL, `canReply` INTEGER NOT NULL, PRIMARY KEY(`cat`, `post`, `page`))",
+        "fields": [
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "post",
+            "columnName": "post",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPages",
+            "columnName": "totalPages",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFirstPostOwner",
+            "columnName": "isFirstPostOwner",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pollJson",
+            "columnName": "pollJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "numreponses",
+            "columnName": "numreponses",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authMode",
+            "columnName": "authMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subcat",
+            "columnName": "subcat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canReply",
+            "columnName": "canReply",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cat",
+            "post",
+            "page"
+          ]
+        }
+      },
+      {
+        "tableName": "posts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cat` INTEGER NOT NULL, `numreponse` INTEGER NOT NULL, `post` INTEGER NOT NULL, `author` TEXT NOT NULL, `date` INTEGER NOT NULL, `content` TEXT NOT NULL, `avatarUrl` TEXT, `isEditable` INTEGER NOT NULL, `isOwnPost` INTEGER NOT NULL, `quotedAuthors` TEXT NOT NULL, `postIndex` INTEGER, `fetchedAt` INTEGER NOT NULL, `authMode` TEXT NOT NULL, `quoteRef` INTEGER, `profileId` INTEGER, `editedAt` INTEGER, `signature` TEXT, PRIMARY KEY(`cat`, `numreponse`))",
+        "fields": [
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numreponse",
+            "columnName": "numreponse",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "post",
+            "columnName": "post",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isEditable",
+            "columnName": "isEditable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOwnPost",
+            "columnName": "isOwnPost",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quotedAuthors",
+            "columnName": "quotedAuthors",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postIndex",
+            "columnName": "postIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authMode",
+            "columnName": "authMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quoteRef",
+            "columnName": "quoteRef",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "editedAt",
+            "columnName": "editedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "signature",
+            "columnName": "signature",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cat",
+            "numreponse"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_posts_cat_post",
+            "unique": false,
+            "columnNames": [
+              "cat",
+              "post"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_posts_cat_post` ON `${TABLE_NAME}` (`cat`, `post`)"
+          }
+        ]
+      },
+      {
+        "tableName": "flag_topics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `type` TEXT NOT NULL, `cat` INTEGER NOT NULL, `subcat` INTEGER, `topicId` INTEGER NOT NULL, `title` TEXT NOT NULL, `totalPages` INTEGER NOT NULL, `replyCount` INTEGER NOT NULL, `isFavorite` INTEGER NOT NULL DEFAULT 0, `hasUnread` INTEGER NOT NULL, `lastReadPage` INTEGER NOT NULL, `lastPostReadId` INTEGER, `firstPostAuthor` TEXT NOT NULL, `lastReplyAuthor` TEXT NOT NULL, `lastReplyAt` TEXT NOT NULL, `fetchedAt` INTEGER NOT NULL, `authMode` TEXT NOT NULL, PRIMARY KEY(`userId`, `type`, `cat`, `topicId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cat",
+            "columnName": "cat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subcat",
+            "columnName": "subcat",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "topicId",
+            "columnName": "topicId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPages",
+            "columnName": "totalPages",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "replyCount",
+            "columnName": "replyCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hasUnread",
+            "columnName": "hasUnread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadPage",
+            "columnName": "lastReadPage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPostReadId",
+            "columnName": "lastPostReadId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "firstPostAuthor",
+            "columnName": "firstPostAuthor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReplyAuthor",
+            "columnName": "lastReplyAuthor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReplyAt",
+            "columnName": "lastReplyAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authMode",
+            "columnName": "authMode",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "type",
+            "cat",
+            "topicId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_flag_topics_userId_type",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_flag_topics_userId_type` ON `${TABLE_NAME}` (`userId`, `type`)"
+          },
+          {
+            "name": "index_flag_topics_userId_fetchedAt",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "fetchedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_flag_topics_userId_fetchedAt` ON `${TABLE_NAME}` (`userId`, `fetchedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "mp_read_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `threadId` INTEGER NOT NULL, `page` INTEGER NOT NULL, PRIMARY KEY(`userId`, `threadId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "threadId",
+            "columnName": "threadId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "threadId"
+          ]
+        }
+      },
+      {
+        "tableName": "editor_drafts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`draftKey` TEXT NOT NULL, `ownerId` TEXT NOT NULL, `body` TEXT NOT NULL, `subject` TEXT, `recipients` TEXT, `updatedAt` INTEGER NOT NULL, `isPrivate` INTEGER NOT NULL, PRIMARY KEY(`draftKey`))",
+        "fields": [
+          {
+            "fieldPath": "draftKey",
+            "columnName": "draftKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subject",
+            "columnName": "subject",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "recipients",
+            "columnName": "recipients",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrivate",
+            "columnName": "isPrivate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "draftKey"
+          ]
+        }
+      },
+      {
+        "tableName": "uploaded_images",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `provider` TEXT NOT NULL, `picId` TEXT NOT NULL, `imageUrl` TEXT NOT NULL, `thumbnailUrl` TEXT, `deleteHandle` TEXT, `uploadedAt` INTEGER NOT NULL, `expiresAt` INTEGER, PRIMARY KEY(`userId`, `provider`, `picId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "picId",
+            "columnName": "picId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deleteHandle",
+            "columnName": "deleteHandle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "uploadedAt",
+            "columnName": "uploadedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "provider",
+            "picId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_uploaded_images_userId_uploadedAt",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "uploadedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_uploaded_images_userId_uploadedAt` ON `${TABLE_NAME}` (`userId`, `uploadedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "mp_storage_locations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `threadId` INTEGER NOT NULL, `numreponse` INTEGER NOT NULL, PRIMARY KEY(`userId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "threadId",
+            "columnName": "threadId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numreponse",
+            "columnName": "numreponse",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9ab3e3cc16fead190e136b6c9f2bfb7b')"
+    ]
+  }
+}

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/RedfaceDatabase.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/RedfaceDatabase.kt
@@ -28,7 +28,7 @@ import fr.forumhfr.redface2.core.database.entities.UploadedImageEntity
         UploadedImageEntity::class,
         MpStorageLocationEntity::class,
     ],
-    version = 13,
+    version = 14,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/converters/Converters.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/converters/Converters.kt
@@ -54,6 +54,21 @@ internal object Converters {
     fun postContentFromJson(value: String): PostContent =
         PostContentSerializer.decode(value)
 
+    /**
+     * #330 — nullable variant for `posts.signature`. A `null` AST (the common case: most posts
+     * carry no signature) maps to a SQL `NULL` rather than an encoded empty document, so the
+     * column stays sparse and `cursor.isNull(...)` reads true for signature-less rows.
+     */
+    @TypeConverter
+    @JvmStatic
+    fun nullablePostContentToJson(value: PostContent?): String? =
+        value?.let(PostContentSerializer::encode)
+
+    @TypeConverter
+    @JvmStatic
+    fun nullablePostContentFromJson(value: String?): PostContent? =
+        value?.let(PostContentSerializer::decode)
+
     @TypeConverter
     @JvmStatic
     fun fetchModeToString(value: FetchMode): String = value.name

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/di/DatabaseModule.kt
@@ -17,6 +17,7 @@ import fr.forumhfr.redface2.core.database.dao.UploadedImageDao
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_10_11
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_11_12
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_12_13
+import fr.forumhfr.redface2.core.database.migrations.MIGRATION_13_14
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_1_2
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_2_3
 import fr.forumhfr.redface2.core.database.migrations.MIGRATION_3_4
@@ -53,6 +54,7 @@ object DatabaseModule {
             MIGRATION_10_11,
             MIGRATION_11_12,
             MIGRATION_12_13,
+            MIGRATION_13_14,
         )
         .build()
 

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/entities/PostEntity.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/entities/PostEntity.kt
@@ -77,4 +77,14 @@ data class PostEntity(
      *   whose `div.edited` only holds the « Message cité N fois » citation link.
      */
     val editedAt: Instant? = null,
+    /**
+     * #330 — the author signature AST (`<span class="signature">`), persisted as JSON via the
+     * nullable [Converters.nullablePostContentToJson] converter so the « Afficher les signatures »
+     * reading preference is a pure render-time switch (no refetch when toggled). Persisted in
+     * Room v14 (`MIGRATION_13_14`). Nullable on disk:
+     *
+     * - pre-v14 rows backfill to `NULL` (recovered on the next live fetch);
+     * - most posts legitimately carry no signature.
+     */
+    val signature: PostContent? = null,
 )

--- a/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/migrations/Migrations.kt
+++ b/core/database/src/main/kotlin/fr/forumhfr/redface2/core/database/migrations/Migrations.kt
@@ -372,3 +372,24 @@ val MIGRATION_12_13: Migration = object : Migration(12, 13) {
         )
     }
 }
+
+/**
+ * v13 → v14 (#330):
+ *
+ * Adds `signature` to `posts`. Stores the author's signature block (the HFR
+ * `<span class="signature">` trailer) as JSON in the same `PostContent` AST shape as `content`,
+ * so the « Afficher les signatures » reading preference is a pure render-time switch — toggling
+ * it never triggers a refetch.
+ *
+ * Nullable `TEXT` on disk because:
+ * - pre-v14 rows backfill to `NULL` (the next live fetch sets the real value);
+ * - most posts legitimately carry no signature.
+ *
+ * Pure DDL, no row rewrite — posts are short-lived cache and the next fetch overwrites every row
+ * with a parsed (possibly null) signature.
+ */
+val MIGRATION_13_14: Migration = object : Migration(13, 14) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE posts ADD COLUMN signature TEXT")
+    }
+}

--- a/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/migrations/MigrationTest.kt
+++ b/core/database/src/test/kotlin/fr/forumhfr/redface2/core/database/migrations/MigrationTest.kt
@@ -26,8 +26,9 @@ import org.robolectric.annotation.Config
  * in v8), `MIGRATION_8_9` (#384 follow-up added `FlagTopic.isFavorite` in v9),
  * `MIGRATION_9_10` (#430 added the `mp_read_positions` table in v10),
  * `MIGRATION_10_11` (#405 added the `editor_drafts` table in v11),
- * `MIGRATION_11_12` (#459 added the `uploaded_images` table in v12) and
- * `MIGRATION_12_13` (#6/ADR-014 added the `mp_storage_locations` table in v13).
+ * `MIGRATION_11_12` (#459 added the `uploaded_images` table in v12),
+ * `MIGRATION_12_13` (#6/ADR-014 added the `mp_storage_locations` table in v13) and
+ * `MIGRATION_13_14` (#330 added `Post.signature` in v14).
  * Without these tests a typo (missing column, wrong index name, wrong default)
  * would only crash on a real upgrade-in-place install, where the diagnostic loop is
  * days long. The tests take seconds.
@@ -125,6 +126,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -268,6 +270,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -371,6 +374,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -446,6 +450,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -517,6 +522,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -579,6 +585,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -655,6 +662,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -718,6 +726,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -771,6 +780,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -828,6 +838,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -890,6 +901,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -952,6 +964,7 @@ class MigrationTest {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
+                MIGRATION_13_14,
             )
             .build()
 
@@ -966,6 +979,74 @@ class MigrationTest {
                 assertTrue("the migrated table must accept and return a row", cursor.moveToFirst())
                 assertEquals(9100200, cursor.getInt(0))
                 assertEquals(1980664234, cursor.getInt(1))
+            }
+        } finally {
+            migrated.close()
+        }
+    }
+
+    /**
+     * #330 — v13 → v14 adds nullable `signature` to `posts`.
+     *
+     * Verifies:
+     * 1. The migration runs cleanly against the v13 fixture and matches the exported v14 schema.
+     * 2. Pre-existing post rows survive the migration.
+     * 3. The new column defaults to NULL on old rows (recovered on the next live fetch).
+     */
+    @Test
+    fun migrate_13_to_14_adds_nullable_signature_to_posts() {
+        val dbName = "migration_13_14_test"
+
+        // 1. Create a v13 database and insert a posts row that pre-dates `signature`.
+        helper.createDatabase(dbName, 13).apply {
+            execSQL(
+                """INSERT INTO topic_pages (cat, post, page, title, totalPages, isFirstPostOwner,
+                   numreponses, fetchedAt, authMode, subcat, canReply)
+                   VALUES (23, 35395, 1, 'v13 cached topic', 10, 0, '[]', 1000, 'AUTHENTICATED', 550, 1)""",
+            )
+            execSQL(
+                """INSERT INTO posts (cat, numreponse, post, author, date, content, avatarUrl,
+                   isEditable, isOwnPost, quotedAuthors, postIndex, fetchedAt, authMode, quoteRef,
+                   profileId, editedAt)
+                   VALUES (23, 100, 35395, 'XaTriX', 1000,
+                   '{"blocks":[]}', NULL, 0, 0, '[]', 1, 1000, 'AUTHENTICATED', NULL, NULL, NULL)""",
+            )
+            close()
+        }
+
+        // 2. Run MIGRATION_13_14 and validate against the v14 schema.
+        helper.runMigrationsAndValidate(dbName, 14, true, MIGRATION_13_14).close()
+
+        // 3. Open the production Room database (which chains every migration).
+        val migrated = Room.databaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            RedfaceDatabase::class.java,
+            dbName,
+        )
+            .allowMainThreadQueries()
+            .addMigrations(
+                MIGRATION_1_2,
+                MIGRATION_2_3,
+                MIGRATION_3_4,
+                MIGRATION_4_5,
+                MIGRATION_5_6,
+                MIGRATION_6_7,
+                MIGRATION_7_8,
+                MIGRATION_8_9,
+                MIGRATION_9_10,
+                MIGRATION_10_11,
+                MIGRATION_11_12,
+                MIGRATION_12_13,
+                MIGRATION_13_14,
+            )
+            .build()
+
+        try {
+            migrated.openHelper.readableDatabase.query(
+                "SELECT signature FROM posts WHERE cat = 23 AND numreponse = 100",
+            ).use { cursor ->
+                assertTrue("pre-v14 post row must survive MIGRATION_13_14", cursor.moveToFirst())
+                assertTrue("signature must be NULL for pre-v14 rows", cursor.isNull(0))
             }
         } finally {
             migrated.close()

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -286,4 +286,17 @@ interface UserPreferencesRepository {
 
     /** Persists [observeFontScale]. Default [FontScalePreference.M] until the first call. */
     suspend fun setFontScale(scale: FontScalePreference)
+
+    /**
+     * Debug bounds overlay (#445): when `true`, the app draws a full-screen overlay outlining the
+     * bounds of every laid-out component (walked from the Compose semantics tree) so a developer can
+     * eyeball layout/spacing while dogfooding. Default `false`. The toggle is exposed in Settings on
+     * the DEV channel ONLY (gated by the `:app` build flavor), and the overlay itself early-returns
+     * when disabled so it costs nothing in production. Observed at the app root
+     * ([fr.forumhfr.redface2.navigation.RedfaceApp]).
+     */
+    fun observeDebugBoundsOverlay(): Flow<Boolean>
+
+    /** Persists [observeDebugBoundsOverlay]. Default `false` until the first call. */
+    suspend fun setDebugBoundsOverlay(enabled: Boolean)
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -201,6 +201,18 @@ interface UserPreferencesRepository {
     suspend fun setTopicPollsExpanded(enabled: Boolean)
 
     /**
+     * #330 — whether each post's author signature (`<span class="signature">`, web parity) is
+     * rendered beneath the post body, in a subdued style separated by a divider. Default `false`:
+     * signatures are noisy and most readers scroll past them, so they are opt-in. Toggling is a
+     * pure render-time switch (the signature is always parsed and cached, no refetch). Observed by
+     * `:feature:topic`, toggled in Settings.
+     */
+    fun observeTopicSignatures(): Flow<Boolean>
+
+    /** Persists [observeTopicSignatures]. Default `false` until the first call. */
+    suspend fun setTopicSignatures(enabled: Boolean)
+
+    /**
      * #458 — which top-level tab (and optional Forum category) a cold start opens on. Default
      * [StartScreenChoice.FLAGS] (historical behaviour). The navigation reads the SYNCHRONOUS
      * [StartScreenBootstrapStore] mirror at cold start; this flow is the source of truth and

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -213,6 +213,19 @@ interface UserPreferencesRepository {
     suspend fun setTopicSignatures(enabled: Boolean)
 
     /**
+     * #332 — whether a "long" top-level citation folds to a one-line header by default (the
+     * `isLongQuote` behaviour: a wall-of-text quote is collapsed and revealed on tap). Default
+     * `true` = the historical fold; `false` disables it entirely so a long quote always renders
+     * expanded inline like a short one (the beta feedback that the auto-fold is « trop strict »).
+     * Pure render-time switch (no refetch), provided to the post renderer through a CompositionLocal
+     * at the app root ([fr.forumhfr.redface2.navigation.RedfaceApp]) and mirrored in Settings.
+     */
+    fun observeFoldLongQuotes(): Flow<Boolean>
+
+    /** Persists [observeFoldLongQuotes]. Default `true` until the first call. */
+    suspend fun setFoldLongQuotes(enabled: Boolean)
+
+    /**
      * #458 — which top-level tab (and optional Forum category) a cold start opens on. Default
      * [StartScreenChoice.FLAGS] (historical behaviour). The navigation reads the SYNCHRONOUS
      * [StartScreenBootstrapStore] mirror at cold start; this flow is the source of truth and

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/AuthState.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/AuthState.kt
@@ -3,5 +3,16 @@ package fr.forumhfr.redface2.core.model
 sealed interface AuthState {
     data object Anonymous : AuthState
 
-    data class Authenticated(val pseudo: String) : AuthState
+    /**
+     * @param pseudo the connected user's display pseudo (decoded from the `md_user` cookie).
+     * @param userId the connected user's numeric HFR id (from the `md_id` cookie), or `null`
+     *   when HFR did not set it (older sessions / partial cookie set). Used to fetch the
+     *   user's public profile — e.g. the avatar shown in the top-bar account badge (#479) —
+     *   keyed by `/hfr/profil-{userId}.htm`. Display-only: the auth verdict itself never
+     *   depends on it (only `md_user` proves the session, cf. `AuthRemoteDataSource.classify`).
+     */
+    data class Authenticated(
+        val pseudo: String,
+        val userId: Int? = null,
+    ) : AuthState
 }

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/Post.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/Post.kt
@@ -56,4 +56,20 @@ data class Post(
      * marker; pre-v8 rows backfill to `NULL` and recover on the next live fetch.
      */
     val editedAt: Instant? = null,
+    /**
+     * #330 — the author's signature block (the HFR `<span class="signature">`
+     * trailer rendered under the post body on the web), parsed into the same
+     * [PostContent] AST as [content] so it can be rendered with the shared
+     * `PostRenderer`. `null` when the post has no signature (most posts) — the
+     * span is absent or empty.
+     *
+     * Gated for DISPLAY behind the `topic_signatures` reading preference (default
+     * OFF, signatures are noisy); the field is always parsed and persisted so the
+     * toggle is a pure render-time switch with no refetch.
+     *
+     * Persisted in Room v14 (cf. `MIGRATION_13_14`) so a cache hit keeps the
+     * signature without a network round-trip. Pre-v14 rows backfill to `NULL`
+     * and recover the real value on the next live fetch.
+     */
+    val signature: PostContent? = null,
 )

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
@@ -15,6 +15,7 @@ class PostContentParser {
             return ParsedPostContent(
                 quotedAuthors = emptyList(),
                 ast = deletedFallbackAst(),
+                signature = null,
             )
         }
 
@@ -29,7 +30,23 @@ class PostContentParser {
         return ParsedPostContent(
             quotedAuthors = quotedAuthors,
             ast = ast,
+            signature = parseSignature(contentElement),
         )
+    }
+
+    /**
+     * #330 — extracts the author signature trailer (`<span class="signature">`, a descendant of
+     * the `div[id^=para]` content element, after the post body and any `div.edited` marker) into
+     * the same AST as the body so it renders with the shared `PostRenderer`. HFR opens every
+     * signature with a horizontal-rule-ish dashes line and a trailing `clear: both` spacer div
+     * (both stripped by [parseBlocks]'s edge-trim / IGNORE rules), so an EMPTY signature
+     * (`<span class="signature"></span>`, or one carrying only decoration) yields no real block
+     * and is reported as `null` — same "no noise" contract as a never-edited [editedAt].
+     */
+    private fun parseSignature(contentElement: Element): PostContent? {
+        val span = contentElement.selectFirst(HfrSelectors.POST_SIGNATURE) ?: return null
+        val blocks = parseBlocks(span.clone().childNodes())
+        return blocks.takeIf { it.isNotEmpty() }?.let { PostContent(blocks = it) }
     }
 
     private fun deletedFallbackAst(): PostContent = PostContent(
@@ -709,4 +726,9 @@ internal fun sanitizeImageHref(rawSrc: String): String? =
 data class ParsedPostContent(
     val quotedAuthors: List<String>,
     val ast: PostContent,
+    /**
+     * #330 — the author signature AST (`<span class="signature">`), or `null` when the post has
+     * no signature (the span is absent, or holds only decoration that edge-trims to nothing).
+     */
+    val signature: PostContent? = null,
 )

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
@@ -37,17 +37,37 @@ class PostContentParser {
     /**
      * #330 — extracts the author signature trailer (`<span class="signature">`, a descendant of
      * the `div[id^=para]` content element, after the post body and any `div.edited` marker) into
-     * the same AST as the body so it renders with the shared `PostRenderer`. HFR opens every
-     * signature with a horizontal-rule-ish dashes line and a trailing `clear: both` spacer div
-     * (both stripped by [parseBlocks]'s edge-trim / IGNORE rules), so an EMPTY signature
-     * (`<span class="signature"></span>`, or one carrying only decoration) yields no real block
-     * and is reported as `null` — same "no noise" contract as a never-edited [editedAt].
+     * the same AST as the body so it renders with the shared `PostRenderer`.
+     *
+     * HFR opens every signature span with a literal separator « --------------- » (a dashes-only
+     * text node, then a `<br>`) before the author's real signature, and closes it with a trailing
+     * `clear: both` spacer div. The spacer edge-trims away, but the dashes are a NON-blank text node
+     * so [parseBlocks]' edge-trim never drops them (they leaked as the first signature line, web
+     * separator chrome the app must not show — XaaT). The leading separator node is therefore removed
+     * explicitly before parsing; its following `<br>` then becomes a leading break and edge-trims
+     * away too. A signature that is ONLY the separator + decoration yields no real block and is
+     * reported as `null` — same "no noise" contract as a never-edited [editedAt].
      */
     private fun parseSignature(contentElement: Element): PostContent? {
-        val span = contentElement.selectFirst(HfrSelectors.POST_SIGNATURE) ?: return null
-        val blocks = parseBlocks(span.clone().childNodes())
+        val span = contentElement.selectFirst(HfrSelectors.POST_SIGNATURE)?.clone() ?: return null
+        // Match HFR's exact separator shape — a leading dashes-only text node IMMEDIATELY followed by
+        // the `<br>` it always emits — before removing it. Requiring the `<br>` sibling keeps the
+        // strip precise to the server chrome and guards a (hypothetical) real signature that merely
+        // opens with dashes (Codex review): on raw HFR the user's content always sits AFTER this pair.
+        (span.childNodes().firstOrNull() as? TextNode)
+            ?.takeIf { it.wholeText.isHfrSignatureSeparator() && it.nextSibling().isLineBreakElement() }
+            ?.remove()
+        val blocks = parseBlocks(span.childNodes())
         return blocks.takeIf { it.isNotEmpty() }?.let { PostContent(blocks = it) }
     }
+
+    /** HFR's server-inserted signature separator: a run of dashes only (after trimming whitespace). */
+    private fun String.isHfrSignatureSeparator(): Boolean {
+        val trimmed = trim { it.isWhitespace() || it == NBSP }
+        return trimmed.length >= MIN_SIGNATURE_SEPARATOR_DASHES && trimmed.all { it == '-' }
+    }
+
+    private fun Node?.isLineBreakElement(): Boolean = (this as? Element)?.tagName() == "br"
 
     private fun deletedFallbackAst(): PostContent = PostContent(
         blocks = listOf(PostBlock.Paragraph(listOf(PostInline.Text(DELETED_PLACEHOLDER)))),
@@ -672,6 +692,11 @@ class PostContentParser {
         // #466 — non-breaking space (U+00A0). HFR encodes inter-paragraph blank lines as runs of
         // `&nbsp;` between sibling <p>; Jsoup keeps them as this literal char until normalizeText.
         const val NBSP = '\u00A0'
+
+        // #330 follow-up \u2014 minimum dashes for a text node to count as HFR's signature separator
+        // \u00AB --------------- \u00BB (server-inserted before every signature). 3+ avoids treating a stray
+        // \u00AB -- \u00BB in real signature content as the separator.
+        const val MIN_SIGNATURE_SEPARATOR_DASHES = 3
 
         val WHITESPACE_REGEX = Regex("\\s+")
         val HEX_REGEX = Regex("[0-9a-fA-F]+")

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostsParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostsParser.kt
@@ -82,6 +82,9 @@ class PostsParser(
             quoteRef = parseQuoteRef(postTable),
             profileId = parseProfileId(postTable),
             editedAt = parseEditedAt(postTable),
+            // #330 — parsed from the same content element as `content` (the signature span is a
+            // descendant of `div[id^=para]`, stripped from the body but surfaced here).
+            signature = content.signature,
         )
     }
 

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
@@ -195,6 +195,72 @@ class PostContentParserTest {
     }
 
     @Test
+    fun `signature span surfaces as a separate signature AST and is stripped from the body`() {
+        // #330 — HFR appends the author signature as a <span class="signature"> trailer inside
+        // the post content div, after the body and any div.edited marker. It is parsed into its
+        // own AST (rendered subdued, web parity) and removed from the body content.
+        val html = """
+            <div id="para1980664234"><p>Le corps du message.<div style="clear: both;"> </div></p>
+            <div class="edited"><br />Message édité par alice le 16-03-2016&nbsp;à&nbsp;14:35:19</div>
+            <br /><span class="signature"> ---------------
+            <br />Ma signature avec un <b>mot</b> en gras.<br /><div style="clear: both;"> </div></span></div>
+        """.trimIndent()
+        val contentElement = Jsoup.parse(html).selectFirst("div[id^=para]")
+
+        val parsed = PostContentParser().parse(contentElement)
+
+        val signature = requireNotNull(parsed.signature) { "the signature span must surface" }
+        val signatureText = signature.allInlines()
+            .filterIsInstance<PostInline.Text>()
+            .joinToString(" ") { it.value }
+        assertTrue(
+            "signature content must be parsed, got=$signatureText",
+            signatureText.contains("Ma signature avec un"),
+        )
+        // Inline formatting inside the signature survives (shared parseBlocks pipeline).
+        assertTrue(
+            "signature inline formatting must survive",
+            signature.allInlines().any { it is PostInline.Strong },
+        )
+        // The signature text must NOT leak into the body AST.
+        val bodyText = parsed.ast.allInlines()
+            .filterIsInstance<PostInline.Text>()
+            .joinToString(" ") { it.value }
+        assertTrue("body must keep its own text, got=$bodyText", bodyText.contains("Le corps du message"))
+        assertFalse(
+            "signature must not leak into the body, got=$bodyText",
+            bodyText.contains("Ma signature avec un"),
+        )
+    }
+
+    @Test
+    fun `post without a signature span yields a null signature`() {
+        val html = """
+            <div id="para1980664235"><p>Un message sans signature.<div style="clear: both;"> </div></p></div>
+        """.trimIndent()
+        val contentElement = Jsoup.parse(html).selectFirst("div[id^=para]")
+
+        val parsed = PostContentParser().parse(contentElement)
+
+        assertEquals("a post without a signature span must report null", null, parsed.signature)
+    }
+
+    @Test
+    fun `signature span with only decoration edge-trims to null`() {
+        // The dashes line + the trailing `clear: both` spacer are HFR boilerplate; a signature
+        // carrying nothing else must report null (no empty subdued block under the post).
+        val html = """
+            <div id="para1980664236"><p>Corps.<div style="clear: both;"> </div></p>
+            <br /><span class="signature"><br /><div style="clear: both;"> </div></span></div>
+        """.trimIndent()
+        val contentElement = Jsoup.parse(html).selectFirst("div[id^=para]")
+
+        val parsed = PostContentParser().parse(contentElement)
+
+        assertEquals("a decoration-only signature must report null", null, parsed.signature)
+    }
+
+    @Test
     fun `a quote whose quoted content embeds a spoiler stays a Quote`() {
         // #393 — post t2787065 (topic RF2-DEV page 6, the live repro) : XaTriX cites a post
         // shaped "Test / [spoiler]caca rose[/spoiler] / Suite". The container div used to be

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
@@ -217,6 +217,12 @@ class PostContentParserTest {
             "signature content must be parsed, got=$signatureText",
             signatureText.contains("Ma signature avec un"),
         )
+        // The HFR « --------------- » separator that opens every signature span is server chrome,
+        // not content — it must be stripped, never rendered as the first signature line (XaaT).
+        assertFalse(
+            "the HFR signature separator must not leak into the signature, got=$signatureText",
+            signatureText.contains("---"),
+        )
         // Inline formatting inside the signature survives (shared parseBlocks pipeline).
         assertTrue(
             "signature inline formatting must survive",
@@ -246,18 +252,20 @@ class PostContentParserTest {
     }
 
     @Test
-    fun `signature span with only decoration edge-trims to null`() {
-        // The dashes line + the trailing `clear: both` spacer are HFR boilerplate; a signature
-        // carrying nothing else must report null (no empty subdued block under the post).
+    fun `signature span with only the separator and decoration edge-trims to null`() {
+        // The « --------------- » separator line + the trailing `clear: both` spacer are HFR
+        // boilerplate; a signature carrying nothing else must report null (no empty subdued block
+        // under the post). Real-shape fixture: the separator dashes text node, a <br>, the spacer.
         val html = """
             <div id="para1980664236"><p>Corps.<div style="clear: both;"> </div></p>
-            <br /><span class="signature"><br /><div style="clear: both;"> </div></span></div>
+            <br /><span class="signature"> ---------------
+            <br /><div style="clear: both;"> </div></span></div>
         """.trimIndent()
         val contentElement = Jsoup.parse(html).selectFirst("div[id^=para]")
 
         val parsed = PostContentParser().parse(contentElement)
 
-        assertEquals("a decoration-only signature must report null", null, parsed.signature)
+        assertEquals("a separator-only signature must report null", null, parsed.signature)
     }
 
     @Test

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/TopicPageParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/TopicPageParserTest.kt
@@ -803,6 +803,23 @@ class TopicPageParserTest {
         )
     }
 
+    @Test
+    fun `parses author signatures into Post signature when present`() {
+        // #330 — the single-page fixture carries posts with a <span class="signature"> trailer.
+        // The parser surfaces each one as Post.signature (its own AST) without leaking it into the
+        // body content. Posts with no signature span keep Post.signature == null.
+        val topic = parser.parse(fixture("topic_page_single.html"))
+
+        val withSignature = topic.posts.filter { it.signature != null }
+        assertTrue("the single-page fixture should expose at least one author signature", withSignature.isNotEmpty())
+        withSignature.forEach { post ->
+            assertTrue(
+                "parsed signature #${post.numreponse} should hold at least one block",
+                post.signature!!.blocks.isNotEmpty(),
+            )
+        }
+    }
+
     private fun fixture(name: String): String {
         return requireNotNull(javaClass.getResource("/fixtures/$name")) {
             "Fixture not found: $name"

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
@@ -92,33 +91,13 @@ fun FlagItem(
                 fontWeight = if (flag.hasUnread) FontWeight.SemiBold else FontWeight.Normal,
                 maxLines = 2,
             )
-            if (metadata.start.isNotEmpty() || metadata.end.isNotEmpty()) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = metadata.start,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        // #325 — only the START segment may truncate; the end-aligned
-                        // timestamp keeps its intrinsic width (weight measures this text
-                        // in the remaining space).
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f),
-                    )
-                    if (metadata.end.isNotEmpty()) {
-                        Text(
-                            text = metadata.end,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
-                            modifier = Modifier.padding(start = 8.dp),
-                        )
-                    }
-                }
-            }
+            // #376 — shared two-segment metadata line (start truncatable + date pinned right),
+            // common to the drapeaux / catégorie / recherche lists.
+            TopicMetadataLine(
+                metadata = metadata,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagMetadata.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagMetadata.kt
@@ -1,9 +1,74 @@
 package fr.forumhfr.redface2.core.ui
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+
 /**
- * Footer line of a [FlagItem] row, split in two segments (#325 follow-up). [start] is the
- * only segment allowed to truncate (ellipsis); [end] — typically the last-reply
- * timestamp — keeps its intrinsic width, pinned to the row's end. Either side may be
- * empty. Bundled as one value so callers stay under the detekt parameter-count threshold.
+ * Footer line of a topic row, split in two segments (#325, generalised to all three topic
+ * lists in #376). [start] is the only segment allowed to truncate (ellipsis); [end] —
+ * typically the last-reply timestamp — keeps its intrinsic width, pinned to the row's end.
+ * Either side may be empty. Bundled as one value so callers stay under the detekt
+ * parameter-count threshold.
  */
 data class FlagMetadata(val start: String = "", val end: String = "")
+
+/**
+ * #376 — shared two-segment metadata line for every topic-list row (drapeaux, catégorie,
+ * recherche). Extracted from [FlagItem] so the three lists render the SAME template:
+ *
+ *  - [FlagMetadata.start] (e.g. `auteur · p.X/Y`) takes the remaining width and ellipsises;
+ *  - [FlagMetadata.end] (the last-reply timestamp) keeps its intrinsic width, end-aligned,
+ *    and is NEVER truncated — the date survives on narrow screens, the left segment clips
+ *    first (dogfooding feedback on v102, where the date was last in a single string and was
+ *    the part being cut off).
+ *
+ * Renders nothing when both segments are blank. [style] / [color] are passed in so each list
+ * keeps its own typography role (drapeaux/catégorie use `labelSmall`, recherche uses
+ * `bodySmall`) and its own highlight tint — only the LAYOUT is harmonised, not the chrome.
+ */
+@Composable
+fun TopicMetadataLine(
+    metadata: FlagMetadata,
+    modifier: Modifier = Modifier,
+    style: TextStyle = LocalTextStyle.current,
+    color: Color = MaterialTheme.colorScheme.onSurfaceVariant,
+) {
+    if (metadata.start.isEmpty() && metadata.end.isEmpty()) return
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Start,
+    ) {
+        Text(
+            text = metadata.start,
+            style = style,
+            color = color,
+            maxLines = 1,
+            // Only the START segment may truncate; the end-aligned timestamp keeps its
+            // intrinsic width (weight measures this text in the remaining space).
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        if (metadata.end.isNotEmpty()) {
+            Text(
+                text = metadata.end,
+                style = style,
+                color = color,
+                maxLines = 1,
+                modifier = Modifier.padding(start = 8.dp),
+            )
+        }
+    }
+}

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/RedfaceTheme.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/RedfaceTheme.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalContext
 import fr.forumhfr.redface2.core.ui.theme.DisplayMetrics
 import fr.forumhfr.redface2.core.ui.theme.LocalDisplayMetrics
+import fr.forumhfr.redface2.core.ui.theme.LocalFoldLongQuotes
 import fr.forumhfr.redface2.core.ui.theme.ReadingDisplaySettings
 import fr.forumhfr.redface2.core.ui.theme.RedfaceAmoledColorScheme
 import fr.forumhfr.redface2.core.ui.theme.RedfaceDarkColorScheme
@@ -39,6 +40,9 @@ fun RedfaceTheme(
 
     CompositionLocalProvider(
         LocalDisplayMetrics provides DisplayMetrics.of(reading.density),
+        // #332 — expose the « fold long quotes » preference to the post renderer (read via
+        // LocalFoldLongQuotes.current in QuoteBlock) so flipping the toggle re-renders posts.
+        LocalFoldLongQuotes provides reading.foldLongQuotes,
     ) {
         MaterialTheme(
             colorScheme = colorScheme,

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/account/RedfaceAccountMenu.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/account/RedfaceAccountMenu.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.ui.R
+import fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar
 
 /**
  * Account / alpha-tools menu shown in the top-right of every main screen (#198).
@@ -55,12 +56,17 @@ fun RedfaceAccountMenu(
     onOpenDiagnostics: () -> Unit,
     onReportContent: () -> Unit,
     modifier: Modifier = Modifier,
+    // #479 — real HFR avatar of the connected user. Null (anonymous, loading, or no avatar set)
+    // falls back to the pseudo-initial badge. The host (RedfaceNavHost) resolves it from the
+    // connected user's profile via AppAccountViewModel.
+    avatarUrl: String? = null,
 ) {
     var expanded by remember { mutableStateOf(false) }
 
     Box(modifier = modifier) {
         AccountBadge(
             authState = authState,
+            avatarUrl = avatarUrl,
             onClick = { expanded = true },
         )
         DropdownMenu(
@@ -122,8 +128,22 @@ fun RedfaceAccountMenu(
 @Composable
 private fun AccountBadge(
     authState: AuthState?,
+    avatarUrl: String?,
     onClick: () -> Unit,
 ) {
+    // #479 — when the connected user has a resolved avatar, show it instead of the initial. The
+    // text-badge branch below is kept verbatim for anonymous / loading / no-avatar so the
+    // anti-flicker contract ("…" never "?") and the existing colour scheme are unchanged.
+    val authenticated = authState as? AuthState.Authenticated
+    if (authenticated != null && !avatarUrl.isNullOrBlank()) {
+        AvatarBadge(
+            avatarUrl = avatarUrl,
+            pseudo = authenticated.pseudo,
+            onClick = onClick,
+        )
+        return
+    }
+
     val label = when (authState) {
         null -> "…"
         AuthState.Anonymous -> "?"
@@ -169,6 +189,35 @@ private fun AccountBadge(
                 fontWeight = FontWeight.SemiBold,
             )
         }
+    }
+}
+
+@Composable
+private fun AvatarBadge(
+    avatarUrl: String,
+    pseudo: String,
+    onClick: () -> Unit,
+) {
+    // #479 — same interaction contract as the text [AccountBadge]: a clickable M3 `Surface`
+    // (ripple clipped to the rounded shape, `Role.Button` for TalkBack) with the 40dp visual and
+    // the explicit `minimumInteractiveComponentSize()` (BEFORE `.size`) expanding the touch
+    // target to 48dp. The Surface owns the "Ouvrir le menu compte" semantics
+    // (`mergeDescendants = true`) so the avatar's own "Avatar de <pseudo>" description does not
+    // leak as a second TalkBack node — the badge announces as the menu button, not the avatar.
+    val accessibilityLabel = stringResource(R.string.account_menu_open_description)
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(BADGE_CORNER_RADIUS),
+        modifier = Modifier
+            .minimumInteractiveComponentSize()
+            .size(BADGE_SIZE)
+            .semantics(mergeDescendants = true) { contentDescription = accessibilityLabel },
+    ) {
+        RedfaceUserAvatar(
+            avatarUrl = avatarUrl,
+            author = pseudo,
+            size = BADGE_SIZE,
+        )
     }
 }
 

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/debug/DebugBoundsOverlay.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/debug/DebugBoundsOverlay.kt
@@ -1,0 +1,131 @@
+package fr.forumhfr.redface2.core.ui.debug
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.node.RootForTest
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.semantics.SemanticsNode
+
+/**
+ * #445 — full-screen debug overlay that outlines the bounds of every laid-out component, drawn ON TOP
+ * of the app content so a developer can eyeball layout/spacing while dogfooding. Exposed in Settings on
+ * the DEV channel only, default OFF.
+ *
+ * Bounds source: the Compose semantics tree. [LocalView] under an `AndroidComposeView` is a
+ * [RootForTest], whose `semanticsOwner.unmergedRootSemanticsNode` roots a walk where each node exposes
+ * `boundsInRoot` — already in this overlay's own coordinate space (the overlay fills the same root).
+ * The cast is guarded ([rememberDebugBounds] swallows a `ClassCastException` / a `@Preview` host) so a
+ * non-`RootForTest` view degrades to drawing nothing instead of crashing.
+ *
+ * The walk is re-sampled on a throttled ~8 Hz tick (not every frame) into a snapshot `State`, so the
+ * overlay does not re-walk the (potentially large) tree on each of the 60–120 fps content frames.
+ *
+ * Perf when disabled: this composable is gated by the caller (`if (enabled) DebugBoundsOverlay()`),
+ * so when the preference is off it is never composed and the tick loop never starts.
+ */
+@Composable
+fun DebugBoundsOverlay(modifier: Modifier = Modifier) {
+    val bounds = rememberDebugBounds()
+    // Fills the same root the bounds are measured against, so `boundsInRoot` maps 1:1 to draw
+    // coordinates. `Canvas` is a `Spacer`-backed drawing node with NO pointer handling, so it paints
+    // over the content without intercepting taps.
+    Canvas(modifier = modifier.fillMaxSize()) {
+        bounds.forEach { box ->
+            drawRect(
+                color = depthColor(box.depth),
+                topLeft = Offset(box.rect.left, box.rect.top),
+                size = Size(box.rect.width, box.rect.height),
+                style = STROKE,
+            )
+        }
+    }
+}
+
+/** A single outlined node: its [rect] (in root coordinates) and tree [depth] (drives the colour). */
+internal data class DebugBoundsBox(val rect: Rect, val depth: Int)
+
+/**
+ * Re-samples the semantics tree into a bounds snapshot on a throttled ~8 Hz tick. Held in a plain
+ * `State` so the [Canvas] repaints only when the snapshot is replaced (≈ every [TICK_INTERVAL_NANOS]),
+ * not on every content frame. The root view is resolved once; the cast is guarded so a host that is
+ * not a [RootForTest] (e.g. a `@Preview`) yields an empty list rather than throwing.
+ */
+@OptIn(InternalComposeUiApi::class)
+@Composable
+private fun rememberDebugBounds(): List<DebugBoundsBox> {
+    val view = LocalView.current
+    var snapshot by remember { mutableStateOf(emptyList<DebugBoundsBox>()) }
+    LaunchedEffect(view) {
+        var lastTickNanos = 0L
+        while (true) {
+            val now = withFrameNanos { it }
+            if (now - lastTickNanos >= TICK_INTERVAL_NANOS) {
+                lastTickNanos = now
+                snapshot = sampleBounds(view as? RootForTest)
+            }
+        }
+    }
+    return snapshot
+}
+
+/**
+ * Walks the semantics tree from the root (depth-first, iterative to avoid recursion-depth limits) and
+ * collects each node's `boundsInRoot`. Returns an empty list when [root] is null (non-`RootForTest`
+ * host) or when accessing the tree throws (defensive: the semantics owner is an internal surface).
+ */
+@OptIn(InternalComposeUiApi::class)
+private fun sampleBounds(root: RootForTest?): List<DebugBoundsBox> {
+    // Unmerged root (#445 design): the unmerged tree keeps the individual layout/text/interactive
+    // nodes that a merged subtree would collapse into one accessibility node — that finer granularity
+    // is the whole point of a "outline every component" debug overlay.
+    val rootNode = root?.semanticsOwner?.unmergedRootSemanticsNode ?: return emptyList()
+    return runCatching { walkBounds(rootNode) }.getOrDefault(emptyList())
+}
+
+/** Iterative depth-first collection of every node's finite, non-empty `boundsInRoot`. */
+private fun walkBounds(rootNode: SemanticsNode): List<DebugBoundsBox> {
+    val out = ArrayList<DebugBoundsBox>()
+    val stack = ArrayDeque<Pair<SemanticsNode, Int>>()
+    stack.addLast(rootNode to 0)
+    while (stack.isNotEmpty()) {
+        val (node, depth) = stack.removeLast()
+        val rect = node.boundsInRoot
+        if (rect.width > 0f && rect.height > 0f && rect.isFinite) {
+            out.add(DebugBoundsBox(rect, depth))
+        }
+        node.children.forEach { child -> stack.addLast(child to depth + 1) }
+    }
+    return out
+}
+
+/** Cycles a small palette by tree depth so nested components stay visually distinguishable. */
+private fun depthColor(depth: Int): Color = DEPTH_PALETTE[depth % DEPTH_PALETTE.size]
+
+private val STROKE = Stroke(width = 2f)
+
+// Semi-transparent so the underlying content stays readable through the outlines.
+private val DEPTH_PALETTE = listOf(
+    Color(0x88E53935), // red
+    Color(0x881E88E5), // blue
+    Color(0x8843A047), // green
+    Color(0x88FB8C00), // orange
+    Color(0x888E24AA), // purple
+    Color(0x8800ACC1), // cyan
+)
+
+// ~8 Hz refresh: 125 ms between re-walks of the tree (1_000 ms / 8).
+private const val TICK_INTERVAL_NANOS = 125_000_000L

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/icon/RedfaceVectorIcon.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/icon/RedfaceVectorIcon.kt
@@ -1,0 +1,50 @@
+package fr.forumhfr.redface2.core.ui.icon
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Icône-bouton vectorielle unifiée (#360, ADR-015).
+ *
+ * Le projet **interdit `androidx.compose.material.*`** (détekt `ForbiddenImport`) : pas d'`Icons.*`
+ * Material. Les icônes sont donc des **vector drawables locaux** (`:core:ui/res/drawable`) tracés en
+ * *stroke* (`strokeWidth` 2.5, caps/joins ronds) pour un poids optique homogène — c'est ce composable
+ * qui matérialise la convention décidée pour la flèche retour et étendue aux chevrons de page et au
+ * crayon (cf. ADR-015).
+ *
+ * Un glyphe texte (`Text("←")`, `Text("✎")`…) dépendait de la police système, de la baseline et du
+ * font-scale : rendu incohérent selon l'appareil. Ce vector dimensionné en dp est indépendant de la
+ * police et optiquement centré par le conteneur (`IconButton` / `*FloatingActionButton`).
+ *
+ * L'icône est **décorative** : l'étiquette d'accessibilité reste portée par le conteneur cliquable
+ * (`contentDescription` sur l'`IconButton`/le FAB), donc [contentDescription] vaut `null` par défaut.
+ */
+@Composable
+fun RedfaceVectorIcon(
+    @DrawableRes resId: Int,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+    tint: Color = LocalContentColor.current,
+    size: Dp = RedfaceIconDefaults.Size,
+) {
+    Icon(
+        painter = painterResource(resId),
+        contentDescription = contentDescription,
+        modifier = modifier.size(size),
+        tint = tint,
+    )
+}
+
+/** Valeurs de référence de l'iconographie (#360, ADR-015). */
+object RedfaceIconDefaults {
+    /** Taille canonique des icônes-boutons, alignée sur la flèche retour des top bars. */
+    val Size: Dp = 24.dp
+}

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/ImageShimmer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/ImageShimmer.kt
@@ -1,0 +1,93 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import android.provider.Settings
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * #249 — animated shimmer painted INSIDE the already-reserved block-image box (see
+ * [PostMediaDisplayPolicy.reservedBlockImageHeight]) while the bitmap loads. A diagonal highlight band
+ * sweeps left→right over a tinted base, so the user reads "image en cours de chargement ici" without a
+ * spinner — and because the box is pre-sized to the final image, the crossfade reveal causes no bump.
+ *
+ * Allocation profile mirrors [fr.forumhfr.redface2.core.ui.pager.PageSwipe]: a single
+ * [Modifier.drawBehind] reads one animated progress float and rebuilds only a lightweight linear
+ * [Brush] per frame over the box width — no per-frame composable, no full-screen overdraw.
+ *
+ * Accessibility (#249 §4 "réduire les animations") : when [animated] is false (system animator scale
+ * 0, see [rememberAnimationsEnabled]) the band is parked at rest and the box shows a STATIC tint — no
+ * infinite animation, no crossfade upstream. The reveal is then instant.
+ */
+@Composable
+internal fun ImageShimmer(animated: Boolean, modifier: Modifier = Modifier) {
+    val base = MaterialTheme.colorScheme.surfaceContainerHighest
+    val highlight = MaterialTheme.colorScheme.surfaceContainerHigh
+    val shimmerColors = remember(base, highlight) { listOf(base, highlight, base) }
+
+    val progress = if (animated) {
+        val transition = rememberInfiniteTransition(label = "post_image_shimmer")
+        transition.animateFloat(
+            initialValue = 0f,
+            targetValue = 1f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = SHIMMER_PERIOD_MS, easing = LinearEasing),
+                repeatMode = RepeatMode.Restart,
+            ),
+            label = "post_image_shimmer_progress",
+        ).value
+    } else {
+        // Reduce-motion: park the band mid-box so the static tint blends base↔highlight, no harsh edge.
+        STATIC_PROGRESS
+    }
+
+    Box(
+        modifier = modifier
+            .drawBehind {
+                // Travel the band from off-left to off-right so the highlight enters and exits the box
+                // cleanly each period (width × 2 of travel keeps the diagonal visible throughout).
+                val travel = size.width * 2f
+                val start = -size.width + travel * progress
+                drawRect(
+                    brush = Brush.linearGradient(
+                        colors = shimmerColors,
+                        start = Offset(start, 0f),
+                        end = Offset(start + size.width, size.height),
+                    ),
+                )
+            },
+    )
+}
+
+/**
+ * #249 §4 — `true` unless the user disabled animations system-wide (Developer options / "Remove
+ * animations", or an accessibility profile setting `ANIMATOR_DURATION_SCALE` to 0). Reading the system
+ * setting (rather than the app's unwired `future_a11y_reduce_motion` row) honours the OS-level
+ * preference the same way Compose's own animations do. Defaults to enabled if the setting is absent.
+ */
+@Composable
+internal fun rememberAnimationsEnabled(): Boolean {
+    val resolver = LocalContext.current.contentResolver
+    return remember(resolver) {
+        val scale = Settings.Global.getFloat(resolver, Settings.Global.ANIMATOR_DURATION_SCALE, 1f)
+        scale != 0f
+    }
+}
+
+/** One full sweep period. ~1.1 s reads as "loading" without being distracting (dogfood-tunable). */
+private const val SHIMMER_PERIOD_MS = 1100
+
+private const val STATIC_PROGRESS = 0.5f

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
@@ -122,6 +122,30 @@ internal object PostMediaDisplayPolicy {
     }
 
     /**
+     * #249 — exact RESERVED height (dp) for a block `[img]`, computed BEFORE the bitmap arrives so the
+     * loading placeholder occupies the same vertical slot the loaded image will, hence zero layout
+     * shift (anti-CLS) when it crossfades in.
+     *
+     * Reuses the same measured intrinsic size the #175/#224 path already caches: at the block width
+     * [availableWidthDp] the image will render `availableWidthDp × (h/w)` tall (`ContentScale.Fit`,
+     * full width), so we reserve exactly that, clamped to the existing [blockImageMinHeight] /
+     * [blockImageMaxHeight] slot. A landscape shot narrower-than-tall and a portrait shot both land on
+     * their real height; only the rare clamp cases differ — exactly the bounds the loaded image already
+     * obeys, so no over-reserve vs the #175 sizing.
+     *
+     * [measured] is `null` for a not-yet-measured image (a standalone `PostBlock.Image` is not fed by
+     * the paragraph measure effect): callers then fall back to the legacy [blockImageMinHeight] slot.
+     */
+    fun reservedBlockImageHeight(measured: PixelSize?, availableWidthDp: Float): Dp? {
+        val size = measured?.takeIf { it.width > 0 && it.height > 0 }
+        if (size == null || availableWidthDp <= 0f) return null
+        val rawHeight = availableWidthDp * (size.height.toFloat() / size.width.toFloat())
+        return rawHeight
+            .coerceIn(blockImageMinHeight.value, blockImageMaxHeight.value)
+            .dp
+    }
+
+    /**
      * #416 — box for a DEAD smiley sprite (recorded as a fresh measurement failure). HFR's BBCode
      * engine turns ANY `:word:` into an `<img>` without checking existence, so an unknown code is
      * served as a 404 gif : web/RF1 then show the typed token at text size. The token replaces the

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -80,6 +80,7 @@ import coil3.size.Precision
 import coil3.size.Scale
 import fr.forumhfr.redface2.core.ui.R
 import fr.forumhfr.redface2.core.ui.theme.LocalFoldLongQuotes
+import fr.forumhfr.redface2.core.ui.theme.LocalIgnoreInlineColors
 import fr.forumhfr.redface2.core.model.PostBlock
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.PostInline
@@ -256,10 +257,12 @@ private fun ParagraphBlock(inlines: List<PostInline>) {
         )
     }
     val imageAlt = stringResource(R.string.post_inline_image_alt)
+    // #553 — signatures provide LocalIgnoreInlineColors = true so author `[color]` is dropped.
+    val ignoreColors = LocalIgnoreInlineColors.current
     // The AnnotatedString is INVARIANT — it carries only the U+FFFC markers + IDs (via MediaCounter),
     // never a size — so it is never rebuilt when a measurement lands (#175 stability pivot).
-    val annotated = remember(inlines, linkStyles, imageAlt) {
-        buildInlineText(inlines, linkStyles, imageAlt)
+    val annotated = remember(inlines, linkStyles, imageAlt, ignoreColors) {
+        buildInlineText(inlines, linkStyles, imageAlt, ignoreColors)
     }
     val hasMedia = remember(inlines) { hasInlineMedia(inlines) }
 
@@ -894,9 +897,13 @@ internal fun buildInlineText(
     inlines: List<PostInline>,
     linkStyles: TextLinkStyles,
     imageAlt: String,
+    // #553 — when true, the author's inline `[color]` styling is dropped (used for signatures, whose
+    // web-tuned colours read as garish/illegible on the app theme). Text falls back to the caller's
+    // colour. Default false: post bodies keep author colours.
+    ignoreColors: Boolean = false,
 ): AnnotatedString = buildAnnotatedString {
     val media = MediaCounter()
-    appendInlines(inlines, linkStyles, media, imageAlt)
+    appendInlines(inlines, linkStyles, media, imageAlt, ignoreColors)
 }
 
 private fun AnnotatedString.Builder.appendInlines(
@@ -904,8 +911,9 @@ private fun AnnotatedString.Builder.appendInlines(
     linkStyles: TextLinkStyles,
     media: MediaCounter,
     imageAlt: String,
+    ignoreColors: Boolean,
 ) {
-    inlines.forEach { inline -> appendInline(inline, linkStyles, media, imageAlt) }
+    inlines.forEach { inline -> appendInline(inline, linkStyles, media, imageAlt, ignoreColors) }
 }
 
 @Suppress("CyclomaticComplexMethod")
@@ -914,32 +922,39 @@ private fun AnnotatedString.Builder.appendInline(
     linkStyles: TextLinkStyles,
     media: MediaCounter,
     imageAlt: String,
+    ignoreColors: Boolean,
 ) {
     when (inline) {
         is PostInline.Text -> append(inline.value)
         PostInline.LineBreak -> append('\n')
         is PostInline.Strong -> withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
-            appendInlines(inline.children, linkStyles, media, imageAlt)
+            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors)
         }
 
         is PostInline.Emphasis -> withStyle(SpanStyle(fontStyle = FontStyle.Italic)) {
-            appendInlines(inline.children, linkStyles, media, imageAlt)
+            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors)
         }
 
         is PostInline.Underline -> withStyle(SpanStyle(textDecoration = TextDecoration.Underline)) {
-            appendInlines(inline.children, linkStyles, media, imageAlt)
+            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors)
         }
 
         is PostInline.Strike -> withStyle(SpanStyle(textDecoration = TextDecoration.LineThrough)) {
-            appendInlines(inline.children, linkStyles, media, imageAlt)
+            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors)
         }
 
-        is PostInline.Color -> withStyle(SpanStyle(color = parseColor(inline.colorHex))) {
-            appendInlines(inline.children, linkStyles, media, imageAlt)
+        // #553 — drop the author colour when asked (signatures): render the children plain so they
+        // inherit the caller's neutral colour instead of the web-tuned, often-illegible author hue.
+        is PostInline.Color -> if (ignoreColors) {
+            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors)
+        } else {
+            withStyle(SpanStyle(color = parseColor(inline.colorHex))) {
+                appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors)
+            }
         }
 
         is PostInline.Link -> withLink(LinkAnnotation.Url(inline.url, linkStyles)) {
-            appendInlines(inline.children, linkStyles, media, imageAlt)
+            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors)
         }
 
         is PostInline.InlineImage -> appendInlineContent(media.nextImage(), inline.description ?: imageAlt)

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -74,6 +75,7 @@ import coil3.compose.LocalPlatformContext
 import coil3.compose.SubcomposeAsyncImage
 import coil3.compose.SubcomposeAsyncImageContent
 import coil3.request.ImageRequest
+import coil3.request.crossfade
 import coil3.size.Precision
 import coil3.size.Scale
 import fr.forumhfr.redface2.core.ui.R
@@ -516,48 +518,84 @@ private fun ImageBlock(block: PostBlock.Image) = BlockImage(url = block.url, des
  *
  * Bounded so a 4000×3000 RAW screenshot can't blow up the post and destroy the scroll position.
  * SubcomposeAsyncImage exposes loading/error slots so the user gets visual feedback when an HFR image
- * host (rehost.diberie.com, super-h.fr, …) is offline rather than a silent empty Box. Phase 1 keeps the
- * loading + error layout minimal — no material-icons-extended dependency just for a placeholder glyph.
+ * host (rehost.diberie.com, super-h.fr, …) is offline rather than a silent empty Box.
+ *
+ * #249 — anti-CLS: instead of reserving the legacy `minHeight` slot (which then SNAPS to the bitmap's
+ * real height on arrival = a bump), reserve the EXACT final height from the measured intrinsic size
+ * (`width × h/w`, same #175/#224 cache) so the shimmer placeholder occupies the loaded image's slot and
+ * nothing below moves. The image then `crossfade`s in (Coil native) into the already-sized box. A
+ * not-yet-measured image (standalone `PostBlock.Image`, no paragraph measure effect) keeps the legacy
+ * min/max slot. Animations honour the system reduce-motion preference ([rememberAnimationsEnabled]).
  */
 @Composable
 private fun BlockImage(url: String, description: String?, linkUrl: String? = null) {
     val uriHandler = LocalUriHandler.current
     val openLabel = stringResource(R.string.post_image_open_link)
-    val containerModifier = Modifier
-        .fillMaxWidth()
-        .defaultMinSize(minHeight = PostMediaDisplayPolicy.blockImageMinHeight)
-        .heightIn(max = PostMediaDisplayPolicy.blockImageMaxHeight)
-        .clip(RoundedCornerShape(8.dp))
-        .background(MaterialTheme.colorScheme.surfaceContainerHighest)
-        .then(
-            if (linkUrl != null) {
-                // Role.Image (not Button): the element IS an image that opens its full version on tap;
-                // the localized onClickLabel carries the action for TalkBack ("Image, double-tap to …").
-                Modifier.clickable(role = Role.Image, onClickLabel = openLabel) {
-                    runCatching { uriHandler.openUri(linkUrl) }
-                }
-            } else {
-                Modifier
-            },
-        )
-    SubcomposeAsyncImage(
-        model = url,
-        contentDescription = description,
-        contentScale = ContentScale.Fit,
-        modifier = containerModifier,
-        loading = { ImageBlockLoading() },
-        error = { ImageBlockError(description) },
-        success = { SubcomposeAsyncImageContent() },
-    )
-}
+    val animationsEnabled = rememberAnimationsEnabled()
 
-@Composable
-private fun ImageBlockLoading() {
-    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-        Text(
-            text = stringResource(R.string.post_image_loading),
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+    // #249 — reserve the exact final box from the measured intrinsic size when known. The same cache the
+    // #175/#224 paragraph measure effect fills feeds promoted images; a standalone PostBlock.Image is
+    // unmeasured (null) and falls back to the legacy min/max slot below.
+    val sizeCache = LocalIntrinsicMediaSizeCache.current
+    val measured: IntSize? = sizeCache.get(url)
+
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val reservedHeight = PostMediaDisplayPolicy.reservedBlockImageHeight(
+            measured = measured?.let { PixelSize(it.width, it.height) },
+            availableWidthDp = maxWidth.value,
+        )
+        // Reserved box: an exact height when measured (anti-CLS), else the legacy min/max slot.
+        val sizeModifier = if (reservedHeight != null) {
+            Modifier.height(reservedHeight)
+        } else {
+            Modifier
+                .defaultMinSize(minHeight = PostMediaDisplayPolicy.blockImageMinHeight)
+                .heightIn(max = PostMediaDisplayPolicy.blockImageMaxHeight)
+        }
+        val containerModifier = Modifier
+            .fillMaxWidth()
+            .then(sizeModifier)
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+            .then(
+                if (linkUrl != null) {
+                    // Role.Image (not Button): the element IS an image that opens its full version on
+                    // tap; the localized onClickLabel carries the action for TalkBack.
+                    Modifier.clickable(role = Role.Image, onClickLabel = openLabel) {
+                        runCatching { uriHandler.openUri(linkUrl) }
+                    }
+                } else {
+                    Modifier
+                },
+            )
+        val context = LocalPlatformContext.current
+        val request = remember(url, animationsEnabled, context) {
+            ImageRequest.Builder(context)
+                .data(url)
+                // #249 — fondu natif Coil dans la box déjà dimensionnée → zéro saut. Désactivé quand le
+                // système demande de réduire les animations (apparition directe, §4 de l'issue).
+                .crossfade(animationsEnabled)
+                .build()
+        }
+        SubcomposeAsyncImage(
+            model = request,
+            contentDescription = description,
+            contentScale = ContentScale.Fit,
+            modifier = containerModifier,
+            loading = {
+                // Measured: fill the exact reserved box. Unmeasured (max-only constraint): a STABLE
+                // min-height placeholder — NOT fillMaxSize, which would balloon to the max slot and then
+                // collapse to the loaded intrinsic height (a visible shift, Codex review). The legacy
+                // min→intrinsic grow on load remains for these rare standalone images.
+                val shimmerModifier = if (reservedHeight != null) {
+                    Modifier.fillMaxSize()
+                } else {
+                    Modifier.fillMaxWidth().height(PostMediaDisplayPolicy.blockImageMinHeight)
+                }
+                ImageShimmer(animated = animationsEnabled, modifier = shimmerModifier)
+            },
+            error = { ImageBlockError(description) },
+            success = { SubcomposeAsyncImageContent() },
         )
     }
 }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -104,6 +104,68 @@ internal const val MAX_VISIBLE_QUOTE_DEPTH = 3
 internal fun isCollapsedQuoteDepth(depth: Int): Boolean = depth >= MAX_VISIBLE_QUOTE_DEPTH
 
 /**
+ * Issue #332 — character budget above which a TOP-LEVEL `[quote]`/`[quotemsg]` block renders
+ * folded to a one-line header by default ("longues citations… repliées sur une ligne, dépliables
+ * au clic puis repliables"), mirroring the long-quote behaviour of the existing HFR userscript.
+ *
+ * 280 ≈ a few lines of body text: a one- or two-sentence citation (the common "je cite la phrase à
+ * laquelle je réponds" case) stays expanded so the reader never has to tap for a short quote, while
+ * a wall-of-text citation folds away by default and can be opened on demand.
+ *
+ * This is ORTHOGONAL to [MAX_VISIBLE_QUOTE_DEPTH] / [isCollapsedQuoteDepth] (issue #3/#82 — collapse
+ * by NESTING depth, not length): the length fold only applies at depth 0 (see [isLongQuote]) so the
+ * two never compete on the same block.
+ */
+internal const val LONG_QUOTE_CHAR_THRESHOLD = 280
+
+/**
+ * Total length of the visible text carried by a [PostContent] (paragraph text + nested quote text,
+ * line breaks counted as one char, plus one separator per block boundary since consecutive blocks
+ * render on their own lines). Pure so the long-quote rule is pinned in a JVM test without entering
+ * Compose; smiley tokens and image alt-text are deliberately ignored — they are not "reading length"
+ * and a smiley-heavy line should not force a fold. A nested spoiler contributes nothing: its body is
+ * hidden behind its own toggle by default, so it adds no visible reading length to the fold decision
+ * (else a short quote wrapping a long spoiler would fold before the spoiler toggle even shows).
+ */
+internal fun quoteVisibleTextLength(content: PostContent): Int {
+    if (content.blocks.isEmpty()) return 0
+    // +1 per block boundary: consecutive paragraphs/blocks render on separate lines, so a quote made
+    // of many short blocks accumulates the visible breaks between them (Codex review).
+    return content.blocks.sumOf(::blockVisibleTextLength) + (content.blocks.size - 1)
+}
+
+private fun blockVisibleTextLength(block: PostBlock): Int = when (block) {
+    is PostBlock.Paragraph -> block.inlines.sumOf(::inlineVisibleTextLength)
+    is PostBlock.Quote -> quoteVisibleTextLength(block.content)
+    is PostBlock.Spoiler -> 0
+    is PostBlock.Fixed -> block.text.length
+    is PostBlock.CodeBlock -> block.text.length
+    is PostBlock.Image -> 0
+}
+
+private fun inlineVisibleTextLength(inline: PostInline): Int = when (inline) {
+    is PostInline.Text -> inline.value.length
+    PostInline.LineBreak -> 1
+    is PostInline.Strong -> inline.children.sumOf(::inlineVisibleTextLength)
+    is PostInline.Emphasis -> inline.children.sumOf(::inlineVisibleTextLength)
+    is PostInline.Underline -> inline.children.sumOf(::inlineVisibleTextLength)
+    is PostInline.Strike -> inline.children.sumOf(::inlineVisibleTextLength)
+    is PostInline.Color -> inline.children.sumOf(::inlineVisibleTextLength)
+    is PostInline.Link -> inline.children.sumOf(::inlineVisibleTextLength)
+    is PostInline.InlineImage -> 0
+    is PostInline.Smiley -> 0
+}
+
+/**
+ * Issue #332 — true when a quote must fold to a one-line header by default because it is "long".
+ * Restricted to [quoteDepth] == 0: a nested quote is already governed by the depth rule
+ * ([isCollapsedQuoteDepth]) and the parent fold, so folding it again by length would stack two
+ * different toggles on the same sub-tree. Pure decision, pinned in [PostRendererQuoteDepthTest].
+ */
+internal fun isLongQuote(block: PostBlock.Quote, quoteDepth: Int): Boolean =
+    quoteDepth == 0 && quoteVisibleTextLength(block.content) > LONG_QUOTE_CHAR_THRESHOLD
+
+/**
  * Which themed accent the [QuoteFrame] left bar uses. Issue #252 — a **bare** `[quote]` (typed by
  * hand, no author) is the user formatting their own text, not citing a sourced post, so it must read
  * differently from a real HFR citation (`[quotemsg=]`, author set) and from a nested citation:
@@ -320,21 +382,73 @@ private fun QuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
         CollapsedQuoteBlock(block, quoteDepth)
         return
     }
+    if (isLongQuote(block, quoteDepth)) {
+        FoldableQuoteBlock(block, quoteDepth)
+        return
+    }
     QuoteFrame(quoteDepth = quoteDepth, isBareQuote = isBareQuote(block)) {
-        Text(
-            // #252 — a bare quote still gets a "Citation" header (no author), mirroring the
-            // "Citation de X" header of a sourced citation, so the framed block always reads
-            // as a quotation and not as a stray indented paragraph.
-            text = block.author
-                ?.let { stringResource(R.string.post_quote_author, it) }
-                ?: stringResource(R.string.post_quote_bare),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        QuoteHeader(block)
         PostBlocksRenderer(
             blocks = block.content.blocks,
             quoteDepth = quoteDepth + 1,
         )
+    }
+}
+
+/**
+ * #252 — the "Citation de X" / "Citation" header shown above every framed quote so the block always
+ * reads as a quotation, not a stray indented paragraph. A bare quote (no author) falls back to the
+ * generic "Citation" label. Extracted so the expanded, depth-collapsed and long-fold variants share
+ * one source of truth for the header text.
+ */
+@Composable
+private fun QuoteHeader(block: PostBlock.Quote) {
+    Text(
+        text = block.author
+            ?.let { stringResource(R.string.post_quote_author, it) }
+            ?: stringResource(R.string.post_quote_bare),
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+/**
+ * Issue #332 — a "long" top-level citation (`isLongQuote`) folds to a single header line by default,
+ * dépliable au clic puis repliable. Mirrors the [SpoilerBlock] interaction (a `rememberSaveable`
+ * boolean + a clickable header carrying an "Afficher"/"Masquer" affordance) and reuses [QuoteFrame]
+ * so the accent bar, surface and bare-quote palette stay identical to a normal quote. Unlike
+ * [CollapsedQuoteBlock] (issue #3 depth fold, which resets depth to 0 on reveal) this fold keeps the
+ * real [quoteDepth] when expanded so a long quote that also nests deeply still hits the depth rule.
+ */
+@Composable
+private fun FoldableQuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
+    var expanded by rememberSaveable(block) { mutableStateOf(false) }
+    QuoteFrame(
+        quoteDepth = quoteDepth,
+        isBareQuote = isBareQuote(block),
+        modifier = Modifier.clickable { expanded = !expanded },
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            QuoteHeader(block)
+            Text(
+                text = if (expanded) {
+                    stringResource(R.string.post_quote_hide)
+                } else {
+                    stringResource(R.string.post_quote_show)
+                },
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+        if (expanded) {
+            PostBlocksRenderer(
+                blocks = block.content.blocks,
+                quoteDepth = quoteDepth + 1,
+            )
+        }
     }
 }
 
@@ -444,14 +558,8 @@ private fun CollapsedQuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
             )
         }
         if (revealed) {
-            Text(
-                // #252 — same "Citation"/"Citation de X" header rule as the expanded QuoteBlock.
-                text = block.author
-                    ?.let { stringResource(R.string.post_quote_author, it) }
-                    ?: stringResource(R.string.post_quote_bare),
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            // #252 — same "Citation"/"Citation de X" header rule as the expanded QuoteBlock.
+            QuoteHeader(block)
             PostBlocksRenderer(
                 blocks = block.content.blocks,
                 quoteDepth = 0,

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -79,6 +79,7 @@ import coil3.request.crossfade
 import coil3.size.Precision
 import coil3.size.Scale
 import fr.forumhfr.redface2.core.ui.R
+import fr.forumhfr.redface2.core.ui.theme.LocalFoldLongQuotes
 import fr.forumhfr.redface2.core.model.PostBlock
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.PostInline
@@ -382,7 +383,10 @@ private fun QuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
         CollapsedQuoteBlock(block, quoteDepth)
         return
     }
-    if (isLongQuote(block, quoteDepth)) {
+    // #332 — the long-quote fold is gated on the user preference (default ON = historical fold).
+    // When OFF we skip FoldableQuoteBlock entirely and fall through to the normal expanded render,
+    // exactly as if the quote were not "long". The depth fold above is unaffected.
+    if (LocalFoldLongQuotes.current && isLongQuote(block, quoteDepth)) {
         FoldableQuoteBlock(block, quoteDepth)
         return
     }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/DisplayMetrics.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/DisplayMetrics.kt
@@ -70,3 +70,12 @@ val LocalDisplayMetrics = staticCompositionLocalOf { DisplayMetrics.Comfort }
  * resolved value from [ReadingDisplaySettings.foldLongQuotes].
  */
 val LocalFoldLongQuotes = staticCompositionLocalOf { true }
+
+/**
+ * Project CompositionLocal asking the post renderer to IGNORE the author's inline `[color]` styling
+ * for the subtree it wraps (#553). HFR signatures embed colours chosen for the white web background;
+ * rendered as-is on the app theme (especially dark) they read as unreadable/garish, so the signature
+ * render site provides `true` and the text falls back to the theme's neutral colour. Defaults to
+ * `false` (post bodies keep author colours). `staticCompositionLocalOf`: flips rarely, scoped reads.
+ */
+val LocalIgnoreInlineColors = staticCompositionLocalOf { false }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/DisplayMetrics.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/DisplayMetrics.kt
@@ -61,3 +61,12 @@ data class DisplayMetrics(
  * Defaults to [DisplayMetrics.Comfort] for previews / hosts that do not provide it.
  */
 val LocalDisplayMetrics = staticCompositionLocalOf { DisplayMetrics.Comfort }
+
+/**
+ * Project CompositionLocal carrying the #332 « fold long quotes » reading preference. Same
+ * `staticCompositionLocalOf` rationale as [LocalDisplayMetrics]: the value changes only when the
+ * user flips the toggle, so the subtree recomposes once on change. Defaults to `true` (the
+ * historical fold) for previews / hosts that do not provide it; `RedfaceTheme` provides the
+ * resolved value from [ReadingDisplaySettings.foldLongQuotes].
+ */
+val LocalFoldLongQuotes = staticCompositionLocalOf { true }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/ReadingDisplaySettings.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/ReadingDisplaySettings.kt
@@ -15,4 +15,7 @@ import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 data class ReadingDisplaySettings(
     val density: DisplayDensity = DisplayDensity.COMFORT,
     val fontScale: FontScalePreference = FontScalePreference.M,
+    // #332 — whether a long top-level citation folds to a one-line header by default. `true`
+    // (default) keeps the historical fold; `false` disables it so a long quote renders expanded.
+    val foldLongQuotes: Boolean = true,
 )

--- a/core/ui/src/main/res/drawable/ic_arrow_back.xml
+++ b/core/ui/src/main/res/drawable/ic_arrow_back.xml
@@ -4,7 +4,13 @@
     android:viewportWidth="24"
     android:viewportHeight="24"
     android:autoMirrored="true">
+    <!-- #360 — tracé stroke unifié (ADR-015) : hampe + chevron en lignes, strokeWidth 2.5,
+         caps/joins ronds. Plus épais que l'ancien tracé fillColor (retour nicko « plus épaisse »),
+         et optiquement aligné avec ic_chevron_*/ic_edit. Tinté à l'usage. -->
     <path
-        android:fillColor="#FF000000"
-        android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8l8,8l1.41,-1.41L7.83,13H20v-2z" />
+        android:strokeColor="#FF000000"
+        android:strokeWidth="2.5"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M20,12 L4.5,12 M11.5,5 L4.5,12 L11.5,19" />
 </vector>

--- a/core/ui/src/main/res/drawable/ic_chevron_left.xml
+++ b/core/ui/src/main/res/drawable/ic_chevron_left.xml
@@ -4,13 +4,12 @@
     android:viewportWidth="24"
     android:viewportHeight="24"
     android:autoMirrored="true">
-    <!-- #360 — tracé stroke unifié (ADR-015) : chevron « › » en lignes, strokeWidth 2.5,
-         caps/joins ronds, même poids optique que ic_arrow_back/ic_chevron_left/ic_edit.
-         Tinté à l'usage. -->
+    <!-- #360 — tracé stroke unifié (ADR-015) : chevron « ‹ » en lignes, strokeWidth 2.5,
+         caps/joins ronds, miroir de ic_chevron_right, même poids optique que la famille. -->
     <path
         android:strokeColor="#FF000000"
         android:strokeWidth="2.5"
         android:strokeLineCap="round"
         android:strokeLineJoin="round"
-        android:pathData="M9,5 L16,12 L9,19" />
+        android:pathData="M15,5 L8,12 L15,19" />
 </vector>

--- a/core/ui/src/main/res/drawable/ic_edit.xml
+++ b/core/ui/src/main/res/drawable/ic_edit.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- #360 — tracé stroke unifié (ADR-015) : crayon « ✎ » en lignes, strokeWidth 2.5,
+         caps/joins ronds, même poids optique que ic_arrow_back/ic_chevron_*. Remplace le glyphe
+         texte ✎ des FAB « Répondre » (topic + thread MP). Tinté à l'usage. -->
+    <path
+        android:strokeColor="#FF000000"
+        android:strokeWidth="2.5"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M4,20 L4,16 L15,5 L19,9 L8,20 Z M13,7 L17,11" />
+</vector>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -10,7 +10,6 @@
     <string name="post_spoiler_show">(afficher)</string>
     <string name="post_spoiler_hide">(masquer)</string>
     <string name="post_inline_image_alt">[image]</string>
-    <string name="post_image_loading">Chargement…</string>
     <string name="post_image_error">Image indisponible</string>
     <string name="post_image_error_with_alt">Image indisponible — %1$s</string>
     <string name="post_image_open_link">Ouvrir l\'image</string>

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererInlineTest.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.core.ui.post
 
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.unit.sp
@@ -104,6 +105,54 @@ class PostRendererInlineTest {
                 annotated.inlineContentIds(),
             )
         }
+    }
+
+    @Test
+    fun `buildInlineText drops the author color span when ignoreColors is set (#553)`() {
+        val inlines = listOf(
+            PostInline.Color(
+                colorHex = "#FF0000",
+                children = listOf(PostInline.Text("rouge")),
+            ),
+        )
+
+        // Default (post bodies): the author colour is applied as a span.
+        val colored = buildInlineText(inlines, emptyLinkStyles, imageAlt = "img")
+        assertTrue(
+            "by default the author color is applied",
+            colored.spanStyles.any { it.item.color != Color.Unspecified },
+        )
+
+        // Signatures (#553): ignoreColors drops the author colour; the text survives and falls back
+        // to the caller's neutral colour (no specified-colour span left).
+        val neutral = buildInlineText(inlines, emptyLinkStyles, imageAlt = "img", ignoreColors = true)
+        assertEquals("the text content is preserved", "rouge", neutral.text)
+        assertFalse(
+            "with ignoreColors the author color span is dropped (#553 signatures)",
+            neutral.spanStyles.any { it.item.color != Color.Unspecified },
+        )
+
+        // Media nested inside an ignored colour still emits its placeholder: ignoreColors only drops
+        // the colour span, never the recursion, so the MediaCounter symmetry (AnnotatedString IDs ==
+        // inline-content map keys) holds (Codex review #553).
+        val withMedia = listOf(
+            PostInline.Color(
+                colorHex = "#00FF00",
+                children = listOf(
+                    PostInline.Text("vert "),
+                    PostInline.Smiley(
+                        kind = SmileyKind.Perso("rofl"),
+                        imageUrl = "https://forum-images.hardware.fr/images/perso/rofl.gif",
+                    ),
+                ),
+            ),
+        )
+        val neutralMedia = buildInlineText(withMedia, emptyLinkStyles, imageAlt = "img", ignoreColors = true)
+        assertEquals(
+            "media inside an ignored colour keeps its placeholder (MediaCounter symmetry)",
+            collectInlineMedia(withMedia).keys,
+            neutralMedia.inlineContentIds(),
+        )
     }
 
     @Test

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteDepthTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteDepthTest.kt
@@ -2,6 +2,8 @@ package fr.forumhfr.redface2.core.ui.post
 
 import fr.forumhfr.redface2.core.model.PostBlock
 import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.model.PostInline
+import fr.forumhfr.redface2.core.model.SmileyKind
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -95,5 +97,120 @@ class PostRendererQuoteDepthTest {
         assertEquals(QuoteAccentRole.SOURCED_ODD, quoteAccentRole(quoteDepth = 1, isBareQuote = false))
         assertEquals(QuoteAccentRole.SOURCED_EVEN, quoteAccentRole(quoteDepth = 2, isBareQuote = false))
         assertEquals(QuoteAccentRole.SOURCED_ODD, quoteAccentRole(quoteDepth = 3, isBareQuote = false))
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Issue #332 — long top-level quotes fold to one line by default (distinct from the #3 depth fold).
+    // The reveal/re-collapse interaction lives in the @Composable FoldableQuoteBlock; here we pin the
+    // pure decision (isLongQuote) and its length measure (quoteVisibleTextLength).
+    // ---------------------------------------------------------------------------------------------
+
+    private fun quoteOf(text: String, depthContent: PostContent? = null) = PostBlock.Quote(
+        author = "Lt Ripley",
+        numreponse = 1,
+        page = 1,
+        content = depthContent ?: PostContent(
+            blocks = listOf(PostBlock.Paragraph(inlines = listOf(PostInline.Text(text)))),
+        ),
+    )
+
+    @Test
+    fun `a short top-level quote stays expanded`() {
+        // The common "je cite la phrase à laquelle je réponds" case must never force a tap.
+        assertFalse(isLongQuote(quoteOf("Court extrait d'une phrase."), quoteDepth = 0))
+    }
+
+    @Test
+    fun `a long top-level quote folds by default`() {
+        val longText = "Mur de texte. ".repeat(40) // ~560 chars, well over the 280 budget
+        assertTrue(isLongQuote(quoteOf(longText), quoteDepth = 0))
+    }
+
+    @Test
+    fun `a long quote is never length-folded when nested`() {
+        // Nested quotes are governed by the depth rule + the parent fold; length-folding them too
+        // would stack two toggles on the same sub-tree, so isLongQuote is depth-0-only.
+        val longText = "Mur de texte. ".repeat(40)
+        assertFalse(isLongQuote(quoteOf(longText), quoteDepth = 1))
+        assertFalse(isLongQuote(quoteOf(longText), quoteDepth = 2))
+    }
+
+    @Test
+    fun `the fold threshold value stays at the documented budget`() {
+        assertEquals(
+            "Bumping LONG_QUOTE_CHAR_THRESHOLD changes which citations fold by default — keep it a " +
+                "deliberate review step.",
+            280,
+            LONG_QUOTE_CHAR_THRESHOLD,
+        )
+    }
+
+    @Test
+    fun `quoteVisibleTextLength counts text and line breaks across nested blocks`() {
+        val content = PostContent(
+            blocks = listOf(
+                PostBlock.Paragraph(
+                    inlines = listOf(
+                        PostInline.Text("abc"), // 3
+                        PostInline.LineBreak, // 1
+                        PostInline.Strong(listOf(PostInline.Text("de"))), // 2
+                    ),
+                ),
+                PostBlock.Quote(
+                    author = null,
+                    numreponse = null,
+                    page = null,
+                    content = PostContent(
+                        blocks = listOf(
+                            PostBlock.Paragraph(inlines = listOf(PostInline.Text("fghi"))), // 4
+                        ),
+                    ),
+                ),
+            ),
+        )
+        // 3 + 1 + 2 (paragraph) + 4 (nested quote) + 1 (separator between the 2 top-level blocks).
+        assertEquals(3 + 1 + 2 + 4 + 1, quoteVisibleTextLength(content))
+    }
+
+    @Test
+    fun `quoteVisibleTextLength excludes the hidden spoiler body`() {
+        // A short quote wrapping a long spoiler must NOT fold: the spoiler body is hidden behind its
+        // own toggle, so it adds no visible reading length (Codex review).
+        val longSpoiler = "x".repeat(LONG_QUOTE_CHAR_THRESHOLD + 50)
+        val content = PostContent(
+            blocks = listOf(
+                PostBlock.Paragraph(inlines = listOf(PostInline.Text("ab"))), // 2
+                PostBlock.Spoiler(
+                    label = null,
+                    content = PostContent(
+                        blocks = listOf(
+                            PostBlock.Paragraph(inlines = listOf(PostInline.Text(longSpoiler))),
+                        ),
+                    ),
+                ), // 0 — hidden body excluded
+            ),
+        )
+        // 2 (paragraph) + 0 (spoiler) + 1 (block boundary) = 3, far under the fold threshold.
+        assertEquals(3, quoteVisibleTextLength(content))
+    }
+
+    @Test
+    fun `quoteVisibleTextLength ignores smileys and inline images`() {
+        // A smiley-heavy or image-heavy short citation is not "long reading" and must not fold.
+        val content = PostContent(
+            blocks = listOf(
+                PostBlock.Paragraph(
+                    inlines = listOf(
+                        PostInline.Smiley(
+                            kind = SmileyKind.Builtin(":lol:"),
+                            imageUrl = "https://forum-images.hardware.fr/images/perso/x.gif",
+                        ),
+                        PostInline.InlineImage(url = "https://example.com/x.png", description = null),
+                        PostInline.Text("ok"), // only this counts → 2
+                    ),
+                ),
+            ),
+        )
+        assertEquals(2, quoteVisibleTextLength(content))
     }
 }

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteRoborazziTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteRoborazziTest.kt
@@ -142,6 +142,33 @@ class PostRendererQuoteRoborazziTest {
         )
     }
 
+    /**
+     * Issue #332 — a "long" top-level citation folds to a single header line by default ("longues
+     * citations repliées sur une ligne, dépliables au clic puis repliables"). This captures the
+     * default *folded* state: the framed quote shows only its "Citation de X" header + the
+     * "(afficher)" affordance, and the wall-of-text body is hidden until tapped.
+     */
+    @Test
+    fun postRendererLongQuoteFoldedLight() {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                Surface(color = MaterialTheme.colorScheme.surface) {
+                    Box(
+                        modifier = Modifier
+                            .width(360.dp)
+                            .background(MaterialTheme.colorScheme.surface)
+                            .padding(16.dp),
+                    ) {
+                        PostRenderer(content = longQuoteContent())
+                    }
+                }
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage(
+            filePath = "build/outputs/roborazzi/post_renderer_long_quote_folded_light.png",
+        )
+    }
+
     @androidx.compose.runtime.Composable
     private fun AmoledHost(content: @androidx.compose.runtime.Composable () -> Unit) {
         RedfaceTheme(
@@ -227,6 +254,33 @@ class PostRendererQuoteRoborazziTest {
                     blocks = listOf(paragraph("Granfondo : épreuve cyclosportive de longue distance.")),
                 ),
             ),
+        ),
+    )
+
+    private fun longQuoteContent(): PostContent = PostContent(
+        blocks = listOf(
+            paragraph("Je réponds à un très long pavé :"),
+            PostBlock.Quote(
+                author = "XaTriX",
+                numreponse = 74749781,
+                page = 8270,
+                content = PostContent(
+                    blocks = listOf(
+                        paragraph(
+                            "Voilà un mur de texte volontairement très long pour dépasser le " +
+                                "seuil de repli automatique des citations (issue #332). " +
+                                "On répète quelques phrases afin de simuler une citation " +
+                                "interminable qu'un lecteur préfère replier par défaut puis " +
+                                "déplier au clic si le contexte l'intéresse vraiment.",
+                        ),
+                        paragraph(
+                            "Deuxième paragraphe tout aussi bavard, histoire de bien franchir " +
+                                "le budget de caractères et de rendre le repli pertinent.",
+                        ),
+                    ),
+                ),
+            ),
+            paragraph("Bref, replié par défaut c'est plus lisible."),
         ),
     )
 

--- a/docs/adr/015-iconographie-boutons-icones.md
+++ b/docs/adr/015-iconographie-boutons-icones.md
@@ -1,0 +1,85 @@
+---
+title: ADR-015
+parent: ADRs
+grand_parent: Spécifications
+nav_order: 15
+permalink: /adr/015-iconographie-boutons-icones
+---
+
+# ADR-015 — Iconographie des boutons-icônes : vector drawables stroke locaux, pas de Material icons
+
+## Statut
+
+Accepté — 2026-06-16
+
+## Contexte
+
+Les boutons-icônes de l'app (flèche retour des top bars, chevrons de page « ‹ »/« › »,
+crayon « répondre ») étaient initialement des **glyphes texte** (`Text("←")`, `Text("✎")`…).
+Leur taille dépendait de la **police système, de la baseline et du font-scale** : rendu
+incohérent selon l'appareil, jamais aligné optiquement sur le titre voisin (cf. #355/#356/#357).
+
+La flèche retour a été corrigée la première (PR #357) en **vector drawable local
+(`ic_arrow_back.xml`) dimensionné en dp** et rendu via `material3 Icon`. Les autres
+boutons-icônes (chevrons `PageFab`, crayon `ReplyFab` topic + thread MP) souffraient encore
+du même défaut (#360).
+
+Contrainte structurante : `config/detekt/detekt.yml` interdit `androidx.compose.material.*`
+(règle `ForbiddenImport`) → **pas d'`Icons.*` Material** (ni widgets material1, ni
+material-icons). C'est précisément pourquoi la flèche est un vector dessiné à la main et non
+un `Icons.AutoMirrored.Filled.ArrowBack`.
+
+Retour communautaire (nicko) : la flèche vectorielle était jugée **trop fine** (« plus
+épaisse »). La passe d'uniformisation doit donc aussi corriger le **poids optique**, pas
+seulement le pattern.
+
+## Décision
+
+**Tous les boutons-icônes utilisent des vector drawables locaux (`:core:ui/res/drawable`),
+tracés en _stroke_, dimensionnés en dp, rendus via un primitive partagé.** Pas de Material
+icons.
+
+Convention de tracé (famille homogène) :
+- viewport `24×24` ;
+- tracé en **`strokeColor` / `strokeWidth="2.5"`** (pas de `fillColor`), `strokeLineCap` et
+  `strokeLineJoin` **`round`** ;
+- `android:autoMirrored="true"` pour les icônes directionnelles (flèche, chevrons) ;
+- `fillColor`/`strokeColor` neutre `#FF000000`, **tinté à l'usage** (`LocalContentColor`).
+
+Le `strokeWidth` 2.5 donne un trait **plus épais** que l'ancien `ic_arrow_back` en `fillColor`
+(retour nicko) et un poids identique d'une icône à l'autre.
+
+Primitive partagé : **`RedfaceVectorIcon`** (`:core:ui`, package `core.ui.icon`) encapsule
+`material3 Icon` + `painterResource` + la taille canonique (`RedfaceIconDefaults.Size = 24.dp`)
++ le contrat a11y (icône **décorative**, `contentDescription` porté par le conteneur cliquable
+`IconButton`/`*FloatingActionButton`). Tout nouveau bouton-icône passe par ce primitive.
+
+Drawables de la famille : `ic_arrow_back`, `ic_chevron_left`, `ic_chevron_right`, `ic_edit`
+(les `ic_ms_*` Material Symbols préexistants restent du `fillColor`, voir Conséquences).
+
+## Conséquences
+
+- un seul endroit définit taille en dp + a11y des boutons-icônes (`RedfaceVectorIcon`) ;
+- les écrans `topic` (flèche retour, `PageFab`, `ReplyFab`) et `messages` (flèche retour,
+  FAB répondre) consomment le primitive ; les chevrons `‹/›` et crayons `✎` ne sont plus des
+  glyphes texte ;
+- `ic_arrow_back` et `ic_chevron_right` passent de `fillColor` à `stroke` : leur rendu change
+  partout où ils servent (settings, recherche, profil, éditeur MP), mais reste un chevron /
+  une flèche, plus épais et cohérent — c'est l'effet recherché ;
+- coût : maintenir les drawables à la main (pas de dépendance `material-icons`, dont c'était
+  l'objectif de la règle detekt) ;
+- les icônes denses préexistantes (`ic_ms_*`, Material Symbols recadrés grille 960, p.ex.
+  `ic_ms_edit_square` du shell réglages #494) ne sont **pas** retracées en stroke : ce sont des
+  pictogrammes pleins, pas des boutons-icônes simples ; elles peuvent toujours passer par
+  `RedfaceVectorIcon` pour la taille/a11y.
+
+## Alternatives considérées
+
+- **Whitelister `androidx.compose.material.icons.*` dans `ForbiddenImport`** : donnerait
+  `Icons.*` standard, zéro drawable à maintenir, mais assouplit une règle posée volontairement
+  (éviter la dépendance `material-icons` et son poids) — rejeté, on garde la règle.
+- **Garder les glyphes texte mais forcer la taille en dp** (`Box` fixe / `fontSize` en sp) :
+  le tracé reste police-dépendant et le poids n'est pas maîtrisable — rejeté.
+- **`fillColor` (Material filled) plutôt que `stroke`** : c'était l'état initial de
+  `ic_arrow_back`, jugé trop fin par la communauté — le stroke à largeur explicite résout le
+  retour nicko et homogénéise le poids.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,3 +42,4 @@ Les numéros `004` à `007` sont volontairement laissés libres pour des décisi
 | [ADR-012]({{ site.baseurl }}/adr/012-credentials-proxy) | Credentials proxy : extension d'Option A |
 | [ADR-013]({{ site.baseurl }}/adr/013-mp-lecture-cache-prefetch) | Lecture MP : partage topic↔MP, cache à trois étages, prefetch borné |
 | [ADR-014]({{ site.baseurl }}/adr/014-mpstorage-v01-de-facto) | MPStorage : enveloppe v0.1 de facto, lecture d'abord, écriture différée |
+| [ADR-015]({{ site.baseurl }}/adr/015-iconographie-boutons-icones) | Iconographie des boutons-icônes : vector drawables stroke locaux, primitive `RedfaceVectorIcon` |

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -1994,6 +1994,10 @@ class PostEditorViewModelTest {
 
         override suspend fun setTopicSignatures(enabled: Boolean) = Unit
 
+        override fun observeFoldLongQuotes(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setFoldLongQuotes(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -1990,6 +1990,10 @@ class PostEditorViewModelTest {
 
         override suspend fun setTopicPollsExpanded(enabled: Boolean) = Unit
 
+        override fun observeTopicSignatures(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setTopicSignatures(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -2026,6 +2026,10 @@ class PostEditorViewModelTest {
         override fun observeFontScale(): Flow<FontScalePreference> = MutableStateFlow(FontScalePreference.M)
 
         override suspend fun setFontScale(scale: FontScalePreference) = Unit
+
+        override fun observeDebugBoundsOverlay(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setDebugBoundsOverlay(enabled: Boolean) = Unit
     }
 
     /**

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1394,6 +1394,10 @@ class TopicFormViewModelTest {
 
         override suspend fun setTopicSignatures(enabled: Boolean) = Unit
 
+        override fun observeFoldLongQuotes(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setFoldLongQuotes(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1423,6 +1423,10 @@ class TopicFormViewModelTest {
         override fun observeFontScale(): Flow<FontScalePreference> = MutableStateFlow(FontScalePreference.M)
 
         override suspend fun setFontScale(scale: FontScalePreference) = Unit
+
+        override fun observeDebugBoundsOverlay(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setDebugBoundsOverlay(enabled: Boolean) = Unit
     }
 
     /** #405 — in-memory fake [EditorDraftStore], same shape as the one in `PostEditorViewModelTest`. */

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1390,6 +1390,10 @@ class TopicFormViewModelTest {
 
         override suspend fun setTopicPollsExpanded(enabled: Boolean) = Unit
 
+        override fun observeTopicSignatures(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setTopicSignatures(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -50,6 +50,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -140,6 +141,31 @@ fun FlagsRoute(
         tabUnreadFilter = tabUnreadFilter,
         listState = flagsListState,
     )
+
+    // #546 — recall the list to the top after a LANDING auto-refresh (app open / tab switch /
+    // resume): the refresh prepends freshly-surfaced flags and a held scroll position would leave
+    // them off-screen (« faut scroller vers le haut », tinc/Lt Ripley). Driven by a one-shot
+    // ViewModel signal (consumed once handled) rather than a replayable counter, so a rotation /
+    // route recreation does not replay a stale scroll. Return-from-topic refreshes never raise it.
+    val recallListToTop by viewModel.recallListToTop.collectAsStateWithLifecycle()
+    LaunchedEffect(recallListToTop) {
+        if (recallListToTop) {
+            // requestScrollToItem (not scrollToItem) pins index 0 on the next remeasure ignoring the
+            // key-based position restoration — without that, when the refresh prepends freshly-
+            // surfaced flags the old top row stays anchored and the new rows sit above the viewport
+            // (the original #546 bug). But the request is honoured per-remeasure and is NOT durable:
+            // the refreshed list can land a frame later (repository SharedFlow → combine/flatMapLatest
+            // defers the final emission), and a remeasure that ran first on the old list would consume
+            // the request before the prepend. So re-assert it across a few frames — the top then wins
+            // whichever frame the new list lands on. Bounded so a no-change landing still disarms the
+            // signal (no replay on rotation/recreation). Codex review #546.
+            repeat(RECALL_TO_TOP_FRAMES) {
+                flagsListState.requestScrollToItem(0)
+                withFrameNanos { }
+            }
+            viewModel.consumeRecallListToTop()
+        }
+    }
 
     // #309 — display-settings bottom sheet. Opened from the header « Affichage » action; the trigger
     // is only offered when there is a real list to configure (authenticated AND a real FlagType tab,
@@ -773,6 +799,13 @@ private fun FilterFlipScrollResetEffect(
         }
     }
 }
+
+// #546 — number of consecutive frames over which the « recall to top » scroll is re-asserted after a
+// landing auto-refresh. requestScrollToItem is per-remeasure and not durable, while the refreshed list
+// can land a frame or two after the signal (repository SharedFlow → combine/flatMapLatest), so a small
+// window covers the prepend whichever frame it arrives on. Three is generous for an in-memory emission
+// and the loop always terminates, so the one-shot signal is always consumed (no rotation replay).
+private const val RECALL_TO_TOP_FRAMES = 3
 
 // LazyColumn contentType tags (#179 compose-perf): one reuse pool per structurally distinct slot
 // kind so Compose recycles like-for-like across the header→row→header alternation of the grouped

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -382,6 +382,24 @@ class FlagsViewModel @Inject constructor(
     val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
 
     /**
+     * #546 — one-shot signal raised when a LANDING auto-refresh commits (app open, tab switch,
+     * resume) so the screen can recall the list to the top. An auto-refresh prepends freshly-surfaced
+     * flags; a held [androidx.compose.foundation.lazy.LazyListState] would otherwise leave those new
+     * top rows scrolled off-screen, the « faut scroller vers le haut » beta report (tinc, Lt Ripley).
+     * A return-from-topic refresh is deliberately EXCLUDED so the reader keeps their place in the list
+     * they were browsing.
+     *
+     * Modelled as a **consumable** boolean (set on the landing refresh, reset by
+     * [consumeRecallListToTop] once the screen has scrolled), exactly like [removeFlagEvent] — NOT a
+     * replayable counter. A counter's latest value re-arms a brand-new collector, so a rotation or a
+     * route recreation would replay the last scroll-to-top with no fresh refresh behind it (Codex
+     * review #546); a consumed `false` is inert on re-subscription, and an un-consumed `true` survives
+     * the recreation as a genuine still-pending scroll.
+     */
+    private val _recallListToTop = MutableStateFlow(false)
+    val recallListToTop: StateFlow<Boolean> = _recallListToTop.asStateFlow()
+
+    /**
      * Tab selection. Re-tapping [FlagTab.Cyan] while it is **already** selected toggles its
      * « non-lus uniquement » filter (show / hide the already-read participated topics) — the « +lus »
      * shortcut, inline replacement for the former « Cyans lus » FilterChip. Selecting Cyan from
@@ -442,6 +460,11 @@ class FlagsViewModel @Inject constructor(
     /** Consume the one-shot removal event after the snackbar has been shown. */
     fun consumeRemoveFlagEvent() {
         _removeFlagEvent.value = null
+    }
+
+    /** Consume the one-shot « recall to top » signal once the screen has scrolled (#546). */
+    fun consumeRecallListToTop() {
+        _recallListToTop.value = false
     }
 
     /**
@@ -588,6 +611,11 @@ class FlagsViewModel @Inject constructor(
             _isRefreshing.value = true
             try {
                 flagRepository.refresh(type)
+                // #546 — a genuine landing / tab-switch / resume refresh: recall the list to the top
+                // so the freshly prepended flags are visible. A return-from-topic refresh keeps the
+                // reader's current position (it is not a fresh landing). One-shot signal, consumed by
+                // the screen — see [recallListToTop].
+                if (!returningFromTopic) _recallListToTop.value = true
             } finally {
                 _isRefreshing.value = false
             }

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1676,5 +1676,9 @@ class FlagsViewModelTest {
         override fun observeFontScale(): Flow<FontScalePreference> = MutableStateFlow(FontScalePreference.M)
 
         override suspend fun setFontScale(scale: FontScalePreference) = Unit
+
+        override fun observeDebugBoundsOverlay(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setDebugBoundsOverlay(enabled: Boolean) = Unit
     }
 }

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1614,6 +1614,10 @@ class FlagsViewModelTest {
 
         override suspend fun setTopicPollsExpanded(enabled: Boolean) = Unit
 
+        override fun observeTopicSignatures(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setTopicSignatures(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1156,6 +1156,37 @@ class FlagsViewModelTest {
     }
 
     @Test
+    fun `maybeAutoRefresh recalls the list to the top on a landing refresh (#546)`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)
+        val vm = viewModel(auth, flags, FakeForumRepository())
+
+        vm.maybeAutoRefresh()
+        assertTrue(vm.recallListToTop.value)
+
+        // One-shot: consuming it disarms the signal so a recomposition / rotation cannot replay the
+        // scroll with no fresh refresh behind it (Codex review #546).
+        vm.consumeRecallListToTop()
+        assertFalse(vm.recallListToTop.value)
+    }
+
+    @Test
+    fun `a return-from-topic auto-refresh does not recall the list to the top (#546)`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)
+        val clock = SteppingClock(Instant.parse("2026-06-11T12:00:00Z"))
+        val vm = FlagsViewModel(auth, flags, FakeForumRepository(), FakeUserPreferencesRepository(), clock)
+
+        vm.maybeAutoRefresh() // landing refresh → raises the signal
+        vm.consumeRecallListToTop() // screen scrolled and consumed it
+        vm.onFlagOpened() // user opens a topic…
+        vm.maybeAutoRefresh() // …and returns (throttle bypassed): refreshes but must NOT re-raise
+
+        assertEquals(2, flags.refreshCalls.size)
+        assertFalse(vm.recallListToTop.value)
+    }
+
+    @Test
     fun `maybeAutoRefresh honours the Settings opt-out`() = runTest {
         val flags = FakeFlagRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1618,6 +1618,10 @@ class FlagsViewModelTest {
 
         override suspend fun setTopicSignatures(enabled: Boolean) = Unit
 
+        override fun observeFoldLongQuotes(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setFoldLongQuotes(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
@@ -54,6 +54,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.SubCategory
 import fr.forumhfr.redface2.core.model.TopicSummary
+import fr.forumhfr.redface2.core.ui.FlagMetadata
+import fr.forumhfr.redface2.core.ui.TopicMetadataLine
 import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.formatLastReplyTimestamp
 import fr.forumhfr.redface2.core.ui.theme.FlagPalette
@@ -454,18 +456,21 @@ private fun TopicRow(
                 fontWeight = if (topic.hasUnread == true) FontWeight.SemiBold else FontWeight.Normal,
                 maxLines = 2,
             )
-            Text(
-                text = stringResource(
-                    R.string.category_topic_metadata,
-                    topic.author,
-                    topic.lastReplyAuthor,
-                    formatLastReplyTimestamp(topic.lastReplyAt),
-                    topic.replyCount,
-                    topic.totalPages,
+            // #376 — common two-segment metadata line: `par <auteur> · N rép. · N p.` (left,
+            // truncatable) + the last-reply timestamp pinned right and never truncated. Matches
+            // the drapeaux template; the search list uses the same TopicMetadataLine.
+            TopicMetadataLine(
+                metadata = FlagMetadata(
+                    start = stringResource(
+                        R.string.category_topic_metadata,
+                        topic.author,
+                        topic.replyCount,
+                        topic.totalPages,
+                    ),
+                    end = formatLastReplyTimestamp(topic.lastReplyAt),
                 ),
                 style = MaterialTheme.typography.labelSmall,
                 color = metadataColor,
-                maxLines = 1,
             )
             if (topic.isSticky || topic.isLocked) {
                 Text(

--- a/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
+++ b/feature/forum/src/main/kotlin/fr/forumhfr/redface2/feature/forum/ForumCategoryScreen.kt
@@ -14,8 +14,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -35,7 +37,9 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -79,6 +83,16 @@ fun ForumCategoryScreen(
     )
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
+    // #482 — hoisted so the FAB can collapse to icon-only once the listing is scrolled
+    // (Azgor: the extended FAB is "presque envahissant"). Shared with the LazyColumn below.
+    val listState = rememberLazyListState()
+    // Expanded only while resting at the very top; any scroll shrinks it out of the way.
+    val fabExpanded by remember {
+        derivedStateOf {
+            listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
+        }
+    }
+
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         containerColor = MaterialTheme.colorScheme.surface,
@@ -86,6 +100,7 @@ fun ForumCategoryScreen(
             if (state.canCreateTopic) {
                 ExtendedFloatingActionButton(
                     onClick = { onCreateTopic(state.cat, state.selectedSubcat) },
+                    expanded = fabExpanded,
                     text = { Text(text = stringResource(R.string.category_create_topic)) },
                     icon = { Text(text = "+") },
                 )
@@ -142,6 +157,7 @@ fun ForumCategoryScreen(
             ) {
                 TopicsBody(
                     state = activeTopics,
+                    listState = listState,
                     filteredTopics = state.filteredTopics,
                     searchQuery = state.searchQuery,
                     onOpenTopic = onOpenTopic,
@@ -282,6 +298,7 @@ private fun SubcategoryChips(
 @Composable
 private fun TopicsBody(
     state: TopicsUiState,
+    listState: LazyListState,
     filteredTopics: List<TopicSummary>,
     searchQuery: String,
     onOpenTopic: (TopicSummary) -> Unit,
@@ -333,7 +350,7 @@ private fun TopicsBody(
             // The PagerRow always shows the underlying `state.page` total — a search
             // filter only narrows the visible rows in the current page; switching
             // page or subcat is what actually re-fetches.
-            LazyColumn(modifier = Modifier.fillMaxWidth()) {
+            LazyColumn(state = listState, modifier = Modifier.fillMaxWidth()) {
                 if (filteredTopics.isEmpty()) {
                     item { TopicsEmpty(searchQuery = searchQuery) }
                 } else {

--- a/feature/forum/src/main/res/values/strings.xml
+++ b/feature/forum/src/main/res/values/strings.xml
@@ -12,7 +12,9 @@
     <string name="category_filter_all">Toutes</string>
     <string name="category_subcategories_error">Sous-catégories indisponibles</string>
     <string name="category_topics_error">Topics indisponibles</string>
-    <string name="category_topic_metadata">par %1$s · dernier %2$s · %3$s · %4$d réponses · %5$d pages</string>
+    <!-- #376 — segment gauche tronquable de la ligne de métadonnées (la date est alignée à
+         droite, jamais tronquée, cf. le gabarit commun des trois listes). -->
+    <string name="category_topic_metadata">par %1$s · %2$d rép. · %3$d p.</string>
     <!-- #206 — stateDescription a11y sur la ligne du topic fraîchement créé mise en évidence. -->
     <string name="category_topic_new_highlight">Sujet que vous venez de créer</string>
     <string name="category_badge_sticky">Épinglé</string>

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
@@ -19,7 +18,6 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -39,7 +37,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -51,6 +48,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.model.Post
 import fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar
 import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
+import fr.forumhfr.redface2.core.ui.icon.RedfaceVectorIcon
 import fr.forumhfr.redface2.core.ui.list.LazyListScrollbar
 import fr.forumhfr.redface2.core.ui.pager.pageSwipeEdgeHint
 import fr.forumhfr.redface2.core.ui.post.PostRenderer
@@ -148,12 +146,11 @@ fun PrivateMessageThreadScreen(
                         onClick = onBack,
                         modifier = Modifier.semantics { contentDescription = backLabel },
                     ) {
-                        // dp-sized vector instead of a text « ← » glyph (font/baseline-dependent, cf.
-                        // Codex review). a11y label on the IconButton; the icon is decorative.
-                        Icon(
-                            painter = painterResource(fr.forumhfr.redface2.core.ui.R.drawable.ic_arrow_back),
-                            contentDescription = null,
-                            modifier = Modifier.size(24.dp),
+                        // #360 / ADR-015 — vector stroke unifié, dimensionné en dp (indépendant de la
+                        // police et de la baseline, contrairement au glyphe « ← »), via le primitive
+                        // partagé :core:ui. a11y label sur l'IconButton ; l'icône est décorative.
+                        RedfaceVectorIcon(
+                            resId = fr.forumhfr.redface2.core.ui.R.drawable.ic_arrow_back,
                         )
                     }
                 },
@@ -169,7 +166,12 @@ fun PrivateMessageThreadScreen(
                 val replyLabel = stringResource(R.string.messages_reply)
                 ExtendedFloatingActionButton(
                     text = { Text(replyLabel) },
-                    icon = { Text("✎") },
+                    // #360 / ADR-015 — crayon en vector stroke unifié via le primitive :core:ui,
+                    // à la place du glyphe « ✎ » (poids optique aligné sur la flèche retour / les
+                    // chevrons). Pas de Material icons (detekt ForbiddenImport).
+                    icon = {
+                        RedfaceVectorIcon(resId = fr.forumhfr.redface2.core.ui.R.drawable.ic_edit)
+                    },
                     onClick = { onReply(request.threadId, state.page) },
                 )
             }

--- a/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -54,6 +55,8 @@ import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.model.search.SearchPivotCategory
 import fr.forumhfr.redface2.core.model.search.SearchTextScope
 import fr.forumhfr.redface2.core.model.search.SearchTopicResult
+import fr.forumhfr.redface2.core.ui.FlagMetadata
+import fr.forumhfr.redface2.core.ui.TopicMetadataLine
 import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.formatLastReplyTimestamp
 
@@ -542,21 +545,23 @@ private fun SearchResultCard(result: SearchTopicResult, onClick: () -> Unit) {
                     overflow = TextOverflow.Ellipsis,
                 )
             }
-            Text(
-                text = stringResource(R.string.search_result_author, result.author),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Text(
-                text = stringResource(R.string.search_result_replies, result.replyCount, result.viewCount),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Text(
-                text = stringResource(
-                    R.string.search_result_last_reply,
-                    formatLastReplyTimestamp(result.lastReplyAt),
-                    result.lastReplyAuthor,
+            // #376 — common two-segment metadata line, shared with the drapeaux / catégorie
+            // lists: `par <auteur> · N rép. · N vues` (left, truncatable; search has no
+            // pagination so view count takes the page slot) + the last-reply timestamp pinned
+            // right and never truncated.
+            TopicMetadataLine(
+                metadata = FlagMetadata(
+                    start = stringResource(
+                        R.string.search_result_metadata,
+                        result.author,
+                        result.replyCount,
+                        pluralStringResource(
+                            R.plurals.search_result_views,
+                            result.viewCount,
+                            result.viewCount,
+                        ),
+                    ),
+                    end = formatLastReplyTimestamp(result.lastReplyAt),
                 ),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/feature/search/src/main/res/values/strings.xml
+++ b/feature/search/src/main/res/values/strings.xml
@@ -26,8 +26,14 @@
     <string name="search_pivot_hint">HFR affiche les topics d’une catégorie à la fois. Choisir une catégorie relance la même recherche dans ce périmètre.</string>
     <string name="search_result_location">dans %1$s</string>
     <string name="search_result_excerpt">Extrait : %1$s</string>
-    <string name="search_result_replies">%1$d réponses · %2$d vues</string>
-    <string name="search_result_author">par %1$s</string>
-    <string name="search_result_last_reply">Dernier message %1$s par %2$s</string>
+    <!-- #376 — segment gauche tronquable de la ligne de métadonnées commune aux trois listes
+         (la recherche n'expose pas de pagination, donc N pages est remplacé par N vues). La date
+         du dernier message est alignée à droite, jamais tronquée. -->
+    <string name="search_result_metadata">par %1$s · %2$d rép. · %3$s</string>
+    <!-- « vues » (vue complète, pas une abréviation) doit s'accorder : 1 vue / N vues. -->
+    <plurals name="search_result_views">
+        <item quantity="one">%d vue</item>
+        <item quantity="other">%d vues</item>
+    </plurals>
     <string name="search_result_locked">Verrouillé</string>
 </resources>

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsMaintenanceScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsMaintenanceScreen.kt
@@ -44,6 +44,10 @@ fun SettingsMaintenanceScreen(
     onOpenDiagnostics: () -> Unit,
     onOpenMpStorageInspector: () -> Unit,
     modifier: Modifier = Modifier,
+    // #445 — debug bounds overlay row visibility. `:feature:settings` does not own the `:app`
+    // BuildConfig, so the dev-channel gate is computed in `:app` and passed in (same approach as the
+    // version surfaced on the About screen). Defaults to false so a non-dev caller never shows it.
+    debugOverlayAvailable: Boolean = false,
     topBarActions: @Composable (() -> Unit)? = null,
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
@@ -122,6 +126,12 @@ fun SettingsMaintenanceScreen(
             }
 
             IgnoreTopicCacheRow(state = state, onIntent = viewModel::submit)
+
+            // #445 — debug bounds overlay. Dev-channel only: the row is composed solely when the
+            // `:app` flavor gate ([debugOverlayAvailable]) is true, so prod/beta never see it.
+            if (debugOverlayAvailable) {
+                DebugBoundsOverlayRow(state = state, onIntent = viewModel::submit)
+            }
 
             HorizontalDivider()
             RedfaceSettingsListItem(
@@ -221,6 +231,48 @@ private fun IgnoreTopicCacheRow(
     }
     if (state.ignoreTopicCacheError) {
         PreferencePersistError(R.string.settings_ignore_topic_cache_persist_failed)
+    }
+}
+
+/**
+ * #445 — « Surligner les bounds des composants » switch (dev channel only). Mirrors [IgnoreTopicCacheRow]
+ * exactly (title + description + gated Switch + inline persist error). The dev-channel gate lives at the
+ * call site ([SettingsMaintenanceScreen]'s `debugOverlayAvailable`), so this row is simply not composed
+ * off dev.
+ */
+@Composable
+private fun DebugBoundsOverlayRow(
+    state: SettingsState,
+    onIntent: (SettingsIntent) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_debug_bounds_overlay_title),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = stringResource(R.string.settings_debug_bounds_overlay_description),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Switch(
+            checked = state.debugBoundsOverlay,
+            enabled = state.canToggleDebugBoundsOverlay,
+            onCheckedChange = { onIntent(SettingsIntent.DebugBoundsOverlayChanged(it)) },
+        )
+    }
+    if (state.debugBoundsOverlayError) {
+        PreferencePersistError(R.string.settings_debug_bounds_overlay_persist_failed)
     }
 }
 

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -510,6 +510,16 @@ internal fun buildSettingsCatalogue(
                     .takeIf { state.topicPollsExpandedError },
                 onCheckedChange = { onIntent(SettingsIntent.TopicPollsExpandedChanged(it)) },
             ),
+            toggleRow(
+                id = "topic_signatures",
+                title = stringResource(R.string.settings_topic_signatures_title),
+                description = stringResource(R.string.settings_topic_signatures_description),
+                checked = state.topicSignatures,
+                enabled = state.canToggleTopicSignatures,
+                errorRes = R.string.settings_topic_signatures_persist_failed
+                    .takeIf { state.topicSignaturesError },
+                onCheckedChange = { onIntent(SettingsIntent.TopicSignaturesChanged(it)) },
+            ),
             futureRow(
                 id = "future_restore_read_position",
                 title = stringResource(R.string.settings_future_restore_read_position),

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -520,6 +520,17 @@ internal fun buildSettingsCatalogue(
                     .takeIf { state.topicSignaturesError },
                 onCheckedChange = { onIntent(SettingsIntent.TopicSignaturesChanged(it)) },
             ),
+            // #332 — replaces the former `future_collapse_quotes` placeholder, now shipped.
+            toggleRow(
+                id = "fold_long_quotes",
+                title = stringResource(R.string.settings_fold_long_quotes_title),
+                description = stringResource(R.string.settings_fold_long_quotes_description),
+                checked = state.foldLongQuotes,
+                enabled = state.canToggleFoldLongQuotes,
+                errorRes = R.string.settings_fold_long_quotes_persist_failed
+                    .takeIf { state.foldLongQuotesError },
+                onCheckedChange = { onIntent(SettingsIntent.FoldLongQuotesChanged(it)) },
+            ),
             futureRow(
                 id = "future_restore_read_position",
                 title = stringResource(R.string.settings_future_restore_read_position),
@@ -527,10 +538,6 @@ internal fun buildSettingsCatalogue(
             futureRow(
                 id = "future_swipe_page",
                 title = stringResource(R.string.settings_future_swipe_page),
-            ),
-            futureRow(
-                id = "future_collapse_quotes",
-                title = stringResource(R.string.settings_future_collapse_quotes),
             ),
             futureRow(
                 id = "future_prefetch",

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -41,6 +41,13 @@ data class SettingsState(
      * later and overwrite the optimistic flip with a stale snapshot. Never surfaced in the UI.
      */
     val ignoreTopicCacheTouchedLocally: Boolean = false,
+    // #445 — debug bounds overlay toggle (dev-channel only; the channel gate is in the screen, which
+    // hides the row off dev). Same optimistic-flip + startup-race-guard machinery as ignoreTopicCache.
+    // Default false (the overlay is opt-in even on dev).
+    val debugBoundsOverlay: Boolean = false,
+    val isUpdatingDebugBoundsOverlay: Boolean = false,
+    val debugBoundsOverlayError: Boolean = false,
+    val debugBoundsOverlayTouchedLocally: Boolean = false,
     // Drapeaux view preferences (#179 follow-up). Same optimistic-flip + startup-race-guard
     // machinery as ignoreTopicCache: the field is the displayed value, `isUpdating*` gates the
     // switch while DataStore writes, `*Error` surfaces a persist failure, and `*TouchedLocally`
@@ -172,6 +179,10 @@ data class SettingsState(
     val canToggleIgnoreTopicCache: Boolean
         get() = !isUpdatingIgnoreTopicCache
 
+    // #445 — the debug bounds overlay toggle is gated only by its own in-flight write.
+    val canToggleDebugBoundsOverlay: Boolean
+        get() = !isUpdatingDebugBoundsOverlay
+
     val canToggleFlagsGroupByCategory: Boolean
         get() = !isUpdatingFlagsGroupByCategory
 
@@ -286,6 +297,10 @@ sealed interface SettingsIntent {
     // ViewModel applies it optimistically, then reverts on DataStore failure so the UI never
     // shows a value that doesn't match what's persisted.
     data class IgnoreTopicCacheChanged(val enabled: Boolean) : SettingsIntent
+
+    // #445 — debug bounds overlay toggle (dev only). Same optimistic-flip contract: the boolean is
+    // the desired post-flip state.
+    data class DebugBoundsOverlayChanged(val enabled: Boolean) : SettingsIntent
 
     // Drapeaux view preferences (#179 follow-up). Same optimistic-flip contract as
     // IgnoreTopicCacheChanged: the boolean is the desired post-flip state.

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -99,6 +99,12 @@ data class SettingsState(
     val isUpdatingTopicPollsExpanded: Boolean = false,
     val topicPollsExpandedError: Boolean = false,
     val topicPollsExpandedTouchedLocally: Boolean = false,
+    // #330 — afficher les signatures sous les posts. Même machinerie optimistic-flip + garde de
+    // course au démarrage. Default FALSE (masquées) : les signatures sont bruyantes, donc opt-in.
+    val topicSignatures: Boolean = false,
+    val isUpdatingTopicSignatures: Boolean = false,
+    val topicSignaturesError: Boolean = false,
+    val topicSignaturesTouchedLocally: Boolean = false,
     // Publishing preferences (#312). Same optimistic-flip + startup-race-guard machinery:
     // `confirmBeforePosting` is the displayed value, `isUpdating*` gates the switch while DataStore
     // writes, `*Error` surfaces a persist failure, `*TouchedLocally` forbids a late `init` hydration
@@ -199,6 +205,10 @@ data class SettingsState(
     // #456 — the polls toggle is gated only by its own write.
     val canToggleTopicPollsExpanded: Boolean
         get() = !isUpdatingTopicPollsExpanded
+
+    // #330 — the signatures toggle is gated only by its own write.
+    val canToggleTopicSignatures: Boolean
+        get() = !isUpdatingTopicSignatures
 
     // #312 — the confirm-before-posting toggle is gated only by its own write.
     val canToggleConfirmBeforePosting: Boolean
@@ -303,6 +313,9 @@ sealed interface SettingsIntent {
 
     /** #456 — sondages dépliés par défaut dans la lecture de sujet. */
     data class TopicPollsExpandedChanged(val enabled: Boolean) : SettingsIntent
+
+    /** #330 — afficher les signatures des auteurs sous les posts. */
+    data class TopicSignaturesChanged(val enabled: Boolean) : SettingsIntent
 
     // #312 — confirm-before-posting toggle. Optimistic-flip contract, like the flags toggles:
     // the boolean is the desired post-flip state.

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -112,6 +112,13 @@ data class SettingsState(
     val isUpdatingTopicSignatures: Boolean = false,
     val topicSignaturesError: Boolean = false,
     val topicSignaturesTouchedLocally: Boolean = false,
+    // #332 — replier les longues citations. Même machinerie optimistic-flip + garde de course au
+    // démarrage. Default TRUE (repli historique) : le toggle est l'opt-out demandé par le retour
+    // bêta « trop strict ».
+    val foldLongQuotes: Boolean = true,
+    val isUpdatingFoldLongQuotes: Boolean = false,
+    val foldLongQuotesError: Boolean = false,
+    val foldLongQuotesTouchedLocally: Boolean = false,
     // Publishing preferences (#312). Same optimistic-flip + startup-race-guard machinery:
     // `confirmBeforePosting` is the displayed value, `isUpdating*` gates the switch while DataStore
     // writes, `*Error` surfaces a persist failure, `*TouchedLocally` forbids a late `init` hydration
@@ -220,6 +227,10 @@ data class SettingsState(
     // #330 — the signatures toggle is gated only by its own write.
     val canToggleTopicSignatures: Boolean
         get() = !isUpdatingTopicSignatures
+
+    // #332 — the fold-long-quotes toggle is gated only by its own write.
+    val canToggleFoldLongQuotes: Boolean
+        get() = !isUpdatingFoldLongQuotes
 
     // #312 — the confirm-before-posting toggle is gated only by its own write.
     val canToggleConfirmBeforePosting: Boolean
@@ -331,6 +342,9 @@ sealed interface SettingsIntent {
 
     /** #330 — afficher les signatures des auteurs sous les posts. */
     data class TopicSignaturesChanged(val enabled: Boolean) : SettingsIntent
+
+    /** #332 — replier les longues citations sur une ligne. */
+    data class FoldLongQuotesChanged(val enabled: Boolean) : SettingsIntent
 
     // #312 — confirm-before-posting toggle. Optimistic-flip contract, like the flags toggles:
     // the boolean is the desired post-flip state.

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -53,6 +53,11 @@ class SettingsViewModel @Inject constructor(
             apply = { state, value -> state.copy(ignoreTopicCache = value) },
         )
         hydratePreference(
+            read = { userPreferencesRepository.observeDebugBoundsOverlay().first() },
+            isLocked = { it.debugBoundsOverlayTouchedLocally || it.isUpdatingDebugBoundsOverlay },
+            apply = { state, value -> state.copy(debugBoundsOverlay = value) },
+        )
+        hydratePreference(
             read = { userPreferencesRepository.observeFlagsGroupByCategory().first() },
             isLocked = { it.flagsGroupByCategoryTouchedLocally || it.isUpdatingFlagsGroupByCategory },
             apply = { state, value -> state.copy(flagsGroupByCategory = value) },
@@ -198,6 +203,7 @@ class SettingsViewModel @Inject constructor(
                 _state.update { it.copy(showClearImageCacheConfirm = false) }
             SettingsIntent.ClearImageCacheConfirmed -> clearImageCache()
             is SettingsIntent.IgnoreTopicCacheChanged -> updateIgnoreTopicCache(intent.enabled)
+            is SettingsIntent.DebugBoundsOverlayChanged -> updateDebugBoundsOverlay(intent.enabled)
             is SettingsIntent.FlagsGroupByCategoryChanged -> updateFlagsGroupByCategory(intent.enabled)
             is SettingsIntent.FlagsHideReadCategoriesChanged -> updateFlagsHideReadCategories(intent.enabled)
             is SettingsIntent.FlagsPerTabOverrideChanged -> updateFlagsPerTabOverride(intent.enabled)
@@ -357,6 +363,35 @@ class SettingsViewModel @Inject constructor(
                     }
                 }
         }
+    }
+
+    // #445 — debug bounds overlay (dev only). Plain boolean, so it reuses the shared optimistic-flip
+    // helper rather than the bespoke shape, like the flags toggles.
+    private fun updateDebugBoundsOverlay(desired: Boolean) {
+        val previous = _state.value.debugBoundsOverlay
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    debugBoundsOverlay = desired,
+                    isUpdatingDebugBoundsOverlay = true,
+                    debugBoundsOverlayError = false,
+                    debugBoundsOverlayTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(debugBoundsOverlay = desired, isUpdatingDebugBoundsOverlay = false)
+                } else {
+                    state.copy(
+                        debugBoundsOverlay = previous,
+                        isUpdatingDebugBoundsOverlay = false,
+                        debugBoundsOverlayError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setDebugBoundsOverlay,
+        )
     }
 
     private fun updateFlagsGroupByCategory(desired: Boolean) {

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -108,6 +108,11 @@ class SettingsViewModel @Inject constructor(
             apply = { state, value -> state.copy(topicSignatures = value) },
         )
         hydratePreference(
+            read = { userPreferencesRepository.observeFoldLongQuotes().first() },
+            isLocked = { it.foldLongQuotesTouchedLocally || it.isUpdatingFoldLongQuotes },
+            apply = { state, value -> state.copy(foldLongQuotes = value) },
+        )
+        hydratePreference(
             read = { userPreferencesRepository.observeConfirmBeforePosting().first() },
             isLocked = { it.confirmBeforePostingTouchedLocally || it.isUpdatingConfirmBeforePosting },
             apply = { state, value -> state.copy(confirmBeforePosting = value) },
@@ -214,6 +219,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.MpUnreadBadgeChanged -> updateMpUnreadBadge(intent.enabled)
             is SettingsIntent.TopicPollsExpandedChanged -> updateTopicPollsExpanded(intent.enabled)
             is SettingsIntent.TopicSignaturesChanged -> updateTopicSignatures(intent.enabled)
+            is SettingsIntent.FoldLongQuotesChanged -> updateFoldLongQuotes(intent.enabled)
             is SettingsIntent.ShowDtSectionChanged -> updateShowDtSection(intent.enabled)
             is SettingsIntent.ConfirmBeforePostingChanged -> updateConfirmBeforePosting(intent.enabled)
             is SettingsIntent.FlagsAutoRefreshChanged -> updateFlagsAutoRefresh(intent.enabled)
@@ -773,6 +779,33 @@ class SettingsViewModel @Inject constructor(
                 }
             },
             persist = userPreferencesRepository::setTopicSignatures,
+        )
+    }
+
+    private fun updateFoldLongQuotes(desired: Boolean) {
+        val previous = _state.value.foldLongQuotes
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    foldLongQuotes = desired,
+                    isUpdatingFoldLongQuotes = true,
+                    foldLongQuotesError = false,
+                    foldLongQuotesTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(foldLongQuotes = desired, isUpdatingFoldLongQuotes = false)
+                } else {
+                    state.copy(
+                        foldLongQuotes = previous,
+                        isUpdatingFoldLongQuotes = false,
+                        foldLongQuotesError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setFoldLongQuotes,
         )
     }
 

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -98,6 +98,11 @@ class SettingsViewModel @Inject constructor(
             apply = { state, value -> state.copy(topicPollsExpanded = value) },
         )
         hydratePreference(
+            read = { userPreferencesRepository.observeTopicSignatures().first() },
+            isLocked = { it.topicSignaturesTouchedLocally || it.isUpdatingTopicSignatures },
+            apply = { state, value -> state.copy(topicSignatures = value) },
+        )
+        hydratePreference(
             read = { userPreferencesRepository.observeConfirmBeforePosting().first() },
             isLocked = { it.confirmBeforePostingTouchedLocally || it.isUpdatingConfirmBeforePosting },
             apply = { state, value -> state.copy(confirmBeforePosting = value) },
@@ -202,6 +207,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.TopicPageFabsChanged -> updateTopicPageFabs(intent.enabled)
             is SettingsIntent.MpUnreadBadgeChanged -> updateMpUnreadBadge(intent.enabled)
             is SettingsIntent.TopicPollsExpandedChanged -> updateTopicPollsExpanded(intent.enabled)
+            is SettingsIntent.TopicSignaturesChanged -> updateTopicSignatures(intent.enabled)
             is SettingsIntent.ShowDtSectionChanged -> updateShowDtSection(intent.enabled)
             is SettingsIntent.ConfirmBeforePostingChanged -> updateConfirmBeforePosting(intent.enabled)
             is SettingsIntent.FlagsAutoRefreshChanged -> updateFlagsAutoRefresh(intent.enabled)
@@ -705,6 +711,33 @@ class SettingsViewModel @Inject constructor(
                 }
             },
             persist = userPreferencesRepository::setTopicPollsExpanded,
+        )
+    }
+
+    private fun updateTopicSignatures(desired: Boolean) {
+        val previous = _state.value.topicSignatures
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    topicSignatures = desired,
+                    isUpdatingTopicSignatures = true,
+                    topicSignaturesError = false,
+                    topicSignaturesTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(topicSignatures = desired, isUpdatingTopicSignatures = false)
+                } else {
+                    state.copy(
+                        topicSignatures = previous,
+                        isUpdatingTopicSignatures = false,
+                        topicSignaturesError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setTopicSignatures,
         )
     }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -112,7 +112,6 @@
     <!-- §3 Sujet et lecture -->
     <string name="settings_future_restore_read_position">Restaurer la position de lecture</string>
     <string name="settings_future_swipe_page">Changer de page au glissement</string>
-    <string name="settings_future_collapse_quotes">Replier les longues citations</string>
     <string name="settings_future_open_external_in_app">Ouvrir les liens externes dans l\'app</string>
     <string name="settings_future_autoplay_animations">Lecture auto des images animées</string>
     <string name="settings_future_fullscreen_reading">Plein écran en lecture</string>
@@ -294,6 +293,11 @@
     <string name="settings_topic_signatures_title">Afficher les signatures</string>
     <string name="settings_topic_signatures_description">Signature de l\'auteur sous chaque post, en plus discret.</string>
     <string name="settings_topic_signatures_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
+
+    <!-- #332 — Lecture. Replier les longues citations sur une ligne (dépliables au clic). -->
+    <string name="settings_fold_long_quotes_title">Replier les longues citations</string>
+    <string name="settings_fold_long_quotes_description">Les longues citations sont repliées sur une ligne, dépliables au clic ; sinon elles restent affichées en entier.</string>
+    <string name="settings_fold_long_quotes_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
 
     <!-- #312 — Publication. Confirmation avant chaque envoi (réponse/édition de message, sujet,
          message privé) ; persisté en DataStore et lu en direct par les éditeurs.

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -284,6 +284,11 @@
     <string name="settings_topic_polls_expanded_description">Sondages dépliés en haut des sujets ; sinon une ligne repliée.</string>
     <string name="settings_topic_polls_expanded_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
 
+    <!-- #330 — Lecture. Afficher la signature de l'auteur sous chaque post (parité web). -->
+    <string name="settings_topic_signatures_title">Afficher les signatures</string>
+    <string name="settings_topic_signatures_description">Signature de l\'auteur sous chaque post, en plus discret.</string>
+    <string name="settings_topic_signatures_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
+
     <!-- #312 — Publication. Confirmation avant chaque envoi (réponse/édition de message, sujet,
          message privé) ; persisté en DataStore et lu en direct par les éditeurs.
          `settings_future_submit_confirm` (catalogue vitrine #288) renommé selon la convention des

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -213,6 +213,12 @@
     <string name="settings_ignore_topic_cache_description">Force le retéléchargement et le reparse des pages de topic. Utile après un changement de parser/rendu. Désactive le prefetch topic pour éviter de remplir Room inutilement.</string>
     <string name="settings_ignore_topic_cache_persist_failed">Impossible de mémoriser le réglage « Ignorer le cache topic ». Réessayez.</string>
 
+    <!-- #445 — Overlay de debug qui surligne les bounds des composants. Réglage dev uniquement
+         (la ligne n'est affichée que sur le canal dev), désactivé par défaut. -->
+    <string name="settings_debug_bounds_overlay_title">Surligner les bounds des composants</string>
+    <string name="settings_debug_bounds_overlay_description">Dessine par-dessus l\'app un calque qui entoure les composants affichés (issus de l\'arbre sémantique Compose). Outil de debug du layout, canal dev uniquement.</string>
+    <string name="settings_debug_bounds_overlay_persist_failed">Impossible de mémoriser le réglage « Surligner les bounds des composants ». Réessayez.</string>
+
     <!-- #179 follow-up — Préférences d'affichage de l'écran Drapeaux. Persistées (DataStore) et
          observées en direct par l'écran Drapeaux : un changement ici se reflète sans refetch. -->
     <string name="settings_flags_title">Drapeaux</string>

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -1012,6 +1012,45 @@ class SettingsViewModelTest {
     }
 
     // ──────────────────────────────────────────────────────────────────────
+    // Debug bounds overlay (#445)
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `init hydrates debugBoundsOverlay from a persisted true`() = runTest {
+        // Default is false — only a persisted opt-in exercises the hydration path.
+        repository.emitDebugBoundsOverlay(true)
+
+        val viewModel = newViewModel()
+
+        assertTrue(viewModel.state.value.debugBoundsOverlay)
+        assertFalse(viewModel.state.value.debugBoundsOverlayError)
+    }
+
+    @Test
+    fun `DebugBoundsOverlayChanged persists the flip`() = runTest {
+        val viewModel = newViewModel()
+        assertFalse("overlay is off by default", viewModel.state.value.debugBoundsOverlay)
+
+        viewModel.submit(SettingsIntent.DebugBoundsOverlayChanged(true))
+
+        assertTrue(viewModel.state.value.debugBoundsOverlay)
+        assertFalse(viewModel.state.value.isUpdatingDebugBoundsOverlay)
+        assertEquals(1, repository.debugBoundsOverlaySetCalls)
+    }
+
+    @Test
+    fun `DebugBoundsOverlayChanged reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnDebugBoundsOverlaySet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.DebugBoundsOverlayChanged(true))
+
+        assertFalse("failed persist must revert to the previous value", viewModel.state.value.debugBoundsOverlay)
+        assertFalse(viewModel.state.value.isUpdatingDebugBoundsOverlay)
+        assertTrue(viewModel.state.value.debugBoundsOverlayError)
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
     // Confirm before posting (#312)
     // ──────────────────────────────────────────────────────────────────────
 
@@ -1679,6 +1718,25 @@ class SettingsViewModelTest {
 
         fun emitFlagsPerTabOverride(value: Boolean) {
             flagsPerTabOverride.value = value
+        }
+
+        // #445 — debug bounds overlay. Same optimistic-flip seam as topicSignatures so the Settings
+        // tests can assert hydration, the repo call, and the revert-on-failure path.
+        private val debugBoundsOverlay = MutableStateFlow(false)
+        var debugBoundsOverlaySetCalls: Int = 0
+            private set
+        var failOnDebugBoundsOverlaySet: Boolean = false
+
+        override fun observeDebugBoundsOverlay(): Flow<Boolean> = debugBoundsOverlay
+
+        override suspend fun setDebugBoundsOverlay(enabled: Boolean) {
+            debugBoundsOverlaySetCalls += 1
+            check(!failOnDebugBoundsOverlaySet) { "boom" }
+            debugBoundsOverlay.value = enabled
+        }
+
+        fun emitDebugBoundsOverlay(value: Boolean) {
+            debugBoundsOverlay.value = value
         }
     }
 

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -1012,6 +1012,45 @@ class SettingsViewModelTest {
     }
 
     // ──────────────────────────────────────────────────────────────────────
+    // Fold long quotes (#332)
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `init hydrates foldLongQuotes from a persisted false`() = runTest {
+        // Default is true — only a persisted opt-OUT exercises the hydration path.
+        repository.emitFoldLongQuotes(false)
+
+        val viewModel = newViewModel()
+
+        assertFalse(viewModel.state.value.foldLongQuotes)
+        assertFalse(viewModel.state.value.foldLongQuotesError)
+    }
+
+    @Test
+    fun `FoldLongQuotesChanged persists the flip`() = runTest {
+        val viewModel = newViewModel()
+        assertTrue("long quotes fold by default", viewModel.state.value.foldLongQuotes)
+
+        viewModel.submit(SettingsIntent.FoldLongQuotesChanged(false))
+
+        assertFalse(viewModel.state.value.foldLongQuotes)
+        assertFalse(viewModel.state.value.isUpdatingFoldLongQuotes)
+        assertEquals(1, repository.foldLongQuotesSetCalls)
+    }
+
+    @Test
+    fun `FoldLongQuotesChanged reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnFoldLongQuotesSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.FoldLongQuotesChanged(false))
+
+        assertTrue("failed persist must revert to the previous value", viewModel.state.value.foldLongQuotes)
+        assertFalse(viewModel.state.value.isUpdatingFoldLongQuotes)
+        assertTrue(viewModel.state.value.foldLongQuotesError)
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
     // Debug bounds overlay (#445)
     // ──────────────────────────────────────────────────────────────────────
 
@@ -1574,6 +1613,24 @@ class SettingsViewModelTest {
 
         fun emitTopicSignatures(value: Boolean) {
             topicSignatures.value = value
+        }
+
+        // #332 — replier les longues citations. Même seam optimistic-flip ; default TRUE (repli).
+        private val foldLongQuotes = MutableStateFlow(true)
+        var foldLongQuotesSetCalls: Int = 0
+            private set
+        var failOnFoldLongQuotesSet: Boolean = false
+
+        override fun observeFoldLongQuotes(): Flow<Boolean> = foldLongQuotes
+
+        override suspend fun setFoldLongQuotes(enabled: Boolean) {
+            foldLongQuotesSetCalls += 1
+            check(!failOnFoldLongQuotesSet) { "boom" }
+            foldLongQuotes.value = enabled
+        }
+
+        fun emitFoldLongQuotes(value: Boolean) {
+            foldLongQuotes.value = value
         }
 
         // #458 — start screen lives on its own StartScreenSettingsViewModel; this fake only

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -973,6 +973,45 @@ class SettingsViewModelTest {
     }
 
     // ──────────────────────────────────────────────────────────────────────
+    // Author signatures (#330)
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `init hydrates topicSignatures from a persisted true`() = runTest {
+        // Default is false — only a persisted opt-in exercises the hydration path.
+        repository.emitTopicSignatures(true)
+
+        val viewModel = newViewModel()
+
+        assertTrue(viewModel.state.value.topicSignatures)
+        assertFalse(viewModel.state.value.topicSignaturesError)
+    }
+
+    @Test
+    fun `TopicSignaturesChanged persists the flip`() = runTest {
+        val viewModel = newViewModel()
+        assertFalse("signatures are hidden by default", viewModel.state.value.topicSignatures)
+
+        viewModel.submit(SettingsIntent.TopicSignaturesChanged(true))
+
+        assertTrue(viewModel.state.value.topicSignatures)
+        assertFalse(viewModel.state.value.isUpdatingTopicSignatures)
+        assertEquals(1, repository.topicSignaturesSetCalls)
+    }
+
+    @Test
+    fun `TopicSignaturesChanged reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnTopicSignaturesSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.TopicSignaturesChanged(true))
+
+        assertFalse("failed persist must revert to the previous value", viewModel.state.value.topicSignatures)
+        assertFalse(viewModel.state.value.isUpdatingTopicSignatures)
+        assertTrue(viewModel.state.value.topicSignaturesError)
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
     // Confirm before posting (#312)
     // ──────────────────────────────────────────────────────────────────────
 
@@ -1478,6 +1517,24 @@ class SettingsViewModelTest {
 
         fun emitTopicPollsExpanded(value: Boolean) {
             topicPollsExpanded.value = value
+        }
+
+        // #330 — afficher les signatures. Même seam optimistic-flip que topicPollsExpanded.
+        private val topicSignatures = MutableStateFlow(false)
+        var topicSignaturesSetCalls: Int = 0
+            private set
+        var failOnTopicSignaturesSet: Boolean = false
+
+        override fun observeTopicSignatures(): Flow<Boolean> = topicSignatures
+
+        override suspend fun setTopicSignatures(enabled: Boolean) {
+            topicSignaturesSetCalls += 1
+            check(!failOnTopicSignaturesSet) { "boom" }
+            topicSignatures.value = enabled
+        }
+
+        fun emitTopicSignatures(value: Boolean) {
+            topicSignatures.value = value
         }
 
         // #458 — start screen lives on its own StartScreenSettingsViewModel; this fake only

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1850,16 +1850,26 @@ private fun rememberBottomActionsVisible(listState: LazyListState): Boolean {
     LaunchedEffect(listState) {
         var prevIndex = listState.firstVisibleItemIndex
         var prevOffset = listState.firstVisibleItemScrollOffset
-        // snapshotFlow only emits on a REAL position change, so a recomposition / async layout shift
-        // with an identical first-visible item+offset never re-reveals the cluster (Codex review): the
-        // last decision is simply held. A list that cannot scroll stays visible.
-        snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
-            .collect { (index, offset) ->
+        // snapshotFlow keys on the first-visible item+offset AND canScrollForward, so a recomposition /
+        // async layout shift with an identical position never re-reveals the cluster (the last decision
+        // is held) — BUT a change in SCROLLABILITY with an unchanged position (e.g. the list shrinks so
+        // the current position becomes the end without a scroll) still re-fires the collect and re-
+        // evaluates the « visible at the end » rule. Keying on position alone left that case stale until
+        // the next real scroll (multi-agent review finding, scored >65). A list that cannot scroll stays
+        // visible.
+        snapshotFlow {
+            Triple(
+                listState.firstVisibleItemIndex,
+                listState.firstVisibleItemScrollOffset,
+                listState.canScrollForward,
+            )
+        }
+            .collect { (index, offset, canScrollForward) ->
                 visible = when {
                     // At the end of the list (or a short, non-scrollable page) always show: the user is
                     // on the last post and most likely wants to reply, so they should not have to scroll
                     // up to reveal the cluster (#411 beta feedback, tinc t2788220).
-                    !listState.canScrollForward -> true
+                    !canScrollForward -> true
                     index != prevIndex -> index < prevIndex
                     offset != prevOffset -> offset < prevOffset
                     // No real movement (incl. snapshotFlow's initial emission): hold the last decision

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.feature.topic
 
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -12,7 +13,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -28,7 +28,6 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -61,7 +60,6 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -82,6 +80,7 @@ import fr.forumhfr.redface2.core.model.Topic
 import fr.forumhfr.redface2.core.ui.RedfacePlaceholderScreen
 import fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar
 import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
+import fr.forumhfr.redface2.core.ui.icon.RedfaceVectorIcon
 import fr.forumhfr.redface2.core.ui.list.LazyListScrollbar
 import fr.forumhfr.redface2.core.ui.pager.pageSwipeEdgeHint
 import fr.forumhfr.redface2.core.ui.post.PostRenderer
@@ -677,15 +676,12 @@ internal fun TopicContent(
                         onClick = onBack,
                         modifier = Modifier.semantics { contentDescription = backLabel },
                     ) {
-                        // A text glyph used as an icon was unstable: its size depended on the system
-                        // font's `←` rendering, the baseline and the font-scale, never matching the
-                        // title cleanly (cf. Codex review). Use a dp-sized vector instead — optically
-                        // centred by the IconButton, font-independent. The a11y label stays on the
-                        // IconButton, so the icon itself is decorative (contentDescription = null).
-                        Icon(
-                            painter = painterResource(fr.forumhfr.redface2.core.ui.R.drawable.ic_arrow_back),
-                            contentDescription = null,
-                            modifier = Modifier.size(24.dp),
+                        // #360 / ADR-015 — vector stroke unifié, dimensionné en dp (indépendant de la
+                        // police et de la baseline, contrairement à l'ancien glyphe « ← »), via le
+                        // primitive partagé :core:ui. L'étiquette a11y reste sur l'IconButton, donc
+                        // l'icône est décorative (contentDescription = null par défaut).
+                        RedfaceVectorIcon(
+                            resId = fr.forumhfr.redface2.core.ui.R.drawable.ic_arrow_back,
                         )
                     }
                 },
@@ -1851,10 +1847,18 @@ private fun TopicBottomActions(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             if (showPrevious) {
-                PageFab(description = previousLabel, glyph = "‹", onClick = onPreviousPage)
+                PageFab(
+                    description = previousLabel,
+                    iconRes = fr.forumhfr.redface2.core.ui.R.drawable.ic_chevron_left,
+                    onClick = onPreviousPage,
+                )
             }
             if (showNext) {
-                PageFab(description = nextLabel, glyph = "›", onClick = onNextPage)
+                PageFab(
+                    description = nextLabel,
+                    iconRes = fr.forumhfr.redface2.core.ui.R.drawable.ic_chevron_right,
+                    onClick = onNextPage,
+                )
             }
             if (showMultiQuote) {
                 MultiQuoteFab(count = multiQuoteCount, onClick = onMultiQuote)
@@ -1883,31 +1887,32 @@ private fun MultiQuoteFab(count: Int, onClick: () -> Unit) {
 @Composable
 private fun PageFab(
     description: String,
-    glyph: String,
+    @DrawableRes iconRes: Int,
     onClick: () -> Unit,
 ) {
-    // No Material icons (detekt ForbiddenImport blocks androidx.compose.material.*): the glyph is a
-    // decorative Text and the real label rides on the FAB's `contentDescription` for TalkBack — same
-    // pattern as the top-bar back button.
+    // #360 / ADR-015 — chevron en vector stroke unifié (poids optique aligné sur la flèche retour),
+    // dimensionné en dp via le primitive partagé :core:ui plutôt qu'un glyphe « ‹ »/« › » dépendant
+    // de la police. Pas de Material icons (detekt ForbiddenImport). L'étiquette a11y reste sur le FAB,
+    // donc l'icône est décorative.
     SmallFloatingActionButton(
         onClick = onClick,
         modifier = Modifier.semantics { contentDescription = description },
     ) {
-        Text(glyph)
+        RedfaceVectorIcon(resId = iconRes)
     }
 }
 
 @Composable
 private fun ReplyFab(onClick: () -> Unit) {
-    // Same SmallFloatingActionButton footprint as the page FABs (user request): the « Répondre » label
-    // rides on contentDescription for TalkBack and the glyph is decorative (no Material icons — detekt
-    // ForbiddenImport blocks androidx.compose.material.*), mirroring PageFab and the top-bar back button.
+    // #360 / ADR-015 — crayon en vector stroke unifié (même poids optique que la flèche retour / les
+    // chevrons), via le primitive partagé :core:ui, à la place du glyphe « ✎ » dépendant de la police.
+    // Pas de Material icons (detekt ForbiddenImport). L'étiquette a11y reste sur le FAB.
     val replyLabel = stringResource(R.string.topic_fab_reply)
     SmallFloatingActionButton(
         onClick = onClick,
         modifier = Modifier.semantics { contentDescription = replyLabel },
     ) {
-        Text("✎")
+        RedfaceVectorIcon(resId = fr.forumhfr.redface2.core.ui.R.drawable.ic_edit)
     }
 }
 

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1,6 +1,11 @@
 package fr.forumhfr.redface2.feature.topic
 
 import androidx.annotation.DrawableRes
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -51,6 +56,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -625,6 +631,8 @@ internal fun TopicContent(
     // stay visible while the user scrolls (the in-card title/caption scrolls away). When the page
     // is still loading / errored, fall back to a generic title and the requested page.
     val loaded = state.mode as? TopicUiState.Mode.Loaded
+    // #411 — bottom action cluster hides on scroll-down, re-appears on scroll-up (RF1 parity).
+    val bottomActionsVisible = rememberBottomActionsVisible(listState)
     val fallbackTitle = stringResource(R.string.topic_topbar_fallback_title)
     // Honour TopicRequest.titleHint's contract: the cached hint is a LOADING-only stand-in. Once the
     // page is Loaded, the live Topic.title wins (or the generic fallback if it is somehow blank) — we
@@ -695,26 +703,35 @@ internal fun TopicContent(
             // scrollbar (right edge, auto-hiding) — a slight bottom-right overlap is acceptable.
             val current = loaded
             if (current != null) {
-                TopicBottomActions(
-                    showReply = shouldEnableReply(current.topic, state.isAuthenticated),
-                    showPageFabs = state.showPageFabs,
-                    canGoPrevious = state.canGoPrevious,
-                    canGoNext = state.canGoNext,
-                    // #291 — the « Citer N » FAB shares the reply gate: quoting IS replying.
-                    multiQuoteCount = effectiveMultiQuoteCount(
-                        current.topic,
-                        state.isAuthenticated,
-                        multiQuoteSelection,
-                    ),
-                    // Clamp to [1, totalPages]: `canGoPrevious/Next` are derived from `request.page`
-                    // while the target is computed from the parsed `topic.page`; if those ever desync
-                    // (HFR clamps an out-of-range page to the last one), the clamp keeps navigation in
-                    // bounds — same robustness as the header guard and the swipe (#282).
-                    onPreviousPage = { onOpenPage((current.topic.page - 1).coerceAtLeast(1)) },
-                    onNextPage = { onOpenPage((current.topic.page + 1).coerceAtMost(current.topic.totalPages)) },
-                    onReply = { onReply(current.topic.subcat, current.topic.page) },
-                    onMultiQuote = { onMultiQuote(current.topic.subcat, current.topic.page) },
-                )
+                // #411 — tuck the cluster away while reading down, reveal it on the first upward
+                // scroll. AnimatedVisibility in the Scaffold's FAB slot simply collapses to nothing
+                // when hidden; the slide/fade mirrors the collapsible top bar (#286/#338).
+                AnimatedVisibility(
+                    visible = bottomActionsVisible,
+                    enter = fadeIn() + slideInVertically { it },
+                    exit = fadeOut() + slideOutVertically { it },
+                ) {
+                    TopicBottomActions(
+                        showReply = shouldEnableReply(current.topic, state.isAuthenticated),
+                        showPageFabs = state.showPageFabs,
+                        canGoPrevious = state.canGoPrevious,
+                        canGoNext = state.canGoNext,
+                        // #291 — the « Citer N » FAB shares the reply gate: quoting IS replying.
+                        multiQuoteCount = effectiveMultiQuoteCount(
+                            current.topic,
+                            state.isAuthenticated,
+                            multiQuoteSelection,
+                        ),
+                        // Clamp to [1, totalPages]: `canGoPrevious/Next` are derived from `request.page`
+                        // while the target is computed from the parsed `topic.page`; if those ever desync
+                        // (HFR clamps an out-of-range page to the last one), the clamp keeps navigation in
+                        // bounds — same robustness as the header guard and the swipe (#282).
+                        onPreviousPage = { onOpenPage((current.topic.page - 1).coerceAtLeast(1)) },
+                        onNextPage = { onOpenPage((current.topic.page + 1).coerceAtMost(current.topic.totalPages)) },
+                        onReply = { onReply(current.topic.subcat, current.topic.page) },
+                        onMultiQuote = { onMultiQuote(current.topic.subcat, current.topic.page) },
+                    )
+                }
             }
         },
     ) { innerPadding ->
@@ -1809,6 +1826,39 @@ private fun DeletePostConfirmDialog(
             }
         },
     )
+}
+
+/**
+ * #411 — drives the bottom-action cluster's show-on-scroll-up visibility, derived READ-ONLY from
+ * [listState] (it never drives scrolling, so the anchor/restore #307 and the swipe #282 stay
+ * untouched). Hides while the list scrolls DOWN, reveals on the first UPWARD scroll — the M3 idiom,
+ * matching the collapsible top bar. A list that cannot scroll (a short, one-screen topic) stays
+ * visible, so a page with nothing below never hides its actions.
+ */
+@Composable
+private fun rememberBottomActionsVisible(listState: LazyListState): Boolean {
+    var visible by remember(listState) { mutableStateOf(true) }
+    LaunchedEffect(listState) {
+        var prevIndex = listState.firstVisibleItemIndex
+        var prevOffset = listState.firstVisibleItemScrollOffset
+        // snapshotFlow only emits on a REAL position change, so a recomposition / async layout shift
+        // with an identical first-visible item+offset never re-reveals the cluster (Codex review): the
+        // last decision is simply held. A list that cannot scroll stays visible.
+        snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
+            .collect { (index, offset) ->
+                visible = when {
+                    !listState.canScrollForward && !listState.canScrollBackward -> true
+                    index != prevIndex -> index < prevIndex
+                    offset != prevOffset -> offset < prevOffset
+                    // No real movement (incl. snapshotFlow's initial emission): hold the last decision
+                    // so the cluster stays visible on load and never flips without a scroll.
+                    else -> visible
+                }
+                prevIndex = index
+                prevOffset = offset
+            }
+    }
+    return visible
 }
 
 /**

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1832,8 +1832,9 @@ private fun DeletePostConfirmDialog(
  * #411 — drives the bottom-action cluster's show-on-scroll-up visibility, derived READ-ONLY from
  * [listState] (it never drives scrolling, so the anchor/restore #307 and the swipe #282 stay
  * untouched). Hides while the list scrolls DOWN, reveals on the first UPWARD scroll — the M3 idiom,
- * matching the collapsible top bar. A list that cannot scroll (a short, one-screen topic) stays
- * visible, so a page with nothing below never hides its actions.
+ * matching the collapsible top bar. It also stays visible at the END of the list (and on a short,
+ * one-screen topic): reaching the last post is exactly when the reader wants to reply, so the cluster
+ * must be there without scrolling back up (#411 beta feedback).
  */
 @Composable
 private fun rememberBottomActionsVisible(listState: LazyListState): Boolean {
@@ -1847,7 +1848,10 @@ private fun rememberBottomActionsVisible(listState: LazyListState): Boolean {
         snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
             .collect { (index, offset) ->
                 visible = when {
-                    !listState.canScrollForward && !listState.canScrollBackward -> true
+                    // At the end of the list (or a short, non-scrollable page) always show: the user is
+                    // on the last post and most likely wants to reply, so they should not have to scroll
+                    // up to reveal the cluster (#411 beta feedback, tinc t2788220).
+                    !listState.canScrollForward -> true
                     index != prevIndex -> index < prevIndex
                     offset != prevOffset -> offset < prevOffset
                     // No real movement (incl. snapshotFlow's initial emission): hold the last decision

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -91,6 +92,7 @@ import fr.forumhfr.redface2.core.ui.list.LazyListScrollbar
 import fr.forumhfr.redface2.core.ui.pager.pageSwipeEdgeHint
 import fr.forumhfr.redface2.core.ui.post.PostRenderer
 import fr.forumhfr.redface2.core.ui.theme.LocalDisplayMetrics
+import fr.forumhfr.redface2.core.ui.theme.LocalIgnoreInlineColors
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -1705,10 +1707,16 @@ internal fun TopicPostCard(
             post.signature?.let { signature ->
                 if (showSignature) {
                     HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-                    PostRenderer(
-                        content = signature,
-                        modifier = Modifier.alpha(SIGNATURE_ALPHA),
-                    )
+                    // #553 — drop the author's web-tuned `[color]` in the signature: on the app theme
+                    // (especially dark) those colours read as garish/illegible. The signature then
+                    // renders in the neutral subdued body colour (the reduced alpha keeps it
+                    // subordinate). Post bodies are unaffected (they don't provide this local).
+                    CompositionLocalProvider(LocalIgnoreInlineColors provides true) {
+                        PostRenderer(
+                            content = signature,
+                            modifier = Modifier.alpha(SIGNATURE_ALPHA),
+                        )
+                    }
                 }
             }
             if (onQuote != null || onEdit != null || onToggleMultiQuote != null) {

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -1006,6 +1007,9 @@ private fun TopicLoadedContent(
                 post = post,
                 highlighted = highlight == post.numreponse,
                 citedCount = citationCounts[post.numreponse] ?: 0,
+                // #330 — render the author signature beneath the body when the reading preference
+                // is on (the signature is always parsed/cached on the Post; this is render-only).
+                showSignature = state.showSignatures,
                 onQuote = quoteAction,
                 onEdit = editAction,
                 onOpenProfile = profileAction,
@@ -1381,6 +1385,12 @@ internal fun TopicPostCard(
      * #239 — number of posts on the current page that cite this one. 0 hides the badge.
      */
     citedCount: Int,
+    /**
+     * #330 — when `true` (the « Afficher les signatures » reading preference is on), the author's
+     * signature ([Post.signature]) is rendered beneath the body, separated by a divider, in a
+     * subdued style. No-op when the post has no signature. Default `false`.
+     */
+    showSignature: Boolean = false,
     onQuote: (() -> Unit)?,
     onEdit: (() -> Unit)?,
     /**
@@ -1675,6 +1685,19 @@ internal fun TopicPostCard(
         ) {
             // #281 — topic posts are selectable/copyable (opt-in; default is OFF in PostRenderer).
             PostRenderer(content = post.content, selectable = true)
+            // #330 — the author signature (web parity), gated by the reading preference. Rendered
+            // with the shared PostRenderer (the signature is BBCode/HTML like the body) but in a
+            // subdued style: a divider separates it from the body and a reduced alpha makes it
+            // subordinate to the post content. No-op when the post carries no signature.
+            post.signature?.let { signature ->
+                if (showSignature) {
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                    PostRenderer(
+                        content = signature,
+                        modifier = Modifier.alpha(SIGNATURE_ALPHA),
+                    )
+                }
+            }
             if (onQuote != null || onEdit != null || onToggleMultiQuote != null) {
                 // Actions row at the bottom of the post card, sober TextButtons
                 // so they stay subordinate to the post content. « Modifier »
@@ -1747,6 +1770,11 @@ internal fun TopicPostCard(
         }
     }
 }
+
+// #330 — the author signature renders subordinate to the post body: a reduced opacity keeps it
+// visually secondary (it shares the body's typography, so colour-only dimming via alpha is the
+// least invasive subdued treatment without recolouring PostRenderer's internals).
+private const val SIGNATURE_ALPHA = 0.7f
 
 private val topicDateFormatter = DateTimeFormatter
     .ofPattern("dd/MM/yyyy HH:mm:ss", Locale.FRANCE)

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -46,6 +46,13 @@ data class TopicUiState(
      */
     val pollsExpandedDefault: Boolean = false,
     /**
+     * #330 — mirrors `UserPreferencesRepository.observeTopicSignatures()`. When `true`, each post
+     * card renders the author's signature (`Post.signature`) beneath the body, in a subdued style
+     * separated by a divider. Default `false`: signatures are noisy and opt-in. Flips on the first
+     * preference emission; the field is always parsed/cached so toggling never refetches.
+     */
+    val showSignatures: Boolean = false,
+    /**
      * #335 — `true` while a manual pull-to-refresh of the current page is in flight. Drives the
      * Material3 `PullToRefreshBox` spinner. Set on the `Refresh` intent, cleared in the refresh
      * coroutine's `finally` (so a cancellation — e.g. a delete starting mid-refresh — never leaves

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -122,6 +122,13 @@ class TopicViewModel @AssistedInject constructor(
                 _state.update { it.copy(pollsExpandedDefault = expanded) }
             }
             .launchIn(viewModelScope)
+        // #330 — mirror the signatures preference so the post cards can show/hide the author
+        // signature without a refetch (it is always parsed and cached on the Post).
+        userPreferencesRepository.observeTopicSignatures()
+            .onEach { show ->
+                _state.update { it.copy(showSignatures = show) }
+            }
+            .launchIn(viewModelScope)
     }
 
     fun send(intent: TopicIntent) {

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -1406,6 +1406,10 @@ private class FakeUserPreferencesRepository(
 
     override suspend fun setTopicSignatures(enabled: Boolean) = Unit
 
+    override fun observeFoldLongQuotes(): Flow<Boolean> = MutableStateFlow(true)
+
+    override suspend fun setFoldLongQuotes(enabled: Boolean) = Unit
+
     override fun observeStartScreen(): Flow<StartScreenPreference> =
         MutableStateFlow(StartScreenPreference())
 

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -1434,4 +1434,8 @@ private class FakeUserPreferencesRepository(
     override fun observeFontScale(): Flow<FontScalePreference> = MutableStateFlow(FontScalePreference.M)
 
     override suspend fun setFontScale(scale: FontScalePreference) = Unit
+
+    override fun observeDebugBoundsOverlay(): Flow<Boolean> = MutableStateFlow(false)
+
+    override suspend fun setDebugBoundsOverlay(enabled: Boolean) = Unit
 }

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -471,6 +471,25 @@ class TopicViewModelTest {
     }
 
     @Test
+    fun `state showSignatures reflects the user preference (#330)`() = runTest {
+        val hidden = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            userPreferencesRepository = FakeUserPreferencesRepository(topicSignatures = false),
+        )
+        assertEquals(false, hidden.state.value.showSignatures)
+
+        val shown = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            userPreferencesRepository = FakeUserPreferencesRepository(topicSignatures = true),
+        )
+        assertEquals(true, shown.state.value.showSignatures)
+    }
+
+    @Test
     fun `DeletePost success emits PostDeleted and force-refreshes the current page (#292)`() = runTest {
         // Page 2 so the editable post 777 is NOT the first post (the FP lives on page 1 and is
         // excluded from deletion). Editable + authenticated + canReply → the VM gate lets it through.
@@ -1304,15 +1323,16 @@ private class FakeStreamingTopicRepository(
 
 /**
  * No-op preferences fake for the topic ViewModel tests. Only [observeTopicTopBarAutoHide]
- * (build 89 follow-up), [observeTopicPageFabs] (#383) and [observeTopicPollsExpanded] (#456)
- * are read by [TopicViewModel] — everything else returns the DataStore default so the fake
- * stays a thin stand-in. The three relevant values are constructor-injectable so tests can
- * assert they reach state.
+ * (build 89 follow-up), [observeTopicPageFabs] (#383), [observeTopicPollsExpanded] (#456) and
+ * [observeTopicSignatures] (#330) are read by [TopicViewModel] — everything else returns the
+ * DataStore default so the fake stays a thin stand-in. The relevant values are
+ * constructor-injectable so tests can assert they reach state.
  */
 private class FakeUserPreferencesRepository(
     private val topicTopBarAutoHide: Boolean = false,
     private val topicPageFabs: Boolean = true,
     private val topicPollsExpanded: Boolean = false,
+    private val topicSignatures: Boolean = false,
 ) : UserPreferencesRepository {
     override fun observeProxyConfig(): Flow<ProxyConfig> = MutableStateFlow(ProxyConfig())
 
@@ -1381,6 +1401,10 @@ private class FakeUserPreferencesRepository(
     override fun observeTopicPollsExpanded(): Flow<Boolean> = MutableStateFlow(topicPollsExpanded)
 
     override suspend fun setTopicPollsExpanded(enabled: Boolean) = Unit
+
+    override fun observeTopicSignatures(): Flow<Boolean> = MutableStateFlow(topicSignatures)
+
+    override suspend fun setTopicSignatures(enabled: Boolean) = Unit
 
     override fun observeStartScreen(): Flow<StartScreenPreference> =
         MutableStateFlow(StartScreenPreference())


### PR DESCRIPTION
Promotion dev → main pour la **bêta 0.14.0** (app-v155).

## Payload (cf. `app/CHANGELOG.md` v155 — 0.14.0)
- **Ajouts** : signatures sous le message (réglage dédié), avatar du compte dans la top bar, longues citations repliables, barre d'actions drapeaux masquée au scroll.
- **Changements** : ligne d'infos des sujets unifiée, icônes harmonisées, images sans à-coup de layout.
- **Correctifs** : drapeaux recalés en haut après refresh (#546), signatures plus lisibles — couleurs auteur neutralisées + séparateur « --- » retiré (#553/#550), ré-évaluation de la visibilité de la barre d'actions au changement de scrollabilité (#411/#557).

## Validation
- 4-flavor complet (`detektAll` + assemble Prod/Beta/Dev + lint Prod/Dev + `test`) : BUILD SUCCESSFUL.
- Codex final sur le payload `app-v145..dev` : 0 bloquant.
- Review multi-agent (Opus, seuil >65) : 1 finding retenu (F1/#411) corrigé et mergé (#557, CI verte).

versionName 0.14.0 (≠ 0.13.0 précédente bêta → guard versionName OK). versionCode résolu par le ledger de tags `app-v<N>` au build.

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)