### PR TITLE
feat(app): plein écran — masquer la barre de navigation Android (#518)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
@@ -63,4 +63,11 @@ class AppThemeViewModel @Inject constructor(
     val debugBoundsOverlay: StateFlow<Boolean> =
         userPreferencesRepository.observeDebugBoundsOverlay()
             .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    // #518 — immersive mode: hide the bottom Android system navigation bar. Applied on the host window
+    // by RedfaceApp. Eagerly collected like the presets above; off by default, no bootstrap mirror
+    // (it does not paint the pre-first-frame window).
+    val hideSystemNavBar: StateFlow<Boolean> =
+        userPreferencesRepository.observeHideSystemNavBar()
+            .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 }

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -6,6 +6,8 @@ import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
 import android.net.Uri
+import android.view.View
+import android.view.Window
 import android.widget.Toast
 import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.EnterTransition
@@ -46,6 +48,8 @@ import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffo
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.core.net.toUri
 import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Icon
@@ -523,6 +527,9 @@ fun RedfaceApp(intent: Intent?) {
     // #445 — debug bounds overlay preference (the dev-channel gate + render live in
     // [DevDebugBoundsOverlay], emitted last so it paints over everything; off by default).
     val debugBoundsOverlay by themeViewModel.debugBoundsOverlay.collectAsStateWithLifecycle()
+    // #518 — immersive mode: hide the bottom Android system navigation bar (the 3 buttons). Off by
+    // default; applied on the host window below.
+    val hideSystemNavBar by themeViewModel.hideSystemNavBar.collectAsStateWithLifecycle()
     val darkTheme = when (themeMode) {
         ThemeMode.LIGHT -> false
         ThemeMode.DARK -> true
@@ -543,6 +550,17 @@ fun RedfaceApp(intent: Intent?) {
             val controller = WindowCompat.getInsetsController(window, view)
             controller.isAppearanceLightStatusBars = !darkTheme
             controller.isAppearanceLightNavigationBars = !darkTheme
+        }
+        // #518 — apply immersive mode whenever the preference changes, and re-assert it on ON_RESUME
+        // (returning from another app / the recents screen restores the bar without a recomposition).
+        // The transient-bars-by-swipe behaviour handles user swipes; hiding sets the bottom inset to 0
+        // so navigationBarsPadding() collapses cleanly, while a transient swipe-reveal does NOT change
+        // insets (no layout jump). Status bar and the in-app tab bar are untouched.
+        LaunchedEffect(hideSystemNavBar) {
+            applyImmersiveNavBar(window, view, hideSystemNavBar)
+        }
+        LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+            applyImmersiveNavBar(window, view, hideSystemNavBar)
         }
     }
     RedfaceTheme(
@@ -1954,6 +1972,23 @@ private tailrec fun Context.findActivity(): Activity? = when (this) {
     is Activity -> this
     is ContextWrapper -> baseContext.findActivity()
     else -> null
+}
+
+/**
+ * #518 — hide or show ONLY the bottom Android system navigation bar on [window]. Never touches
+ * `Type.statusBars()` (the top bar stays) nor the in-app tab bar. When hiding, the behaviour is set to
+ * [WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE] so a swipe from the bottom edge
+ * re-reveals the bar transiently (documented Android behaviour) without changing layout insets.
+ */
+private fun applyImmersiveNavBar(window: Window, view: View, hide: Boolean) {
+    val controller = WindowCompat.getInsetsController(window, view)
+    if (hide) {
+        controller.systemBarsBehavior =
+            WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        controller.hide(WindowInsetsCompat.Type.navigationBars())
+    } else {
+        controller.show(WindowInsetsCompat.Type.navigationBars())
+    }
 }
 
 // #494 — paramètres de transition (Claude + Codex). MotionScheme M3 absent en stable 1.4.x (1.5.0-alpha)

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -527,8 +527,8 @@ fun RedfaceApp(intent: Intent?) {
     // #445 — debug bounds overlay preference (the dev-channel gate + render live in
     // [DevDebugBoundsOverlay], emitted last so it paints over everything; off by default).
     val debugBoundsOverlay by themeViewModel.debugBoundsOverlay.collectAsStateWithLifecycle()
-    // #518 — immersive mode: hide the bottom Android system navigation bar (the 3 buttons). Off by
-    // default; applied on the host window below.
+    // #518 — immersive mode: hide the bottom Android system navigation bar (3 buttons or gesture pill,
+    // device-dependent). Off by default; applied on the host window below.
     val hideSystemNavBar by themeViewModel.hideSystemNavBar.collectAsStateWithLifecycle()
     val darkTheme = when (themeMode) {
         ThemeMode.LIGHT -> false

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModelTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModelTest.kt
@@ -56,6 +56,8 @@ class AppThemeViewModelTest {
             every { observeDebugBoundsOverlay() } returns MutableStateFlow(false)
             // #332 — eagerly collected by the VM constructor; default on is enough here.
             every { observeFoldLongQuotes() } returns MutableStateFlow(true)
+            // #518 — eagerly collected by the VM constructor; default off is enough here.
+            every { observeHideSystemNavBar() } returns MutableStateFlow(false)
         }
 
         val vm = AppThemeViewModel(
@@ -79,6 +81,8 @@ class AppThemeViewModelTest {
             every { observeDebugBoundsOverlay() } returns MutableStateFlow(false)
             // #332 — eagerly collected by the VM constructor; default on is enough here.
             every { observeFoldLongQuotes() } returns MutableStateFlow(true)
+            // #518 — eagerly collected by the VM constructor; default off is enough here.
+            every { observeHideSystemNavBar() } returns MutableStateFlow(false)
         }
 
         val vm = AppThemeViewModel(

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -505,6 +505,21 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeHideSystemNavBar(): Flow<Boolean> =
+        dataStore.data
+            // Default `false` (#518): immersive mode is opt-in — most users expect the 3 buttons.
+            .map { prefs -> prefs[KEY_HIDE_SYSTEM_NAV_BAR] ?: false }
+            .distinctUntilChanged()
+            .catch { emit(false) }
+
+    override suspend fun setHideSystemNavBar(enabled: Boolean) {
+        persist {
+            dataStore.edit { prefs ->
+                prefs[KEY_HIDE_SYSTEM_NAV_BAR] = enabled
+            }
+        }
+    }
+
     /**
      * Reads [KEY_UPLOAD_PROVIDER] defensively: an unknown / corrupt stored value (older build with a
      * renamed enum, manual edit) falls back to [UploadProviderId.DIBERIE] instead of crashing on
@@ -668,5 +683,6 @@ class DataStoreUserPreferencesRepository @Inject constructor(
 
         // #445 — debug bounds overlay toggle (default false; exposed on the dev channel only).
         val KEY_DEBUG_BOUNDS_OVERLAY = booleanPreferencesKey("debug_bounds_overlay")
+        val KEY_HIDE_SYSTEM_NAV_BAR = booleanPreferencesKey("hide_system_nav_bar")
     }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -627,6 +627,27 @@ class DataStoreUserPreferencesRepositoryTest {
     }
 
     @Test
+    fun `observeHideSystemNavBar defaults to false then persists true and false`() = runTest(dispatcher) {
+        // #518 — immersive mode is opt-in; an empty store keeps the system nav bar visible.
+        repository.observeHideSystemNavBar().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setHideSystemNavBar(true)
+        repository.observeHideSystemNavBar().test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setHideSystemNavBar(false)
+        repository.observeHideSystemNavBar().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `saving disabled proxy removes optional fields from effective config`() = runTest(dispatcher) {
         repository.saveProxyConfig(
             ProxyConfig(

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -613,5 +613,9 @@ class TopicRepositoryImplTest {
         override fun observeDebugBoundsOverlay(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setDebugBoundsOverlay(enabled: Boolean) = Unit
+
+        override fun observeHideSystemNavBar(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setHideSystemNavBar(enabled: Boolean) = Unit
     }
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -315,7 +315,8 @@ interface UserPreferencesRepository {
 
     /**
      * Immersive full-screen (#518): when `true`, the app hides the bottom Android system navigation
-     * bar (the 3 buttons) — the top status bar and the in-app tab bar stay visible. A swipe from the
+     * bar (the 3 buttons, or the gesture pill depending on the device) — the top status bar and the
+     * in-app tab bar stay visible. A swipe from the
      * bottom edge re-reveals the bar transiently (Android `BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE`,
      * documented behaviour, not a bug), then it re-hides. Default `false`. Applied at the app root
      * ([fr.forumhfr.redface2.navigation.RedfaceApp]) on the host window, toggled in Settings > Affichage.

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -312,4 +312,16 @@ interface UserPreferencesRepository {
 
     /** Persists [observeDebugBoundsOverlay]. Default `false` until the first call. */
     suspend fun setDebugBoundsOverlay(enabled: Boolean)
+
+    /**
+     * Immersive full-screen (#518): when `true`, the app hides the bottom Android system navigation
+     * bar (the 3 buttons) — the top status bar and the in-app tab bar stay visible. A swipe from the
+     * bottom edge re-reveals the bar transiently (Android `BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE`,
+     * documented behaviour, not a bug), then it re-hides. Default `false`. Applied at the app root
+     * ([fr.forumhfr.redface2.navigation.RedfaceApp]) on the host window, toggled in Settings > Affichage.
+     */
+    fun observeHideSystemNavBar(): Flow<Boolean>
+
+    /** Persists [observeHideSystemNavBar]. Default `false` until the first call. */
+    suspend fun setHideSystemNavBar(enabled: Boolean)
 }

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -2034,6 +2034,10 @@ class PostEditorViewModelTest {
         override fun observeDebugBoundsOverlay(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setDebugBoundsOverlay(enabled: Boolean) = Unit
+
+        override fun observeHideSystemNavBar(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setHideSystemNavBar(enabled: Boolean) = Unit
     }
 
     /**

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1431,6 +1431,10 @@ class TopicFormViewModelTest {
         override fun observeDebugBoundsOverlay(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setDebugBoundsOverlay(enabled: Boolean) = Unit
+
+        override fun observeHideSystemNavBar(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setHideSystemNavBar(enabled: Boolean) = Unit
     }
 
     /** #405 — in-memory fake [EditorDraftStore], same shape as the one in `PostEditorViewModelTest`. */

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1715,5 +1715,9 @@ class FlagsViewModelTest {
         override fun observeDebugBoundsOverlay(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setDebugBoundsOverlay(enabled: Boolean) = Unit
+
+        override fun observeHideSystemNavBar(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setHideSystemNavBar(enabled: Boolean) = Unit
     }
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsDisplayScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsDisplayScreen.kt
@@ -145,6 +145,23 @@ fun SettingsDisplayScreen(
             if (state.fontScaleError) {
                 PreferencePersistError(R.string.settings_display_font_scale_persist_failed)
             }
+
+            // Immersive full-screen (#518).
+            Text(
+                text = stringResource(R.string.settings_display_fullscreen_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            DisplayToggleRow(
+                title = stringResource(R.string.settings_display_hide_nav_bar_title),
+                description = stringResource(R.string.settings_display_hide_nav_bar_description),
+                checked = state.hideSystemNavBar,
+                enabled = state.canToggleHideSystemNavBar,
+                onCheckedChange = { viewModel.submit(SettingsIntent.HideSystemNavBarChanged(it)) },
+            )
+            if (state.hideSystemNavBarError) {
+                PreferencePersistError(R.string.settings_display_hide_nav_bar_persist_failed)
+            }
         }
     }
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -119,6 +119,12 @@ data class SettingsState(
     val isUpdatingFoldLongQuotes: Boolean = false,
     val foldLongQuotesError: Boolean = false,
     val foldLongQuotesTouchedLocally: Boolean = false,
+    // #518 — masquer la barre de navigation système Android (plein écran immersif). Même machinerie
+    // optimistic-flip + garde de course. Default FALSE (opt-in).
+    val hideSystemNavBar: Boolean = false,
+    val isUpdatingHideSystemNavBar: Boolean = false,
+    val hideSystemNavBarError: Boolean = false,
+    val hideSystemNavBarTouchedLocally: Boolean = false,
     // Publishing preferences (#312). Same optimistic-flip + startup-race-guard machinery:
     // `confirmBeforePosting` is the displayed value, `isUpdating*` gates the switch while DataStore
     // writes, `*Error` surfaces a persist failure, `*TouchedLocally` forbids a late `init` hydration
@@ -231,6 +237,10 @@ data class SettingsState(
     // #332 — the fold-long-quotes toggle is gated only by its own write.
     val canToggleFoldLongQuotes: Boolean
         get() = !isUpdatingFoldLongQuotes
+
+    // #518 — the hide-system-nav-bar toggle is gated only by its own write.
+    val canToggleHideSystemNavBar: Boolean
+        get() = !isUpdatingHideSystemNavBar
 
     // #312 — the confirm-before-posting toggle is gated only by its own write.
     val canToggleConfirmBeforePosting: Boolean
@@ -345,6 +355,9 @@ sealed interface SettingsIntent {
 
     /** #332 — replier les longues citations sur une ligne. */
     data class FoldLongQuotesChanged(val enabled: Boolean) : SettingsIntent
+
+    /** #518 — masquer la barre de navigation système Android (plein écran immersif). */
+    data class HideSystemNavBarChanged(val enabled: Boolean) : SettingsIntent
 
     // #312 — confirm-before-posting toggle. Optimistic-flip contract, like the flags toggles:
     // the boolean is the desired post-flip state.

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -113,6 +113,11 @@ class SettingsViewModel @Inject constructor(
             apply = { state, value -> state.copy(foldLongQuotes = value) },
         )
         hydratePreference(
+            read = { userPreferencesRepository.observeHideSystemNavBar().first() },
+            isLocked = { it.hideSystemNavBarTouchedLocally || it.isUpdatingHideSystemNavBar },
+            apply = { state, value -> state.copy(hideSystemNavBar = value) },
+        )
+        hydratePreference(
             read = { userPreferencesRepository.observeConfirmBeforePosting().first() },
             isLocked = { it.confirmBeforePostingTouchedLocally || it.isUpdatingConfirmBeforePosting },
             apply = { state, value -> state.copy(confirmBeforePosting = value) },
@@ -220,6 +225,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.TopicPollsExpandedChanged -> updateTopicPollsExpanded(intent.enabled)
             is SettingsIntent.TopicSignaturesChanged -> updateTopicSignatures(intent.enabled)
             is SettingsIntent.FoldLongQuotesChanged -> updateFoldLongQuotes(intent.enabled)
+            is SettingsIntent.HideSystemNavBarChanged -> updateHideSystemNavBar(intent.enabled)
             is SettingsIntent.ShowDtSectionChanged -> updateShowDtSection(intent.enabled)
             is SettingsIntent.ConfirmBeforePostingChanged -> updateConfirmBeforePosting(intent.enabled)
             is SettingsIntent.FlagsAutoRefreshChanged -> updateFlagsAutoRefresh(intent.enabled)
@@ -806,6 +812,33 @@ class SettingsViewModel @Inject constructor(
                 }
             },
             persist = userPreferencesRepository::setFoldLongQuotes,
+        )
+    }
+
+    private fun updateHideSystemNavBar(desired: Boolean) {
+        val previous = _state.value.hideSystemNavBar
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    hideSystemNavBar = desired,
+                    isUpdatingHideSystemNavBar = true,
+                    hideSystemNavBarError = false,
+                    hideSystemNavBarTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(hideSystemNavBar = desired, isUpdatingHideSystemNavBar = false)
+                } else {
+                    state.copy(
+                        hideSystemNavBar = previous,
+                        isUpdatingHideSystemNavBar = false,
+                        hideSystemNavBarError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setHideSystemNavBar,
         )
     }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -279,10 +279,10 @@
     <string name="settings_display_font_scale_medium">Moyenne</string>
     <string name="settings_display_font_scale_large">Grande</string>
     <string name="settings_display_font_scale_persist_failed">Impossible de mémoriser la taille de police. Réessayez.</string>
-    <!-- #518 — plein écran immersif : masquer la barre de navigation système Android (3 boutons). -->
+    <!-- #518 — plein écran immersif : masquer la barre de navigation système Android (boutons ou barre gestuelle). -->
     <string name="settings_display_fullscreen_title">Plein écran</string>
     <string name="settings_display_hide_nav_bar_title">Masquer la barre de navigation Android</string>
-    <string name="settings_display_hide_nav_bar_description">Masque la barre système du bas (les 3 boutons). La barre du haut et les onglets de l\'app restent affichés. Elle peut réapparaître temporairement avec un geste depuis le bas de l\'écran.</string>
+    <string name="settings_display_hide_nav_bar_description">Masque la barre de navigation système du bas (les 3 boutons, ou la barre gestuelle selon votre appareil). La barre du haut et les onglets de l\'app restent affichés. Elle peut réapparaître temporairement avec un geste depuis le bas de l\'écran.</string>
     <string name="settings_display_hide_nav_bar_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
 
     <!-- Build 89 follow-up — Lecture des sujets. Masquer la barre du haut (titre + numéro de page)

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -279,6 +279,11 @@
     <string name="settings_display_font_scale_medium">Moyenne</string>
     <string name="settings_display_font_scale_large">Grande</string>
     <string name="settings_display_font_scale_persist_failed">Impossible de mémoriser la taille de police. Réessayez.</string>
+    <!-- #518 — plein écran immersif : masquer la barre de navigation système Android (3 boutons). -->
+    <string name="settings_display_fullscreen_title">Plein écran</string>
+    <string name="settings_display_hide_nav_bar_title">Masquer la barre de navigation Android</string>
+    <string name="settings_display_hide_nav_bar_description">Masque la barre système du bas (les 3 boutons). La barre du haut et les onglets de l\'app restent affichés. Elle peut réapparaître temporairement avec un geste depuis le bas de l\'écran.</string>
+    <string name="settings_display_hide_nav_bar_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
 
     <!-- Build 89 follow-up — Lecture des sujets. Masquer la barre du haut (titre + numéro de page)
          en défilant vers le bas pour libérer de la place ; persisté en DataStore et appliqué en direct. -->

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -1051,6 +1051,45 @@ class SettingsViewModelTest {
     }
 
     // ──────────────────────────────────────────────────────────────────────
+    // Hide system navigation bar (#518)
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `init hydrates hideSystemNavBar from a persisted true`() = runTest {
+        // Default is false — only a persisted opt-in exercises the hydration path.
+        repository.emitHideSystemNavBar(true)
+
+        val viewModel = newViewModel()
+
+        assertTrue(viewModel.state.value.hideSystemNavBar)
+        assertFalse(viewModel.state.value.hideSystemNavBarError)
+    }
+
+    @Test
+    fun `HideSystemNavBarChanged persists the flip`() = runTest {
+        val viewModel = newViewModel()
+        assertFalse("nav bar shown by default", viewModel.state.value.hideSystemNavBar)
+
+        viewModel.submit(SettingsIntent.HideSystemNavBarChanged(true))
+
+        assertTrue(viewModel.state.value.hideSystemNavBar)
+        assertFalse(viewModel.state.value.isUpdatingHideSystemNavBar)
+        assertEquals(1, repository.hideSystemNavBarSetCalls)
+    }
+
+    @Test
+    fun `HideSystemNavBarChanged reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnHideSystemNavBarSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.HideSystemNavBarChanged(true))
+
+        assertFalse("failed persist must revert to the previous value", viewModel.state.value.hideSystemNavBar)
+        assertFalse(viewModel.state.value.isUpdatingHideSystemNavBar)
+        assertTrue(viewModel.state.value.hideSystemNavBarError)
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
     // Debug bounds overlay (#445)
     // ──────────────────────────────────────────────────────────────────────
 
@@ -1794,6 +1833,24 @@ class SettingsViewModelTest {
 
         fun emitDebugBoundsOverlay(value: Boolean) {
             debugBoundsOverlay.value = value
+        }
+
+        // #518 — hide system nav bar. Same optimistic-flip seam as above.
+        private val hideSystemNavBar = MutableStateFlow(false)
+        var hideSystemNavBarSetCalls: Int = 0
+            private set
+        var failOnHideSystemNavBarSet: Boolean = false
+
+        override fun observeHideSystemNavBar(): Flow<Boolean> = hideSystemNavBar
+
+        override suspend fun setHideSystemNavBar(enabled: Boolean) {
+            hideSystemNavBarSetCalls += 1
+            check(!failOnHideSystemNavBarSet) { "boom" }
+            hideSystemNavBar.value = enabled
+        }
+
+        fun emitHideSystemNavBar(value: Boolean) {
+            hideSystemNavBar.value = value
         }
     }
 

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -1564,4 +1564,8 @@ private class FakeUserPreferencesRepository(
     override fun observeDebugBoundsOverlay(): Flow<Boolean> = MutableStateFlow(false)
 
     override suspend fun setDebugBoundsOverlay(enabled: Boolean) = Unit
+
+    override fun observeHideSystemNavBar(): Flow<Boolean> = MutableStateFlow(false)
+
+    override suspend fun setHideSystemNavBar(enabled: Boolean) = Unit
 }


### PR DESCRIPTION
Ajoute un toggle **Réglages > Affichage** (désactivé par défaut, Option A de l'issue) qui masque **uniquement la barre de navigation système Android du bas** (les 3 boutons). La status bar du haut et la barre d'onglets de l'app restent affichées.

## Contenu
- **:core:domain** — `observeHideSystemNavBar()` / `setHideSystemNavBar()`. Clé DataStore `hide_system_nav_bar`, défaut `false`, tolérante à une valeur corrompue (catch → false). Test d'aller-retour.
- **:app** — `AppThemeViewModel` expose `hideSystemNavBar` (eager, seed false, comme les autres presets window-level). `RedfaceApp` l'applique sur la `Window` hôte : `WindowInsetsControllerCompat` avec `BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE` + `hide(Type.navigationBars())` quand activé, `show()` sinon — jamais `Type.statusBars()`. Appliqué via `LaunchedEffect(pref)` et **réasserté sur `ON_RESUME`** (retour depuis une autre app restaure la barre sans recomposition). Masquer met l'inset bas à 0 (donc `navigationBarsPadding()` se replie proprement) ; un réaffichage transitoire au swipe ne change PAS les insets → pas de saut de layout.
- **:feature:settings** — `DisplayToggleRow` dans « Plein écran », machinerie optimistic-flip + garde de course au démarrage. Libellé + description expliquent le réaffichage transitoire (comportement Android documenté, cf. note a11y de l'issue). 3 tests `SettingsViewModel`.

La nouvelle méthode repo se répercute sur ~10 fakes/mocks de `UserPreferencesRepository` (les fakes écrits à la main reçoivent les 2 overrides ; le mockk strict d'`AppThemeViewModelTest` reçoit le stub car la VM la lit eagerly à la construction).

## Limite
Vérification on-device repoussée (device de test S10e indisponible cette session) ; l'API suit la recette validée par Codex dans l'issue + le plumbing est couvert par les tests unitaires.

## Validation
Tests unitaires core:data / settings / topic / editor / flags / app + `detektAll` + `:app:assembleDevDebug` verts (--rerun-tasks).

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)