### PR TITLE
feat(topic): ligne « Suite à la page suivante » sur les pages intermédiaires (#110)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1251,6 +1251,13 @@ private fun TopicLoadedContent(
             item {
                 EndOfTopicFooter()
             }
+        } else if (topic.page < topic.totalPages) {
+            // #110 (nicko) — symmetric marker on an intermediate page: « Suite à la page suivante »,
+            // purely informative (navigation lives in the page controls / swipe #282). Same no-key
+            // sentinel rationale as EndOfTopicFooter above.
+            item {
+                MorePagesFooter()
+            }
         }
     }
     // #362 — per-post contextual menu. The permalink is rebuilt from the LOADED topic's
@@ -1328,6 +1335,36 @@ private fun EndOfTopicFooter() {
         )
         Text(
             text = stringResource(R.string.topic_end_of_topic),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            color = MaterialTheme.colorScheme.outlineVariant,
+        )
+    }
+}
+
+/**
+ * #110 (nicko) — symmetric « more pages below » marker, mirroring [EndOfTopicFooter] but rendered as the
+ * LAST LazyColumn item of an INTERMEDIATE page (`topic.page < topic.totalPages`, condition at the call
+ * site). Informative only — no tap action (navigation is the page controls / swipe #282). Same style.
+ */
+@Composable
+private fun MorePagesFooter() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            color = MaterialTheme.colorScheme.outlineVariant,
+        )
+        Text(
+            text = stringResource(R.string.topic_more_pages),
             style = MaterialTheme.typography.labelMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="topic_loading">Chargement…</string>
     <!-- #379 — marqueur explicite de fin de sujet, rendu après le dernier post de la DERNIÈRE page. -->
     <string name="topic_end_of_topic">Dernier message du sujet</string>
+    <string name="topic_more_pages">Suite à la page suivante</string>
     <!-- #285 — top app bar : back affordance (content description) + fallback title shown while
          the topic page has not loaded yet (or errored), so the bar never reads blank. -->
     <string name="topic_back">Retour</string>


### PR DESCRIPTION
Retour bêta (nicko) : afficher en bas d'une page de sujet **non finale** une ligne « Suite à la page suivante », symétrique du « Dernier message du sujet » (#379) qui n'apparaît que sur la dernière page.

- `MorePagesFooter` informatif (mirror exact d'`EndOfTopicFooter`, même style), rendu comme dernier item de la LazyColumn quand `topic.page < topic.totalPages`.
- **Pas d'action au tap** (Codex) : la navigation reste les contrôles de page / le swipe #282. Sentinelle sans `key` Lazy (même rationale que `EndOfTopicFooter`).

Cadré par Codex (gpt-5.5, xhigh) avant implémentation. Build vert (test topic + assemble + detekt + lint).

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)