### PR TITLE
feat(blacklist): masquer les posts d'auteurs blacklistés par un placeholder (#509 PR-B1)

### DIFF
--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/blacklist/BlacklistRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/blacklist/BlacklistRepository.kt
@@ -22,6 +22,11 @@ interface BlacklistRepository {
     /**
      * Canonical keys of currently blocked users, for cheap membership checks while rendering a topic:
      * `canonicalizePseudo(post.author) in canonicals`.
+     *
+     * Contract: emits the current set **immediately** on subscription (the empty set when nothing is
+     * blocked), then on every change. This lets a consumer `combine` it with another flow to gate the
+     * first emission on a known blacklist without ever stalling. The DataStore-backed implementation
+     * satisfies this by construction (a Preferences `DataStore` always emits its current value first).
      */
     fun observeBlockedCanonicals(): Flow<Set<String>>
 

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -801,6 +801,7 @@ internal fun TopicContent(
                             TopicLoadedContent(
                                 state = state,
                                 topic = mode.topic,
+                                hiddenNumreponses = mode.hiddenNumreponses,
                                 onReply = onReply,
                                 onQuote = onQuote,
                                 onEdit = onEdit,
@@ -828,10 +829,16 @@ internal fun TopicContent(
 }
 
 @Composable
-@Suppress("LongParameterList") // state-hoisted Composable : each param has a distinct call-site.
+// LongParameterList : state-hoisted Composable, each param has a distinct call-site.
+// CyclomaticComplexMethod : dense list builder (header + per-post action gates + #509 hidden branch);
+// splitting it would scatter one visual unit across helpers (same stance as TopicPostCard).
+@Suppress("LongParameterList", "CyclomaticComplexMethod")
 private fun TopicLoadedContent(
     state: TopicUiState,
     topic: Topic,
+    // #509 — `numreponse` of posts whose author is blacklisted; rendered as a collapsed
+    // "post masqué" placeholder instead of the full card (the post stays in the list).
+    hiddenNumreponses: Set<Int> = emptySet(),
     onReply: (subcat: Int, page: Int) -> Unit,
     onQuote: (subcat: Int, page: Int, quotedNumreponse: Int, quoteRef: Int?) -> Unit,
     onEdit: (subcat: Int, page: Int, numreponse: Int) -> Unit,
@@ -860,6 +867,17 @@ private fun TopicLoadedContent(
     // it needs a Hilt ViewModel). Deliberately NOT rememberSaveable: Post is not Parcelable
     // and losing an open overflow menu across process death is acceptable.
     var menuPost by remember { mutableStateOf<Post?>(null) }
+    // #509 — posts the reader chose to reveal despite the author being blacklisted. Temporary and
+    // re-keyed on `topic.page`, not persisted: re-hiding on a page change is the intended "masqué by
+    // default" behaviour (decision #6). This composable instance is bound to one (cat, post), so the
+    // page is the only key dimension that matters here.
+    var revealedHiddenPosts by remember(topic.page) { mutableStateOf(emptySet<Int>()) }
+    // #509 — a post hidden (author blacklisted) while it sat in the multi-quote basket is dropped from
+    // the selection: the placeholder exposes no deselect affordance (decision #1), so leaving it
+    // selected would silently quote a masqué post. The basket is hoisted in :app; reuse its toggle.
+    LaunchedEffect(hiddenNumreponses, multiQuoteSelection) {
+        multiQuoteSelection.filter { it in hiddenNumreponses }.forEach(onToggleMultiQuote)
+    }
     // #282 — shared offset between the gesture (drives translationX) and the edge glow. A plain
     // MutableFloatState: the gesture writes it synchronously per frame (no coroutine/alloc), the draw
     // phase reads it; an Animatable inside the gesture handles only release transitions. Lives in the
@@ -1018,24 +1036,34 @@ private fun TopicLoadedContent(
             val profileAction: (() -> Unit)? = post.profileId?.let { profileId ->
                 { onOpenProfile(profileId, post.author, post.avatarUrl) }
             }
-            TopicPostCard(
-                post = post,
-                highlighted = highlight == post.numreponse,
-                citedCount = citationCounts[post.numreponse] ?: 0,
-                // #330 — render the author signature beneath the body when the reading preference
-                // is on (the signature is always parsed/cached on the Post; this is render-only).
-                showSignature = state.showSignatures,
-                onQuote = quoteAction,
-                onEdit = editAction,
-                onOpenProfile = profileAction,
-                onOpenMenu = { menuPost = post },
-                // #436 — same membership source as the menu entry (PostMenuSheet).
-                multiQuoteSelected = post.numreponse in multiQuoteSelection,
-                // #436 — per-post add/remove affordance (RF1 quote+/quote- parity), reachable
-                // without opening the « … » menu. Null/non-null under the SAME gate as « Citer »
-                // (derived together above), so the « + » and « Citer » always appear as a pair.
-                onToggleMultiQuote = multiQuoteToggle,
-            )
+            // #509 — a blacklisted author's post is replaced by a collapsed placeholder (the post is
+            // kept in the list to preserve index/anchor/numreponse invariants), until the reader taps
+            // « Afficher ». The placeholder exposes no quote/edit/menu action by design (decision #1).
+            if (post.numreponse in hiddenNumreponses && post.numreponse !in revealedHiddenPosts) {
+                HiddenPostCard(
+                    author = post.author,
+                    onReveal = { revealedHiddenPosts = revealedHiddenPosts + post.numreponse },
+                )
+            } else {
+                TopicPostCard(
+                    post = post,
+                    highlighted = highlight == post.numreponse,
+                    citedCount = citationCounts[post.numreponse] ?: 0,
+                    // #330 — render the author signature beneath the body when the reading preference
+                    // is on (the signature is always parsed/cached on the Post; this is render-only).
+                    showSignature = state.showSignatures,
+                    onQuote = quoteAction,
+                    onEdit = editAction,
+                    onOpenProfile = profileAction,
+                    onOpenMenu = { menuPost = post },
+                    // #436 — same membership source as the menu entry (PostMenuSheet).
+                    multiQuoteSelected = post.numreponse in multiQuoteSelection,
+                    // #436 — per-post add/remove affordance (RF1 quote+/quote- parity), reachable
+                    // without opening the « … » menu. Null/non-null under the SAME gate as « Citer »
+                    // (derived together above), so the « + » and « Citer » always appear as a pair.
+                    onToggleMultiQuote = multiQuoteToggle,
+                )
+            }
         }
         // #379 — explicit end-of-topic marker after the last post of the LAST page. The
         // « page X/Y » counter (#284) lets the reader deduce it; this says it. Reflects the
@@ -1379,6 +1407,44 @@ private fun TopicPollCard(
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+            }
+        }
+    }
+}
+
+/**
+ * #509 — collapsed placeholder shown in place of a blacklisted author's post. The post is NOT removed
+ * from the list (index/anchor/`numreponse` invariants stay intact); only its body is replaced by this
+ * one-line card. « Afficher » reveals the real card for the current page only. By design it exposes no
+ * quote/edit/menu action (decision #1): the reader reveals first, then acts on the full card.
+ */
+@Composable
+private fun HiddenPostCard(
+    author: String,
+    onReveal: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        ),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = stringResource(R.string.topic_post_hidden_by_author, author),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.weight(1f, fill = false),
+            )
+            TextButton(onClick = onReveal) {
+                Text(text = stringResource(R.string.topic_post_hidden_reveal))
             }
         }
     }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -78,6 +78,14 @@ data class TopicUiState(
 
         data class Loaded(
             val topic: Topic,
+            /**
+             * #509 — `numreponse` of the posts whose author is blacklisted, computed from the
+             * blacklist combined with `topic.posts` so it is always coherent with [topic]. The screen
+             * renders these as a collapsed "post masqué" placeholder (never removed from the list, so
+             * pagination/anchors/`numreponse` keys stay intact). Empty = nothing hidden. Gated into the
+             * first emission (combine with the blacklist) so a blocked post never flashes before hiding.
+             */
+            val hiddenNumreponses: Set<Int> = emptySet(),
         ) : Mode
 
         data class Error(

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -8,12 +8,15 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
+import fr.forumhfr.redface2.core.domain.blacklist.BlacklistRepository
+import fr.forumhfr.redface2.core.domain.blacklist.canonicalizePseudo
 import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.topic.TopicRepository
 import fr.forumhfr.redface2.core.domain.write.DeletePostRepository
 import fr.forumhfr.redface2.core.domain.write.DeletePostResult
 import fr.forumhfr.redface2.core.model.AuthState
+import fr.forumhfr.redface2.core.model.Topic
 import fr.forumhfr.redface2.core.model.write.EditPostContext
 import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
 import kotlinx.coroutines.CancellationException
@@ -24,6 +27,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -48,10 +52,18 @@ class TopicViewModel @AssistedInject constructor(
     private val authRepository: AuthRepository,
     private val userPreferencesRepository: UserPreferencesRepository,
     private val deletePostRepository: DeletePostRepository,
+    private val blacklistRepository: BlacklistRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(TopicUiState.initial(request))
     val state: StateFlow<TopicUiState> = _state.asStateFlow()
+
+    /**
+     * #509 — latest set of blacklisted canonical pseudos. Kept fresh by the [loadCurrentPage] combine
+     * so the refresh / post-submit / post-delete paths (which bypass `observeTopicPage`) can recompute
+     * the hidden set without re-subscribing to the blacklist.
+     */
+    private var blockedCanonicals: Set<String> = emptySet()
 
     private val _effects: Channel<TopicEffect> = Channel(capacity = Channel.BUFFERED)
     val effects: Flow<TopicEffect> = _effects.receiveAsFlow()
@@ -165,7 +177,7 @@ class TopicViewModel @AssistedInject constructor(
                 val topic = topicRepository.refreshTopicPage(request.cat, request.post, request.page)
                 _state.update {
                     it.copy(
-                        mode = TopicUiState.Mode.Loaded(topic),
+                        mode = TopicUiState.Mode.Loaded(topic, computeHiddenNumreponses(topic, blockedCanonicals)),
                         availablePages = (1..topic.totalPages).toList(),
                     )
                 }
@@ -215,8 +227,15 @@ class TopicViewModel @AssistedInject constructor(
         beginFirstContentSection()
         _state.update { it.copy(mode = TopicUiState.Mode.Loading) }
         loadJob = viewModelScope.launch {
-            topicRepository
-                .observeTopicPage(request.cat, request.post, request.page, forceRefresh = request.forceRefresh)
+            combine(
+                topicRepository
+                    .observeTopicPage(request.cat, request.post, request.page, forceRefresh = request.forceRefresh),
+                // #509 — gate the first Loaded on the blacklist being known so a blocked post never
+                // flashes before it is hidden, and re-filter live when the blacklist changes.
+                // observeBlockedCanonicals emits its current set immediately (its documented contract),
+                // so combine never stalls waiting on the blacklist.
+                blacklistRepository.observeBlockedCanonicals(),
+            ) { topic, blocked -> topic to blocked }
                 .catch { error ->
                     if (error is CancellationException) throw error
                     // Cache-first UX: if we already showed a cached page, keep it on screen
@@ -241,10 +260,11 @@ class TopicViewModel @AssistedInject constructor(
                     // still draws a bounded sliver from intent to terminal state.
                     endFirstContentSectionIfNeeded()
                 }
-                .collect { topic ->
+                .collect { (topic, blocked) ->
+                    blockedCanonicals = blocked
                     _state.update {
                         it.copy(
-                            mode = TopicUiState.Mode.Loaded(topic),
+                            mode = TopicUiState.Mode.Loaded(topic, computeHiddenNumreponses(topic, blockedCanonicals)),
                             availablePages = (1..topic.totalPages).toList(),
                         )
                     }
@@ -256,6 +276,19 @@ class TopicViewModel @AssistedInject constructor(
                     maybeSchedulePrefetch(totalPages = topic.totalPages)
                 }
         }
+    }
+
+    /**
+     * #509 — `numreponse` of the posts in [topic] whose author is blacklisted (canonical match). The
+     * full [Topic.posts] list is kept intact; the screen renders a collapsed placeholder for these so
+     * pagination, anchors and `numreponse` keys are unaffected. Fast-paths the common empty blacklist.
+     */
+    private fun computeHiddenNumreponses(topic: Topic, blocked: Set<String>): Set<Int> {
+        if (blocked.isEmpty()) return emptySet()
+        return topic.posts.asSequence()
+            .filter { canonicalizePseudo(it.author) in blocked }
+            .map { it.numreponse }
+            .toSet()
     }
 
     private suspend fun maybeEmitScroll(visiblePosts: List<Int>) {
@@ -304,7 +337,7 @@ class TopicViewModel @AssistedInject constructor(
                 val topic = topicRepository.refreshTopicPage(request.cat, request.post, request.page)
                 _state.update {
                     it.copy(
-                        mode = TopicUiState.Mode.Loaded(topic),
+                        mode = TopicUiState.Mode.Loaded(topic, computeHiddenNumreponses(topic, blockedCanonicals)),
                         availablePages = (1..topic.totalPages).toList(),
                     )
                 }
@@ -459,7 +492,7 @@ class TopicViewModel @AssistedInject constructor(
                 val topic = topicRepository.refreshTopicPage(request.cat, request.post, request.page)
                 _state.update {
                     it.copy(
-                        mode = TopicUiState.Mode.Loaded(topic),
+                        mode = TopicUiState.Mode.Loaded(topic, computeHiddenNumreponses(topic, blockedCanonicals)),
                         availablePages = (1..topic.totalPages).toList(),
                     )
                 }

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -13,6 +13,9 @@
     <!-- #291 — entrée du menu contextuel : ajoute/retire le post du panier de citation multiple. -->
     <string name="topic_post_menu_multi_quote_add">Ajouter à la citation multiple</string>
     <string name="topic_post_menu_multi_quote_remove">Retirer de la citation multiple</string>
+    <!-- #509 — placeholder replié à la place d'un post d'auteur masqué (blacklist). %1$s = pseudo. -->
+    <string name="topic_post_hidden_by_author">Post de %1$s masqué</string>
+    <string name="topic_post_hidden_reveal">Afficher</string>
     <string name="topic_loading">Chargement…</string>
     <!-- #379 — marqueur explicite de fin de sujet, rendu après le dernier post de la DERNIÈRE page. -->
     <string name="topic_end_of_topic">Dernier message du sujet</string>

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -2,6 +2,7 @@ package fr.forumhfr.redface2.feature.topic
 
 import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
+import fr.forumhfr.redface2.core.domain.blacklist.BlacklistRepository
 import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
@@ -17,6 +18,7 @@ import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import fr.forumhfr.redface2.core.domain.write.DeletePostRepository
 import fr.forumhfr.redface2.core.domain.write.DeletePostResult
 import fr.forumhfr.redface2.core.model.AuthState
+import fr.forumhfr.redface2.core.model.blacklist.BlacklistEntry
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.write.EditPostContext
 import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
@@ -678,18 +680,90 @@ class TopicViewModelTest {
     // Construction seam: the ViewModel now also takes a UserPreferencesRepository (for the build 89
     // top-bar auto-hide preference) which none of these tests exercise, so it defaults to a no-op
     // fake. Keeps every existing call site unchanged bar the constructor → helper rename.
+    @Test
+    fun `blacklisted authors posts are reported hidden by numreponse, others are not`() = runTest {
+        val topic = fakeTopic(
+            page = 1,
+            totalPages = 1,
+            posts = listOf(
+                fakePost(100, author = "Alice"),
+                fakePost(101, author = "Bob"),
+                // canonical match is case/whitespace-insensitive: "alice" matches the "Alice" rule.
+                fakePost(102, author = "  alice  "),
+            ),
+        )
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(topic) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            blacklistRepository = FakeBlacklistRepository(blockedCanonicals = setOf("alice")),
+        )
+
+        viewModel.state.test {
+            val mode = assertMode<TopicUiState.Mode.Loaded>(awaitItem())
+            assertEquals(setOf(100, 102), mode.hiddenNumreponses)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `empty blacklist hides nothing`() = runTest {
+        val topic = fakeTopic(
+            page = 1,
+            totalPages = 1,
+            posts = listOf(fakePost(100, author = "Alice"), fakePost(101, author = "Bob")),
+        )
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(topic) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+
+        viewModel.state.test {
+            val mode = assertMode<TopicUiState.Mode.Loaded>(awaitItem())
+            assertEquals(emptySet<Int>(), mode.hiddenNumreponses)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `blocking an author after load hides their posts live`() = runTest {
+        val topic = fakeTopic(
+            page = 1,
+            totalPages = 1,
+            posts = listOf(fakePost(100, author = "Alice"), fakePost(101, author = "Bob")),
+        )
+        val blacklist = FakeBlacklistRepository()
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(topic) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            blacklistRepository = blacklist,
+        )
+
+        viewModel.state.test {
+            assertEquals(emptySet<Int>(), assertMode<TopicUiState.Mode.Loaded>(awaitItem()).hiddenNumreponses)
+            blacklist.block("alice")
+            assertEquals(setOf(100), assertMode<TopicUiState.Mode.Loaded>(awaitItem()).hiddenNumreponses)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Suppress("LongParameterList") // test factory mirroring the ViewModel's injected dependencies.
     private fun topicViewModel(
         request: TopicRequest,
         topicRepository: TopicRepository,
         authRepository: AuthRepository,
         userPreferencesRepository: UserPreferencesRepository = FakeUserPreferencesRepository(),
         deletePostRepository: DeletePostRepository = FakeDeletePostRepository(),
+        blacklistRepository: BlacklistRepository = FakeBlacklistRepository(),
     ): TopicViewModel = TopicViewModel(
         request = request,
         topicRepository = topicRepository,
         authRepository = authRepository,
         userPreferencesRepository = userPreferencesRepository,
         deletePostRepository = deletePostRepository,
+        blacklistRepository = blacklistRepository,
     )
 
     private fun topicRequest(
@@ -1205,9 +1279,9 @@ class TopicViewModelTest {
         poll = null,
     )
 
-    private fun fakePost(numreponse: Int, isEditable: Boolean = false): Post = Post(
+    private fun fakePost(numreponse: Int, isEditable: Boolean = false, author: String = "tester"): Post = Post(
         numreponse = numreponse,
-        author = "tester",
+        author = author,
         date = java.time.Instant.parse("2026-05-04T12:00:00Z"),
         content = PostContent(blocks = emptyList()),
         avatarUrl = null,
@@ -1304,6 +1378,27 @@ private class FakeDeletePostRepository(
     override suspend fun deletePost(context: EditPostContext): DeletePostResult {
         calls += context
         return result
+    }
+}
+
+private class FakeBlacklistRepository(
+    blockedCanonicals: Set<String> = emptySet(),
+) : BlacklistRepository {
+    private val canonicals = MutableStateFlow(blockedCanonicals)
+
+    override fun observeEntries(): Flow<List<BlacklistEntry>> =
+        MutableStateFlow(canonicals.value.map { BlacklistEntry(it, it, 0L) })
+
+    override fun observeBlockedCanonicals(): Flow<Set<String>> = canonicals
+
+    override suspend fun isBlocked(pseudo: String): Boolean = pseudo in canonicals.value
+
+    override suspend fun block(pseudo: String) {
+        canonicals.value = canonicals.value + pseudo
+    }
+
+    override suspend fun unblock(pseudo: String) {
+        canonicals.value = canonicals.value - pseudo
     }
 }
 


### PR DESCRIPTION
**PR-B1** de la blacklist locale (#509), **côté lecture uniquement**. Un post dont l'auteur est blacklisté est remplacé dans le topic par une carte repliée « **Post de `<pseudo>` masqué — Afficher** » au lieu d'être retiré : le post reste dans `topic.posts`, donc **pagination, ancres de scroll et clés `numreponse` sont préservées** (Codex #1).

## Contenu
- **`TopicViewModel`** combine `observeTopicPage` avec `observeBlockedCanonicals` → le premier `Loaded` est **gaté sur une blacklist connue** (pas de flash, décision #5) et la page se **re-filtre en direct** quand la blacklist change. Les 3 chemins refresh/submit/delete réutilisent le dernier snapshot. `observeBlockedCanonicals` émet immédiatement (contrat documenté), donc le `combine` ne bloque jamais.
- **`Mode.Loaded`** porte `hiddenNumreponses` (cohérent avec `topic.posts`, calculé atomiquement).
- **`TopicScreen`** rend `HiddenPostCard` pour les posts masqués ; « Afficher » révèle pour la **page courante seulement** (décision #6) ; le placeholder n'expose **aucune action** (décision #1). Un post masqué alors qu'il était dans le panier multi-citation est **retiré de la sélection** (sinon citation silencieuse d'un masqué — Codex).
- **Tests** : masquage par auteur (casse/espaces), blacklist vide ne masque rien, blocage live après chargement.

Défaut liste vide ⇒ **zéro changement de comportement**. Décisions produit dans #509 (défauts validés).

## Validation
`:feature:topic:testDebugUnitTest` + `detektAll` + `:app:assembleDevDebug` verts (`--rerun-tasks`). Revue Codex passée (BLOCKER combine = non-réel, contrat d'émission DataStore documenté + testé ; multi-quote purgé ; commentaires corrigés). Suite : PR-B2 (entrée menu post « Masquer »), PR-C (page Réglages).

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)