### PR TITLE
feat(flags): l'onglet DT réutilise la ligne partagée ForumListRow (plus de Card)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
@@ -18,7 +18,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
@@ -60,6 +63,54 @@ fun FlagItem(
     modifier: Modifier = Modifier,
     longPress: FlagItemLongPress? = null,
 ) {
+    // FlagItem is now a thin `Flag`-typed binding over the shared [ForumListRow] : the bucket dot is
+    // the leading slot, the unread state drives the title emphasis. Keeping FlagItem's public
+    // signature stable means its existing callers / tests are untouched while DT (and any future
+    // forum list) renders through the SAME row primitive — change the row once, every list follows.
+    ForumListRow(
+        title = flag.title,
+        metadata = metadata,
+        onClick = onClick,
+        modifier = modifier,
+        emphasized = flag.hasUnread,
+        longPress = longPress,
+        leading = { FlagDot(type = flag.type, isFavorite = flag.isFavorite, hasUnread = flag.hasUnread) },
+    )
+}
+
+/**
+ * The single source of truth for a forum-list row (drapeaux Cyan/Red/Favorite, DT MultiMP, and any
+ * future list). It owns the visual contract — leading slot + a two-line stack (title + shared
+ * [TopicMetadataLine]) — the 16 dp horizontal / density-driven vertical rhythm (#287), the tap /
+ * long-press interaction and the `surface` colours. It is deliberately NOT coupled to [Flag] : a row
+ * is `title` + [metadata] + an optional [leading] composable, so non-drapeau lists (DT) reuse it
+ * without smuggling a fake [Flag] through.
+ *
+ * @param emphasized renders the title in [FontWeight.SemiBold] (unread state across every list).
+ * @param longPress optional long-press affordance (#457) ; `null` keeps a plain tap with no
+ *   long-press semantics advertised.
+ * @param leading optional leading slot (the bucket dot for drapeaux, the inbox dot for DT).
+ * @param contentDescription when non-null, REPLACES the row's announced text via
+ *   [clearAndSetSemantics] on the content (the title + [metadata] texts are folded into this single
+ *   description) — for rows like DT whose visible text is terse but whose state (lu/non-lu,
+ *   interlocuteurs, reprise) must be spoken in full. The tap/long-press action stays announced (it
+ *   lives on the row's own clickable, outside the cleared content subtree). `null` keeps the default
+ *   (title + metadata read as-is), which the drapeau rows rely on alongside their removal action.
+ */
+// A Compose row component legitimately exposes many slots; bundling the @Composable [leading] slot
+// and the [onClick] lambda into a data class would be anti-idiomatic and hurt readability.
+@Suppress("LongParameterList")
+@Composable
+fun ForumListRow(
+    title: String,
+    metadata: FlagMetadata,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    emphasized: Boolean = false,
+    longPress: FlagItemLongPress? = null,
+    leading: (@Composable () -> Unit)? = null,
+    contentDescription: String? = null,
+) {
     val rowInteraction = if (longPress != null) {
         Modifier.combinedClickable(
             onLongClick = longPress.onLongPress,
@@ -79,20 +130,29 @@ fun FlagItem(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        FlagDot(type = flag.type, isFavorite = flag.isFavorite, hasUnread = flag.hasUnread)
+        leading?.invoke()
         Column(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(
+                    if (contentDescription != null) {
+                        Modifier.clearAndSetSemantics { this.contentDescription = contentDescription }
+                    } else {
+                        Modifier
+                    },
+                ),
             verticalArrangement = Arrangement.spacedBy(2.dp),
         ) {
             Text(
-                text = flag.title,
+                text = title,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurface,
-                fontWeight = if (flag.hasUnread) FontWeight.SemiBold else FontWeight.Normal,
+                fontWeight = if (emphasized) FontWeight.SemiBold else FontWeight.Normal,
                 maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
             )
-            // #376 — shared two-segment metadata line (start truncatable + date pinned right),
-            // common to the drapeaux / catégorie / recherche lists.
+            // #376 — shared two-segment metadata line (start truncatable + end pinned right),
+            // common to the drapeaux / catégorie / recherche / DT lists.
             TopicMetadataLine(
                 metadata = metadata,
                 style = MaterialTheme.typography.labelSmall,

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -39,7 +39,6 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
-import androidx.compose.material3.Card
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -80,6 +79,7 @@ import fr.forumhfr.redface2.core.ui.FlagItem
 import fr.forumhfr.redface2.core.ui.FlagItemDivider
 import fr.forumhfr.redface2.core.ui.FlagItemLongPress
 import fr.forumhfr.redface2.core.ui.FlagMetadata
+import fr.forumhfr.redface2.core.ui.ForumListRow
 import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.formatLastReplyTimestamp
 import kotlinx.coroutines.launch
@@ -1185,10 +1185,15 @@ private fun DtListBody(state: DtListUiState, actions: AuthenticatedActions) {
             modifier = Modifier
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.surface),
-            contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            items(state.items, key = { it.conversation.threadId }) { item ->
+            // DT now renders through the SAME row primitive + divider as the Cyan/Red/Favorite lists
+            // (no Card, no contentPadding/spacing) so the four lists stay visually identical and a
+            // row change propagates to all (arbitrage XaTriX 2026-06-19).
+            items(
+                items = state.items,
+                key = { it.conversation.threadId },
+                contentType = { CONTENT_TYPE_ROW },
+            ) { item ->
                 DtConversationRow(
                     item = item,
                     // Open on the page the badge ADVERTISES: the MPStorage resume page when present,
@@ -1201,6 +1206,7 @@ private fun DtListBody(state: DtListUiState, actions: AuthenticatedActions) {
                         actions.onOpenMultiMp(item.conversation.threadId, target)
                     },
                 )
+                FlagItemDivider()
             }
         }
     }
@@ -1270,53 +1276,35 @@ private fun DtErrorBody(cause: Throwable, actions: AuthenticatedActions) {
 @Composable
 private fun DtConversationRow(item: DtListItem, onClick: () -> Unit) {
     val conversation = item.conversation
-    // a11y — the read/unread dot is purely decorative (no semantics of its own), so the row carries
-    // the read state for TalkBack: « Non lu : <sujet> » / « Lu : <sujet> » (Codex review). The
-    // « Interlocuteurs multiples » caption and the resume badge stay separately announced beneath it.
+    // DT renders through the shared [ForumListRow]: the inbox dot is the leading slot, the subject is
+    // the title (unread → SemiBold), and the « Interlocuteurs multiples » caption + the « reprise p.N »
+    // MPStorage badge become the two-segment metadata line (badge in `end`, never truncated — Codex).
+    // The badge is a reading POSITION, never a read/unread state (#361/ADR-013).
+    val multiLabel = stringResource(R.string.flags_dt_multi_recipient)
+    val resumeBadge = item.resumePage?.let { stringResource(R.string.flags_dt_resume_badge, it) }.orEmpty()
+    // a11y — the dot is decorative, so the row carries the full announcement for TalkBack: read state
+    // + subject, then « Interlocuteurs multiples » and the resume page when present (Codex review).
     val rowStateDescription = stringResource(
         if (conversation.hasUnread) R.string.flags_dt_row_unread else R.string.flags_dt_row_read,
         conversation.subject,
     )
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .semantics { contentDescription = rowStateDescription },
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            DtUnreadDot(unread = conversation.hasUnread)
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(2.dp),
-            ) {
-                Text(
-                    text = stringResource(R.string.flags_dt_multi_recipient),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Text(
-                    text = conversation.subject,
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-            item.resumePage?.let { page ->
-                Text(
-                    text = stringResource(R.string.flags_dt_resume_badge, page),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
+    val contentDescription = buildString {
+        append(rowStateDescription)
+        append(". ")
+        append(multiLabel)
+        if (resumeBadge.isNotEmpty()) {
+            append(". ")
+            append(resumeBadge)
         }
     }
+    ForumListRow(
+        title = conversation.subject,
+        metadata = FlagMetadata(start = multiLabel, end = resumeBadge),
+        onClick = onClick,
+        emphasized = conversation.hasUnread,
+        leading = { DtUnreadDot(unread = conversation.hasUnread) },
+        contentDescription = contentDescription,
+    )
 }
 
 /**
@@ -1329,13 +1317,13 @@ private fun DtUnreadDot(unread: Boolean) {
     if (unread) {
         Box(
             modifier = Modifier
-                .size(10.dp)
+                .size(12.dp)
                 .background(MaterialTheme.colorScheme.primary, CircleShape),
         )
     } else {
         Box(
             modifier = Modifier
-                .size(10.dp)
+                .size(12.dp)
                 .border(1.dp, MaterialTheme.colorScheme.outline, CircleShape),
         )
     }


### PR DESCRIPTION
## Contexte

Retour XaTriX (2026-06-19) : la liste de l'onglet **DT** de la vue drapeaux doit être basée sur **les mêmes éléments** que les autres onglets (Cyan/Red/Favorite) — pas de `Card`, des lignes classiques — et **réutiliser le même code**, pour qu'un changement de ligne se répercute partout.

## Constat

Les 3 onglets réels partageaient déjà la ligne `core/ui/FlagItem` (source unique). **DT était le seul à diverger** : `DtConversationRow` était une `Card` maison (`contentPadding=16`, `spacedBy=8`, layout propre). C'était la redite qui « sonnait différent ».

## Changement

- Extraction d'un **`ForumListRow`** dans `core/ui` (source unique du contrat visuel d'une ligne de liste forum : slot leading + titre + [`TopicMetadataLine`], rythme 16 dp / densité `#287`, tap/long-press, fond `surface`). Non couplé à `Flag`.
- `FlagItem` **délègue** à `ForumListRow` (signature publique inchangée → consommateurs/tests intacts).
- `DtConversationRow` passe par `ForumListRow` + `FlagItemDivider` (plus de `Card`/`contentPadding`/`spacing`) : dot inbox en leading, sujet en titre (non-lu → SemiBold), « Interlocuteurs multiples » + badge « reprise p.N » sur la ligne de métadonnées (badge en `end`, jamais tronqué).
- a11y préservée : `ForumListRow` expose un `contentDescription` appliqué via `clearAndSetSemantics` (annonce complète lu/non-lu + interlocuteurs + reprise, sans doubler le titre, action de tap conservée).

Résultat : **les 4 onglets partagent désormais la même ligne** — un changement de rendu se propage à tous.

Suivi : tâche interne (pas d'issue GitHub dédiée).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
