### PR TITLE
feat(flags): onglet DT comme « Mes sujets » — non-lus par défaut + clic onglet (+lus) + pull-to-refresh

### DIFF
--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -138,7 +138,12 @@ fun FlagsRoute(
 
     // Opt-in « DT » tab (Settings toggle). Its MultiMP list is fetched on tab open (#6).
     val showDtTab by viewModel.showDtTab.collectAsStateWithLifecycle()
-    val dtListState by viewModel.dtListState.collectAsStateWithLifecycle()
+    // #546 directive XaTriX — the screen consumes the FILTERED DT state (dtDisplayState), not the raw
+    // union: DT defaults to « non-lus uniquement » and a re-tap of the DT tab toggles « +lus ».
+    val dtListState by viewModel.dtDisplayState.collectAsStateWithLifecycle()
+    val dtIsRefreshing by viewModel.dtIsRefreshing.collectAsStateWithLifecycle()
+    // « +lus » suffix on the DT tab, mirroring [cyanShowsRead]: DT selected AND its unread filter off.
+    val dtShowsRead by viewModel.dtShowsRead.collectAsStateWithLifecycle()
 
     // #6 — trigger the DT scan only when the DT tab is OPENED (a stable LaunchedEffect, not the raw
     // composition): fetchStorage scans the inbox and must stay off the per-category auto-refresh.
@@ -290,6 +295,8 @@ fun FlagsRoute(
                                 removeFlagState = removeFlagState,
                                 showDtTab = showDtTab,
                                 dtListState = dtListState,
+                                dtShowsRead = dtShowsRead,
+                                dtIsRefreshing = dtIsRefreshing,
                             ),
                             actions = AuthenticatedActions(
                                 onSelectTab = viewModel::selectTab,
@@ -618,6 +625,7 @@ private fun ColumnScope.AuthenticatedBody(
 ) {
     val selectedTab = state.selectedTab
     val cyanShowsRead = state.cyanShowsRead
+    val dtShowsRead = state.dtShowsRead
     val tabs = buildList {
         add(FlagTab.Cyan to stringResource(R.string.flags_tab_my_topics))
         add(FlagTab.Red to stringResource(R.string.flags_tab_read_only))
@@ -629,15 +637,16 @@ private fun ColumnScope.AuthenticatedBody(
     }
     val selectedIndex = tabs.indexOfFirst { it.first == selectedTab }.coerceAtLeast(0)
     // Discreet « +lus » suffix on the Cyan label so the user knows read participated topics
-    // are currently shown — re-tapping the (already selected) Cyan tab toggles it.
-    val cyanReadSuffix = stringResource(R.string.flags_tab_cyan_read_shown_suffix)
+    // are currently shown — re-tapping the (already selected) Cyan tab toggles it. #546 directive
+    // XaTriX — the SAME suffix marks the DT tab when its read conversations are shown (mirror).
+    val readSuffix = stringResource(R.string.flags_tab_cyan_read_shown_suffix)
 
     PrimaryTabRow(selectedTabIndex = selectedIndex) {
         tabs.forEachIndexed { index, (tab, label) ->
-            val displayLabel = if (tab == FlagTab.Cyan && cyanShowsRead) {
-                label + cyanReadSuffix
-            } else {
-                label
+            val displayLabel = when {
+                tab == FlagTab.Cyan && cyanShowsRead -> label + readSuffix
+                tab == FlagTab.Dt && dtShowsRead -> label + readSuffix
+                else -> label
             }
             // Low-level `content` overload INSTEAD of the `text` slot : the text slot pads a
             // non-configurable 16 dp each side, which left « Mes sujets » with exactly its own
@@ -703,7 +712,11 @@ private fun ColumnScope.AuthenticatedBody(
             FlagTab.Super -> SuperPlaceholderBody()
             // #6 — DT is a real list now: the user's MultiMP conversations, enriched best-effort
             // with the MPStorage reading positions.
-            FlagTab.Dt -> DtListBody(state = state.dtListState, actions = actions)
+            FlagTab.Dt -> DtListBody(
+                state = state.dtListState,
+                isRefreshing = state.dtIsRefreshing,
+                actions = actions,
+            )
             else -> FlagListBody(state = state, actions = actions, listState = listState)
         }
     }
@@ -1172,8 +1185,28 @@ private fun DtTabOpenEffect(
  * list intact, just without badges (cf. [FlagsViewModel.loadDt]). Only an inbox load failure
  * reaches [DtListUiState.Error], which offers a reconnect/retry CTA like the flag list.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun DtListBody(state: DtListUiState, actions: AuthenticatedActions) {
+private fun DtListBody(state: DtListUiState, isRefreshing: Boolean, actions: AuthenticatedActions) {
+    // #546 directive XaTriX — pull-to-refresh (swipe down) on the DT list, like the flag tabs. Wraps
+    // the whole body (every branch) so the indicator stays anchored over the existing content during
+    // the refresh round-trip and the gesture has a target even on the listless states (#229 pattern).
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
+        onRefresh = actions.onRefreshDt,
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        DtListContent(state = state, actions = actions)
+    }
+}
+
+/**
+ * The DT body content under the [DtListBody] pull-to-refresh layer. Dispatches the [DtListUiState]
+ * to its branch. The listless states ([DtListUiState.Loading]/[Empty]/[NoUnread]/[Error]) are made
+ * vertically scrollable so the surrounding `PullToRefreshBox` keeps a target (#229).
+ */
+@Composable
+private fun DtListContent(state: DtListUiState, actions: AuthenticatedActions) {
     when (state) {
         DtListUiState.Loading -> Box(
             modifier = Modifier
@@ -1185,6 +1218,10 @@ private fun DtListBody(state: DtListUiState, actions: AuthenticatedActions) {
         }
 
         DtListUiState.Empty -> DtMessageBody(text = stringResource(R.string.flags_dt_empty))
+
+        // #546 — the union is non-empty but « non-lus uniquement » hid every row: a dedicated message
+        // (not the « aucune conversation » empty copy). Re-tapping the DT tab reveals « +lus ».
+        DtListUiState.NoUnread -> DtNoUnreadBody()
 
         is DtListUiState.Error -> DtErrorBody(cause = state.cause, actions = actions)
 
@@ -1244,6 +1281,35 @@ private fun DtRow(item: DtListItem, onOpenMultiMp: (threadId: Int, page: Int) ->
             item = item,
             // No lastPage for an orphan: open on the MPStorage resume page (clamped ≥ 1), else page 1.
             onClick = { onOpenMultiMp(item.threadId, (item.resumePage ?: 1).coerceAtLeast(1)) },
+        )
+    }
+}
+
+/**
+ * #546 directive XaTriX — body for the « filtered to no unread » state ([DtListUiState.NoUnread]):
+ * the union holds conversations but none is unread. Shows a discreet « aucune conversation non lue »
+ * message and keeps the scan-note footer visible (the user can re-tap the DT tab for « +lus »).
+ * Scrollable so the surrounding `PullToRefreshBox` keeps a swipe target (#229).
+ */
+@Composable
+private fun DtNoUnreadBody() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 24.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.flags_dt_no_unread),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = stringResource(R.string.flags_dt_scan_note),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
 }
@@ -1412,8 +1478,12 @@ private data class FlagsBodyState(
     val removeFlagState: RemoveFlagState,
     /** Whether the opt-in « DT » tab is shown (Settings toggle). */
     val showDtTab: Boolean,
-    /** #6 — the DT (MultiMP) tab list state, fetched on tab open. */
+    /** #6 — the DT (MultiMP) tab list state, fetched on tab open, FILTERED by « non-lus uniquement ». */
     val dtListState: DtListUiState,
+    /** #546 — whether the DT tab currently shows read conversations (« +lus » suffix). */
+    val dtShowsRead: Boolean,
+    /** #546 — toggled around the DT pull-to-refresh round-trip (anchors the indicator). */
+    val dtIsRefreshing: Boolean,
 )
 
 private data class AuthenticatedActions(

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -1314,15 +1314,19 @@ private fun DtNoUnreadBody() {
     }
 }
 
-/** Centered single-line message body (DT empty state), sharing the surface background. */
+/**
+ * Single-line message body (DT empty state), sharing the surface background. Vertically scrollable
+ * so the surrounding [PullToRefreshBox] keeps a swipe target on this listless state (#229) — a
+ * non-scrollable body would give the pull-to-refresh gesture nothing to anchor on.
+ */
 @Composable
 private fun DtMessageBody(text: String) {
-    Box(
+    Column(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.surface)
+            .verticalScroll(rememberScrollState())
             .padding(24.dp),
-        contentAlignment = Alignment.Center,
     ) {
         Text(
             text = text,

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -117,6 +117,58 @@ class FlagsViewModel @Inject constructor(
     private val _dtListState = MutableStateFlow<DtListUiState>(DtListUiState.Loading)
     val dtListState: StateFlow<DtListUiState> = _dtListState.asStateFlow()
 
+    /**
+     * #546 directive XaTriX — « non-lus uniquement » filter for the DT tab, mirroring CYAN's
+     * [cyanUnreadOnly]: default `true` so the DT list opens on the actionable unread subset, and a
+     * re-tap of the already-selected DT tab toggles it (the « +lus » shortcut, cf. [selectTab]).
+     *
+     * Per-SESSION only (in-memory ViewModel state), NOT persisted: persisting it would mean adding a
+     * method to [UserPreferencesRepository], which breaks every fake (the eager constructor read of
+     * the new flow throws a MockKException in the theme tests). Persistence is a deliberate FOLLOW-UP.
+     */
+    private val _dtUnreadOnly = MutableStateFlow(true)
+    val dtUnreadOnly: StateFlow<Boolean> = _dtUnreadOnly.asStateFlow()
+
+    /**
+     * #546 directive XaTriX — toggled around the user-driven [refreshDt] round-trip so the Material 3
+     * `PullToRefreshBox` indicator stays anchored over the existing DT list instead of blanking it to
+     * a cold spinner. Same pattern as [isRefreshing] for the flag tabs.
+     */
+    private val _dtIsRefreshing = MutableStateFlow(false)
+    val dtIsRefreshing: StateFlow<Boolean> = _dtIsRefreshing.asStateFlow()
+
+    /**
+     * #546 directive XaTriX — whether the DT tab currently shows read conversations (drives the
+     * discreet « +lus » tab-label suffix): DT selected AND its unread filter off. Mirrors
+     * [cyanShowsReadShortcut].
+     */
+    val dtShowsRead: StateFlow<Boolean> = combine(
+        selectedTab,
+        _dtUnreadOnly,
+    ) { tab, unreadOnly -> tab == FlagTab.Dt && !unreadOnly }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = false,
+        )
+
+    /**
+     * #546 directive XaTriX — the DT list state the SCREEN consumes: the raw [_dtListState] union
+     * passed through the « non-lus uniquement » filter ([_dtUnreadOnly]). [dtListState] stays exposed
+     * for the union/dedup tests; this is the displayed projection. When the filter is on, only the
+     * inbox-backed conversations with an unread message survive — orphan storage-only rows (unknown
+     * read state) and read inbox rows are excluded (cf. [filterDt]).
+     */
+    val dtDisplayState: StateFlow<DtListUiState> = combine(
+        _dtListState,
+        _dtUnreadOnly,
+    ) { state, unreadOnly -> filterDt(state, unreadOnly) }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = DtListUiState.Loading,
+        )
+
     /** One-shot guard so re-entering the composition (recomposition, ON_RESUME) does not re-scan. */
     private var dtFetchStarted = false
 
@@ -446,19 +498,13 @@ class FlagsViewModel @Inject constructor(
      * another tab only switches to it (no toggle). Other tabs just switch.
      */
     fun selectTab(tab: FlagTab) {
-        if (tab == FlagTab.Cyan && _selectedTab.value == FlagTab.Cyan) {
-            // Re-tapping the already-selected Cyan tab toggles its « non-lus uniquement » filter
-            // (the « +lus » shortcut). It flips the CYAN per-type value, persisted via
-            // [setFlagsUnreadOnly] — the same write the bottom-sheet toggle uses (single mutation
-            // point). Flip from [cyanUnreadOnly], which tracks CYAN specifically (not the selected
-            // tab) with an optimistic shim and an eager `true` default — so a tab switch, the cold
-            // start, or a rapid double re-tap can never feed it a lagging value and lose a toggle.
-            setFlagsUnreadOnly(!cyanUnreadOnly.value)
+        // A re-tap on the already-selected tab is handled in [handleReTap] (Cyan/DT « +lus » toggle,
+        // or a no-op for the other tabs) — it returns true when it consumed the tap, so a real
+        // transition is everything below.
+        if (tab == _selectedTab.value) {
+            handleReTap(tab)
             return
         }
-        // #106 (tinc) — re-tapping the already-selected (non-Cyan) tab is a no-op : keep its scroll
-        // position, raise nothing.
-        if (tab == _selectedTab.value) return
         _selectedTab.value = tab
         // #106 — a real tab transition (tap OR swipe commit, both route through selectTab) recalls the
         // shared list to the top, reusing the one-shot #546 signal (consumed by the screen via
@@ -466,6 +512,22 @@ class FlagsViewModel @Inject constructor(
         // FilterFlipScrollResetEffect handles that) nor on a no-op re-tap nor on return-from-topic
         // (selectedTab unchanged there) — so no spurious reset on rotation either.
         _recallListToTop.value = true
+    }
+
+    /**
+     * Handles a re-tap on the already-selected [tab]. Cyan and DT flip their « non-lus uniquement »
+     * filter (the « +lus » shortcut) — Cyan through the persisted [setFlagsUnreadOnly] write (reading
+     * the optimistic [cyanUnreadOnly]), DT through the in-memory [_dtUnreadOnly] (per-session, not
+     * persisted). Every other tab re-tap is a deliberate no-op (#106 tinc — keep the scroll position).
+     * Never raises [_recallListToTop]: a filter flip is not a tab transition (the screen's
+     * FilterFlipScrollResetEffect handles the scroll for Cyan).
+     */
+    private fun handleReTap(tab: FlagTab) {
+        when (tab) {
+            FlagTab.Cyan -> setFlagsUnreadOnly(!cyanUnreadOnly.value)
+            FlagTab.Dt -> _dtUnreadOnly.value = !_dtUnreadOnly.value
+            else -> Unit // #106 — re-tapping any other tab is a no-op.
+        }
     }
 
     /** User tapped « Retirer le drapeau » on [flag] : raise the confirmation dialog. */
@@ -680,12 +742,17 @@ class FlagsViewModel @Inject constructor(
      */
     fun onDtTabOpened() {
         if (dtFetchStarted) return
-        loadDt()
+        loadDt(isRefresh = false)
     }
 
-    /** Explicit user-driven reload of the DT list (pull-to-refresh / retry), bypassing the guard. */
+    /**
+     * Explicit user-driven reload of the DT list (pull-to-refresh / retry), bypassing the guard.
+     * [isRefresh] keeps the current content visible under the `PullToRefreshBox` indicator instead of
+     * blanking it to a cold spinner (#546 directive XaTriX) — the retry CTA path also lands here, so
+     * the (already-Error) state is simply re-loaded; only a refresh-over-content needs the no-blank.
+     */
     fun refreshDt() {
-        loadDt()
+        loadDt(isRefresh = true)
     }
 
     /**
@@ -711,47 +778,72 @@ class FlagsViewModel @Inject constructor(
      * inbox sweep stays DEFERRED, so older pages are not covered — the UI carries a scan note footer
      * (`flags_dt_scan_note`) and the empty-state copy (`flags_dt_empty`) assumes that semantics.
      */
-    private fun loadDt() {
+    private fun loadDt(isRefresh: Boolean) {
         dtFetchStarted = true
         // Latest-wins: cancel any in-flight DT fetch and out-generation it so a previous load's
         // late completion is ignored (two rapid refreshDt, or a refresh racing a still-running open).
         dtFetchJob?.cancel()
         val generation = ++dtGeneration
-        dtFetchJob = viewModelScope.launch {
+        // #546 — a user refresh keeps the current content visible (the PullToRefreshBox indicator
+        // anchors over it); a cold open shows the centered spinner. So only the cold path writes
+        // Loading, and the refresh path raises [_dtIsRefreshing] instead.
+        if (isRefresh) {
+            _dtIsRefreshing.value = true
+        } else {
             _dtListState.value = DtListUiState.Loading
-            val inboxMulti = try {
-                messagesRepository.getPrivateMessageList(page = DT_INBOX_PAGE)
-                    .items
-                    .filter { it.isMultiRecipient }
-            } catch (cancellation: kotlinx.coroutines.CancellationException) {
-                throw cancellation
-            } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
-                // Reset the guard so a retry can re-run; the inbox is the list's only hard source.
-                // Only the live generation may publish — a fetch invalidated by an account switch
-                // (resetDtState bumped the generation) must not overwrite the new session's Loading.
-                if (generation == dtGeneration) {
-                    dtFetchStarted = false
-                    _dtListState.value = DtListUiState.Error(error)
-                }
-                return@launch
-            }
-
-            // Best-effort: a missing / unreadable / failed storage read leaves an empty list, so the
-            // union degrades to the inbox rows alone (no resume badge, no orphan rows). The list is
-            // never blocked. NOTE: no early-return on an empty inbox — orphan MPStorage entries may
-            // still populate the list (a page-1 box without any MultiMP is NOT necessarily Empty).
-            val entries = fetchStorageEntries()
-            // Re-check the generation AFTER the (suspending) storage scan too: the account may have
-            // switched while the scan was in flight, so the stale result must not republish.
-            if (generation != dtGeneration) return@launch
-
-            val items = buildDtItems(inboxMulti, entries)
-            if (items.isEmpty()) {
-                if (generation == dtGeneration) _dtListState.value = DtListUiState.Empty
-                return@launch
-            }
-            _dtListState.value = DtListUiState.Content(items)
         }
+        dtFetchJob = viewModelScope.launch {
+            try {
+                loadDtBody(generation)
+            } finally {
+                // Clear the refresh indicator only for the LIVE generation: a load cancelled by a
+                // newer refreshDt or an account switch (resetDtState bumped the generation and already
+                // owns the indicator reset) must not clear the indicator the new load just raised.
+                if (generation == dtGeneration) _dtIsRefreshing.value = false
+            }
+        }
+    }
+
+    /**
+     * Body of [loadDt], extracted so the [isRefresh] indicator bookkeeping (the `try`/`finally`) stays
+     * out of the fetch logic and the cyclomatic budget. Publishes only for the still-live [generation]
+     * (stale-write guard, cf. [loadDt] KDoc): a fetch invalidated by an account switch or a newer
+     * refresh never overwrites the current session's state.
+     */
+    @Suppress("ReturnCount") // The stale-write generation guards are the natural shape of this fetch.
+    private suspend fun loadDtBody(generation: Int) {
+        val inboxMulti = try {
+            messagesRepository.getPrivateMessageList(page = DT_INBOX_PAGE)
+                .items
+                .filter { it.isMultiRecipient }
+        } catch (cancellation: kotlinx.coroutines.CancellationException) {
+            throw cancellation
+        } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
+            // Reset the guard so a retry can re-run; the inbox is the list's only hard source.
+            // Only the live generation may publish — a fetch invalidated by an account switch
+            // (resetDtState bumped the generation) must not overwrite the new session's Loading.
+            if (generation == dtGeneration) {
+                dtFetchStarted = false
+                _dtListState.value = DtListUiState.Error(error)
+            }
+            return
+        }
+
+        // Best-effort: a missing / unreadable / failed storage read leaves an empty list, so the
+        // union degrades to the inbox rows alone (no resume badge, no orphan rows). The list is
+        // never blocked. NOTE: no early-return on an empty inbox — orphan MPStorage entries may
+        // still populate the list (a page-1 box without any MultiMP is NOT necessarily Empty).
+        val entries = fetchStorageEntries()
+        // Re-check the generation AFTER the (suspending) storage scan too: the account may have
+        // switched while the scan was in flight, so the stale result must not republish.
+        if (generation != dtGeneration) return
+
+        val items = buildDtItems(inboxMulti, entries)
+        if (items.isEmpty()) {
+            if (generation == dtGeneration) _dtListState.value = DtListUiState.Empty
+            return
+        }
+        if (generation == dtGeneration) _dtListState.value = DtListUiState.Content(items)
     }
 
     /**
@@ -900,6 +992,10 @@ class FlagsViewModel @Inject constructor(
         dtGeneration++
         dtFetchStarted = false
         _dtListState.value = DtListUiState.Loading
+        // Clear any in-flight refresh indicator (the cancelled fetch's finally is out-generationed
+        // and won't). KEEP [_dtUnreadOnly] — it is a display preference, not session data, so an
+        // account switch must not silently reset the user's « +lus » choice (#546 directive XaTriX).
+        _dtIsRefreshing.value = false
     }
 }
 
@@ -1035,6 +1131,14 @@ sealed interface DtListUiState {
     data object Empty : DtListUiState
 
     /**
+     * #546 directive XaTriX — the union is NON-empty but the « non-lus uniquement » filter
+     * ([FlagsViewModel.dtUnreadOnly]) hid every row (no unread inbox-backed conversation). Distinct
+     * from [Empty] (no conversation at all): the screen shows « aucune conversation non lue » and the
+     * user can re-tap the DT tab to reveal the read ones (« +lus »). Produced only by [filterDt].
+     */
+    data object NoUnread : DtListUiState
+
+    /**
      * The DT union: inbox PAGE 1 MultiMP rows ∪ orphan MPStorage entries, deduplicated by
      * `threadId` and ordered inbox-first then `mpFlags.list` order (#6). The multi-page inbox limit
      * remains — surfaced by the scan-note footer (`flags_dt_scan_note`).
@@ -1109,4 +1213,26 @@ internal fun buildDtItems(
                 add(DtListItem.StorageOnly(entry.threadId, entry.page, entry.numreponse))
             }
     }
+}
+
+/**
+ * Pure « non-lus uniquement » filter for the DT list (#546 directive XaTriX), applied to the raw
+ * union [state] before it reaches the screen. Mirrors the flag-list [FlagsViewModel.filterUnreadOnly]
+ * but for the DT channel's two item natures:
+ *
+ *  - [unreadOnly] off → passthrough (the full union, « +lus »).
+ *  - [unreadOnly] on, [DtListUiState.Content] → keep ONLY the [DtListItem.InboxBacked] rows whose
+ *    conversation has an unread message. [DtListItem.StorageOnly] orphans (read state UNKNOWN off
+ *    inbox) and read inbox rows are excluded — the unread view is the actionable subset only.
+ *  - Filtered to empty while the raw union was NON-empty → [DtListUiState.NoUnread] (distinct from
+ *    [DtListUiState.Empty]: there ARE conversations, just none unread; the screen invites « +lus »).
+ *  - [DtListUiState.Loading] / [DtListUiState.Empty] / [DtListUiState.Error] → passthrough.
+ */
+internal fun filterDt(state: DtListUiState, unreadOnly: Boolean): DtListUiState {
+    // Passthrough unless we are filtering a loaded Content union (Loading/Empty/Error and the
+    // « +lus » view keep the state as-is). Single return point (detekt ReturnCount).
+    if (!unreadOnly || state !is DtListUiState.Content) return state
+    val unread = state.items.filter { it is DtListItem.InboxBacked && it.conversation.hasUnread }
+    // The union held conversations but none is unread → a dedicated NoUnread state, not Empty.
+    return if (unread.isEmpty()) DtListUiState.NoUnread else DtListUiState.Content(unread)
 }

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -33,6 +33,10 @@
          différé (cf. DT_INBOX_PAGE). Le wording assume « récente » pour ne pas affirmer qu'AUCUNE
          MultiMP n'existe ailleurs (ni en page 1, ni connue de la synchro DT). -->
     <string name="flags_dt_empty">Aucune conversation multi-destinataires récente.</string>
+    <!-- #546 — état « non-lus uniquement » actif mais aucune conversation non lue (l'union n'est pas
+         vide, juste filtrée). Re-taper l'onglet DT affiche aussi les lues (« +lus »). Distinct de
+         flags_dt_empty (aucune conversation du tout). -->
+    <string name="flags_dt_no_unread">Aucune conversation non lue. Re-tape l\'onglet DT pour afficher aussi les lues.</string>
     <!-- Description a11y d'une ligne DT : état lu/non-lu, annoncé par TalkBack (le point coloré
          est purement décoratif). %1$s = sujet de la conversation. -->
     <string name="flags_dt_row_unread">Non lu : %1$s</string>

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1740,6 +1740,194 @@ class FlagsViewModelTest {
         }
     }
 
+    // #546 directive XaTriX — DT « non-lus par défaut » + re-tap toggle (« +lus ») + pull-to-refresh.
+
+    @Test
+    fun `dtUnreadOnly defaults to true`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val vm = viewModel(auth, flags, FakeForumRepository())
+
+        assertTrue("DT opens on the unread subset by default", vm.dtUnreadOnly.value)
+    }
+
+    @Test
+    fun `re-tapping the already selected DT tab toggles its unread-only filter`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val vm = viewModel(auth, flags, FakeForumRepository())
+
+        vm.selectTab(FlagTab.Dt) // first tap from Cyan: just select, no toggle
+        assertEquals(FlagTab.Dt, vm.selectedTab.value)
+        assertTrue("a plain selection must not toggle the filter", vm.dtUnreadOnly.value)
+
+        vm.selectTab(FlagTab.Dt) // re-tap: true → false (« +lus » shown)
+        assertFalse(vm.dtUnreadOnly.value)
+        vm.selectTab(FlagTab.Dt) // re-tap: false → true
+        assertTrue(vm.dtUnreadOnly.value)
+        // The re-tap must not move the selected tab nor recall the list to the top (like Cyan).
+        assertEquals(FlagTab.Dt, vm.selectedTab.value)
+        assertFalse("DT re-tap must not recall the list to the top", vm.recallListToTop.value)
+    }
+
+    @Test
+    fun `selecting DT from another tab does not toggle the filter`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val vm = viewModel(auth, flags, FakeForumRepository())
+
+        vm.selectTab(FlagTab.Red)
+        vm.selectTab(FlagTab.Dt) // first tap onto DT: selects, keeps the default unread-only
+        assertEquals(FlagTab.Dt, vm.selectedTab.value)
+        assertTrue(vm.dtUnreadOnly.value)
+    }
+
+    @Test
+    fun `dtShowsRead mirrors DT selected and unread filter off`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val vm = viewModel(auth, flags, FakeForumRepository())
+
+        assertFalse("Cyan selected, no suffix", vm.dtShowsRead.value)
+        vm.selectTab(FlagTab.Dt)
+        assertFalse("DT selected but unread-only on → no « +lus »", vm.dtShowsRead.value)
+        vm.selectTab(FlagTab.Dt) // re-tap → +lus
+        assertTrue("DT selected with read shown → « +lus »", vm.dtShowsRead.value)
+    }
+
+    @Test
+    fun `dtDisplayState keeps only unread inbox rows by default and excludes orphans and read rows`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val messages = FakeMessagesRepository(
+            inboxResult = Result.success(
+                inboxPage(
+                    stubSummary(threadId = 10, isMultiRecipient = true, hasUnread = true),
+                    stubSummary(threadId = 20, isMultiRecipient = true, hasUnread = false),
+                ),
+            ),
+        )
+        // An orphan storage-only entry (state unknown) must be excluded by the unread filter.
+        val mpStorage = FakeMpStorageRepository(
+            result = MpStorageResult.Found(
+                mpDoc(MpStorageFlagEntry(threadId = 99, page = 2, numreponse = null, uri = null)),
+            ),
+        )
+        val vm = viewModel(auth, flags, FakeForumRepository(), messages = messages, mpStorage = mpStorage)
+
+        vm.dtDisplayState.test {
+            assertEquals(DtListUiState.Loading, awaitItem())
+            vm.onDtTabOpened()
+            val unreadOnly = awaitItem() as DtListUiState.Content
+            assertEquals(
+                "default unread-only keeps only the unread inbox row (10)",
+                listOf(10),
+                unreadOnly.items.map { it.threadId },
+            )
+            // The raw union still carries all three (10 + 20 + orphan 99).
+            assertEquals(listOf(10, 20, 99), (vm.dtListState.value as DtListUiState.Content).items.map { it.threadId })
+
+            vm.selectTab(FlagTab.Dt) // re-tap → +lus reveals the full union
+            val full = awaitItem() as DtListUiState.Content
+            assertEquals(listOf(10, 20, 99), full.items.map { it.threadId })
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `dtDisplayState is NoUnread when the union is non-empty but nothing is unread`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val messages = FakeMessagesRepository(
+            inboxResult = Result.success(
+                inboxPage(stubSummary(threadId = 10, isMultiRecipient = true, hasUnread = false)),
+            ),
+        )
+        val vm = viewModel(auth, flags, FakeForumRepository(), messages = messages)
+
+        vm.dtDisplayState.test {
+            assertEquals(DtListUiState.Loading, awaitItem())
+            vm.onDtTabOpened()
+            // Union is non-empty (one read conversation) but the unread filter hides it → NoUnread,
+            // distinct from Empty (which means no conversation at all).
+            assertEquals(DtListUiState.NoUnread, awaitItem())
+            assertTrue("the raw union still holds the read conversation", vm.dtListState.value is DtListUiState.Content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `dtDisplayState stays Empty (not NoUnread) when there is no conversation at all`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val messages = FakeMessagesRepository(
+            inboxResult = Result.success(inboxPage(stubSummary(threadId = 20, isMultiRecipient = false))),
+        )
+        val vm = viewModel(auth, flags, FakeForumRepository(), messages = messages)
+
+        vm.dtDisplayState.test {
+            assertEquals(DtListUiState.Loading, awaitItem())
+            vm.onDtTabOpened()
+            assertEquals(DtListUiState.Empty, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `refreshDt toggles dtIsRefreshing around the round-trip without blanking the content to Loading`() =
+        runTest {
+            val flags = FakeFlagRepository()
+            val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+            val messages = FakeMessagesRepository(
+                inboxResult = Result.success(
+                    inboxPage(stubSummary(threadId = 10, isMultiRecipient = true, hasUnread = true)),
+                ),
+            )
+            messages.blockInboxUntil = kotlinx.coroutines.CompletableDeferred()
+            val vm = viewModel(auth, flags, FakeForumRepository(), messages = messages)
+
+            // Cold open first (ungated), so there is content to keep during the refresh.
+            messages.blockInboxUntil!!.complete(Unit)
+            vm.onDtTabOpened()
+            assertTrue(vm.dtListState.value is DtListUiState.Content)
+
+            // Now gate the refresh round-trip so the in-flight indicator is observable.
+            messages.blockInboxUntil = kotlinx.coroutines.CompletableDeferred()
+            vm.refreshDt()
+            assertTrue("dtIsRefreshing rises during the refresh", vm.dtIsRefreshing.value)
+            assertTrue(
+                "the content must NOT blank to Loading during a refresh (#225 pattern)",
+                vm.dtListState.value is DtListUiState.Content,
+            )
+
+            messages.blockInboxUntil!!.complete(Unit)
+            advanceUntilIdle()
+            assertFalse("dtIsRefreshing falls after the round-trip", vm.dtIsRefreshing.value)
+            assertTrue(vm.dtListState.value is DtListUiState.Content)
+        }
+
+    @Test
+    fun `account switch keeps the DT unread filter but clears the refresh indicator`() = runTest {
+        val flags = FakeFlagRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val messages = FakeMessagesRepository(
+            inboxResult = Result.success(
+                inboxPage(stubSummary(threadId = 10, isMultiRecipient = true, hasUnread = true)),
+            ),
+        )
+        val vm = viewModel(auth, flags, FakeForumRepository(), messages = messages)
+
+        vm.selectTab(FlagTab.Dt)
+        vm.selectTab(FlagTab.Dt) // re-tap → +lus (unread filter off)
+        assertFalse(vm.dtUnreadOnly.value)
+
+        auth.emit(AuthState.Authenticated("other")) // account switch → resetDtState
+
+        assertEquals(DtListUiState.Loading, vm.dtListState.value)
+        assertFalse("the refresh indicator is reset on account switch", vm.dtIsRefreshing.value)
+        assertFalse("the « +lus » display preference survives the account switch", vm.dtUnreadOnly.value)
+    }
+
     private fun stubSummary(
         threadId: Int,
         isMultiRecipient: Boolean,


### PR DESCRIPTION
Directive XaTriX 2026-06-19 : l'onglet DT doit se comporter comme « Mes sujets » (Cyan).

## Changement

- **Non-lus par défaut** : la liste DT n'affiche que les conversations **non lues** (`dtUnreadOnly`, défaut `true`). Filtre dérivé `dtDisplayState = combine(dtListState, dtUnreadOnly)` → ne garde que les lignes `InboxBacked` à `hasUnread`. Les entrées MPStorage orphelines (état lu/non-lu inconnu) et les conversations lues n'apparaissent qu'en mode « +lus ».
- **Clic sur le nom de l'onglet** : re-taper l'onglet DT déjà sélectionné bascule l'affichage des lus, exactement comme le re-tap de Cyan (suffixe « +lus » sur le label via `dtShowsRead`). L'union complète (page 1 inbox + entrées MPStorage) est la vue « +lus ».
- **Pull-to-refresh** : `PullToRefreshBox` sur la liste DT (swipe vers le bas), comme les autres onglets. `loadDt(isRefresh)` garde le contenu courant sous l'indicateur au lieu de blanker en `Loading` ; `dtIsRefreshing` éteint dans un `finally` gardé par la génération (pas d'extinction par une requête périmée). États sans liste rendus scrollables (#229) pour ancrer le geste, y compris le nouvel état **NoUnread** (« Aucune conversation non lue », distinct de `Empty`).

Le filtre `dtUnreadOnly` est en mémoire (per-session), non persisté — parité complète avec Cyan (DataStore) = follow-up assumé (éviter d'ajouter une méthode à `UserPreferencesRepository` qui casserait tous les fakes).

## Revue
Relu par Codex : aucun bug logique (filtre/NoUnread/Empty, race dtIsRefreshing vs génération, re-tap, switch compte conservant le filtre). 1 point UI corrigé : l'état Empty (`DtMessageBody`) rendu scrollable pour que le pull-to-refresh s'y ancre aussi.

8 tests ajoutés (défaut, re-tap toggle, filtre unread-only vs +lus, NoUnread vs Empty, refresh sans blank, switch compte).

Suivi : tâche interne #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
