### PR TITLE
feat(flags): onglet DT = liste des MultiMP + reprise de lecture MPStorage

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -1372,6 +1372,13 @@ private fun RedfaceNavHost(
                     onOpenCategory = { catId ->
                         backStack.add(CategoryRoute(cat = catId, subcat = null, page = 1))
                     },
+                    // #6 — DT (MultiMP) row tap: open the existing PrivateMessageThread route inside
+                    // the Flags tab. DT rows are always multi-recipient, so record the hint (the
+                    // route itself stays opaque, like the Messages tab does, cf. onOpenThread).
+                    onOpenMultiMp = { threadId, page ->
+                        privateMessageNavState.onThreadOpenedAsMulti(threadId)
+                        backStack.add(PrivateMessageThreadRoute(threadId = threadId, page = page))
+                    },
                     topBarActions = accountMenu,
                 )
             }

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -143,8 +143,17 @@ fun FlagsRoute(
     // #6 — trigger the DT scan only when the DT tab is OPENED (a stable LaunchedEffect, not the raw
     // composition): fetchStorage scans the inbox and must stay off the per-category auto-refresh.
     // The ViewModel guards it to once per session, so re-selecting DT reuses the loaded list.
-    // Extracted so its branch stays out of FlagsRoute's cyclomatic-complexity budget.
-    DtTabOpenEffect(selectedTab = selectedTab, onDtTabOpened = viewModel::onDtTabOpened)
+    // Gated on showDtTab (a stale `selectedTab == Dt` while the toggle is off must NOT scan) and
+    // keyed on the auth session pseudo so an account switch — which resets the DT state to Loading
+    // without changing selectedTab — re-runs the effect and re-scans for the new session (Codex
+    // review). Extracted so its branch stays out of FlagsRoute's cyclomatic-complexity budget.
+    val authSessionKey = (authState as? AuthState.Authenticated)?.pseudo
+    DtTabOpenEffect(
+        selectedTab = selectedTab,
+        showDtTab = showDtTab,
+        authSessionKey = authSessionKey,
+        onDtTabOpened = viewModel::onDtTabOpened,
+    )
 
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -1121,14 +1130,28 @@ private fun DtTabFallbackEffect(
 }
 
 /**
- * #6 — fires the DT (MultiMP) scan once the DT tab becomes the selected one. Keyed on the tab so it
- * only re-runs on a real tab change (the ViewModel guards the actual fetch to once per session).
+ * #6 — fires the DT (MultiMP) scan once the DT tab becomes the selected one. The fetch only starts
+ * when DT is selected AND the Settings toggle still shows it ([showDtTab]) — a stale
+ * `selectedTab == Dt` left behind while the toggle is off (before [DtTabFallbackEffect] swaps back
+ * to Cyan) must never scan the inbox.
+ *
+ * Keyed on the tab, [showDtTab], AND [authSessionKey] (the authenticated pseudo). The session key is
+ * load-bearing: an account switch resets the DT state back to Loading without changing
+ * `selectedTab`, so a Unit/tab-only key would never re-fire and the screen would stay stuck on the
+ * spinner while sitting on the DT tab (Codex review). The ViewModel guards the actual fetch to once
+ * per session, so a benign re-key (returning to DT) reuses the loaded list.
+ *
  * Extracted so its branch stays out of [FlagsRoute]'s cyclomatic-complexity budget.
  */
 @Composable
-private fun DtTabOpenEffect(selectedTab: FlagTab, onDtTabOpened: () -> Unit) {
-    LaunchedEffect(selectedTab) {
-        if (selectedTab == FlagTab.Dt) onDtTabOpened()
+private fun DtTabOpenEffect(
+    selectedTab: FlagTab,
+    showDtTab: Boolean,
+    authSessionKey: String?,
+    onDtTabOpened: () -> Unit,
+) {
+    LaunchedEffect(selectedTab, showDtTab, authSessionKey) {
+        if (selectedTab == FlagTab.Dt && showDtTab) onDtTabOpened()
     }
 }
 
@@ -1168,8 +1191,14 @@ private fun DtListBody(state: DtListUiState, actions: AuthenticatedActions) {
             items(state.items, key = { it.conversation.threadId }) { item ->
                 DtConversationRow(
                     item = item,
+                    // Open on the page the badge ADVERTISES: the MPStorage resume page when present,
+                    // else the conversation's last inbox page (#430). Tapping must land where the
+                    // « reprise p.N » badge says it will — opening lastPage while showing « reprise
+                    // p.N » was a badge/action contradiction (Codex review). Clamp ≥ 1 so a bogus
+                    // stored 0/negative page never produces an invalid route argument.
                     onClick = {
-                        actions.onOpenMultiMp(item.conversation.threadId, item.conversation.lastPage)
+                        val target = (item.resumePage ?: item.conversation.lastPage).coerceAtLeast(1)
+                        actions.onOpenMultiMp(item.conversation.threadId, target)
                     },
                 )
             }
@@ -1241,10 +1270,18 @@ private fun DtErrorBody(cause: Throwable, actions: AuthenticatedActions) {
 @Composable
 private fun DtConversationRow(item: DtListItem, onClick: () -> Unit) {
     val conversation = item.conversation
+    // a11y — the read/unread dot is purely decorative (no semantics of its own), so the row carries
+    // the read state for TalkBack: « Non lu : <sujet> » / « Lu : <sujet> » (Codex review). The
+    // « Interlocuteurs multiples » caption and the resume badge stay separately announced beneath it.
+    val rowStateDescription = stringResource(
+        if (conversation.hasUnread) R.string.flags_dt_row_unread else R.string.flags_dt_row_read,
+        conversation.subject,
+    )
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick),
+            .clickable(onClick = onClick)
+            .semantics { contentDescription = rowStateDescription },
     ) {
         Row(
             modifier = Modifier

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -3,6 +3,7 @@ package fr.forumhfr.redface2.feature.flags
 import android.annotation.SuppressLint
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -21,6 +23,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
@@ -36,6 +39,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
+import androidx.compose.material3.Card
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -71,6 +75,7 @@ import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
+import fr.forumhfr.redface2.core.model.messages.PrivateMessageSummary
 import fr.forumhfr.redface2.core.ui.FlagItem
 import fr.forumhfr.redface2.core.ui.FlagItemDivider
 import fr.forumhfr.redface2.core.ui.FlagItemLongPress
@@ -110,6 +115,9 @@ fun FlagsRoute(
     onOpenFlag: (Flag) -> Unit,
     onLoginRequested: () -> Unit,
     onOpenCategory: (Int) -> Unit = {},
+    // #6 — open a DT (MultiMP) conversation : the host pushes the existing PrivateMessageThread
+    // route. `page` is the conversation's last inbox page (web parity, #430).
+    onOpenMultiMp: (threadId: Int, page: Int) -> Unit = { _, _ -> },
     topBarActions: @Composable (() -> Unit)? = null,
 ) {
     val viewModel: FlagsViewModel = hiltViewModel()
@@ -128,8 +136,15 @@ fun FlagsRoute(
     // a cold start or a tab switch before DataStore re-resolves the selected tab (#317).
     val cyanShowsRead by viewModel.cyanShowsReadShortcut.collectAsStateWithLifecycle()
 
-    // Opt-in « DT » placeholder tab (Settings toggle ; MPStorage sync #6 lands later).
+    // Opt-in « DT » tab (Settings toggle). Its MultiMP list is fetched on tab open (#6).
     val showDtTab by viewModel.showDtTab.collectAsStateWithLifecycle()
+    val dtListState by viewModel.dtListState.collectAsStateWithLifecycle()
+
+    // #6 — trigger the DT scan only when the DT tab is OPENED (a stable LaunchedEffect, not the raw
+    // composition): fetchStorage scans the inbox and must stay off the per-category auto-refresh.
+    // The ViewModel guards it to once per session, so re-selecting DT reuses the loaded list.
+    // Extracted so its branch stays out of FlagsRoute's cyclomatic-complexity budget.
+    DtTabOpenEffect(selectedTab = selectedTab, onDtTabOpened = viewModel::onDtTabOpened)
 
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -265,6 +280,7 @@ fun FlagsRoute(
                                 isRefreshing = isRefreshing,
                                 removeFlagState = removeFlagState,
                                 showDtTab = showDtTab,
+                                dtListState = dtListState,
                             ),
                             actions = AuthenticatedActions(
                                 onSelectTab = viewModel::selectTab,
@@ -279,6 +295,8 @@ fun FlagsRoute(
                                 onLoginRequested = onLoginRequested,
                                 onRequestRemoveFlag = viewModel::requestRemoveFlag,
                                 onOpenCategory = onOpenCategory,
+                                onOpenMultiMp = onOpenMultiMp,
+                                onRefreshDt = viewModel::refreshDt,
                             ),
                             listState = flagsListState,
                         )
@@ -672,9 +690,11 @@ private fun ColumnScope.AuthenticatedBody(
             ),
     ) {
         when (selectedTab) {
-            // Placeholders — no backend, no fetch, no pull-to-refresh (cf. their KDoc).
+            // Super has no backend, no fetch, no pull-to-refresh (cf. its KDoc).
             FlagTab.Super -> SuperPlaceholderBody()
-            FlagTab.Dt -> DtPlaceholderBody()
+            // #6 — DT is a real list now: the user's MultiMP conversations, enriched best-effort
+            // with the MPStorage reading positions.
+            FlagTab.Dt -> DtListBody(state = state.dtListState, actions = actions)
             else -> FlagListBody(state = state, actions = actions, listState = listState)
         }
     }
@@ -1101,26 +1121,185 @@ private fun DtTabFallbackEffect(
 }
 
 /**
- * Sober M3 placeholder for the opt-in « DT » [FlagTab.Dt] tab. The content (followed
- * discussions whose flags sync through the MPStorage document, #6) lands later.
+ * #6 — fires the DT (MultiMP) scan once the DT tab becomes the selected one. Keyed on the tab so it
+ * only re-runs on a real tab change (the ViewModel guards the actual fetch to once per session).
+ * Extracted so its branch stays out of [FlagsRoute]'s cyclomatic-complexity budget.
  */
 @Composable
-private fun DtPlaceholderBody() {
+private fun DtTabOpenEffect(selectedTab: FlagTab, onDtTabOpened: () -> Unit) {
+    LaunchedEffect(selectedTab) {
+        if (selectedTab == FlagTab.Dt) onDtTabOpened()
+    }
+}
+
+/**
+ * #6 — body of the opt-in « DT » tab: the user's MultiMP conversations (inbox `cat=prive`,
+ * filtered on [PrivateMessageSummary.isMultiRecipient]) enriched best-effort with the MPStorage
+ * reading positions (a discreet « reprise p.N » badge). Tapping a row opens the existing
+ * `PrivateMessageThread` route via [AuthenticatedActions.onOpenMultiMp].
+ *
+ * The MPStorage enrichment is best-effort: a missing / unreadable / failed storage read leaves the
+ * list intact, just without badges (cf. [FlagsViewModel.loadDt]). Only an inbox load failure
+ * reaches [DtListUiState.Error], which offers a reconnect/retry CTA like the flag list.
+ */
+@Composable
+private fun DtListBody(state: DtListUiState, actions: AuthenticatedActions) {
+    when (state) {
+        DtListUiState.Loading -> Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(vertical = 32.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            CircularProgressIndicator()
+        }
+
+        DtListUiState.Empty -> DtMessageBody(text = stringResource(R.string.flags_dt_empty))
+
+        is DtListUiState.Error -> DtErrorBody(cause = state.cause, actions = actions)
+
+        is DtListUiState.Content -> LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.surface),
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            items(state.items, key = { it.conversation.threadId }) { item ->
+                DtConversationRow(
+                    item = item,
+                    onClick = {
+                        actions.onOpenMultiMp(item.conversation.threadId, item.conversation.lastPage)
+                    },
+                )
+            }
+        }
+    }
+}
+
+/** Centered single-line message body (DT empty state), sharing the surface background. */
+@Composable
+private fun DtMessageBody(text: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(24.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+/**
+ * Error body for the DT list, mirroring the flag-list failure branch: a session-expired cause
+ * offers a reconnect CTA, every other cause a retry. The MPStorage read never lands here (it is
+ * best-effort) — only the inbox primary load.
+ */
+@Composable
+private fun DtErrorBody(cause: Throwable, actions: AuthenticatedActions) {
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 24.dp, vertical = 32.dp),
+            .verticalScroll(rememberScrollState())
+            .padding(24.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
+        val sessionExpired = cause is SessionExpiredException
         Text(
-            text = stringResource(R.string.flags_dt_placeholder_title),
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
-        Text(
-            text = stringResource(R.string.flags_dt_placeholder_body),
+            text = stringResource(
+                if (sessionExpired) {
+                    R.string.flags_session_expired
+                } else {
+                    classifyHfrError(cause).sharedLabelResOrNull() ?: R.string.flags_dt_error
+                },
+            ),
             style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            color = MaterialTheme.colorScheme.error,
+        )
+        if (sessionExpired) {
+            TextButton(onClick = actions.onLoginRequested) {
+                Text(stringResource(R.string.flags_login_cta))
+            }
+        } else {
+            TextButton(onClick = actions.onRefreshDt) {
+                Text(stringResource(R.string.flags_retry))
+            }
+        }
+    }
+}
+
+/**
+ * One DT conversation row: the « Interlocuteurs multiples » label, the conversation subject, an
+ * unread dot ([PrivateMessageSummary.hasUnread]), and — when present — the discreet « reprise p.N »
+ * MPStorage badge. The badge is a reading POSITION, never a read/unread state (#361/ADR-013).
+ */
+@Composable
+private fun DtConversationRow(item: DtListItem, onClick: () -> Unit) {
+    val conversation = item.conversation
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            DtUnreadDot(unread = conversation.hasUnread)
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.flags_dt_multi_recipient),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = conversation.subject,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            item.resumePage?.let { page ->
+                Text(
+                    text = stringResource(R.string.flags_dt_resume_badge, page),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Inbox unread marker for a DT row: a filled primary dot when unread, a hollow outline ring when
+ * read. Mirrors the Messages tab's `ReadStateDot` without depending on `feature/messages`; the a11y
+ * state is carried by the row text, so this stays decorative.
+ */
+@Composable
+private fun DtUnreadDot(unread: Boolean) {
+    if (unread) {
+        Box(
+            modifier = Modifier
+                .size(10.dp)
+                .background(MaterialTheme.colorScheme.primary, CircleShape),
+        )
+    } else {
+        Box(
+            modifier = Modifier
+                .size(10.dp)
+                .border(1.dp, MaterialTheme.colorScheme.outline, CircleShape),
         )
     }
 }
@@ -1136,8 +1315,10 @@ private data class FlagsBodyState(
     val cyanShowsRead: Boolean,
     val isRefreshing: Boolean,
     val removeFlagState: RemoveFlagState,
-    /** Whether the opt-in « DT » placeholder tab is shown (Settings toggle). */
+    /** Whether the opt-in « DT » tab is shown (Settings toggle). */
     val showDtTab: Boolean,
+    /** #6 — the DT (MultiMP) tab list state, fetched on tab open. */
+    val dtListState: DtListUiState,
 )
 
 private data class AuthenticatedActions(
@@ -1148,6 +1329,10 @@ private data class AuthenticatedActions(
     val onRequestRemoveFlag: (Flag) -> Unit,
     /** #414 — tap on a category band opens that category's topic listing. */
     val onOpenCategory: (Int) -> Unit,
+    /** #6 — open a DT conversation (threadId, last inbox page). */
+    val onOpenMultiMp: (threadId: Int, page: Int) -> Unit = { _, _ -> },
+    /** #6 — explicit user reload of the DT list (retry). */
+    val onRefreshDt: () -> Unit = {},
 )
 
 /**

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -8,12 +8,16 @@ import fr.forumhfr.redface2.core.domain.flags.FlagRepository
 import fr.forumhfr.redface2.core.domain.flags.FlagsResult
 import fr.forumhfr.redface2.core.domain.forum.ForumRepository
 import fr.forumhfr.redface2.core.domain.forum.ForumResult
+import fr.forumhfr.redface2.core.domain.messages.MessagesRepository
+import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.Category
 import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
+import fr.forumhfr.redface2.core.model.messages.PrivateMessageSummary
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageResult
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -46,11 +50,17 @@ import kotlinx.coroutines.launch
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
+// Hilt-injected dependency cluster : flags + forum + messages + MPStorage + prefs + auth + clock,
+// each provided independently by the graph — there is no cohesive bundle to extract (a wrapper
+// would only relay them). Same pragmatic exception as the hoisted-composable suppressions elsewhere.
+@Suppress("LongParameterList")
 class FlagsViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val flagRepository: FlagRepository,
     private val forumRepository: ForumRepository,
     private val userPreferencesRepository: UserPreferencesRepository,
+    private val messagesRepository: MessagesRepository,
+    private val mpStorageRepository: MpStorageRepository,
     private val clock: Clock,
 ) : ViewModel() {
 
@@ -90,6 +100,24 @@ class FlagsViewModel @Inject constructor(
             started = SharingStarted.Eagerly,
             initialValue = false,
         )
+
+    /**
+     * #6 — UI state for the « DT » tab: the user's MultiMP conversations (inbox `cat=prive`,
+     * [PrivateMessageSummary.isMultiRecipient]) enriched best-effort with the MPStorage reading
+     * positions (DTCloud's `mpFlags`). A dedicated state (NOT a [FlagsListUiState] / [Flag] reuse,
+     * arbitrage Codex): the DT channel is a private-message list, not a flag list, so it never
+     * shares the flag model's contract (`flagType == null` stays a pure « no backend » marker for
+     * Super/DT placeholders elsewhere in this ViewModel).
+     *
+     * The fetch is triggered on tab OPENING ([onDtTabOpened]) — never from the per-category
+     * auto-refresh — because [MpStorageRepository.fetchStorage] is expensive (it scans the inbox to
+     * discover the storage MP). Idle until first opened.
+     */
+    private val _dtListState = MutableStateFlow<DtListUiState>(DtListUiState.Loading)
+    val dtListState: StateFlow<DtListUiState> = _dtListState.asStateFlow()
+
+    /** One-shot guard so re-entering the composition (recomposition, ON_RESUME) does not re-scan. */
+    private var dtFetchStarted = false
 
     val authState: StateFlow<AuthState?> = authRepository.observeAuthState()
         .stateIn(
@@ -622,6 +650,88 @@ class FlagsViewModel @Inject constructor(
         }
     }
 
+    /**
+     * #6 — the screen calls this when the « DT » tab is OPENED (a stable [LaunchedEffect], not the
+     * raw composition). Loads the MultiMP conversations once per session: re-entering the
+     * composition reuses the already-loaded state ([dtFetchStarted] guard). The fan-out (inbox page
+     * + MPStorage scan) is deliberately kept off the per-category auto-refresh path. Use
+     * [refreshDt] for an explicit user re-pull.
+     */
+    fun onDtTabOpened() {
+        if (dtFetchStarted) return
+        loadDt()
+    }
+
+    /** Explicit user-driven reload of the DT list (pull-to-refresh / retry), bypassing the guard. */
+    fun refreshDt() {
+        loadDt()
+    }
+
+    /**
+     * Loads the DT list: the inbox MultiMP rows, each joined best-effort with its MPStorage reading
+     * position. The join tolerates every degraded MPStorage outcome ([MpStorageResult.NotFound] /
+     * [MpStorageResult.Unreadable] / an exception): the list still renders, just without the
+     * « reprise p.N » badge — the storage scan must never fail the conversation list.
+     *
+     * Only the inbox load itself is fatal: it is the list's primary source, so a network/session
+     * error there surfaces [DtListUiState.Error] (the screen offers a retry / reconnect CTA).
+     */
+    private fun loadDt() {
+        dtFetchStarted = true
+        viewModelScope.launch {
+            _dtListState.value = DtListUiState.Loading
+            val conversations = try {
+                messagesRepository.getPrivateMessageList(page = DT_INBOX_PAGE)
+                    .items
+                    .filter { it.isMultiRecipient }
+            } catch (cancellation: kotlinx.coroutines.CancellationException) {
+                throw cancellation
+            } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
+                // Reset the guard so a retry can re-run; the inbox is the list's only hard source.
+                dtFetchStarted = false
+                _dtListState.value = DtListUiState.Error(error)
+                return@launch
+            }
+
+            if (conversations.isEmpty()) {
+                _dtListState.value = DtListUiState.Empty
+                return@launch
+            }
+
+            // Best-effort enrichment: a missing / unreadable / failed storage read leaves an empty
+            // map, so every row simply renders without a resume badge (the list is never blocked).
+            val resumeByThread = fetchResumePositions()
+            _dtListState.value = DtListUiState.Content(
+                conversations.map { summary ->
+                    DtListItem(
+                        conversation = summary,
+                        resumePage = resumeByThread[summary.threadId],
+                    )
+                },
+            )
+        }
+    }
+
+    /**
+     * Best-effort MPStorage read for the « reprise p.N » badges. Returns a `threadId → page` map of
+     * the DTCloud `mpFlags` entries, EMPTY for every degraded outcome ([MpStorageResult.NotFound] /
+     * [MpStorageResult.Unreadable]) or transport failure — the caller renders the list regardless.
+     * `mpFlags` is a reading-RESUME position, NOT a read/unread state (#361/ADR-013): the unread dot
+     * is the inbox [PrivateMessageSummary.hasUnread], never this page number.
+     */
+    @Suppress("SwallowedException") // best-effort: a storage read failure deliberately degrades to
+    // « no resume badge » so the conversation list still renders (cf. KDoc); the cause is irrelevant.
+    private suspend fun fetchResumePositions(): Map<Int, Int> = try {
+        when (val storage = mpStorageRepository.fetchStorage()) {
+            is MpStorageResult.Found -> storage.document.mpFlags.associate { it.threadId to it.page }
+            MpStorageResult.NotFound, MpStorageResult.Unreadable -> emptyMap()
+        }
+    } catch (cancellation: kotlinx.coroutines.CancellationException) {
+        throw cancellation
+    } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
+        emptyMap()
+    }
+
     // Round-2 review (PR #207): `logout()` was removed from this ViewModel — the global account
     // menu (#198) now drives the logout from `AppAccountViewModel.logout()`, which owns the
     // canonical `clearSessionCache → authRepository.logout` ordering. Keeping a second copy
@@ -722,6 +832,7 @@ class FlagsViewModel @Inject constructor(
             null -> Unit
             AuthState.Anonymous -> {
                 observedPseudo = null
+                resetDtState()
                 flagRepository.clearSessionCache()
             }
             is AuthState.Authenticated -> {
@@ -729,11 +840,19 @@ class FlagsViewModel @Inject constructor(
                 // singleton and may outlive this ViewModel, so a recreated Flags screen
                 // must not trust whatever per-user cache was left in memory.
                 if (observedPseudo != state.pseudo) {
+                    resetDtState()
                     flagRepository.clearSessionCache()
                 }
                 observedPseudo = state.pseudo
             }
         }
+    }
+
+    /** Drop the DT list (and its one-shot guard) so a logout / account switch never shows the
+     * previous user's MultiMP conversations; the next [onDtTabOpened] re-scans for the new session. */
+    private fun resetDtState() {
+        dtFetchStarted = false
+        _dtListState.value = DtListUiState.Loading
     }
 }
 
@@ -847,3 +966,43 @@ sealed interface RemoveFlagEvent {
     data class Success(val title: String) : RemoveFlagEvent
     data class Failure(val title: String) : RemoveFlagEvent
 }
+
+/**
+ * #6 — inbox page scanned for the DT (MultiMP) list. Page 1 holds the most recent conversations;
+ * the inbox is paged at 50 newest-first, so this covers the active DT in practice. A full
+ * multi-page sweep is deliberately deferred (it would multiply the cost of an already-expensive
+ * MPStorage scan) — see the rapport / follow-up note.
+ */
+private const val DT_INBOX_PAGE = 1
+
+/**
+ * #6 — UI state for the « DT » tab (the user's MultiMP conversations). A dedicated channel, NOT a
+ * reuse of [FlagsListUiState] / [Flag] : a DT row is a private-message conversation enriched with
+ * an MPStorage reading position, never a forum flag (arbitrage Codex).
+ */
+sealed interface DtListUiState {
+    /** First scan in flight (or reset after a logout / account switch). */
+    data object Loading : DtListUiState
+
+    /** The inbox loaded but holds no MultiMP conversation. */
+    data object Empty : DtListUiState
+
+    /** Loaded MultiMP conversations, each best-effort joined with its MPStorage resume position. */
+    data class Content(val items: List<DtListItem>) : DtListUiState
+
+    /** The inbox load failed (network / session). The MPStorage read NEVER reaches this state —
+     * it is best-effort and degrades to « no badge ». [cause] drives the reconnect/retry CTA. */
+    data class Error(val cause: Throwable) : DtListUiState
+}
+
+/**
+ * One DT row: a MultiMP [conversation] plus its optional MPStorage reading-resume page
+ * ([resumePage], DTCloud `mpFlags`). [resumePage] is the « reprise p.N » badge — a reading
+ * POSITION, never a read/unread state (#361/ADR-013): the unread dot is
+ * [PrivateMessageSummary.hasUnread]. `null` when the conversation has no MPStorage entry (or the
+ * storage was absent / unreadable / failed to load).
+ */
+data class DtListItem(
+    val conversation: PrivateMessageSummary,
+    val resumePage: Int?,
+)

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -119,6 +119,17 @@ class FlagsViewModel @Inject constructor(
     /** One-shot guard so re-entering the composition (recomposition, ON_RESUME) does not re-scan. */
     private var dtFetchStarted = false
 
+    /**
+     * #6 Codex review — the in-flight DT fetch and a monotonic generation counter, together guarding
+     * against STALE WRITES. A logout / account switch ([resetDtState]) cancels [dtFetchJob] AND bumps
+     * [dtGeneration]; each [loadDt] captures its generation at launch and only publishes [_dtListState]
+     * while that capture still equals [dtGeneration]. So a fetch that was mid-flight when the account
+     * switched can never republish the previous account's MultiMP into the new session. Two rapid
+     * [refreshDt] calls are also latest-wins: the second cancels the first's job and out-generations it.
+     */
+    private var dtFetchJob: kotlinx.coroutines.Job? = null
+    private var dtGeneration = 0
+
     val authState: StateFlow<AuthState?> = authRepository.observeAuthState()
         .stateIn(
             scope = viewModelScope,
@@ -675,10 +686,19 @@ class FlagsViewModel @Inject constructor(
      *
      * Only the inbox load itself is fatal: it is the list's primary source, so a network/session
      * error there surfaces [DtListUiState.Error] (the screen offers a retry / reconnect CTA).
+     *
+     * MVP scope (#6): only inbox PAGE 1 ([DT_INBOX_PAGE]) is scanned — the most recent conversations.
+     * A full multi-page sweep is deliberately DEFERRED (it would multiply the cost of the already
+     * expensive MPStorage scan), so [DtListUiState.Empty] means « none on the recent page », not
+     * « none at all » — the empty-state copy assumes that semantics (`flags_dt_empty`).
      */
     private fun loadDt() {
         dtFetchStarted = true
-        viewModelScope.launch {
+        // Latest-wins: cancel any in-flight DT fetch and out-generation it so a previous load's
+        // late completion is ignored (two rapid refreshDt, or a refresh racing a still-running open).
+        dtFetchJob?.cancel()
+        val generation = ++dtGeneration
+        dtFetchJob = viewModelScope.launch {
             _dtListState.value = DtListUiState.Loading
             val conversations = try {
                 messagesRepository.getPrivateMessageList(page = DT_INBOX_PAGE)
@@ -688,19 +708,26 @@ class FlagsViewModel @Inject constructor(
                 throw cancellation
             } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
                 // Reset the guard so a retry can re-run; the inbox is the list's only hard source.
-                dtFetchStarted = false
-                _dtListState.value = DtListUiState.Error(error)
+                // Only the live generation may publish — a fetch invalidated by an account switch
+                // (resetDtState bumped the generation) must not overwrite the new session's Loading.
+                if (generation == dtGeneration) {
+                    dtFetchStarted = false
+                    _dtListState.value = DtListUiState.Error(error)
+                }
                 return@launch
             }
 
             if (conversations.isEmpty()) {
-                _dtListState.value = DtListUiState.Empty
+                if (generation == dtGeneration) _dtListState.value = DtListUiState.Empty
                 return@launch
             }
 
             // Best-effort enrichment: a missing / unreadable / failed storage read leaves an empty
             // map, so every row simply renders without a resume badge (the list is never blocked).
             val resumeByThread = fetchResumePositions()
+            // Re-check the generation AFTER the (suspending) storage scan too: the account may have
+            // switched while the scan was in flight, so the stale result must not republish.
+            if (generation != dtGeneration) return@launch
             _dtListState.value = DtListUiState.Content(
                 conversations.map { summary ->
                     DtListItem(
@@ -849,8 +876,13 @@ class FlagsViewModel @Inject constructor(
     }
 
     /** Drop the DT list (and its one-shot guard) so a logout / account switch never shows the
-     * previous user's MultiMP conversations; the next [onDtTabOpened] re-scans for the new session. */
+     * previous user's MultiMP conversations; the next [onDtTabOpened] re-scans for the new session.
+     * Cancels any in-flight fetch and bumps [dtGeneration] so a load that was mid-flight when the
+     * account switched can no longer publish the previous account's conversations (stale write). */
     private fun resetDtState() {
+        dtFetchJob?.cancel()
+        dtFetchJob = null
+        dtGeneration++
         dtFetchStarted = false
         _dtListState.value = DtListUiState.Loading
     }

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -21,10 +21,18 @@
     <string name="flags_super_placeholder_title">Super favoris — à venir</string>
     <string name="flags_super_placeholder_body">Les « super favoris » permettront d\'épingler les sujets les plus importants. Cette vue arrivera dans une prochaine version.</string>
 
-    <!-- Onglet « DT » opt-in (toggle Réglages) : placeholder en attendant la synchro MPStorage (#6). -->
+    <!-- Onglet « DT » opt-in (toggle Réglages) : liste des conversations MultiMP enrichie via MPStorage (#6). -->
     <string name="flags_tab_dt">DT</string>
-    <string name="flags_dt_placeholder_title">Discussions suivies — à venir</string>
-    <string name="flags_dt_placeholder_body">Cette section listera vos DT avec des drapeaux synchronisés entre appareils via MPStorage. Le contenu arrivera dans une prochaine version.</string>
+    <!-- Libellé de l'interlocuteur d'une conversation MultiMP (HFR affiche « Interlocuteurs multiples »). -->
+    <string name="flags_dt_multi_recipient">Interlocuteurs multiples</string>
+    <!-- Badge discret de reprise de lecture, alimenté par MPStorage (mpFlags). %1$d = page de reprise.
+         C'est une POSITION de lecture, PAS un état lu/non-lu (le point non-lu vient de l'inbox). -->
+    <string name="flags_dt_resume_badge">reprise p.%1$d</string>
+    <!-- Aucune conversation MultiMP dans la boîte de réception. -->
+    <string name="flags_dt_empty">Aucune conversation à interlocuteurs multiples.</string>
+    <!-- Échec du chargement de la liste DT (boîte de réception). La lecture MPStorage, best-effort,
+         n'atteint jamais cet état (elle se dégrade en « pas de badge »). -->
+    <string name="flags_dt_error">Impossible de charger les conversations. Vérifie ta connexion ou réessaie.</string>
 
     <!-- #179 — Vue drapeaux groupée par catégorie (parité vue web par défaut). -->
     <!-- Cyan (« Mes sujets ») : section de catégorie sans nouveau message non lu. Wording parité web. -->

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -28,8 +28,14 @@
     <!-- Badge discret de reprise de lecture, alimenté par MPStorage (mpFlags). %1$d = page de reprise.
          C'est une POSITION de lecture, PAS un état lu/non-lu (le point non-lu vient de l'inbox). -->
     <string name="flags_dt_resume_badge">reprise p.%1$d</string>
-    <!-- Aucune conversation MultiMP dans la boîte de réception. -->
-    <string name="flags_dt_empty">Aucune conversation à interlocuteurs multiples.</string>
+    <!-- État vide DT. La liste ne lit que la PAGE 1 de la boîte de réception (les conversations
+         les plus récentes) — un balayage multi-pages est différé (cf. DT_INBOX_PAGE). Le wording
+         assume donc « récente » pour ne pas affirmer qu'AUCUNE MultiMP n'existe ailleurs. -->
+    <string name="flags_dt_empty">Aucune conversation multi-destinataires récente.</string>
+    <!-- Description a11y d'une ligne DT : état lu/non-lu, annoncé par TalkBack (le point coloré
+         est purement décoratif). %1$s = sujet de la conversation. -->
+    <string name="flags_dt_row_unread">Non lu : %1$s</string>
+    <string name="flags_dt_row_read">Lu : %1$s</string>
     <!-- Échec du chargement de la liste DT (boîte de réception). La lecture MPStorage, best-effort,
          n'atteint jamais cet état (elle se dégrade en « pas de badge »). -->
     <string name="flags_dt_error">Impossible de charger les conversations. Vérifie ta connexion ou réessaie.</string>

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1526,6 +1526,97 @@ class FlagsViewModelTest {
         }
     }
 
+    @Test
+    fun `a DT fetch in flight when the account switches never publishes the previous account's list`() = runTest {
+        // #6 Codex review (BLOCKING — stale write): a loadDt mid-flight when resetDtState fires (logout
+        // / account switch) must NOT republish the previous account's MultiMP into the new session.
+        // resetDtState cancels the fetch and bumps the generation, so the in-flight load is dropped and
+        // the state stays at the post-switch Loading.
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val messages = FakeMessagesRepository(
+            inboxResult = Result.success(inboxPage(stubSummary(threadId = 10, isMultiRecipient = true))),
+        )
+        messages.blockInboxUntil = kotlinx.coroutines.CompletableDeferred()
+        val vm = viewModel(auth, flags, FakeForumRepository(), messages = messages)
+
+        vm.dtListState.test {
+            assertEquals(DtListUiState.Loading, awaitItem())
+            vm.onDtTabOpened() // fetch starts but suspends on the gated inbox load (in flight)
+
+            auth.emit(AuthState.Authenticated("other")) // account switch → resetDtState cancels it
+            // resetDtState republishes Loading; the value is identical to the seed so the StateFlow
+            // dedupes it — no new emission, the state is still Loading.
+
+            messages.blockInboxUntil!!.complete(Unit) // release the now-cancelled previous-account load
+            advanceUntilIdle()
+
+            // The stale (xaat) list must never surface: the only state remains Loading.
+            assertEquals(DtListUiState.Loading, vm.dtListState.value)
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `two rapid refreshDt are latest-wins so the stale earlier result never overwrites the recent one`() =
+        runTest {
+            // #6 Codex review (concurrent refreshDt): a second refreshDt cancels the first's job and
+            // out-generations it, so an earlier in-flight scan can never overwrite the newer result.
+            val flags = FakeFlagRepository()
+            val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+            val messages = FakeMessagesRepository(
+                inboxResult = Result.success(inboxPage(stubSummary(threadId = 10, isMultiRecipient = true))),
+            )
+            messages.blockInboxUntil = kotlinx.coroutines.CompletableDeferred()
+            val vm = viewModel(auth, flags, FakeForumRepository(), messages = messages)
+
+            vm.refreshDt() // first scan, suspended on the gated inbox load (would yield thread 10)
+            messages.inboxResult =
+                Result.success(inboxPage(stubSummary(threadId = 99, isMultiRecipient = true)))
+            vm.refreshDt() // second scan cancels the first and out-generations it
+
+            messages.blockInboxUntil!!.complete(Unit) // release both; the cancelled first must not win
+            advanceUntilIdle()
+
+            val content = vm.dtListState.value as DtListUiState.Content
+            assertEquals(
+                "the latest refreshDt wins; the cancelled earlier scan's result is dropped",
+                listOf(99),
+                content.items.map { it.conversation.threadId },
+            )
+        }
+
+    @Test
+    fun `the DT list only scans inbox page 1 even when the inbox spans multiple pages`() = runTest {
+        // #6 MVP scope: a multi-page sweep is deliberately DEFERRED (it would multiply the cost of the
+        // expensive MPStorage scan). Even with totalPages > 1, only page 1 (the most recent
+        // conversations) is read, and the list reflects only that page — documented behaviour, the
+        // empty-state copy assumes « recent page » semantics.
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val messages = FakeMessagesRepository(
+            inboxResult = Result.success(
+                PrivateMessageListPage(
+                    page = 1,
+                    totalPages = 4, // the inbox spans several pages…
+                    items = listOf(stubSummary(threadId = 10, isMultiRecipient = true)),
+                ),
+            ),
+        )
+        val vm = viewModel(auth, flags, FakeForumRepository(), messages = messages)
+
+        vm.dtListState.test {
+            assertEquals(DtListUiState.Loading, awaitItem())
+            vm.onDtTabOpened()
+            val content = awaitItem() as DtListUiState.Content
+            // …yet only page 1 is reflected; no further page is scanned (multi-page deferred).
+            assertEquals(listOf(10), content.items.map { it.conversation.threadId })
+            assertEquals("only inbox page 1 is ever requested", listOf(1), messages.requestedPages)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
     private fun stubSummary(
         threadId: Int,
         isMultiRecipient: Boolean,
@@ -1983,12 +2074,22 @@ class FlagsViewModelTest {
         var getListCalls: Int = 0
             private set
 
+        /** Records the `page` argument of each [getPrivateMessageList] call (DT must only read page 1). */
+        var requestedPages: List<Int> = emptyList()
+            private set
+
+        /** When set, gates [getPrivateMessageList] so a test can hold the inbox load in flight (e.g.
+         * to fire an account switch and prove the stale result never publishes). */
+        var blockInboxUntil: kotlinx.coroutines.CompletableDeferred<Unit>? = null
+
         override fun observeUnreadMpCount(): Flow<Int?> = MutableStateFlow(null)
         override fun requestUnreadRefresh() = Unit
         override fun markThreadRead(threadId: Int) = Unit
 
         override suspend fun getPrivateMessageList(page: Int): PrivateMessageListPage {
             getListCalls += 1
+            requestedPages = requestedPages + page
+            blockInboxUntil?.await()
             return inboxResult.getOrThrow()
         }
 

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -12,6 +12,8 @@ import fr.forumhfr.redface2.core.domain.flags.FlagsResult
 import fr.forumhfr.redface2.core.domain.forum.FlagFilterBucket
 import fr.forumhfr.redface2.core.domain.forum.ForumRepository
 import fr.forumhfr.redface2.core.domain.forum.ForumResult
+import fr.forumhfr.redface2.core.domain.messages.MessagesRepository
+import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
@@ -29,6 +31,12 @@ import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.SubCategory
 import fr.forumhfr.redface2.core.model.TopicListPage
+import fr.forumhfr.redface2.core.model.messages.PrivateMessageListPage
+import fr.forumhfr.redface2.core.model.messages.PrivateMessageSummary
+import fr.forumhfr.redface2.core.model.messages.PrivateMessageThread
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageDocument
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageFlagEntry
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageResult
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
@@ -267,7 +275,7 @@ class FlagsViewModelTest {
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository() // CYAN default unreadOnly = true
         prefs.blockUnreadOnlySetUntil = kotlinx.coroutines.CompletableDeferred()
-        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
+        val vm = viewModel(auth, flags, forum, prefs)
 
         vm.selectTab(FlagTab.Cyan) // re-tap: true → write(false) gated, pending = false
         vm.selectTab(FlagTab.Cyan) // re-tap: reads optimistic false → write(true) gated, pending = true
@@ -292,7 +300,7 @@ class FlagsViewModelTest {
         val prefs = FakeUserPreferencesRepository() // CYAN default unreadOnly = true
         prefs.blockUnreadOnlySetForType = FlagType.RED
         prefs.blockUnreadOnlySetUntil = kotlinx.coroutines.CompletableDeferred()
-        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
+        val vm = viewModel(auth, flags, forum, prefs)
 
         vm.selectTab(FlagTab.Red)
         vm.setFlagsUnreadOnly(false) // RED write goes in flight (gated), must not touch the CYAN shim
@@ -776,7 +784,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1, 13))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(groupByCategory = false)
-        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
+        val vm = viewModel(auth, flags, forum, prefs)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -801,7 +809,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(groupByCategory = true)
-        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
+        val vm = viewModel(auth, flags, forum, prefs)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -823,7 +831,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1, 10))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(hideReadCategories = true)
-        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
+        val vm = viewModel(auth, flags, forum, prefs)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -851,7 +859,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1, 10))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(hideReadCategories = true)
-        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
+        val vm = viewModel(auth, flags, forum, prefs)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -883,7 +891,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1, 10))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(hideReadCategories = true)
-        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
+        val vm = viewModel(auth, flags, forum, prefs)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -912,7 +920,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1, 10))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(hideReadCategories = true)
-        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
+        val vm = viewModel(auth, flags, forum, prefs)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -943,7 +951,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(groupByCategory = true, perTabOverride = true)
-        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
+        val vm = viewModel(auth, flags, forum, prefs)
         prefs.setFlagsGroupByCategoryForType(FlagType.CYAN, false)
 
         vm.flagsState.test {
@@ -972,7 +980,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(groupByCategory = true)
-        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
+        val vm = viewModel(auth, flags, forum, prefs)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -1003,7 +1011,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(groupByCategory = true, perTabOverride = true)
-        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
+        val vm = viewModel(auth, flags, forum, prefs)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -1034,7 +1042,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(groupByCategory = true, perTabOverride = true)
-        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
+        val vm = viewModel(auth, flags, forum, prefs)
         prefs.setFlagsGroupByCategoryForType(FlagType.RED, false)
 
         vm.flagsViewSettings.test {
@@ -1055,7 +1063,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository()
-        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
+        val vm = viewModel(auth, flags, forum, prefs)
 
         assertFalse(vm.flagsViewSettings.value.hideReadCategories)
         vm.setFlagsHideReadCategories(true)
@@ -1073,7 +1081,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(perTabOverride = true)
-        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
+        val vm = viewModel(auth, flags, forum, prefs)
 
         vm.setFlagsHideReadCategories(true) // CYAN selected
         assertTrue("CYAN per-type hide-read on", vm.flagsViewSettings.value.hideReadCategories)
@@ -1095,7 +1103,7 @@ class FlagsViewModelTest {
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository() // persisted override OFF
         prefs.blockPerTabOverrideSetUntil = kotlinx.coroutines.CompletableDeferred()
-        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
+        val vm = viewModel(auth, flags, forum, prefs)
 
         vm.setFlagsPerTabOverride(true) // optimistic ON; persisted write GATED (never commits here)
         vm.setFlagsGroupByCategory(false)
@@ -1115,7 +1123,7 @@ class FlagsViewModelTest {
         val forum = FakeForumRepository(catIds = listOf(1))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val prefs = FakeUserPreferencesRepository(groupByCategory = true) // override OFF initially
-        val vm = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
+        val vm = viewModel(auth, flags, forum, prefs)
 
         vm.flagsState.test {
             awaitItem() // initial null
@@ -1177,7 +1185,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)
         val clock = SteppingClock(Instant.parse("2026-06-11T12:00:00Z"))
-        val vm = FlagsViewModel(auth, flags, FakeForumRepository(), FakeUserPreferencesRepository(), clock)
+        val vm = viewModelWithClock(auth, flags, clock)
 
         vm.maybeAutoRefresh() // landing refresh → raises the signal
         vm.consumeRecallListToTop() // screen scrolled and consumed it
@@ -1217,7 +1225,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)
         val clock = SteppingClock(Instant.parse("2026-06-11T12:00:00Z"))
-        val vm = FlagsViewModel(auth, flags, FakeForumRepository(), FakeUserPreferencesRepository(), clock)
+        val vm = viewModelWithClock(auth, flags, clock)
 
         vm.maybeAutoRefresh()
         vm.maybeAutoRefresh() // immediate re-landing (back-and-forth) — throttled
@@ -1253,7 +1261,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)
         val clock = SteppingClock(Instant.parse("2026-06-11T12:00:00Z"))
-        val vm = FlagsViewModel(auth, flags, FakeForumRepository(), FakeUserPreferencesRepository(), clock)
+        val vm = viewModelWithClock(auth, flags, clock)
 
         vm.maybeAutoRefresh() // landing refresh, arms the throttle
         vm.onFlagOpened() // user opens a topic from the list…
@@ -1267,7 +1275,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)
         val clock = SteppingClock(Instant.parse("2026-06-11T12:00:00Z"))
-        val vm = FlagsViewModel(auth, flags, FakeForumRepository(), FakeUserPreferencesRepository(), clock)
+        val vm = viewModelWithClock(auth, flags, clock)
 
         vm.maybeAutoRefresh()
         vm.onFlagOpened()
@@ -1287,7 +1295,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)
         val clock = SteppingClock(Instant.parse("2026-06-11T12:00:00Z"))
-        val vm = FlagsViewModel(auth, flags, FakeForumRepository(), FakeUserPreferencesRepository(), clock)
+        val vm = viewModelWithClock(auth, flags, clock)
         advanceUntilIdle() // settle the init collectors
 
         vm.maybeAutoRefresh() // landing — generation snapshot taken now, body not yet run
@@ -1307,7 +1315,7 @@ class FlagsViewModelTest {
         val flags = FakeFlagRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("XaT"), flagRepository = flags)
         val clock = SteppingClock(Instant.parse("2026-06-11T12:00:00Z"))
-        val vm = FlagsViewModel(auth, flags, FakeForumRepository(), FakeUserPreferencesRepository(), clock)
+        val vm = viewModelWithClock(auth, flags, clock)
 
         vm.maybeAutoRefresh() // arms the throttle
         vm.onFlagOpened()
@@ -1329,6 +1337,216 @@ class FlagsViewModelTest {
         assertEquals(2, flags.refreshCalls.size)
     }
 
+    // #6 — DT tab: MultiMP list + best-effort MPStorage enrichment.
+
+    @Test
+    fun `onDtTabOpened lists the MultiMP conversations joined with their MPStorage resume page`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val messages = FakeMessagesRepository(
+            inboxResult = Result.success(
+                inboxPage(
+                    stubSummary(threadId = 10, isMultiRecipient = true, lastPage = 3),
+                    stubSummary(threadId = 20, isMultiRecipient = false), // 1:1 MP → filtered out
+                    stubSummary(threadId = 30, isMultiRecipient = true),
+                ),
+            ),
+        )
+        val mpStorage = FakeMpStorageRepository(
+            result = MpStorageResult.Found(
+                mpDoc(MpStorageFlagEntry(threadId = 10, page = 7, numreponse = null, uri = null)),
+            ),
+        )
+        val vm = viewModel(auth, flags, FakeForumRepository(), messages = messages, mpStorage = mpStorage)
+
+        vm.dtListState.test {
+            assertEquals(DtListUiState.Loading, awaitItem())
+            vm.onDtTabOpened()
+            val content = awaitItem() as DtListUiState.Content
+            // The 1:1 MP (20) is dropped; only the two MultiMP rows remain, in inbox order.
+            assertEquals(listOf(10, 30), content.items.map { it.conversation.threadId })
+            // Thread 10 has an mpFlags entry → its resume page joins; 30 has none → null badge.
+            assertEquals(7, content.items.first { it.conversation.threadId == 10 }.resumePage)
+            assertNull(content.items.first { it.conversation.threadId == 30 }.resumePage)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onDtTabOpened renders the list without badges when MPStorage is NotFound`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val messages = FakeMessagesRepository(
+            inboxResult = Result.success(inboxPage(stubSummary(threadId = 10, isMultiRecipient = true))),
+        )
+        val mpStorage = FakeMpStorageRepository(result = MpStorageResult.NotFound)
+        val vm = viewModel(auth, flags, FakeForumRepository(), messages = messages, mpStorage = mpStorage)
+
+        vm.dtListState.test {
+            assertEquals(DtListUiState.Loading, awaitItem())
+            vm.onDtTabOpened()
+            val content = awaitItem() as DtListUiState.Content
+            assertEquals(listOf(10), content.items.map { it.conversation.threadId })
+            assertNull("NotFound storage → no resume badge", content.items.single().resumePage)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onDtTabOpened keeps the list when MPStorage read throws (best-effort)`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val messages = FakeMessagesRepository(
+            inboxResult = Result.success(inboxPage(stubSummary(threadId = 10, isMultiRecipient = true))),
+        )
+        // The MPStorage scan FAILS — it must never fail the conversation list.
+        val mpStorage = FakeMpStorageRepository(thrown = IllegalStateException("storage scan down"))
+        val vm = viewModel(auth, flags, FakeForumRepository(), messages = messages, mpStorage = mpStorage)
+
+        vm.dtListState.test {
+            assertEquals(DtListUiState.Loading, awaitItem())
+            vm.onDtTabOpened()
+            val content = awaitItem() as DtListUiState.Content
+            assertEquals(listOf(10), content.items.map { it.conversation.threadId })
+            assertNull("a failed storage read degrades to no badge", content.items.single().resumePage)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onDtTabOpened surfaces Empty when the inbox holds no MultiMP`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val messages = FakeMessagesRepository(
+            inboxResult = Result.success(
+                inboxPage(stubSummary(threadId = 20, isMultiRecipient = false)),
+            ),
+        )
+        val vm = viewModel(auth, flags, FakeForumRepository(), messages = messages)
+
+        vm.dtListState.test {
+            assertEquals(DtListUiState.Loading, awaitItem())
+            vm.onDtTabOpened()
+            assertEquals(DtListUiState.Empty, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onDtTabOpened surfaces Error when the inbox load fails`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val expired = SessionExpiredException("https://forum.hardware.fr/login.php")
+        val messages = FakeMessagesRepository(inboxResult = Result.failure(expired))
+        val vm = viewModel(auth, flags, FakeForumRepository(), messages = messages)
+
+        vm.dtListState.test {
+            assertEquals(DtListUiState.Loading, awaitItem())
+            vm.onDtTabOpened()
+            val error = awaitItem() as DtListUiState.Error
+            assertTrue(error.cause is SessionExpiredException)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onDtTabOpened fetches once per session then reuses the loaded list`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val messages = FakeMessagesRepository(
+            inboxResult = Result.success(inboxPage(stubSummary(threadId = 10, isMultiRecipient = true))),
+        )
+        val mpStorage = FakeMpStorageRepository(result = MpStorageResult.NotFound)
+        val vm = viewModel(auth, flags, FakeForumRepository(), messages = messages, mpStorage = mpStorage)
+
+        vm.onDtTabOpened()
+        vm.onDtTabOpened() // re-selecting DT must NOT re-scan (the MPStorage scan is expensive)
+
+        assertEquals("only one inbox scan per session", 1, messages.getListCalls)
+        assertEquals("only one MPStorage scan per session", 1, mpStorage.fetchCalls)
+    }
+
+    @Test
+    fun `refreshDt re-runs the scan even after a successful load`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val messages = FakeMessagesRepository(
+            inboxResult = Result.success(inboxPage(stubSummary(threadId = 10, isMultiRecipient = true))),
+        )
+        val vm = viewModel(auth, flags, FakeForumRepository(), messages = messages)
+
+        vm.onDtTabOpened()
+        vm.refreshDt()
+
+        assertEquals("explicit refresh bypasses the once-per-session guard", 2, messages.getListCalls)
+    }
+
+    @Test
+    fun `a failed inbox load can be retried via onDtTabOpened`() = runTest {
+        // The inbox is the list's only hard source: an Error resets the guard so a retry re-runs.
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val messages = FakeMessagesRepository(inboxResult = Result.failure(IllegalStateException("net")))
+        val vm = viewModel(auth, flags, FakeForumRepository(), messages = messages)
+
+        vm.dtListState.test {
+            assertEquals(DtListUiState.Loading, awaitItem())
+            vm.onDtTabOpened()
+            assertTrue(awaitItem() is DtListUiState.Error)
+
+            messages.inboxResult =
+                Result.success(inboxPage(stubSummary(threadId = 10, isMultiRecipient = true)))
+            vm.onDtTabOpened() // guard was reset by the failure → retry re-runs
+            val content = awaitItem() as DtListUiState.Content
+            assertEquals(listOf(10), content.items.map { it.conversation.threadId })
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(2, messages.getListCalls)
+    }
+
+    @Test
+    fun `switching authenticated pseudo resets the DT list back to Loading`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val messages = FakeMessagesRepository(
+            inboxResult = Result.success(inboxPage(stubSummary(threadId = 10, isMultiRecipient = true))),
+        )
+        // flagsState is an Eagerly stateIn, so clearFlagsCacheIfSessionChanged already observes the
+        // auth emissions without an explicit collector here.
+        val vm = viewModel(auth, flags, FakeForumRepository(), messages = messages)
+
+        vm.dtListState.test {
+            assertEquals(DtListUiState.Loading, awaitItem())
+            vm.onDtTabOpened()
+            assertTrue(awaitItem() is DtListUiState.Content)
+
+            auth.emit(AuthState.Authenticated("other")) // account switch must drop the list
+            assertEquals(DtListUiState.Loading, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private fun stubSummary(
+        threadId: Int,
+        isMultiRecipient: Boolean,
+        hasUnread: Boolean = false,
+        lastPage: Int = 1,
+    ): PrivateMessageSummary = PrivateMessageSummary(
+        threadId = threadId,
+        correspondent = if (isMultiRecipient) "" else "someone",
+        subject = "Conversation $threadId",
+        date = Instant.parse("2026-06-18T12:00:00Z"),
+        hasUnread = hasUnread,
+        isMultiRecipient = isMultiRecipient,
+        lastPage = lastPage,
+    )
+
+    private fun inboxPage(vararg items: PrivateMessageSummary): PrivateMessageListPage =
+        PrivateMessageListPage(page = 1, totalPages = 1, items = items.toList())
+
+    private fun mpDoc(vararg entries: MpStorageFlagEntry): MpStorageDocument =
+        MpStorageDocument(sourceName = "DTCloud", mpFlags = entries.toList(), rawEnvelope = "{}")
+
     /** Mutable [Clock] for the #378 throttle tests — `now` is advanced by hand. */
     private class SteppingClock(start: Instant) : Clock() {
         var now: Instant = start
@@ -1337,12 +1555,31 @@ class FlagsViewModelTest {
         override fun instant(): Instant = now
     }
 
+    @Suppress("LongParameterList") // test fake-builder: each repo fake is an independent collaborator
     private fun viewModel(
         auth: FakeAuthRepository,
         flags: FakeFlagRepository,
         forum: FakeForumRepository,
         prefs: FakeUserPreferencesRepository = FakeUserPreferencesRepository(),
-    ): FlagsViewModel = FlagsViewModel(auth, flags, forum, prefs, fixedClock)
+        messages: FakeMessagesRepository = FakeMessagesRepository(),
+        mpStorage: FakeMpStorageRepository = FakeMpStorageRepository(),
+    ): FlagsViewModel = FlagsViewModel(auth, flags, forum, prefs, messages, mpStorage, fixedClock)
+
+    /** Builds a ViewModel with a custom [clock] for the #378 throttle tests; everything else is a
+     * fresh default fake. */
+    private fun viewModelWithClock(
+        auth: FakeAuthRepository,
+        flags: FakeFlagRepository,
+        clock: Clock,
+    ): FlagsViewModel = FlagsViewModel(
+        auth,
+        flags,
+        FakeForumRepository(),
+        FakeUserPreferencesRepository(),
+        FakeMessagesRepository(),
+        FakeMpStorageRepository(),
+        clock,
+    )
 
     /** Flattens whatever content shape into the topics order for assertions on flag content. */
     private fun flatTopics(state: FlagsListUiState.Success): List<Flag> =
@@ -1732,5 +1969,59 @@ class FlagsViewModelTest {
         override suspend fun setImmersiveNavBarReveal(mode: ImmersiveNavBarReveal) = Unit
         override fun observeAccentColor(): Flow<AccentColor> = MutableStateFlow(AccentColor.ROSE)
         override suspend fun setAccentColor(color: AccentColor) = Unit
+    }
+
+    /**
+     * Fake [MessagesRepository] for the #6 DT tab tests. Only [getPrivateMessageList] is exercised
+     * by FlagsViewModel (the DT list source) ; [inboxResult] lets a test seed the inbox page or
+     * make the load throw. The unread-count / thread members are stubbed at no-op defaults.
+     */
+    private class FakeMessagesRepository(
+        var inboxResult: Result<PrivateMessageListPage> =
+            Result.success(PrivateMessageListPage(page = 1, totalPages = 1, items = emptyList())),
+    ) : MessagesRepository {
+        var getListCalls: Int = 0
+            private set
+
+        override fun observeUnreadMpCount(): Flow<Int?> = MutableStateFlow(null)
+        override fun requestUnreadRefresh() = Unit
+        override fun markThreadRead(threadId: Int) = Unit
+
+        override suspend fun getPrivateMessageList(page: Int): PrivateMessageListPage {
+            getListCalls += 1
+            return inboxResult.getOrThrow()
+        }
+
+        override suspend fun getPrivateMessageThread(
+            threadId: Int,
+            page: Int,
+            fallbackCorrespondent: String?,
+        ): PrivateMessageThread = PrivateMessageThread(
+            threadId = threadId,
+            subject = "",
+            correspondent = "",
+            messages = emptyList(),
+            page = page,
+            totalPages = 1,
+        )
+    }
+
+    /**
+     * Fake [MpStorageRepository] for the #6 DT tests. [result] seeds the lookup outcome (or a thrown
+     * error via [thrown]) so a test can prove the best-effort join tolerates NotFound / Unreadable /
+     * a transport failure — the list must still render in every case.
+     */
+    private class FakeMpStorageRepository(
+        var result: MpStorageResult = MpStorageResult.NotFound,
+        var thrown: Throwable? = null,
+    ) : MpStorageRepository {
+        var fetchCalls: Int = 0
+            private set
+
+        override suspend fun fetchStorage(): MpStorageResult {
+            fetchCalls += 1
+            thrown?.let { throw it }
+            return result
+        }
     }
 }


### PR DESCRIPTION
Travail de nuit — chantier A. L'onglet **« DT »** des Drapeaux n'est plus un placeholder : il liste les **MultiMP** (conversations multi-destinataires de l'inbox MP) et, en best-effort, la **position de reprise de lecture** issue de MPStorage v1.

## Implémentation
- `DtListUiState` dédié (Loading/Empty/Content/Error), **séparé** du modèle `Flag` (décision Codex : canal DT séparé, pas `flagType==null` comme contrat métier).
- Source primaire = `MessagesRepository` (inbox `cat=prive` filtrée `isMultiRecipient`).
- Enrichissement best-effort via `MpStorageRepository.fetchStorage()` (jointure `threadId` → page de reprise). `NotFound`/`Unreadable`/exception → liste affichée sans badge. **`mpFlags` = position de lecture, jamais un lu/non-lu** (le non-lu vient de `hasUnread`).
- Fetch déclenché à l'**ouverture du tab** (hors auto-refresh), nav vers la route `PrivateMessageThread` existante (ouvre `resumePage ?: lastPage`).

## Robustesse (review Codex en 2 passes)
- **Anti stale-write** : `dtFetchJob` + `dtGeneration` — `resetDtState()` (switch compte/logout) annule le fetch en vol et invalide par génération ; `loadDt` ne publie l'état que si la génération est courante (re-vérifiée après le scan MPStorage suspendant). `refreshDt` = latest-wins.
- `DtTabOpenEffect` gated par `showDtTab` ; `LaunchedEffect` keyé `(selectedTab, showDtTab, authSessionKey)` → relance au switch de compte.
- a11y : sémantique non-lu/lu sur la row.

## Scope MVP / non observé
- **Inbox page 1 only** (multi-page différé — `fetchStorage` est coûteux) : copy « récente » + documenté + testé `totalPages>1`.
- Gating Compose + ouverture `resumePage` non couverts par test auto (pas de suite Compose dans `feature/flags`) → vérif lecture seule + device.

## Validation
`:feature:flags:testDebugUnitTest` (66 tests, 0 échec, 9+3 nouveaux DT) + `:app:assembleDevDebug` + `detektAll` + `lintDebug` verts. Revue Codex (gpt-5.5, xhigh) **×2 passes** : 0 bloquant après correctifs.

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)