### PR TITLE
fix(#568): images de post — restaurer pleine largeur + espace de chargement réservé (régression #249)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeMeasurer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeMeasurer.kt
@@ -7,6 +7,7 @@ import coil3.request.ImageRequest
 import coil3.request.SuccessResult
 import coil3.size.Precision
 import coil3.size.Scale
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * #175/#257 — probe a media's dimensions via a **bounded** Coil decode (aspect ratio + size class).
@@ -46,4 +47,40 @@ internal suspend fun measureIntrinsicMediaSize(
     )
     val image = (result as? SuccessResult)?.image ?: return null
     return if (image.width > 0 && image.height > 0) IntSize(image.width, image.height) else null
+}
+
+/**
+ * #249 follow-up — measure [url] and store the outcome in [cache], but ONLY when it is neither already
+ * known nor a fresh failure. Single shared seam for every caller that feeds the intrinsic-size cache:
+ * the paragraph measure effect (#175/#224 — smileys + inline images) AND the standalone `PostBlock.Image`
+ * effect. Keeping one implementation prevents the two paths from drifting (e.g. one forgetting the
+ * [IntrinsicMediaSizeCache.isFailureFresh] guard and re-probing a dead host every recomposition).
+ *
+ * Idempotent: a cached success / fresh failure short-circuits without a probe, so once the first result
+ * lands the `SnapshotStateMap` write recomposes readers and subsequent calls no-op.
+ *
+ * The cache guard is a non-atomic check-then-act, so two callers racing on the SAME cold URL (the
+ * BlockImage effect vs the paragraph effect, or two on-screen copies) could each start a probe before
+ * the first result lands. [inFlightMeasurements] de-dupes that window: the first caller wins the URL and
+ * the others no-op until it clears the entry (in a `finally`, so a cancelled probe also releases it).
+ * Process-wide like [ProcessIntrinsicMediaSizeCache]; keyed by URL (native sizes are URL-immutable).
+ */
+private val inFlightMeasurements: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+internal suspend fun measureAndCacheIntrinsicMediaSize(
+    url: String,
+    cache: IntrinsicMediaSizeCache,
+    context: PlatformContext,
+    imageLoader: ImageLoader,
+) {
+    val now = System.currentTimeMillis()
+    if (cache.get(url) != null || cache.isFailureFresh(url, now)) return
+    // Lost the race to another in-flight probe for this URL — its putSuccess/putFailure will recompose us.
+    if (!inFlightMeasurements.add(url)) return
+    try {
+        val size = measureIntrinsicMediaSize(url, context, imageLoader)
+        if (size != null) cache.putSuccess(url, size) else cache.putFailure(url, now)
+    } finally {
+        inFlightMeasurements.remove(url)
+    }
 }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
@@ -133,8 +133,10 @@ internal object PostMediaDisplayPolicy {
      * their real height; only the rare clamp cases differ — exactly the bounds the loaded image already
      * obeys, so no over-reserve vs the #175 sizing.
      *
-     * [measured] is `null` for a not-yet-measured image (a standalone `PostBlock.Image` is not fed by
-     * the paragraph measure effect): callers then fall back to the legacy [blockImageMinHeight] slot.
+     * [measured] is `null` for a not-yet-measured image — a cold cache before the measure effect lands,
+     * or a measurement failure (dead host / 404). Both the paragraph effect (#175/#224) and, since the
+     * #249 follow-up, the standalone `PostBlock.Image` effect feed the cache; callers fall back to the
+     * legacy [blockImageMinHeight] slot until (or unless) a size lands.
      */
     fun reservedBlockImageHeight(measured: PixelSize?, availableWidthDp: Float): Dp? {
         val size = measured?.takeIf { it.width > 0 && it.height > 0 }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -309,11 +309,7 @@ private fun ParagraphBlock(inlines: List<PostInline>) {
     LaunchedEffect(measurableUrls) {
         val loader = SingletonImageLoader.get(platformContext)
         measurableUrls.forEach { url ->
-            val now = System.currentTimeMillis()
-            if (sizeCache.get(url) == null && !sizeCache.isFailureFresh(url, now)) {
-                val size = measureIntrinsicMediaSize(url, platformContext, loader)
-                if (size != null) sizeCache.putSuccess(url, size) else sizeCache.putFailure(url, now)
-            }
+            measureAndCacheIntrinsicMediaSize(url, sizeCache, platformContext, loader)
         }
     }
 
@@ -648,11 +644,26 @@ private fun BlockImage(url: String, description: String?, linkUrl: String? = nul
     val openLabel = stringResource(R.string.post_image_open_link)
     val animationsEnabled = rememberAnimationsEnabled()
 
-    // #249 — reserve the exact final box from the measured intrinsic size when known. The same cache the
-    // #175/#224 paragraph measure effect fills feeds promoted images; a standalone PostBlock.Image is
-    // unmeasured (null) and falls back to the legacy min/max slot below.
+    // #249 — reserve the exact final box from the measured intrinsic size when known. The cache is fed by
+    // the #175/#224 paragraph measure effect (promoted images) AND, since #249 follow-up, by the effect
+    // just below for standalone PostBlock.Image. Until a measurement lands (cold cache) it is null and the
+    // legacy min/max slot is used for that first frame.
     val sizeCache = LocalIntrinsicMediaSizeCache.current
     val measured: IntSize? = sizeCache.get(url)
+    // #249 follow-up — a standalone PostBlock.Image is NOT covered by the paragraph measure effect, so
+    // without this its intrinsic size never lands in the cache: reservedBlockImageHeight stays null, the
+    // image falls into the legacy min/max slot and loses both the full-width fit and the reserved loading
+    // space (#249 anti-CLS). Measure it here through the same guarded seam the paragraph effect uses; the
+    // SnapshotStateMap write then recomposes this block onto the reserved-box path.
+    val platformContext = LocalPlatformContext.current
+    LaunchedEffect(url, sizeCache, platformContext) {
+        measureAndCacheIntrinsicMediaSize(
+            url = url,
+            cache = sizeCache,
+            context = platformContext,
+            imageLoader = SingletonImageLoader.get(platformContext),
+        )
+    }
 
     BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
         val reservedHeight = PostMediaDisplayPolicy.reservedBlockImageHeight(
@@ -683,9 +694,8 @@ private fun BlockImage(url: String, description: String?, linkUrl: String? = nul
                     Modifier
                 },
             )
-        val context = LocalPlatformContext.current
-        val request = remember(url, animationsEnabled, context) {
-            ImageRequest.Builder(context)
+        val request = remember(url, animationsEnabled, platformContext) {
+            ImageRequest.Builder(platformContext)
                 .data(url)
                 // #249 — fondu natif Coil dans la box déjà dimensionnée → zéro saut. Désactivé quand le
                 // système demande de réduire les animations (apparition directe, §4 de l'issue).

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/MeasureAndCacheIntrinsicMediaSizeTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/MeasureAndCacheIntrinsicMediaSizeTest.kt
@@ -1,0 +1,71 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import android.content.Context
+import androidx.compose.ui.unit.IntSize
+import androidx.test.core.app.ApplicationProvider
+import coil3.ColorImage
+import coil3.ImageLoader
+import coil3.test.FakeImageLoaderEngine
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * #249 follow-up — guards for the shared [measureAndCacheIntrinsicMediaSize] seam now used by BOTH the
+ * paragraph measure effect and the standalone `PostBlock.Image` effect. The bug it fixes was that
+ * standalone images were never measured (their cache entry stayed null → no reserved box → no full-width
+ * fit / no reserved loading space). These pin the cache-feeding contract: measure once on a miss, never
+ * re-probe a known size or a fresh failure.
+ */
+@RunWith(RobolectricTestRunner::class)
+class MeasureAndCacheIntrinsicMediaSizeTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun loaderReturning(url: String, image: ColorImage): ImageLoader {
+        val engine = FakeImageLoaderEngine.Builder().intercept(url, image).build()
+        return ImageLoader.Builder(context).components { add(engine) }.build()
+    }
+
+    @Test
+    fun `cold miss measures once and stores the native size`() = runTest {
+        val cache = DefaultIntrinsicMediaSizeCache()
+        val url = "https://hfr/photo800x600.jpg"
+        val loader = loaderReturning(url, ColorImage(width = 800, height = 600))
+
+        measureAndCacheIntrinsicMediaSize(url, cache, context, loader)
+
+        assertEquals(IntSize(800, 600), cache.get(url))
+    }
+
+    @Test
+    fun `a URL already in the cache is not re-measured`() = runTest {
+        val cache = DefaultIntrinsicMediaSizeCache()
+        val url = "https://hfr/photo.jpg"
+        cache.putSuccess(url, IntSize(800, 600))
+        // The fake loader would report a DIFFERENT size if a probe ran — proving a no-op if it doesn't.
+        val loader = loaderReturning(url, ColorImage(width = 70, height = 50))
+
+        measureAndCacheIntrinsicMediaSize(url, cache, context, loader)
+
+        assertEquals("the pre-cached size must survive (no re-probe)", IntSize(800, 600), cache.get(url))
+    }
+
+    @Test
+    fun `a fresh failure is not re-probed`() = runTest {
+        val cache = DefaultIntrinsicMediaSizeCache()
+        val url = "https://hfr/dead.jpg"
+        cache.putFailure(url, System.currentTimeMillis())
+        // Would succeed if probed — so a non-null result here would mean the failure guard was ignored.
+        val loader = loaderReturning(url, ColorImage(width = 70, height = 50))
+
+        measureAndCacheIntrinsicMediaSize(url, cache, context, loader)
+
+        assertNull("a fresh failure must short-circuit before probing", cache.get(url))
+        assertTrue(cache.isFailureFresh(url, System.currentTimeMillis()))
+    }
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicyTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicyTest.kt
@@ -38,6 +38,57 @@ class PostMediaDisplayPolicyTest {
         assertEquals(PostMediaDisplayPolicy.persoSmiley, PostMediaDisplayPolicy.smileyBox(variant))
     }
 
+    // #249 / #249 follow-up — reserved block-image height: exact aspect at full width, clamped to the
+    // [blockImageMinHeight, blockImageMaxHeight] slot, null when the size is unknown/invalid.
+    @Test
+    fun `reserved height is the aspect-exact height at full width when within the slot`() {
+        // 400 dp wide, 4:3 image → 300 dp, inside [160, 480].
+        val height = PostMediaDisplayPolicy.reservedBlockImageHeight(
+            measured = PixelSize(width = 400, height = 300),
+            availableWidthDp = 400f,
+        )
+        assertEquals(300.dp, height)
+    }
+
+    @Test
+    fun `reserved height clamps a tall portrait to the max slot`() {
+        // 400 dp wide, very tall (1:3) → 1200 dp raw → clamped to 480 dp (letterbox is the intended cap).
+        val height = PostMediaDisplayPolicy.reservedBlockImageHeight(
+            measured = PixelSize(width = 400, height = 1200),
+            availableWidthDp = 400f,
+        )
+        assertEquals(PostMediaDisplayPolicy.blockImageMaxHeight, height)
+    }
+
+    @Test
+    fun `reserved height clamps a very wide image to the min slot`() {
+        // 400 dp wide, very flat (10:1) → 40 dp raw → floored to 160 dp.
+        val height = PostMediaDisplayPolicy.reservedBlockImageHeight(
+            measured = PixelSize(width = 400, height = 40),
+            availableWidthDp = 400f,
+        )
+        assertEquals(PostMediaDisplayPolicy.blockImageMinHeight, height)
+    }
+
+    @Test
+    fun `reserved height is null when the size is unknown or invalid`() {
+        assertEquals(null, PostMediaDisplayPolicy.reservedBlockImageHeight(measured = null, availableWidthDp = 400f))
+        assertEquals(
+            null,
+            PostMediaDisplayPolicy.reservedBlockImageHeight(
+                measured = PixelSize(width = 0, height = 300),
+                availableWidthDp = 400f,
+            ),
+        )
+        assertEquals(
+            null,
+            PostMediaDisplayPolicy.reservedBlockImageHeight(
+                measured = PixelSize(width = 400, height = 300),
+                availableWidthDp = 0f,
+            ),
+        )
+    }
+
     @Test
     fun `builtin and perso buckets are distinct`() {
         // Sanity check: if these collapse to the same instance, the parser dispatch becomes


### PR DESCRIPTION
Corrige #568 (régression d'affichage signalée sur le topic DEV).

## Symptômes
- Les images de post ne prennent plus toute la largeur quand il le faut.
- L'espace de chargement (placeholder anti-CLS) n'est plus réservé.

## Cause
#249/#538 a fait dépendre `BlockImage` d'une **box réservée** dimensionnée depuis la taille intrinsèque en cache. Mais le cache n'est alimenté que par l'effet de mesure **paragraphe** (smileys + images inline). Une image **postée standalone** (`PostBlock.Image`) n'est jamais mesurée → cache `null` → `reservedBlockImageHeight` `null` → slot legacy `min/max` + `ContentScale.Fit` (letterbox possible, pas d'espace réservé).

## Fix
- Helper partagé `measureAndCacheIntrinsicMediaSize` (gardes `get()==null` + `isFailureFresh`, **de-dup in-flight** par URL), réutilisé par l'effet paragraphe (anti-divergence).
- Nouveau `LaunchedEffect(url)` dans `BlockImage` → mesure les images standalone → la reserved-box pleine largeur + l'anti-CLS s'appliquent à elles aussi.

## Tests
- `measureAndCacheIntrinsicMediaSize` : miss→mesure, hit→pas de re-probe, fresh-failure→pas de probe.
- `reservedBlockImageHeight` : aspect-exact, clamp min, clamp max, null si taille inconnue/invalide.

## Limite connue (inhérente, conservée)
Au tout premier rendu sur cache froid, la taille n'est pas encore connue → bref passage par le slot 160dp avant le snap exact (identique au chemin paragraphe). Portraits très hauts toujours clampés à 480dp (politique #249).

## Validation
`:core:ui:testDebugUnitTest` + `detektAll` + `:app:assembleDevDebug` verts. Raisonnement + review Codex : finding « cold-first-frame » inhérent assumé, finding « double-probe borné » fermé par le de-dup in-flight.

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)