### PR TITLE
docs: consolidation post-audit (Phase, limites DT/MPStorage/recherche, CHANGELOG dev)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,27 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## v157–v170 — `0.14.0` — `internal` (dev) — 2026-06-18/19
+
+Builds **dev (internal)** accumulés depuis la bêta 0.14.0 (`v156`), même `versionName 0.14.0`. À consolider en
+entrées propres + bump `versionName 0.15.0` avant la prochaine bêta (le `CHANGELOG.md` racine reste à mettre à jour aussi).
+
+- **v157** — Blacklist locale #509 (masquer un utilisateur : menu post + fiche profil + sous-page Réglages).
+- **v158** — Plein écran #518 : masquer la barre de navigation Android (+ pseudo créateur doré #221).
+- **v159** — Bouton retour flottant en plein écran (#518, option).
+- **v160** — Fix régression images postées seules (#568).
+- **v161** — Révélation auto de la barre système en plein écran (#518, multi-comportements).
+- **v162** — Fix jitter de la barre système à l'arrivée en bas (#518).
+- **v163** — Option couleur d'accent « Rouge REDFACE1 » + retrait du fond de mise en avant (TU 2788511).
+- **v164** — Liseré post ciblé + pastille « Ajouté à la citation » hors du bandeau d'identité.
+- **v165** — Post ciblé : bandeau d'identité teinté `tertiaryContainer` (remplace le liseré).
+- **v166** — Onglet « DT » des Drapeaux = liste des MultiMP + reprise de lecture MPStorage (#509/#6).
+- **v167** — Recherche intra-topic (`transsearch.php`) : mot/pseudo + filtre serveur (#150 suite ; next/prev différé).
+- **v168** — Ligne « Suite à la page suivante » sur les pages intermédiaires d'un sujet (#110).
+- **v169** — Changement d'onglet Drapeaux → retour en haut de liste (#106).
+- **v170** — Option « Afficher l'ascenseur » (#105).
+- *(mergé sans release)* — Mécanique d'écriture MPStorage v1 RMW **guardée** (POST différé, non observé live, #6/#577).
+
 ## v156 — `0.14.0` — 2026-06-17
 
 **Statut** : `open` (track open testing — canal beta, Play Edit committed) + F-Droid `.beta`

--- a/docs/guides/known-issues.md
+++ b/docs/guides/known-issues.md
@@ -42,6 +42,12 @@ Liste **vivante** des limitations connues de Redface 2 et des compromis **assum�
 - **Prefetch non authentifié — volontaire.** Le préchargement utilise des requêtes non authentifiées, délibérément, pour **ne pas marquer les drapeaux comme lus** côté serveur.
 - **Deep links HFR — domaine non vérifiable.** Le domaine HFR n'est pas vérifiable côté Play Console ; les fragments d'URI (`#t<id>`) sont parsés dans `RedfaceApp` (Compose Navigation 3 ne gère pas les fragments nativement) (cf. #127).
 
+## Messages privés &amp; DT (Phase 3 — éléments reportés)
+
+- **Écriture MPStorage v1 non activée — POST non observé.** La mécanique de write-back (read-modify-write préservant tous les namespaces tiers du document JSON, cap 256 KiB, sélection déterministe du document cible) est implémentée et unit-testée, mais **aucun POST réel n'est déclenché** : le contrat `bdd.php cat=prive` n'a jamais été capturé en conditions réelles (pas de device cette nuit-là). L'API publique reste en lecture/préparation ; le POST live n'est accessible que par un chemin module-interne test-only. Activation réelle reportée après observation du contrat (#6, ADR-014 §4).
+- **Onglet « DT » — première page de l'inbox seulement.** La liste des MultiMP se base sur la 1ʳᵉ page de la boîte (conversations récentes) ; le balayage multi-pages est différé (coût du scan MPStorage). Le badge « reprise p.N » est une **position de reprise de lecture** (MPStorage), **pas** un état lu/non-lu — le non-lu vient du dot inbox (`hasUnread`). Pas de « vrais » `Flag` MP (HFR n'expose pas de drapeaux côté MP).
+- **Recherche intra-topic — pas de navigation résultat suivant/précédent.** La recherche `transsearch.php` (mot/pseudo) et le filtre serveur (« n'afficher que les correspondances ») sont livrés, mais la navigation entre résultats (`currentnum`) n'est **pas** câblée : la réponse `transsearch` n'a jamais été observée live. À finir après capture du comportement serveur.
+
 ---
 
 *Page maintenue au fil de l'eau : ajouter ici tout compromis délibéré ou limite plateforme nouvellement constaté, avec un lien vers l'issue de suivi.*

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,7 +71,7 @@ graph TB
 
 ## État du projet
 
-Phase courante : **Phase 2 — Écriture, close-out alpha** ([roadmap]({{ site.baseurl }}/specs/roadmap)). La Phase 1 (lecture : login, drapeaux, forum, topics, cache, deep links, recherche de base) est livrée ; la Phase 2 ferme les derniers flux d'écriture et de polish avant de basculer vers les MPs.
+Phase courante : **Phase 4 — Extensions** ([roadmap]({{ site.baseurl }}/specs/roadmap)). Phases 1 (lecture), 2 (écriture) et 3 (messages) sont **livrées** : login, drapeaux, forum, topics, cache, deep links, recherche, écriture/édition/citation/création, MPs classiques et MultiMPs (lecture, reply, quote, onglet DT). Seule la synchronisation/écriture MPStorage reste reportée (#6, Phase 4). Le dev (canal interne) accumule en `0.14.0` avant la prochaine bêta.
 
 Les specs restent la source de vérité du projet, mais elles doivent désormais refléter le code réel : tout écart entre une page canonique et le repo est traité comme un bug de spec, pas comme une dette future. Voir [`/spec-reality`](https://github.com/ForumHFR/redface2/blob/main/.agents/skills/spec-reality/SKILL.md) pour la procédure d'audit cross-fichier.
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -90,9 +90,9 @@ class FlagsViewModel @Inject constructor(
     val selectedTab: StateFlow<FlagTab> = _selectedTab.asStateFlow()
 
     /**
-     * Whether the opt-in « DT » placeholder tab is shown (Settings toggle, default off).
-     * The content arrives with the MPStorage sync (#6) — until then the tab only renders
-     * a placeholder body, like [FlagTab.Super].
+     * Whether the opt-in « DT » tab is shown (Settings toggle, default off). The tab lists the user's
+     * MultiMP conversations enriched with MPStorage reading positions (see [dtListState]) — it is a
+     * real backed list now (#6), NOT a placeholder like [FlagTab.Super].
      */
     val showDtTab: StateFlow<Boolean> = userPreferencesRepository.observeShowDtSection()
         .stateIn(
@@ -106,8 +106,8 @@ class FlagsViewModel @Inject constructor(
      * [PrivateMessageSummary.isMultiRecipient]) enriched best-effort with the MPStorage reading
      * positions (DTCloud's `mpFlags`). A dedicated state (NOT a [FlagsListUiState] / [Flag] reuse,
      * arbitrage Codex): the DT channel is a private-message list, not a flag list, so it never
-     * shares the flag model's contract (`flagType == null` stays a pure « no backend » marker for
-     * Super/DT placeholders elsewhere in this ViewModel).
+     * shares the flag model's contract (`flagType == null` stays a pure « no flag-pipeline fetch »
+     * marker — for the [FlagTab.Super] placeholder, and for DT which is served by [dtListState] instead).
      *
      * The fetch is triggered on tab OPENING ([onDtTabOpened]) — never from the per-category
      * auto-refresh — because [MpStorageRepository.fetchStorage] is expensive (it scans the inbox to

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1728,8 +1728,9 @@ internal fun TopicPostCard(
     onOpenMenu: () -> Unit = {},
     /**
      * #436 — true when this post sits in the multi-quote basket (#291). Marks the card with a
-     * primary border + an « Ajouté à la citation » pill in the identity band, so the selection
-     * is visible without opening the per-post menu (dev feedback by Dintr-un lemn).
+     * primary border + an « Ajouté à la citation » pill rendered BELOW the identity band (moved out of
+     * the band so it no longer grows it on selection), so the selection is visible without opening the
+     * per-post menu (dev feedback by Dintr-un lemn).
      */
     multiQuoteSelected: Boolean = false,
     /**


### PR DESCRIPTION
Ferme les **oublis de doc** relevés par l'audit Codex « mandat vs livré » :
- `docs/index.md` : « Phase courante » Phase 2 → **Phase 4** (Phases 1/2/3 livrées ; sync/écriture MPStorage reportée → #6).
- `docs/guides/known-issues.md` : **centralise 3 limites/reports** — écriture MPStorage non activée (POST `bdd.php cat=prive` non observé), onglet DT **page 1 only** (badge « reprise » ≠ non-lu), recherche intra-topic **sans suivant/précédent** (`currentnum` non câblé).
- `app/CHANGELOG.md` : entrées dev **v157-v170** (à consolider + bump `versionName 0.15.0` avant la prochaine bêta).
- Commentaires périmés : `FlagTab.Dt` n'est plus un placeholder ; pastille multi-quote **sous** le bandeau d'identité.

Doc + commentaires uniquement. Build (assemble + detekt + lint) vert.

> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)