### PR TITLE
feat(blacklist): page Réglages « Utilisateurs masqués » (#509 PR-C)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -98,6 +98,7 @@ import fr.forumhfr.redface2.feature.settings.SettingsCategoryDetailScreen
 import fr.forumhfr.redface2.feature.settings.SettingsDisplayScreen
 import fr.forumhfr.redface2.feature.settings.SettingsImagesScreen
 import fr.forumhfr.redface2.feature.settings.SettingsMaintenanceScreen
+import fr.forumhfr.redface2.feature.settings.SettingsBlacklistScreen
 import fr.forumhfr.redface2.feature.settings.SettingsProxyScreen
 import fr.forumhfr.redface2.feature.settings.SettingsScreen
 import fr.forumhfr.redface2.feature.topic.TopicRequest
@@ -360,6 +361,10 @@ data object SettingsImagesRoute : RedfaceNavKey
 
 @Serializable
 data object SettingsAccountAboutRoute : RedfaceNavKey
+
+/** #509 — sous-page « Utilisateurs masqués » (blacklist). */
+@Serializable
+data object SettingsBlacklistRoute : RedfaceNavKey
 
 /** #494 v2 — détail générique d'une catégorie de réglages (cf. SettingsCategoryDetailScreen). */
 @Serializable
@@ -1364,6 +1369,7 @@ private fun RedfaceNavHost(
                     onOpenDisplay = { backStack.add(SettingsDisplayRoute) },
                     onOpenImages = { backStack.add(SettingsImagesRoute) },
                     onOpenAccountAbout = { backStack.add(SettingsAccountAboutRoute) },
+                    onOpenBlacklist = { backStack.add(SettingsBlacklistRoute) },
                     // #494 v2 — catégories sans sous-page dédiée → détail générique.
                     onOpenCategory = { categoryId -> backStack.add(SettingsCategoryRoute(categoryId)) },
                     topBarActions = accountMenu,
@@ -1382,6 +1388,17 @@ private fun RedfaceNavHost(
                     onOpenDisplay = { backStack.add(SettingsDisplayRoute) },
                     onOpenImages = { backStack.add(SettingsImagesRoute) },
                     onOpenAccountAbout = { backStack.add(SettingsAccountAboutRoute) },
+                    onOpenBlacklist = { backStack.add(SettingsBlacklistRoute) },
+                    topBarActions = accountMenu,
+                )
+            }
+            entry<SettingsBlacklistRoute> {
+                SettingsBlacklistScreen(
+                    onBack = {
+                        if (backStack.size > 1) {
+                            backStack.removeAt(backStack.lastIndex)
+                        }
+                    },
                     topBarActions = accountMenu,
                 )
             }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsBlacklistScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsBlacklistScreen.kt
@@ -1,0 +1,157 @@
+package fr.forumhfr.redface2.feature.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.model.blacklist.BlacklistEntry
+
+/**
+ * #509 — « Utilisateurs masqués » sub-page: lists the blacklisted users, lets the reader add a pseudo
+ * (text field + button) or remove one per row. The list is the source of truth for the masking applied
+ * in topics ([fr.forumhfr.redface2.core.domain.blacklist.BlacklistRepository]). Local-only; no MPStorage
+ * sync (#6 deferred).
+ */
+@Composable
+fun SettingsBlacklistScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    topBarActions: @Composable (() -> Unit)? = null,
+    viewModel: SettingsBlacklistViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    SettingsBlacklistContent(
+        state = state,
+        onIntent = viewModel::submit,
+        onBack = onBack,
+        modifier = modifier,
+        topBarActions = topBarActions,
+    )
+}
+
+@Composable
+internal fun SettingsBlacklistContent(
+    state: SettingsBlacklistState,
+    onIntent: (SettingsBlacklistIntent) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    topBarActions: @Composable (() -> Unit)? = null,
+) {
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            SettingsSubPageTopBar(
+                title = stringResource(R.string.settings_blacklist_title),
+                onBack = onBack,
+                topBarActions = topBarActions,
+            )
+        },
+    ) { innerPadding ->
+        // One LazyColumn for the whole page (intro + add form as header items) so the editable list
+        // never nests inside a verticalScroll — and the keyboard inset shrinks the viewport so the add
+        // field stays above the IME (same stance as SettingsProxyScreen).
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .windowInsetsPadding(
+                    WindowInsets.navigationBars
+                        .union(WindowInsets.ime)
+                        .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom),
+                )
+                .padding(horizontal = 16.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item {
+                Text(
+                    text = stringResource(R.string.settings_blacklist_intro),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            item {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    OutlinedTextField(
+                        value = state.newPseudo,
+                        onValueChange = { onIntent(SettingsBlacklistIntent.PseudoChanged(it)) },
+                        singleLine = true,
+                        label = { Text(stringResource(R.string.settings_blacklist_add_label)) },
+                        modifier = Modifier.weight(1f),
+                    )
+                    Button(
+                        onClick = { onIntent(SettingsBlacklistIntent.AddClicked) },
+                        enabled = state.canAdd,
+                    ) {
+                        Text(stringResource(R.string.settings_blacklist_add_button))
+                    }
+                }
+            }
+            if (state.entries.isEmpty()) {
+                item {
+                    Text(
+                        text = stringResource(R.string.settings_blacklist_empty),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            } else {
+                items(items = state.entries, key = { it.canonical }) { entry ->
+                    BlacklistEntryRow(
+                        entry = entry,
+                        onRemove = { onIntent(SettingsBlacklistIntent.RemoveClicked(entry)) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BlacklistEntryRow(entry: BlacklistEntry, onRemove: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = entry.display,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        TextButton(onClick = onRemove) {
+            Text(stringResource(R.string.settings_blacklist_remove_button))
+        }
+    }
+}

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsBlacklistState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsBlacklistState.kt
@@ -1,0 +1,21 @@
+package fr.forumhfr.redface2.feature.settings
+
+import fr.forumhfr.redface2.core.model.blacklist.BlacklistEntry
+
+/**
+ * #509 — state of the « Utilisateurs masqués » sub-page: the ordered list of blacklisted users and the
+ * pseudo currently being typed in the add field.
+ */
+data class SettingsBlacklistState(
+    val entries: List<BlacklistEntry> = emptyList(),
+    val newPseudo: String = "",
+) {
+    /** The add button is enabled only when the field holds a non-blank pseudo. */
+    val canAdd: Boolean get() = newPseudo.isNotBlank()
+}
+
+sealed interface SettingsBlacklistIntent {
+    data class PseudoChanged(val pseudo: String) : SettingsBlacklistIntent
+    data object AddClicked : SettingsBlacklistIntent
+    data class RemoveClicked(val entry: BlacklistEntry) : SettingsBlacklistIntent
+}

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsBlacklistViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsBlacklistViewModel.kt
@@ -1,0 +1,64 @@
+package fr.forumhfr.redface2.feature.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.blacklist.BlacklistRepository
+import fr.forumhfr.redface2.core.model.blacklist.BlacklistEntry
+import java.io.IOException
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * #509 — ViewModel for the « Utilisateurs masqués » sub-page. Mirrors the live blacklist from
+ * [BlacklistRepository.observeEntries] and exposes add / remove actions. Add reuses the repository's
+ * canonicalisation + first-wins dedup; remove targets the stored [BlacklistEntry.canonical].
+ */
+@HiltViewModel
+class SettingsBlacklistViewModel @Inject constructor(
+    private val blacklistRepository: BlacklistRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(SettingsBlacklistState())
+    val state: StateFlow<SettingsBlacklistState> = _state.asStateFlow()
+
+    init {
+        blacklistRepository.observeEntries()
+            .onEach { entries -> _state.update { it.copy(entries = entries) } }
+            .launchIn(viewModelScope)
+    }
+
+    fun submit(intent: SettingsBlacklistIntent) {
+        when (intent) {
+            is SettingsBlacklistIntent.PseudoChanged ->
+                _state.update { it.copy(newPseudo = intent.pseudo) }
+            SettingsBlacklistIntent.AddClicked -> addCurrentPseudo()
+            is SettingsBlacklistIntent.RemoveClicked ->
+                viewModelScope.launch { blacklistRepository.unblock(intent.entry.canonical) }
+        }
+    }
+
+    private fun addCurrentPseudo() {
+        val pseudo = _state.value.newPseudo
+        if (pseudo.isBlank()) return
+        // Clear the field up-front (synchronously): a fast double-tap then sees a blank field and is a
+        // no-op, so we never issue two block() writes for the same pseudo. The new entry arrives via
+        // observeEntries.
+        _state.update { it.copy(newPseudo = "") }
+        viewModelScope.launch {
+            try {
+                blacklistRepository.block(pseudo)
+            } catch (_: IOException) {
+                // Local DataStore write failed (rare). Restore the typed pseudo so it isn't lost — but
+                // only if the user hasn't already started typing something else in the meantime.
+                _state.update { if (it.newPseudo.isBlank()) it.copy(newPseudo = pseudo) else it }
+            }
+        }
+    }
+}

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsCategoryDetailScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsCategoryDetailScreen.kt
@@ -22,7 +22,7 @@ import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsSection
  * passent PAS par ici — elles ouvrent directement leur écran (cf. [routeSettingsCategory]).
  */
 @Composable
-@Suppress("LongParameterList") // détail : id + back + 5 nav-rows de sous-pages + 2 VMs + slots.
+@Suppress("LongParameterList") // détail : id + back + 6 nav-rows de sous-pages + 2 VMs + slots.
 fun SettingsCategoryDetailScreen(
     categoryId: String,
     onBack: () -> Unit,
@@ -31,6 +31,7 @@ fun SettingsCategoryDetailScreen(
     onOpenDisplay: () -> Unit,
     onOpenImages: () -> Unit,
     onOpenAccountAbout: () -> Unit,
+    onOpenBlacklist: () -> Unit,
     modifier: Modifier = Modifier,
     topBarActions: @Composable (() -> Unit)? = null,
     viewModel: SettingsViewModel = hiltViewModel(),
@@ -48,6 +49,7 @@ fun SettingsCategoryDetailScreen(
         onOpenDisplay = onOpenDisplay,
         onOpenImages = onOpenImages,
         onOpenAccountAbout = onOpenAccountAbout,
+        onOpenBlacklist = onOpenBlacklist,
     )
     val wanted = sectionIdsForCategory(categoryId)
     val shown = sections.filter { it.id in wanted }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -52,13 +52,14 @@ import fr.forumhfr.redface2.core.ui.settings.shell.SettingsHomeScreen
  * [startScreenViewModel] (#458 « Démarrage ») — both `hiltViewModel()` in the same `ViewModelStore`.
  */
 @Composable
-@Suppress("LongParameterList") // racine v2 : 5 sous-pages + onOpenCategory + 2 VMs + slots, chacun distinct.
+@Suppress("LongParameterList") // racine v2 : 6 sous-pages + onOpenCategory + 2 VMs + slots, chacun distinct.
 fun SettingsScreen(
     onOpenProxy: () -> Unit,
     onOpenMaintenance: () -> Unit,
     onOpenDisplay: () -> Unit,
     onOpenImages: () -> Unit,
     onOpenAccountAbout: () -> Unit,
+    onOpenBlacklist: () -> Unit,
     onOpenCategory: (String) -> Unit,
     modifier: Modifier = Modifier,
     topBarActions: @Composable (() -> Unit)? = null,
@@ -77,6 +78,7 @@ fun SettingsScreen(
         onOpenDisplay = onOpenDisplay,
         onOpenImages = onOpenImages,
         onOpenAccountAbout = onOpenAccountAbout,
+        onOpenBlacklist = onOpenBlacklist,
         onOpenCategory = onOpenCategory,
         modifier = modifier,
         topBarActions = topBarActions,
@@ -99,6 +101,7 @@ internal fun SettingsRoot(
     onOpenDisplay: () -> Unit,
     onOpenImages: () -> Unit,
     onOpenAccountAbout: () -> Unit,
+    onOpenBlacklist: () -> Unit,
     onOpenCategory: (String) -> Unit,
     modifier: Modifier = Modifier,
     topBarActions: @Composable (() -> Unit)? = null,
@@ -144,6 +147,7 @@ internal fun SettingsRoot(
         onOpenDisplay = onOpenDisplay,
         onOpenImages = onOpenImages,
         onOpenAccountAbout = onOpenAccountAbout,
+        onOpenBlacklist = onOpenBlacklist,
     )
     val renderers: Map<String, @Composable () -> Unit> = sections
         .flatMap { it.items }
@@ -259,6 +263,7 @@ internal fun buildSettingsCatalogue(
     onOpenDisplay: () -> Unit,
     onOpenImages: () -> Unit,
     onOpenAccountAbout: () -> Unit,
+    onOpenBlacklist: () -> Unit,
 ): List<SettingsCatalogueSection> = listOf(
     // Réseau et cache.
     SettingsCatalogueSection(
@@ -771,9 +776,16 @@ internal fun buildSettingsCatalogue(
                 id = "future_ext_keyword_filters",
                 title = stringResource(R.string.settings_future_ext_keyword_filters),
             ),
-            futureRow(
-                id = "future_ext_blacklist",
+            // #509 — the blacklist is the first real extension: a nav row to the « Utilisateurs
+            // masqués » sub-page (the other extension entries stay futureRow placeholders for now).
+            navRow(
+                id = "ext_blacklist",
                 title = stringResource(R.string.settings_future_ext_blacklist),
+                description = stringResource(R.string.settings_blacklist_description),
+                keywords = listOf(
+                    "blacklist", "ignoré", "ignorer", "masquer", "masqués", "utilisateurs", "liste noire",
+                ),
+                onClick = onOpenBlacklist,
             ),
             futureRow(
                 id = "future_ext_color_tag",

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -156,7 +156,15 @@
     <!-- §12 Extensions et filtrage -->
     <string name="settings_future_ext_ignore_list">Liste d\'ignorés</string>
     <string name="settings_future_ext_keyword_filters">Filtres par mots-clés</string>
-    <string name="settings_future_ext_blacklist">Blacklist</string>
+    <string name="settings_future_ext_blacklist">Utilisateurs masqués</string>
+    <!-- #509 — sous-page de gestion de la blacklist (liste + ajout/retrait). -->
+    <string name="settings_blacklist_title">Utilisateurs masqués</string>
+    <string name="settings_blacklist_description">Masquer les posts de certains utilisateurs.</string>
+    <string name="settings_blacklist_intro">Les posts des utilisateurs ajoutés ici sont repliés dans les sujets (« post masqué »). Vous pouvez toujours les afficher au cas par cas.</string>
+    <string name="settings_blacklist_add_label">Pseudo à masquer</string>
+    <string name="settings_blacklist_add_button">Ajouter</string>
+    <string name="settings_blacklist_remove_button">Retirer</string>
+    <string name="settings_blacklist_empty">Aucun utilisateur masqué pour le moment.</string>
     <string name="settings_future_ext_color_tag">Color Tag</string>
     <string name="settings_future_ext_qualitay">Qualitay</string>
     <string name="settings_future_ext_redflag">Redflag</string>

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsBlacklistViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsBlacklistViewModelTest.kt
@@ -1,0 +1,101 @@
+package fr.forumhfr.redface2.feature.settings
+
+import fr.forumhfr.redface2.core.domain.blacklist.BlacklistRepository
+import fr.forumhfr.redface2.core.domain.blacklist.canonicalizePseudo
+import fr.forumhfr.redface2.core.model.blacklist.BlacklistEntry
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsBlacklistViewModelTest {
+
+    private val repository = FakeBlacklistRepository()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `mirrors the repository entries`() = runTest {
+        repository.block("Alice")
+        val viewModel = SettingsBlacklistViewModel(repository)
+
+        assertEquals(listOf("alice"), viewModel.state.value.entries.map { it.canonical })
+    }
+
+    @Test
+    fun `add blocks the typed pseudo and clears the field`() = runTest {
+        val viewModel = SettingsBlacklistViewModel(repository)
+        viewModel.submit(SettingsBlacklistIntent.PseudoChanged("  Alice  "))
+        viewModel.submit(SettingsBlacklistIntent.AddClicked)
+
+        val entry = viewModel.state.value.entries.single()
+        assertEquals("alice", entry.canonical)
+        assertEquals("Alice", entry.display)
+        assertEquals("", viewModel.state.value.newPseudo)
+    }
+
+    @Test
+    fun `blank pseudo cannot be added`() = runTest {
+        val viewModel = SettingsBlacklistViewModel(repository)
+        viewModel.submit(SettingsBlacklistIntent.PseudoChanged("   "))
+
+        assertFalse(viewModel.state.value.canAdd)
+        viewModel.submit(SettingsBlacklistIntent.AddClicked)
+        assertTrue(viewModel.state.value.entries.isEmpty())
+    }
+
+    @Test
+    fun `remove unblocks by canonical`() = runTest {
+        repository.block("Alice")
+        val viewModel = SettingsBlacklistViewModel(repository)
+        val entry = viewModel.state.value.entries.single()
+
+        viewModel.submit(SettingsBlacklistIntent.RemoveClicked(entry))
+
+        assertTrue(viewModel.state.value.entries.isEmpty())
+    }
+}
+
+private class FakeBlacklistRepository : BlacklistRepository {
+    private val entries = MutableStateFlow<List<BlacklistEntry>>(emptyList())
+
+    override fun observeEntries(): Flow<List<BlacklistEntry>> = entries
+
+    override fun observeBlockedCanonicals(): Flow<Set<String>> =
+        entries.map { list -> list.map { it.canonical }.toSet() }
+
+    override suspend fun isBlocked(pseudo: String): Boolean =
+        entries.value.any { it.canonical == canonicalizePseudo(pseudo) }
+
+    override suspend fun block(pseudo: String) {
+        val canonical = canonicalizePseudo(pseudo)
+        if (canonical.isNotEmpty() && entries.value.none { it.canonical == canonical }) {
+            entries.value = entries.value + BlacklistEntry(canonical, pseudo.trim(), 0L)
+        }
+    }
+
+    override suspend fun unblock(pseudo: String) {
+        val canonical = canonicalizePseudo(pseudo)
+        entries.value = entries.value.filterNot { it.canonical == canonical }
+    }
+}


### PR DESCRIPTION
**PR-C** de la blacklist locale (#509) — la **dernière tranche** : la gestion. La catégorie de réglages « Extensions et filtrage » gagne une vraie entrée « **Utilisateurs masqués** » (qui remplace le placeholder `futureRow` désactivé) ouvrant une sous-page : liste des pseudos masqués, **ajout** (champ texte) et **retrait** par ligne.

## Contenu
- Nouveaux `SettingsBlacklistScreen` + `SettingsBlacklistViewModel` + state/intent. Le VM reflète `BlacklistRepository.observeEntries` et délègue add/remove. **Un seul `LazyColumn`** (intro + formulaire d'ajout en items d'en-tête) → la liste éditable ne s'imbrique jamais dans un `verticalScroll` ; l'inset clavier réduit le viewport comme `SettingsProxyScreen`.
- `onOpenBlacklist` threadé via `SettingsScreen` → `SettingsRoot` → `buildSettingsCatalogue` et `SettingsCategoryDetailScreen` ; nouvelle route `SettingsBlacklistRoute` câblée dans les entries racine **et** détail-catégorie (la section extensions passe par le détail générique).
- **Tests** : le VM reflète les entrées, l'ajout canonicalise + vide le champ, le blanc est rejeté, le retrait par canonical.

## Validation
`:feature:settings:testDebugUnitTest` + `detektAll` + `:app:assembleDevDebug` verts (`--rerun-tasks`). Revue Codex : ajout vide le champ en amont (double-tap = no-op) et restaure la saisie sur `IOException` rare ; pseudos longs ellipsés. (`observeEntries` est déjà protégé par le `.catch` du repo PR-A.)

**Clôt le chantier blacklist #509** (PR-A core, PR-B1 masquage, PR-B2 menu, PR-C réglages). Stockage **local** ; synchro MPStorage différée (#6).

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)