### PR TITLE
feat(settings): option « Afficher l'ascenseur » (#105) + fix fakes inspector MPStorage

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
@@ -66,6 +66,13 @@ class AppThemeViewModel @Inject constructor(
         userPreferencesRepository.observeFoldLongQuotes()
             .stateIn(viewModelScope, SharingStarted.Eagerly, true)
 
+    // #105 — « afficher l'ascenseur » reading preference, eagerly collected like the presets above.
+    // No bootstrap mirror (it does not paint the pre-first-frame window); the seed is the `true`
+    // default and DataStore resolves on the first Eagerly read.
+    val showScrollbar: StateFlow<Boolean> =
+        userPreferencesRepository.observeShowScrollbar()
+            .stateIn(viewModelScope, SharingStarted.Eagerly, true)
+
     // #445 — debug bounds overlay toggle (dev channel only; the channel gate lives in RedfaceApp).
     // No bootstrap mirror: it does not paint the pre-first-frame window, so the seed is the `false`
     // default and DataStore resolves on the first Eagerly read.

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -538,6 +538,8 @@ fun RedfaceApp(intent: Intent?) {
     val fontScale by themeViewModel.fontScale.collectAsStateWithLifecycle()
     // #332 — « fold long quotes » reading preference, provided to the post renderer via RedfaceTheme.
     val foldLongQuotes by themeViewModel.foldLongQuotes.collectAsStateWithLifecycle()
+    // #105 — « afficher l'ascenseur » reading preference, provided to the reading scrollbar via RedfaceTheme.
+    val showScrollbar by themeViewModel.showScrollbar.collectAsStateWithLifecycle()
     // #445 — debug bounds overlay preference (the dev-channel gate + render live in
     // [DevDebugBoundsOverlay], emitted last so it paints over everything; off by default).
     val debugBoundsOverlay by themeViewModel.debugBoundsOverlay.collectAsStateWithLifecycle()
@@ -600,6 +602,7 @@ fun RedfaceApp(intent: Intent?) {
             density = displayDensity,
             fontScale = fontScale,
             foldLongQuotes = foldLongQuotes,
+            showScrollbar = showScrollbar,
         ),
     ) {
         // #458 — cold-start screen, read synchronously from the bootstrap mirror and frozen for

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModelTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModelTest.kt
@@ -58,6 +58,8 @@ class AppThemeViewModelTest {
             every { observeDebugBoundsOverlay() } returns MutableStateFlow(false)
             // #332 — eagerly collected by the VM constructor; default on is enough here.
             every { observeFoldLongQuotes() } returns MutableStateFlow(true)
+            // #105 — eagerly collected by the VM constructor; default on is enough here.
+            every { observeShowScrollbar() } returns MutableStateFlow(true)
             // #518 — eagerly collected by the VM constructor; default off is enough here.
             every { observeHideSystemNavBar() } returns MutableStateFlow(false)
             // #518 follow-up — eagerly collected by the VM constructor; default on is enough here.
@@ -87,6 +89,8 @@ class AppThemeViewModelTest {
             every { observeDebugBoundsOverlay() } returns MutableStateFlow(false)
             // #332 — eagerly collected by the VM constructor; default on is enough here.
             every { observeFoldLongQuotes() } returns MutableStateFlow(true)
+            // #105 — eagerly collected by the VM constructor; default on is enough here.
+            every { observeShowScrollbar() } returns MutableStateFlow(true)
             // #518 — eagerly collected by the VM constructor; default off is enough here.
             every { observeHideSystemNavBar() } returns MutableStateFlow(false)
             // #518 follow-up — eagerly collected by the VM constructor; default on is enough here.

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -368,6 +368,22 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeShowScrollbar(): Flow<Boolean> =
+        dataStore.data
+            // Default `true` (#105): the reading scrollbar is the historical behaviour; hiding it is
+            // the opt-out requested in the beta thread (styx42).
+            .map { prefs -> prefs[KEY_SHOW_SCROLLBAR] ?: true }
+            .distinctUntilChanged()
+            .catch { emit(true) }
+
+    override suspend fun setShowScrollbar(enabled: Boolean) {
+        persist {
+            dataStore.edit { prefs ->
+                prefs[KEY_SHOW_SCROLLBAR] = enabled
+            }
+        }
+    }
+
     override fun observeStartScreen(): Flow<StartScreenPreference> =
         dataStore.data
             .map(::readStartScreen)
@@ -734,6 +750,9 @@ class DataStoreUserPreferencesRepository @Inject constructor(
 
         // #332 — fold long top-level citations by default (default true = historical fold; opt-out).
         val KEY_FOLD_LONG_QUOTES = booleanPreferencesKey("fold_long_quotes")
+
+        // #105 — show the intra-page reading scrollbar (default true = historical; opt-out).
+        val KEY_SHOW_SCROLLBAR = booleanPreferencesKey("show_scrollbar")
 
         // #458 — cold-start tab (StartScreenChoice.name, defensively parsed) + optional Forum
         // category id (absent unless screen == FORUM and a category was picked).

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -587,6 +587,27 @@ class DataStoreUserPreferencesRepositoryTest {
     }
 
     @Test
+    fun `observeShowScrollbar defaults to true then persists false and true`() = runTest(dispatcher) {
+        // #105 — the reading scrollbar is the historical behaviour; disabling it is the opt-out.
+        repository.observeShowScrollbar().test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setShowScrollbar(false)
+        repository.observeShowScrollbar().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setShowScrollbar(true)
+        repository.observeShowScrollbar().test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `observeConfirmBeforePosting defaults to false then persists true and false`() = runTest(dispatcher) {
         // #312 — publishing stays one-tap by default; the guard is strictly opt-in.
         repository.observeConfirmBeforePosting().test {

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -583,6 +583,10 @@ class TopicRepositoryImplTest {
 
         override suspend fun setFoldLongQuotes(enabled: Boolean) = Unit
 
+        override fun observeShowScrollbar(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setShowScrollbar(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -237,6 +237,19 @@ interface UserPreferencesRepository {
     suspend fun setFoldLongQuotes(enabled: Boolean)
 
     /**
+     * #105 — whether the intra-page reading scrollbar ([LazyListScrollbar], the thin auto-hiding
+     * fast-scroll thumb on the right edge of a topic page / private-message thread) is shown. Default
+     * `true` (the historical behaviour); `false` hides it entirely (sujets AND MP) — the beta feedback
+     * from styx42 that the ascenseur is unwanted. Pure render-time switch (no refetch), provided to the
+     * scrollbar through a CompositionLocal at the app root ([fr.forumhfr.redface2.navigation.RedfaceApp])
+     * and mirrored in Settings.
+     */
+    fun observeShowScrollbar(): Flow<Boolean>
+
+    /** Persists [observeShowScrollbar]. Default `true` until the first call. */
+    suspend fun setShowScrollbar(enabled: Boolean)
+
+    /**
      * #458 — which top-level tab (and optional Forum category) a cold start opens on. Default
      * [StartScreenChoice.FLAGS] (historical behaviour). The navigation reads the SYNCHRONOUS
      * [StartScreenBootstrapStore] mirror at cold start; this flow is the source of truth and

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/RedfaceTheme.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/RedfaceTheme.kt
@@ -14,6 +14,7 @@ import fr.forumhfr.redface2.core.domain.preferences.AccentColor
 import fr.forumhfr.redface2.core.ui.theme.DisplayMetrics
 import fr.forumhfr.redface2.core.ui.theme.LocalDisplayMetrics
 import fr.forumhfr.redface2.core.ui.theme.LocalFoldLongQuotes
+import fr.forumhfr.redface2.core.ui.theme.LocalShowScrollbar
 import fr.forumhfr.redface2.core.ui.theme.ReadingDisplaySettings
 import fr.forumhfr.redface2.core.ui.theme.RedfaceAmoledColorScheme
 import fr.forumhfr.redface2.core.ui.theme.RedfaceDarkColorScheme
@@ -49,6 +50,9 @@ fun RedfaceTheme(
         // #332 — expose the « fold long quotes » preference to the post renderer (read via
         // LocalFoldLongQuotes.current in QuoteBlock) so flipping the toggle re-renders posts.
         LocalFoldLongQuotes provides reading.foldLongQuotes,
+        // #105 — expose the « afficher l'ascenseur » preference to the reading scrollbar (read via
+        // LocalShowScrollbar.current in LazyListScrollbar) so flipping the toggle hides/shows it.
+        LocalShowScrollbar provides reading.showScrollbar,
     ) {
         MaterialTheme(
             colorScheme = colorScheme,

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/list/LazyListScrollbar.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/list/LazyListScrollbar.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.ui.theme.LocalShowScrollbar
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -83,6 +84,11 @@ fun LazyListScrollbar(
     listState: LazyListState,
     modifier: Modifier = Modifier,
 ) {
+    // #105 — « afficher l'ascenseur » opt-out: render nothing when the preference is off (sujets AND
+    // MP, both call-sites go through this composable). Read at the call-site of the local so flipping
+    // the Settings toggle recomposes this away; the early-return keeps the scrollbar's per-frame
+    // derivedState machinery from running at all while hidden.
+    if (!LocalShowScrollbar.current) return
     val canScroll by remember {
         derivedStateOf { listState.canScrollForward || listState.canScrollBackward }
     }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/DisplayMetrics.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/DisplayMetrics.kt
@@ -72,6 +72,16 @@ val LocalDisplayMetrics = staticCompositionLocalOf { DisplayMetrics.Comfort }
 val LocalFoldLongQuotes = staticCompositionLocalOf { true }
 
 /**
+ * Project CompositionLocal carrying the #105 « afficher l'ascenseur » reading preference. Same
+ * `staticCompositionLocalOf` rationale as [LocalFoldLongQuotes]: the value changes only when the
+ * user flips the toggle, so the subtree recomposes once on change. Defaults to `true` (the
+ * historical scrollbar) for previews / hosts that do not provide it; `RedfaceTheme` provides the
+ * resolved value from [ReadingDisplaySettings.showScrollbar]. Read by
+ * [fr.forumhfr.redface2.core.ui.list.LazyListScrollbar], which renders nothing when `false`.
+ */
+val LocalShowScrollbar = staticCompositionLocalOf { true }
+
+/**
  * Project CompositionLocal asking the post renderer to IGNORE the author's inline `[color]` styling
  * for the subtree it wraps (#553). HFR signatures embed colours chosen for the white web background;
  * rendered as-is on the app theme (especially dark) they read as unreadable/garish, so the signature

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/ReadingDisplaySettings.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/ReadingDisplaySettings.kt
@@ -18,4 +18,7 @@ data class ReadingDisplaySettings(
     // #332 — whether a long top-level citation folds to a one-line header by default. `true`
     // (default) keeps the historical fold; `false` disables it so a long quote renders expanded.
     val foldLongQuotes: Boolean = true,
+    // #105 — whether the intra-page reading scrollbar is shown. `true` (default) keeps the
+    // historical ascenseur; `false` hides it entirely (topic pages AND private-message threads).
+    val showScrollbar: Boolean = true,
 )

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -2000,6 +2000,10 @@ class PostEditorViewModelTest {
 
         override suspend fun setFoldLongQuotes(enabled: Boolean) = Unit
 
+        override fun observeShowScrollbar(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setShowScrollbar(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1400,6 +1400,10 @@ class TopicFormViewModelTest {
 
         override suspend fun setFoldLongQuotes(enabled: Boolean) = Unit
 
+        override fun observeShowScrollbar(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setShowScrollbar(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -2003,6 +2003,10 @@ class FlagsViewModelTest {
 
         override suspend fun setFoldLongQuotes(enabled: Boolean) = Unit
 
+        override fun observeShowScrollbar(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setShowScrollbar(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -536,6 +536,17 @@ internal fun buildSettingsCatalogue(
                     .takeIf { state.foldLongQuotesError },
                 onCheckedChange = { onIntent(SettingsIntent.FoldLongQuotesChanged(it)) },
             ),
+            // #105 — afficher l'ascenseur de lecture (sujets et MP), retour bêta styx42.
+            toggleRow(
+                id = "show_scrollbar",
+                title = stringResource(R.string.settings_show_scrollbar_title),
+                description = stringResource(R.string.settings_show_scrollbar_description),
+                checked = state.showScrollbar,
+                enabled = state.canToggleShowScrollbar,
+                errorRes = R.string.settings_show_scrollbar_persist_failed
+                    .takeIf { state.showScrollbarError },
+                onCheckedChange = { onIntent(SettingsIntent.ShowScrollbarChanged(it)) },
+            ),
             futureRow(
                 id = "future_restore_read_position",
                 title = stringResource(R.string.settings_future_restore_read_position),

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -127,6 +127,12 @@ data class SettingsState(
     val isUpdatingFoldLongQuotes: Boolean = false,
     val foldLongQuotesError: Boolean = false,
     val foldLongQuotesTouchedLocally: Boolean = false,
+    // #105 — afficher l'ascenseur de lecture. Même machinerie optimistic-flip + garde de course au
+    // démarrage. Default TRUE (ascenseur historique) : le toggle est l'opt-out (retour bêta styx42).
+    val showScrollbar: Boolean = true,
+    val isUpdatingShowScrollbar: Boolean = false,
+    val showScrollbarError: Boolean = false,
+    val showScrollbarTouchedLocally: Boolean = false,
     // #518 — masquer la barre de navigation système Android (plein écran immersif). Même machinerie
     // optimistic-flip + garde de course. Default FALSE (opt-in).
     val hideSystemNavBar: Boolean = false,
@@ -263,6 +269,10 @@ data class SettingsState(
     val canToggleFoldLongQuotes: Boolean
         get() = !isUpdatingFoldLongQuotes
 
+    // #105 — the show-scrollbar toggle is gated only by its own write.
+    val canToggleShowScrollbar: Boolean
+        get() = !isUpdatingShowScrollbar
+
     // #518 — the hide-system-nav-bar toggle is gated only by its own write.
     val canToggleHideSystemNavBar: Boolean
         get() = !isUpdatingHideSystemNavBar
@@ -389,6 +399,9 @@ sealed interface SettingsIntent {
 
     /** #332 — replier les longues citations sur une ligne. */
     data class FoldLongQuotesChanged(val enabled: Boolean) : SettingsIntent
+
+    /** #105 — afficher l'ascenseur de lecture (sujets et MP). */
+    data class ShowScrollbarChanged(val enabled: Boolean) : SettingsIntent
 
     /** #518 — masquer la barre de navigation système Android (plein écran immersif). */
     data class HideSystemNavBarChanged(val enabled: Boolean) : SettingsIntent

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -115,6 +115,11 @@ class SettingsViewModel @Inject constructor(
             apply = { state, value -> state.copy(foldLongQuotes = value) },
         )
         hydratePreference(
+            read = { userPreferencesRepository.observeShowScrollbar().first() },
+            isLocked = { it.showScrollbarTouchedLocally || it.isUpdatingShowScrollbar },
+            apply = { state, value -> state.copy(showScrollbar = value) },
+        )
+        hydratePreference(
             read = { userPreferencesRepository.observeHideSystemNavBar().first() },
             isLocked = { it.hideSystemNavBarTouchedLocally || it.isUpdatingHideSystemNavBar },
             apply = { state, value -> state.copy(hideSystemNavBar = value) },
@@ -243,6 +248,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.TopicPollsExpandedChanged -> updateTopicPollsExpanded(intent.enabled)
             is SettingsIntent.TopicSignaturesChanged -> updateTopicSignatures(intent.enabled)
             is SettingsIntent.FoldLongQuotesChanged -> updateFoldLongQuotes(intent.enabled)
+            is SettingsIntent.ShowScrollbarChanged -> updateShowScrollbar(intent.enabled)
             is SettingsIntent.HideSystemNavBarChanged -> updateHideSystemNavBar(intent.enabled)
             is SettingsIntent.ImmersiveBackButtonChanged -> updateImmersiveBackButton(intent.enabled)
             is SettingsIntent.ImmersiveNavBarRevealChanged -> updateImmersiveNavBarReveal(intent.mode)
@@ -832,6 +838,33 @@ class SettingsViewModel @Inject constructor(
                 }
             },
             persist = userPreferencesRepository::setFoldLongQuotes,
+        )
+    }
+
+    private fun updateShowScrollbar(desired: Boolean) {
+        val previous = _state.value.showScrollbar
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    showScrollbar = desired,
+                    isUpdatingShowScrollbar = true,
+                    showScrollbarError = false,
+                    showScrollbarTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(showScrollbar = desired, isUpdatingShowScrollbar = false)
+                } else {
+                    state.copy(
+                        showScrollbar = previous,
+                        isUpdatingShowScrollbar = false,
+                        showScrollbarError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setShowScrollbar,
         )
     }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -326,6 +326,9 @@
     <string name="settings_fold_long_quotes_title">Replier les longues citations</string>
     <string name="settings_fold_long_quotes_description">Les longues citations sont repliées sur une ligne, dépliables au clic ; sinon elles restent affichées en entier.</string>
     <string name="settings_fold_long_quotes_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
+    <string name="settings_show_scrollbar_title">Afficher l\'ascenseur</string>
+    <string name="settings_show_scrollbar_description">Affiche l\'ascenseur de défilement sur le bord droit lors de la lecture d\'un sujet ou d\'un message privé.</string>
+    <string name="settings_show_scrollbar_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
 
     <!-- #312 — Publication. Confirmation avant chaque envoi (réponse/édition de message, sujet,
          message privé) ; persisté en DataStore et lu en direct par les éditeurs.

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/MpStorageInspectorViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/MpStorageInspectorViewModelTest.kt
@@ -8,6 +8,7 @@ import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.mpstorage.MpStorageDocument
 import fr.forumhfr.redface2.core.model.mpstorage.MpStorageFlagEntry
 import fr.forumhfr.redface2.core.model.mpstorage.MpStorageResult
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageWriteResult
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -171,6 +172,10 @@ class MpStorageInspectorViewModelTest {
                     ),
                 )
             }
+
+            // Read-only inspector: a write must NEVER happen here — fail loudly if one slips in (Codex review).
+            override suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult =
+                error("Unexpected writeBackFlag call in the read-only inspector test")
         }
         val auth = FakeAuthRepository(AuthState.Authenticated("Alice"))
         val viewModel = MpStorageInspectorViewModel(repo, FakeLocationStore(), auth)
@@ -216,6 +221,10 @@ class MpStorageInspectorViewModelTest {
             error?.let { throw it }
             return result
         }
+
+        // Read-only inspector: a write must NEVER happen here — fail loudly if one slips in (Codex review).
+        override suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult =
+            error("Unexpected writeBackFlag call in the read-only inspector test")
     }
 
     private class FakeLocationStore(

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -1052,6 +1052,41 @@ class SettingsViewModelTest {
         assertTrue(viewModel.state.value.foldLongQuotesError)
     }
 
+    @Test
+    fun `init hydrates showScrollbar from a persisted false`() = runTest {
+        // #105 — default is true; only a persisted opt-OUT exercises the hydration path.
+        repository.emitShowScrollbar(false)
+
+        val viewModel = newViewModel()
+
+        assertFalse(viewModel.state.value.showScrollbar)
+        assertFalse(viewModel.state.value.showScrollbarError)
+    }
+
+    @Test
+    fun `ShowScrollbarChanged persists the flip`() = runTest {
+        val viewModel = newViewModel()
+        assertTrue("scrollbar shown by default", viewModel.state.value.showScrollbar)
+
+        viewModel.submit(SettingsIntent.ShowScrollbarChanged(false))
+
+        assertFalse(viewModel.state.value.showScrollbar)
+        assertFalse(viewModel.state.value.isUpdatingShowScrollbar)
+        assertEquals(1, repository.showScrollbarSetCalls)
+    }
+
+    @Test
+    fun `ShowScrollbarChanged reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnShowScrollbarSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.ShowScrollbarChanged(false))
+
+        assertTrue("failed persist must revert to the previous value", viewModel.state.value.showScrollbar)
+        assertFalse(viewModel.state.value.isUpdatingShowScrollbar)
+        assertTrue(viewModel.state.value.showScrollbarError)
+    }
+
     // ──────────────────────────────────────────────────────────────────────
     // Hide system navigation bar (#518)
     // ──────────────────────────────────────────────────────────────────────
@@ -1783,6 +1818,24 @@ class SettingsViewModelTest {
 
         fun emitFoldLongQuotes(value: Boolean) {
             foldLongQuotes.value = value
+        }
+
+        // #105 — afficher l'ascenseur. Même seam optimistic-flip ; default TRUE (ascenseur affiché).
+        private val showScrollbar = MutableStateFlow(true)
+        var showScrollbarSetCalls: Int = 0
+            private set
+        var failOnShowScrollbarSet: Boolean = false
+
+        override fun observeShowScrollbar(): Flow<Boolean> = showScrollbar
+
+        override suspend fun setShowScrollbar(enabled: Boolean) {
+            showScrollbarSetCalls += 1
+            check(!failOnShowScrollbarSet) { "boom" }
+            showScrollbar.value = enabled
+        }
+
+        fun emitShowScrollbar(value: Boolean) {
+            showScrollbar.value = value
         }
 
         // #458 — start screen lives on its own StartScreenSettingsViewModel; this fake only

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -1744,6 +1744,10 @@ private class FakeUserPreferencesRepository(
 
     override suspend fun setFoldLongQuotes(enabled: Boolean) = Unit
 
+    override fun observeShowScrollbar(): Flow<Boolean> = MutableStateFlow(true)
+
+    override suspend fun setShowScrollbar(enabled: Boolean) = Unit
+
     override fun observeStartScreen(): Flow<StartScreenPreference> =
         MutableStateFlow(StartScreenPreference())
 


### PR DESCRIPTION
Retour bêta (styx42) : pouvoir **masquer l'ascenseur** (scrollbar) des listes.

- Réglage booléen **« Afficher l'ascenseur »** (défaut activé) dans Réglages > Affichage, calqué à l'identique sur `foldLongQuotes` (#332) : pref `UserPreferencesRepository` + DataStore (`show_scrollbar`, lecture défensive `?: true`), `ReadingDisplaySettings.showScrollbar`, `LocalShowScrollbar` posé par `RedfaceTheme`, **early-return dans `LazyListScrollbar`** (masque l'ascenseur sur sujets ET MP), `AppThemeViewModel` eager + injection dans le reading bundle, toggle Settings.
- Tests : round-trip DataStore + hydratation/toggle/revert SettingsViewModel. **Tous les fakes** `UserPreferencesRepository` (6) + le mockk `AppThemeViewModel` mis à jour (piège connu).

**Fix collatéral** : les 2 fakes de `MpStorageInspectorViewModelTest` n'implémentaient pas `writeBackFlag` (ajouté à l'interface par le chantier B #577, validation incomplète) → `:feature:settings:testDebugUnitTest` ne compilait pas sur dev. Stub ajouté puis durci en `error(...)` (inspecteur read-only, fail-loud — review Codex). Remet ce module au vert sur dev.

Build : tous les modules à fakes + Konsist `:app:testDevDebugUnitTest` + detekt + lint verts. Revue Codex (gpt-5.5, xhigh) : 0 bloquant.

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)