### PR TITLE
feat(blacklist): fondation locale — repo + normalisation + DataStore JSON (#509 PR-A)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/blacklist/BlacklistDataStore.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/blacklist/BlacklistDataStore.kt
@@ -1,0 +1,12 @@
+package fr.forumhfr.redface2.core.data.blacklist
+
+import javax.inject.Qualifier
+
+/**
+ * Qualifies the [androidx.datastore.core.DataStore] dedicated to the local blacklist, so it is not
+ * confused with the user-preferences store ([fr.forumhfr.redface2.core.data.preferences.UserPreferencesDataStore]).
+ * Kept in its own file so the business list and the simple preferences never share a store.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class BlacklistDataStore

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/blacklist/BlacklistModule.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/blacklist/BlacklistModule.kt
@@ -1,0 +1,46 @@
+package fr.forumhfr.redface2.core.data.blacklist
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import fr.forumhfr.redface2.core.domain.blacklist.BlacklistRepository
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object BlacklistModule {
+
+    @Provides
+    @Singleton
+    @BlacklistDataStore
+    fun provideBlacklistDataStore(@ApplicationContext context: Context): DataStore<Preferences> =
+        PreferenceDataStoreFactory.create(
+            // A corrupt Preferences file (proto-level) resets to an empty blacklist rather than
+            // crashing on first read — a bad on-disk store must never hide the whole forum.
+            corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+            produceFile = { context.preferencesDataStoreFile(DATASTORE_FILE_NAME) },
+        )
+
+    private const val DATASTORE_FILE_NAME = "blacklist"
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class BlacklistBindingsModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindBlacklistRepository(
+        impl: DefaultBlacklistRepository,
+    ): BlacklistRepository
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/blacklist/DefaultBlacklistRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/blacklist/DefaultBlacklistRepository.kt
@@ -1,0 +1,119 @@
+package fr.forumhfr.redface2.core.data.blacklist
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import fr.forumhfr.redface2.core.domain.blacklist.BlacklistRepository
+import fr.forumhfr.redface2.core.domain.blacklist.canonicalizePseudo
+import fr.forumhfr.redface2.core.domain.coroutines.ApplicationScope
+import fr.forumhfr.redface2.core.model.blacklist.BlacklistDocument
+import fr.forumhfr.redface2.core.model.blacklist.BlacklistEntry
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+
+/**
+ * Local [BlacklistRepository] backed by a dedicated Preferences [DataStore] holding a single
+ * versioned JSON document (see [BlacklistDocument]). Reads tolerate a missing or corrupt document by
+ * falling back to an empty blacklist, so a bad write can never hide the whole forum.
+ *
+ * Writes are read-modify-write **inside** [DataStore.edit] (transactional) and run on the
+ * application-lifetime [externalScope] via [persist], mirroring
+ * [fr.forumhfr.redface2.core.data.preferences.DataStoreUserPreferencesRepository]: a caller whose
+ * coroutine is cancelled mid-write (a menu sheet dismissed right after the tap) still lands the
+ * change.
+ */
+@Singleton
+class DefaultBlacklistRepository @Inject constructor(
+    @param:BlacklistDataStore private val dataStore: DataStore<Preferences>,
+    @param:ApplicationScope private val externalScope: CoroutineScope,
+) : BlacklistRepository {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    override fun observeEntries(): Flow<List<BlacklistEntry>> =
+        dataStore.data
+            .map { prefs -> readDocument(prefs).entries }
+            .catch { emit(emptyList()) }
+
+    override fun observeBlockedCanonicals(): Flow<Set<String>> =
+        observeEntries()
+            .map { entries -> entries.mapTo(LinkedHashSet()) { it.canonical } }
+            .distinctUntilChanged()
+
+    override suspend fun isBlocked(pseudo: String): Boolean {
+        val canonical = canonicalizePseudo(pseudo)
+        if (canonical.isEmpty()) return false
+        return readDocument(dataStore.data.first()).entries.any { it.canonical == canonical }
+    }
+
+    override suspend fun block(pseudo: String) {
+        val canonical = canonicalizePseudo(pseudo)
+        if (canonical.isEmpty()) return
+        val display = pseudo.trim()
+        persist {
+            dataStore.edit { prefs ->
+                val document = readDocument(prefs)
+                if (document.entries.none { it.canonical == canonical }) {
+                    val entry = BlacklistEntry(canonical, display, System.currentTimeMillis())
+                    prefs[KEY_DOCUMENT] = json.encodeToString(
+                        BlacklistDocument.serializer(),
+                        document.copy(entries = document.entries + entry),
+                    )
+                }
+            }
+        }
+    }
+
+    override suspend fun unblock(pseudo: String) {
+        // Canonicalise so the call works whether the caller passes a raw author pseudo (post menu) or
+        // an already-canonical key (management screen). canonicalizePseudo is idempotent, so passing a
+        // stored BlacklistEntry.canonical back through it is a no-op.
+        val canonical = canonicalizePseudo(pseudo)
+        if (canonical.isEmpty()) return
+        persist {
+            dataStore.edit { prefs ->
+                val document = readDocument(prefs)
+                val remaining = document.entries.filterNot { it.canonical == canonical }
+                if (remaining.size != document.entries.size) {
+                    prefs[KEY_DOCUMENT] = json.encodeToString(
+                        BlacklistDocument.serializer(),
+                        document.copy(entries = remaining),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun readDocument(prefs: Preferences): BlacklistDocument {
+        val raw = prefs[KEY_DOCUMENT] ?: return BlacklistDocument()
+        return try {
+            json.decodeFromString(BlacklistDocument.serializer(), raw)
+        } catch (_: SerializationException) {
+            // A v1 document we cannot parse is treated as empty; the next write replaces it. For v1
+            // this is acceptable (the data was unreadable anyway). Revisit once a v2 shape ships so an
+            // older reader never silently overwrites a newer document.
+            BlacklistDocument()
+        }
+    }
+
+    private suspend fun persist(block: suspend () -> Unit) {
+        externalScope.async { block() }.await()
+    }
+
+    private companion object {
+        val KEY_DOCUMENT = stringPreferencesKey("blacklist_v1")
+    }
+}

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/blacklist/DefaultBlacklistRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/blacklist/DefaultBlacklistRepositoryTest.kt
@@ -1,0 +1,127 @@
+package fr.forumhfr.redface2.core.data.blacklist
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import app.cash.turbine.test
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultBlacklistRepositoryTest {
+
+    @get:Rule val tempFolder = TemporaryFolder()
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val externalScope = CoroutineScope(dispatcher + SupervisorJob())
+
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var repository: DefaultBlacklistRepository
+
+    @Before
+    fun setUp() {
+        dataStore = PreferenceDataStoreFactory.create(
+            produceFile = { tempFolder.newFile("blacklist.preferences_pb") },
+        )
+        repository = DefaultBlacklistRepository(dataStore, externalScope)
+    }
+
+    @Test
+    fun `empty store hides nothing`() = runTest(dispatcher) {
+        assertEquals(emptyList<Any>(), repository.observeEntries().first())
+        assertEquals(emptySet<String>(), repository.observeBlockedCanonicals().first())
+        assertFalse(repository.isBlocked("Foo"))
+    }
+
+    @Test
+    fun `block stores canonical key and preserves the display spelling`() = runTest(dispatcher) {
+        repository.block("FooBar")
+
+        val entry = repository.observeEntries().first().single()
+        assertEquals("foobar", entry.canonical)
+        assertEquals("FooBar", entry.display)
+        assertEquals(setOf("foobar"), repository.observeBlockedCanonicals().first())
+    }
+
+    @Test
+    fun `isBlocked matches case and whitespace variants`() = runTest(dispatcher) {
+        repository.block("Foo")
+
+        assertTrue(repository.isBlocked("foo"))
+        assertTrue(repository.isBlocked("FOO"))
+        assertTrue(repository.isBlocked("  Foo  "))
+        assertFalse(repository.isBlocked("Bar"))
+    }
+
+    @Test
+    fun `unblock accepts a raw pseudo, not just the canonical key`() = runTest(dispatcher) {
+        repository.block("Foo")
+
+        repository.unblock("  FOO  ")
+
+        assertFalse(repository.isBlocked("Foo"))
+    }
+
+    @Test
+    fun `blocking the same canonical twice keeps a single entry with the first spelling`() = runTest(dispatcher) {
+        repository.block("Foo")
+        repository.block("foo ")
+
+        val entries = repository.observeEntries().first()
+        assertEquals(1, entries.size)
+        assertEquals("Foo", entries.single().display)
+    }
+
+    @Test
+    fun `block preserves insertion order`() = runTest(dispatcher) {
+        repository.block("Alice")
+        repository.block("Bob")
+
+        assertEquals(listOf("Alice", "Bob"), repository.observeEntries().first().map { it.display })
+    }
+
+    @Test
+    fun `unblock removes the matching entry and is a no-op when absent`() = runTest(dispatcher) {
+        repository.block("Foo")
+        repository.unblock("nope")
+        assertTrue(repository.isBlocked("Foo"))
+
+        repository.unblock("foo")
+        assertEquals(emptyList<Any>(), repository.observeEntries().first())
+    }
+
+    @Test
+    fun `blank pseudo is never blocked`() = runTest(dispatcher) {
+        repository.block("   ")
+        assertEquals(emptyList<Any>(), repository.observeEntries().first())
+    }
+
+    @Test
+    fun `a fresh repository decodes the persisted document`() = runTest(dispatcher) {
+        repository.block("Foo")
+
+        val reopened = DefaultBlacklistRepository(dataStore, externalScope)
+        assertTrue(reopened.isBlocked("foo"))
+    }
+
+    @Test
+    fun `a corrupt document falls back to an empty blacklist`() = runTest(dispatcher) {
+        dataStore.edit { it[stringPreferencesKey("blacklist_v1")] = "{ not valid json" }
+
+        assertEquals(emptyList<Any>(), repository.observeEntries().first())
+        assertFalse(repository.isBlocked("Foo"))
+    }
+}

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/blacklist/BlacklistRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/blacklist/BlacklistRepository.kt
@@ -1,0 +1,42 @@
+package fr.forumhfr.redface2.core.domain.blacklist
+
+import fr.forumhfr.redface2.core.model.blacklist.BlacklistEntry
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Local store of blacklisted (hidden) HFR users — the "local first" half of #509. The blacklist is
+ * applied at the UI/MVI layer (post kept in the list, rendered as a collapsed placeholder), never in
+ * the parser or cache, so pagination, anchors and `numreponse` keys stay intact.
+ *
+ * Identity is matched on the **pseudo** (always present on a [fr.forumhfr.redface2.core.model.Post];
+ * the profile id is nullable, hence unusable as a key), normalised through [canonicalizePseudo].
+ *
+ * Designed so a later MPStorage sync becomes an additive adapter, not a rewrite: it is a proper
+ * repository over a versioned document, not a throwaway `Set` in a ViewModel.
+ */
+interface BlacklistRepository {
+
+    /** Blocked users in insertion order, for the management screen. Empty when nothing is blocked. */
+    fun observeEntries(): Flow<List<BlacklistEntry>>
+
+    /**
+     * Canonical keys of currently blocked users, for cheap membership checks while rendering a topic:
+     * `canonicalizePseudo(post.author) in canonicals`.
+     */
+    fun observeBlockedCanonicals(): Flow<Set<String>>
+
+    /** Whether [pseudo] is currently blocked (canonicalised internally). */
+    suspend fun isBlocked(pseudo: String): Boolean
+
+    /**
+     * Block [pseudo]. No-op if blank or already blocked (canonical match). The first spelling seen is
+     * kept as the entry's display name.
+     */
+    suspend fun block(pseudo: String)
+
+    /**
+     * Unblock [pseudo]. Canonicalised internally, so it accepts either a raw author pseudo (post
+     * menu) or a stored [BlacklistEntry.canonical] (management screen). No-op if blank or absent.
+     */
+    suspend fun unblock(pseudo: String)
+}

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/blacklist/PseudoCanonicalizer.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/blacklist/PseudoCanonicalizer.kt
@@ -1,0 +1,41 @@
+package fr.forumhfr.redface2.core.domain.blacklist
+
+import java.text.Normalizer
+import java.util.Locale
+
+/**
+ * Canonical match key for an HFR pseudo, used by the blacklist to decide whether a post author is
+ * hidden. A plain `lowercase()` is not enough (Codex review on #509): HFR pseudos can carry
+ * non-breaking / doubled whitespace, mixed Unicode normalisation forms, and stray invisible format
+ * characters, all of which must collapse to the same key so "Foo", "foo" and "foo " match.
+ *
+ * Steps, in order:
+ * 1. drop Unicode format characters (general category Cf: zero-width space/joiners, BOM, word
+ *    joiner, bidi controls…) that never carry meaning in a pseudo;
+ * 2. collapse every run of whitespace (incl. non-breaking spaces — [Char.isWhitespace] covers them)
+ *    to a single ASCII space, and trim the ends;
+ * 3. normalise to Unicode NFC — **without** stripping accents: HFR shows accented pseudos verbatim,
+ *    so "Crème" and "Creme" are deliberately different users;
+ * 4. lowercase with [Locale.ROOT] for a stable, locale-independent key.
+ *
+ * Returns an empty string for blank input (the repository treats that as "nothing to block").
+ */
+fun canonicalizePseudo(raw: String): String {
+    val collapsed = buildString {
+        var pendingSpace = false
+        var started = false
+        for (ch in raw) {
+            when {
+                Character.getType(ch.code) == Character.FORMAT.toInt() -> Unit
+                ch.isWhitespace() -> if (started) pendingSpace = true
+                else -> {
+                    if (pendingSpace) append(' ')
+                    append(ch)
+                    pendingSpace = false
+                    started = true
+                }
+            }
+        }
+    }
+    return Normalizer.normalize(collapsed, Normalizer.Form.NFC).lowercase(Locale.ROOT)
+}

--- a/core/domain/src/test/kotlin/fr/forumhfr/redface2/core/domain/blacklist/PseudoCanonicalizerTest.kt
+++ b/core/domain/src/test/kotlin/fr/forumhfr/redface2/core/domain/blacklist/PseudoCanonicalizerTest.kt
@@ -1,0 +1,65 @@
+package fr.forumhfr.redface2.core.domain.blacklist
+
+import java.text.Normalizer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class PseudoCanonicalizerTest {
+
+    // Special characters built from code points so the source carries no invisible glyphs.
+    private val nbsp = Char(0x00A0).toString()
+    private val zwsp = Char(0x200B).toString()
+    private val zwnj = Char(0x200C).toString()
+    private val zwj = Char(0x200D).toString()
+    private val bom = Char(0xFEFF).toString()
+    private val wordJoiner = Char(0x2060).toString()
+
+    @Test
+    fun `lowercases ascii`() {
+        assertEquals("foobar", canonicalizePseudo("FooBar"))
+    }
+
+    @Test
+    fun `trims surrounding whitespace`() {
+        assertEquals("foo", canonicalizePseudo("  Foo  "))
+    }
+
+    @Test
+    fun `collapses internal whitespace runs to a single space`() {
+        assertEquals("le foo", canonicalizePseudo("Le   Foo"))
+    }
+
+    @Test
+    fun `treats a non-breaking space like a regular space`() {
+        // U+00A0 around the edges (trimmed) and in the middle (collapsed to one ASCII space).
+        assertEquals("le foo", canonicalizePseudo("${nbsp}Le$nbsp${nbsp}Foo$nbsp"))
+    }
+
+    @Test
+    fun `keeps accents - accented and unaccented pseudos stay distinct`() {
+        assertEquals("crème", canonicalizePseudo("Crème"))
+        assertNotEquals(canonicalizePseudo("Crème"), canonicalizePseudo("Creme"))
+    }
+
+    @Test
+    fun `normalises NFD to NFC so the two spellings of an accented pseudo match`() {
+        val nfc = "Crème"
+        val nfd = Normalizer.normalize(nfc, Normalizer.Form.NFD)
+        // Pre-condition: the two forms differ byte-wise before canonicalisation.
+        assertNotEquals(nfc, nfd)
+        assertEquals(canonicalizePseudo(nfc), canonicalizePseudo(nfd))
+    }
+
+    @Test
+    fun `strips zero-width and other invisible format characters`() {
+        assertEquals("foo", canonicalizePseudo("$bom${zwsp}Fo${zwnj}o$zwj$wordJoiner"))
+    }
+
+    @Test
+    fun `blank input canonicalises to empty`() {
+        assertEquals("", canonicalizePseudo(""))
+        assertEquals("", canonicalizePseudo("   "))
+        assertEquals("", canonicalizePseudo("$nbsp$zwsp"))
+    }
+}

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/blacklist/Blacklist.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/blacklist/Blacklist.kt
@@ -1,0 +1,39 @@
+package fr.forumhfr.redface2.core.model.blacklist
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * One blacklisted (hidden) HFR user.
+ *
+ * - [canonical] is the normalised match key (see `canonicalizePseudo` in `:core:domain`) — what we
+ *   compare a post author against. It is what makes "Foo", "foo" and " foo " collapse to one entry.
+ * - [display] preserves the spelling first seen when the user was blocked, for the management screen.
+ *   When two spellings normalise to the same [canonical], the first one wins (no duplicate entry).
+ * - [addedAt] is an epoch-millis timestamp, kept so a future MPStorage sync can resolve conflicts and
+ *   so the management list can be ordered by recency if desired.
+ *
+ * Stored as a versioned JSON document ([BlacklistDocument]) rather than a `Set<String>` so the schema
+ * can grow additively (block reason, per-category/topic scope, sync origin) without breaking the
+ * production key. Every field carries an explicit [SerialName] for forward-compatible persistence.
+ */
+@Serializable
+data class BlacklistEntry(
+    @SerialName("canonical") val canonical: String,
+    @SerialName("display") val display: String,
+    @SerialName("addedAt") val addedAt: Long,
+)
+
+/**
+ * Versioned container persisted for the local blacklist. [version] lets a later reader migrate an
+ * older shape; [entries] is kept in insertion order so the management screen is stable.
+ */
+@Serializable
+data class BlacklistDocument(
+    @SerialName("version") val version: Int = CURRENT_VERSION,
+    @SerialName("entries") val entries: List<BlacklistEntry> = emptyList(),
+) {
+    companion object {
+        const val CURRENT_VERSION = 1
+    }
+}


### PR DESCRIPTION
**PR-A** de la blacklist locale (#509) — couche `:core` seule, **aucun consommateur UI**, défaut liste vide → **zéro changement de comportement**. Stockage **local** (DataStore JSON versionné), pas de MPStorage (différé, ADR-014).

## Contenu
- **`:core:model`** — `BlacklistDocument` / `BlacklistEntry` versionnés (`@Serializable`, `@SerialName` explicites pour une persistance évolutive).
- **`:core:domain`** — `canonicalizePseudo()` (retire les caractères Unicode FORMAT, collapse les espaces dont NBSP, NFC, `lowercase(ROOT)`, **conserve les accents**) + interface `BlacklistRepository`.
- **`:core:data`** — `DefaultBlacklistRepository` sur un `DataStore<Preferences>` dédié, **un document JSON** sous `blacklist_v1` ; read-modify-write transactionnel dans `edit{}`, écritures sur l'`ApplicationScope` (survivent à l'annulation de l'appelant), fichier proto corrompu (corruption handler) **et** JSON corrompu (`SerializationException` ciblée) retombent sur liste vide. Module Hilt + binding.
- **Tests** — canonicalisation (casse/espaces/NBSP/NFD/format chars/blanc) + repository (block/isBlocked/dédup première-gagne/ordre/unblock par pseudo brut/persistance/corruption).

## Décisions produit
Conception + 6 décisions transverses dans #509 (défauts approuvés par @XaTriX). Les prochaines PR : B1 (`HiddenPostCard` + reveal dans `:feature:topic`), B2 (entrée `PostMenuSheet`), C (page Réglages « Utilisateurs masqués »).

## Validation
4-flavor non requis (couche core) ; localement : `:core:domain:test` + `:core:data:testDebugUnitTest` + `detektAll` verts, `:app:assembleDevDebug` vert (graphe Hilt OK). Revue Codex passée (5 findings corrigés : decode explicite, corruption handler, catch ciblé, `unblock` canonicalisé, FORMAT chars).

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)