### PR TITLE
feat: recherche tout-topic (fix #586) + onglet DT = union MPStorage ∪ inbox page 1

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicSearchRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicSearchRepositoryImpl.kt
@@ -56,9 +56,12 @@ class TopicSearchRepositoryImpl @Inject constructor(
             spseudo = request.spseudo,
             onlyMatches = request.onlyMatches,
             hashCheck = request.form.hashCheck,
-            // Chantier B (#546) — a navigation STEP omits firstnum (the client drops `dep` too).
-            // Re-sending firstnum re-anchors HFR on the first match (the live-verified stepping bug).
-            firstnum = if (request.isStep) null else request.form.firstnum,
+            // #546 — on ne renvoie JAMAIS firstnum (le client omet firstnum+dep quand firstnum=null) :
+            // avec firstnum HFR ancre la recherche en avant de la page courante et rate les matches
+            // antérieurs ; sans firstnum elle couvre tout le topic — vérifié live #546/bug tinc 2788609.
+            // Fresh comme step l'omettent : la recherche fraîche trouve le 1er match du topic entier,
+            // puis next/prev avance via currentnum.
+            firstnum = null,
             owntopic = request.form.owntopic,
             currentnum = request.currentNum,
         )

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicSearchRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicSearchRepositoryImplTest.kt
@@ -31,7 +31,7 @@ import org.junit.Test
 class TopicSearchRepositoryImplTest {
 
     @Test
-    fun `forwards every form field and the filter flag to the HfrClient`() = runTest {
+    fun `forwards every form field and the filter flag, but never firstnum (whole-topic search)`() = runTest {
         val hfrClient = mockk<HfrClient>()
         coEvery {
             hfrClient.searchInTopic(
@@ -66,7 +66,10 @@ class TopicSearchRepositoryImplTest {
                 spseudo = "XaTriX",
                 onlyMatches = true,
                 hashCheck = "tok",
-                firstnum = 2783602,
+                // #546 (bug tinc 2788609) — a FRESH search must NOT send firstnum: with firstnum HFR
+                // anchors the search ahead of the current page and misses earlier matches. firstnum=null
+                // makes it cover the whole topic from the start, even though form.firstnum is non-null.
+                firstnum = null,
                 owntopic = 0,
                 currentnum = null,
             )
@@ -74,7 +77,7 @@ class TopicSearchRepositoryImplTest {
     }
 
     @Test
-    fun `carries the navigation cursor and owntopic verbatim`() = runTest {
+    fun `carries the navigation cursor and owntopic verbatim, still omitting firstnum`() = runTest {
         val hfrClient = mockk<HfrClient>()
         coEvery {
             hfrClient.searchInTopic(
@@ -94,17 +97,19 @@ class TopicSearchRepositoryImplTest {
         )
 
         coVerify(exactly = 1) {
+            // owntopic + currentnum forwarded verbatim ; firstnum dropped (#546 whole-topic search).
             hfrClient.searchInTopic(
                 cat = 32, topicId = 7, word = "", spseudo = "someone", onlyMatches = false,
-                hashCheck = "tok", firstnum = 16244, owntopic = 1, currentnum = "16300",
+                hashCheck = "tok", firstnum = null, owntopic = 1, currentnum = "16300",
             )
         }
     }
 
     @Test
-    fun `omits firstnum on a navigation step so HFR advances the cursor`() = runTest {
-        // Chantier B (#546) — a STEP request (isStep=true) must drop firstnum so HFR does not re-anchor
-        // on the first match. The repository passes firstnum=null to the client; a fresh search keeps it.
+    fun `omits firstnum on a navigation step and forwards currentnum so HFR advances the cursor`() = runTest {
+        // #546 — a STEP request (isStep=true) drops firstnum so HFR does not re-anchor on the first match,
+        // and advances via currentnum. Since the bug-tinc fix, a FRESH search ALSO drops firstnum (whole
+        // topic) — both modes pass firstnum=null ; only currentnum tells fresh (null) from step here.
         val hfrClient = mockk<HfrClient>()
         coEvery {
             hfrClient.searchInTopic(

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -843,6 +843,10 @@ private const val CONTENT_TYPE_HEADER = "category_header"
 private const val CONTENT_TYPE_EMPTY = "empty_section"
 private const val CONTENT_TYPE_ROW = "flag_row"
 
+// #6 — the DT scan-note footer is a distinct, non-row item (not a clickable ForumListRow), so it
+// keeps its own recycling pool and never reuses a row slot.
+private const val CONTENT_TYPE_DT_FOOTER = "dt_scan_note"
+
 /**
  * Category-grouped flag list (#179). Renders one sticky band per [FlagCategorySection] in the
  * canonical category order the ViewModel produced, with the rows under each band. Empty sections
@@ -1156,10 +1160,13 @@ private fun DtTabOpenEffect(
 }
 
 /**
- * #6 — body of the opt-in « DT » tab: the user's MultiMP conversations (inbox `cat=prive`,
- * filtered on [PrivateMessageSummary.isMultiRecipient]) enriched best-effort with the MPStorage
- * reading positions (a discreet « reprise p.N » badge). Tapping a row opens the existing
- * `PrivateMessageThread` route via [AuthenticatedActions.onOpenMultiMp].
+ * #6 — body of the opt-in « DT » tab: the UNION of the user's MultiMP conversations on inbox PAGE 1
+ * (`cat=prive`, filtered on [PrivateMessageSummary.isMultiRecipient]) and the orphan MPStorage
+ * entries absent from that page, deduplicated by `threadId`. Inbox rows render the rich
+ * [DtListItem.InboxBacked] (subject, unread dot, « reprise p.N » badge) ; orphans render the
+ * placeholder [DtListItem.StorageOnly] (« Conversation #threadId », neutral dot). A discreet
+ * scan-note footer states the page-1 limit. Tapping a row opens the existing `PrivateMessageThread`
+ * route via [AuthenticatedActions.onOpenMultiMp].
  *
  * The MPStorage enrichment is best-effort: a missing / unreadable / failed storage read leaves the
  * list intact, just without badges (cf. [FlagsViewModel.loadDt]). Only an inbox load failure
@@ -1188,27 +1195,56 @@ private fun DtListBody(state: DtListUiState, actions: AuthenticatedActions) {
         ) {
             // DT now renders through the SAME row primitive + divider as the Cyan/Red/Favorite lists
             // (no Card, no contentPadding/spacing) so the four lists stay visually identical and a
-            // row change propagates to all (arbitrage XaTriX 2026-06-19).
+            // row change propagates to all (arbitrage XaTriX 2026-06-19). The list is the union of
+            // inbox PAGE 1 MultiMP rows + orphan MPStorage entries (#6) — dispatched per variant.
             items(
                 items = state.items,
-                key = { it.conversation.threadId },
+                key = { it.threadId },
                 contentType = { CONTENT_TYPE_ROW },
             ) { item ->
-                DtConversationRow(
-                    item = item,
-                    // Open on the page the badge ADVERTISES: the MPStorage resume page when present,
-                    // else the conversation's last inbox page (#430). Tapping must land where the
-                    // « reprise p.N » badge says it will — opening lastPage while showing « reprise
-                    // p.N » was a badge/action contradiction (Codex review). Clamp ≥ 1 so a bogus
-                    // stored 0/negative page never produces an invalid route argument.
-                    onClick = {
-                        val target = (item.resumePage ?: item.conversation.lastPage).coerceAtLeast(1)
-                        actions.onOpenMultiMp(item.conversation.threadId, target)
-                    },
-                )
+                DtRow(item = item, onOpenMultiMp = actions.onOpenMultiMp)
                 FlagItemDivider()
             }
+            // Scan-note footer (#6): the list only covers inbox PAGE 1 + what the DT sync knows;
+            // older inbox pages are deliberately not swept. A discreet, non-clickable trailing item.
+            item(key = "dt-scan-note", contentType = CONTENT_TYPE_DT_FOOTER) {
+                Text(
+                    text = stringResource(R.string.flags_dt_scan_note),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
+                )
+            }
         }
+    }
+}
+
+/**
+ * Dispatches a [DtListItem] to its row composable (#6): an [DtListItem.InboxBacked] renders the rich
+ * inbox row, a [DtListItem.StorageOnly] the placeholder orphan row. Both open via [onOpenMultiMp] on
+ * the page the « reprise p.N » badge advertises (clamped ≥ 1).
+ */
+@Composable
+private fun DtRow(item: DtListItem, onOpenMultiMp: (threadId: Int, page: Int) -> Unit) {
+    when (item) {
+        is DtListItem.InboxBacked -> DtConversationRow(
+            item = item,
+            // Open on the page the badge ADVERTISES: the MPStorage resume page when present, else the
+            // conversation's last inbox page (#430). Tapping must land where the « reprise p.N » badge
+            // says it will — opening lastPage while showing « reprise p.N » was a badge/action
+            // contradiction (Codex review). Clamp ≥ 1 so a bogus stored 0/negative page never
+            // produces an invalid route argument.
+            onClick = {
+                val target = (item.resumePage ?: item.conversation.lastPage).coerceAtLeast(1)
+                onOpenMultiMp(item.threadId, target)
+            },
+        )
+
+        is DtListItem.StorageOnly -> DtStorageOnlyRow(
+            item = item,
+            // No lastPage for an orphan: open on the MPStorage resume page (clamped ≥ 1), else page 1.
+            onClick = { onOpenMultiMp(item.threadId, (item.resumePage ?: 1).coerceAtLeast(1)) },
+        )
     }
 }
 
@@ -1274,7 +1310,7 @@ private fun DtErrorBody(cause: Throwable, actions: AuthenticatedActions) {
  * MPStorage badge. The badge is a reading POSITION, never a read/unread state (#361/ADR-013).
  */
 @Composable
-private fun DtConversationRow(item: DtListItem, onClick: () -> Unit) {
+private fun DtConversationRow(item: DtListItem.InboxBacked, onClick: () -> Unit) {
     val conversation = item.conversation
     // DT renders through the shared [ForumListRow]: the inbox dot is the leading slot, the subject is
     // the title (unread → SemiBold), and the « Interlocuteurs multiples » caption + the « reprise p.N »
@@ -1303,6 +1339,40 @@ private fun DtConversationRow(item: DtListItem, onClick: () -> Unit) {
         onClick = onClick,
         emphasized = conversation.hasUnread,
         leading = { DtUnreadDot(unread = conversation.hasUnread) },
+        contentDescription = contentDescription,
+    )
+}
+
+/**
+ * One ORPHAN DT row (#6): a MPStorage `mpFlags` entry absent from inbox PAGE 1. No subject and no
+ * read/unread state are available, so the title is a localized placeholder « Conversation #threadId »
+ * and the leading dot is the neutral (hollow) variant whose a11y reads « état inconnu », never
+ * « Lu ». The « reprise p.N » badge ([DtListItem.StorageOnly.resumePage]) is shown when present.
+ */
+@Composable
+private fun DtStorageOnlyRow(item: DtListItem.StorageOnly, onClick: () -> Unit) {
+    val title = stringResource(R.string.flags_dt_storage_only_title, item.threadId)
+    val multiLabel = stringResource(R.string.flags_dt_multi_recipient)
+    val resumeBadge = item.resumePage?.let { stringResource(R.string.flags_dt_resume_badge, it) }.orEmpty()
+    // a11y — the read/unread state is unknown off-inbox, so the row announces « état inconnu » (never
+    // « Lu »/« Non lu ») followed by the placeholder title, « Interlocuteurs multiples » and the badge.
+    // stringResource resolved here (it is @Composable, unusable inside the plain buildString lambda).
+    val stateUnknown = stringResource(R.string.flags_dt_row_state_unknown, title)
+    val contentDescription = buildString {
+        append(stateUnknown)
+        append(". ")
+        append(multiLabel)
+        if (resumeBadge.isNotEmpty()) {
+            append(". ")
+            append(resumeBadge)
+        }
+    }
+    ForumListRow(
+        title = title,
+        metadata = FlagMetadata(start = multiLabel, end = resumeBadge),
+        onClick = onClick,
+        emphasized = false,
+        leading = { DtUnreadDot(unread = false) },
         contentDescription = contentDescription,
     )
 }

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -1093,15 +1093,18 @@ internal fun buildDtItems(
     inboxMulti: List<PrivateMessageSummary>,
     storageEntries: List<MpStorageFlagEntry>,
 ): List<DtListItem> {
-    val resumeByThread = storageEntries.associate { it.threadId to it.page }
+    // Dedup the MPStorage entries by threadId FIRST (keep first occurrence) so both the inbox-row
+    // resume join and the orphan rows agree on the same page when mpFlags carries a duplicate
+    // threadId (Codex review: `associate` kept the LAST, diverging from the orphans' `distinctBy`).
+    val dedupedEntries = storageEntries.distinctBy { it.threadId }
+    val resumeByThread = dedupedEntries.associate { it.threadId to it.page }
     val inboxThreadIds = inboxMulti.mapTo(HashSet()) { it.threadId }
     return buildList {
         inboxMulti.forEach { summary ->
             add(DtListItem.InboxBacked(summary, resumeByThread[summary.threadId]))
         }
-        storageEntries.asSequence()
+        dedupedEntries.asSequence()
             .filter { it.threadId !in inboxThreadIds }
-            .distinctBy { it.threadId }
             .forEach { entry ->
                 add(DtListItem.StorageOnly(entry.threadId, entry.page, entry.numreponse))
             }

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -17,6 +17,7 @@ import fr.forumhfr.redface2.core.model.Category
 import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.messages.PrivateMessageSummary
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageFlagEntry
 import fr.forumhfr.redface2.core.model.mpstorage.MpStorageResult
 import java.time.Clock
 import java.time.Duration
@@ -688,18 +689,27 @@ class FlagsViewModel @Inject constructor(
     }
 
     /**
-     * Loads the DT list: the inbox MultiMP rows, each joined best-effort with its MPStorage reading
-     * position. The join tolerates every degraded MPStorage outcome ([MpStorageResult.NotFound] /
-     * [MpStorageResult.Unreadable] / an exception): the list still renders, just without the
-     * « reprise p.N » badge — the storage scan must never fail the conversation list.
+     * Loads the DT list as the UNION of two sources, deduplicated by `threadId` (#6, directive
+     * XaTriX 2026-06-19):
+     *  - the inbox MultiMP rows of PAGE 1 ([DT_INBOX_PAGE]) — the hard, fully-described source
+     *    ([DtListItem.InboxBacked]: subject, unread dot, lastPage), each best-effort joined with its
+     *    MPStorage resume page ;
+     *  - the MPStorage `mpFlags` entries whose `threadId` is ABSENT from that page
+     *    ([DtListItem.StorageOnly]: thread id + resume page only — no subject, no read/unread state).
+     *
+     * Rows are concatenated inbox-first (recent activity, complete + reliable data) then the orphan
+     * entries in `mpFlags.list` order (no per-entry date to sort on). The MPStorage read is
+     * best-effort: every degraded outcome ([MpStorageResult.NotFound] / [MpStorageResult.Unreadable]
+     * / an exception) yields no entries, so the list still renders from the inbox alone — the storage
+     * scan never fails the conversation list.
      *
      * Only the inbox load itself is fatal: it is the list's primary source, so a network/session
      * error there surfaces [DtListUiState.Error] (the screen offers a retry / reconnect CTA).
      *
-     * MVP scope (#6): only inbox PAGE 1 ([DT_INBOX_PAGE]) is scanned — the most recent conversations.
-     * A full multi-page sweep is deliberately DEFERRED (it would multiply the cost of the already
-     * expensive MPStorage scan), so [DtListUiState.Empty] means « none on the recent page », not
-     * « none at all » — the empty-state copy assumes that semantics (`flags_dt_empty`).
+     * [DtListUiState.Empty] iff the inbox PAGE 1 has no MultiMP AND MPStorage has no orphan entry.
+     * Scope (#6): only inbox PAGE 1 is scanned + whatever MPStorage already knows ; a full multi-page
+     * inbox sweep stays DEFERRED, so older pages are not covered — the UI carries a scan note footer
+     * (`flags_dt_scan_note`) and the empty-state copy (`flags_dt_empty`) assumes that semantics.
      */
     private fun loadDt() {
         dtFetchStarted = true
@@ -709,7 +719,7 @@ class FlagsViewModel @Inject constructor(
         val generation = ++dtGeneration
         dtFetchJob = viewModelScope.launch {
             _dtListState.value = DtListUiState.Loading
-            val conversations = try {
+            val inboxMulti = try {
                 messagesRepository.getPrivateMessageList(page = DT_INBOX_PAGE)
                     .items
                     .filter { it.isMultiRecipient }
@@ -726,46 +736,42 @@ class FlagsViewModel @Inject constructor(
                 return@launch
             }
 
-            if (conversations.isEmpty()) {
-                if (generation == dtGeneration) _dtListState.value = DtListUiState.Empty
-                return@launch
-            }
-
-            // Best-effort enrichment: a missing / unreadable / failed storage read leaves an empty
-            // map, so every row simply renders without a resume badge (the list is never blocked).
-            val resumeByThread = fetchResumePositions()
+            // Best-effort: a missing / unreadable / failed storage read leaves an empty list, so the
+            // union degrades to the inbox rows alone (no resume badge, no orphan rows). The list is
+            // never blocked. NOTE: no early-return on an empty inbox — orphan MPStorage entries may
+            // still populate the list (a page-1 box without any MultiMP is NOT necessarily Empty).
+            val entries = fetchStorageEntries()
             // Re-check the generation AFTER the (suspending) storage scan too: the account may have
             // switched while the scan was in flight, so the stale result must not republish.
             if (generation != dtGeneration) return@launch
-            _dtListState.value = DtListUiState.Content(
-                conversations.map { summary ->
-                    DtListItem(
-                        conversation = summary,
-                        resumePage = resumeByThread[summary.threadId],
-                    )
-                },
-            )
+
+            val items = buildDtItems(inboxMulti, entries)
+            if (items.isEmpty()) {
+                if (generation == dtGeneration) _dtListState.value = DtListUiState.Empty
+                return@launch
+            }
+            _dtListState.value = DtListUiState.Content(items)
         }
     }
 
     /**
-     * Best-effort MPStorage read for the « reprise p.N » badges. Returns a `threadId → page` map of
-     * the DTCloud `mpFlags` entries, EMPTY for every degraded outcome ([MpStorageResult.NotFound] /
+     * Best-effort MPStorage read for the DT union. Returns the FULL list of DTCloud `mpFlags`
+     * entries, EMPTY for every degraded outcome ([MpStorageResult.NotFound] /
      * [MpStorageResult.Unreadable]) or transport failure — the caller renders the list regardless.
-     * `mpFlags` is a reading-RESUME position, NOT a read/unread state (#361/ADR-013): the unread dot
-     * is the inbox [PrivateMessageSummary.hasUnread], never this page number.
+     * Each entry's `page` is a reading-RESUME position, NOT a read/unread state (#361/ADR-013): the
+     * unread dot is the inbox [PrivateMessageSummary.hasUnread], never this page number.
      */
     @Suppress("SwallowedException") // best-effort: a storage read failure deliberately degrades to
-    // « no resume badge » so the conversation list still renders (cf. KDoc); the cause is irrelevant.
-    private suspend fun fetchResumePositions(): Map<Int, Int> = try {
+    // « inbox rows only, no orphan, no resume badge » so the list still renders; the cause is irrelevant.
+    private suspend fun fetchStorageEntries(): List<MpStorageFlagEntry> = try {
         when (val storage = mpStorageRepository.fetchStorage()) {
-            is MpStorageResult.Found -> storage.document.mpFlags.associate { it.threadId to it.page }
-            MpStorageResult.NotFound, MpStorageResult.Unreadable -> emptyMap()
+            is MpStorageResult.Found -> storage.document.mpFlags
+            MpStorageResult.NotFound, MpStorageResult.Unreadable -> emptyList()
         }
     } catch (cancellation: kotlinx.coroutines.CancellationException) {
         throw cancellation
     } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
-        emptyMap()
+        emptyList()
     }
 
     // Round-2 review (PR #207): `logout()` was removed from this ViewModel — the global account
@@ -1028,7 +1034,11 @@ sealed interface DtListUiState {
     /** The inbox loaded but holds no MultiMP conversation. */
     data object Empty : DtListUiState
 
-    /** Loaded MultiMP conversations, each best-effort joined with its MPStorage resume position. */
+    /**
+     * The DT union: inbox PAGE 1 MultiMP rows ∪ orphan MPStorage entries, deduplicated by
+     * `threadId` and ordered inbox-first then `mpFlags.list` order (#6). The multi-page inbox limit
+     * remains — surfaced by the scan-note footer (`flags_dt_scan_note`).
+     */
     data class Content(val items: List<DtListItem>) : DtListUiState
 
     /** The inbox load failed (network / session). The MPStorage read NEVER reaches this state —
@@ -1037,13 +1047,63 @@ sealed interface DtListUiState {
 }
 
 /**
- * One DT row: a MultiMP [conversation] plus its optional MPStorage reading-resume page
- * ([resumePage], DTCloud `mpFlags`). [resumePage] is the « reprise p.N » badge — a reading
- * POSITION, never a read/unread state (#361/ADR-013): the unread dot is
- * [PrivateMessageSummary.hasUnread]. `null` when the conversation has no MPStorage entry (or the
- * storage was absent / unreadable / failed to load).
+ * One DT row (#6). Two natures, both carrying a [threadId] (identity / dedup key) and an optional
+ * MPStorage [resumePage] — the « reprise p.N » badge, a reading POSITION never a read/unread state
+ * (#361/ADR-013).
  */
-data class DtListItem(
-    val conversation: PrivateMessageSummary,
-    val resumePage: Int?,
-)
+sealed interface DtListItem {
+    val threadId: Int
+    val resumePage: Int?
+
+    /**
+     * A conversation present on inbox PAGE 1: the rich, fully-described row (subject, `hasUnread`
+     * dot, `lastPage`). [resumePage] is `null` when the conversation has no MPStorage entry (or the
+     * storage was absent / unreadable / failed to load).
+     */
+    data class InboxBacked(
+        val conversation: PrivateMessageSummary,
+        override val resumePage: Int?,
+    ) : DtListItem {
+        override val threadId: Int get() = conversation.threadId
+    }
+
+    /**
+     * An MPStorage `mpFlags` entry absent from inbox PAGE 1: only [threadId] + reading position are
+     * known — NO subject, NO read/unread state. [resumePage] is the entry's `page` (non-null in
+     * practice; the parser falls back to 1). [numreponse] is kept for a future anchor but does not
+     * influence navigation today.
+     */
+    data class StorageOnly(
+        override val threadId: Int,
+        override val resumePage: Int?,
+        val numreponse: Int?,
+    ) : DtListItem
+}
+
+/**
+ * Pure builder of the DT union (#6, directive XaTriX 2026-06-19). [inboxMulti] are the inbox PAGE 1
+ * MultiMP summaries (already filtered) ; [storageEntries] are the DTCloud `mpFlags` entries
+ * (best-effort, possibly empty). Returns inbox-backed rows first (in inbox order, each joined with
+ * its MPStorage resume page), then the orphan storage-only rows whose `threadId` is absent from the
+ * inbox, in `mpFlags.list` order. Dedup is by `threadId`: an entry already inbox-backed is never
+ * doubled as storage-only, and an internal `mpFlags` `threadId` duplicate keeps the first occurrence
+ * (so the [Content] list never holds two items with the same LazyColumn key).
+ */
+internal fun buildDtItems(
+    inboxMulti: List<PrivateMessageSummary>,
+    storageEntries: List<MpStorageFlagEntry>,
+): List<DtListItem> {
+    val resumeByThread = storageEntries.associate { it.threadId to it.page }
+    val inboxThreadIds = inboxMulti.mapTo(HashSet()) { it.threadId }
+    return buildList {
+        inboxMulti.forEach { summary ->
+            add(DtListItem.InboxBacked(summary, resumeByThread[summary.threadId]))
+        }
+        storageEntries.asSequence()
+            .filter { it.threadId !in inboxThreadIds }
+            .distinctBy { it.threadId }
+            .forEach { entry ->
+                add(DtListItem.StorageOnly(entry.threadId, entry.page, entry.numreponse))
+            }
+    }
+}

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -28,14 +28,25 @@
     <!-- Badge discret de reprise de lecture, alimenté par MPStorage (mpFlags). %1$d = page de reprise.
          C'est une POSITION de lecture, PAS un état lu/non-lu (le point non-lu vient de l'inbox). -->
     <string name="flags_dt_resume_badge">reprise p.%1$d</string>
-    <!-- État vide DT. La liste ne lit que la PAGE 1 de la boîte de réception (les conversations
-         les plus récentes) — un balayage multi-pages est différé (cf. DT_INBOX_PAGE). Le wording
-         assume donc « récente » pour ne pas affirmer qu'AUCUNE MultiMP n'existe ailleurs. -->
+    <!-- État vide DT. La liste = PAGE 1 de la boîte de réception (les conversations les plus
+         récentes) ∪ entrées connues de la synchro DT (MPStorage) — un balayage multi-pages est
+         différé (cf. DT_INBOX_PAGE). Le wording assume « récente » pour ne pas affirmer qu'AUCUNE
+         MultiMP n'existe ailleurs (ni en page 1, ni connue de la synchro DT). -->
     <string name="flags_dt_empty">Aucune conversation multi-destinataires récente.</string>
     <!-- Description a11y d'une ligne DT : état lu/non-lu, annoncé par TalkBack (le point coloré
          est purement décoratif). %1$s = sujet de la conversation. -->
     <string name="flags_dt_row_unread">Non lu : %1$s</string>
     <string name="flags_dt_row_read">Lu : %1$s</string>
+    <!-- #6 — Titre placeholder d'une conversation DT connue de la synchro mais absente de la page 1
+         de la boîte : MPStorage ne porte aucun sujet, on n'a que l'id de la conversation.
+         %1$d = threadId HFR. -->
+    <string name="flags_dt_storage_only_title">Conversation #%1$d</string>
+    <!-- #6 — Description a11y d'une ligne DT orpheline (hors inbox) : l'état lu/non-lu est INCONNU,
+         on n'annonce donc ni « Lu » ni « Non lu ». %1$s = titre placeholder de la conversation. -->
+    <string name="flags_dt_row_state_unknown">État inconnu : %1$s</string>
+    <!-- #6 — Note de bas de liste DT : la liste ne couvre que la page 1 de la boîte + ce que la
+         synchro DT connaît ; les pages plus anciennes ne sont pas balayées (balayage différé). -->
+    <string name="flags_dt_scan_note">Seules les conversations de la première page de la boîte et celles connues de la synchro DT sont listées. Les pages plus anciennes ne sont pas balayées.</string>
     <!-- Échec du chargement de la liste DT (boîte de réception). La lecture MPStorage, best-effort,
          n'atteint jamais cet état (elle se dégrade en « pas de badge »). -->
     <string name="flags_dt_error">Impossible de charger les conversations. Vérifie ta connexion ou réessaie.</string>

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1360,7 +1360,7 @@ class FlagsViewModelTest {
     // #6 — DT tab: MultiMP list + best-effort MPStorage enrichment.
 
     @Test
-    fun `onDtTabOpened lists the MultiMP conversations joined with their MPStorage resume page`() = runTest {
+    fun `onDtTabOpened unions inbox MultiMP rows with orphan MPStorage entries`() = runTest {
         val flags = FakeFlagRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val messages = FakeMessagesRepository(
@@ -1374,7 +1374,11 @@ class FlagsViewModelTest {
         )
         val mpStorage = FakeMpStorageRepository(
             result = MpStorageResult.Found(
-                mpDoc(MpStorageFlagEntry(threadId = 10, page = 7, numreponse = null, uri = null)),
+                mpDoc(
+                    MpStorageFlagEntry(threadId = 10, page = 7, numreponse = null, uri = null),
+                    // Orphan: a known DT conversation absent from inbox page 1 → StorageOnly row.
+                    MpStorageFlagEntry(threadId = 99, page = 2, numreponse = 555, uri = null),
+                ),
             ),
         )
         val vm = viewModel(auth, flags, FakeForumRepository(), messages = messages, mpStorage = mpStorage)
@@ -1383,11 +1387,16 @@ class FlagsViewModelTest {
             assertEquals(DtListUiState.Loading, awaitItem())
             vm.onDtTabOpened()
             val content = awaitItem() as DtListUiState.Content
-            // The 1:1 MP (20) is dropped; only the two MultiMP rows remain, in inbox order.
-            assertEquals(listOf(10, 30), content.items.map { it.conversation.threadId })
+            // Inbox MultiMP rows first (1:1 MP 20 dropped), then orphan MPStorage entries.
+            assertEquals(listOf(10, 30, 99), content.items.map { it.threadId })
             // Thread 10 has an mpFlags entry → its resume page joins; 30 has none → null badge.
-            assertEquals(7, content.items.first { it.conversation.threadId == 10 }.resumePage)
-            assertNull(content.items.first { it.conversation.threadId == 30 }.resumePage)
+            assertEquals(7, content.items.first { it.threadId == 10 }.resumePage)
+            assertNull(content.items.first { it.threadId == 30 }.resumePage)
+            // The two inbox rows are InboxBacked, the orphan is StorageOnly carrying its resume page.
+            assertTrue(content.items.first { it.threadId == 10 } is DtListItem.InboxBacked)
+            val orphan = content.items.first { it.threadId == 99 } as DtListItem.StorageOnly
+            assertEquals(2, orphan.resumePage)
+            assertEquals(555, orphan.numreponse)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -1406,7 +1415,7 @@ class FlagsViewModelTest {
             assertEquals(DtListUiState.Loading, awaitItem())
             vm.onDtTabOpened()
             val content = awaitItem() as DtListUiState.Content
-            assertEquals(listOf(10), content.items.map { it.conversation.threadId })
+            assertEquals(listOf(10), content.items.map { it.threadId })
             assertNull("NotFound storage → no resume badge", content.items.single().resumePage)
             cancelAndIgnoreRemainingEvents()
         }
@@ -1427,14 +1436,15 @@ class FlagsViewModelTest {
             assertEquals(DtListUiState.Loading, awaitItem())
             vm.onDtTabOpened()
             val content = awaitItem() as DtListUiState.Content
-            assertEquals(listOf(10), content.items.map { it.conversation.threadId })
+            assertEquals(listOf(10), content.items.map { it.threadId })
             assertNull("a failed storage read degrades to no badge", content.items.single().resumePage)
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `onDtTabOpened surfaces Empty when the inbox holds no MultiMP`() = runTest {
+    fun `onDtTabOpened surfaces Empty only when inbox has no MultiMP AND MPStorage has no entry`() = runTest {
+        // True-empty: no inbox MultiMP and the default fake returns NotFound (no orphan) → Empty.
         val flags = FakeFlagRepository()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val messages = FakeMessagesRepository(
@@ -1448,6 +1458,99 @@ class FlagsViewModelTest {
             assertEquals(DtListUiState.Loading, awaitItem())
             vm.onDtTabOpened()
             assertEquals(DtListUiState.Empty, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onDtTabOpened is Content (not Empty) when inbox has no MultiMP but MPStorage has an entry`() = runTest {
+        // Regression on the removed `conversations.isEmpty()` early-return: a page-1 box without any
+        // MultiMP but with a known DT entry must still render that orphan (#6), never Empty.
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val messages = FakeMessagesRepository(
+            inboxResult = Result.success(
+                inboxPage(stubSummary(threadId = 20, isMultiRecipient = false)), // 1:1 only
+            ),
+        )
+        val mpStorage = FakeMpStorageRepository(
+            result = MpStorageResult.Found(
+                mpDoc(MpStorageFlagEntry(threadId = 99, page = 2, numreponse = null, uri = null)),
+            ),
+        )
+        val vm = viewModel(auth, flags, FakeForumRepository(), messages = messages, mpStorage = mpStorage)
+
+        vm.dtListState.test {
+            assertEquals(DtListUiState.Loading, awaitItem())
+            vm.onDtTabOpened()
+            val content = awaitItem() as DtListUiState.Content
+            assertEquals(listOf(99), content.items.map { it.threadId })
+            assertTrue(content.items.single() is DtListItem.StorageOnly)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onDtTabOpened dedups a threadId present in both inbox and MPStorage to a single InboxBacked row`() =
+        runTest {
+            // A threadId in BOTH sources appears once, as InboxBacked (never doubled as StorageOnly),
+            // carrying the joined resume badge — and the LazyColumn key (threadId) stays unique.
+            val flags = FakeFlagRepository()
+            val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+            val messages = FakeMessagesRepository(
+                inboxResult = Result.success(
+                    inboxPage(stubSummary(threadId = 10, isMultiRecipient = true)),
+                ),
+            )
+            val mpStorage = FakeMpStorageRepository(
+                result = MpStorageResult.Found(
+                    mpDoc(MpStorageFlagEntry(threadId = 10, page = 4, numreponse = null, uri = null)),
+                ),
+            )
+            val vm = viewModel(auth, flags, FakeForumRepository(), messages = messages, mpStorage = mpStorage)
+
+            vm.dtListState.test {
+                assertEquals(DtListUiState.Loading, awaitItem())
+                vm.onDtTabOpened()
+                val content = awaitItem() as DtListUiState.Content
+                assertEquals(listOf(10), content.items.map { it.threadId })
+                val row = content.items.single()
+                assertTrue(row is DtListItem.InboxBacked)
+                assertEquals(4, row.resumePage)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `onDtTabOpened orders inbox rows first then orphans in mpFlags list order`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val messages = FakeMessagesRepository(
+            inboxResult = Result.success(
+                inboxPage(
+                    stubSummary(threadId = 10, isMultiRecipient = true),
+                    stubSummary(threadId = 30, isMultiRecipient = true),
+                ),
+            ),
+        )
+        // mpFlags carries one inbox-backed (10) and two orphans (88, 99) in this list order.
+        val mpStorage = FakeMpStorageRepository(
+            result = MpStorageResult.Found(
+                mpDoc(
+                    MpStorageFlagEntry(threadId = 10, page = 1, numreponse = null, uri = null),
+                    MpStorageFlagEntry(threadId = 88, page = 5, numreponse = null, uri = null),
+                    MpStorageFlagEntry(threadId = 99, page = 2, numreponse = null, uri = null),
+                ),
+            ),
+        )
+        val vm = viewModel(auth, flags, FakeForumRepository(), messages = messages, mpStorage = mpStorage)
+
+        vm.dtListState.test {
+            assertEquals(DtListUiState.Loading, awaitItem())
+            vm.onDtTabOpened()
+            val content = awaitItem() as DtListUiState.Content
+            // Inbox order (10, 30) first, then orphans in mpFlags.list order (88, 99).
+            assertEquals(listOf(10, 30, 88, 99), content.items.map { it.threadId })
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -1518,7 +1621,7 @@ class FlagsViewModelTest {
                 Result.success(inboxPage(stubSummary(threadId = 10, isMultiRecipient = true)))
             vm.onDtTabOpened() // guard was reset by the failure → retry re-runs
             val content = awaitItem() as DtListUiState.Content
-            assertEquals(listOf(10), content.items.map { it.conversation.threadId })
+            assertEquals(listOf(10), content.items.map { it.threadId })
             cancelAndIgnoreRemainingEvents()
         }
         assertEquals(2, messages.getListCalls)
@@ -1603,7 +1706,7 @@ class FlagsViewModelTest {
             assertEquals(
                 "the latest refreshDt wins; the cancelled earlier scan's result is dropped",
                 listOf(99),
-                content.items.map { it.conversation.threadId },
+                content.items.map { it.threadId },
             )
         }
 
@@ -1631,7 +1734,7 @@ class FlagsViewModelTest {
             vm.onDtTabOpened()
             val content = awaitItem() as DtListUiState.Content
             // …yet only page 1 is reflected; no further page is scanned (multi-page deferred).
-            assertEquals(listOf(10), content.items.map { it.conversation.threadId })
+            assertEquals(listOf(10), content.items.map { it.threadId })
             assertEquals("only inbox page 1 is ever requested", listOf(1), messages.requestedPages)
             cancelAndIgnoreRemainingEvents()
         }


### PR DESCRIPTION
Bundle « repasse sur la recherche + DT » (directive XaTriX 2788616 + retour tinc 2788609).

## 1. Recherche intra-topic : chercher TOUT le topic (fix bug tinc) — #586

**Bug** (reproduit en live, authentifié) : sur un gros topic (Ukraine, page 15000), une recherche non filtrée de « canal » renvoyait « Aucun résultat » alors que le web a des résultats.

**Cause racine** : la recherche fraîche transmettait `firstnum` = 1er post de la page courante → HFR `transsearch.php` ancre la recherche **en avant** de ce post et rate tous les matches antérieurs. Vérifié : « canal » + firstnum(page 15000) → page 15137 ; **sans firstnum → page 3** (tout le topic). `owntopic` et la règle 50 % MyISAM ne sont pas en cause.

**Fix** : `TopicSearchRepositoryImpl` ne transmet **jamais** `firstnum` (`null` toujours). La recherche fraîche couvre désormais tout le topic ; next/prev continue via `currentnum` (inchangé). Tests repo adaptés (`firstnum=null`).

## 2. Onglet DT : union MPStorage ∪ page 1 inbox + note de scan

Directive : lister **au moins toutes les entrées DT connues de MPStorage**, en plus de la page 1 de la boîte, et indiquer qu'on ne balaie pas toutes les pages (~50 sur certains comptes).

- `DtListItem` devient une **sealed interface** : `InboxBacked` (conversation page-1 complète) + `StorageOnly` (entrée MPStorage orpheline : `threadId` + reprise, sans sujet ni état lu/non-lu).
- `loadDt` construit l'**union** (helper pur `buildDtItems`) : lignes inbox d'abord, puis orphelines (`threadId ∉ inbox`, dédup), ordre `mpFlags.list`. `Empty` ssi l'union est vide (une boîte sans MultiMP en page 1 mais avec des entrées MPStorage affiche désormais ces orphelines). Garde anti-stale `dtGeneration` conservée.
- Coût **nul** : `fetchStorage()` était déjà appelé pour les badges « reprise p.N » ; on garde maintenant toutes les entrées au lieu de la seule page.
- Orpheline = « Conversation #threadId » + badge reprise, dot **état inconnu** (a11y dédiée), ouvre sur la page de reprise.
- **Footer de liste** discret : « Seules les conversations de la première page de la boîte et celles connues de la synchro DT sont listées. Les pages plus anciennes ne sont pas balayées. » (limite assumée, à revoir plus tard).
- 5 tests ajoutés (union+orpheline, inbox-sans-MultiMP→Content, dédup, vrai vide→Empty, ordre).

## Revue
Investigation cadrée par workflow multi-agent + relecture Codex du diff : 1 correction appliquée (dédup MPStorage par `threadId` cohérente première-occurrence entre lignes inbox et orphelines).

Suivi : tâches internes #118/#119 ; bug recherche = #586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
