### PR TITLE
feat(blacklist): masquer/réafficher un auteur depuis le menu post (#509 PR-B2)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostMenuSheet.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostMenuSheet.kt
@@ -100,6 +100,16 @@ internal fun PostMenuSheet(
      * as « Citer » (`shouldShowQuoteAction`): locked topic or anonymous session.
      */
     onToggleMultiQuote: (() -> Unit)? = null,
+    /**
+     * #509 — whether this post's author is currently blacklisted; flips the entry's label between
+     * « Masquer cet utilisateur » and « Ne plus masquer cet utilisateur ».
+     */
+    authorBlocked: Boolean = false,
+    /**
+     * #509 — blocks / unblocks this post's author. Null hides the entry (e.g. the user's own posts —
+     * blacklisting oneself is pointless).
+     */
+    onToggleBlockAuthor: (() -> Unit)? = null,
 ) {
     val sheetState = rememberModalBottomSheetState()
     val coroutineScope = rememberCoroutineScope()
@@ -202,6 +212,29 @@ internal fun PostMenuSheet(
                                 R.string.topic_post_menu_multi_quote_remove
                             } else {
                                 R.string.topic_post_menu_multi_quote_add
+                            },
+                        ),
+                    )
+                }
+            }
+
+            if (onToggleBlockAuthor != null) {
+                Spacer(Modifier.height(8.dp))
+                // #509 — blacklist the post's author (or lift it). Closing on tap lets the reader see
+                // the post collapse to the « masqué » placeholder immediately as feedback.
+                OutlinedButton(
+                    onClick = {
+                        onToggleBlockAuthor()
+                        hideThenDismiss(coroutineScope, sheetState, onDismiss)
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        stringResource(
+                            if (authorBlocked) {
+                                R.string.topic_post_menu_unblock_author
+                            } else {
+                                R.string.topic_post_menu_block_author
                             },
                         ),
                     )

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -813,6 +813,9 @@ internal fun TopicContent(
                                 listState = listState,
                                 multiQuoteSelection = multiQuoteSelection,
                                 onToggleMultiQuote = onToggleMultiQuote,
+                                onSetAuthorBlocked = { author, blocked ->
+                                    onIntent(TopicIntent.SetAuthorBlocked(author, blocked))
+                                },
                                 pollManualExpanded = pollManualExpanded,
                                 onPollExpansionChanged = onPollExpansionChanged,
                             )
@@ -852,6 +855,8 @@ private fun TopicLoadedContent(
     // #291 — selection state + toggle for the post menu's multi-quote entry.
     multiQuoteSelection: List<Int> = emptyList(),
     onToggleMultiQuote: (numreponse: Int) -> Unit = {},
+    // #509 — block/unblock a post's author from the post menu (blacklist).
+    onSetAuthorBlocked: (author: String, blocked: Boolean) -> Unit = { _, _ -> },
     // #465 — the topic's manual poll choice (owned by :app, null = follow the global default) + the
     // callback recording a tap on the poll card. Threaded down to the header card's poll.
     pollManualExpanded: Boolean? = null,
@@ -1120,6 +1125,15 @@ private fun TopicLoadedContent(
                 { onToggleMultiQuote(post.numreponse) }
             } else {
                 null
+            },
+            // #509 — a post reachable through the menu is either not blocked, or blocked-but-revealed;
+            // either way `numreponse in hiddenNumreponses` tells whether the author is blacklisted, so
+            // the entry flips between Masquer / Ne plus masquer. Hidden for the user's own posts.
+            authorBlocked = post.numreponse in hiddenNumreponses,
+            onToggleBlockAuthor = if (post.isOwnPost) {
+                null
+            } else {
+                { onSetAuthorBlocked(post.author, post.numreponse !in hiddenNumreponses) }
             },
         )
     }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -126,6 +126,13 @@ sealed interface TopicIntent {
      * identifies the post to delete (unique per category).
      */
     data class DeletePost(val numreponse: Int) : TopicIntent
+
+    /**
+     * #509 — blacklist (or un-blacklist) [author] from the post menu. [blocked] = true blocks (their
+     * posts collapse to the « masqué » placeholder), false unblocks. The ViewModel delegates to
+     * `BlacklistRepository`; the topic re-filters live through the page combine.
+     */
+    data class SetAuthorBlocked(val author: String, val blocked: Boolean) : TopicIntent
 }
 
 /**

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -151,6 +151,20 @@ class TopicViewModel @AssistedInject constructor(
             TopicIntent.Retry -> loadCurrentPage()
             is TopicIntent.DeletePost -> deletePost(intent.numreponse)
             TopicIntent.Refresh -> refresh()
+            is TopicIntent.SetAuthorBlocked -> setAuthorBlocked(intent.author, intent.blocked)
+        }
+    }
+
+    /**
+     * #509 — block / unblock [author] from the post menu. This launch is on [viewModelScope], but the
+     * DataStore commit still survives the sheet/ViewModel going away mid-write: the repository's
+     * `persist {}` offloads the actual write to the application scope (the #507 pattern), so only the
+     * `await` is cancelled, not the commit. The page re-filters live via the [loadCurrentPage] combine,
+     * so no manual state poke is needed here.
+     */
+    private fun setAuthorBlocked(author: String, blocked: Boolean) {
+        viewModelScope.launch {
+            if (blocked) blacklistRepository.block(author) else blacklistRepository.unblock(author)
         }
     }
 

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -42,6 +42,9 @@
     <string name="topic_post_menu_open_in_browser">Ouvrir dans le navigateur</string>
     <string name="topic_post_menu_no_browser">Aucun navigateur disponible</string>
     <string name="topic_post_menu_report_soon">Alerter (à venir)</string>
+    <!-- #509 — entrée du menu post : masquer / réafficher tous les posts de l'auteur (blacklist). -->
+    <string name="topic_post_menu_block_author">Masquer cet utilisateur</string>
+    <string name="topic_post_menu_unblock_author">Ne plus masquer cet utilisateur</string>
     <string name="topic_post_menu_edited">Édité le %1$s</string>
     <!-- #483 — compact inline marker next to the post date when the post was edited; the full
          « Édité le … » timestamp stays in the post menu (R.string.topic_post_menu_edited). -->

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -3,6 +3,7 @@ package fr.forumhfr.redface2.feature.topic
 import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.blacklist.BlacklistRepository
+import fr.forumhfr.redface2.core.domain.blacklist.canonicalizePseudo
 import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
@@ -749,6 +750,30 @@ class TopicViewModelTest {
         }
     }
 
+    @Test
+    fun `SetAuthorBlocked intent blocks then unblocks the author live`() = runTest {
+        val topic = fakeTopic(
+            page = 1,
+            totalPages = 1,
+            posts = listOf(fakePost(100, author = "Alice"), fakePost(101, author = "Bob")),
+        )
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(topic) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            blacklistRepository = FakeBlacklistRepository(),
+        )
+
+        viewModel.state.test {
+            assertEquals(emptySet<Int>(), assertMode<TopicUiState.Mode.Loaded>(awaitItem()).hiddenNumreponses)
+            viewModel.send(TopicIntent.SetAuthorBlocked("Alice", blocked = true))
+            assertEquals(setOf(100), assertMode<TopicUiState.Mode.Loaded>(awaitItem()).hiddenNumreponses)
+            viewModel.send(TopicIntent.SetAuthorBlocked("Alice", blocked = false))
+            assertEquals(emptySet<Int>(), assertMode<TopicUiState.Mode.Loaded>(awaitItem()).hiddenNumreponses)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
     @Suppress("LongParameterList") // test factory mirroring the ViewModel's injected dependencies.
     private fun topicViewModel(
         request: TopicRequest,
@@ -1391,14 +1416,16 @@ private class FakeBlacklistRepository(
 
     override fun observeBlockedCanonicals(): Flow<Set<String>> = canonicals
 
-    override suspend fun isBlocked(pseudo: String): Boolean = pseudo in canonicals.value
+    // Mirror the real repository: the stored/observed keys are canonical, so block/unblock/isBlocked
+    // canonicalise their raw-pseudo argument (a post author like "Alice" → "alice").
+    override suspend fun isBlocked(pseudo: String): Boolean = canonicalizePseudo(pseudo) in canonicals.value
 
     override suspend fun block(pseudo: String) {
-        canonicals.value = canonicals.value + pseudo
+        canonicals.value = canonicals.value + canonicalizePseudo(pseudo)
     }
 
     override suspend fun unblock(pseudo: String) {
-        canonicals.value = canonicals.value - pseudo
+        canonicals.value = canonicals.value - canonicalizePseudo(pseudo)
     }
 }
 


### PR DESCRIPTION
**PR-B2** de la blacklist locale (#509) — le **côté action**. Le menu « ⋯ » d'un post gagne une entrée « **Masquer cet utilisateur** » / « **Ne plus masquer cet utilisateur** » qui blackliste (ou réaffiche) l'auteur du post. Au tap, la feuille se ferme et le post se replie en placeholder #509 (ou se ré-affiche) **en direct**.

## Contenu
- **`TopicIntent.SetAuthorBlocked(author, blocked)`** ; `TopicViewModel` délègue à `BlacklistRepository.block/unblock`. La page se re-filtre via le `combine` de PR-B1 (pas de poke d'état manuel). Le commit **survit à une fermeture mid-write** (le `persist{}` du repo offload sur l'ApplicationScope, pattern #507).
- **`PostMenuSheet`** : le label bascule selon `authorBlocked` ; entrée **cachée pour ses propres posts** (se blacklister soi-même n'a pas de sens). `authorBlocked = numreponse in hiddenNumreponses` (un post atteignable par le menu est soit non bloqué, soit bloqué-mais-révélé).
- **Test** : `SetAuthorBlocked` bloque puis débloque en direct ; le fake canonicalise comme le vrai repo.

## Validation
`:feature:topic:testDebugUnitTest` + `detektAll` + `:app:assembleDevDebug` verts (`--rerun-tasks`). Revue Codex : mergeable (toggle/label cohérents, état cible absolu = pas d'inversion de race ; commentaire scope clarifié). Suite : PR-C (page Réglages « Utilisateurs masqués »).

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)