### PR TITLE
feat(#518): bouton retour flottant en mode plein écran (option désactivable)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
@@ -70,4 +70,10 @@ class AppThemeViewModel @Inject constructor(
     val hideSystemNavBar: StateFlow<Boolean> =
         userPreferencesRepository.observeHideSystemNavBar()
             .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    // #518 follow-up — in-app back button shown while immersive mode is active. Default true (it only
+    // renders when hideSystemNavBar is on), eager like the presets above.
+    val immersiveBackButton: StateFlow<Boolean> =
+        userPreferencesRepository.observeImmersiveBackButton()
+            .stateIn(viewModelScope, SharingStarted.Eagerly, true)
 }

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -19,6 +19,8 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -30,13 +32,21 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.navigationBars
@@ -530,6 +540,12 @@ fun RedfaceApp(intent: Intent?) {
     // #518 — immersive mode: hide the bottom Android system navigation bar (3 buttons or gesture pill,
     // device-dependent). Off by default; applied on the host window below.
     val hideSystemNavBar by themeViewModel.hideSystemNavBar.collectAsStateWithLifecycle()
+    // #518 follow-up — in-app back button shown while immersive mode is active (companion to the above).
+    val immersiveBackButton by themeViewModel.immersiveBackButton.collectAsStateWithLifecycle()
+    // #518 follow-up — the in-app back FAB fires the SAME dispatcher the system back button drives, so a
+    // press follows nav3's onBack (pop the active tab's back stack). Resolved here in composable scope;
+    // null only on the @Preview path (no host Activity), where the FAB also never renders.
+    val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val darkTheme = when (themeMode) {
         ThemeMode.LIGHT -> false
         ThemeMode.DARK -> true
@@ -770,100 +786,119 @@ fun RedfaceApp(intent: Intent?) {
             // so the nav host no longer steals 8 dp/side from every screen. The Surface is kept
             // for the theme background/elevation; only its horizontal padding was removed.
             // #529 — consumes the bottom nav-bar inset under a bottom-bar layout (no-op otherwise).
-            Surface(modifier = contentInsetModifier) {
-                val activeBackStack = backStacks.getValue(currentDestination)
-                val accountMenu: @Composable () -> Unit = {
-                    RedfaceAccountMenu(
-                        authState = authState,
-                        versionName = BuildConfig.VERSION_NAME,
-                        versionCode = BuildConfig.VERSION_CODE,
-                        onLogin = { activeBackStack.add(LoginRoute) },
-                        onLogout = accountViewModel::logout,
-                        onOpenDiagnostics = { activeBackStack.add(DiagnosticsRoute) },
+            val activeBackStack = backStacks.getValue(currentDestination)
+            Box(modifier = Modifier.fillMaxSize()) {
+                Surface(modifier = contentInsetModifier) {
+                    val accountMenu: @Composable () -> Unit = {
+                        RedfaceAccountMenu(
+                            authState = authState,
+                            versionName = BuildConfig.VERSION_NAME,
+                            versionCode = BuildConfig.VERSION_CODE,
+                            onLogin = { activeBackStack.add(LoginRoute) },
+                            onLogout = accountViewModel::logout,
+                            onOpenDiagnostics = { activeBackStack.add(DiagnosticsRoute) },
+                            onReportContent = {
+                                startReportEmail(context, reportEmailSubject, reportNoEmailClient)
+                            },
+                            avatarUrl = accountAvatarUrl,
+                        )
+                    }
+                    RedfaceNavHost(
+                        backStack = activeBackStack,
+                        accountMenu = accountMenu,
                         onReportContent = {
                             startReportEmail(context, reportEmailSubject, reportNoEmailClient)
                         },
-                        avatarUrl = accountAvatarUrl,
+                        privateMessageNavState = PrivateMessageNavState(
+                            readThreadIds = readPrivateMessageThreadIds,
+                            multiRecipientThreadIds = multiRecipientThreadIds,
+                            onThreadLoaded = { threadId ->
+                                // #453 (Codex review) — decrement the badge ONLY when the conversation was
+                                // unread when opened AND this is its first read of the session (predicate
+                                // extracted to keep this composable under detekt's complexity threshold).
+                                val decrement = shouldDecrementUnreadBadge(
+                                    threadId = threadId,
+                                    unreadOnOpen = unreadOnOpenThreadIds,
+                                    alreadyRead = readPrivateMessageThreadIds,
+                                )
+                                if (decrement) {
+                                    mpBadgeViewModel.onThreadRead(threadId)
+                                }
+                                readPrivateMessageThreadIds = readPrivateMessageThreadIds + threadId
+                            },
+                            onThreadOpenedAsMulti = { threadId ->
+                                multiRecipientThreadIds = multiRecipientThreadIds + threadId
+                            },
+                            onThreadOpenedUnread = { threadId ->
+                                unreadOnOpenThreadIds = unreadOnOpenThreadIds + threadId
+                            },
+                            sentSignal = privateMessageSentSignal,
+                            onConversationSent = {
+                                privateMessageSentSignal = System.currentTimeMillis()
+                            },
+                        ),
+                        topicTitleNavState = TopicTitleNavState(
+                            titles = topicTitleCache,
+                            onTitleLoaded = { cat, post, title ->
+                                topicTitleCache = topicTitleCache.withTitle(TopicTitleKey(cat, post), title)
+                            },
+                        ),
+                        topicScrollNavState = TopicScrollNavState(
+                            anchors = topicScrollAnchorCache,
+                            onAnchorSaved = { cat, post, page, anchor ->
+                                topicScrollAnchorCache = topicScrollAnchorCache.withScrollAnchor(
+                                    TopicScrollKey(cat, post, page),
+                                    anchor,
+                                )
+                            },
+                            pendingBottomLanding = topicPendingBottomLanding,
+                            onPendingBottomLanding = { topicPendingBottomLanding = it },
+                        ),
+                        multiQuoteNavState = MultiQuoteNavState(
+                            basket = multiQuoteBasket,
+                            onToggle = { cat, post, numreponse ->
+                                multiQuoteBasket = multiQuoteBasket.toggled(cat, post, numreponse)
+                            },
+                            onClear = { multiQuoteBasket = null },
+                        ),
+                        topicPollNavState = TopicPollNavState(
+                            expansions = topicPollExpansionCache,
+                            onExpansionChanged = { cat, post, expanded ->
+                                topicPollExpansionCache = topicPollExpansionCache.withPollExpansion(
+                                    TopicPollKey(cat, post),
+                                    expanded,
+                                )
+                            },
+                        ),
+                        onOpenProfile = { userId, pseudo, avatarUrl ->
+                            // Review feedback I3: capture the **origin** tab so that
+                            // « Voir le profil complet » lands on the correct back stack
+                            // even if the user switches tabs while the sheet is open.
+                            profileSheetRequest = ProfileSheetRequest(
+                                userId = userId,
+                                pseudo = pseudo,
+                                avatarUrl = avatarUrl,
+                                origin = currentDestination,
+                            )
+                        },
                     )
                 }
-                RedfaceNavHost(
-                    backStack = activeBackStack,
-                    accountMenu = accountMenu,
-                    onReportContent = {
-                        startReportEmail(context, reportEmailSubject, reportNoEmailClient)
-                    },
-                    privateMessageNavState = PrivateMessageNavState(
-                        readThreadIds = readPrivateMessageThreadIds,
-                        multiRecipientThreadIds = multiRecipientThreadIds,
-                        onThreadLoaded = { threadId ->
-                            // #453 (Codex review) — decrement the badge ONLY when the conversation was
-                            // unread when opened AND this is its first read of the session (predicate
-                            // extracted to keep this composable under detekt's complexity threshold).
-                            val decrement = shouldDecrementUnreadBadge(
-                                threadId = threadId,
-                                unreadOnOpen = unreadOnOpenThreadIds,
-                                alreadyRead = readPrivateMessageThreadIds,
-                            )
-                            if (decrement) {
-                                mpBadgeViewModel.onThreadRead(threadId)
-                            }
-                            readPrivateMessageThreadIds = readPrivateMessageThreadIds + threadId
-                        },
-                        onThreadOpenedAsMulti = { threadId ->
-                            multiRecipientThreadIds = multiRecipientThreadIds + threadId
-                        },
-                        onThreadOpenedUnread = { threadId ->
-                            unreadOnOpenThreadIds = unreadOnOpenThreadIds + threadId
-                        },
-                        sentSignal = privateMessageSentSignal,
-                        onConversationSent = {
-                            privateMessageSentSignal = System.currentTimeMillis()
-                        },
+                // #518 follow-up — in-app back affordance for immersive mode: a discreet FAB that
+                // fires the SAME back action as the system button (OnBackPressedDispatcher), so the
+                // hidden Android nav bar never has to be swiped back in. Visibility predicate is a pure
+                // helper (keeps RedfaceApp under detekt's complexity threshold); the composable no-ops
+                // when not visible so the `.align`/`.padding` BoxScope modifier stays at this call site.
+                ImmersiveBackButton(
+                    visible = shouldShowImmersiveBackButton(
+                        hideSystemNavBar = hideSystemNavBar,
+                        immersiveBackButton = immersiveBackButton,
+                        backStackSize = activeBackStack.size,
+                        topRoute = topRoute,
                     ),
-                    topicTitleNavState = TopicTitleNavState(
-                        titles = topicTitleCache,
-                        onTitleLoaded = { cat, post, title ->
-                            topicTitleCache = topicTitleCache.withTitle(TopicTitleKey(cat, post), title)
-                        },
-                    ),
-                    topicScrollNavState = TopicScrollNavState(
-                        anchors = topicScrollAnchorCache,
-                        onAnchorSaved = { cat, post, page, anchor ->
-                            topicScrollAnchorCache = topicScrollAnchorCache.withScrollAnchor(
-                                TopicScrollKey(cat, post, page),
-                                anchor,
-                            )
-                        },
-                        pendingBottomLanding = topicPendingBottomLanding,
-                        onPendingBottomLanding = { topicPendingBottomLanding = it },
-                    ),
-                    multiQuoteNavState = MultiQuoteNavState(
-                        basket = multiQuoteBasket,
-                        onToggle = { cat, post, numreponse ->
-                            multiQuoteBasket = multiQuoteBasket.toggled(cat, post, numreponse)
-                        },
-                        onClear = { multiQuoteBasket = null },
-                    ),
-                    topicPollNavState = TopicPollNavState(
-                        expansions = topicPollExpansionCache,
-                        onExpansionChanged = { cat, post, expanded ->
-                            topicPollExpansionCache = topicPollExpansionCache.withPollExpansion(
-                                TopicPollKey(cat, post),
-                                expanded,
-                            )
-                        },
-                    ),
-                    onOpenProfile = { userId, pseudo, avatarUrl ->
-                        // Review feedback I3: capture the **origin** tab so that
-                        // « Voir le profil complet » lands on the correct back stack
-                        // even if the user switches tabs while the sheet is open.
-                        profileSheetRequest = ProfileSheetRequest(
-                            userId = userId,
-                            pseudo = pseudo,
-                            avatarUrl = avatarUrl,
-                            origin = currentDestination,
-                        )
-                    },
+                    onBack = { backDispatcher?.onBackPressed() },
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(16.dp),
                 )
             }
         }
@@ -922,6 +957,56 @@ fun RedfaceApp(intent: Intent?) {
 private fun DevDebugBoundsOverlay(enabled: Boolean) {
     if (enabled && BuildConfig.FLAVOR == DEV_CHANNEL) {
         DebugBoundsOverlay()
+    }
+}
+
+/**
+ * #518 follow-up — whether to show the in-app immersive « back » FAB. Pure predicate, extracted so
+ * [RedfaceApp] stays under detekt's cyclomatic-complexity threshold. Shown only when:
+ * - immersive mode hides the system navigation bar ([hideSystemNavBar]), AND
+ * - the companion option is on ([immersiveBackButton]), AND
+ * - there is a back entry in the active tab ([backStackSize] > 1) — never an app-exit at a tab root, AND
+ * - the current route is not a full-screen editor ([topRoute] does not hide the navigation suite): those
+ *   own the bottom region for their IME-pinned submit bar, so a bottom-start FAB would overlap it. A
+ *   3-button user there can still swipe-reveal the bar; gesture users keep the edge back gesture.
+ */
+private fun shouldShowImmersiveBackButton(
+    hideSystemNavBar: Boolean,
+    immersiveBackButton: Boolean,
+    backStackSize: Int,
+    topRoute: NavKey?,
+): Boolean = hideSystemNavBar &&
+    immersiveBackButton &&
+    backStackSize > 1 &&
+    !topRoute.hidesNavigationSuite()
+
+/**
+ * #518 follow-up — discreet in-app « back » affordance for immersive mode. A [SmallFloatingActionButton]
+ * pinned bottom-start that fires [onBack] — wired in [RedfaceApp] to the host's `OnBackPressedDispatcher`,
+ * i.e. the EXACT action of the system back button (nav3 pops the active tab's back stack). It lets a user
+ * navigate back without swiping the hidden Android navigation bar in. Low-key secondary-container colours
+ * so it does not fight the content. No-ops when [visible] is false (the visibility rule lives in
+ * [shouldShowImmersiveBackButton]); the early return keeps the BoxScope `.align`/`.padding` modifier at
+ * the single call site rather than duplicated here.
+ */
+@Composable
+private fun ImmersiveBackButton(
+    visible: Boolean,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (!visible) return
+    val description = stringResource(R.string.immersive_back_description)
+    SmallFloatingActionButton(
+        onClick = onBack,
+        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        modifier = modifier.semantics { contentDescription = description },
+    ) {
+        Icon(
+            painter = painterResource(CoreUiR.drawable.ic_arrow_back),
+            contentDescription = null,
+        )
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,6 @@
     <string name="nav_settings">Réglages</string>
     <!-- #313 — badge MP non lus sur l'item Messages ; au-delà de 9 le badge plafonne. -->
     <string name="nav_messages_badge_overflow">9+</string>
+    <!-- #518 follow-up — description d'accessibilité du bouton retour flottant en mode plein écran. -->
+    <string name="immersive_back_description">Retour</string>
 </resources>

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModelTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModelTest.kt
@@ -58,6 +58,8 @@ class AppThemeViewModelTest {
             every { observeFoldLongQuotes() } returns MutableStateFlow(true)
             // #518 — eagerly collected by the VM constructor; default off is enough here.
             every { observeHideSystemNavBar() } returns MutableStateFlow(false)
+            // #518 follow-up — eagerly collected by the VM constructor; default on is enough here.
+            every { observeImmersiveBackButton() } returns MutableStateFlow(true)
         }
 
         val vm = AppThemeViewModel(
@@ -83,6 +85,8 @@ class AppThemeViewModelTest {
             every { observeFoldLongQuotes() } returns MutableStateFlow(true)
             // #518 — eagerly collected by the VM constructor; default off is enough here.
             every { observeHideSystemNavBar() } returns MutableStateFlow(false)
+            // #518 follow-up — eagerly collected by the VM constructor; default on is enough here.
+            every { observeImmersiveBackButton() } returns MutableStateFlow(true)
         }
 
         val vm = AppThemeViewModel(

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -520,6 +520,22 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeImmersiveBackButton(): Flow<Boolean> =
+        dataStore.data
+            // Default `true` (#518 follow-up): only ever shown WHILE immersive mode is on, so the
+            // default-on keeps 3-button users able to go back; the toggle is the opt-out.
+            .map { prefs -> prefs[KEY_IMMERSIVE_BACK_BUTTON] ?: true }
+            .distinctUntilChanged()
+            .catch { emit(true) }
+
+    override suspend fun setImmersiveBackButton(enabled: Boolean) {
+        persist {
+            dataStore.edit { prefs ->
+                prefs[KEY_IMMERSIVE_BACK_BUTTON] = enabled
+            }
+        }
+    }
+
     /**
      * Reads [KEY_UPLOAD_PROVIDER] defensively: an unknown / corrupt stored value (older build with a
      * renamed enum, manual edit) falls back to [UploadProviderId.DIBERIE] instead of crashing on
@@ -684,5 +700,6 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         // #445 — debug bounds overlay toggle (default false; exposed on the dev channel only).
         val KEY_DEBUG_BOUNDS_OVERLAY = booleanPreferencesKey("debug_bounds_overlay")
         val KEY_HIDE_SYSTEM_NAV_BAR = booleanPreferencesKey("hide_system_nav_bar")
+        val KEY_IMMERSIVE_BACK_BUTTON = booleanPreferencesKey("immersive_back_button")
     }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -648,6 +648,27 @@ class DataStoreUserPreferencesRepositoryTest {
     }
 
     @Test
+    fun `observeImmersiveBackButton defaults to true then persists false and true`() = runTest(dispatcher) {
+        // #518 follow-up — default ON (only shown while immersive is active); an empty store reports true.
+        repository.observeImmersiveBackButton().test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setImmersiveBackButton(false)
+        repository.observeImmersiveBackButton().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setImmersiveBackButton(true)
+        repository.observeImmersiveBackButton().test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `saving disabled proxy removes optional fields from effective config`() = runTest(dispatcher) {
         repository.saveProxyConfig(
             ProxyConfig(

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -617,5 +617,9 @@ class TopicRepositoryImplTest {
         override fun observeHideSystemNavBar(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setHideSystemNavBar(enabled: Boolean) = Unit
+
+        override fun observeImmersiveBackButton(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setImmersiveBackButton(enabled: Boolean) = Unit
     }
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -325,4 +325,17 @@ interface UserPreferencesRepository {
 
     /** Persists [observeHideSystemNavBar]. Default `false` until the first call. */
     suspend fun setHideSystemNavBar(enabled: Boolean)
+
+    /**
+     * Immersive full-screen companion (#518 follow-up): when `true`, an in-app « back » button is shown
+     * while [observeHideSystemNavBar] is active, so the user can go back without swiping the hidden
+     * Android nav bar back into view (a real need in 3-button mode, where there is no system back
+     * gesture). Default `true` — it only ever renders WHEN immersive mode is on, so off-by-default would
+     * leave immersive 3-button users stranded; the toggle lets gesture-nav users (who keep the edge
+     * back-swipe) turn it off. Observed at the app root, toggled in Settings > Affichage.
+     */
+    fun observeImmersiveBackButton(): Flow<Boolean>
+
+    /** Persists [observeImmersiveBackButton]. Default `true` until the first call. */
+    suspend fun setImmersiveBackButton(enabled: Boolean)
 }

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -2038,6 +2038,10 @@ class PostEditorViewModelTest {
         override fun observeHideSystemNavBar(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setHideSystemNavBar(enabled: Boolean) = Unit
+
+        override fun observeImmersiveBackButton(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setImmersiveBackButton(enabled: Boolean) = Unit
     }
 
     /**

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1435,6 +1435,10 @@ class TopicFormViewModelTest {
         override fun observeHideSystemNavBar(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setHideSystemNavBar(enabled: Boolean) = Unit
+
+        override fun observeImmersiveBackButton(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setImmersiveBackButton(enabled: Boolean) = Unit
     }
 
     /** #405 — in-memory fake [EditorDraftStore], same shape as the one in `PostEditorViewModelTest`. */

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1719,5 +1719,9 @@ class FlagsViewModelTest {
         override fun observeHideSystemNavBar(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setHideSystemNavBar(enabled: Boolean) = Unit
+
+        override fun observeImmersiveBackButton(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setImmersiveBackButton(enabled: Boolean) = Unit
     }
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsDisplayScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsDisplayScreen.kt
@@ -162,6 +162,19 @@ fun SettingsDisplayScreen(
             if (state.hideSystemNavBarError) {
                 PreferencePersistError(R.string.settings_display_hide_nav_bar_persist_failed)
             }
+            // #518 follow-up — sous-option du plein écran : le bouton retour flottant ne sert que
+            // lorsque la barre système est masquée, donc la ligne reste désactivée tant que le
+            // plein écran est off (en plus de sa propre garde d'écriture optimiste).
+            DisplayToggleRow(
+                title = stringResource(R.string.settings_display_immersive_back_button_title),
+                description = stringResource(R.string.settings_display_immersive_back_button_description),
+                checked = state.immersiveBackButton,
+                enabled = state.hideSystemNavBar && state.canToggleImmersiveBackButton,
+                onCheckedChange = { viewModel.submit(SettingsIntent.ImmersiveBackButtonChanged(it)) },
+            )
+            if (state.immersiveBackButtonError) {
+                PreferencePersistError(R.string.settings_display_immersive_back_button_persist_failed)
+            }
         }
     }
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -125,6 +125,13 @@ data class SettingsState(
     val isUpdatingHideSystemNavBar: Boolean = false,
     val hideSystemNavBarError: Boolean = false,
     val hideSystemNavBarTouchedLocally: Boolean = false,
+    // #518 follow-up — bouton « retour » flottant affiché en mode plein écran (compagnon du toggle
+    // ci-dessus). Même machinerie optimistic-flip + garde de course. Default TRUE (il ne s'affiche que
+    // quand le plein écran est actif) ; l'option permet de le retirer pour les utilisateurs en gestes.
+    val immersiveBackButton: Boolean = true,
+    val isUpdatingImmersiveBackButton: Boolean = false,
+    val immersiveBackButtonError: Boolean = false,
+    val immersiveBackButtonTouchedLocally: Boolean = false,
     // Publishing preferences (#312). Same optimistic-flip + startup-race-guard machinery:
     // `confirmBeforePosting` is the displayed value, `isUpdating*` gates the switch while DataStore
     // writes, `*Error` surfaces a persist failure, `*TouchedLocally` forbids a late `init` hydration
@@ -242,6 +249,10 @@ data class SettingsState(
     val canToggleHideSystemNavBar: Boolean
         get() = !isUpdatingHideSystemNavBar
 
+    // #518 follow-up — the immersive back-button toggle is gated only by its own write.
+    val canToggleImmersiveBackButton: Boolean
+        get() = !isUpdatingImmersiveBackButton
+
     // #312 — the confirm-before-posting toggle is gated only by its own write.
     val canToggleConfirmBeforePosting: Boolean
         get() = !isUpdatingConfirmBeforePosting
@@ -358,6 +369,9 @@ sealed interface SettingsIntent {
 
     /** #518 — masquer la barre de navigation système Android (plein écran immersif). */
     data class HideSystemNavBarChanged(val enabled: Boolean) : SettingsIntent
+
+    /** #518 follow-up — afficher le bouton « retour » flottant en mode plein écran. */
+    data class ImmersiveBackButtonChanged(val enabled: Boolean) : SettingsIntent
 
     // #312 — confirm-before-posting toggle. Optimistic-flip contract, like the flags toggles:
     // the boolean is the desired post-flip state.

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -118,6 +118,11 @@ class SettingsViewModel @Inject constructor(
             apply = { state, value -> state.copy(hideSystemNavBar = value) },
         )
         hydratePreference(
+            read = { userPreferencesRepository.observeImmersiveBackButton().first() },
+            isLocked = { it.immersiveBackButtonTouchedLocally || it.isUpdatingImmersiveBackButton },
+            apply = { state, value -> state.copy(immersiveBackButton = value) },
+        )
+        hydratePreference(
             read = { userPreferencesRepository.observeConfirmBeforePosting().first() },
             isLocked = { it.confirmBeforePostingTouchedLocally || it.isUpdatingConfirmBeforePosting },
             apply = { state, value -> state.copy(confirmBeforePosting = value) },
@@ -226,6 +231,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.TopicSignaturesChanged -> updateTopicSignatures(intent.enabled)
             is SettingsIntent.FoldLongQuotesChanged -> updateFoldLongQuotes(intent.enabled)
             is SettingsIntent.HideSystemNavBarChanged -> updateHideSystemNavBar(intent.enabled)
+            is SettingsIntent.ImmersiveBackButtonChanged -> updateImmersiveBackButton(intent.enabled)
             is SettingsIntent.ShowDtSectionChanged -> updateShowDtSection(intent.enabled)
             is SettingsIntent.ConfirmBeforePostingChanged -> updateConfirmBeforePosting(intent.enabled)
             is SettingsIntent.FlagsAutoRefreshChanged -> updateFlagsAutoRefresh(intent.enabled)
@@ -839,6 +845,33 @@ class SettingsViewModel @Inject constructor(
                 }
             },
             persist = userPreferencesRepository::setHideSystemNavBar,
+        )
+    }
+
+    private fun updateImmersiveBackButton(desired: Boolean) {
+        val previous = _state.value.immersiveBackButton
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    immersiveBackButton = desired,
+                    isUpdatingImmersiveBackButton = true,
+                    immersiveBackButtonError = false,
+                    immersiveBackButtonTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(immersiveBackButton = desired, isUpdatingImmersiveBackButton = false)
+                } else {
+                    state.copy(
+                        immersiveBackButton = previous,
+                        isUpdatingImmersiveBackButton = false,
+                        immersiveBackButtonError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setImmersiveBackButton,
         )
     }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -284,6 +284,10 @@
     <string name="settings_display_hide_nav_bar_title">Masquer la barre de navigation Android</string>
     <string name="settings_display_hide_nav_bar_description">Masque la barre de navigation système du bas (les 3 boutons, ou la barre gestuelle selon votre appareil). La barre du haut et les onglets de l\'app restent affichés. Elle peut réapparaître temporairement avec un geste depuis le bas de l\'écran.</string>
     <string name="settings_display_hide_nav_bar_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
+    <!-- #518 follow-up — sous-option du plein écran : bouton retour flottant pour ne pas avoir à faire réapparaître la barre système. -->
+    <string name="settings_display_immersive_back_button_title">Bouton retour flottant</string>
+    <string name="settings_display_immersive_back_button_description">Affiche un bouton « retour » discret en bas à gauche quand la barre de navigation est masquée, pour revenir en arrière sans faire réapparaître la barre système. Désactivez-le si vous utilisez la navigation gestuelle.</string>
+    <string name="settings_display_immersive_back_button_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
 
     <!-- Build 89 follow-up — Lecture des sujets. Masquer la barre du haut (titre + numéro de page)
          en défilant vers le bas pour libérer de la place ; persisté en DataStore et appliqué en direct. -->

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -1089,6 +1089,41 @@ class SettingsViewModelTest {
         assertTrue(viewModel.state.value.hideSystemNavBarError)
     }
 
+    @Test
+    fun `init hydrates immersiveBackButton from a persisted false`() = runTest {
+        // Default is true — only a persisted opt-OUT exercises the hydration path.
+        repository.emitImmersiveBackButton(false)
+
+        val viewModel = newViewModel()
+
+        assertFalse(viewModel.state.value.immersiveBackButton)
+        assertFalse(viewModel.state.value.immersiveBackButtonError)
+    }
+
+    @Test
+    fun `ImmersiveBackButtonChanged persists the flip`() = runTest {
+        val viewModel = newViewModel()
+        assertTrue("back button on by default", viewModel.state.value.immersiveBackButton)
+
+        viewModel.submit(SettingsIntent.ImmersiveBackButtonChanged(false))
+
+        assertFalse(viewModel.state.value.immersiveBackButton)
+        assertFalse(viewModel.state.value.isUpdatingImmersiveBackButton)
+        assertEquals(1, repository.immersiveBackButtonSetCalls)
+    }
+
+    @Test
+    fun `ImmersiveBackButtonChanged reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnImmersiveBackButtonSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.ImmersiveBackButtonChanged(false))
+
+        assertTrue("failed persist must revert to the previous value", viewModel.state.value.immersiveBackButton)
+        assertFalse(viewModel.state.value.isUpdatingImmersiveBackButton)
+        assertTrue(viewModel.state.value.immersiveBackButtonError)
+    }
+
     // ──────────────────────────────────────────────────────────────────────
     // Debug bounds overlay (#445)
     // ──────────────────────────────────────────────────────────────────────
@@ -1851,6 +1886,24 @@ class SettingsViewModelTest {
 
         fun emitHideSystemNavBar(value: Boolean) {
             hideSystemNavBar.value = value
+        }
+
+        // #518 follow-up — immersive back button. Default TRUE, same optimistic-flip seam as above.
+        private val immersiveBackButton = MutableStateFlow(true)
+        var immersiveBackButtonSetCalls: Int = 0
+            private set
+        var failOnImmersiveBackButtonSet: Boolean = false
+
+        override fun observeImmersiveBackButton(): Flow<Boolean> = immersiveBackButton
+
+        override suspend fun setImmersiveBackButton(enabled: Boolean) {
+            immersiveBackButtonSetCalls += 1
+            check(!failOnImmersiveBackButtonSet) { "boom" }
+            immersiveBackButton.value = enabled
+        }
+
+        fun emitImmersiveBackButton(value: Boolean) {
+            immersiveBackButton.value = value
         }
     }
 

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -1568,4 +1568,8 @@ private class FakeUserPreferencesRepository(
     override fun observeHideSystemNavBar(): Flow<Boolean> = MutableStateFlow(false)
 
     override suspend fun setHideSystemNavBar(enabled: Boolean) = Unit
+
+    override fun observeImmersiveBackButton(): Flow<Boolean> = MutableStateFlow(true)
+
+    override suspend fun setImmersiveBackButton(enabled: Boolean) = Unit
 }


### PR DESCRIPTION
Suivi de #518 (plein écran immersif). Donne un moyen de revenir en arrière en mode plein écran **sans faire réapparaître la barre système**.

## Quoi
- **FAB retour flottant** (`SmallFloatingActionButton`, couleurs `secondaryContainer`, glyphe `ic_arrow_back`) en bas à gauche, affiché uniquement en mode plein écran. Il déclenche le **même `OnBackPressedDispatcher`** que le bouton retour système → comportement identique (nav3 dépile la pile de l'onglet courant).
- **Toggle « Bouton retour flottant »** sous « Plein écran » dans les réglages d'affichage. Défaut **on** (il ne s'affiche que quand le plein écran est actif) ; **opt-out** pour les utilisateurs en navigation gestuelle (qui gardent le swipe-retour). Désactivé tant que le plein écran est off.

## Visibilité (`shouldShowImmersiveBackButton`, prédicat pur)
Le FAB n'apparaît que si : plein écran actif **ET** option on **ET** `backStackSize > 1` (jamais d'exit-app à la racine d'un onglet) **ET** route non-éditeur plein écran (l'éditeur a sa propre barre « Envoyer » en bas — un FAB bottom-start la chevaucherait ; le swipe-révèle/geste y reste dispo). Extrait en helper pour garder `RedfaceApp` sous le seuil de complexité detekt.

## Persistance
`UserPreferencesRepository.observe/setImmersiveBackButton` (DataStore `immersive_back_button`, défaut `true`, `catch { emit(true) }`). `SettingsViewModel` en optimistic-flip comme les autres toggles.

## Validation
- `:core:data` + `:feature:settings` + `:feature:topic/editor/flags` + `:app` tests unitaires verts, `detektAll` vert, `:app:assembleDevDebug` (graphe Hilt) OK.
- Revue Codex (back-dispatcher, gating, contrat DataStore, optimistic-flip) : **0 finding**.

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)