### PR TITLE
feat(topic): recherche intra-topic (transsearch.php) — requête + filtre serveur

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryModule.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryModule.kt
@@ -5,6 +5,7 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import fr.forumhfr.redface2.core.domain.topic.TopicRepository
+import fr.forumhfr.redface2.core.domain.topic.TopicSearchRepository
 import javax.inject.Singleton
 
 @Module
@@ -13,4 +14,9 @@ abstract class TopicRepositoryModule {
     @Binds
     @Singleton
     abstract fun bindTopicRepository(impl: TopicRepositoryImpl): TopicRepository
+
+    // Chantier C (#546) — intra-topic search (transsearch.php).
+    @Binds
+    @Singleton
+    abstract fun bindTopicSearchRepository(impl: TopicSearchRepositoryImpl): TopicSearchRepository
 }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicSearchRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicSearchRepositoryImpl.kt
@@ -1,0 +1,70 @@
+package fr.forumhfr.redface2.core.data.topic
+
+import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
+import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
+import fr.forumhfr.redface2.core.domain.topic.TopicSearchRepository
+import fr.forumhfr.redface2.core.model.Topic
+import fr.forumhfr.redface2.core.model.TopicSearchRequest
+import fr.forumhfr.redface2.core.network.HfrClient
+import fr.forumhfr.redface2.core.parser.HfrParser
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+
+/**
+ * Chantier C (#546) — default [TopicSearchRepository] hitting HFR's `POST /transsearch.php` and
+ * re-parsing the response (a topic page) into a [Topic] via the shared [HfrParser.parseTopicPage].
+ *
+ * Both the HTTP call and the parse run inside a single `withContext(ioDispatcher)` block, mandated
+ * by `feedback_repos_must_wrap_io` (the Jsoup pass and `.execute()` must never land on
+ * `Dispatchers.Main.immediate`).
+ *
+ * **Privacy** : the search term ([TopicSearchRequest.word]) and the author filter
+ * ([TopicSearchRequest.spseudo]) are free user text ; the `hash_check` is a session secret. NONE of
+ * them is ever logged — diagnostics record only presence flags + the `onlyMatches` mode, never the
+ * values. The network layer never logs the POST body either.
+ *
+ * **Cache** : intentionally none. A `transsearch` response is a transient, possibly-filtered view
+ * of the topic ; persisting it as the `(cat, post, page)` row would corrupt the cache the normal
+ * topic flow reads (cf. `TopicRepositoryImpl`). It is parsed and handed straight back to the
+ * ViewModel.
+ */
+@Singleton
+class TopicSearchRepositoryImpl @Inject constructor(
+    private val client: HfrClient,
+    private val parser: HfrParser,
+    private val diagnostics: DiagnosticsLog,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) : TopicSearchRepository {
+
+    override suspend fun searchInTopic(request: TopicSearchRequest): Topic = withContext(ioDispatcher) {
+        diagnostics.record(
+            DiagnosticsLog.Level.INFO,
+            LOG_TAG,
+            // No word / spseudo / hash_check verbatim — only presence flags + the filter mode.
+            "POST transsearch cat=${request.form.cat} post=${request.form.topicId} " +
+                "hasWord=${request.word.isNotBlank()} hasPseudo=${request.spseudo.isNotBlank()} " +
+                "onlyMatches=${request.onlyMatches} hasCursor=${!request.currentNum.isNullOrBlank()}",
+        )
+        val html = client.searchInTopic(
+            cat = request.form.cat,
+            topicId = request.form.topicId,
+            word = request.word,
+            spseudo = request.spseudo,
+            onlyMatches = request.onlyMatches,
+            hashCheck = request.form.hashCheck,
+            firstnum = request.form.firstnum,
+            owntopic = request.form.owntopic,
+            currentnum = request.currentNum,
+        )
+        // The transsearch response IS a topic page (documented contract — never observed live, so
+        // best-effort). Re-parse with the canonical topic-page parser ; an unexpected shape would
+        // surface as a normal parse error the ViewModel reports, never a poisoned cache row.
+        parser.parseTopicPage(html)
+    }
+
+    private companion object {
+        private const val LOG_TAG = "TopicSearchRepository"
+    }
+}

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicSearchRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicSearchRepositoryImplTest.kt
@@ -1,0 +1,136 @@
+package fr.forumhfr.redface2.core.data.topic
+
+import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
+import fr.forumhfr.redface2.core.model.TopicSearchForm
+import fr.forumhfr.redface2.core.model.TopicSearchRequest
+import fr.forumhfr.redface2.core.network.HfrClient
+import fr.forumhfr.redface2.core.parser.HfrParser
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+/**
+ * Chantier C (#546) — tests for [TopicSearchRepositoryImpl].
+ *
+ * The HfrClient is mocked ; the parser stays real so the response → [fr.forumhfr.redface2.core.model.Topic]
+ * mapping is exercised. We assert the REQUEST construction (each form field forwarded verbatim from
+ * the parsed [TopicSearchForm]) and that the response page is re-parsed as a topic. The `transsearch`
+ * RESPONSE is never asserted against a real capture — none exists (see the model KDoc) — so we feed
+ * the parser a known topic-page fixture as a stand-in to prove the round-trip wiring.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class TopicSearchRepositoryImplTest {
+
+    @Test
+    fun `forwards every form field and the filter flag to the HfrClient`() = runTest {
+        val hfrClient = mockk<HfrClient>()
+        coEvery {
+            hfrClient.searchInTopic(
+                cat = any(),
+                topicId = any(),
+                word = any(),
+                spseudo = any(),
+                onlyMatches = any(),
+                hashCheck = any(),
+                firstnum = any(),
+                owntopic = any(),
+                currentnum = any(),
+            )
+        } returns fixture("topic_page_single.html")
+
+        val topic = buildRepository(hfrClient).searchInTopic(
+            TopicSearchRequest(
+                form = TopicSearchForm(hashCheck = "tok", topicId = 35395, cat = 23, firstnum = 2783602),
+                word = "betatest",
+                spseudo = "XaTriX",
+                onlyMatches = true,
+            ),
+        )
+
+        // The response re-parsed as a Topic (proves the parseTopicPage round-trip wiring).
+        assertEquals(999395, topic.post)
+        coVerify(exactly = 1) {
+            hfrClient.searchInTopic(
+                cat = 23,
+                topicId = 35395,
+                word = "betatest",
+                spseudo = "XaTriX",
+                onlyMatches = true,
+                hashCheck = "tok",
+                firstnum = 2783602,
+                owntopic = 0,
+                currentnum = null,
+            )
+        }
+    }
+
+    @Test
+    fun `carries the navigation cursor and owntopic verbatim`() = runTest {
+        val hfrClient = mockk<HfrClient>()
+        coEvery {
+            hfrClient.searchInTopic(
+                cat = any(), topicId = any(), word = any(), spseudo = any(), onlyMatches = any(),
+                hashCheck = any(), firstnum = any(), owntopic = any(), currentnum = any(),
+            )
+        } returns fixture("topic_page_single.html")
+
+        buildRepository(hfrClient).searchInTopic(
+            TopicSearchRequest(
+                form = TopicSearchForm(hashCheck = "tok", topicId = 7, cat = 32, firstnum = 16244, owntopic = 1),
+                word = "",
+                spseudo = "someone",
+                onlyMatches = false,
+                currentNum = "16300",
+            ),
+        )
+
+        coVerify(exactly = 1) {
+            hfrClient.searchInTopic(
+                cat = 32, topicId = 7, word = "", spseudo = "someone", onlyMatches = false,
+                hashCheck = "tok", firstnum = 16244, owntopic = 1, currentnum = "16300",
+            )
+        }
+    }
+
+    @Test
+    fun `propagates a SessionExpiredException from the network layer`() {
+        val hfrClient = mockk<HfrClient>()
+        coEvery {
+            hfrClient.searchInTopic(
+                cat = any(), topicId = any(), word = any(), spseudo = any(), onlyMatches = any(),
+                hashCheck = any(), firstnum = any(), owntopic = any(), currentnum = any(),
+            )
+        } throws SessionExpiredException("<redacted>")
+
+        assertThrows(SessionExpiredException::class.java) {
+            runBlocking {
+                buildRepository(hfrClient).searchInTopic(
+                    TopicSearchRequest(
+                        form = TopicSearchForm(hashCheck = "tok", topicId = 1, cat = 1, firstnum = 1),
+                        word = "x",
+                        spseudo = "",
+                        onlyMatches = true,
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun buildRepository(hfrClient: HfrClient) = TopicSearchRepositoryImpl(
+        client = hfrClient,
+        parser = HfrParser(),
+        diagnostics = DiagnosticsLog(),
+        ioDispatcher = UnconfinedTestDispatcher(),
+    )
+
+    private fun fixture(name: String): String =
+        requireNotNull(javaClass.getResource("/fixtures/$name")) { "Fixture not found: $name" }.readText()
+}

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicSearchRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicSearchRepositoryImplTest.kt
@@ -101,6 +101,38 @@ class TopicSearchRepositoryImplTest {
     }
 
     @Test
+    fun `never logs the search term, the author filter or the hash_check (privacy)`() = runTest {
+        // #546 finding #3 — the diagnostics trail records only presence flags + the filter mode, never
+        // the free-text criteria nor the session secret. Lock that with sentinels: if any of them ever
+        // leaked into a log message, this fails. (cf. the privacy KDoc on TopicSearchRepositoryImpl.)
+        val hfrClient = mockk<HfrClient>()
+        coEvery {
+            hfrClient.searchInTopic(
+                cat = any(), topicId = any(), word = any(), spseudo = any(), onlyMatches = any(),
+                hashCheck = any(), firstnum = any(), owntopic = any(), currentnum = any(),
+            )
+        } returns fixture("topic_page_single.html")
+        val diagnostics = DiagnosticsLog()
+
+        buildRepository(hfrClient, diagnostics).searchInTopic(
+            TopicSearchRequest(
+                form = TopicSearchForm(hashCheck = "hash-secret", topicId = 35395, cat = 23, firstnum = 1),
+                word = "word-secret",
+                spseudo = "pseudo-secret",
+                onlyMatches = true,
+            ),
+        )
+
+        val sentinels = listOf("word-secret", "pseudo-secret", "hash-secret")
+        val leaked = diagnostics.entries.value
+            .map { it.message }
+            .filter { message -> sentinels.any { message.contains(it) } }
+        assertEquals("no diagnostics entry may leak the criteria or hash_check", emptyList<String>(), leaked)
+        // Sanity: the search DID leave a trail (so the assertion above is not vacuously true).
+        assertEquals(true, diagnostics.entries.value.any { it.message.contains("POST transsearch") })
+    }
+
+    @Test
     fun `propagates a SessionExpiredException from the network layer`() {
         val hfrClient = mockk<HfrClient>()
         coEvery {
@@ -124,10 +156,13 @@ class TopicSearchRepositoryImplTest {
         }
     }
 
-    private fun buildRepository(hfrClient: HfrClient) = TopicSearchRepositoryImpl(
+    private fun buildRepository(
+        hfrClient: HfrClient,
+        diagnostics: DiagnosticsLog = DiagnosticsLog(),
+    ) = TopicSearchRepositoryImpl(
         client = hfrClient,
         parser = HfrParser(),
-        diagnostics = DiagnosticsLog(),
+        diagnostics = diagnostics,
         ioDispatcher = UnconfinedTestDispatcher(),
     )
 

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/topic/TopicSearchRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/topic/TopicSearchRepository.kt
@@ -1,0 +1,33 @@
+package fr.forumhfr.redface2.core.domain.topic
+
+import fr.forumhfr.redface2.core.model.Topic
+import fr.forumhfr.redface2.core.model.TopicSearchRequest
+
+/**
+ * Chantier C (#546) — domain entry point for the intra-topic search (`transsearch.php`).
+ *
+ * One-shot suspend `fun` rather than a `Flow` : the search is user-triggered, has no observable
+ * upstream signal, and the ViewModel models its own loading/error/results state around the call
+ * (same rationale as `SearchRepository`). It deliberately does NOT touch the topic-page cache : a
+ * filtered/anchored `transsearch` page is a transient view, not the canonical `(cat, post, page)`
+ * row, so persisting it would poison the cache the normal topic flow reads.
+ *
+ * Implementations must redact the user's [TopicSearchRequest.word] / [TopicSearchRequest.spseudo]
+ * and the `hash_check` from any error message / persistent log before propagating.
+ */
+interface TopicSearchRepository {
+    /**
+     * Builds and POSTs the [request] to `transsearch.php` (authenticated), then re-parses the
+     * returned topic page into a [Topic].
+     *
+     * @return the parsed [Topic] of the `transsearch` response. **The response shape was never
+     *   observed live** : we trust the documented contract that it is a topic page and parse it
+     *   with the existing topic-page parser. Navigation via [TopicSearchRequest.currentNum] is
+     *   EXPERIMENTAL / best-effort for the same reason.
+     *
+     * Failures surface as exceptions (typed where the network layer typed them, e.g.
+     * [fr.forumhfr.redface2.core.domain.auth.SessionExpiredException] /
+     * [fr.forumhfr.redface2.core.domain.error.HfrServerException]).
+     */
+    suspend fun searchInTopic(request: TopicSearchRequest): Topic
+}

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/Topic.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/Topic.kt
@@ -39,6 +39,15 @@ data class Topic(
      * logged-out. See `docs/specs/protocol-hfr.md` § POST `bddpost.php`.
      */
     val canReply: Boolean = false,
+    /**
+     * Chantier C (#546) — the intra-topic search form (`transsearch.php`) hidden fields parsed from
+     * THIS page, or `null` when the page carried no usable search form. It is **transient, never
+     * persisted** : the cache mapper reconstructs it as `null`, so a cached row keeps the
+     * intra-topic-search affordance disabled until a live authenticated re-fetch surfaces a usable
+     * form ([TopicSearchForm.canSearch] additionally requires a non-empty `hash_check`). Coupling it
+     * to the parsed page keeps the form in lockstep with the `(cat, post, page)` it belongs to.
+     */
+    val searchForm: TopicSearchForm? = null,
 ) {
     companion object {
         const val SUBCAT_UNKNOWN: Int = -1

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/TopicSearch.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/TopicSearch.kt
@@ -1,0 +1,78 @@
+package fr.forumhfr.redface2.core.model
+
+/**
+ * Chantier C (#546) — intra-topic search, a MODE of `feature/topic` (NOT an extension of
+ * `feature/search`, which models the cross-topic listing).
+ *
+ * HFR ships a small search form in the header of every topic page (`form[action=/transsearch.php]`,
+ * cf. fixtures `topic_*.html` / `write_*topic*.html`). Submitting it re-renders the SAME topic page,
+ * optionally filtered to only the messages matching the term/author. The whole feature therefore
+ * reuses the topic-page contract end to end :
+ *
+ *  - request  → POST `/transsearch.php` with the hidden form fields + `word` / `spseudo` / `filter`
+ *  - response → a topic page, re-parsed with the existing `TopicPageParser` into a [Topic]
+ *
+ * The form's hidden fields (`hash_check`, `post`, `cat`, `firstnum`, …) are parsed from the
+ * currently-loaded topic page into [TopicSearchForm]. A non-empty [TopicSearchForm.hashCheck]
+ * means the page was served to an AUTHENTICATED session — the only case in which `transsearch.php`
+ * accepts the search (HFR rejects an empty `hash_check`).
+ */
+
+/**
+ * The hidden fields of the topic-page `transsearch.php` form, extracted from the loaded topic page.
+ *
+ * Every field is forwarded verbatim to [fr.forumhfr.redface2.core.network.HfrClient.searchInTopic] —
+ * HFR keys the search on them. The form carries no `currentnum` input in the static HTML : HFR's own
+ * JS creates and manages it at runtime (the submit button's `onclick` clears it). We therefore send
+ * `currentnum` empty for a fresh search and only carry a cursor value for best-effort next/previous
+ * navigation (see [TopicSearchRequest.currentNum]).
+ *
+ * @property hashCheck HFR anti-CSRF token. EMPTY on an anonymous capture (the form is rendered but
+ *   inert) ; non-empty only on an authenticated page. `transsearch.php` requires it non-empty, hence
+ *   intra-topic search is an authenticated-only feature.
+ * @property topicId the `post` hidden field — the topic id.
+ * @property cat the topic's category id.
+ * @property firstnum the `numreponse` of the first message on the page the form was rendered on.
+ *   HFR uses it as the search anchor ; forwarded verbatim.
+ * @property owntopic the `owntopic` flag verbatim from the form (`0` on a normal topic, `1` observed
+ *   on the cat-IA owned-topic capture). Wire detail, kept as-is.
+ */
+data class TopicSearchForm(
+    val hashCheck: String,
+    val topicId: Int,
+    val cat: Int,
+    val firstnum: Int,
+    val owntopic: Int = 0,
+) {
+    /**
+     * `transsearch.php` rejects an empty `hash_check`, so the search affordance must only be
+     * offered when the form was parsed from an authenticated page. Mirrors the `Topic.canReply`
+     * "authenticated form present" contract.
+     */
+    val canSearch: Boolean get() = hashCheck.isNotBlank()
+}
+
+/**
+ * A caller-side intra-topic search, built by the ViewModel from the user input + the parsed
+ * [TopicSearchForm] of the loaded page.
+ *
+ * @property word the term to look for (HFR `word`). May be blank when filtering by author only.
+ * @property spseudo author filter (HFR `spseudo`). May be blank when searching by term only. At
+ *   least one of [word] / [spseudo] must be non-blank — the ViewModel enforces this.
+ * @property onlyMatches the real semantics of HFR's `filter` checkbox : when `true`, HFR re-renders
+ *   the topic page showing ONLY the messages matching the search ; when `false` it returns the
+ *   page with the matches highlighted in place. Named for intent, not for the wire (`filter=1`).
+ * @property currentNum the server-side navigation cursor (HFR's JS-managed `currentnum`). `null`/blank
+ *   for a fresh search (the documented "clear on submit" behaviour) ; a value is carried only for
+ *   the EXPERIMENTAL next/previous navigation. **Never observed live** — see [TopicSearchForm].
+ */
+data class TopicSearchRequest(
+    val form: TopicSearchForm,
+    val word: String,
+    val spseudo: String,
+    val onlyMatches: Boolean,
+    val currentNum: String? = null,
+) {
+    /** HFR needs at least a term or an author ; an all-blank search is meaningless. */
+    val isMeaningful: Boolean get() = word.isNotBlank() || spseudo.isNotBlank()
+}

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
@@ -444,6 +444,76 @@ class HfrClient @Inject constructor(
     }
 
     /**
+     * Chantier C (#546) — POST the intra-topic search to `/transsearch.php`.
+     *
+     * **AUTHENTICATED by design.** `transsearch.php` rejects an empty `hash_check`, so the search is
+     * only meaningful with the token parsed from an authenticated topic page. Routing through the
+     * authenticated client also means a freshly-expired session surfaces [SessionExpiredException]
+     * (via [executeAuthenticatedHtml]) instead of silently returning anonymous HTML.
+     *
+     * Wire shape (cf. the `transsearch` form in fixtures `topic_*.html` / `write_*topic*.html`,
+     * captured 2026-05/06) :
+     *
+     * `POST /transsearch.php` with `hash_check`, `post`(=topic id), `cat`, `config=hfr.inc`, `p=1`,
+     * `sondage=0`, `owntopic`, `word`, `spseudo`, `filter` (=`1` only when [onlyMatches]), `dep=0`,
+     * `firstnum`, `currentnum`.
+     *
+     * - [onlyMatches] maps to the form's `filter` checkbox : included as `filter=1` only when `true`
+     *   (an unchecked HTML checkbox sends no field at all), so HFR re-renders the page showing ONLY
+     *   the matching messages. When `false` we omit `filter`, matching the unchecked form.
+     * - [currentnum] is HFR's JS-managed navigation cursor. The static form has NO `currentnum`
+     *   input — HFR's own script creates it and the submit button clears it. We therefore send it
+     *   empty for a fresh search and only carry a value for the **EXPERIMENTAL / best-effort**
+     *   next/previous navigation. **The `transsearch` response has NEVER been observed live** (no
+     *   fixture), so the cursor semantics are unverified ; callers must treat navigation as
+     *   best-effort and re-parse whatever topic page comes back.
+     *
+     * The response IS a topic page → the data layer re-parses it with the existing topic-page parser.
+     *
+     * `hashCheck`, `word` and `spseudo` are **never** logged here (cf. the submit-reply precedent ;
+     * the repository performs the redacted diagnostics).
+     */
+    @Suppress("LongParameterList") // HFR transsearch form : one parameter per wire field.
+    suspend fun searchInTopic(
+        cat: Int,
+        topicId: Int,
+        word: String,
+        spseudo: String,
+        onlyMatches: Boolean,
+        hashCheck: String,
+        firstnum: Int,
+        owntopic: Int = 0,
+        currentnum: String? = null,
+    ): String {
+        val url = baseUrl.newBuilder()
+            .addPathSegment("transsearch.php")
+            .build()
+        val formBody = FormBody.Builder()
+            .add("hash_check", hashCheck)
+            .add("post", topicId.toString())
+            .add("cat", cat.toString())
+            .add("config", "hfr.inc")
+            .add("p", "1")
+            .add("sondage", "0")
+            .add("owntopic", owntopic.toString())
+            .add("word", word)
+            .add("spseudo", spseudo)
+            .apply {
+                // An unchecked HTML checkbox sends no field at all ; mirror that so HFR's
+                // server-side branch behaves exactly like the web form.
+                if (onlyMatches) add("filter", "1")
+            }
+            .add("dep", "0")
+            .add("firstnum", firstnum.toString())
+            // HFR's JS clears `currentnum` on a fresh submit (empty string) and only sets it for
+            // in-result navigation. Best-effort : the value is unverified (no live response capture).
+            .add("currentnum", currentnum.orEmpty())
+            .build()
+        val request = Request.Builder().url(url).post(formBody).build()
+        return authenticated.newCall(request).executeAuthenticatedHtml()
+    }
+
+    /**
      * Phase 2 finish (#99) — GET `/user/delflag.php` to remove a single drapeau the user
      * owns. Per ADR-003 the drapeau mutations stay HTML (the REST `PUT topics/{id}/`
      * semantics for downgrade/no-op are opaque), so this is a GET on the legacy endpoint.

--- a/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/HfrClientTest.kt
+++ b/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/HfrClientTest.kt
@@ -191,6 +191,92 @@ class HfrClientTest {
     }
 
     @Test
+    fun `searchInTopic POSTs transsearch on the authenticated client with the form contract`() = runTest {
+        // Chantier C (#546) — the response is a topic page ; here we only assert the REQUEST shape
+        // (the response round-trip is NOT testable — no live transsearch capture, see the model KDoc).
+        server.enqueue(MockResponse().setResponseCode(200).setBody("<html><body>ok</body></html>"))
+
+        val html = client.searchInTopic(
+            cat = 23,
+            topicId = 35395,
+            word = "betatest",
+            spseudo = "XaTriX",
+            onlyMatches = true,
+            hashCheck = "deadbeef",
+            firstnum = 2783602,
+            owntopic = 0,
+        )
+
+        assertEquals("<html><body>ok</body></html>", html)
+        val request = server.takeRequest()
+        assertEquals("authenticated", request.headers["X-RF2-Client"])
+        assertEquals("POST", request.method)
+        assertEquals("/transsearch.php", requireNotNull(request.requestUrl).encodedPath)
+        val body = formFields(request.body.readUtf8())
+        assertEquals("deadbeef", body["hash_check"])
+        assertEquals("35395", body["post"])
+        assertEquals("23", body["cat"])
+        assertEquals("hfr.inc", body["config"])
+        assertEquals("1", body["p"])
+        assertEquals("0", body["sondage"])
+        assertEquals("0", body["owntopic"])
+        assertEquals("betatest", body["word"])
+        assertEquals("XaTriX", body["spseudo"])
+        // onlyMatches=true ⇒ HFR's `filter` checkbox is checked.
+        assertEquals("1", body["filter"])
+        assertEquals("0", body["dep"])
+        assertEquals("2783602", body["firstnum"])
+        // Fresh search ⇒ the JS-managed cursor is sent empty (HFR clears it on submit).
+        assertEquals("", body["currentnum"])
+    }
+
+    @Test
+    fun `searchInTopic omits filter when onlyMatches is false and carries the nav cursor`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("<html><body>ok</body></html>"))
+
+        client.searchInTopic(
+            cat = 32,
+            topicId = 7,
+            word = "",
+            spseudo = "someone",
+            onlyMatches = false,
+            hashCheck = "tok",
+            firstnum = 16244,
+            owntopic = 1,
+            currentnum = "16300",
+        )
+
+        val body = formFields(server.takeRequest().body.readUtf8())
+        // An unchecked HTML checkbox sends no field at all — `filter` must be absent.
+        assertNull("filter must be omitted when onlyMatches=false", body["filter"])
+        assertEquals("1", body["owntopic"])
+        // EXPERIMENTAL navigation cursor carried verbatim (best-effort, never observed live).
+        assertEquals("16300", body["currentnum"])
+        assertEquals("someone", body["spseudo"])
+        assertEquals("", body["word"])
+    }
+
+    @Test
+    fun `searchInTopic raises SessionExpired when the authenticated POST lands on login`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(302).addHeader("Location", "/login.php"))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("<html>login</html>"))
+
+        val error = runCatching {
+            client.searchInTopic(
+                cat = 23,
+                topicId = 35395,
+                word = "x",
+                spseudo = "",
+                onlyMatches = true,
+                hashCheck = "tok",
+                firstnum = 1,
+            )
+        }.exceptionOrNull()
+
+        assertTrue("expected SessionExpiredException, got $error", error is SessionExpiredException)
+    }
+
+    @Test
     fun `removeFlag builds the delflag URL on the authenticated client mapping each type to owntopic`() = runTest {
         // owntopic discriminator: CYAN→1, RED→2, FAVORITE→3 (cf. Flag.kt / protocol-hfr.md).
         listOf(
@@ -362,6 +448,19 @@ class HfrClientTest {
             ?: throw AssertionError("expected HfrServerException, got $error")
         assertEquals(500, typed.code)
     }
+
+    /**
+     * Decodes an `application/x-www-form-urlencoded` POST body into a field map. A field absent from
+     * the body (e.g. an unchecked checkbox) is simply not a key — `map["filter"]` is then `null`.
+     */
+    private fun formFields(body: String): Map<String, String> =
+        body.split("&")
+            .filter { it.isNotEmpty() }
+            .associate { pair ->
+                val name = pair.substringBefore("=")
+                val value = pair.substringAfter("=", "")
+                java.net.URLDecoder.decode(name, "UTF-8") to java.net.URLDecoder.decode(value, "UTF-8")
+            }
 
     private fun taggedClient(tag: String): OkHttpClient =
         OkHttpClient.Builder()

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/HfrParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/HfrParser.kt
@@ -2,6 +2,7 @@ package fr.forumhfr.redface2.core.parser
 
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.Topic
+import fr.forumhfr.redface2.core.model.TopicSearchForm
 import fr.forumhfr.redface2.core.model.UserProfile
 import fr.forumhfr.redface2.core.parser.profile.ProfileParser
 
@@ -9,8 +10,17 @@ class HfrParser(
     private val topicPageParser: TopicPageParser = TopicPageParser(),
     private val bbcodeContentParser: BbcodeContentParser = BbcodeContentParser(),
     private val profileParser: ProfileParser = ProfileParser(),
+    private val topicSearchFormParser: TopicSearchFormParser = TopicSearchFormParser(),
 ) {
     fun parseTopicPage(html: String): Topic = topicPageParser.parse(html)
+
+    /**
+     * Chantier C (#546) — extracts the intra-topic search form (`transsearch.php`) hidden fields
+     * (`hash_check`, `post`, `cat`, `firstnum`, …) from a loaded topic page so the data layer can
+     * build the search POST. Returns `null` when the page carries no usable search form. The
+     * `transsearch` RESPONSE is itself a topic page and is re-parsed with [parseTopicPage].
+     */
+    fun parseTopicSearchForm(html: String): TopicSearchForm? = topicSearchFormParser.parse(html)
 
     /**
      * Phase 2 finish (#208) — parses a HFR user profile page (`/hfr/profil-{userId}.htm`)

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/TopicPageParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/TopicPageParser.kt
@@ -11,6 +11,7 @@ import org.jsoup.nodes.TextNode
 
 class TopicPageParser(
     private val postsParser: PostsParser = PostsParser(),
+    private val searchFormParser: TopicSearchFormParser = TopicSearchFormParser(),
 ) {
     fun parse(html: String): Topic {
         val document = Jsoup.parse(html)
@@ -57,6 +58,9 @@ class TopicPageParser(
             // column since v1.
             isFirstPostOwner = pageInfo.current == 1 && posts.firstOrNull()?.isEditable == true,
             poll = parsePoll(document),
+            // Chantier C (#546) — the intra-topic search form is part of THIS page ; parse it here so
+            // the ViewModel gets it for free on every live load. Null when absent ; not persisted.
+            searchForm = searchFormParser.parse(document),
         )
     }
 

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/TopicSearchFormParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/TopicSearchFormParser.kt
@@ -1,0 +1,64 @@
+package fr.forumhfr.redface2.core.parser
+
+import fr.forumhfr.redface2.core.model.TopicSearchForm
+import fr.forumhfr.redface2.core.parser.common.HfrSelectors
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+
+/**
+ * Chantier C (#546) — extracts the intra-topic search form (`transsearch.php`) hidden fields from a
+ * loaded topic page. The result feeds [fr.forumhfr.redface2.core.network.HfrClient.searchInTopic].
+ *
+ * The form is present on every topic page (authenticated, locked, logged-out, cat-IA), but its
+ * `hash_check` is only non-empty on an AUTHENTICATED capture (cf. [TopicSearchForm.canSearch]) —
+ * `transsearch.php` rejects a blank token. We still parse the form on an anonymous page so the
+ * caller can read `canSearch == false` and keep the affordance disabled, mirroring how
+ * `TopicPageParser` reads `canReply` from the reply-form presence.
+ *
+ * Every field lookup is scoped to the `transsearch` form element (not document-wide) because the
+ * topic page ships sibling `cat`/`post` inputs on the reply and fast-search forms.
+ */
+class TopicSearchFormParser {
+
+    /**
+     * @return the parsed [TopicSearchForm], or `null` when the page carries no `transsearch` form or
+     *   is missing one of its required ids (`post` / `cat` / `firstnum`). A `null` lets the caller
+     *   keep the intra-topic-search affordance hidden rather than crash a topic that lacks the form
+     *   (e.g. a synthetic / truncated cache row).
+     */
+    fun parse(html: String): TopicSearchForm? = parse(Jsoup.parse(html))
+
+    /**
+     * Document overload — lets [TopicPageParser] reuse its already-parsed [Document] instead of
+     * re-running Jsoup over the same HTML.
+     */
+    fun parse(document: Document): TopicSearchForm? =
+        document.selectFirst(HfrSelectors.TOPIC_SEARCH_FORM)?.let(::toForm)
+
+    /**
+     * Builds the model from the located form element, or `null` when any required id (`post` / `cat`
+     * / `firstnum`) is missing/unparsable. Single exit point keeps detekt's ReturnCount happy.
+     */
+    private fun toForm(form: Element): TopicSearchForm? {
+        val topicId = form.intValue(HfrSelectors.TOPIC_SEARCH_POST)
+        val cat = form.intValue(HfrSelectors.TOPIC_SEARCH_CAT)
+        val firstnum = form.intValue(HfrSelectors.TOPIC_SEARCH_FIRSTNUM)
+        return if (topicId == null || cat == null || firstnum == null) {
+            null
+        } else {
+            TopicSearchForm(
+                // An absent value attribute (a logged-out page renders `<input name="hash_check" />`
+                // without `value=`) is normalised to "" so `canSearch` reads false.
+                hashCheck = form.selectFirst(HfrSelectors.TOPIC_SEARCH_HASH_CHECK)?.attr("value").orEmpty(),
+                topicId = topicId,
+                cat = cat,
+                firstnum = firstnum,
+                owntopic = form.intValue(HfrSelectors.TOPIC_SEARCH_OWNTOPIC) ?: 0,
+            )
+        }
+    }
+
+    private fun Element.intValue(selector: String): Int? =
+        selectFirst(selector)?.attr("value")?.trim()?.toIntOrNull()
+}

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/common/HfrSelectors.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/common/HfrSelectors.kt
@@ -26,6 +26,18 @@ object HfrSelectors {
     const val POST_EDITED = "div.edited"
     const val POST_SIGNATURE = "span.signature"
 
+    // Chantier C (#546) — the intra-topic search form HFR renders in the topic-page header
+    // (`<form action="/transsearch.php" method="post">`). Its hidden inputs carry the anti-CSRF
+    // `hash_check`, the `(post, cat)` ids and the `firstnum` page anchor. We scope every field
+    // lookup to THIS form (not `input[name=cat]` document-wide) because the topic page also ships
+    // a `cat`/`post` input on the reply + fast-search forms.
+    const val TOPIC_SEARCH_FORM = "form[action*=transsearch.php]"
+    const val TOPIC_SEARCH_HASH_CHECK = "input[name=hash_check]"
+    const val TOPIC_SEARCH_POST = "input[name=post]"
+    const val TOPIC_SEARCH_CAT = "input[name=cat]"
+    const val TOPIC_SEARCH_FIRSTNUM = "input[name=firstnum]"
+    const val TOPIC_SEARCH_OWNTOPIC = "input[name=owntopic]"
+
     const val POLL = "div.sondage"
     const val POLL_QUESTION = "b.s2"
     const val POLL_OPTION_BAR = ".sondageLeft"

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/TopicPageParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/TopicPageParserTest.kt
@@ -820,6 +820,31 @@ class TopicPageParserTest {
         }
     }
 
+    // ─── intra-topic search form (#546) ──────────────────────────────────────────
+
+    @Test
+    fun `parsed topic surfaces the transsearch form with a usable hash_check when authenticated`() {
+        // Chantier C (#546) — the authenticated multipage capture carries a non-empty hash_check in
+        // its transsearch form, so the parsed Topic exposes a searchForm with canSearch=true.
+        val topic = parser.parse(fixture("topic_page_multipage.html"))
+
+        val form = requireNotNull(topic.searchForm)
+        assertEquals(21748, form.topicId)
+        assertEquals(23, form.cat)
+        assertEquals(520051, form.firstnum)
+        assertTrue("authenticated page ⇒ intra-topic search is available", form.canSearch)
+    }
+
+    @Test
+    fun `parsed topic searchForm is present but not usable on a logged-out page`() {
+        // Logged-out capture : the form ships with an empty hash_check, so canSearch=false (the
+        // affordance stays disabled until a live authenticated re-fetch).
+        val topic = parser.parse(fixture("topic_khakha_page_1.html"))
+
+        val form = requireNotNull(topic.searchForm)
+        assertFalse("empty hash_check ⇒ search not available", form.canSearch)
+    }
+
     private fun fixture(name: String): String {
         return requireNotNull(javaClass.getResource("/fixtures/$name")) {
             "Fixture not found: $name"

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/TopicSearchFormParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/TopicSearchFormParserTest.kt
@@ -1,0 +1,94 @@
+package fr.forumhfr.redface2.core.parser
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Chantier C (#546) — extraction of the intra-topic search form (`transsearch.php`) hidden fields
+ * from existing topic-page fixtures. The `transsearch` RESPONSE is never asserted here : it was
+ * NEVER captured live, so there is no response fixture to round-trip (see the class KDoc of
+ * `TopicSearchFormParser`). These tests cover only the request-side extraction the parser owns.
+ */
+class TopicSearchFormParserTest {
+    private val parser = TopicSearchFormParser()
+
+    @Test
+    fun `extracts hash_check, ids and firstnum from an authenticated multipage topic`() {
+        // `topic_page_multipage.html` is an authenticated capture : the transsearch form carries a
+        // non-empty (scrubbed) hash_check and the real ids/anchor (post=21748, cat=23, firstnum=520051).
+        val form = requireNotNull(parser.parse(fixture("topic_page_multipage.html")))
+
+        assertEquals(21748, form.topicId)
+        assertEquals(23, form.cat)
+        assertEquals(520051, form.firstnum)
+        assertEquals(0, form.owntopic)
+        assertTrue("non-empty hash_check ⇒ authenticated, search is allowed", form.hashCheck.isNotBlank())
+        assertTrue(form.canSearch)
+    }
+
+    @Test
+    fun `extracts the cat-IA owned-topic form with owntopic flag`() {
+        // `write_ia_topic_page.html` is the authenticated cat=32 « IA » capture : post=7, cat=32,
+        // owntopic=1, firstnum=16244 — proves owntopic is read verbatim (not assumed 0).
+        val form = requireNotNull(parser.parse(fixture("write_ia_topic_page.html")))
+
+        assertEquals(7, form.topicId)
+        assertEquals(32, form.cat)
+        assertEquals(16244, form.firstnum)
+        assertEquals(1, form.owntopic)
+        assertTrue(form.canSearch)
+    }
+
+    @Test
+    fun `canSearch is false on a logged-out topic page whose hash_check is empty`() {
+        // `topic_khakha_page_1.html` was captured logged-out : HFR still renders the transsearch
+        // form but with an empty hash_check, which `transsearch.php` rejects. The affordance must
+        // stay disabled (canSearch=false) while the ids are still extracted.
+        val form = requireNotNull(parser.parse(fixture("topic_khakha_page_1.html")))
+
+        assertEquals(84540, form.topicId)
+        assertEquals(13, form.cat)
+        assertTrue(form.firstnum > 0)
+        assertEquals("", form.hashCheck)
+        assertFalse("empty hash_check ⇒ search not available", form.canSearch)
+    }
+
+    @Test
+    fun `returns null when the page carries no transsearch form`() {
+        // A reply-only / synthetic page without the header search form must degrade to null so the
+        // caller hides the search affordance instead of crashing.
+        val html = """
+            <html><body>
+              <form action="/bddpost.php?config=hfr.inc">
+                <input type="hidden" name="cat" value="23" />
+                <input type="hidden" name="post" value="35395" />
+                <input type="hidden" name="subcat" value="550" />
+              </form>
+            </body></html>
+        """.trimIndent()
+
+        assertNull(parser.parse(html))
+    }
+
+    @Test
+    fun `returns null when the transsearch form is missing a required id`() {
+        // A transsearch form without `firstnum` is unusable for the search anchor : degrade to null.
+        val html = """
+            <html><body>
+              <form action="/transsearch.php" method="post">
+                <input type="hidden" name="hash_check" value="abc" />
+                <input type="hidden" name="post" value="35395" />
+                <input type="hidden" name="cat" value="23" />
+              </form>
+            </body></html>
+        """.trimIndent()
+
+        assertNull(parser.parse(html))
+    }
+
+    private fun fixture(name: String): String =
+        requireNotNull(javaClass.getResource("/fixtures/$name")) { "Fixture not found: $name" }.readText()
+}

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -102,9 +103,13 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 
 @Composable
-@Suppress("LongParameterList") // state-hoisted Composable : each callback has a distinct call-site
+// LongParameterList : state-hoisted Composable : each callback has a distinct call-site
 // (reply / quote / edit-post / edit-FP / openPage) and bundling them in a callbacks holder would
 // hide the navigation surface rather than simplify it.
+// CyclomaticComplexMethod : the one-shot effects `when` (scroll / refresh / delete / search) is a
+// flat dispatch table — every branch is a distinct, independent side effect ; splitting it would
+// scatter one logical sink (same stance as TopicContent / TopicLoadedContent).
+@Suppress("LongParameterList", "CyclomaticComplexMethod")
 fun TopicScreen(
     request: TopicRequest,
     /**
@@ -275,6 +280,8 @@ fun TopicScreen(
     val refreshFailedMsg = stringResource(R.string.topic_post_submit_refresh_failed)
     // #335 — manual pull-to-refresh failure message (resolved upfront, same rationale).
     val refreshManualFailedMsg = stringResource(R.string.topic_refresh_failed)
+    // Chantier C (#546) — intra-topic search failure message (resolved upfront, same rationale).
+    val searchFailedMsg = stringResource(R.string.topic_search_failed)
     // #292 — delete feedback messages, resolved upfront (same rationale as refreshFailedMsg).
     val deleteSuccessMsg = stringResource(R.string.topic_post_delete_success)
     val deleteFailedLoginMsg = stringResource(R.string.topic_post_delete_failed_login)
@@ -393,6 +400,15 @@ fun TopicScreen(
                     android.widget.Toast.makeText(
                         context,
                         message,
+                        android.widget.Toast.LENGTH_LONG,
+                    ).show()
+                }
+                TopicEffect.SearchFailed -> {
+                    // Chantier C (#546) — the transsearch POST failed; the normal page is restored by
+                    // the ViewModel and the Toast invites a retry.
+                    android.widget.Toast.makeText(
+                        context,
+                        searchFailedMsg,
                         android.widget.Toast.LENGTH_LONG,
                     ).show()
                 }
@@ -687,37 +703,15 @@ internal fun TopicContent(
             Modifier
         },
         topBar = {
-            TopAppBar(
-                title = {
-                    Column {
-                        Text(
-                            text = barTitle,
-                            style = MaterialTheme.typography.titleMedium,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                        Text(
-                            text = stringResource(R.string.topic_page_indicator, barCurrentPage, barTotalPages),
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                },
-                navigationIcon = {
-                    IconButton(
-                        onClick = onBack,
-                        modifier = Modifier.semantics { contentDescription = backLabel },
-                    ) {
-                        // #360 / ADR-015 — vector stroke unifié, dimensionné en dp (indépendant de la
-                        // police et de la baseline, contrairement à l'ancien glyphe « ← »), via le
-                        // primitive partagé :core:ui. L'étiquette a11y reste sur l'IconButton, donc
-                        // l'icône est décorative (contentDescription = null par défaut).
-                        RedfaceVectorIcon(
-                            resId = fr.forumhfr.redface2.core.ui.R.drawable.ic_arrow_back,
-                        )
-                    }
-                },
+            TopicTopBar(
+                state = state,
+                barTitle = barTitle,
+                barCurrentPage = barCurrentPage,
+                barTotalPages = barTotalPages,
+                backLabel = backLabel,
                 scrollBehavior = scrollBehavior,
+                onBack = onBack,
+                onIntent = onIntent,
             )
         },
         floatingActionButton = {
@@ -847,6 +841,156 @@ internal fun TopicContent(
                             )
                         }
                     }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * #285/#284 + Chantier C (#546) — the topic top app bar (title + page counter + back) plus the
+ * intra-topic search affordance : a search icon in `actions` (only when the loaded page exposes a
+ * usable, authenticated transsearch form) that opens the [TopicSearchBar] directly beneath the bar.
+ * Extracted from `TopicContent` to keep that builder under detekt's cyclomatic-complexity cap.
+ */
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+@Suppress("LongParameterList") // hoisted bar : title/page/back inputs + the search intent sink.
+private fun TopicTopBar(
+    state: TopicUiState,
+    barTitle: String,
+    barCurrentPage: Int,
+    barTotalPages: Int,
+    backLabel: String,
+    scrollBehavior: androidx.compose.material3.TopAppBarScrollBehavior?,
+    onBack: () -> Unit,
+    onIntent: (TopicIntent) -> Unit,
+) {
+    val searchLabel = stringResource(R.string.topic_search_open)
+    Column {
+        TopAppBar(
+            title = {
+                Column {
+                    Text(
+                        text = barTitle,
+                        style = MaterialTheme.typography.titleMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = stringResource(R.string.topic_page_indicator, barCurrentPage, barTotalPages),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            },
+            navigationIcon = {
+                IconButton(
+                    onClick = onBack,
+                    modifier = Modifier.semantics { contentDescription = backLabel },
+                ) {
+                    // #360 / ADR-015 — vector stroke unifié, dimensionné en dp (indépendant de la
+                    // police et de la baseline, contrairement à l'ancien glyphe « ← »), via le
+                    // primitive partagé :core:ui. L'étiquette a11y reste sur l'IconButton, donc
+                    // l'icône est décorative (contentDescription = null par défaut).
+                    RedfaceVectorIcon(
+                        resId = fr.forumhfr.redface2.core.ui.R.drawable.ic_arrow_back,
+                    )
+                }
+            },
+            actions = {
+                if (state.canSearchInTopic && !state.search.isActive) {
+                    IconButton(
+                        onClick = { onIntent(TopicIntent.OpenSearch) },
+                        modifier = Modifier.semantics { contentDescription = searchLabel },
+                    ) {
+                        RedfaceVectorIcon(resId = fr.forumhfr.redface2.core.ui.R.drawable.ic_search)
+                    }
+                }
+            },
+            scrollBehavior = scrollBehavior,
+        )
+        if (state.search.isActive) {
+            TopicSearchBar(search = state.search, onIntent = onIntent)
+        }
+    }
+}
+
+/**
+ * Chantier C (#546) — the intra-topic search bar, shown under the top app bar when search is active.
+ *
+ * Two fields (term / author) + a « Filtrer » toggle (HFR's `filter`, i.e. show only matching posts)
+ * + submit + close. Submitting POSTs `transsearch.php` ; the response (a topic page) replaces the
+ * loaded page. There is intentionally no next/previous control : the server-side `currentnum`
+ * cursor was never observed live, so result navigation is left out of the MVP rather than guessed
+ * (see the ViewModel / model KDoc — best-effort, not yet wired).
+ */
+@Composable
+private fun TopicSearchBar(
+    search: TopicSearchUiState,
+    onIntent: (TopicIntent) -> Unit,
+) {
+    val closeLabel = stringResource(R.string.topic_search_close)
+    Surface(
+        tonalElevation = 2.dp,
+        color = MaterialTheme.colorScheme.surface,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                OutlinedTextField(
+                    value = search.word,
+                    onValueChange = { onIntent(TopicIntent.SearchWordChanged(it)) },
+                    label = { Text(stringResource(R.string.topic_search_word_hint)) },
+                    singleLine = true,
+                    enabled = search.status != TopicSearchStatus.Loading,
+                    modifier = Modifier.weight(1f),
+                )
+                OutlinedTextField(
+                    value = search.spseudo,
+                    onValueChange = { onIntent(TopicIntent.SearchPseudoChanged(it)) },
+                    label = { Text(stringResource(R.string.topic_search_pseudo_hint)) },
+                    singleLine = true,
+                    enabled = search.status != TopicSearchStatus.Loading,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Checkbox(
+                    checked = search.onlyMatches,
+                    onCheckedChange = { onIntent(TopicIntent.SearchOnlyMatchesChanged(it)) },
+                    enabled = search.status != TopicSearchStatus.Loading,
+                )
+                Text(
+                    text = stringResource(R.string.topic_search_only_matches),
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier
+                        .weight(1f)
+                        .clickable(enabled = search.status != TopicSearchStatus.Loading) {
+                            onIntent(TopicIntent.SearchOnlyMatchesChanged(!search.onlyMatches))
+                        },
+                )
+                IconButton(
+                    onClick = { onIntent(TopicIntent.CloseSearch) },
+                    modifier = Modifier.semantics { contentDescription = closeLabel },
+                ) {
+                    RedfaceVectorIcon(resId = fr.forumhfr.redface2.core.ui.R.drawable.ic_close)
+                }
+                Button(
+                    onClick = { onIntent(TopicIntent.SubmitSearch) },
+                    enabled = search.canSubmit && search.status != TopicSearchStatus.Loading,
+                ) {
+                    Text(stringResource(R.string.topic_search_submit))
                 }
             }
         }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -59,6 +59,13 @@ data class TopicUiState(
      * the indicator stuck).
      */
     val isRefreshing: Boolean = false,
+    /**
+     * Chantier C (#546) — intra-topic search (HFR `transsearch.php`), a MODE of this screen. Holds
+     * the search bar visibility, the typed criteria and the search lifecycle. The matching topic
+     * page returned by HFR is surfaced through [Mode.Loaded] like any other page (`transsearch`
+     * answers a topic page), so there is no separate "results list" model here.
+     */
+    val search: TopicSearchUiState = TopicSearchUiState(),
 ) {
     /**
      * Helper used by the screen / ViewModel : `true` when the user has navigated to a
@@ -100,6 +107,15 @@ data class TopicUiState(
         ) : Mode
     }
 
+    /**
+     * Helper used by the screen : `true` when the loaded topic page exposes a usable intra-topic
+     * search form (authenticated, non-empty `hash_check`). Drives the search icon affordance,
+     * symmetric with the reply gate. The form is transient (never cached), so a cold cache row
+     * keeps search disabled until a live authenticated load.
+     */
+    val canSearchInTopic: Boolean
+        get() = (mode as? Mode.Loaded)?.topic?.searchForm?.canSearch == true
+
     companion object {
         fun initial(request: TopicRequest): TopicUiState =
             TopicUiState(
@@ -108,6 +124,36 @@ data class TopicUiState(
                 availablePages = emptyList(),
             )
     }
+}
+
+/**
+ * Chantier C (#546) — UI state for the intra-topic search mode.
+ *
+ * @property isActive whether the search bar is open. When `false`, [word] / [spseudo] are kept so
+ *   re-opening restores the last criteria, but no search is in effect.
+ * @property word the term field (HFR `word`).
+ * @property spseudo the author field (HFR `spseudo`).
+ * @property onlyMatches the « Filtrer » toggle — HFR's `filter` checkbox (only show matching posts).
+ * @property status the search lifecycle. Idle before the first submit ; Loading while the POST is in
+ *   flight ; Done once a `transsearch` page has been loaded into [TopicUiState.Mode.Loaded] (the
+ *   page itself carries the matches) ; Error on failure.
+ */
+data class TopicSearchUiState(
+    val isActive: Boolean = false,
+    val word: String = "",
+    val spseudo: String = "",
+    val onlyMatches: Boolean = true,
+    val status: TopicSearchStatus = TopicSearchStatus.Idle,
+) {
+    /** HFR needs at least a term or an author ; the submit button is disabled otherwise. */
+    val canSubmit: Boolean get() = word.isNotBlank() || spseudo.isNotBlank()
+}
+
+enum class TopicSearchStatus {
+    Idle,
+    Loading,
+    Done,
+    Error,
 }
 
 sealed interface TopicIntent {
@@ -133,6 +179,26 @@ sealed interface TopicIntent {
      * `BlacklistRepository`; the topic re-filters live through the page combine.
      */
     data class SetAuthorBlocked(val author: String, val blocked: Boolean) : TopicIntent
+
+    // ─── intra-topic search (#546) ───────────────────────────────────────────────
+
+    /** Open the search bar. No-op if the loaded page has no usable search form. */
+    data object OpenSearch : TopicIntent
+
+    /**
+     * Close the search bar AND clear any active search by reloading the normal current page. Keeps
+     * the typed criteria so re-opening restores them.
+     */
+    data object CloseSearch : TopicIntent
+
+    data class SearchWordChanged(val word: String) : TopicIntent
+
+    data class SearchPseudoChanged(val pseudo: String) : TopicIntent
+
+    data class SearchOnlyMatchesChanged(val onlyMatches: Boolean) : TopicIntent
+
+    /** Submit the intra-topic search (`POST transsearch.php`). */
+    data object SubmitSearch : TopicIntent
 }
 
 /**
@@ -220,4 +286,11 @@ sealed interface TopicEffect {
      * and leaves the post in place.
      */
     data class PostDeleteFailed(val reason: DeleteFailureReason) : TopicEffect
+
+    /**
+     * Chantier C (#546) — emitted when the intra-topic search (`transsearch.php`) failed to reach
+     * HFR or returned an unparsable page. The current page stays on screen ; the screen surfaces a
+     * Toast inviting a retry.
+     */
+    data object SearchFailed : TopicEffect
 }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -581,10 +581,19 @@ class TopicViewModel @AssistedInject constructor(
      * that is still on the wire is dropped on arrival. Called at the head of every normal-load path
      * (load / refresh / force-refresh / post-delete) so a stale search result can never overwrite a
      * more recent normal page (latest-wins strict).
+     *
+     * Also clears a `status == Loading` left dangling by the cancelled search: bumping the generation
+     * drops the reply, but [submitSearch]'s own `status = Done/Error` write is then guarded out, so
+     * without this reset the search bar would spin forever after a normal load took over. We reset to
+     * [TopicSearchStatus.Idle] only the Loading state — the bar stays open (`isActive` kept) with the
+     * typed criteria preserved so the user can retry; we never close the bar from here.
      */
     private fun takeOverFromSearch() {
         searchJob?.cancel()
         searchGeneration++
+        if (_state.value.search.status == TopicSearchStatus.Loading) {
+            _state.update { it.copy(search = it.search.copy(status = TopicSearchStatus.Idle)) }
+        }
     }
 
     /**

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -80,6 +80,16 @@ class TopicViewModel @AssistedInject constructor(
     private var searchJob: Job? = null
 
     /**
+     * Chantier C (#546) — monotonic token guarding against a stale `transsearch` write.
+     * Incremented whenever ANY flow that owns the page (a normal load, refresh, force-refresh,
+     * post-delete refetch or a new search) takes over. [submitSearch] snapshots it before the POST
+     * and only applies the returned page + final `search.status` while the token is still current —
+     * so a slow `transsearch` reply can never clobber a more recent normal page (latest-wins strict).
+     * Symmetric with cancelling [searchJob] at the head of every normal-load path.
+     */
+    private var searchGeneration: Int = 0
+
+    /**
      * Tracks whether the current value of [TopicRequest.scrollTo] has already been
      * dispatched to the screen as a [TopicEffect.ScrollToPost]. Once true, a subsequent
      * refresh of the same page will not re-scroll — the user may have scrolled away
@@ -198,6 +208,7 @@ class TopicViewModel @AssistedInject constructor(
      */
     private fun refresh() {
         if (_state.value.mode !is TopicUiState.Mode.Loaded || _state.value.isRefreshing) return
+        takeOverFromSearch()
         loadJob?.cancel()
         prefetchJob?.cancel()
         prefetchedPage = null
@@ -251,6 +262,7 @@ class TopicViewModel @AssistedInject constructor(
     }
 
     private fun loadCurrentPage() {
+        takeOverFromSearch()
         loadJob?.cancel()
         prefetchJob?.cancel()
         prefetchedPage = null
@@ -357,6 +369,7 @@ class TopicViewModel @AssistedInject constructor(
      * not an anonymous warmup escalating to authenticated.
      */
     private fun forceRefreshCurrentPage() {
+        takeOverFromSearch()
         loadJob?.cancel()
         prefetchJob?.cancel()
         prefetchedPage = null
@@ -513,6 +526,7 @@ class TopicViewModel @AssistedInject constructor(
      * user-confirmed deletion, not an anonymous warmup escalating to authenticated.
      */
     private fun refreshAfterDelete() {
+        takeOverFromSearch()
         loadJob?.cancel()
         prefetchJob?.cancel()
         prefetchedPage = null
@@ -553,17 +567,39 @@ class TopicViewModel @AssistedInject constructor(
      * actually applied (`status == Done`) to avoid a needless refetch on a cancel-before-submit.
      */
     private fun closeSearch() {
-        searchJob?.cancel()
         val hadResults = _state.value.search.status == TopicSearchStatus.Done
         _state.update {
             it.copy(search = it.search.copy(isActive = false, status = TopicSearchStatus.Idle))
         }
-        if (hadResults) loadCurrentPage()
+        // loadCurrentPage already cancels searchJob + bumps the generation (takeOverFromSearch). When
+        // there is nothing to reload, drop the in-flight search ourselves so a late reply can't write.
+        if (hadResults) loadCurrentPage() else takeOverFromSearch()
+    }
+
+    /**
+     * Cancel any in-flight intra-topic search and bump [searchGeneration] so a `transsearch` reply
+     * that is still on the wire is dropped on arrival. Called at the head of every normal-load path
+     * (load / refresh / force-refresh / post-delete) so a stale search result can never overwrite a
+     * more recent normal page (latest-wins strict).
+     */
+    private fun takeOverFromSearch() {
+        searchJob?.cancel()
+        searchGeneration++
     }
 
     /**
      * Submit the intra-topic search : `POST transsearch.php` (authenticated) with the parsed form +
      * the typed criteria, then render the returned topic page in [TopicUiState.Mode.Loaded].
+     *
+     * The current page STAYS visible while the POST is in flight — only `search.status` flips to
+     * [TopicSearchStatus.Loading] (the search bar shows the progress), per the documented contract
+     * ([TopicEffect.SearchFailed]'s KDoc : « the current page stays on screen »). We never switch the
+     * whole screen to [TopicUiState.Mode.Loading], which would blank the posts the user is reading.
+     *
+     * Latest-wins : a generation token is snapshotted before the POST (incremented by every normal-load
+     * path AND by a fresh submit through [searchJob]'s cancellation). The result page + final status
+     * are applied ONLY while that token is still current, so a slow `transsearch` reply that lost the
+     * race to a more recent normal page (refresh / page change / new search) is dropped, never written.
      *
      * Best-effort by contract : the `transsearch` response was never observed live, so we trust it
      * is a topic page and parse it as one — no result counter is promised. Server-side result
@@ -583,18 +619,22 @@ class TopicViewModel @AssistedInject constructor(
             onlyMatches = current.search.onlyMatches,
         )
         if (!request.isMeaningful) return
+        // Take over from any previous search and snapshot the generation this POST belongs to.
         searchJob?.cancel()
+        // Cancel the in-flight normal load / prefetch so a late `observeTopicPage` refresh emission
+        // cannot land on top of the filtered page this search is about to render. The screen keeps
+        // the page currently on display until the search reply (or its failure) settles.
         loadJob?.cancel()
         prefetchJob?.cancel()
-        _state.update {
-            it.copy(
-                mode = TopicUiState.Mode.Loading,
-                search = it.search.copy(status = TopicSearchStatus.Loading),
-            )
-        }
+        val generation = ++searchGeneration
+        // Stay on the loaded page — only drive the search status, never blank the posts.
+        _state.update { it.copy(search = it.search.copy(status = TopicSearchStatus.Loading)) }
         searchJob = viewModelScope.launch {
             try {
                 val topic = topicSearchRepository.searchInTopic(request)
+                // Drop a stale reply: a newer normal load / refresh / search bumped the generation
+                // while this POST was on the wire, so its page must not clobber the current one.
+                if (generation != searchGeneration) return@launch
                 _state.update {
                     it.copy(
                         mode = TopicUiState.Mode.Loaded(topic, computeHiddenNumreponses(topic, blockedCanonicals)),
@@ -608,10 +648,12 @@ class TopicViewModel @AssistedInject constructor(
                 throw cancellation
             } catch (@Suppress("TooGenericExceptionCaught") searchError: Exception) {
                 android.util.Log.w(LOG_TAG, "Intra-topic search failed", searchError)
+                // A stale failure must not stomp a fresher page's status either.
+                if (generation != searchGeneration) return@launch
                 _effects.send(TopicEffect.SearchFailed)
-                // Restore the normal page so the user is not stranded on a Loading screen.
+                // The current page is still on screen (we never left Mode.Loaded) — just mark the
+                // search as failed in the bar so the user can retry or close it.
                 _state.update { it.copy(search = it.search.copy(status = TopicSearchStatus.Error)) }
-                loadCurrentPage()
             }
         }
     }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -13,10 +13,12 @@ import fr.forumhfr.redface2.core.domain.blacklist.canonicalizePseudo
 import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.topic.TopicRepository
+import fr.forumhfr.redface2.core.domain.topic.TopicSearchRepository
 import fr.forumhfr.redface2.core.domain.write.DeletePostRepository
 import fr.forumhfr.redface2.core.domain.write.DeletePostResult
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.Topic
+import fr.forumhfr.redface2.core.model.TopicSearchRequest
 import fr.forumhfr.redface2.core.model.write.EditPostContext
 import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
 import kotlinx.coroutines.CancellationException
@@ -46,6 +48,7 @@ import kotlinx.coroutines.launch
  * synthetic chain of pages.
  */
 @HiltViewModel(assistedFactory = TopicViewModel.Factory::class)
+@Suppress("LongParameterList") // ViewModel aggregates its injected repositories; one per concern.
 class TopicViewModel @AssistedInject constructor(
     @Assisted private val request: TopicRequest,
     private val topicRepository: TopicRepository,
@@ -53,6 +56,7 @@ class TopicViewModel @AssistedInject constructor(
     private val userPreferencesRepository: UserPreferencesRepository,
     private val deletePostRepository: DeletePostRepository,
     private val blacklistRepository: BlacklistRepository,
+    private val topicSearchRepository: TopicSearchRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(TopicUiState.initial(request))
@@ -71,6 +75,9 @@ class TopicViewModel @AssistedInject constructor(
     private var loadJob: Job? = null
     private var prefetchJob: Job? = null
     private var prefetchedPage: Int? = null
+
+    /** Chantier C (#546) — at most one intra-topic search POST in flight at a time. */
+    private var searchJob: Job? = null
 
     /**
      * Tracks whether the current value of [TopicRequest.scrollTo] has already been
@@ -152,6 +159,15 @@ class TopicViewModel @AssistedInject constructor(
             is TopicIntent.DeletePost -> deletePost(intent.numreponse)
             TopicIntent.Refresh -> refresh()
             is TopicIntent.SetAuthorBlocked -> setAuthorBlocked(intent.author, intent.blocked)
+            TopicIntent.OpenSearch -> openSearch()
+            TopicIntent.CloseSearch -> closeSearch()
+            is TopicIntent.SearchWordChanged ->
+                _state.update { it.copy(search = it.search.copy(word = intent.word)) }
+            is TopicIntent.SearchPseudoChanged ->
+                _state.update { it.copy(search = it.search.copy(spseudo = intent.pseudo)) }
+            is TopicIntent.SearchOnlyMatchesChanged ->
+                _state.update { it.copy(search = it.search.copy(onlyMatches = intent.onlyMatches)) }
+            TopicIntent.SubmitSearch -> submitSearch()
         }
     }
 
@@ -514,6 +530,87 @@ class TopicViewModel @AssistedInject constructor(
                 throw cancellation
             } catch (@Suppress("TooGenericExceptionCaught") refreshError: Exception) {
                 android.util.Log.w(LOG_TAG, "Post-delete refresh failed", refreshError)
+                loadCurrentPage()
+            }
+        }
+    }
+
+    // ─── intra-topic search (#546) ───────────────────────────────────────────────
+
+    /**
+     * Open the search bar. No-op unless the loaded page exposes a usable search form
+     * ([TopicUiState.canSearchInTopic]) — the screen only shows the affordance in that case, but we
+     * re-check here so a stale tap can never open an inert bar.
+     */
+    private fun openSearch() {
+        if (!_state.value.canSearchInTopic) return
+        _state.update { it.copy(search = it.search.copy(isActive = true)) }
+    }
+
+    /**
+     * Close the search bar and drop any active filtered view by reloading the normal current page.
+     * The typed criteria are kept so re-opening restores them. We only reload when a search was
+     * actually applied (`status == Done`) to avoid a needless refetch on a cancel-before-submit.
+     */
+    private fun closeSearch() {
+        searchJob?.cancel()
+        val hadResults = _state.value.search.status == TopicSearchStatus.Done
+        _state.update {
+            it.copy(search = it.search.copy(isActive = false, status = TopicSearchStatus.Idle))
+        }
+        if (hadResults) loadCurrentPage()
+    }
+
+    /**
+     * Submit the intra-topic search : `POST transsearch.php` (authenticated) with the parsed form +
+     * the typed criteria, then render the returned topic page in [TopicUiState.Mode.Loaded].
+     *
+     * Best-effort by contract : the `transsearch` response was never observed live, so we trust it
+     * is a topic page and parse it as one — no result counter is promised. Server-side result
+     * navigation (HFR `currentnum`) is intentionally NOT wired yet : the cursor value is only known
+     * from a live response we have never captured, so navigating would guess. We surface the
+     * filtered page HFR returns and stop there (documented in the brief / model KDoc).
+     */
+    private fun submitSearch() {
+        val current = _state.value
+        val form = (current.mode as? TopicUiState.Mode.Loaded)?.topic?.searchForm
+        // Re-validate the gate server-side: never POST without a usable (authenticated) form.
+        if (form == null || !form.canSearch || !current.search.canSubmit) return
+        val request = TopicSearchRequest(
+            form = form,
+            word = current.search.word.trim(),
+            spseudo = current.search.spseudo.trim(),
+            onlyMatches = current.search.onlyMatches,
+        )
+        if (!request.isMeaningful) return
+        searchJob?.cancel()
+        loadJob?.cancel()
+        prefetchJob?.cancel()
+        _state.update {
+            it.copy(
+                mode = TopicUiState.Mode.Loading,
+                search = it.search.copy(status = TopicSearchStatus.Loading),
+            )
+        }
+        searchJob = viewModelScope.launch {
+            try {
+                val topic = topicSearchRepository.searchInTopic(request)
+                _state.update {
+                    it.copy(
+                        mode = TopicUiState.Mode.Loaded(topic, computeHiddenNumreponses(topic, blockedCanonicals)),
+                        // The transsearch response is a filtered/anchored view of the topic — its
+                        // pager is not the canonical topic pager, so we do NOT touch availablePages
+                        // (leaving the previously-known set) and never schedule a prefetch off it.
+                        search = it.search.copy(status = TopicSearchStatus.Done),
+                    )
+                }
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (@Suppress("TooGenericExceptionCaught") searchError: Exception) {
+                android.util.Log.w(LOG_TAG, "Intra-topic search failed", searchError)
+                _effects.send(TopicEffect.SearchFailed)
+                // Restore the normal page so the user is not stranded on a Loading screen.
+                _state.update { it.copy(search = it.search.copy(status = TopicSearchStatus.Error)) }
                 loadCurrentPage()
             }
         }

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -23,6 +23,14 @@
          the topic page has not loaded yet (or errored), so the bar never reads blank. -->
     <string name="topic_back">Retour</string>
     <string name="topic_topbar_fallback_title">Sujet</string>
+    <!-- Chantier C (#546) — recherche intra-sujet (transsearch.php). -->
+    <string name="topic_search_open">Rechercher dans le sujet</string>
+    <string name="topic_search_close">Fermer la recherche</string>
+    <string name="topic_search_word_hint">Mot</string>
+    <string name="topic_search_pseudo_hint">Pseudo</string>
+    <string name="topic_search_only_matches">Filtrer (résultats uniquement)</string>
+    <string name="topic_search_submit">Rechercher</string>
+    <string name="topic_search_failed">La recherche dans le sujet a échoué.</string>
     <string name="topic_error_title">Erreur de chargement</string>
     <string name="topic_error_body">Impossible d’ouvrir la page %1$d.\n\n%2$s</string>
     <string name="topic_caption">post %1$d • page %2$d / %3$d</string>

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -16,6 +16,9 @@ import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.topic.TopicRepository
+import fr.forumhfr.redface2.core.domain.topic.TopicSearchRepository
+import fr.forumhfr.redface2.core.model.TopicSearchForm
+import fr.forumhfr.redface2.core.model.TopicSearchRequest
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import fr.forumhfr.redface2.core.domain.write.DeletePostRepository
@@ -776,6 +779,102 @@ class TopicViewModelTest {
         }
     }
 
+    // ─── intra-topic search (#546) ───────────────────────────────────────────────
+
+    @Test
+    fun `OpenSearch is a no-op when the loaded page exposes no usable search form`() = runTest {
+        // No searchForm ⇒ canSearchInTopic=false ⇒ the bar must not open.
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+
+        viewModel.send(TopicIntent.OpenSearch)
+
+        assertEquals(false, viewModel.state.value.search.isActive)
+    }
+
+    @Test
+    fun `SubmitSearch posts the parsed form plus criteria and renders the returned page`() = runTest {
+        val form = TopicSearchForm(hashCheck = "tok", topicId = SAMPLE_POST, cat = SAMPLE_CAT, firstnum = 999)
+        val resultTopic = fakeTopic(page = 1, totalPages = 1, title = "filtered", searchForm = form)
+        val searchRepo = FakeTopicSearchRepository(result = resultTopic)
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(
+                flowsToReturn = listOf(flow { emit(fakeTopic(1, 5, searchForm = form)) }),
+            ),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            topicSearchRepository = searchRepo,
+        )
+
+        viewModel.send(TopicIntent.OpenSearch)
+        assertEquals(true, viewModel.state.value.search.isActive)
+        viewModel.send(TopicIntent.SearchWordChanged("betatest"))
+        viewModel.send(TopicIntent.SearchPseudoChanged("XaTriX"))
+        viewModel.send(TopicIntent.SubmitSearch)
+
+        assertEquals(1, searchRepo.requests.size)
+        val request = searchRepo.requests.single()
+        assertEquals("betatest", request.word)
+        assertEquals("XaTriX", request.spseudo)
+        assertEquals(true, request.onlyMatches)
+        assertEquals(form, request.form)
+        assertEquals(null, request.currentNum)
+        val loaded = assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value)
+        assertEquals("filtered", loaded.topic.title)
+        assertEquals(TopicSearchStatus.Done, viewModel.state.value.search.status)
+    }
+
+    @Test
+    fun `SubmitSearch does not POST when neither term nor author is set`() = runTest {
+        val form = TopicSearchForm(hashCheck = "tok", topicId = SAMPLE_POST, cat = SAMPLE_CAT, firstnum = 1)
+        val searchRepo = FakeTopicSearchRepository(result = fakeTopic(1, 1))
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(
+                flowsToReturn = listOf(flow { emit(fakeTopic(1, 1, searchForm = form)) }),
+            ),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            topicSearchRepository = searchRepo,
+        )
+
+        viewModel.send(TopicIntent.OpenSearch)
+        viewModel.send(TopicIntent.SubmitSearch)
+
+        assertEquals(0, searchRepo.requests.size)
+    }
+
+    @Test
+    fun `SubmitSearch failure restores the normal page and emits SearchFailed`() = runTest {
+        val form = TopicSearchForm(hashCheck = "tok", topicId = SAMPLE_POST, cat = SAMPLE_CAT, firstnum = 1)
+        val searchRepo = FakeTopicSearchRepository(error = IllegalStateException("boom"))
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(
+                flowsToReturn = listOf(
+                    flow { emit(fakeTopic(1, 3, searchForm = form)) },
+                    // The failure path falls back to loadCurrentPage() which re-collects the page.
+                    flow { emit(fakeTopic(1, 3, searchForm = form)) },
+                ),
+            ),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            topicSearchRepository = searchRepo,
+        )
+
+        viewModel.effects.test {
+            viewModel.send(TopicIntent.OpenSearch)
+            viewModel.send(TopicIntent.SearchWordChanged("x"))
+            viewModel.send(TopicIntent.SubmitSearch)
+
+            assertEquals(TopicEffect.SearchFailed, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        // The fallback restored a Loaded page (not stranded on Loading).
+        assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value)
+    }
+
     @Suppress("LongParameterList") // test factory mirroring the ViewModel's injected dependencies.
     private fun topicViewModel(
         request: TopicRequest,
@@ -784,6 +883,7 @@ class TopicViewModelTest {
         userPreferencesRepository: UserPreferencesRepository = FakeUserPreferencesRepository(),
         deletePostRepository: DeletePostRepository = FakeDeletePostRepository(),
         blacklistRepository: BlacklistRepository = FakeBlacklistRepository(),
+        topicSearchRepository: TopicSearchRepository = FakeTopicSearchRepository(),
     ): TopicViewModel = TopicViewModel(
         request = request,
         topicRepository = topicRepository,
@@ -791,6 +891,7 @@ class TopicViewModelTest {
         userPreferencesRepository = userPreferencesRepository,
         deletePostRepository = deletePostRepository,
         blacklistRepository = blacklistRepository,
+        topicSearchRepository = topicSearchRepository,
     )
 
     private fun topicRequest(
@@ -1285,12 +1386,14 @@ class TopicViewModelTest {
         )
     }
 
+    @Suppress("LongParameterList") // test builder mirroring the Topic model's fields, all defaulted.
     private fun fakeTopic(
         page: Int,
         totalPages: Int,
         title: String = "fake",
         posts: List<Post> = emptyList(),
         subcat: Int = SAMPLE_SUBCAT,
+        searchForm: TopicSearchForm? = null,
     ): Topic = Topic(
         cat = SAMPLE_CAT,
         post = SAMPLE_POST,
@@ -1304,6 +1407,7 @@ class TopicViewModelTest {
         // read-only topic (the previous default was the Topic model's `false`, never asserted here).
         canReply = true,
         poll = null,
+        searchForm = searchForm,
     )
 
     private fun fakePost(numreponse: Int, isEditable: Boolean = false, author: String = "tester"): Post = Post(
@@ -1428,6 +1532,23 @@ private class FakeBlacklistRepository(
 
     override suspend fun unblock(pseudo: String) {
         canonicals.value = canonicals.value - canonicalizePseudo(pseudo)
+    }
+}
+
+/**
+ * Chantier C (#546) — intra-topic search fake. Returns [result] on `searchInTopic`, or throws
+ * [error] when set, and records the request for assertions.
+ */
+private class FakeTopicSearchRepository(
+    private val result: Topic? = null,
+    private val error: Throwable? = null,
+) : TopicSearchRepository {
+    val requests = mutableListOf<TopicSearchRequest>()
+
+    override suspend fun searchInTopic(request: TopicSearchRequest): Topic {
+        requests += request
+        error?.let { throw it }
+        return result ?: error("FakeTopicSearchRepository has no result configured")
     }
 }
 

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -847,17 +847,15 @@ class TopicViewModelTest {
     }
 
     @Test
-    fun `SubmitSearch failure restores the normal page and emits SearchFailed`() = runTest {
+    fun `SubmitSearch failure keeps the current page and emits SearchFailed`() = runTest {
         val form = TopicSearchForm(hashCheck = "tok", topicId = SAMPLE_POST, cat = SAMPLE_CAT, firstnum = 1)
         val searchRepo = FakeTopicSearchRepository(error = IllegalStateException("boom"))
         val viewModel = topicViewModel(
             request = topicRequest(page = 1),
             topicRepository = FakeTopicRepository(
-                flowsToReturn = listOf(
-                    flow { emit(fakeTopic(1, 3, searchForm = form)) },
-                    // The failure path falls back to loadCurrentPage() which re-collects the page.
-                    flow { emit(fakeTopic(1, 3, searchForm = form)) },
-                ),
+                // A single flow: the failure path never switches to Mode.Loading and never reloads the
+                // page — the page on screen is kept as-is, so observeTopicPage is collected only once.
+                flowsToReturn = listOf(flow { emit(fakeTopic(1, 3, title = "loaded", searchForm = form)) }),
             ),
             authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
             topicSearchRepository = searchRepo,
@@ -871,8 +869,60 @@ class TopicViewModelTest {
             assertEquals(TopicEffect.SearchFailed, awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
-        // The fallback restored a Loaded page (not stranded on Loading).
-        assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value)
+        // The page the user was reading stays on screen (never stranded on Loading, never reloaded).
+        val loaded = assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value)
+        assertEquals("loaded", loaded.topic.title)
+        // #546 finding #4 — the search bar reflects the failure and stays open so the user can retry
+        // or close it; the status settles on Error rather than back to Idle / Loading.
+        assertEquals(TopicSearchStatus.Error, viewModel.state.value.search.status)
+        assertTrue(
+            "the search bar stays open after a failure so the user can retry",
+            viewModel.state.value.search.isActive,
+        )
+    }
+
+    @Test
+    fun `a stale SubmitSearch reply never clobbers a more recent normal page (#546)`() = runTest {
+        // #546 finding #1 (latest-wins) — a search POST is on the wire when the user pulls to refresh.
+        // The refresh (a normal-load path) bumps the search generation, so when the slow transsearch
+        // reply finally lands it must be DROPPED, never overwrite the freshly-refreshed page.
+        val form = TopicSearchForm(hashCheck = "tok", topicId = SAMPLE_POST, cat = SAMPLE_CAT, firstnum = 1)
+        val loaded = fakeTopic(page = 1, totalPages = 3, title = "loaded", searchForm = form)
+        val refreshed = fakeTopic(page = 1, totalPages = 3, title = "refreshed", searchForm = form)
+        // The (now stale) search result, would-be title if the guard were missing.
+        val staleSearch = fakeTopic(page = 1, totalPages = 1, title = "stale-search", searchForm = form)
+        val searchRepo = FakeTopicSearchRepository(result = staleSearch)
+        val gate = CompletableDeferred<Unit>()
+        searchRepo.gate = { gate.await() }
+        val repository = FakeTopicRepository(
+            flowsToReturn = listOf(flow { emit(loaded) }),
+            refreshTopicsToReturn = listOf(refreshed),
+        )
+
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            topicSearchRepository = searchRepo,
+        )
+
+        viewModel.send(TopicIntent.OpenSearch)
+        viewModel.send(TopicIntent.SearchWordChanged("x"))
+        viewModel.send(TopicIntent.SubmitSearch) // suspends in the gate → search in flight
+        assertEquals(TopicSearchStatus.Loading, viewModel.state.value.search.status)
+
+        // A normal-load path takes over while the search is still on the wire.
+        viewModel.send(TopicIntent.Refresh)
+        assertEquals(
+            "the refresh wins, not the stale search",
+            "refreshed",
+            (viewModel.state.value.mode as TopicUiState.Mode.Loaded).topic.title,
+        )
+
+        // Release the slow search reply: the generation moved on, so its page is discarded.
+        gate.complete(Unit)
+        val finalMode = assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value)
+        assertEquals("the stale search reply must not clobber the refreshed page", "refreshed", finalMode.topic.title)
     }
 
     @Suppress("LongParameterList") // test factory mirroring the ViewModel's injected dependencies.
@@ -1545,8 +1595,15 @@ private class FakeTopicSearchRepository(
 ) : TopicSearchRepository {
     val requests = mutableListOf<TopicSearchRequest>()
 
+    /**
+     * Optional gate to suspend inside `searchInTopic` so a test can hold the `transsearch` reply
+     * in flight, drive a competing normal-load path, then release it to prove the stale-write guard.
+     */
+    var gate: (suspend () -> Unit)? = null
+
     override suspend fun searchInTopic(request: TopicSearchRequest): Topic {
         requests += request
+        gate?.invoke()
         error?.let { throw it }
         return result ?: error("FakeTopicSearchRepository has no result configured")
     }

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -36,6 +36,7 @@ import java.net.UnknownHostException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -45,6 +46,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -894,6 +896,11 @@ class TopicViewModelTest {
         val searchRepo = FakeTopicSearchRepository(result = staleSearch)
         val gate = CompletableDeferred<Unit>()
         searchRepo.gate = { gate.await() }
+        // Non-cooperative wait: cancelling searchJob (the refresh taking over) must NOT cut the await,
+        // so the fake truly DELIVERS staleSearch after the refresh. This is what forces the result
+        // through the `generation` guard — with a cancellable await the reply would never be produced
+        // and the test would stay green even if the guard were deleted.
+        searchRepo.ignoreCancellation = true
         val repository = FakeTopicRepository(
             flowsToReturn = listOf(flow { emit(loaded) }),
             refreshTopicsToReturn = listOf(refreshed),
@@ -918,11 +925,27 @@ class TopicViewModelTest {
             "refreshed",
             (viewModel.state.value.mode as TopicUiState.Mode.Loaded).topic.title,
         )
+        // Fix 1 — the takeover clears the dangling Loading spinner instead of leaving it stuck (the
+        // search reply will be guarded out, so submitSearch never writes its own Done/Error status).
+        assertEquals(
+            "the dangling search spinner is cleared by the takeover, not left spinning",
+            TopicSearchStatus.Idle,
+            viewModel.state.value.search.status,
+        )
 
-        // Release the slow search reply: the generation moved on, so its page is discarded.
+        // Release the slow search reply: it IS produced (non-cancellable await) but the generation
+        // moved on, so the guard discards it. Without `generation != searchGeneration` the line below
+        // would clobber the refreshed page with "stale-search" and flip the status back to Done.
         gate.complete(Unit)
         val finalMode = assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value)
         assertEquals("the stale search reply must not clobber the refreshed page", "refreshed", finalMode.topic.title)
+        // The stale reply must not rewrite the search status either (it stays at the takeover's Idle,
+        // never re-flipped to Done by the dropped reply).
+        assertEquals(
+            "the dropped stale reply must not rewrite the search status",
+            TopicSearchStatus.Idle,
+            viewModel.state.value.search.status,
+        )
     }
 
     @Suppress("LongParameterList") // test factory mirroring the ViewModel's injected dependencies.
@@ -1601,9 +1624,18 @@ private class FakeTopicSearchRepository(
      */
     var gate: (suspend () -> Unit)? = null
 
+    /**
+     * When `true`, the [gate] wait is run under [NonCancellable] so that cancelling [searchJob] (a
+     * normal-load path taking over) does NOT short-circuit the await. The fake then truly returns its
+     * (now stale) [result] AFTER the competing refresh — the only setup that actually exercises the
+     * `generation != searchGeneration` guard in `submitSearch`. Without this the await is cancellable,
+     * the reply is never produced, and the test would pass even with the guard removed.
+     */
+    var ignoreCancellation: Boolean = false
+
     override suspend fun searchInTopic(request: TopicSearchRequest): Topic {
         requests += request
-        gate?.invoke()
+        gate?.let { g -> if (ignoreCancellation) withContext(NonCancellable) { g() } else g() }
         error?.let { throw it }
         return result ?: error("FakeTopicSearchRepository has no result configured")
     }


### PR DESCRIPTION
Travail de nuit — chantier C. Recherche **dans le topic courant** via la fonction HFR `transsearch.php` (mot / pseudo / filtre).

## Implémentation
- **Mode de `feature/topic`** (pas une extension de `feature/search`). `POST /transsearch.php` **authentifié** (besoin du `hash_check`) ; la réponse **est une page topic** → reparsée via le `TopicPageParser` existant et rendue via `Mode.Loaded`. `filter=1` (« n'afficher que les correspondances ») piloté par un toggle.
- Nouveau : `TopicSearchForm`/`TopicSearchRequest` (model), `TopicSearchFormParser` (extrait `hash_check`+`firstnum` de la page topic, testé sur fixtures existantes), `HfrClient.searchInTopic(...)`, `TopicSearchRepository`(+impl), `TopicSearchUiState` + intents dans `TopicViewModel`, UI (icône recherche dans la top bar gated `canSearchInTopic` + barre mot/pseudo/Filtrer).
- `Topic.searchForm` = champ **transient** (non persisté Room).

## Robustesse (review Codex en 3 passes)
- **Anti stale-write** : `searchGeneration` + `takeOverFromSearch()` (annule `searchJob` + bump génération dans tous les flux de chargement normal) ; `submitSearch` capture la génération avant le POST et n'applique page/status QUE si courante. Test race **prouvé probant** par mutation (retirer le garde → le test casse).
- Page courante **conservée** pendant la recherche (`Mode.Loaded` + `search.status=Loading`, jamais blanchie) ; échec → page gardée + `SearchFailed` + status `Error` ; takeover → status remis `Idle` (pas de spinner bloqué).
- Privacy : `word`/`spseudo`/`hash_check` jamais loggés (test anti-régression sentinelles).

## ⚠️ Non observé live (best-effort)
La réponse `transsearch` n'a **jamais** été capturée (device down) : aucune fixture de réponse, **aucun round-trip testé** — on fait confiance au contrat « c'est une page topic ». La **navigation suivant/précédent (`currentnum`) est volontairement NON câblée** (param présent + testé, pas d'UI) : à finir quand une vraie réponse sera observée.

## Validation
`:feature:topic:testDebugUnitTest` + `:core:parser:test` + `:core:network:test` + `:core:data:testDebugUnitTest` + `:app:testDevDebugUnitTest` + `:app:assembleDevDebug` + `detektAll` + `lintDebug` verts. Revue Codex (gpt-5.5, xhigh) **×3 passes** : 0 bloquant après correctifs.

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)