### PR TITLE
fix(release): trim Play whatsnew <500 (re-ship beta 0.15.0)

### DIFF
--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,13 +1,12 @@
 Redface 2 v0.15.0 — beta.
 
 New:
-- Hide a user (blacklist): their posts collapse away.
-- Full-screen mode: hide the Android navigation bar.
-- In-topic search: by word or username, navigate between results, covers the whole topic.
-- DT tab (MultiMP): unread-only by default, tap the tab to reveal read ones, pull to refresh.
-- Topic creator's name in gold; optional "Rouge REDFACE1" accent colour.
+- Hide a user (blacklist).
+- Full-screen mode (hide the Android nav bar).
+- In-topic search: word/username, jump between results, whole topic.
+- DT tab: unread-only by default, tap to show read, pull to refresh.
+- Creator's name in gold; optional "Rouge REDFACE1" accent.
 
-Fixes:
-- Blacklist now applies live; MP badge fixed when opening a MultiMP.
+Fixes: live blacklist, MP badge.
 
-Report bugs via the beta or GitHub.
+Bugs: via the beta or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,13 +1,12 @@
 Redface 2 v0.15.0 — bêta.
 
 Nouveautés :
-- Masquer un utilisateur (blacklist) : ses messages se replient.
-- Mode plein écran : masquer la barre de navigation Android.
-- Recherche dans un sujet : par mot ou pseudo, navigation entre les résultats, couvre tout le sujet.
-- Onglet DT (MultiMP) : non-lus par défaut, clic sur l'onglet pour voir les lus, tirer pour rafraîchir.
-- Pseudo du créateur en doré ; couleur d'accent « Rouge REDFACE1 » en option.
+- Masquer un utilisateur (blacklist).
+- Mode plein écran (masquer la barre Android).
+- Recherche dans un sujet : mot/pseudo, navigation entre résultats, tout le sujet.
+- Onglet DT : non-lus par défaut, clic pour voir les lus, tirer pour rafraîchir.
+- Pseudo créateur en doré ; accent « Rouge REDFACE1 » optionnel.
 
-Correctifs :
-- Blacklist appliquée en direct ; badge des MP corrigé à l'ouverture d'un MultiMP.
+Correctifs : blacklist en direct, badge des MP.
 
-Signalez les bugs via la bêta ou GitHub.
+Bugs : via la bêta ou GitHub.


### PR DESCRIPTION
Notes Play trop longues (en 510>500) → commit Play échoué pour la bêta 0.15.0/app-v174. Notes trimmées (fr 447 / en 371). Re-ship de la bêta 0.15.0 après ce merge. 🤖 Generated with [Claude Code](https://claude.com/claude-code)