### PR TITLE
feat(mpstorage): mécanique d'écriture v1 (RMW guardée, POST différé — non observé live)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepository.kt
@@ -8,8 +8,13 @@ import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageLocation
 import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageLocationStore
 import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
 import fr.forumhfr.redface2.core.model.AuthState
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageDocument
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageFlagEntry
 import fr.forumhfr.redface2.core.model.mpstorage.MpStorageResult
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageWriteResult
+import fr.forumhfr.redface2.core.model.write.ReplyForm
 import fr.forumhfr.redface2.core.network.HfrClient
+import fr.forumhfr.redface2.core.network.HfrConstants
 import fr.forumhfr.redface2.core.parser.messages.PrivateMessageListParser
 import fr.forumhfr.redface2.core.parser.mpstorage.MpStorageParser
 import fr.forumhfr.redface2.core.parser.messages.PrivateMessageThreadParser
@@ -20,6 +25,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
+import okhttp3.FormBody
 
 /**
  * Default [MpStorageRepository] (#6, ADR-014) — read-only, zero writes.
@@ -51,6 +57,7 @@ class DefaultMpStorageRepository @Inject constructor(
     private val threadParser: PrivateMessageThreadParser,
     private val replyFormParser: ReplyFormParser,
     private val storageParser: MpStorageParser,
+    private val envelopeWriter: MpStorageEnvelopeWriter,
     private val locationStore: MpStorageLocationStore,
     private val authRepository: AuthRepository,
     private val diagnostics: DiagnosticsLog,
@@ -115,6 +122,177 @@ class DefaultMpStorageRepository @Inject constructor(
                 "fetchStorage FAILED: ${error::class.simpleName}",
             )
             throw error
+        }
+    }
+
+    /**
+     * WRITE path (#6, ADR-014 §4) — GUARDED, NOT OBSERVED LIVE.
+     *
+     * Locates the storage document (same deterministic discovery as [fetchStorage] : cached location,
+     * else inbox scan for the conversation whose subject is EXACTLY [MpStorageRepository.STORAGE_SUBJECT_HASH]),
+     * reads its first-post edit form, runs the read-modify-write on the RAW JSON tree
+     * ([MpStorageEnvelopeWriter] — third-party namespaces preserved), enforces the
+     * [MpStorageRepository.MAX_CONTENT_FORM_BYTES] cap, and builds the `bdd.php cat=prive` POST body.
+     *
+     * GUARD : [dryRun] defaults to `true` → the POST is NEVER sent (the body is built & validated only).
+     * Nothing in the app calls this with `dryRun = false`, and there is no UI trigger — the
+     * `bdd.php cat=prive` write contract is unconfirmed (device down). A located-but-unreadable document
+     * or a [MpStorageWriteResult.TargetNotFound] is surfaced, NEVER repaired / created (ADR-014 §3 :
+     * creating a fresh document would fork the cross-userscript storage).
+     */
+    @Suppress("ReturnCount") // Guard clauses (auth / not-found / unreadable / oversize) + the prepared return.
+    override suspend fun writeBackFlag(entry: MpStorageFlagEntry, dryRun: Boolean): MpStorageWriteResult {
+        return withContext(ioDispatcher) {
+            val owner = activePseudo()
+                ?: return@withContext MpStorageWriteResult.TargetNotFound
+
+            val location = locateForWrite(owner)
+                ?: return@withContext MpStorageWriteResult.TargetNotFound
+            val read = readFormAndDocument(location)
+                ?: return@withContext MpStorageWriteResult.TargetNotFound
+            val document = read.document
+                ?: return@withContext MpStorageWriteResult.TargetUnreadable
+
+            when (val outcome = envelopeWriter.upsertFlag(document.rawEnvelope, entry)) {
+                MpStorageEnvelopeWriter.Outcome.NotJsonEnvelope ->
+                    // Defensive : the parser already accepted it, so this should not happen — but if the
+                    // raw text is somehow not a JSON object we surface it, never overwrite (ADR-014 §3).
+                    MpStorageWriteResult.TargetUnreadable
+
+                is MpStorageEnvelopeWriter.Outcome.TooLarge -> {
+                    val cap = MpStorageRepository.MAX_CONTENT_FORM_BYTES
+                    diagnostics.record(
+                        DiagnosticsLog.Level.WARN,
+                        LOG_TAG,
+                        "writeBackFlag oversize: ${outcome.sizeBytes} bytes > $cap",
+                    )
+                    MpStorageWriteResult.TooLarge(outcome.sizeBytes)
+                }
+
+                is MpStorageEnvelopeWriter.Outcome.Mutated ->
+                    prepareAndMaybePost(location, read.form, outcome.body, dryRun)
+            }
+        }
+    }
+
+    /**
+     * Builds the `bdd.php cat=prive` [FormBody] from the mutated [body] and the parsed [form], then —
+     * ONLY when [dryRun] is `false` — POSTs it. By default ([dryRun] = `true`) NO request is sent : the
+     * body is built and validated, and [MpStorageWriteResult.Prepared] carries `posted = false`.
+     * The live POST branch is unconfirmed (NOT OBSERVED LIVE).
+     */
+    private suspend fun prepareAndMaybePost(
+        location: MpStorageLocation,
+        form: ReplyForm,
+        body: String,
+        dryRun: Boolean,
+    ): MpStorageWriteResult {
+        val formBody = buildPrivateMessageEditBody(location, form, body)
+        if (dryRun) {
+            diagnostics.record(
+                DiagnosticsLog.Level.INFO,
+                LOG_TAG,
+                "writeBackFlag dryRun: body built (${body.length} chars), POST skipped — not observed live",
+            )
+            return MpStorageWriteResult.Prepared(body = body, posted = false)
+        }
+        // GUARDED branch — reached only with dryRun=false, which nothing in the app sets. The
+        // bdd.php cat=prive write contract is unconfirmed; the response is intentionally NOT parsed
+        // here (no live success/error capture). Surfaced as Prepared(posted = true).
+        hfrClient.submitPrivateMessageEdit(formBody)
+        diagnostics.record(DiagnosticsLog.Level.WARN, LOG_TAG, "writeBackFlag POSTED (live, unconfirmed contract)")
+        return MpStorageWriteResult.Prepared(body = body, posted = true)
+    }
+
+    /**
+     * The `bdd.php cat=prive` POST body. Mirrors [fr.forumhfr.redface2.core.data.write.DefaultEditPostRepository]'s
+     * edit body, with TWO deliberate differences :
+     *  - `cat` is the String `"prive"` (the storage post lives under the private-message category ;
+     *    the public edit flow passes an Int) — this is the whole reason for the dedicated wire method ;
+     *  - `content_form` is the mutated JSON document, not user BBCode.
+     * `numreponse` targets the storage first post, `numrep` stays empty, `sujet` / `hash_check` /
+     * `verifrequet` / the preserved hidden fields come from the parsed edit form. `password` and
+     * `delete` are hard-denied (never resend the deletion checkbox).
+     */
+    private fun buildPrivateMessageEditBody(
+        location: MpStorageLocation,
+        form: ReplyForm,
+        contentForm: String,
+    ): FormBody {
+        val builder = FormBody.Builder(Charsets.UTF_8)
+        val emitted = mutableSetOf<String>()
+        val overrides = buildMap {
+            put("hash_check", form.hashCheck)
+            put("verifrequet", HfrConstants.VERIF_REQUET)
+            put("content_form", contentForm)
+            put("numreponse", location.numreponse.toString())
+            put("numrep", "")
+            // The private-message discriminator — String, unlike the public edit flow's Int cat.
+            put("cat", "prive")
+            put("post", location.threadId.toString())
+            put("page", "1")
+            put("sujet", form.sujet)
+            form.msgIcon?.let { put("MsgIcon", it) }
+        }
+        overrides.forEach { (key, value) ->
+            builder.add(key, value)
+            emitted += key
+        }
+        form.hiddenFields.forEach { (key, value) ->
+            if (key in emitted) return@forEach
+            // Hard deny: never resend `password` (defence-in-depth; the parser already filters it)
+            // nor the `delete=1` checkbox the edit form ships (deletion is destructive, out of scope).
+            if (key == "password" || key == "delete") return@forEach
+            builder.add(key, value)
+            emitted += key
+        }
+        return builder.build()
+    }
+
+    /** Reading the storage edit form for the write path : the form + the parsed document (null = unreadable). */
+    private data class WriteRead(val form: ReplyForm, val document: MpStorageDocument?)
+
+    /**
+     * GETs and parses the storage first-post edit form at [location] for the WRITE path, returning the
+     * [ReplyForm] (for hash_check / sujet / hidden fields) plus the parsed [MpStorageDocument] (null when
+     * the body is not a readable v0.1 envelope — surfaced as unreadable, never repaired). Returns `null`
+     * when the edit form itself cannot be obtained (stale location). Throws [SessionExpiredException] on
+     * an anonymous composer.
+     */
+    private suspend fun readFormAndDocument(location: MpStorageLocation): WriteRead? {
+        val form = replyFormParser
+            .parse(hfrClient.getPrivateMessageEditForm(location.threadId, location.numreponse))
+            .getOrElse { error ->
+                diagnostics.record(
+                    DiagnosticsLog.Level.WARN,
+                    LOG_TAG,
+                    "write edit form parse FAILED: ${error::class.simpleName}",
+                )
+                return null
+            }
+        if (form.isAnonymous) {
+            throw SessionExpiredException("MPStorage write edit form served anonymous composer")
+        }
+        val document = storageParser.parse(form.initialContent).getOrNull()
+        return WriteRead(form = form, document = document)
+    }
+
+    /**
+     * Resolves the storage location for the write path : the cached id if present, else a fresh inbox
+     * scan (caching the discovery). Returns `null` when the account has no storage MP at all
+     * (deterministic exact-hash miss → the caller maps it to [MpStorageWriteResult.TargetNotFound],
+     * NEVER a creation — ADR-014 §3).
+     */
+    private suspend fun locateForWrite(owner: String): MpStorageLocation? {
+        locationStore.read(owner)?.let { return it }
+        return when (val discovery = discoverByInboxScan()) {
+            is Discovery.Located -> discovery.location.also {
+                locationStore.save(owner, it.threadId, it.numreponse)
+            }
+            // HitUnreadable = the conversation exists but its first post is unreachable. There is no
+            // numreponse to address an edit, so the write has no valid target — treat as not-found
+            // for the write path (still never creates a document).
+            Discovery.HitUnreadable, Discovery.Absent -> null
         }
     }
 

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepository.kt
@@ -134,14 +134,26 @@ class DefaultMpStorageRepository @Inject constructor(
      * ([MpStorageEnvelopeWriter] — third-party namespaces preserved), enforces the
      * [MpStorageRepository.MAX_CONTENT_FORM_BYTES] cap, and builds the `bdd.php cat=prive` POST body.
      *
-     * GUARD : [dryRun] defaults to `true` → the POST is NEVER sent (the body is built & validated only).
-     * Nothing in the app calls this with `dryRun = false`, and there is no UI trigger — the
-     * `bdd.php cat=prive` write contract is unconfirmed (device down). A located-but-unreadable document
-     * or a [MpStorageWriteResult.TargetNotFound] is surfaced, NEVER repaired / created (ADR-014 §3 :
-     * creating a fresh document would fork the cross-userscript storage).
+     * GUARD (structural, Codex review) : the public [writeBackFlag] runs with [post] = `false` → the POST is
+     * NEVER sent (body built & validated only). The live POST is reachable ONLY through the module-internal,
+     * test-only [writeBackFlagLive] — it is NOT on the public interface, so app/prod code cannot flip it. The
+     * `bdd.php cat=prive` write contract is unconfirmed (device down). A located-but-unreadable document or a
+     * [MpStorageWriteResult.TargetNotFound] is surfaced, NEVER repaired / created (ADR-014 §3 : creating a
+     * fresh document would fork the cross-userscript storage).
      */
+    override suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult =
+        runWriteBack(entry, post = false)
+
+    /**
+     * Module-INTERNAL, TEST-ONLY live POST path — deliberately NOT on the [MpStorageRepository] interface
+     * so app/prod code cannot reach it (Codex review : the guard is structural, not a default parameter).
+     * The `bdd.php cat=prive` write contract is unconfirmed — NOT OBSERVED LIVE.
+     */
+    internal suspend fun writeBackFlagLive(entry: MpStorageFlagEntry): MpStorageWriteResult =
+        runWriteBack(entry, post = true)
+
     @Suppress("ReturnCount") // Guard clauses (auth / not-found / unreadable / oversize) + the prepared return.
-    override suspend fun writeBackFlag(entry: MpStorageFlagEntry, dryRun: Boolean): MpStorageWriteResult {
+    private suspend fun runWriteBack(entry: MpStorageFlagEntry, post: Boolean): MpStorageWriteResult {
         return withContext(ioDispatcher) {
             val owner = activePseudo()
                 ?: return@withContext MpStorageWriteResult.TargetNotFound
@@ -170,35 +182,35 @@ class DefaultMpStorageRepository @Inject constructor(
                 }
 
                 is MpStorageEnvelopeWriter.Outcome.Mutated ->
-                    prepareAndMaybePost(location, read.form, outcome.body, dryRun)
+                    prepareAndMaybePost(location, read.form, outcome.body, post)
             }
         }
     }
 
     /**
      * Builds the `bdd.php cat=prive` [FormBody] from the mutated [body] and the parsed [form], then —
-     * ONLY when [dryRun] is `false` — POSTs it. By default ([dryRun] = `true`) NO request is sent : the
-     * body is built and validated, and [MpStorageWriteResult.Prepared] carries `posted = false`.
-     * The live POST branch is unconfirmed (NOT OBSERVED LIVE).
+     * ONLY when [post] is `true` (the internal test-only path) — POSTs it. From the public [writeBackFlag]
+     * ([post] = `false`) NO request is sent : the body is built and validated, and
+     * [MpStorageWriteResult.Prepared] carries `posted = false`. The live POST branch is NOT OBSERVED LIVE.
      */
     private suspend fun prepareAndMaybePost(
         location: MpStorageLocation,
         form: ReplyForm,
         body: String,
-        dryRun: Boolean,
+        post: Boolean,
     ): MpStorageWriteResult {
         val formBody = buildPrivateMessageEditBody(location, form, body)
-        if (dryRun) {
+        if (!post) {
             diagnostics.record(
                 DiagnosticsLog.Level.INFO,
                 LOG_TAG,
-                "writeBackFlag dryRun: body built (${body.length} chars), POST skipped — not observed live",
+                "writeBackFlag dry-run: body built (${body.length} chars), POST skipped — not observed live",
             )
             return MpStorageWriteResult.Prepared(body = body, posted = false)
         }
-        // GUARDED branch — reached only with dryRun=false, which nothing in the app sets. The
-        // bdd.php cat=prive write contract is unconfirmed; the response is intentionally NOT parsed
-        // here (no live success/error capture). Surfaced as Prepared(posted = true).
+        // GUARDED branch — reached only via the internal writeBackFlagLive (tests). The bdd.php cat=prive
+        // write contract is unconfirmed; the response is intentionally NOT parsed here (no live
+        // success/error capture). Surfaced as Prepared(posted = true).
         hfrClient.submitPrivateMessageEdit(formBody)
         diagnostics.record(DiagnosticsLog.Level.WARN, LOG_TAG, "writeBackFlag POSTED (live, unconfirmed contract)")
         return MpStorageWriteResult.Prepared(body = body, posted = true)

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/MpStorageEnvelopeWriter.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/MpStorageEnvelopeWriter.kt
@@ -1,0 +1,161 @@
+package fr.forumhfr.redface2.core.data.mpstorage
+
+import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageFlagEntry
+import javax.inject.Inject
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * MPStorage (#6, ADR-014 §4) — the read-modify-WRITE core, kept as a pure, side-effect-free
+ * transform so it is the part with the real test value (Codex : parser/RMW > UI).
+ *
+ * It MUTATES THE RAW JSON TREE of [fr.forumhfr.redface2.core.model.mpstorage.MpStorageDocument.rawEnvelope]
+ * — it NEVER rebuilds the envelope from the projected `MpStorageDocument` model (the parser projects,
+ * it does not reconstruct ; rebuilding from the model would silently drop every key Redface 2 does not
+ * consume). Concretely : parse the verbatim text into a [JsonObject], walk to the v0.1 `data[]` entry's
+ * `mpFlags.list[]`, upsert one entry, and re-serialise. Every key it does not touch — third-party
+ * top-level keys (`sourceName`, `lastUpdate`, `hfr4k`, …), sibling `data[]` entries (a `version != 0.1`
+ * entry written by another tool), and unknown keys WITHIN the v0.1 entry or within a list item — is
+ * carried through untouched.
+ *
+ * NOT OBSERVED LIVE : the bytes produced here have never been round-tripped against a real HFR
+ * `bdd.php cat=prive` POST (device down). The output is validated against
+ * [MpStorageRepository.MAX_CONTENT_FORM_BYTES] (fail-closed) ; whether HFR accepts it is unconfirmed.
+ */
+class MpStorageEnvelopeWriter @Inject constructor() {
+
+    /**
+     * Compact, stable serialiser. The envelope is machine-written by userscripts, so we do not try
+     * to preserve the source's exact whitespace on write (only reads keep the verbatim text) — we
+     * emit canonical compact JSON. `encodeDefaults`/`explicitNulls` are irrelevant : we only ever
+     * serialise an already-built [JsonElement] tree, never @Serializable models.
+     */
+    private val json = Json { prettyPrint = false }
+
+    /** Result of the pure mutation : either the mutated body or a typed, non-throwing failure. */
+    sealed interface Outcome {
+        data class Mutated(val body: String) : Outcome
+        data object NotJsonEnvelope : Outcome
+        data class TooLarge(val sizeBytes: Int) : Outcome
+    }
+
+    /**
+     * Upserts [entry] into the v0.1 `mpFlags.list[]` of [rawEnvelope] and returns the mutated text.
+     *
+     *  - matching is by `post` == [MpStorageFlagEntry.threadId] : an existing list item is UPDATED in
+     *    place (its `post`/`page`/`href`/`uri` are overwritten, every OTHER key it holds — e.g. `p`,
+     *    or a tool-specific key — is preserved) ; no match → a new item is APPENDED ;
+     *  - a missing `data` array / missing v0.1 entry / missing `mpFlags` / missing `list` is CREATED
+     *    minimally, respecting the v0.1 shape, without disturbing sibling keys ;
+     *  - the result is rejected ([Outcome.TooLarge]) when its UTF-8 size exceeds
+     *    [MpStorageRepository.MAX_CONTENT_FORM_BYTES].
+     *
+     * Returns [Outcome.NotJsonEnvelope] when [rawEnvelope] is not a JSON object (the caller maps this
+     * to "unreadable" and NEVER writes a repaired default — ADR-014 §3).
+     */
+    @Suppress("ReturnCount") // Guard (not-JSON) + cap rejection + the mutated return.
+    fun upsertFlag(rawEnvelope: String, entry: MpStorageFlagEntry): Outcome {
+        val root = parseObjectOrNull(rawEnvelope) ?: return Outcome.NotJsonEnvelope
+
+        val mutated = mutateEnvelope(root, entry)
+        val body = json.encodeToString(JsonObject.serializer(), mutated)
+
+        val sizeBytes = body.toByteArray(Charsets.UTF_8).size
+        if (sizeBytes > MpStorageRepository.MAX_CONTENT_FORM_BYTES) {
+            return Outcome.TooLarge(sizeBytes)
+        }
+        return Outcome.Mutated(body)
+    }
+
+    private fun parseObjectOrNull(rawEnvelope: String): JsonObject? {
+        if (rawEnvelope.isBlank()) return null
+        return try {
+            json.parseToJsonElement(rawEnvelope) as? JsonObject
+        } catch (@Suppress("SwallowedException") error: kotlinx.serialization.SerializationException) {
+            null
+        }
+    }
+
+    /** Rebuilds the top-level object preserving every key, replacing only `data` with the mutated array. */
+    private fun mutateEnvelope(root: JsonObject, entry: MpStorageFlagEntry): JsonObject {
+        val dataArray = root["data"] as? JsonArray ?: JsonArray(emptyList())
+        val mutatedData = mutateDataArray(dataArray, entry)
+        return JsonObject(root.toMutableMap().apply { put("data", mutatedData) })
+    }
+
+    /**
+     * Replaces (or creates) the v0.1 entry inside `data[]`, preserving the order and every sibling
+     * entry. When no v0.1 entry exists yet, a minimal one is appended (other entries untouched).
+     */
+    private fun mutateDataArray(dataArray: JsonArray, entry: MpStorageFlagEntry): JsonArray {
+        val v01Index = dataArray.indexOfFirst {
+            (it as? JsonObject)?.get("version")?.let { v -> v is JsonPrimitive && v.content == V01 } == true
+        }
+        return if (v01Index >= 0) {
+            val v01Entry = dataArray[v01Index] as JsonObject
+            JsonArray(
+                dataArray.toMutableList().apply { this[v01Index] = mutateV01Entry(v01Entry, entry) },
+            )
+        } else {
+            JsonArray(dataArray + mutateV01Entry(emptyV01Entry(), entry))
+        }
+    }
+
+    private fun emptyV01Entry(): JsonObject = buildJsonObject { put("version", V01) }
+
+    /** Preserves every key of the v0.1 entry, replacing only its `mpFlags` (itself merged, not clobbered). */
+    private fun mutateV01Entry(v01Entry: JsonObject, entry: MpStorageFlagEntry): JsonObject {
+        val mpFlags = v01Entry["mpFlags"] as? JsonObject ?: JsonObject(emptyMap())
+        val list = mpFlags["list"] as? JsonArray ?: JsonArray(emptyList())
+        val mutatedList = upsertList(list, entry)
+        val mutatedMpFlags = JsonObject(mpFlags.toMutableMap().apply { put("list", mutatedList) })
+        return JsonObject(v01Entry.toMutableMap().apply { put("mpFlags", mutatedMpFlags) })
+    }
+
+    /**
+     * Upserts the item whose `post` matches [MpStorageFlagEntry.threadId]. On an UPDATE, only the
+     * four owned wire fields are written ; all other keys on the matched item survive verbatim.
+     */
+    private fun upsertList(list: JsonArray, entry: MpStorageFlagEntry): JsonArray {
+        val matchIndex = list.indexOfFirst { item ->
+            (item as? JsonObject)?.get("post")?.asIntOrNull() == entry.threadId
+        }
+        return if (matchIndex >= 0) {
+            val existing = list[matchIndex] as JsonObject
+            JsonArray(
+                list.toMutableList().apply { this[matchIndex] = writeWireFields(existing, entry) },
+            )
+        } else {
+            JsonArray(list + writeWireFields(JsonObject(emptyMap()), entry))
+        }
+    }
+
+    /**
+     * Overwrites the four owned wire fields on [base] (preserving any other key, e.g. `p`):
+     * `post`, `page`, `href` (= `"t<numreponse>"`, omitted/null when [MpStorageFlagEntry.numreponse]
+     * is null), `uri` (omitted/null when absent). Numbers are emitted as JSON numbers (the read parser
+     * tolerates both, the original userscript writes numbers).
+     */
+    private fun writeWireFields(base: JsonObject, entry: MpStorageFlagEntry): JsonObject =
+        JsonObject(
+            base.toMutableMap().apply {
+                put("post", JsonPrimitive(entry.threadId))
+                put("page", JsonPrimitive(entry.page))
+                put("href", entry.numreponse?.let { JsonPrimitive("t$it") } ?: JsonNull)
+                put("uri", entry.uri?.let { JsonPrimitive(it) } ?: JsonNull)
+            },
+        )
+
+    private fun JsonElement.asIntOrNull(): Int? = (this as? JsonPrimitive)?.content?.toIntOrNull()
+
+    private companion object {
+        private const val V01 = "0.1"
+    }
+}

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepositoryTest.kt
@@ -8,6 +8,7 @@ import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.mpstorage.MpStorageDocument
 import fr.forumhfr.redface2.core.model.mpstorage.MpStorageFlagEntry
 import fr.forumhfr.redface2.core.model.mpstorage.MpStorageResult
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageWriteResult
 import fr.forumhfr.redface2.core.network.HfrClient
 import fr.forumhfr.redface2.core.parser.messages.PrivateMessageListParser
 import fr.forumhfr.redface2.core.parser.messages.PrivateMessageThreadParser
@@ -24,6 +25,7 @@ import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -74,6 +76,7 @@ class DefaultMpStorageRepositoryTest {
             threadParser = PrivateMessageThreadParser(),
             replyFormParser = ReplyFormParser(),
             storageParser = storageParser,
+            envelopeWriter = MpStorageEnvelopeWriter(),
             locationStore = locationStore,
             authRepository = mockk<AuthRepository> {
                 every { observeAuthState() } returns MutableStateFlow(authState)
@@ -206,6 +209,144 @@ class DefaultMpStorageRepositoryTest {
         assertEquals("9100200", edit.queryParameter("post"))
         assertEquals("1980664234", edit.queryParameter("numreponse"))
     }
+
+    // --- WRITE path (#6, ADR-014 §4) — GUARDED, NOT OBSERVED LIVE ---------------------------------
+
+    @Test
+    fun `writeBackFlag dryRun prepares the mutated body and sends NO POST`() = runTest {
+        val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [] } } ], "sourceName": "DTCloud" }"""
+        repository = buildRepository(
+            storageParser = mockk {
+                every { parse(any()) } returns Result.success(
+                    MpStorageDocument(sourceName = "DTCloud", mpFlags = emptyList(), rawEnvelope = raw),
+                )
+            },
+        )
+        locationStore.saved[OWNER] = MpStorageLocation(threadId = 9100200, numreponse = 1980664234)
+        // Only the edit-form GET is enqueued — a dry run must not POST anything.
+        server.enqueue(MockResponse().setBody(fixture("write_edit_form_test_post.html")))
+
+        val result = repository.writeBackFlag(MpStorageFlagEntry(threadId = 777, page = 4, numreponse = 9, uri = "/u"))
+
+        val prepared = result as MpStorageWriteResult.Prepared
+        assertEquals(false, prepared.posted)
+        assertTrue("the new flag must be in the prepared body", prepared.body.contains("\"post\":777"))
+        // Exactly one request: the GET of the edit form. No POST hit the wire.
+        assertEquals(1, server.requestCount)
+        assertEquals("GET", server.takeRequest().method)
+    }
+
+    @Test
+    fun `writeBackFlag with dryRun=false POSTs bdd_php with cat=prive and the preserved hidden fields`() = runTest {
+        val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [] } } ] }"""
+        repository = buildRepository(
+            storageParser = mockk {
+                every { parse(any()) } returns Result.success(
+                    MpStorageDocument(sourceName = null, mpFlags = emptyList(), rawEnvelope = raw),
+                )
+            },
+        )
+        locationStore.saved[OWNER] = MpStorageLocation(threadId = 9100200, numreponse = 2784595)
+        server.enqueue(MockResponse().setBody(fixture("write_edit_form_test_post.html"))) // GET edit form
+        server.enqueue(MockResponse().setBody("<html><body>ok</body></html>")) // POST bdd.php
+
+        // dryRun=false is the GUARDED branch — exercised only by this test, never by app code.
+        val result = repository.writeBackFlag(
+            MpStorageFlagEntry(threadId = 42, page = 2, numreponse = 5, uri = null),
+            dryRun = false,
+        )
+
+        val prepared = result as MpStorageWriteResult.Prepared
+        assertTrue("the live POST branch reports posted = true", prepared.posted)
+        assertEquals(2, server.requestCount)
+
+        server.takeRequest() // skip the GET
+        val post = server.takeRequest()
+        assertEquals("POST", post.method)
+        assertEquals("bdd.php", requireNotNull(post.requestUrl).pathSegments.first())
+        val body = formFields(post.body.readUtf8())
+        // The whole point of submitPrivateMessageEdit : cat is the String "prive", not an Int.
+        assertEquals("prive", body["cat"])
+        assertEquals("9100200", body["post"])
+        assertEquals("2784595", body["numreponse"])
+        assertEquals("", body["numrep"])
+        assertEquals("1100", body["verifrequet"])
+        // content_form carries the mutated JSON, not BBCode.
+        assertTrue(body["content_form"]!!.contains("\"post\":42"))
+        // hash_check + sujet come from the parsed edit form; hidden fields preserved.
+        assertEquals("REDACTED_HASH_CHECK", body["hash_check"])
+        assertEquals("Redface 2 — PHASE 2 @ ALPHA", body["sujet"])
+        // password / delete are hard-denied — never resent.
+        assertNull("password must never be resent", body["password"])
+        assertNull("the delete checkbox must never be resent", body["delete"])
+    }
+
+    @Test
+    fun `writeBackFlag returns TargetNotFound when no storage MP exists and writes nothing`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("mp_storage_inbox_no_hit.html")))
+
+        val result = repository.writeBackFlag(MpStorageFlagEntry(threadId = 1, page = 1, numreponse = 1, uri = null))
+
+        assertEquals(MpStorageWriteResult.TargetNotFound, result)
+        // Only the inbox scan happened — anti-doublon: NEVER create a fresh document (ADR-014 §3).
+        assertEquals(1, server.requestCount)
+        assertNull(locationStore.saved[OWNER])
+    }
+
+    @Test
+    fun `writeBackFlag returns TargetNotFound on an anonymous session without any request`() = runTest {
+        repository = buildRepository(authState = AuthState.Anonymous)
+
+        val result = repository.writeBackFlag(MpStorageFlagEntry(threadId = 1, page = 1, numreponse = 1, uri = null))
+
+        assertEquals(MpStorageWriteResult.TargetNotFound, result)
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun `writeBackFlag returns TargetUnreadable when the located document is not a v01 envelope`() = runTest {
+        // The real edit-form fixture's content_form is plain BBCode — not a readable v0.1 envelope.
+        // Per ADR-014 §3 this is surfaced, NEVER repaired / overwritten with a default.
+        locationStore.saved[OWNER] = MpStorageLocation(threadId = 9100200, numreponse = 2784595)
+        server.enqueue(MockResponse().setBody(fixture("write_edit_form_test_post.html")))
+
+        val result = repository.writeBackFlag(MpStorageFlagEntry(threadId = 1, page = 1, numreponse = 1, uri = null))
+
+        assertEquals(MpStorageWriteResult.TargetUnreadable, result)
+        // GET the form only — no POST: an unreadable target must never be written over.
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `writeBackFlag returns TooLarge when the mutated body exceeds the 256 KiB cap`() = runTest {
+        val filler = "x".repeat(260 * 1024)
+        val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [] } } ], "blob": "$filler" }"""
+        repository = buildRepository(
+            storageParser = mockk {
+                every { parse(any()) } returns Result.success(
+                    MpStorageDocument(sourceName = null, mpFlags = emptyList(), rawEnvelope = raw),
+                )
+            },
+        )
+        locationStore.saved[OWNER] = MpStorageLocation(threadId = 9100200, numreponse = 2784595)
+        server.enqueue(MockResponse().setBody(fixture("write_edit_form_test_post.html")))
+
+        val result = repository.writeBackFlag(MpStorageFlagEntry(threadId = 1, page = 1, numreponse = 1, uri = null))
+
+        assertTrue(result is MpStorageWriteResult.TooLarge)
+        // The oversize body is never POSTed (fail-closed): only the GET happened.
+        assertEquals(1, server.requestCount)
+    }
+
+    /** Decodes an `application/x-www-form-urlencoded` POST body into a field map (absent field ⇒ null). */
+    private fun formFields(body: String): Map<String, String> =
+        body.split("&")
+            .filter { it.isNotEmpty() }
+            .associate { pair ->
+                val name = java.net.URLDecoder.decode(pair.substringBefore("="), "UTF-8")
+                val value = java.net.URLDecoder.decode(pair.substringAfter("=", ""), "UTF-8")
+                name to value
+            }
 
     private fun fixture(name: String): String {
         val stream = requireNotNull(

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepositoryTest.kt
@@ -213,7 +213,7 @@ class DefaultMpStorageRepositoryTest {
     // --- WRITE path (#6, ADR-014 §4) — GUARDED, NOT OBSERVED LIVE ---------------------------------
 
     @Test
-    fun `writeBackFlag dryRun prepares the mutated body and sends NO POST`() = runTest {
+    fun `writeBackFlag (public path) prepares the mutated body and sends NO POST`() = runTest {
         val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [] } } ], "sourceName": "DTCloud" }"""
         repository = buildRepository(
             storageParser = mockk {
@@ -237,7 +237,7 @@ class DefaultMpStorageRepositoryTest {
     }
 
     @Test
-    fun `writeBackFlag with dryRun=false POSTs bdd_php with cat=prive and the preserved hidden fields`() = runTest {
+    fun `writeBackFlagLive POSTs bdd_php with cat=prive and the preserved hidden fields`() = runTest {
         val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [] } } ] }"""
         repository = buildRepository(
             storageParser = mockk {
@@ -250,10 +250,9 @@ class DefaultMpStorageRepositoryTest {
         server.enqueue(MockResponse().setBody(fixture("write_edit_form_test_post.html"))) // GET edit form
         server.enqueue(MockResponse().setBody("<html><body>ok</body></html>")) // POST bdd.php
 
-        // dryRun=false is the GUARDED branch — exercised only by this test, never by app code.
-        val result = repository.writeBackFlag(
+        // writeBackFlagLive is the module-internal, TEST-ONLY POST path (not on the public interface).
+        val result = repository.writeBackFlagLive(
             MpStorageFlagEntry(threadId = 42, page = 2, numreponse = 5, uri = null),
-            dryRun = false,
         )
 
         val prepared = result as MpStorageWriteResult.Prepared

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/mpstorage/MpStorageEnvelopeWriterTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/mpstorage/MpStorageEnvelopeWriterTest.kt
@@ -1,0 +1,243 @@
+package fr.forumhfr.redface2.core.data.mpstorage
+
+import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageFlagEntry
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * MPStorage read-modify-WRITE core (#6, ADR-014 §4). The mutation operates on the RAW JSON tree of
+ * the verbatim `rawEnvelope`, never on the projected model — so the cross-userscript namespaces must
+ * survive every round-trip. These are the highest-value tests of the write chantier (Codex : RMW > UI).
+ *
+ * The output is re-parsed (not string-compared) so the assertions are robust to key ordering /
+ * whitespace : what matters is the semantic shape, not the exact bytes (NOT OBSERVED LIVE — no real
+ * HFR round-trip to byte-match against).
+ */
+class MpStorageEnvelopeWriterTest {
+
+    private val writer = MpStorageEnvelopeWriter()
+    private val json = Json
+
+    private fun mutate(raw: String, entry: MpStorageFlagEntry): MpStorageEnvelopeWriter.Outcome =
+        writer.upsertFlag(raw, entry)
+
+    private fun bodyOf(outcome: MpStorageEnvelopeWriter.Outcome): JsonObject {
+        val mutated = outcome as MpStorageEnvelopeWriter.Outcome.Mutated
+        return json.parseToJsonElement(mutated.body).jsonObject
+    }
+
+    private fun JsonObject.v01Entry(): JsonObject =
+        this["data"]!!.jsonArray.map { it.jsonObject }
+            .first { it["version"]?.jsonPrimitive?.content == "0.1" }
+
+    private fun JsonObject.flagList(): JsonArray =
+        v01Entry()["mpFlags"]!!.jsonObject["list"]!!.jsonArray
+
+    @Test
+    fun `upsert preserves an unknown third-party top-level key and a sibling tool key in the v01 entry`() {
+        val raw = """
+            {
+              "data": [
+                { "version": "0.1",
+                  "hfr4k": { "opaque": [1, 2, 3], "nested": { "k": "v" } },
+                  "mpFlags": { "list": [] } }
+              ],
+              "sourceName": "HFR4K",
+              "lastUpdate": 1718064000000,
+              "someOtherTool": { "deep": [ { "x": true } ] }
+            }
+        """.trimIndent()
+
+        val body = bodyOf(mutate(raw, MpStorageFlagEntry(threadId = 999, page = 2, numreponse = 7, uri = "/u")))
+
+        // Third-party TOP-LEVEL keys survive verbatim.
+        assertEquals("HFR4K", body["sourceName"]!!.jsonPrimitive.content)
+        assertEquals(JsonPrimitive(1718064000000L), body["lastUpdate"])
+        assertTrue("unknown top-level tool key must survive", body.containsKey("someOtherTool"))
+        assertEquals(
+            true,
+            body["someOtherTool"]!!.jsonObject["deep"]!!.jsonArray.first().jsonObject["x"]!!.jsonPrimitive.content
+                .toBoolean(),
+        )
+
+        // The sibling tool key INSIDE the v0.1 entry survives untouched.
+        val v01 = body.v01Entry()
+        assertTrue("sibling tool key in v0.1 entry must survive", v01.containsKey("hfr4k"))
+        assertEquals(
+            "v",
+            v01["hfr4k"]!!.jsonObject["nested"]!!.jsonObject["k"]!!.jsonPrimitive.content,
+        )
+
+        // The new flag was appended.
+        assertEquals(1, body.flagList().size)
+        assertEquals(999, body.flagList().first().jsonObject["post"]!!.jsonPrimitive.content.toInt())
+    }
+
+    @Test
+    fun `upsert preserves a sibling data entry written by another tool (version != 0_1)`() {
+        val raw = """
+            { "data": [
+                { "version": "0.2", "somethingNew": true },
+                { "version": "0.1", "mpFlags": { "list": [] } }
+            ] }
+        """.trimIndent()
+
+        val body = bodyOf(mutate(raw, MpStorageFlagEntry(threadId = 5, page = 1, numreponse = null, uri = null)))
+
+        val entries = body["data"]!!.jsonArray.map { it.jsonObject }
+        assertEquals(2, entries.size)
+        val v02 = entries.first { it["version"]?.jsonPrimitive?.content == "0.2" }
+        assertEquals(true, v02["somethingNew"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals(1, body.flagList().size)
+    }
+
+    @Test
+    fun `updating an existing entry by threadId overwrites wire fields and preserves its extra keys`() {
+        val raw = """
+            { "data": [ { "version": "0.1", "mpFlags": { "list": [
+                { "uri": "/old", "post": 12345, "page": 3, "href": "t1980000001", "p": 2, "custom": "keepme" },
+                { "post": 67890, "page": 1, "href": "t42", "p": 9 }
+            ] } } ] }
+        """.trimIndent()
+
+        val body = bodyOf(
+            mutate(raw, MpStorageFlagEntry(threadId = 12345, page = 7, numreponse = 555, uri = "/new")),
+        )
+
+        // SAME list size — this is an UPDATE, not an append.
+        val list = body.flagList()
+        assertEquals(2, list.size)
+        val updated = list.map { it.jsonObject }.first { it["post"]!!.jsonPrimitive.content.toInt() == 12345 }
+        assertEquals(7, updated["page"]!!.jsonPrimitive.content.toInt())
+        assertEquals("t555", updated["href"]!!.jsonPrimitive.content)
+        assertEquals("/new", updated["uri"]!!.jsonPrimitive.content)
+        // The non-owned key on the matched item survives.
+        assertEquals("keepme", updated["custom"]!!.jsonPrimitive.content)
+        // The OTHER entry is untouched.
+        val other = list.map { it.jsonObject }.first { it["post"]!!.jsonPrimitive.content.toInt() == 67890 }
+        assertEquals("t42", other["href"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `a new threadId is appended without disturbing existing entries`() {
+        val raw = """
+            { "data": [ { "version": "0.1", "mpFlags": { "list": [
+                { "post": 111, "page": 1, "href": "t1" }
+            ] } } ] }
+        """.trimIndent()
+
+        val body = bodyOf(mutate(raw, MpStorageFlagEntry(threadId = 222, page = 4, numreponse = 2, uri = null)))
+
+        val list = body.flagList()
+        assertEquals(2, list.size)
+        assertEquals(111, list[0].jsonObject["post"]!!.jsonPrimitive.content.toInt())
+        assertEquals(222, list[1].jsonObject["post"]!!.jsonPrimitive.content.toInt())
+        assertEquals("t2", list[1].jsonObject["href"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `a null numreponse and null uri are emitted as JSON null`() {
+        val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [] } } ] }"""
+
+        val body = bodyOf(mutate(raw, MpStorageFlagEntry(threadId = 7, page = 1, numreponse = null, uri = null)))
+
+        val item = body.flagList().first().jsonObject
+        assertNull(item["href"]!!.jsonPrimitive.contentOrNullSafe())
+        assertNull(item["uri"]!!.jsonPrimitive.contentOrNullSafe())
+    }
+
+    @Test
+    fun `an envelope with a data array but no v01 entry gets a minimal v01 entry appended`() {
+        val raw = """{ "data": [ { "version": "0.2", "foo": 1 } ], "sourceName": "Other" }"""
+
+        val body = bodyOf(mutate(raw, MpStorageFlagEntry(threadId = 9, page = 1, numreponse = 3, uri = null)))
+
+        // The pre-existing non-v0.1 entry is kept, a v0.1 entry is created.
+        assertEquals(2, body["data"]!!.jsonArray.size)
+        assertEquals("Other", body["sourceName"]!!.jsonPrimitive.content)
+        assertEquals(9, body.flagList().first().jsonObject["post"]!!.jsonPrimitive.content.toInt())
+    }
+
+    @Test
+    fun `an envelope with no data array at all gets the minimal v01 structure created`() {
+        val raw = """{ "sourceName": "DTCloud", "lastUpdate": 1 }"""
+
+        val body = bodyOf(mutate(raw, MpStorageFlagEntry(threadId = 4, page = 2, numreponse = 6, uri = "/x")))
+
+        // Third-party keys preserved, minimal data[]/v0.1/mpFlags/list created.
+        assertEquals("DTCloud", body["sourceName"]!!.jsonPrimitive.content)
+        assertEquals(1, body["data"]!!.jsonArray.size)
+        assertEquals(1, body.flagList().size)
+        assertEquals(4, body.flagList().first().jsonObject["post"]!!.jsonPrimitive.content.toInt())
+    }
+
+    @Test
+    fun `string-typed post from a JS-written list is matched as an update, not appended`() {
+        // The original userscript serialises loosely — an existing entry may carry post as a String.
+        val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [
+            { "post": "12345", "page": "1", "href": "t1" }
+        ] } } ] }"""
+
+        val body = bodyOf(mutate(raw, MpStorageFlagEntry(threadId = 12345, page = 9, numreponse = 8, uri = null)))
+
+        assertEquals(1, body.flagList().size)
+        assertEquals(9, body.flagList().first().jsonObject["page"]!!.jsonPrimitive.content.toInt())
+    }
+
+    @Test
+    fun `a content_form mutation over 256 KiB is rejected as TooLarge`() {
+        // Stuff a huge third-party blob so the mutated body crosses the cap. The mutation itself is
+        // tiny — the cap protects against an uncontrolled POST when the storage is already huge
+        // (the DTCloud list is never pruned — ADR-014 risk).
+        val filler = "x".repeat(MpStorageRepository.MAX_CONTENT_FORM_BYTES + 1024)
+        val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [] } } ], "blob": "$filler" }"""
+
+        val outcome = mutate(raw, MpStorageFlagEntry(threadId = 1, page = 1, numreponse = 1, uri = null))
+
+        assertTrue(outcome is MpStorageEnvelopeWriter.Outcome.TooLarge)
+        val sizeBytes = (outcome as MpStorageEnvelopeWriter.Outcome.TooLarge).sizeBytes
+        assertTrue(sizeBytes > MpStorageRepository.MAX_CONTENT_FORM_BYTES)
+    }
+
+    @Test
+    fun `a mutation just under the cap is accepted`() {
+        // Build a body that lands comfortably under 256 KiB after the mutation.
+        val filler = "x".repeat(100 * 1024)
+        val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [] } } ], "blob": "$filler" }"""
+
+        val outcome = mutate(raw, MpStorageFlagEntry(threadId = 1, page = 1, numreponse = 1, uri = null))
+
+        assertTrue(outcome is MpStorageEnvelopeWriter.Outcome.Mutated)
+    }
+
+    @Test
+    fun `non-JSON-object content yields NotJsonEnvelope, never a repaired default`() {
+        assertEquals(
+            MpStorageEnvelopeWriter.Outcome.NotJsonEnvelope,
+            mutate("Bonjour, ceci est un MP normal.", MpStorageFlagEntry(1, 1, 1, null)),
+        )
+        // A JSON array (not an object) is also rejected.
+        assertEquals(
+            MpStorageEnvelopeWriter.Outcome.NotJsonEnvelope,
+            mutate("[1, 2, 3]", MpStorageFlagEntry(1, 1, 1, null)),
+        )
+        assertEquals(
+            MpStorageEnvelopeWriter.Outcome.NotJsonEnvelope,
+            mutate("   ", MpStorageFlagEntry(1, 1, 1, null)),
+        )
+    }
+
+    /** `JsonPrimitive.content` is "null" for a literal null — distinguish it from the string "null". */
+    private fun JsonPrimitive.contentOrNullSafe(): String? =
+        if (this is kotlinx.serialization.json.JsonNull) null else content
+}

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/mpstorage/MpStorageRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/mpstorage/MpStorageRepository.kt
@@ -34,10 +34,11 @@ interface MpStorageRepository {
      * build the `bdd.php cat=prive` POST body.
      *
      * GUARDED BY DESIGN — NOT OBSERVED LIVE. The `bdd.php cat=prive` write contract was never captured
-     * (device down). This method exists, is unit-tested, but is **impossible to trigger by accident** :
-     *  - [dryRun] defaults to `true` → the body is built & validated but **no request hits the wire** ;
-     *  - nothing in the app calls it with `dryRun = false`, and there is **no UI entry point** ;
-     *  - the ADR-014 §4 trigger (« on leaving a DT conversation ») is intentionally NOT wired.
+     * (device down). This public method is **DRY-RUN ONLY** : it locates, mutates, validates and builds the
+     * body, then returns [MpStorageWriteResult.Prepared] with `posted = false` — **no request ever hits the
+     * wire**, and there is no parameter to make it. The actual POST lives behind a module-internal,
+     * test-only path on the implementation (NOT on this public interface) so it is **structurally
+     * impossible to trigger from app/prod code** (Codex review) ; the ADR-014 §4 trigger is NOT wired.
      *
      * Target selection (Codex decision) is DETERMINISTIC : the first MP whose subject equals EXACTLY
      * [STORAGE_SUBJECT_HASH]. A miss is [MpStorageWriteResult.TargetNotFound] — NEVER a creation /
@@ -48,12 +49,8 @@ interface MpStorageRepository {
      * past it) : the real HFR MP body limit is unknown, so the cap fails CLOSED.
      *
      * @param entry the DT reading-resume position to upsert.
-     * @param dryRun keep `true` until the live write contract is confirmed ; `true` skips the POST.
      */
-    suspend fun writeBackFlag(
-        entry: MpStorageFlagEntry,
-        dryRun: Boolean = true,
-    ): MpStorageWriteResult
+    suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult
 
     companion object {
         /** Fixed storage subject — the de-facto v0.1 contract's discriminator (#6). */

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/mpstorage/MpStorageRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/mpstorage/MpStorageRepository.kt
@@ -1,6 +1,8 @@
 package fr.forumhfr.redface2.core.domain.mpstorage
 
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageFlagEntry
 import fr.forumhfr.redface2.core.model.mpstorage.MpStorageResult
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageWriteResult
 
 /**
  * MPStorage read access (#6, ADR-014) — the cross-userscript storage document living in the
@@ -25,8 +27,44 @@ interface MpStorageRepository {
 
     suspend fun fetchStorage(): MpStorageResult
 
+    /**
+     * WRITE path (#6, ADR-014 §4 — deferred / opt-in). Read-modify-write of the storage document :
+     * locate the dedicated MP, mutate its `mpFlags.list[]` to upsert [entry] (by [MpStorageFlagEntry.threadId])
+     * **in place on the raw JSON tree** so every third-party namespace survives the round-trip, then
+     * build the `bdd.php cat=prive` POST body.
+     *
+     * GUARDED BY DESIGN — NOT OBSERVED LIVE. The `bdd.php cat=prive` write contract was never captured
+     * (device down). This method exists, is unit-tested, but is **impossible to trigger by accident** :
+     *  - [dryRun] defaults to `true` → the body is built & validated but **no request hits the wire** ;
+     *  - nothing in the app calls it with `dryRun = false`, and there is **no UI entry point** ;
+     *  - the ADR-014 §4 trigger (« on leaving a DT conversation ») is intentionally NOT wired.
+     *
+     * Target selection (Codex decision) is DETERMINISTIC : the first MP whose subject equals EXACTLY
+     * [STORAGE_SUBJECT_HASH]. A miss is [MpStorageWriteResult.TargetNotFound] — NEVER a creation /
+     * overwrite (ADR-014 §3 forbids the destructive reset ; creating a fresh doc would fork the
+     * cross-userscript storage).
+     *
+     * The mutated `content_form` is capped at [MAX_CONTENT_FORM_BYTES] ([MpStorageWriteResult.TooLarge]
+     * past it) : the real HFR MP body limit is unknown, so the cap fails CLOSED.
+     *
+     * @param entry the DT reading-resume position to upsert.
+     * @param dryRun keep `true` until the live write contract is confirmed ; `true` skips the POST.
+     */
+    suspend fun writeBackFlag(
+        entry: MpStorageFlagEntry,
+        dryRun: Boolean = true,
+    ): MpStorageWriteResult
+
     companion object {
         /** Fixed storage subject — the de-facto v0.1 contract's discriminator (#6). */
         const val STORAGE_SUBJECT_HASH: String = "a2bcc09b796b8c6fab77058ff8446c34"
+
+        /**
+         * Hard cap (Codex decision) on the mutated `content_form` UTF-8 size, 256 KiB. The real HFR
+         * private-message body limit has never been observed ; 256 KiB comfortably exceeds any
+         * realistic DTCloud `mpFlags.list` (the list is never pruned by the original library, hence
+         * the risk) while bounding an uncontrolled POST. Crossing it fails CLOSED — NOT OBSERVED LIVE.
+         */
+        const val MAX_CONTENT_FORM_BYTES: Int = 256 * 1024
     }
 }

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/mpstorage/MpStorage.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/mpstorage/MpStorage.kt
@@ -58,3 +58,42 @@ data class MpStorageFlagEntry(
     /** Desktop-format URI, relayed verbatim (DTCloud rebuilds its links from it). */
     val uri: String?,
 )
+
+/**
+ * Outcome of an MPStorage WRITE attempt (#6, ADR-014 §4 — deferred / opt-in).
+ *
+ * NOTE — NOT OBSERVED LIVE : the `bdd.php cat=prive` write contract has never been captured
+ * (device down, no real round-trip). The write mechanism is implemented and unit-tested but
+ * stays GUARDED — by default [fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository.writeBackFlag]
+ * runs `dryRun = true` (read-modify-build only, no POST) and nothing in the app calls it with
+ * `dryRun = false`. There is no UI entry point. These variants describe what the path WOULD
+ * return once the contract is confirmed.
+ */
+sealed interface MpStorageWriteResult {
+
+    /**
+     * The read-modify-write completed. [body] is the verbatim mutated JSON that WOULD be (or was)
+     * sent as `content_form`. [posted] is `false` for the guarded dry-run (the nominal case today:
+     * the body was built and validated but no request hit the wire), `true` once a real POST is
+     * confirmed accepted by HFR.
+     */
+    data class Prepared(val body: String, val posted: Boolean) : MpStorageWriteResult
+
+    /**
+     * The target storage document could not be located (ADR-014 §3 : NEVER create or overwrite a
+     * fresh document — that would fork the cross-userscript storage / spawn a duplicate). The
+     * caller must surface this, not "repair" it.
+     */
+    data object TargetNotFound : MpStorageWriteResult
+
+    /** The located document is not a readable v0.1 envelope — surfaced, never repaired (ADR-014 §3). */
+    data object TargetUnreadable : MpStorageWriteResult
+
+    /**
+     * The mutated `content_form` exceeds the hard size cap
+     * ([fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository.MAX_CONTENT_FORM_BYTES]).
+     * The real HFR MP body limit is unknown (never observed) ; this cap fails CLOSED rather than
+     * risk an uncontrolled / truncated POST. [sizeBytes] is the offending UTF-8 size.
+     */
+    data class TooLarge(val sizeBytes: Int) : MpStorageWriteResult
+}

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/mpstorage/MpStorage.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/mpstorage/MpStorage.kt
@@ -64,10 +64,10 @@ data class MpStorageFlagEntry(
  *
  * NOTE — NOT OBSERVED LIVE : the `bdd.php cat=prive` write contract has never been captured
  * (device down, no real round-trip). The write mechanism is implemented and unit-tested but
- * stays GUARDED — by default [fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository.writeBackFlag]
- * runs `dryRun = true` (read-modify-build only, no POST) and nothing in the app calls it with
- * `dryRun = false`. There is no UI entry point. These variants describe what the path WOULD
- * return once the contract is confirmed.
+ * stays GUARDED — the public [fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository.writeBackFlag]
+ * only ever read-modify-builds (no POST), and the live POST is reachable solely via a module-internal,
+ * test-only path (not on the public interface). There is no UI entry point. These variants describe
+ * what the path WOULD return once the contract is confirmed.
  */
 sealed interface MpStorageWriteResult {
 

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
@@ -315,8 +315,9 @@ class HfrClient @Inject constructor(
      * preserved hidden fields) is shaped identically by the repository.
      *
      * NOT OBSERVED LIVE : the `bdd.php cat=prive` write contract has never been captured (no device
-     * round-trip). The caller GUARDS this — it is reached only with `dryRun = false`, which nothing
-     * in the app sets. Same HTTP-200-with-body-text contract as the reply / edit flows ; the response
+     * round-trip). The caller GUARDS this — it is reached only via the repository's module-internal,
+     * test-only POST path (never from app/prod code). Same HTTP-200-with-body-text contract as the reply
+     * / edit flows ; the response
      * (when ever exercised) is classified by `ReplySubmitResponseParser`. `hash_check` is never logged.
      */
     suspend fun submitPrivateMessageEdit(formBody: FormBody): String {

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
@@ -306,6 +306,29 @@ class HfrClient @Inject constructor(
     }
 
     /**
+     * MPStorage write (#6, ADR-014 §4) — POST the edited FIRST post of the dedicated storage MP to
+     * `bdd.php?config=hfr.inc`, the same endpoint as [submitEditPost]. The ONLY wire difference is
+     * that the storage post lives under `cat=prive`, so the [formBody] carries `cat=prive` as a
+     * **String** (the public edit flow passes `cat` as an Int) — that is why this is a distinct
+     * method rather than a reuse of [submitEditPost] : the typed public path cannot express `prive`.
+     * Everything else (`hash_check`, `verifrequet`, `content_form`, `numreponse`, `sujet`, the
+     * preserved hidden fields) is shaped identically by the repository.
+     *
+     * NOT OBSERVED LIVE : the `bdd.php cat=prive` write contract has never been captured (no device
+     * round-trip). The caller GUARDS this — it is reached only with `dryRun = false`, which nothing
+     * in the app sets. Same HTTP-200-with-body-text contract as the reply / edit flows ; the response
+     * (when ever exercised) is classified by `ReplySubmitResponseParser`. `hash_check` is never logged.
+     */
+    suspend fun submitPrivateMessageEdit(formBody: FormBody): String {
+        val url = baseUrl.newBuilder()
+            .addPathSegment("bdd.php")
+            .addQueryParameter("config", "hfr.inc")
+            .build()
+        val request = Request.Builder().url(url).post(formBody).build()
+        return authenticated.newCall(request).executeAuthenticatedHtml()
+    }
+
+    /**
      * Phase 2E (#149) — GET the HFR new-topic form for [cat] / [entrySubcat].
      * `entrySubcat` is nullable because the user can land on the create-topic
      * composer either with a sub-category chip selected (`entrySubcat = 550`)

--- a/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/HfrClientTest.kt
+++ b/core/network/src/test/kotlin/fr/forumhfr/redface2/core/network/HfrClientTest.kt
@@ -277,6 +277,33 @@ class HfrClientTest {
     }
 
     @Test
+    fun `submitPrivateMessageEdit POSTs bdd_php on the authenticated client and forwards the form body`() = runTest {
+        // MPStorage write (#6, ADR-014 §4) — GUARDED, NOT OBSERVED LIVE: the bdd.php cat=prive write
+        // contract was never captured. Here we only assert the REQUEST shape (endpoint + that the
+        // repository-built body, carrying cat=prive as a String, is forwarded verbatim).
+        server.enqueue(MockResponse().setResponseCode(200).setBody("<html><body>ok</body></html>"))
+
+        val body = okhttp3.FormBody.Builder(Charsets.UTF_8)
+            .add("hash_check", "deadbeef")
+            .add("cat", "prive")
+            .add("content_form", """{"data":[]}""")
+            .build()
+
+        val html = client.submitPrivateMessageEdit(body)
+
+        assertEquals("<html><body>ok</body></html>", html)
+        val request = server.takeRequest()
+        assertEquals("authenticated", request.headers["X-RF2-Client"])
+        assertEquals("POST", request.method)
+        assertEquals("/bdd.php", requireNotNull(request.requestUrl).encodedPath)
+        assertEquals("hfr.inc", request.requestUrl!!.queryParameter("config"))
+        val fields = formFields(request.body.readUtf8())
+        assertEquals("deadbeef", fields["hash_check"])
+        assertEquals("prive", fields["cat"])
+        assertEquals("""{"data":[]}""", fields["content_form"])
+    }
+
+    @Test
     fun `removeFlag builds the delflag URL on the authenticated client mapping each type to owntopic`() = runTest {
         // owntopic discriminator: CYAN→1, RED→2, FAVORITE→3 (cf. Flag.kt / protocol-hfr.md).
         listOf(


### PR DESCRIPTION
Travail de nuit — chantier B. Implémente la **mécanique d'écriture** d'un drapeau MPStorage v1 (position de reprise DT), **entièrement guardée** : aucun POST réel n'est déclenché (le contrat `bdd.php cat=prive` n'a jamais été observé live, device down).

## Mécanique
- `MpStorageEnvelopeWriter` (pur, injectable, 11 tests) : **RMW sur l'arbre `JsonObject` verbatim** (`rawEnvelope`), jamais reconstruit depuis le modèle → **préserve tous les namespaces tiers** à chaque niveau (racine, `data[]` sœurs `version!=0.1`, clés sœurs de l'entrée v0.1, clés non-possédées d'un item de `list` lors d'un update). Upsert par `post==threadId` (match string/int), création minimale v0.1 si absente.
- Sélection du document cible **déterministe** (Codex) : premier MP au sujet == hash ADR exact ; `NotFound`/`Unreadable` → échec, **jamais de création/écrasement** (ADR-014 §3).
- Cap **256 KiB** UTF-8 sur `content_form` (fail-closed, limite HFR réelle inconnue).
- `submitPrivateMessageEdit` (POST `bdd.php cat=prive`) ajouté à `HfrClient`.

## Guard STRUCTUREL (review Codex)
La méthode publique `MpStorageRepository.writeBackFlag(entry)` ne prend **aucun flag** et ne POSTe **jamais** (read-modify-build only → `Prepared(posted=false)`). Le POST réel vit dans un `internal suspend fun writeBackFlagLive(entry)` sur l'impl — **hors interface publique**, donc inatteignable depuis l'app/prod, exercé uniquement par le test. Pas d'UI, déclencheur ADR-014 §4 NON câblé.

## ⚠️ Non observé live (à valider plus tard)
Contrat `bdd.php cat=prive` jamais capturé (forme du body, champs cachés, classification réponse). Cap 256 KiB à requalifier. Convention `href` (`null` vs `""`) tranchée « explicite », à confirmer vs DTCloud. **Aucune fixture de réponse inventée.**

## Validation
`:core:data:testDebugUnitTest` + `:core:domain:test` + `:core:network:test` + `:core:parser:test` + `:app:assembleDevDebug` + `detektAll` + `lintDebug` verts. Revue Codex (gpt-5.5, xhigh) : RMW/anti-doublon/cap OK ; guard rendu structurel sur sa demande.

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)