### PR TITLE
fix(beta): blacklist #509 re-filtrage live + badge MP à l'ouverture DT (2 MAJOR, review 4-flavor)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -1378,8 +1378,15 @@ private fun RedfaceNavHost(
                     // #6 — DT (MultiMP) row tap: open the existing PrivateMessageThread route inside
                     // the Flags tab. DT rows are always multi-recipient, so record the hint (the
                     // route itself stays opaque, like the Messages tab does, cf. onOpenThread).
-                    onOpenMultiMp = { threadId, page ->
+                    onOpenMultiMp = { threadId, page, wasUnread ->
                         privateMessageNavState.onThreadOpenedAsMulti(threadId)
+                        // Badge fix — record the unread-on-open state so the badge decrements on
+                        // first read, exactly like the Messages tab's onOpenThread. Without this the
+                        // DT path never fed `unreadOnOpenThreadIds`, so shouldDecrementUnreadBadge
+                        // was always false for a DT-opened conversation and the MP badge stayed high.
+                        if (wasUnread) {
+                            privateMessageNavState.onThreadOpenedUnread(threadId)
+                        }
                         backStack.add(PrivateMessageThreadRoute(threadId = threadId, page = page))
                     },
                     topBarActions = accountMenu,

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -116,8 +116,10 @@ fun FlagsRoute(
     onLoginRequested: () -> Unit,
     onOpenCategory: (Int) -> Unit = {},
     // #6 — open a DT (MultiMP) conversation : the host pushes the existing PrivateMessageThread
-    // route. `page` is the conversation's last inbox page (web parity, #430).
-    onOpenMultiMp: (threadId: Int, page: Int) -> Unit = { _, _ -> },
+    // route. `page` is the conversation's last inbox page (web parity, #430). `wasUnread` lets the
+    // host decrement the MP unread badge on first read, mirroring the Messages tab's onOpenThread
+    // (badge regression: the DT path never reported it, so the badge stayed stuck high).
+    onOpenMultiMp: (threadId: Int, page: Int, wasUnread: Boolean) -> Unit = { _, _, _ -> },
     topBarActions: @Composable (() -> Unit)? = null,
 ) {
     val viewModel: FlagsViewModel = hiltViewModel()
@@ -1262,7 +1264,7 @@ private fun DtListContent(state: DtListUiState, actions: AuthenticatedActions) {
  * the page the « reprise p.N » badge advertises (clamped ≥ 1).
  */
 @Composable
-private fun DtRow(item: DtListItem, onOpenMultiMp: (threadId: Int, page: Int) -> Unit) {
+private fun DtRow(item: DtListItem, onOpenMultiMp: (threadId: Int, page: Int, wasUnread: Boolean) -> Unit) {
     when (item) {
         is DtListItem.InboxBacked -> DtConversationRow(
             item = item,
@@ -1270,19 +1272,34 @@ private fun DtRow(item: DtListItem, onOpenMultiMp: (threadId: Int, page: Int) ->
             // conversation's last inbox page (#430). Tapping must land where the « reprise p.N » badge
             // says it will — opening lastPage while showing « reprise p.N » was a badge/action
             // contradiction (Codex review). Clamp ≥ 1 so a bogus stored 0/negative page never
-            // produces an invalid route argument.
+            // produces an invalid route argument. `wasUnread` mirrors the Messages tab so the host
+            // decrements the MP badge on first read (HFR has no server read flag, so a stuck-high
+            // badge never self-corrects on re-fetch).
             onClick = {
                 val target = (item.resumePage ?: item.conversation.lastPage).coerceAtLeast(1)
-                onOpenMultiMp(item.threadId, target)
+                onOpenMultiMp(item.threadId, target, dtRowWasUnread(item))
             },
         )
 
         is DtListItem.StorageOnly -> DtStorageOnlyRow(
             item = item,
             // No lastPage for an orphan: open on the MPStorage resume page (clamped ≥ 1), else page 1.
-            onClick = { onOpenMultiMp(item.threadId, (item.resumePage ?: 1).coerceAtLeast(1)) },
+            // The read/unread state of an orphan is unknown off inbox PAGE 1, so wasUnread = false
+            // (dtRowWasUnread) — never speculatively decrement the badge for an unknown state.
+            onClick = { onOpenMultiMp(item.threadId, (item.resumePage ?: 1).coerceAtLeast(1), dtRowWasUnread(item)) },
         )
     }
+}
+
+/**
+ * #6 / badge — whether a DT row was UNREAD when tapped, used by the host to decrement the MP unread
+ * badge on first read (mirror of the Messages tab's onOpenThread `wasUnread`). An [DtListItem.InboxBacked]
+ * carries the live inbox read state ([PrivateMessageSummary.hasUnread]); an orphan [DtListItem.StorageOnly]
+ * has no known read state off inbox PAGE 1, so it reports `false` (never speculatively decrement).
+ */
+internal fun dtRowWasUnread(item: DtListItem): Boolean = when (item) {
+    is DtListItem.InboxBacked -> item.conversation.hasUnread
+    is DtListItem.StorageOnly -> false
 }
 
 /**
@@ -1498,8 +1515,8 @@ private data class AuthenticatedActions(
     val onRequestRemoveFlag: (Flag) -> Unit,
     /** #414 — tap on a category band opens that category's topic listing. */
     val onOpenCategory: (Int) -> Unit,
-    /** #6 — open a DT conversation (threadId, last inbox page). */
-    val onOpenMultiMp: (threadId: Int, page: Int) -> Unit = { _, _ -> },
+    /** #6 — open a DT conversation (threadId, last inbox page, unread-on-open for the badge). */
+    val onOpenMultiMp: (threadId: Int, page: Int, wasUnread: Boolean) -> Unit = { _, _, _ -> },
     /** #6 — explicit user reload of the DT list (retry). */
     val onRefreshDt: () -> Unit = {},
 )

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1936,6 +1936,35 @@ class FlagsViewModelTest {
         assertFalse("the « +lus » display preference survives the account switch", vm.dtUnreadOnly.value)
     }
 
+    // ──────────────────────────────────────────────────────────────────────
+    // Badge regression (beta) — DT row unread-on-open reported to the host
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `dtRowWasUnread reports the inbox-backed conversation unread state for the badge`() {
+        // The DT-open handler never fed unreadOnOpenThreadIds, so the MP badge never decremented when a
+        // MultiMP was read via the DT tab. dtRowWasUnread is the value DtRow now passes to onOpenMultiMp;
+        // for an inbox-backed row it MUST mirror the conversation's live hasUnread (like onOpenThread).
+        val unread = DtListItem.InboxBacked(
+            conversation = stubSummary(threadId = 1, isMultiRecipient = true, hasUnread = true),
+            resumePage = null,
+        )
+        val read = DtListItem.InboxBacked(
+            conversation = stubSummary(threadId = 2, isMultiRecipient = true, hasUnread = false),
+            resumePage = 3,
+        )
+        assertTrue("an unread inbox-backed DT row must report wasUnread = true", dtRowWasUnread(unread))
+        assertFalse("a read inbox-backed DT row must report wasUnread = false", dtRowWasUnread(read))
+    }
+
+    @Test
+    fun `dtRowWasUnread reports false for a storage-only orphan whose read state is unknown`() {
+        // An orphan off inbox PAGE 1 has no known read/unread state, so the badge must never be
+        // speculatively decremented for it: wasUnread = false.
+        val orphan = DtListItem.StorageOnly(threadId = 9, resumePage = 4, numreponse = null)
+        assertFalse("a storage-only DT row must report wasUnread = false", dtRowWasUnread(orphan))
+    }
+
     private fun stubSummary(
         threadId: Int,
         isMultiRecipient: Boolean,

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -223,11 +223,17 @@ class TopicViewModel @AssistedInject constructor(
      * replace), so a block / unblock applies live on the page currently on screen whatever path put it
      * there. On each emission it (a) caches the set in [blockedCanonicals] (so every load path can
      * compute the initial hidden set with the up-to-date blacklist) and (b) recomputes
-     * [TopicUiState.Mode.Loaded.hiddenNumreponses] on the current loaded page and re-emits it. The
-     * `observeBlockedCanonicals` flow emits its current value immediately (documented contract), so
-     * launching this FIRST in [init] seeds [blockedCanonicals] before the initial load computes its own
-     * hidden set — no blocked post flashes unhidden. A non-loaded state (Loading / Error) is left
-     * untouched; the next load reads the freshest [blockedCanonicals].
+     * [TopicUiState.Mode.Loaded.hiddenNumreponses] on the current loaded page and re-emits it. A
+     * non-loaded state (Loading / Error) is left untouched; the next load reads the freshest
+     * [blockedCanonicals].
+     *
+     * Launched FIRST in [init] so its emission usually seeds [blockedCanonicals] before the initial
+     * page renders. But `observeBlockedCanonicals` is a COLD DataStore flow (not a StateFlow), so that
+     * first emission is asynchronous — the ordering vs the initial load is NOT guaranteed (Codex
+     * review). The (b) re-filter is the real guarantee: even if a load renders before the blacklist
+     * lands, this collector immediately re-hides the blocked posts. The residual is at most a one-frame
+     * flash on a cold open whose page-1 already contains a blocked author — and in practice the network
+     * page load is slower than the (memory-cached) DataStore read, so it rarely shows.
      */
     private fun observeBlockedCanonicals() {
         blacklistRepository.observeBlockedCanonicals()
@@ -242,6 +248,11 @@ class TopicViewModel @AssistedInject constructor(
                     )
                 }
             }
+            // This collector is independent of any load job, so an unhandled error here would tear
+            // down viewModelScope and kill the screen. A DataStore read hiccup on the blacklist must
+            // not do that — keep the last known set; the next emission recovers (Codex review; mirrors
+            // the catch the former loadCurrentPage combine carried).
+            .catch { error -> android.util.Log.w(LOG_TAG, "Blacklist observe failed", error) }
             .launchIn(viewModelScope)
     }
 

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -65,9 +64,10 @@ class TopicViewModel @AssistedInject constructor(
     val state: StateFlow<TopicUiState> = _state.asStateFlow()
 
     /**
-     * #509 — latest set of blacklisted canonical pseudos. Kept fresh by the [loadCurrentPage] combine
-     * so the refresh / post-submit / post-delete paths (which bypass `observeTopicPage`) can recompute
-     * the hidden set without re-subscribing to the blacklist.
+     * #509 — latest set of blacklisted canonical pseudos. Kept fresh by the independent
+     * [observeBlockedCanonicals] collector launched in [init] (NOT by a load job), so EVERY page that
+     * is on screen — whatever path put it there (cache-aside load, pull-to-refresh, post-submit force
+     * refresh, post-delete refetch, intra-topic search) — re-filters live when the blacklist changes.
      */
     private var blockedCanonicals: Set<String> = emptySet()
 
@@ -123,6 +123,13 @@ class TopicViewModel @AssistedInject constructor(
     private var firstContentInFlight: Boolean = false
 
     init {
+        // #509 — own the blacklist as a single independent collector (NOT tied to a load job). It
+        // seeds [blockedCanonicals] and re-filters the page on screen live, so a block / unblock
+        // applies on every load path (refresh / force-refresh / search) and not just the cache-aside
+        // load. Launched FIRST so observeBlockedCanonicals' immediate first emission (its documented
+        // contract) seeds [blockedCanonicals] before the load below computes the initial hidden set —
+        // a blocked post therefore never flashes before it is hidden, even on the force-refresh path.
+        observeBlockedCanonicals()
         if (request.submitSignal != null) {
             // Issue #200 — the user just published a reply / quote / edit / edit-FP and the
             // navigation host signalled us to skip the cache so the freshly-published post
@@ -200,13 +207,42 @@ class TopicViewModel @AssistedInject constructor(
      * #509 — block / unblock [author] from the post menu. This launch is on [viewModelScope], but the
      * DataStore commit still survives the sheet/ViewModel going away mid-write: the repository's
      * `persist {}` offloads the actual write to the application scope (the #507 pattern), so only the
-     * `await` is cancelled, not the commit. The page re-filters live via the [loadCurrentPage] combine,
-     * so no manual state poke is needed here.
+     * `await` is cancelled, not the commit. The page re-filters live through the independent
+     * [observeBlockedCanonicals] collector (launched in [init]), so the write here applies on whatever
+     * page is currently on screen, regardless of how it was loaded — no manual state poke is needed.
      */
     private fun setAuthorBlocked(author: String, blocked: Boolean) {
         viewModelScope.launch {
             if (blocked) blacklistRepository.block(author) else blacklistRepository.unblock(author)
         }
+    }
+
+    /**
+     * #509 — single, load-independent owner of the blacklist. Collected once on [viewModelScope] (NOT
+     * inside [loadJob], which the refresh / force-refresh / post-delete / search paths cancel and
+     * replace), so a block / unblock applies live on the page currently on screen whatever path put it
+     * there. On each emission it (a) caches the set in [blockedCanonicals] (so every load path can
+     * compute the initial hidden set with the up-to-date blacklist) and (b) recomputes
+     * [TopicUiState.Mode.Loaded.hiddenNumreponses] on the current loaded page and re-emits it. The
+     * `observeBlockedCanonicals` flow emits its current value immediately (documented contract), so
+     * launching this FIRST in [init] seeds [blockedCanonicals] before the initial load computes its own
+     * hidden set — no blocked post flashes unhidden. A non-loaded state (Loading / Error) is left
+     * untouched; the next load reads the freshest [blockedCanonicals].
+     */
+    private fun observeBlockedCanonicals() {
+        blacklistRepository.observeBlockedCanonicals()
+            .onEach { blocked ->
+                blockedCanonicals = blocked
+                _state.update { current ->
+                    val loaded = current.mode as? TopicUiState.Mode.Loaded ?: return@update current
+                    current.copy(
+                        mode = loaded.copy(
+                            hiddenNumreponses = computeHiddenNumreponses(loaded.topic, blocked),
+                        ),
+                    )
+                }
+            }
+            .launchIn(viewModelScope)
     }
 
     /**
@@ -284,15 +320,13 @@ class TopicViewModel @AssistedInject constructor(
         beginFirstContentSection()
         _state.update { it.copy(mode = TopicUiState.Mode.Loading) }
         loadJob = viewModelScope.launch {
-            combine(
-                topicRepository
-                    .observeTopicPage(request.cat, request.post, request.page, forceRefresh = request.forceRefresh),
-                // #509 — gate the first Loaded on the blacklist being known so a blocked post never
-                // flashes before it is hidden, and re-filter live when the blacklist changes.
-                // observeBlockedCanonicals emits its current set immediately (its documented contract),
-                // so combine never stalls waiting on the blacklist.
-                blacklistRepository.observeBlockedCanonicals(),
-            ) { topic, blocked -> topic to blocked }
+            topicRepository
+                .observeTopicPage(request.cat, request.post, request.page, forceRefresh = request.forceRefresh)
+                // #509 — the blacklist is owned by the independent observeBlockedCanonicals collector
+                // (launched in init), NOT combined here: it has already seeded blockedCanonicals by the
+                // time this load runs (its first emission is synchronous, documented contract), so the
+                // initial hidden set below is correct and there is no double-source / clignotement
+                // between this load and the live re-filter — the init collector is the sole re-filter.
                 .catch { error ->
                     if (error is CancellationException) throw error
                     // Cache-first UX: if we already showed a cached page, keep it on screen
@@ -317,8 +351,7 @@ class TopicViewModel @AssistedInject constructor(
                     // still draws a bounded sliver from intent to terminal state.
                     endFirstContentSectionIfNeeded()
                 }
-                .collect { (topic, blocked) ->
-                    blockedCanonicals = blocked
+                .collect { topic ->
                     _state.update {
                         it.copy(
                             mode = TopicUiState.Mode.Loaded(topic, computeHiddenNumreponses(topic, blockedCanonicals)),

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -782,6 +782,124 @@ class TopicViewModelTest {
         }
     }
 
+    @Test
+    fun `blocking an author after a pull-to-refresh hides their posts live (#509 beta)`() = runTest {
+        // Beta regression: the blacklist used to be collected only inside loadCurrentPage's combine, so
+        // a refresh (which cancels loadJob and runs a one-shot refetch) FROZE the live re-filter — a
+        // block after a pull did nothing until the next page change. The independent init collector now
+        // owns the re-filter so it applies on the refreshed page too.
+        val loaded = fakeTopic(
+            page = 1,
+            totalPages = 1,
+            posts = listOf(fakePost(100, author = "Alice"), fakePost(101, author = "Bob")),
+        )
+        val refreshed = fakeTopic(
+            page = 1,
+            totalPages = 1,
+            title = "refreshed",
+            posts = listOf(fakePost(100, author = "Alice"), fakePost(101, author = "Bob")),
+        )
+        val blacklist = FakeBlacklistRepository()
+        val repository = FakeTopicRepository(
+            flowsToReturn = listOf(flow { emit(loaded) }),
+            refreshTopicsToReturn = listOf(refreshed),
+        )
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            blacklistRepository = blacklist,
+        )
+
+        viewModel.send(TopicIntent.Refresh)
+        assertEquals(
+            "the refreshed page is on screen with nothing hidden yet",
+            "refreshed",
+            assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value).topic.title,
+        )
+        assertEquals(emptySet<Int>(), assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value).hiddenNumreponses)
+
+        viewModel.send(TopicIntent.SetAuthorBlocked("Alice", blocked = true))
+
+        // Live re-filter on the refreshed page — NOT only after a page change.
+        val mode = assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value)
+        assertEquals("refreshed", mode.topic.title)
+        assertEquals(setOf(100), mode.hiddenNumreponses)
+    }
+
+    @Test
+    fun `a post-submit landing hides authors already blacklisted before the force refresh (#509 beta)`() =
+        runTest {
+            // Beta regression: a VM created with submitSignal != null lands via forceRefreshCurrentPage
+            // and NEVER calls loadCurrentPage, so the blacklist combine never ran → blockedCanonicals
+            // stayed emptySet() and an already-blocked author was NOT hidden on the landing page. The
+            // init collector now seeds blockedCanonicals before the force refresh computes its hidden set.
+            val fresh = fakeTopic(
+                page = 2,
+                totalPages = 5,
+                posts = listOf(fakePost(900, author = "Alice"), fakePost(901, author = "Bob")),
+            )
+            val repository = FakeTopicRepository(
+                flowsToReturn = emptyList(),
+                refreshTopicsToReturn = listOf(fresh),
+            )
+            val viewModel = topicViewModel(
+                request = topicRequest(page = 2, submitSignal = 1_700_000_000_000L),
+                topicRepository = repository,
+                authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+                // Alice is ALREADY blacklisted when the VM is constructed.
+                blacklistRepository = FakeBlacklistRepository(blockedCanonicals = setOf("alice")),
+            )
+
+            val mode = assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value)
+            assertEquals(fresh, mode.topic)
+            assertEquals(
+                "an already-blacklisted author must be hidden on the force-refresh landing page",
+                setOf(900),
+                mode.hiddenNumreponses,
+            )
+            assertTrue("the landing went through the force-refresh path", repository.calls.isEmpty())
+        }
+
+    @Test
+    fun `blocking an author while a search result page is shown hides them live (#509 beta)`() = runTest {
+        // Beta regression: a transsearch result page is rendered outside loadCurrentPage (launchSearch),
+        // so the frozen combine never re-filtered it. The init collector now re-filters whatever page is
+        // on screen, including a search result page.
+        val form = TopicSearchForm(hashCheck = "tok", topicId = SAMPLE_POST, cat = SAMPLE_CAT, firstnum = 1)
+        val resultForm = form.copy(currentNum = 100)
+        val resultTopic = fakeTopic(
+            page = 1, totalPages = 1, title = "search-result",
+            posts = listOf(fakePost(100, author = "Alice"), fakePost(200, author = "Bob")),
+            searchForm = resultForm,
+        )
+        val searchRepo = FakeTopicSearchRepository(result = resultTopic)
+        val blacklist = FakeBlacklistRepository()
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = searchableRepo(form),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            blacklistRepository = blacklist,
+            topicSearchRepository = searchRepo,
+        )
+
+        viewModel.send(TopicIntent.OpenSearch)
+        viewModel.send(TopicIntent.SearchWordChanged("x"))
+        viewModel.send(TopicIntent.SearchOnlyMatchesChanged(false))
+        viewModel.send(TopicIntent.SubmitSearch)
+        assertEquals(
+            "the search result page is on screen",
+            "search-result",
+            assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value).topic.title,
+        )
+
+        viewModel.send(TopicIntent.SetAuthorBlocked("Alice", blocked = true))
+
+        val mode = assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value)
+        assertEquals("search-result", mode.topic.title)
+        assertEquals(setOf(100), mode.hiddenNumreponses)
+    }
+
     // ─── intra-topic search (#546) ───────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
Deux bugs **MAJOR** trouvés par la revue 4-flavor de la bêta candidate (`app-v156..dev`), corrigés avant la promotion. Tous deux **introduits par ce payload** (#509 / #6), dans des features-phares.

## 1. Blacklist #509 — re-filtrage live cassé hors de `loadCurrentPage`
**Bug** (consensus 4 flavors, conf. 80-85) : `observeBlockedCanonicals()` n'était collecté que dans le `combine` de `loadCurrentPage()` (porté par `loadJob`). Or `refresh()`, `forceRefreshCurrentPage()`, `refreshAfterDelete()` et `launchSearch()` annulent `loadJob` → `blockedCanonicals` figé, et `setAuthorBlocked()` ne pokait aucun état. Conséquences : masquer un auteur après pull-to-refresh / réponse / suppression / recherche ne repliait rien en direct ; **pire**, à l'atterrissage post-réponse (`forceRefreshCurrentPage`, jamais `loadCurrentPage`), même les auteurs **déjà** blacklistés restaient visibles.

**Fix** : `observeBlockedCanonicals()` devient un **collecteur indépendant lancé en premier dans `init`** (sur `viewModelScope`, hors `loadJob`) qui met à jour `blockedCanonicals` ET recalcule `hiddenNumreponses` sur le `Mode.Loaded` courant + ré-émet. Le `combine` blacklist est retiré de `loadCurrentPage` (source unique = collecteur init). Un block/unblock s'applique donc en direct **sur tous les chemins**. KDoc trompeur corrigé.

**Durcissement (revue Codex)** : ajout d'un `.catch` sur le collecteur (un échec de lecture DataStore ne doit pas tuer `viewModelScope`) ; KDoc honnête sur le seed (flow DataStore froid → le re-filtre, pas l'ordre de lancement, est la vraie garantie ; résidu = flash ≤1 frame en cold-open, rare car le réseau est plus lent que DataStore).

## 2. Badge MP non décrémenté à l'ouverture d'un MultiMP via l'onglet DT
**Bug** (conf. 85) : `onOpenMultiMp` n'appelait pas `onThreadOpenedUnread` (contrairement à `onOpenThread`) → le badge MP restait durablement trop haut (HFR sans flag lu/non-lu serveur).

**Fix** : signature `onOpenMultiMp` étendue à `(threadId, page, wasUnread)` ; le handler DT appelle `onThreadOpenedUnread(threadId)` si `wasUnread`. Helper pur `dtRowWasUnread` (`InboxBacked → hasUnread`, `StorageOnly → false` : pas de décrément spéculatif sur les orphelines, état inconnu).

## Validation
`:feature:topic:testDebugUnitTest` (60 tests) + `:feature:flags:testDebugUnitTest` (81 tests) + `:app:testDevDebugUnitTest` + `assembleDevDebug` + `detektAll` + `lintDebug` — tous verts. 5 tests ajoutés (block après refresh/post-réponse/recherche ; mapping `dtRowWasUnread`). Revue Codex : 2 points adressés (catch + KDoc).

Suivi : #123, #124. Prépare la bêta 0.15.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
