### PR TITLE
feat(topic): pseudo créateur en doré animé (#221, premier lot)

### DIFF
--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/author/Rf2Creators.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/author/Rf2Creators.kt
@@ -1,0 +1,18 @@
+package fr.forumhfr.redface2.core.domain.author
+
+import fr.forumhfr.redface2.core.domain.blacklist.canonicalizePseudo
+
+/**
+ * #221 — static, app-embedded list of the Redface 2 creator pseudo(s). Their pseudo is rendered in a
+ * shiny gold sheen everywhere it appears (assumed easter egg, cf. issue #221 « doré étincelant »).
+ *
+ * Stored canonicalised ([canonicalizePseudo]) so the match is robust to the exact HFR rendering of the
+ * pseudo (accents, casing, zero-width / format characters, NBSP) — the same normalisation the blacklist
+ * relies on. This is the simplest of the three highlight categories in #221 (a hard-coded set); the
+ * admin / section-moderator categories need an HFR role source and land in follow-up commits.
+ */
+private val RF2_CREATOR_CANONICALS: Set<String> =
+    setOf("XaTriX").mapTo(mutableSetOf(), ::canonicalizePseudo)
+
+/** `true` when [pseudo] designates a Redface 2 creator (case/accent/format-char insensitive). */
+fun isRf2Creator(pseudo: String): Boolean = canonicalizePseudo(pseudo) in RF2_CREATOR_CANONICALS

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/author/Rf2Creators.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/author/Rf2Creators.kt
@@ -7,12 +7,13 @@ import fr.forumhfr.redface2.core.domain.blacklist.canonicalizePseudo
  * shiny gold sheen everywhere it appears (assumed easter egg, cf. issue #221 « doré étincelant »).
  *
  * Stored canonicalised ([canonicalizePseudo]) so the match is robust to the exact HFR rendering of the
- * pseudo (accents, casing, zero-width / format characters, NBSP) — the same normalisation the blacklist
- * relies on. This is the simplest of the three highlight categories in #221 (a hard-coded set); the
- * admin / section-moderator categories need an HFR role source and land in follow-up commits.
+ * pseudo (casing, zero-width / format characters, NBSP, NFC form) — the same normalisation the blacklist
+ * relies on. Note [canonicalizePseudo] keeps accents (NFC, not stripped), irrelevant here since the only
+ * creator pseudo carries none. This is the simplest of the three highlight categories in #221 (a
+ * hard-coded set); the admin / section-moderator categories need an HFR role source and land later.
  */
 private val RF2_CREATOR_CANONICALS: Set<String> =
     setOf("XaTriX").mapTo(mutableSetOf(), ::canonicalizePseudo)
 
-/** `true` when [pseudo] designates a Redface 2 creator (case/accent/format-char insensitive). */
+/** `true` when [pseudo] designates a Redface 2 creator (case / format-char / NBSP insensitive). */
 fun isRf2Creator(pseudo: String): Boolean = canonicalizePseudo(pseudo) in RF2_CREATOR_CANONICALS

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/CreatorHighlight.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/CreatorHighlight.kt
@@ -93,12 +93,14 @@ private const val CREATOR_SHEEN_PERIOD_MS = 2600
 /** Surfaces darker than this read as a dark/AMOLED theme → brighter gold palette. */
 private const val DARK_SURFACE_LUMINANCE = 0.5f
 
-// Deeper gold on light surfaces so the SemiBold pseudo keeps enough contrast on white. The highlight
-// stays a saturated mid-gold (not a pale wash) so even the sweep's brightest pass remains legible — a
-// pale gold like #FFD700 is inherently low-contrast on white, so on light we trade some sparkle for
-// readability (#221 §5); the full brilliance lives on the dark palette below.
+// Deeper gold on light surfaces so the SemiBold pseudo keeps enough contrast on white. BOTH the base
+// and the highlight stay dark golds that clear WCAG: the base ≈6.2:1, and the highlight is kept dark
+// enough to stay ≥3:1 (large-bold threshold) on a light surface even at the sweep's brightest pass —
+// it also sits at the centre of the STATIC reduce-motion gradient, so it must be legible there too.
+// A pale gold (#FFD700 / the earlier #C8901A ≈2.7:1) is inherently low-contrast on white, so on light
+// we trade sparkle for readability (#221 §5); the full brilliance lives on the dark palette below.
 private val CreatorGoldBaseLight = Color(0xFF7A5C00)
-private val CreatorGoldHighlightLight = Color(0xFFC8901A)
+private val CreatorGoldHighlightLight = Color(0xFF946E00)
 
 // Brighter gold on dark / AMOLED where a deep gold would be muddy.
 private val CreatorGoldBaseDark = Color(0xFFD4AF37)

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/CreatorHighlight.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/CreatorHighlight.kt
@@ -1,0 +1,105 @@
+package fr.forumhfr.redface2.core.ui.theme
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import fr.forumhfr.redface2.core.ui.post.rememberAnimationsEnabled
+
+/**
+ * #221 — the gold "sheen" [Brush] applied to a Redface 2 creator's pseudo (see
+ * [fr.forumhfr.redface2.core.domain.author.isRf2Creator]). A metallic base gold with a brighter band
+ * that slowly sweeps across the text — the "doré étincelant" easter egg.
+ *
+ * Two palettes keep the pseudo legible on every theme: a deeper gold on light surfaces (so it does not
+ * wash out on white) and a brighter gold on dark / AMOLED. Dark is detected from the surface luminance
+ * so it follows AMOLED too, not just the system dark flag.
+ *
+ * Accessibility (#221 §5 "réduire les animations") : when the OS animator scale is 0
+ * ([rememberAnimationsEnabled], same source Compose's own animations honour) the sweep is dropped and a
+ * STATIC base→highlight→base gold gradient is returned — the pseudo still reads "doré", just without
+ * motion.
+ *
+ * Caller note: read the returned brush from a LEAF composable (e.g. a dedicated pseudo `Text`) so the
+ * per-frame animation invalidates only that text node, never the enclosing post card.
+ */
+@Composable
+fun rememberCreatorPseudoBrush(): Brush {
+    val dark = MaterialTheme.colorScheme.surface.luminance() < DARK_SURFACE_LUMINANCE
+    val base = if (dark) CreatorGoldBaseDark else CreatorGoldBaseLight
+    val highlight = if (dark) CreatorGoldHighlightDark else CreatorGoldHighlightLight
+
+    if (!rememberAnimationsEnabled()) {
+        return remember(base, highlight) { Brush.linearGradient(listOf(base, highlight, base)) }
+    }
+
+    val transition = rememberInfiniteTransition(label = "creator_gold")
+    val travel by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = CREATOR_SHEEN_PERIOD_MS, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart,
+        ),
+        label = "creator_gold_sheen",
+    )
+    return creatorSheenBrush(travel, base, highlight)
+}
+
+/**
+ * A base-gold gradient carrying a narrow [highlight] band centred at the swept position. [travel] in
+ * [0, 1] moves the band from off-left to off-right (it sits outside the text most of the period, so the
+ * pseudo rests as plain gold between sweeps).
+ */
+private fun creatorSheenBrush(travel: Float, base: Color, highlight: Color): Brush =
+    Brush.linearGradient(colorStops = creatorSheenStops(travel, base, highlight).toTypedArray())
+
+/**
+ * Builds the gradient colour stops for a sweep position. Every interior stop is added only while it
+ * lies STRICTLY inside `(0, 1)`, so the endpoints `0f`/`1f` are never duplicated and the resulting list
+ * is guaranteed strictly increasing — `Brush.linearGradient` rejects out-of-order / duplicate stops at
+ * the band's extremities (`travel = 0` → right edge at `0f`; `travel = 1` → left edge at `1f`). Pure and
+ * `internal` so [CreatorHighlightTest] can assert the monotonicity invariant across the whole sweep.
+ */
+internal fun creatorSheenStops(travel: Float, base: Color, highlight: Color): List<Pair<Float, Color>> {
+    // Map travel so the band fully enters and exits: centre runs from -BAND to 1 + BAND.
+    val centre = travel * (1f + 2f * SHEEN_BAND) - SHEEN_BAND
+    return buildList {
+        add(0f to base)
+        val left = centre - SHEEN_BAND
+        if (left > 0f && left < 1f) add(left to base)
+        if (centre > 0f && centre < 1f) add(centre to highlight)
+        val right = centre + SHEEN_BAND
+        if (right > 0f && right < 1f) add(right to base)
+        add(1f to base)
+    }
+}
+
+/** Half-width of the bright sweeping band, as a fraction of the text width. */
+private const val SHEEN_BAND = 0.22f
+
+/** One full sweep. Slow enough to read as a gentle shimmer, not a strobe. */
+private const val CREATOR_SHEEN_PERIOD_MS = 2600
+
+/** Surfaces darker than this read as a dark/AMOLED theme → brighter gold palette. */
+private const val DARK_SURFACE_LUMINANCE = 0.5f
+
+// Deeper gold on light surfaces so the SemiBold pseudo keeps enough contrast on white. The highlight
+// stays a saturated mid-gold (not a pale wash) so even the sweep's brightest pass remains legible — a
+// pale gold like #FFD700 is inherently low-contrast on white, so on light we trade some sparkle for
+// readability (#221 §5); the full brilliance lives on the dark palette below.
+private val CreatorGoldBaseLight = Color(0xFF7A5C00)
+private val CreatorGoldHighlightLight = Color(0xFFC8901A)
+
+// Brighter gold on dark / AMOLED where a deep gold would be muddy.
+private val CreatorGoldBaseDark = Color(0xFFD4AF37)
+private val CreatorGoldHighlightDark = Color(0xFFFFE9A8)

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/theme/CreatorHighlightTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/theme/CreatorHighlightTest.kt
@@ -1,0 +1,57 @@
+package fr.forumhfr.redface2.core.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #221 — pure-JVM guard on [creatorSheenStops]: the gold sheen gradient must always produce strictly
+ * increasing colour stops, including at the band's extremities where a naive build duplicates an
+ * endpoint (`travel = 0` puts the band's right edge exactly on `0f`; `travel = 1` puts its left edge
+ * exactly on `1f`). `Brush.linearGradient` rejects out-of-order or duplicate stops, so this invariant is
+ * what keeps the animation from crashing mid-sweep.
+ */
+class CreatorHighlightTest {
+
+    private val base = Color(0xFF7A5C00)
+    private val highlight = Color(0xFFC8901A)
+
+    @Test
+    fun `stops are strictly increasing across the whole sweep`() {
+        // Sample densely, hitting both extremities (0f, 1f) and the interior crossings.
+        var travel = 0f
+        while (travel <= 1f) {
+            val stops = creatorSheenStops(travel, base, highlight)
+            for (i in 1 until stops.size) {
+                assertTrue(
+                    "stops not strictly increasing at travel=$travel: ${stops.map { it.first }}",
+                    stops[i].first > stops[i - 1].first,
+                )
+            }
+            travel += STEP
+        }
+    }
+
+    @Test
+    fun `the gradient always spans the full 0f to 1f range`() {
+        listOf(0f, 0.1f, 0.5f, 0.9f, 1f).forEach { travel ->
+            val stops = creatorSheenStops(travel, base, highlight)
+            assertEquals("first stop at travel=$travel", 0f, stops.first().first)
+            assertEquals("last stop at travel=$travel", 1f, stops.last().first)
+        }
+    }
+
+    @Test
+    fun `mid-sweep carries a highlight band, extremities rest on base gold`() {
+        // At travel=0.5 the band centre sits in the middle of the text, so the highlight colour is present.
+        assertTrue(creatorSheenStops(0.5f, base, highlight).any { it.second == highlight })
+        // At the extremities the band has slid off the text: only base gold remains.
+        assertTrue(creatorSheenStops(0f, base, highlight).all { it.second == base })
+        assertTrue(creatorSheenStops(1f, base, highlight).all { it.second == base })
+    }
+
+    private companion object {
+        const val STEP = 0.013f
+    }
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/theme/CreatorHighlightTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/theme/CreatorHighlightTest.kt
@@ -15,21 +15,22 @@ import org.junit.Test
 class CreatorHighlightTest {
 
     private val base = Color(0xFF7A5C00)
-    private val highlight = Color(0xFFC8901A)
+    private val highlight = Color(0xFF946E00)
 
     @Test
     fun `stops are strictly increasing across the whole sweep`() {
-        // Sample densely, hitting both extremities (0f, 1f) and the interior crossings.
-        var travel = 0f
-        while (travel <= 1f) {
+        // 101 evenly-spaced samples so the loop lands EXACTLY on both extremities (travel=0f at i=0,
+        // travel=1f at i=100) — those are the degenerate cases (band edge on 0f / 1f) the strict
+        // (0, 1) guards must keep from duplicating an endpoint.
+        (0..SAMPLES).forEach { i ->
+            val travel = i.toFloat() / SAMPLES
             val stops = creatorSheenStops(travel, base, highlight)
-            for (i in 1 until stops.size) {
+            for (j in 1 until stops.size) {
                 assertTrue(
                     "stops not strictly increasing at travel=$travel: ${stops.map { it.first }}",
-                    stops[i].first > stops[i - 1].first,
+                    stops[j].first > stops[j - 1].first,
                 )
             }
-            travel += STEP
         }
     }
 
@@ -52,6 +53,6 @@ class CreatorHighlightTest {
     }
 
     private companion object {
-        const val STEP = 0.013f
+        const val SAMPLES = 100
     }
 }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -81,6 +81,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.domain.author.isRf2Creator
 import fr.forumhfr.redface2.core.model.Poll
 import fr.forumhfr.redface2.core.model.Post
 import fr.forumhfr.redface2.core.model.Topic
@@ -93,6 +94,7 @@ import fr.forumhfr.redface2.core.ui.pager.pageSwipeEdgeHint
 import fr.forumhfr.redface2.core.ui.post.PostRenderer
 import fr.forumhfr.redface2.core.ui.theme.LocalDisplayMetrics
 import fr.forumhfr.redface2.core.ui.theme.LocalIgnoreInlineColors
+import fr.forumhfr.redface2.core.ui.theme.rememberCreatorPseudoBrush
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -1464,6 +1466,23 @@ private fun HiddenPostCard(
     }
 }
 
+/**
+ * #221 — a Redface 2 creator's pseudo, painted with the animated gold sheen. Kept as its own leaf
+ * composable so the per-frame shimmer ([rememberCreatorPseudoBrush]) invalidates only this text node,
+ * never the enclosing (and expensive) post card.
+ */
+@Composable
+private fun CreatorPseudoText(author: String, modifier: Modifier = Modifier) {
+    Text(
+        text = author,
+        style = MaterialTheme.typography.titleSmall.copy(brush = rememberCreatorPseudoBrush()),
+        fontWeight = FontWeight.SemiBold,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier = modifier,
+    )
+}
+
 @Composable
 // Rich post card : each optional affordance (highlight anchor, multi-quote border + pill + « + »
 // toggle, citation badge, profile tap, contextual menu, edit, quote) is its own guarded branch, so
@@ -1641,17 +1660,23 @@ internal fun TopicPostCard(
                                     fontWeight = FontWeight.SemiBold,
                                 )
                             }
-                            Text(
-                                text = post.author,
-                                style = MaterialTheme.typography.titleSmall,
-                                fontWeight = FontWeight.SemiBold,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                // Clickable on the pseudo only — the date stays inert.
-                                modifier = Modifier
-                                    .weight(weight = 1f, fill = false)
-                                    .then(pseudoModifier),
-                            )
+                            // Clickable on the pseudo only — the date stays inert.
+                            val pseudoLayout = Modifier
+                                .weight(weight = 1f, fill = false)
+                                .then(pseudoModifier)
+                            // #221 — the RF2 creator's pseudo gets the gold sheen easter egg.
+                            if (isRf2Creator(post.author)) {
+                                CreatorPseudoText(author = post.author, modifier = pseudoLayout)
+                            } else {
+                                Text(
+                                    text = post.author,
+                                    style = MaterialTheme.typography.titleSmall,
+                                    fontWeight = FontWeight.SemiBold,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    modifier = pseudoLayout,
+                                )
+                            }
                         }
                         // #483 — the date line carries a compact « · édité » marker when the post was
                         // edited (beta feedback Azgor). The exact edit time stays in the « … » menu

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1665,7 +1665,11 @@ internal fun TopicPostCard(
                                 .weight(weight = 1f, fill = false)
                                 .then(pseudoModifier)
                             // #221 — the RF2 creator's pseudo gets the gold sheen easter egg.
-                            if (isRf2Creator(post.author)) {
+                            // remember() keyed on the author so canonicalizePseudo (NFC + char walk)
+                            // runs once per author, not on every recomposition of this hot list row —
+                            // same off-the-render-path stance #509 took with hiddenNumreponses.
+                            val isCreator = remember(post.author) { isRf2Creator(post.author) }
+                            if (isCreator) {
                                 CreatorPseudoText(author = post.author, modifier = pseudoLayout)
                             } else {
                                 Text(


### PR DESCRIPTION
Premier lot de #221 (mise en valeur de certains pseudos) : le pseudo du **créateur de Redface 2** (XaTriX) s'affiche avec un **dégradé doré « brillant »** dans l'en-tête des posts — l'easter egg assumé de l'issue. Les rôles admin / modérateur-de-section (qui nécessitent une source de rôle HFR) restent pour des lots suivants ; ce lot ne livre que le cas « créateur » (set statique).

## Contenu
- **:core:domain** — `isRf2Creator(pseudo)` : match canonicalisé (insensible casse/accents/format chars, réutilise le canonicalizer de la blacklist) contre un set créateur en dur.
- **:core:ui** — `rememberCreatorPseudoBrush()` : `Brush` doré métallique avec une bande qui balaie lentement le texte. Deux palettes (or profond en clair pour le contraste, or vif en sombre/AMOLED, détecté via luminance). Respecte « réduire les animations » de l'OS (animator scale 0 → dégradé statique). `creatorSheenStops()` garantit des color stops strictement croissants (pas de doublon aux extrémités du sweep).
- **:feature:topic** — l'en-tête bascule vers un composable feuille `CreatorPseudoText` pour un créateur, donc le shimmer par frame n'invalide QUE ce nœud texte, pas la carte de post.

## Revue
Passe de style Codex appliquée : corrigé le cas-limite de duplication d'endpoint dans les color stops + assombri la palette claire pour la lisibilité sur blanc.

## Tests
`CreatorHighlightTest` (monotonie stricte sur tout le sweep + span complet 0→1 + présence du highlight). `:core:ui` + `:feature:topic` + `:app:assembleDevDebug` + detekt verts.

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)