### PR TITLE
feat(profile): masquer/démasquer un utilisateur depuis la fiche profil (#509)

### DIFF
--- a/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfilePreviewSheet.kt
+++ b/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfilePreviewSheet.kt
@@ -202,24 +202,28 @@ private fun ProfilePreviewContent(
 
         // #509 — blacklist toggle, parity with the post menu entry. The sheet stays open so the label
         // flips in place as immediate feedback; the post collapse to its « masqué » placeholder shows
-        // once the sheet is dismissed. Always available (the pseudo is known even while the profile
-        // loads), so it sits outside the mode branch above.
-        OutlinedButton(
-            onClick = { onIntent(ProfileIntent.ToggleBlocked) },
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Text(
-                stringResource(
-                    if (state.isBlocked) {
-                        R.string.profile_action_unblock_user
-                    } else {
-                        R.string.profile_action_block_user
-                    },
-                ),
-            )
-        }
+        // once the sheet is dismissed. Shown regardless of the load mode (the pseudo is known even while
+        // the profile loads), but HIDDEN on one's own profile (blacklisting oneself is pointless — same
+        // guard as the post menu's `isOwnPost`), and DISABLED while a write is in flight (double-tap).
+        if (!state.isOwnProfile) {
+            OutlinedButton(
+                onClick = { onIntent(ProfileIntent.ToggleBlocked) },
+                enabled = !state.isUpdatingBlocked,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    stringResource(
+                        if (state.isBlocked) {
+                            R.string.profile_action_unblock_user
+                        } else {
+                            R.string.profile_action_block_user
+                        },
+                    ),
+                )
+            }
 
-        Spacer(Modifier.height(8.dp))
+            Spacer(Modifier.height(8.dp))
+        }
     }
 }
 

--- a/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfilePreviewSheet.kt
+++ b/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfilePreviewSheet.kt
@@ -199,6 +199,27 @@ private fun ProfilePreviewContent(
         }
 
         Spacer(Modifier.height(8.dp))
+
+        // #509 — blacklist toggle, parity with the post menu entry. The sheet stays open so the label
+        // flips in place as immediate feedback; the post collapse to its « masqué » placeholder shows
+        // once the sheet is dismissed. Always available (the pseudo is known even while the profile
+        // loads), so it sits outside the mode branch above.
+        OutlinedButton(
+            onClick = { onIntent(ProfileIntent.ToggleBlocked) },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                stringResource(
+                    if (state.isBlocked) {
+                        R.string.profile_action_unblock_user
+                    } else {
+                        R.string.profile_action_block_user
+                    },
+                ),
+            )
+        }
+
+        Spacer(Modifier.height(8.dp))
     }
 }
 

--- a/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileUiState.kt
+++ b/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileUiState.kt
@@ -29,7 +29,17 @@ data class ProfileUiState(
      * reflects the live state (including a toggle made from the post menu while the sheet is open).
      */
     val isBlocked: Boolean = false,
+    /** #509 — a blacklist write is in flight; the toggle button is disabled to prevent a double-tap. */
+    val isUpdatingBlocked: Boolean = false,
+    /**
+     * #509 — `true` when the previewed user is the logged-in user. The blacklist toggle is hidden then,
+     * for parity with the post menu (which hides « Masquer » on one's own posts — blacklisting oneself
+     * is pointless).
+     */
+    val isOwnProfile: Boolean = false,
 ) {
+    /** #509 — the blacklist toggle is shown only on someone else's profile, and gated by its own write. */
+    val canToggleBlocked: Boolean get() = !isOwnProfile && !isUpdatingBlocked
     sealed interface Mode {
         data object Loading : Mode
 

--- a/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileUiState.kt
+++ b/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileUiState.kt
@@ -23,6 +23,12 @@ data class ProfileUiState(
      */
     val avatarUrlHint: String?,
     val mode: Mode,
+    /**
+     * #509 — whether this user is currently on the local blacklist. Driven by the repository's
+     * `observeBlockedCanonicals` flow so the « Masquer / Ne plus masquer » button label always
+     * reflects the live state (including a toggle made from the post menu while the sheet is open).
+     */
+    val isBlocked: Boolean = false,
 ) {
     sealed interface Mode {
         data object Loading : Mode
@@ -58,6 +64,9 @@ data class ProfileUiState(
 
 sealed interface ProfileIntent {
     data object Retry : ProfileIntent
+
+    /** #509 — add or remove this user from the local blacklist (toggles on [ProfileUiState.isBlocked]). */
+    data object ToggleBlocked : ProfileIntent
 }
 
 /**

--- a/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileViewModel.kt
+++ b/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileViewModel.kt
@@ -6,6 +6,8 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.blacklist.BlacklistRepository
+import fr.forumhfr.redface2.core.domain.blacklist.canonicalizePseudo
 import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.profile.ProfileRepository
 import kotlinx.coroutines.Job
@@ -35,6 +37,7 @@ import kotlinx.coroutines.launch
 @HiltViewModel(assistedFactory = ProfileViewModel.Factory::class)
 class ProfileViewModel @AssistedInject constructor(
     private val profileRepository: ProfileRepository,
+    private val blacklistRepository: BlacklistRepository,
     @Assisted("userId") private val userId: Int,
     @Assisted("pseudoHint") private val pseudoHint: String,
     @Assisted("avatarUrlHint") private val avatarUrlHint: String?,
@@ -46,6 +49,13 @@ class ProfileViewModel @AssistedInject constructor(
     val state: StateFlow<ProfileUiState> = _state.asStateFlow()
 
     /**
+     * #509 — canonical key of the previewed user. [pseudoHint] is the post author pseudo from the tap
+     * site (always present, and the same identity the post menu blocks), so matching the blacklist on
+     * its canonical form keeps the two entry points in sync.
+     */
+    private val pseudoCanonical = canonicalizePseudo(pseudoHint)
+
+    /**
      * In-flight load job. Held so a Retry (or a follow-up [loadProfile] call) can
      * cancel a previous load that has not completed yet — without this, rapid taps
      * on Retry spawn N concurrent coroutines whose results race to update [_state].
@@ -54,11 +64,38 @@ class ProfileViewModel @AssistedInject constructor(
 
     init {
         loadProfile()
+        observeBlacklist()
     }
 
     fun onIntent(intent: ProfileIntent) {
         when (intent) {
             ProfileIntent.Retry -> loadProfile()
+            ProfileIntent.ToggleBlocked -> toggleBlocked()
+        }
+    }
+
+    /**
+     * Keeps [ProfileUiState.isBlocked] in sync with the live blacklist. `observeBlockedCanonicals`
+     * emits its current value immediately (documented contract), so the button renders the right label
+     * from the first frame, and flips if the same user is (un)blocked elsewhere while the sheet is open.
+     */
+    private fun observeBlacklist() {
+        viewModelScope.launch {
+            blacklistRepository.observeBlockedCanonicals().collect { blocked ->
+                _state.update { it.copy(isBlocked = pseudoCanonical in blocked) }
+            }
+        }
+    }
+
+    private fun toggleBlocked() {
+        viewModelScope.launch {
+            if (_state.value.isBlocked) {
+                blacklistRepository.unblock(pseudoHint)
+            } else {
+                blacklistRepository.block(pseudoHint)
+            }
+            // `isBlocked` is not flipped here: the `observeBlacklist` collector is the single source of
+            // truth and updates it once the store write lands.
         }
     }
 

--- a/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileViewModel.kt
+++ b/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileViewModel.kt
@@ -6,10 +6,12 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.blacklist.BlacklistRepository
 import fr.forumhfr.redface2.core.domain.blacklist.canonicalizePseudo
 import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.profile.ProfileRepository
+import fr.forumhfr.redface2.core.model.AuthState
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -38,6 +40,7 @@ import kotlinx.coroutines.launch
 class ProfileViewModel @AssistedInject constructor(
     private val profileRepository: ProfileRepository,
     private val blacklistRepository: BlacklistRepository,
+    private val authRepository: AuthRepository,
     @Assisted("userId") private val userId: Int,
     @Assisted("pseudoHint") private val pseudoHint: String,
     @Assisted("avatarUrlHint") private val avatarUrlHint: String?,
@@ -65,6 +68,7 @@ class ProfileViewModel @AssistedInject constructor(
     init {
         loadProfile()
         observeBlacklist()
+        observeOwnProfile()
     }
 
     fun onIntent(intent: ProfileIntent) {
@@ -87,15 +91,45 @@ class ProfileViewModel @AssistedInject constructor(
         }
     }
 
-    private fun toggleBlocked() {
+    /**
+     * #509 — flags the previewed user as the logged-in user, so the blacklist toggle is hidden on one's
+     * OWN profile (parity with the post menu, which sets `onToggleBlockAuthor = null` for `isOwnPost` —
+     * « blacklisting oneself is pointless »). Matched on the numeric id when HFR provided it, else on the
+     * canonical pseudo. `observeAuthState` emits immediately and on every login/logout (cold flow).
+     */
+    private fun observeOwnProfile() {
         viewModelScope.launch {
-            if (_state.value.isBlocked) {
-                blacklistRepository.unblock(pseudoHint)
-            } else {
-                blacklistRepository.block(pseudoHint)
+            authRepository.observeAuthState().collect { auth ->
+                val own = auth is AuthState.Authenticated &&
+                    (
+                        (auth.userId != null && auth.userId == userId) ||
+                            canonicalizePseudo(auth.pseudo) == pseudoCanonical
+                        )
+                _state.update { it.copy(isOwnProfile = own) }
             }
-            // `isBlocked` is not flipped here: the `observeBlacklist` collector is the single source of
-            // truth and updates it once the store write lands.
+        }
+    }
+
+    private fun toggleBlocked() {
+        // Guard re-entrancy: `isBlocked` only flips once the store write lands and `observeBlacklist`
+        // re-emits, so without this a rapid double-tap reads the same stale value twice and fires the
+        // same direction twice (block+block) instead of toggling. The button is also disabled while
+        // `isUpdatingBlocked` (see ProfilePreviewSheet) — this is the model-side backstop.
+        if (_state.value.isUpdatingBlocked) return
+        val wasBlocked = _state.value.isBlocked
+        _state.update { it.copy(isUpdatingBlocked = true) }
+        viewModelScope.launch {
+            try {
+                if (wasBlocked) {
+                    blacklistRepository.unblock(pseudoHint)
+                } else {
+                    blacklistRepository.block(pseudoHint)
+                }
+                // `isBlocked` is not flipped here: the `observeBlacklist` collector is the single source
+                // of truth and updates it once the store write lands.
+            } finally {
+                _state.update { it.copy(isUpdatingBlocked = false) }
+            }
         }
     }
 

--- a/feature/profile/src/main/res/values/strings.xml
+++ b/feature/profile/src/main/res/values/strings.xml
@@ -24,6 +24,9 @@
     <string name="profile_action_open_full">Voir le profil complet</string>
     <string name="profile_action_retry">Réessayer</string>
     <string name="profile_action_recent_posts">Derniers messages</string>
+    <!-- #509 — blacklist toggle, parity with the post menu « Masquer cet utilisateur ». -->
+    <string name="profile_action_block_user">Masquer cet utilisateur</string>
+    <string name="profile_action_unblock_user">Ne plus masquer cet utilisateur</string>
 
     <!-- Error messages -->
     <string name="profile_error_load_failed">Impossible de charger le profil.</string>

--- a/feature/profile/src/test/kotlin/fr/forumhfr/redface2/feature/profile/ProfileViewModelTest.kt
+++ b/feature/profile/src/test/kotlin/fr/forumhfr/redface2/feature/profile/ProfileViewModelTest.kt
@@ -6,10 +6,12 @@ import fr.forumhfr.redface2.core.domain.blacklist.canonicalizePseudo
 import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.domain.profile.ProfileRepository
+import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.UserProfile
 import fr.forumhfr.redface2.core.model.blacklist.BlacklistEntry
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import java.io.IOException
 import kotlinx.coroutines.CompletableDeferred
@@ -73,9 +75,11 @@ class ProfileViewModelTest {
         userId: Int = 54596,
         pseudo: String = "XaTriX",
         avatarUrl: String? = null,
+        authState: AuthState = AuthState.Anonymous,
     ): ProfileViewModel = ProfileViewModel(
         profileRepository = repository,
         blacklistRepository = blacklist,
+        authRepository = mockk { every { observeAuthState() } returns MutableStateFlow(authState) },
         userId = userId,
         pseudoHint = pseudo,
         avatarUrlHint = avatarUrl,
@@ -231,22 +235,20 @@ class ProfileViewModelTest {
     fun `ToggleBlocked blocks then unblocks the previewed user and isBlocked tracks the store`() = runTest {
         coEvery { repository.getProfile(54596) } returns Result.success(dummyProfile)
 
+        // UnconfinedTestDispatcher runs the toggle's launch{} to completion before onIntent returns,
+        // so the settled state is readable directly (the intermediate isUpdatingBlocked=true emission
+        // would otherwise trip a strict awaitItem sequence).
         val vm = createViewModel(pseudo = "XaTriX")
+        assertFalse("Not blocked initially", vm.state.value.isBlocked)
 
-        vm.state.test {
-            // From the first frame the button reflects the (empty) blacklist.
-            assertFalse("Not blocked initially", awaitItem().isBlocked)
+        vm.onIntent(ProfileIntent.ToggleBlocked)
+        assertTrue("Blocked after first toggle", vm.state.value.isBlocked)
+        assertTrue("Store holds the canonical pseudo", blacklist.isBlocked("XaTriX"))
+        assertFalse("Write settled", vm.state.value.isUpdatingBlocked)
 
-            vm.onIntent(ProfileIntent.ToggleBlocked)
-            assertTrue("Blocked after first toggle", awaitItem().isBlocked)
-            assertTrue("Store holds the canonical pseudo", blacklist.isBlocked("XaTriX"))
-
-            vm.onIntent(ProfileIntent.ToggleBlocked)
-            assertFalse("Unblocked after second toggle", awaitItem().isBlocked)
-            assertFalse("Store cleared", blacklist.isBlocked("XaTriX"))
-
-            cancelAndIgnoreRemainingEvents()
-        }
+        vm.onIntent(ProfileIntent.ToggleBlocked)
+        assertFalse("Unblocked after second toggle", vm.state.value.isBlocked)
+        assertFalse("Store cleared", blacklist.isBlocked("XaTriX"))
     }
 
     @Test
@@ -260,6 +262,46 @@ class ProfileViewModelTest {
             assertTrue("Already-blocked user renders the unblock label from frame one", awaitItem().isBlocked)
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun `the blacklist toggle is hidden on one's own profile`() = runTest {
+        coEvery { repository.getProfile(54596) } returns Result.success(dummyProfile)
+
+        // Same numeric id AND pseudo as the logged-in user → own profile.
+        val vm = createViewModel(
+            pseudo = "XaTriX",
+            authState = AuthState.Authenticated(pseudo = "XaTriX", userId = 54596),
+        )
+
+        assertTrue("own profile detected", vm.state.value.isOwnProfile)
+        assertFalse("toggle hidden / not actionable on own profile", vm.state.value.canToggleBlocked)
+    }
+
+    @Test
+    fun `own profile is matched on the canonical pseudo when the auth userId is missing`() = runTest {
+        coEvery { repository.getProfile(54596) } returns Result.success(dummyProfile)
+
+        // Older session without md_id → userId null, but the pseudo still matches (case-insensitive).
+        val vm = createViewModel(
+            pseudo = "XaTriX",
+            authState = AuthState.Authenticated(pseudo = "xatrix", userId = null),
+        )
+
+        assertTrue(vm.state.value.isOwnProfile)
+    }
+
+    @Test
+    fun `another user's profile is not flagged as own`() = runTest {
+        coEvery { repository.getProfile(54596) } returns Result.success(dummyProfile)
+
+        val vm = createViewModel(
+            pseudo = "XaTriX",
+            authState = AuthState.Authenticated(pseudo = "SomeoneElse", userId = 999),
+        )
+
+        assertFalse(vm.state.value.isOwnProfile)
+        assertTrue("toggle available on another user's profile", vm.state.value.canToggleBlocked)
     }
 
     @Test

--- a/feature/profile/src/test/kotlin/fr/forumhfr/redface2/feature/profile/ProfileViewModelTest.kt
+++ b/feature/profile/src/test/kotlin/fr/forumhfr/redface2/feature/profile/ProfileViewModelTest.kt
@@ -1,10 +1,13 @@
 package fr.forumhfr.redface2.feature.profile
 
 import app.cash.turbine.test
+import fr.forumhfr.redface2.core.domain.blacklist.BlacklistRepository
+import fr.forumhfr.redface2.core.domain.blacklist.canonicalizePseudo
 import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.domain.profile.ProfileRepository
 import fr.forumhfr.redface2.core.model.UserProfile
+import fr.forumhfr.redface2.core.model.blacklist.BlacklistEntry
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -12,12 +15,16 @@ import java.io.IOException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -36,6 +43,7 @@ import org.junit.Test
 class ProfileViewModelTest {
 
     private lateinit var repository: ProfileRepository
+    private lateinit var blacklist: FakeBlacklistRepository
 
     @Before
     fun setUp() {
@@ -43,6 +51,7 @@ class ProfileViewModelTest {
         // synchronously, matching the test pattern used in FlagsViewModelTest.
         Dispatchers.setMain(UnconfinedTestDispatcher())
         repository = mockk()
+        blacklist = FakeBlacklistRepository()
     }
 
     @After
@@ -66,6 +75,7 @@ class ProfileViewModelTest {
         avatarUrl: String? = null,
     ): ProfileViewModel = ProfileViewModel(
         profileRepository = repository,
+        blacklistRepository = blacklist,
         userId = userId,
         pseudoHint = pseudo,
         avatarUrlHint = avatarUrl,
@@ -218,6 +228,41 @@ class ProfileViewModelTest {
     }
 
     @Test
+    fun `ToggleBlocked blocks then unblocks the previewed user and isBlocked tracks the store`() = runTest {
+        coEvery { repository.getProfile(54596) } returns Result.success(dummyProfile)
+
+        val vm = createViewModel(pseudo = "XaTriX")
+
+        vm.state.test {
+            // From the first frame the button reflects the (empty) blacklist.
+            assertFalse("Not blocked initially", awaitItem().isBlocked)
+
+            vm.onIntent(ProfileIntent.ToggleBlocked)
+            assertTrue("Blocked after first toggle", awaitItem().isBlocked)
+            assertTrue("Store holds the canonical pseudo", blacklist.isBlocked("XaTriX"))
+
+            vm.onIntent(ProfileIntent.ToggleBlocked)
+            assertFalse("Unblocked after second toggle", awaitItem().isBlocked)
+            assertFalse("Store cleared", blacklist.isBlocked("XaTriX"))
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `isBlocked is true on first frame when the user is already blacklisted`() = runTest {
+        coEvery { repository.getProfile(54596) } returns Result.success(dummyProfile)
+        blacklist.block("XaTriX")
+
+        val vm = createViewModel(pseudo = "XaTriX")
+
+        vm.state.test {
+            assertTrue("Already-blocked user renders the unblock label from frame one", awaitItem().isBlocked)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `rapid Retry taps - only the last result is observable in state`() = runTest {
         // Review feedback I8: when the user taps Retry multiple times before the previous
         // attempt completes, only the freshest result should land in the state — otherwise
@@ -248,5 +293,31 @@ class ProfileViewModelTest {
             assertEquals(dummyProfile, lastState.mode.profile)
             cancelAndIgnoreRemainingEvents()
         }
+    }
+}
+
+/**
+ * In-memory [BlacklistRepository] mirroring the real repo's canonical semantics (block/unblock match on
+ * [canonicalizePseudo]) so the profile sheet's toggle is exercised against the same normalisation the
+ * post menu uses. Backed by a [MutableStateFlow] so `observeBlockedCanonicals` emits its current value
+ * immediately, as the production contract requires.
+ */
+private class FakeBlacklistRepository : BlacklistRepository {
+    private val canonicals = MutableStateFlow<Set<String>>(emptySet())
+
+    override fun observeEntries(): Flow<List<BlacklistEntry>> =
+        canonicals.map { set -> set.map { BlacklistEntry(canonical = it, display = it, addedAt = 0L) } }
+
+    override fun observeBlockedCanonicals(): Flow<Set<String>> = canonicals
+
+    override suspend fun isBlocked(pseudo: String): Boolean =
+        canonicalizePseudo(pseudo) in canonicals.value
+
+    override suspend fun block(pseudo: String) {
+        canonicals.value = canonicals.value + canonicalizePseudo(pseudo)
+    }
+
+    override suspend fun unblock(pseudo: String) {
+        canonicals.value = canonicals.value - canonicalizePseudo(pseudo)
     }
 }


### PR DESCRIPTION
Parité avec l'entrée blacklist du menu de post : la bottom sheet profil (ouverte en tapant un pseudo/avatar) porte désormais un bouton **« Masquer / Ne plus masquer cet utilisateur »**, donc la blacklist est atteignable depuis le profil aussi, pas seulement depuis le menu « … » d'un post précis.

## Contenu
- `ProfileViewModel` injecte `BlacklistRepository` et observe `observeBlockedCanonicals()`, en matchant sur `canonicalizePseudo(pseudoHint)` — la même identité que masque le menu de post, donc les deux points d'entrée restent synchronisés (et le libellé est correct dès la première frame).
- `ProfileIntent.ToggleBlocked` appelle `block()`/`unblock()` ; `isBlocked` est piloté uniquement par le collector d'observation (source de vérité unique), donc un toggle externe pendant que la sheet est ouverte rebascule aussi le libellé.
- La sheet reste ouverte au tap (le libellé bascule sur place comme feedback) ; le post se replie sur son placeholder « masqué » à la fermeture.

## Tests
`FakeBlacklistRepository` (sémantique canonique réelle) + aller-retour du toggle + cas « déjà bloqué dès la 1ʳᵉ frame ». `ProfileViewModelTest` 9/9, detekt + `:app:assembleDevDebug` (graphe Hilt) verts.

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)