### PR TITLE
feat(flags): le changement d'onglet ramène la liste en haut (#106) + fix fake DT

### DIFF
--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -455,7 +455,16 @@ class FlagsViewModel @Inject constructor(
             setFlagsUnreadOnly(!cyanUnreadOnly.value)
             return
         }
+        // #106 (tinc) — re-tapping the already-selected (non-Cyan) tab is a no-op : keep its scroll
+        // position, raise nothing.
+        if (tab == _selectedTab.value) return
         _selectedTab.value = tab
+        // #106 — a real tab transition (tap OR swipe commit, both route through selectTab) recalls the
+        // shared list to the top, reusing the one-shot #546 signal (consumed by the screen via
+        // recallListToTop → requestScrollToItem(0)). NOT raised on the Cyan « +lus » filter re-tap (the
+        // FilterFlipScrollResetEffect handles that) nor on a no-op re-tap nor on return-from-topic
+        // (selectedTab unchanged there) — so no spurious reset on rotation either.
+        _recallListToTop.value = true
     }
 
     /** User tapped « Retirer le drapeau » on [flag] : raise the confirmation dialog. */

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -37,6 +37,7 @@ import fr.forumhfr.redface2.core.model.messages.PrivateMessageThread
 import fr.forumhfr.redface2.core.model.mpstorage.MpStorageDocument
 import fr.forumhfr.redface2.core.model.mpstorage.MpStorageFlagEntry
 import fr.forumhfr.redface2.core.model.mpstorage.MpStorageResult
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageWriteResult
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
@@ -164,6 +165,25 @@ class FlagsViewModelTest {
 
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun `selectTab to a different tab recalls the list to the top (#106)`() = runTest {
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1))
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val vm = viewModel(auth, flags, forum)
+
+        assertFalse("no recall before any tab change", vm.recallListToTop.value)
+
+        vm.selectTab(FlagTab.Red) // real transition (tap or swipe commit both route here)
+        assertTrue("a real tab switch recalls the list to the top", vm.recallListToTop.value)
+
+        vm.consumeRecallListToTop()
+        assertFalse(vm.recallListToTop.value)
+
+        vm.selectTab(FlagTab.Red) // re-tap the same tab: no-op, no recall (keeps scroll position)
+        assertFalse("re-tapping the already-selected tab must not recall", vm.recallListToTop.value)
     }
 
     @Test
@@ -2124,5 +2144,11 @@ class FlagsViewModelTest {
             thrown?.let { throw it }
             return result
         }
+
+        // The DT tab only READS MPStorage; the write path (#6, guarded) is never exercised here, so the
+        // fake stubs it. Added when chantier B extended MpStorageRepository with writeBackFlag (cross-module
+        // fake update the B build missed — its validation didn't compile :feature:flags tests).
+        override suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult =
+            MpStorageWriteResult.TargetNotFound
     }
 }


### PR DESCRIPTION
Retour bêta (tinc) : changer d'onglet Drapeaux doit ramener la liste **en haut** (actuellement après un swipe il faut scroller à la main).

- `selectTab` (qui centralise tap ET commit de swipe) lève le signal one-shot **`recallListToTop`** (#546, déjà consommé par l'écran → `requestScrollToItem(0)`) sur une **vraie transition** d'onglet.
- **Pas** levé sur : le re-tap Cyan « +lus » (géré par `FilterFlipScrollResetEffect`), un re-tap no-op du même onglet, ni le retour-depuis-un-sujet (`selectedTab` inchangé) → aucun reset intempestif sur rotation. Cadré **Option C** par Codex.
- Test ajouté.

**Fix collatéral** : `FakeMpStorageRepository` (test `feature/flags`, #509) n'implémentait pas `writeBackFlag` (ajouté à l'interface par le chantier B #577, dont la validation n'incluait pas `:feature:flags:testDebugUnitTest`) → la compil du test était **cassée sur dev**. Stub ajouté (le tab DT ne fait que lire). Cette PR remet `:feature:flags:testDebugUnitTest` au vert sur dev.

Build : `:feature:flags:testDebugUnitTest` + `:app:assembleDevDebug` + `detektAll` + `lintDebug` verts.

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)