### PR TITLE
feat(#518): révélation auto de la barre système en plein écran (option multi-comportements)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
+import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
@@ -76,4 +77,10 @@ class AppThemeViewModel @Inject constructor(
     val immersiveBackButton: StateFlow<Boolean> =
         userPreferencesRepository.observeImmersiveBackButton()
             .stateIn(viewModelScope, SharingStarted.Eagerly, true)
+
+    // #518 follow-up — when the hidden system nav bar auto-reveals from inside the app (scroll-driven).
+    // Default MANUAL (swipe-only, historical #518). Only acts while hideSystemNavBar is on. Eager seed.
+    val immersiveNavBarReveal: StateFlow<ImmersiveNavBarReveal> =
+        userPreferencesRepository.observeImmersiveNavBarReveal()
+            .stateIn(viewModelScope, SharingStarted.Eagerly, ImmersiveNavBarReveal.MANUAL)
 }

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -79,6 +79,8 @@ import fr.forumhfr.redface2.BuildConfig
 import fr.forumhfr.redface2.R
 import fr.forumhfr.redface2.core.ui.R as CoreUiR
 import fr.forumhfr.redface2.core.model.AuthState
+import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
+import fr.forumhfr.redface2.core.domain.preferences.shouldRevealNavBar
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.ui.RedfaceTheme
@@ -546,6 +548,14 @@ fun RedfaceApp(intent: Intent?) {
     // press follows nav3's onBack (pop the active tab's back stack). Resolved here in composable scope;
     // null only on the @Preview path (no host Activity), where the FAB also never renders.
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+    // #518 follow-up — scroll-driven reveal of the hidden system nav bar. The MODE is the user preference;
+    // the raw scroll FACTS are reported up by the active topic screen. RedfaceApp stays the single owner
+    // of the window bar (no dual ownership): it combines mode + facts via the pure shouldRevealNavBar and
+    // drives the window below. topicNavBarScroll resets when the active route is no longer a topic.
+    val immersiveNavBarReveal by themeViewModel.immersiveNavBarReveal.collectAsStateWithLifecycle()
+    var topicNavBarScroll by remember { mutableStateOf(NavBarScrollFacts()) }
+    // Effective hide + scroll-report gate are pure helpers so RedfaceApp stays under detekt's complexity.
+    val hideNavBarNow = immersiveNavBarHidden(hideSystemNavBar, immersiveNavBarReveal, topicNavBarScroll)
     val darkTheme = when (themeMode) {
         ThemeMode.LIGHT -> false
         ThemeMode.DARK -> true
@@ -567,16 +577,17 @@ fun RedfaceApp(intent: Intent?) {
             controller.isAppearanceLightStatusBars = !darkTheme
             controller.isAppearanceLightNavigationBars = !darkTheme
         }
-        // #518 — apply immersive mode whenever the preference changes, and re-assert it on ON_RESUME
-        // (returning from another app / the recents screen restores the bar without a recomposition).
-        // The transient-bars-by-swipe behaviour handles user swipes; hiding sets the bottom inset to 0
-        // so navigationBarsPadding() collapses cleanly, while a transient swipe-reveal does NOT change
-        // insets (no layout jump). Status bar and the in-app tab bar are untouched.
-        LaunchedEffect(hideSystemNavBar) {
-            applyImmersiveNavBar(window, view, hideSystemNavBar)
+        // #518 — apply immersive mode whenever the EFFECTIVE hide state changes (the master toggle, or a
+        // scroll-driven reveal request flipping, #518 follow-up), and re-assert it on ON_RESUME (returning
+        // from another app / the recents screen restores the bar without a recomposition). The
+        // transient-bars-by-swipe behaviour handles user swipes; hiding sets the bottom inset to 0 so
+        // navigationBarsPadding() collapses cleanly, while a transient swipe-reveal does NOT change insets
+        // (no layout jump). Status bar and the in-app tab bar are untouched.
+        LaunchedEffect(hideNavBarNow) {
+            applyImmersiveNavBar(window, view, hideNavBarNow)
         }
         LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
-            applyImmersiveNavBar(window, view, hideSystemNavBar)
+            applyImmersiveNavBar(window, view, hideNavBarNow)
         }
     }
     RedfaceTheme(
@@ -757,6 +768,11 @@ fun RedfaceApp(intent: Intent?) {
         // routes makes the editor full-screen: its submit bar then sits at the window bottom and the IME
         // inset lands exactly on the keyboard. Bonus UX: no tab switching mid-compose (would drop the draft).
         val topRoute = backStacks.getValue(currentDestination).lastOrNull()
+        // #518 follow-up — only a topic screen reports scroll facts; clear them whenever the active top
+        // route is something else (other tab, editor, profile…) so a stale « at bottom » never keeps the
+        // nav bar revealed off-topic. Returning to a topic re-emits its current facts on first frame. The
+        // branch lives in the helper composable to keep RedfaceApp under detekt's complexity threshold.
+        ResetNavBarScrollOffTopic(topRoute) { topicNavBarScroll = NavBarScrollFacts() }
         val adaptiveType = NavigationSuiteScaffoldDefaults.calculateFromAdaptiveInfo(currentWindowAdaptiveInfo())
         val navLayoutType = resolveNavLayoutType(topRoute.hidesNavigationSuite(), adaptiveType)
         // #529 — consume the bottom nav-bar inset for the content only under a bottom-bar layout
@@ -868,6 +884,14 @@ fun RedfaceApp(intent: Intent?) {
                                     TopicPollKey(cat, post),
                                     expanded,
                                 )
+                            },
+                        ),
+                        immersiveNavBarNavState = ImmersiveNavBarNavState(
+                            // #518 follow-up — observe scroll only when immersive is on AND a scroll-driven
+                            // mode is selected (helper keeps the && out of RedfaceApp's complexity budget).
+                            active = immersiveScrollReportActive(hideSystemNavBar, immersiveNavBarReveal),
+                            onScrollFacts = { atBottom, scrollingUp ->
+                                topicNavBarScroll = NavBarScrollFacts(atBottom, scrollingUp)
                             },
                         ),
                         onOpenProfile = { userId, pseudo, avatarUrl ->
@@ -1149,6 +1173,61 @@ private data class TopicPollNavState(
 )
 
 /**
+ * #518 follow-up — raw scroll facts of the active topic, reported UP so RedfaceApp (the single owner of
+ * the window navigation bar) can decide whether to reveal the hidden bar (cf. [shouldRevealNavBar]).
+ * Plain booleans, structural equality so re-reporting identical facts is a recomposition no-op.
+ */
+private data class NavBarScrollFacts(
+    val atBottom: Boolean = false,
+    val scrollingUp: Boolean = false,
+)
+
+/**
+ * #518 follow-up — immersive nav-bar reveal plumbing threaded into [RedfaceNavHost], same hoisted-bundle
+ * shape as [TopicScrollNavState]. [active] (immersive on AND mode != MANUAL) gates the topic screen's
+ * scroll observer so it is a no-op otherwise; [onScrollFacts] bubbles the facts up to the `var` in
+ * [RedfaceApp].
+ */
+private data class ImmersiveNavBarNavState(
+    val active: Boolean,
+    val onScrollFacts: (atBottom: Boolean, scrollingUp: Boolean) -> Unit,
+)
+
+/**
+ * #518 follow-up — effective « hide the system nav bar now » state: immersive on AND no active
+ * scroll-driven reveal ([shouldRevealNavBar]). Extracted so the `&&` stays out of RedfaceApp's
+ * cyclomatic-complexity budget.
+ */
+private fun immersiveNavBarHidden(
+    hideSystemNavBar: Boolean,
+    mode: ImmersiveNavBarReveal,
+    scroll: NavBarScrollFacts,
+): Boolean = hideSystemNavBar && !shouldRevealNavBar(mode, scroll.atBottom, scroll.scrollingUp)
+
+/**
+ * #518 follow-up — whether the topic screen should report its scroll facts: immersive on AND a
+ * scroll-driven reveal mode selected (MANUAL / immersive-off makes the reporter a no-op). Extracted
+ * to keep the `&&` out of RedfaceApp's complexity budget.
+ */
+private fun immersiveScrollReportActive(
+    hideSystemNavBar: Boolean,
+    mode: ImmersiveNavBarReveal,
+): Boolean = hideSystemNavBar && mode != ImmersiveNavBarReveal.MANUAL
+
+/**
+ * #518 follow-up — clears the reported scroll facts whenever the active top route is NOT a topic, so a
+ * stale « at bottom » can never keep the nav bar revealed off-topic. The `topRoute is TopicRoute` guard
+ * (and thus its branch) lives here rather than in RedfaceApp's body, keeping the latter under detekt's
+ * cyclomatic-complexity threshold.
+ */
+@Composable
+private fun ResetNavBarScrollOffTopic(topRoute: NavKey?, onReset: () -> Unit) {
+    LaunchedEffect(topRoute) {
+        if (topRoute !is TopicRoute) onReset()
+    }
+}
+
+/**
  * #291 — multi-quote selection, hoisted to RedfaceApp (same survival rationale as
  * [TopicScrollNavState]: a page change replaces the TopicRoute entry, so any state owned by the
  * topic screen dies with it). [numreponses] keeps SELECTION ORDER — the quotes are concatenated
@@ -1231,6 +1310,8 @@ private fun RedfaceNavHost(
     multiQuoteNavState: MultiQuoteNavState,
     // #465 — per-topic poll-expansion cache, same hoisting rationale (survives the per-page swap).
     topicPollNavState: TopicPollNavState,
+    // #518 follow-up — immersive nav-bar reveal: the topic reports scroll facts up through this bundle.
+    immersiveNavBarNavState: ImmersiveNavBarNavState,
     onOpenProfile: (userId: Int, pseudo: String, avatarUrl: String?) -> Unit = { _, _, _ -> },
 ) {
     NavDisplay(
@@ -1844,6 +1925,11 @@ private fun RedfaceNavHost(
                             postSubmitOverflowLanding = true,
                         )
                     },
+                    // #518 follow-up — report scroll facts so RedfaceApp can reveal the hidden system
+                    // nav bar per the chosen mode. `active` is false (no-op) unless immersive + a
+                    // scroll-driven mode are on; the screen clears stale facts when inactive.
+                    immersiveNavBarRevealActive = immersiveNavBarNavState.active,
+                    onImmersiveNavBarScroll = immersiveNavBarNavState.onScrollFacts,
                 )
             }
             entry<PostEditorRoute> { route ->

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModelTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModelTest.kt
@@ -2,6 +2,7 @@ package fr.forumhfr.redface2.navigation
 
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
+import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrap
 import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
@@ -60,6 +61,7 @@ class AppThemeViewModelTest {
             every { observeHideSystemNavBar() } returns MutableStateFlow(false)
             // #518 follow-up — eagerly collected by the VM constructor; default on is enough here.
             every { observeImmersiveBackButton() } returns MutableStateFlow(true)
+            every { observeImmersiveNavBarReveal() } returns MutableStateFlow(ImmersiveNavBarReveal.MANUAL)
         }
 
         val vm = AppThemeViewModel(
@@ -87,6 +89,7 @@ class AppThemeViewModelTest {
             every { observeHideSystemNavBar() } returns MutableStateFlow(false)
             // #518 follow-up — eagerly collected by the VM constructor; default on is enough here.
             every { observeImmersiveBackButton() } returns MutableStateFlow(true)
+            every { observeImmersiveNavBarReveal() } returns MutableStateFlow(ImmersiveNavBarReveal.MANUAL)
         }
 
         val vm = AppThemeViewModel(

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import fr.forumhfr.redface2.core.domain.coroutines.ApplicationScope
 import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
+import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
@@ -536,6 +537,21 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeImmersiveNavBarReveal(): Flow<ImmersiveNavBarReveal> =
+        dataStore.data
+            // Default MANUAL (#518 follow-up): swipe-from-bottom only, the historical immersive behaviour.
+            .map(::readImmersiveNavBarReveal)
+            .distinctUntilChanged()
+            .catch { emit(ImmersiveNavBarReveal.MANUAL) }
+
+    override suspend fun setImmersiveNavBarReveal(mode: ImmersiveNavBarReveal) {
+        persist {
+            dataStore.edit { prefs ->
+                prefs[KEY_IMMERSIVE_NAV_BAR_REVEAL] = mode.name
+            }
+        }
+    }
+
     /**
      * Reads [KEY_UPLOAD_PROVIDER] defensively: an unknown / corrupt stored value (older build with a
      * renamed enum, manual edit) falls back to [UploadProviderId.DIBERIE] instead of crashing on
@@ -561,6 +577,16 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         prefs[KEY_DISPLAY_DENSITY]
             ?.let { stored -> runCatching { DisplayDensity.valueOf(stored) }.getOrNull() }
             ?: DisplayDensity.COMFORT
+
+    /**
+     * Reads [KEY_IMMERSIVE_NAV_BAR_REVEAL] defensively (#518 follow-up): an unknown / corrupt stored
+     * value falls back to [ImmersiveNavBarReveal.MANUAL] instead of crashing on
+     * `ImmersiveNavBarReveal.valueOf`, same stance as [readDisplayDensity].
+     */
+    private fun readImmersiveNavBarReveal(prefs: Preferences): ImmersiveNavBarReveal =
+        prefs[KEY_IMMERSIVE_NAV_BAR_REVEAL]
+            ?.let { stored -> runCatching { ImmersiveNavBarReveal.valueOf(stored) }.getOrNull() }
+            ?: ImmersiveNavBarReveal.MANUAL
 
     /**
      * Reads [KEY_FONT_SCALE] defensively (#287): an unknown / corrupt stored value falls back to
@@ -701,5 +727,6 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         val KEY_DEBUG_BOUNDS_OVERLAY = booleanPreferencesKey("debug_bounds_overlay")
         val KEY_HIDE_SYSTEM_NAV_BAR = booleanPreferencesKey("hide_system_nav_bar")
         val KEY_IMMERSIVE_BACK_BUTTON = booleanPreferencesKey("immersive_back_button")
+        val KEY_IMMERSIVE_NAV_BAR_REVEAL = stringPreferencesKey("immersive_nav_bar_reveal")
     }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -8,6 +8,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
+import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
@@ -664,6 +665,27 @@ class DataStoreUserPreferencesRepositoryTest {
         repository.setImmersiveBackButton(true)
         repository.observeImmersiveBackButton().test {
             assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `observeImmersiveNavBarReveal defaults to MANUAL then persists chosen modes`() = runTest(dispatcher) {
+        // #518 follow-up — default MANUAL (swipe-only) on an empty store.
+        repository.observeImmersiveNavBarReveal().test {
+            assertEquals(ImmersiveNavBarReveal.MANUAL, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setImmersiveNavBarReveal(ImmersiveNavBarReveal.AT_BOTTOM)
+        repository.observeImmersiveNavBarReveal().test {
+            assertEquals(ImmersiveNavBarReveal.AT_BOTTOM, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setImmersiveNavBarReveal(ImmersiveNavBarReveal.ON_SCROLL_UP)
+        repository.observeImmersiveNavBarReveal().test {
+            assertEquals(ImmersiveNavBarReveal.ON_SCROLL_UP, awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -9,6 +9,7 @@ import fr.forumhfr.redface2.core.database.entities.FetchMode
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
+import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
@@ -621,5 +622,10 @@ class TopicRepositoryImplTest {
         override fun observeImmersiveBackButton(): Flow<Boolean> = MutableStateFlow(true)
 
         override suspend fun setImmersiveBackButton(enabled: Boolean) = Unit
+
+        override fun observeImmersiveNavBarReveal(): Flow<ImmersiveNavBarReveal> =
+            MutableStateFlow(ImmersiveNavBarReveal.MANUAL)
+
+        override suspend fun setImmersiveNavBarReveal(mode: ImmersiveNavBarReveal) = Unit
     }
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/ImmersiveNavBarReveal.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/ImmersiveNavBarReveal.kt
@@ -1,0 +1,40 @@
+package fr.forumhfr.redface2.core.domain.preferences
+
+/**
+ * #518 follow-up — when, in full-screen mode (the Android system navigation bar hidden via
+ * `hideSystemNavBar`), the hidden bar should be revealed again from inside the app, based on the
+ * reading scroll position. Only meaningful while `hideSystemNavBar` is on.
+ *
+ * - [MANUAL] (default) keeps the historical #518 behaviour: the bar stays hidden and is only
+ *   revealed by the Android transient swipe-from-bottom gesture.
+ * - [AT_BOTTOM] reveals the bar when the topic is scrolled to the very bottom (nothing left to
+ *   scroll forward), and hides it again as soon as the reader scrolls back up — the least intrusive
+ *   auto-reveal.
+ * - [ON_SCROLL_UP] reveals the bar whenever the reader scrolls UP (or is at the bottom) and hides it
+ *   while scrolling down — mirrors the top-bar auto-hide (#285), the most eager auto-reveal.
+ *
+ * Persisted by its [name] like [ThemeMode] / [DisplayDensity]; observed at the app root.
+ */
+enum class ImmersiveNavBarReveal {
+    MANUAL,
+    AT_BOTTOM,
+    ON_SCROLL_UP,
+}
+
+/**
+ * Pure policy mapping a [ImmersiveNavBarReveal] mode + the current topic scroll facts onto whether the
+ * system navigation bar should be revealed right now. Extracted so the decision is unit-testable and
+ * lives in one place (the app root reads scroll facts reported by the topic screen and applies this).
+ *
+ * @param atBottom the topic list cannot scroll forward any further (the last post is fully reached).
+ * @param scrollingUp the most recent scroll movement was towards the top of the list.
+ */
+fun shouldRevealNavBar(
+    mode: ImmersiveNavBarReveal,
+    atBottom: Boolean,
+    scrollingUp: Boolean,
+): Boolean = when (mode) {
+    ImmersiveNavBarReveal.MANUAL -> false
+    ImmersiveNavBarReveal.AT_BOTTOM -> atBottom
+    ImmersiveNavBarReveal.ON_SCROLL_UP -> atBottom || scrollingUp
+}

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -338,4 +338,16 @@ interface UserPreferencesRepository {
 
     /** Persists [observeImmersiveBackButton]. Default `true` until the first call. */
     suspend fun setImmersiveBackButton(enabled: Boolean)
+
+    /**
+     * Immersive full-screen companion (#518 follow-up): WHEN the hidden Android navigation bar should be
+     * revealed again from inside the app, based on the reading scroll position (cf. [ImmersiveNavBarReveal]).
+     * Only meaningful while [observeHideSystemNavBar] is active. Default [ImmersiveNavBarReveal.MANUAL]
+     * (the historical #518 behaviour: swipe-from-bottom only). Observed at the app root, set in
+     * Settings > Affichage.
+     */
+    fun observeImmersiveNavBarReveal(): Flow<ImmersiveNavBarReveal>
+
+    /** Persists [observeImmersiveNavBarReveal]. Default [ImmersiveNavBarReveal.MANUAL] until the first call. */
+    suspend fun setImmersiveNavBarReveal(mode: ImmersiveNavBarReveal)
 }

--- a/core/domain/src/test/kotlin/fr/forumhfr/redface2/core/domain/preferences/ShouldRevealNavBarTest.kt
+++ b/core/domain/src/test/kotlin/fr/forumhfr/redface2/core/domain/preferences/ShouldRevealNavBarTest.kt
@@ -1,0 +1,36 @@
+package fr.forumhfr.redface2.core.domain.preferences
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #518 follow-up — pure policy [shouldRevealNavBar]: which scroll facts reveal the hidden system
+ * navigation bar for each mode.
+ */
+class ShouldRevealNavBarTest {
+
+    @Test
+    fun `MANUAL never reveals regardless of scroll`() {
+        for (atBottom in listOf(true, false)) {
+            for (up in listOf(true, false)) {
+                assertFalse(shouldRevealNavBar(ImmersiveNavBarReveal.MANUAL, atBottom, up))
+            }
+        }
+    }
+
+    @Test
+    fun `AT_BOTTOM reveals only at the bottom`() {
+        assertTrue(shouldRevealNavBar(ImmersiveNavBarReveal.AT_BOTTOM, atBottom = true, scrollingUp = false))
+        assertTrue(shouldRevealNavBar(ImmersiveNavBarReveal.AT_BOTTOM, atBottom = true, scrollingUp = true))
+        assertFalse(shouldRevealNavBar(ImmersiveNavBarReveal.AT_BOTTOM, atBottom = false, scrollingUp = true))
+        assertFalse(shouldRevealNavBar(ImmersiveNavBarReveal.AT_BOTTOM, atBottom = false, scrollingUp = false))
+    }
+
+    @Test
+    fun `ON_SCROLL_UP reveals when scrolling up or at the bottom, hides when scrolling down`() {
+        assertTrue(shouldRevealNavBar(ImmersiveNavBarReveal.ON_SCROLL_UP, atBottom = false, scrollingUp = true))
+        assertTrue(shouldRevealNavBar(ImmersiveNavBarReveal.ON_SCROLL_UP, atBottom = true, scrollingUp = false))
+        assertFalse(shouldRevealNavBar(ImmersiveNavBarReveal.ON_SCROLL_UP, atBottom = false, scrollingUp = false))
+    }
+}

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -13,6 +13,7 @@ import fr.forumhfr.redface2.core.domain.editor.EditorDraftStore
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
+import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
@@ -2042,6 +2043,11 @@ class PostEditorViewModelTest {
         override fun observeImmersiveBackButton(): Flow<Boolean> = MutableStateFlow(true)
 
         override suspend fun setImmersiveBackButton(enabled: Boolean) = Unit
+
+        override fun observeImmersiveNavBarReveal(): Flow<ImmersiveNavBarReveal> =
+            MutableStateFlow(ImmersiveNavBarReveal.MANUAL)
+
+        override suspend fun setImmersiveNavBarReveal(mode: ImmersiveNavBarReveal) = Unit
     }
 
     /**

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -12,6 +12,7 @@ import fr.forumhfr.redface2.core.domain.editor.EditorDraftStore
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
+import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
@@ -1439,6 +1440,11 @@ class TopicFormViewModelTest {
         override fun observeImmersiveBackButton(): Flow<Boolean> = MutableStateFlow(true)
 
         override suspend fun setImmersiveBackButton(enabled: Boolean) = Unit
+
+        override fun observeImmersiveNavBarReveal(): Flow<ImmersiveNavBarReveal> =
+            MutableStateFlow(ImmersiveNavBarReveal.MANUAL)
+
+        override suspend fun setImmersiveNavBarReveal(mode: ImmersiveNavBarReveal) = Unit
     }
 
     /** #405 — in-memory fake [EditorDraftStore], same shape as the one in `PostEditorViewModelTest`. */

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -15,6 +15,7 @@ import fr.forumhfr.redface2.core.domain.forum.ForumResult
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
+import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
@@ -1723,5 +1724,10 @@ class FlagsViewModelTest {
         override fun observeImmersiveBackButton(): Flow<Boolean> = MutableStateFlow(true)
 
         override suspend fun setImmersiveBackButton(enabled: Boolean) = Unit
+
+        override fun observeImmersiveNavBarReveal(): Flow<ImmersiveNavBarReveal> =
+            MutableStateFlow(ImmersiveNavBarReveal.MANUAL)
+
+        override suspend fun setImmersiveNavBarReveal(mode: ImmersiveNavBarReveal) = Unit
     }
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsDisplayScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsDisplayScreen.kt
@@ -23,6 +23,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
+import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsChoice
 import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsChoiceGroup
@@ -61,6 +62,21 @@ fun SettingsDisplayScreen(
         RedfaceSettingsChoice(FontScalePreference.S, stringResource(R.string.settings_display_font_scale_small)),
         RedfaceSettingsChoice(FontScalePreference.M, stringResource(R.string.settings_display_font_scale_medium)),
         RedfaceSettingsChoice(FontScalePreference.L, stringResource(R.string.settings_display_font_scale_large)),
+    )
+    // #518 follow-up — immersive nav-bar reveal behaviours.
+    val navBarRevealOptions = listOf(
+        RedfaceSettingsChoice(
+            ImmersiveNavBarReveal.MANUAL,
+            stringResource(R.string.settings_display_nav_bar_reveal_manual),
+        ),
+        RedfaceSettingsChoice(
+            ImmersiveNavBarReveal.AT_BOTTOM,
+            stringResource(R.string.settings_display_nav_bar_reveal_at_bottom),
+        ),
+        RedfaceSettingsChoice(
+            ImmersiveNavBarReveal.ON_SCROLL_UP,
+            stringResource(R.string.settings_display_nav_bar_reveal_on_scroll_up),
+        ),
     )
     Scaffold(
         modifier = modifier.fillMaxSize(),
@@ -174,6 +190,22 @@ fun SettingsDisplayScreen(
             )
             if (state.immersiveBackButtonError) {
                 PreferencePersistError(R.string.settings_display_immersive_back_button_persist_failed)
+            }
+            // #518 follow-up — sous-option du plein écran : quand révéler la barre système masquée selon
+            // le défilement. Désactivée tant que le plein écran est off (en plus de sa propre garde).
+            Text(
+                text = stringResource(R.string.settings_display_nav_bar_reveal_intro),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            RedfaceSettingsChoiceGroup(
+                options = navBarRevealOptions,
+                selected = state.immersiveNavBarReveal,
+                onSelected = { viewModel.submit(SettingsIntent.ImmersiveNavBarRevealChanged(it)) },
+                enabled = state.hideSystemNavBar && state.canChangeImmersiveNavBarReveal,
+            )
+            if (state.immersiveNavBarRevealError) {
+                PreferencePersistError(R.string.settings_display_nav_bar_reveal_persist_failed)
             }
         }
     }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -2,6 +2,7 @@ package fr.forumhfr.redface2.feature.settings
 
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
+import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
@@ -132,6 +133,12 @@ data class SettingsState(
     val isUpdatingImmersiveBackButton: Boolean = false,
     val immersiveBackButtonError: Boolean = false,
     val immersiveBackButtonTouchedLocally: Boolean = false,
+    // #518 follow-up — quand la barre système masquée se révèle automatiquement (selon le scroll).
+    // Default MANUAL (balayage seul, comportement #518 historique). Même machinerie que DisplayDensity.
+    val immersiveNavBarReveal: ImmersiveNavBarReveal = ImmersiveNavBarReveal.MANUAL,
+    val isUpdatingImmersiveNavBarReveal: Boolean = false,
+    val immersiveNavBarRevealError: Boolean = false,
+    val immersiveNavBarRevealTouchedLocally: Boolean = false,
     // Publishing preferences (#312). Same optimistic-flip + startup-race-guard machinery:
     // `confirmBeforePosting` is the displayed value, `isUpdating*` gates the switch while DataStore
     // writes, `*Error` surfaces a persist failure, `*TouchedLocally` forbids a late `init` hydration
@@ -253,6 +260,10 @@ data class SettingsState(
     val canToggleImmersiveBackButton: Boolean
         get() = !isUpdatingImmersiveBackButton
 
+    // #518 follow-up — the nav-bar reveal-mode selector is gated only by its own write.
+    val canChangeImmersiveNavBarReveal: Boolean
+        get() = !isUpdatingImmersiveNavBarReveal
+
     // #312 — the confirm-before-posting toggle is gated only by its own write.
     val canToggleConfirmBeforePosting: Boolean
         get() = !isUpdatingConfirmBeforePosting
@@ -372,6 +383,9 @@ sealed interface SettingsIntent {
 
     /** #518 follow-up — afficher le bouton « retour » flottant en mode plein écran. */
     data class ImmersiveBackButtonChanged(val enabled: Boolean) : SettingsIntent
+
+    /** #518 follow-up — comportement de révélation de la barre système masquée (plein écran). */
+    data class ImmersiveNavBarRevealChanged(val mode: ImmersiveNavBarReveal) : SettingsIntent
 
     // #312 — confirm-before-posting toggle. Optimistic-flip contract, like the flags toggles:
     // the boolean is the desired post-flip state.

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -7,6 +7,7 @@ import fr.forumhfr.redface2.core.domain.cache.ImageCacheMaintenance
 import fr.forumhfr.redface2.core.domain.cache.TopicCacheMaintenance
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
+import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
@@ -123,6 +124,11 @@ class SettingsViewModel @Inject constructor(
             apply = { state, value -> state.copy(immersiveBackButton = value) },
         )
         hydratePreference(
+            read = { userPreferencesRepository.observeImmersiveNavBarReveal().first() },
+            isLocked = { it.immersiveNavBarRevealTouchedLocally || it.isUpdatingImmersiveNavBarReveal },
+            apply = { state, value -> state.copy(immersiveNavBarReveal = value) },
+        )
+        hydratePreference(
             read = { userPreferencesRepository.observeConfirmBeforePosting().first() },
             isLocked = { it.confirmBeforePostingTouchedLocally || it.isUpdatingConfirmBeforePosting },
             apply = { state, value -> state.copy(confirmBeforePosting = value) },
@@ -232,6 +238,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.FoldLongQuotesChanged -> updateFoldLongQuotes(intent.enabled)
             is SettingsIntent.HideSystemNavBarChanged -> updateHideSystemNavBar(intent.enabled)
             is SettingsIntent.ImmersiveBackButtonChanged -> updateImmersiveBackButton(intent.enabled)
+            is SettingsIntent.ImmersiveNavBarRevealChanged -> updateImmersiveNavBarReveal(intent.mode)
             is SettingsIntent.ShowDtSectionChanged -> updateShowDtSection(intent.enabled)
             is SettingsIntent.ConfirmBeforePostingChanged -> updateConfirmBeforePosting(intent.enabled)
             is SettingsIntent.FlagsAutoRefreshChanged -> updateFlagsAutoRefresh(intent.enabled)
@@ -873,6 +880,36 @@ class SettingsViewModel @Inject constructor(
             },
             persist = userPreferencesRepository::setImmersiveBackButton,
         )
+    }
+
+    // #518 follow-up — enum preference; same bespoke optimistic-flip shape as updateDisplayDensity.
+    private fun updateImmersiveNavBarReveal(desired: ImmersiveNavBarReveal) {
+        val previous = _state.value.immersiveNavBarReveal
+        _state.update {
+            it.copy(
+                immersiveNavBarReveal = desired,
+                isUpdatingImmersiveNavBarReveal = true,
+                immersiveNavBarRevealError = false,
+                immersiveNavBarRevealTouchedLocally = true,
+            )
+        }
+        viewModelScope.launch {
+            runCatching { userPreferencesRepository.setImmersiveNavBarReveal(desired) }
+                .onSuccess {
+                    _state.update {
+                        it.copy(immersiveNavBarReveal = desired, isUpdatingImmersiveNavBarReveal = false)
+                    }
+                }
+                .onFailure {
+                    _state.update {
+                        it.copy(
+                            immersiveNavBarReveal = previous,
+                            isUpdatingImmersiveNavBarReveal = false,
+                            immersiveNavBarRevealError = true,
+                        )
+                    }
+                }
+        }
     }
 
     private fun updateMpUnreadBadge(desired: Boolean) {

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -288,6 +288,12 @@
     <string name="settings_display_immersive_back_button_title">Bouton retour flottant</string>
     <string name="settings_display_immersive_back_button_description">Affiche un bouton « retour » discret en bas à gauche quand la barre de navigation est masquée, pour revenir en arrière sans faire réapparaître la barre système. Désactivez-le si vous utilisez la navigation gestuelle.</string>
     <string name="settings_display_immersive_back_button_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
+    <!-- #518 follow-up — comportement de révélation de la barre système masquée selon le défilement. -->
+    <string name="settings_display_nav_bar_reveal_intro">Quand faire réapparaître la barre de navigation masquée :</string>
+    <string name="settings_display_nav_bar_reveal_manual">Manuel (balayage depuis le bas)</string>
+    <string name="settings_display_nav_bar_reveal_at_bottom">En bas du sujet</string>
+    <string name="settings_display_nav_bar_reveal_on_scroll_up">En remontant</string>
+    <string name="settings_display_nav_bar_reveal_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
 
     <!-- Build 89 follow-up — Lecture des sujets. Masquer la barre du haut (titre + numéro de page)
          en défilant vers le bas pour libérer de la place ; persisté en DataStore et appliqué en direct. -->

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -5,6 +5,7 @@ import fr.forumhfr.redface2.core.domain.cache.TopicCacheMaintenance
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
+import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
@@ -1124,6 +1125,44 @@ class SettingsViewModelTest {
         assertTrue(viewModel.state.value.immersiveBackButtonError)
     }
 
+    @Test
+    fun `init hydrates immersiveNavBarReveal from a persisted mode`() = runTest {
+        repository.emitImmersiveNavBarReveal(ImmersiveNavBarReveal.AT_BOTTOM)
+
+        val viewModel = newViewModel()
+
+        assertEquals(ImmersiveNavBarReveal.AT_BOTTOM, viewModel.state.value.immersiveNavBarReveal)
+        assertFalse(viewModel.state.value.immersiveNavBarRevealError)
+    }
+
+    @Test
+    fun `ImmersiveNavBarRevealChanged persists the chosen mode`() = runTest {
+        val viewModel = newViewModel()
+        assertEquals(ImmersiveNavBarReveal.MANUAL, viewModel.state.value.immersiveNavBarReveal)
+
+        viewModel.submit(SettingsIntent.ImmersiveNavBarRevealChanged(ImmersiveNavBarReveal.ON_SCROLL_UP))
+
+        assertEquals(ImmersiveNavBarReveal.ON_SCROLL_UP, viewModel.state.value.immersiveNavBarReveal)
+        assertFalse(viewModel.state.value.isUpdatingImmersiveNavBarReveal)
+        assertEquals(1, repository.immersiveNavBarRevealSetCalls)
+    }
+
+    @Test
+    fun `ImmersiveNavBarRevealChanged reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnImmersiveNavBarRevealSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.ImmersiveNavBarRevealChanged(ImmersiveNavBarReveal.AT_BOTTOM))
+
+        assertEquals(
+            "failed persist must revert to the previous mode",
+            ImmersiveNavBarReveal.MANUAL,
+            viewModel.state.value.immersiveNavBarReveal,
+        )
+        assertFalse(viewModel.state.value.isUpdatingImmersiveNavBarReveal)
+        assertTrue(viewModel.state.value.immersiveNavBarRevealError)
+    }
+
     // ──────────────────────────────────────────────────────────────────────
     // Debug bounds overlay (#445)
     // ──────────────────────────────────────────────────────────────────────
@@ -1904,6 +1943,24 @@ class SettingsViewModelTest {
 
         fun emitImmersiveBackButton(value: Boolean) {
             immersiveBackButton.value = value
+        }
+
+        // #518 follow-up — immersive nav-bar reveal mode. Default MANUAL, enum optimistic-flip seam.
+        private val immersiveNavBarReveal = MutableStateFlow(ImmersiveNavBarReveal.MANUAL)
+        var immersiveNavBarRevealSetCalls: Int = 0
+            private set
+        var failOnImmersiveNavBarRevealSet: Boolean = false
+
+        override fun observeImmersiveNavBarReveal(): Flow<ImmersiveNavBarReveal> = immersiveNavBarReveal
+
+        override suspend fun setImmersiveNavBarReveal(mode: ImmersiveNavBarReveal) {
+            immersiveNavBarRevealSetCalls += 1
+            check(!failOnImmersiveNavBarRevealSet) { "boom" }
+            immersiveNavBarReveal.value = mode
+        }
+
+        fun emitImmersiveNavBarReveal(value: ImmersiveNavBarReveal) {
+            immersiveNavBarReveal.value = value
         }
     }
 

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -241,12 +241,32 @@ fun TopicScreen(
      * [pollManualExpanded], keeping the poll collapsed / expanded across page navigation.
      */
     onPollExpansionChanged: (Boolean) -> Unit = {},
+    /**
+     * #518 follow-up — `true` when `:app` wants this screen to report its scroll facts for the
+     * immersive nav-bar reveal (immersive on AND a scroll-driven mode selected). When `false` the
+     * reporter is a no-op and clears any stale facts. `:feature:topic` stays free of the reveal-mode
+     * enum: it only reports raw `(atBottom, scrollingUp)` facts; `:app` applies the policy.
+     */
+    immersiveNavBarRevealActive: Boolean = false,
+    /**
+     * #518 follow-up — reports the topic's raw scroll facts UP so `:app` (single owner of the window
+     * nav bar) can reveal the hidden bar per the chosen mode. Only fires while
+     * [immersiveNavBarRevealActive] and only on a change.
+     */
+    onImmersiveNavBarScroll: (atBottom: Boolean, scrollingUp: Boolean) -> Unit = { _, _ -> },
 ) {
     val viewModel = hiltViewModel<TopicViewModel, TopicViewModel.Factory>(
         creationCallback = { factory -> factory.create(request) },
     )
     val state by viewModel.state.collectAsStateWithLifecycle()
     val lazyListState = rememberLazyListState()
+    // #518 follow-up — report scroll facts up so `:app` can reveal the hidden system nav bar per the
+    // chosen mode. No-op (and clears stale facts) when the feature is inactive.
+    ImmersiveNavBarScrollReporter(
+        listState = lazyListState,
+        active = immersiveNavBarRevealActive,
+        onScrollFacts = onImmersiveNavBarScroll,
+    )
     val context = androidx.compose.ui.platform.LocalContext.current
     // Resolve the string at composition time, not inside the LaunchedEffect collect block.
     // Lint flags `context.getString(R.string.…)` inside a Compose call site (the call is in a
@@ -1990,6 +2010,83 @@ private fun rememberBottomActionsVisible(listState: LazyListState): Boolean {
             }
     }
     return visible
+}
+
+/** #518 follow-up — one snapshot the reveal reporter reacts to (see [ImmersiveNavBarScrollReporter]). */
+private data class NavBarScrollSample(
+    val index: Int,
+    val offset: Int,
+    val canScrollForward: Boolean,
+    val scrolling: Boolean,
+)
+
+/**
+ * #518 follow-up — reports the topic's raw scroll facts (at-bottom + scrolling-up) UP to `:app` so it
+ * can reveal the hidden system navigation bar per the user's chosen mode. READ-ONLY on [listState]
+ * (never drives scrolling, like [rememberBottomActionsVisible]). When [active] is false (immersive off /
+ * MANUAL mode) it only clears any stale facts once. `:feature:topic` stays free of the reveal-mode enum
+ * — it ships facts, `:app` decides.
+ *
+ * CRITICAL anti-feedback-loop: revealing the bar consumes the bottom system-bar inset, which shrinks the
+ * list viewport and can flip `canScrollForward` / `firstVisibleItemScrollOffset` ON ITS OWN — with no
+ * user gesture. If those rest-time, inset-induced changes fed the decision, « at bottom » reveal would
+ * grow the inset → flip canScrollForward → un-reveal → shrink the inset → … (a visible jitter), and a
+ * pure layout shift would read as a fake scroll direction. So facts are only trusted DURING an active
+ * user scroll ([LazyListState.isScrollInProgress]); the first sample is emitted once to seed the static
+ * case (a short topic already at the bottom), and afterwards the last facts are LATCHED at rest.
+ */
+@Composable
+private fun ImmersiveNavBarScrollReporter(
+    listState: LazyListState,
+    active: Boolean,
+    onScrollFacts: (atBottom: Boolean, scrollingUp: Boolean) -> Unit,
+) {
+    val report by rememberUpdatedState(onScrollFacts)
+    if (!active) {
+        LaunchedEffect(Unit) { report(false, false) }
+        return
+    }
+    LaunchedEffect(listState) {
+        var prevIndex = listState.firstVisibleItemIndex
+        var prevOffset = listState.firstVisibleItemScrollOffset
+        var scrollingUp = false
+        var emitted = false
+        var lastAtBottom: Boolean? = null
+        var lastScrollingUp: Boolean? = null
+        snapshotFlow {
+            NavBarScrollSample(
+                index = listState.firstVisibleItemIndex,
+                offset = listState.firstVisibleItemScrollOffset,
+                canScrollForward = listState.canScrollForward,
+                scrolling = listState.isScrollInProgress,
+            )
+        }
+            .collect { sample ->
+                val positionChanged = sample.index != prevIndex || sample.offset != prevOffset
+                // Trust a direction change ONLY during an active user scroll; a rest-time shift (the nav
+                // bar's own inset toggling) must never be read as a scroll direction.
+                if (sample.scrolling && positionChanged) {
+                    scrollingUp = if (sample.index != prevIndex) {
+                        sample.index < prevIndex
+                    } else {
+                        sample.offset < prevOffset
+                    }
+                }
+                prevIndex = sample.index
+                prevOffset = sample.offset
+                val atBottom = !sample.canScrollForward
+                // Emit the first sample once (seed the static case: a short topic already at the bottom),
+                // then only while actively scrolling — never on a rest-time inset-induced change (loop).
+                val mayEmit = !emitted || sample.scrolling
+                val factsChanged = atBottom != lastAtBottom || scrollingUp != lastScrollingUp
+                if (mayEmit && factsChanged) {
+                    lastAtBottom = atBottom
+                    lastScrollingUp = scrollingUp
+                    emitted = true
+                    report(atBottom, scrollingUp)
+                }
+            }
+    }
 }
 
 /**

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -9,6 +9,7 @@ import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
+import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
@@ -1572,4 +1573,9 @@ private class FakeUserPreferencesRepository(
     override fun observeImmersiveBackButton(): Flow<Boolean> = MutableStateFlow(true)
 
     override suspend fun setImmersiveBackButton(enabled: Boolean) = Unit
+
+    override fun observeImmersiveNavBarReveal(): Flow<ImmersiveNavBarReveal> =
+        MutableStateFlow(ImmersiveNavBarReveal.MANUAL)
+
+    override suspend fun setImmersiveNavBarReveal(mode: ImmersiveNavBarReveal) = Unit
 }


### PR DESCRIPTION
Suite de #518 (plein écran immersif). Répond à la demande : un moyen de **faire réapparaître la barre de navigation système** en bas d'un sujet sans le geste système, avec une option offrant plusieurs comportements.

## Option « Quand faire réapparaître la barre » (Réglages > Affichage > Plein écran)
- **Manuel (balayage)** — défaut, comportement #518 historique (swipe depuis le bas) ;
- **En bas du sujet** — révèle en atteignant le bas, masque en remontant ;
- **En remontant** — révèle au scroll vers le haut (ou en bas), masque en descendant (miroir du scroll-hide top-bar #285).

Désactivé tant que le plein écran est off.

## Architecture
`RedfaceApp` reste **seul propriétaire** de la fenêtre (pas de double-ownership). `TopicScreen` remonte des **faits de scroll bruts** `(atBottom, scrollingUp)` via un bundle nav-state (comme `TopicTitleNavState`) ; `RedfaceApp` applique la fonction **pure** `shouldRevealNavBar(mode, …)` → `hideNavBarNow` → `applyImmersiveNavBar`. Reset des faits hors-sujet (`ResetNavBarScrollOffTopic`). `feature:topic` ne dépend pas de l'enum.

## Anti-boucle (signalé puis vérifié par review Codex)
Afficher la barre consomme l'inset bas → réduit le viewport → peut flipper `canScrollForward` **sans geste**. Sans garde, « en bas » bouclerait (révèle → inset → flip → masque → …). Le reporter ne fait donc confiance aux faits que **pendant un scroll actif** (`isScrollInProgress`), émet le 1er sample une fois (cas statique d'un sujet court déjà en bas), puis **latche** au repos. Trade-off assumé : un jump programmatique instantané au repos ne révèle pas la barre avant un scroll.

## Tests
- `shouldRevealNavBar` (3 modes), `DataStore` round-trip enum, `SettingsViewModel` optimistic-flip enum, + ~7 fakes `UserPreferencesRepository` à jour.
- `:core:domain:test` + `:core:data` + `:feature:settings` + `:feature:topic` + `:app` tests + `detektAll` + `:app:assembleDevDebug` verts.
- Raisonnement Codex + 2 reviews Codex (la 2ᵉ confirme la boucle cassée).

Limite connue : 1er rendu sur cache froid, bref créneau par défaut ; portraits très hauts toujours plafonnés (politique #249/#518). Périmètre v1 = écran de lecture d'un sujet.

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)