### PR TITLE
feat(mpstorage): activer l'écriture v0.1 (opt-in OFF + verify-after-write)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepository.kt
@@ -251,13 +251,26 @@ class DefaultMpStorageRepository @Inject constructor(
             return MpStorageWriteResult.Success(verified = true)
         }
 
-        // Mismatch : restore the verbatim backup through the same guarded builder.
+        // Not byte-identical. Tell a HEALTHY document apart from a CORRUPTED one before deciding to
+        // restore (Codex review): a valid JSON envelope that merely differs means HFR re-encoded
+        // entities OR a concurrent client (DTCloud) wrote between our GET and this re-GET — restoring
+        // the backup there would CLOBBER a legitimate last-write-wins update. Only a null / non-JSON
+        // read-back is real corruption (the HFR non-UTF-8 truncation, #114) → that is what we restore.
+        if (readBack != null && envelopeWriter.isJsonEnvelope(readBack)) {
+            diagnostics.record(
+                DiagnosticsLog.Level.INFO,
+                LOG_TAG,
+                "writeBackFlag: valid-but-different read-back (re-encoding / concurrent) — kept, not restored",
+            )
+            return MpStorageWriteResult.Success(verified = false)
+        }
+
         val expectedBytes = mutatedBody.toByteArray(Charsets.UTF_8).size
         val actualBytes = readBack?.toByteArray(Charsets.UTF_8)?.size ?: 0
         diagnostics.record(
             DiagnosticsLog.Level.WARN,
             LOG_TAG,
-            "writeBackFlag verify MISMATCH (expected=$expectedBytes actual=$actualBytes) → restoring backup",
+            "writeBackFlag verify CORRUPTION (expected=$expectedBytes actual=$actualBytes) → restoring backup",
         )
         return restoreBackup(location, form, pseudo, backupBody, expectedBytes, actualBytes)
     }
@@ -270,6 +283,9 @@ class DefaultMpStorageRepository @Inject constructor(
         expectedBytes: Int,
         actualBytes: Int,
     ): MpStorageWriteResult {
+        // Reuse the initial edit form: HFR's hash_check is session-stable (verified live, NOT rotated
+        // per-request), so the original form is valid for the restore. The guarded builder still
+        // refuses if its subject is not the storage hash.
         val restoreBody = buildPrivateMessageEditBody(location, form, pseudo, backupBody)
             ?: return MpStorageWriteResult.VerificationFailedRestoreFailed(expectedBytes, actualBytes)
 
@@ -293,13 +309,16 @@ class DefaultMpStorageRepository @Inject constructor(
         }
     }
 
-    /** Re-reads the raw `content_form` of the first post at [location] for verification (null when unreadable). */
-    private suspend fun reReadContentForm(location: MpStorageLocation): String? =
+    /** Re-fetches the full edit [ReplyForm] of the first post at [location] (null when unreadable). */
+    private suspend fun reReadForm(location: MpStorageLocation): ReplyForm? =
         replyFormParser
             .parse(hfrClient.getPrivateMessageEditForm(location.threadId, location.numreponse))
             .getOrNull()
             ?.takeUnless { it.isAnonymous }
-            ?.initialContent
+
+    /** Re-reads the raw `content_form` of the first post at [location] for verification (null when unreadable). */
+    private suspend fun reReadContentForm(location: MpStorageLocation): String? =
+        reReadForm(location)?.initialContent
 
     /**
      * The `bdd.php cat=prive` POST body for the storage first post. TWO deliberate differences from

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepository.kt
@@ -7,6 +7,8 @@ import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
 import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageLocation
 import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageLocationStore
 import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
+import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageWritePreview
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.mpstorage.MpStorageDocument
 import fr.forumhfr.redface2.core.model.mpstorage.MpStorageFlagEntry
@@ -28,7 +30,7 @@ import kotlinx.coroutines.withContext
 import okhttp3.FormBody
 
 /**
- * Default [MpStorageRepository] (#6, ADR-014) — read-only, zero writes.
+ * Default [MpStorageRepository] (#6, ADR-014) — read pipeline + the opt-in verify-after-write path.
  *
  * Discovery matches the de-facto userscript contract (`MPStorage.user.js` / DTCloud), NOT a
  * title search (HFR's subject index never returns the 32-hex hash, so the search-based discovery
@@ -47,9 +49,15 @@ import okhttp3.FormBody
  * original library's destructive reset-to-default trap). Diagnostics never log document content
  * (it aggregates private reading positions from every userscript) — only presence flags, sizes and
  * failure classes (#316 stance).
+ *
+ * The WRITE path ([writeBackFlag]) is the REAL, opt-in path : gated by
+ * [UserPreferencesRepository.observeSyncPrivateMessagesWriteEnabled] (default OFF), it locates the
+ * document, backs up its verbatim `content_form`, runs the pure read-modify-write, POSTs (with the
+ * active account's pseudo and the CONSTANT subject hash), then VERIFIES by re-reading — restoring the
+ * backup on a mismatch. NOT OBSERVED LIVE : the `bdd.php cat=prive` write contract is unconfirmed.
  */
 @Singleton
-// LongParameterList: one dep per pipeline stage (inbox/thread/edit parsers) + cache, auth, diagnostics, dispatcher.
+// LongParameterList: one dep per pipeline stage (inbox/thread/edit parsers) + cache, auth, prefs, diagnostics, disp.
 @Suppress("LongParameterList")
 class DefaultMpStorageRepository @Inject constructor(
     private val hfrClient: HfrClient,
@@ -60,6 +68,7 @@ class DefaultMpStorageRepository @Inject constructor(
     private val envelopeWriter: MpStorageEnvelopeWriter,
     private val locationStore: MpStorageLocationStore,
     private val authRepository: AuthRepository,
+    private val userPreferencesRepository: UserPreferencesRepository,
     private val diagnostics: DiagnosticsLog,
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : MpStorageRepository {
@@ -126,50 +135,59 @@ class DefaultMpStorageRepository @Inject constructor(
     }
 
     /**
-     * WRITE path (#6, ADR-014 §4) — GUARDED, NOT OBSERVED LIVE.
+     * WRITE path (#6, ADR-014 §4) — REAL, opt-in (OFF by default), verify-after-write.
      *
-     * Locates the storage document (same deterministic discovery as [fetchStorage] : cached location,
-     * else inbox scan for the conversation whose subject is EXACTLY [MpStorageRepository.STORAGE_SUBJECT_HASH]),
-     * reads its first-post edit form, runs the read-modify-write on the RAW JSON tree
-     * ([MpStorageEnvelopeWriter] — third-party namespaces preserved), enforces the
-     * [MpStorageRepository.MAX_CONTENT_FORM_BYTES] cap, and builds the `bdd.php cat=prive` POST body.
+     * The 15-step flow (cf. the spec) : read the pref → if OFF return [MpStorageWriteResult.DisabledByPreference]
+     * (NO request) → resolve the active pseudo → GET the edit form + raw `content_form` → keep a VERBATIM backup
+     * → refuse an unreadable JSON ([MpStorageWriteResult.Unreadable]) → run the pure writer → if no-op return
+     * [MpStorageWriteResult.Success] (verified, no POST) → enforce the [MpStorageRepository.MAX_CONTENT_FORM_BYTES]
+     * cap ([MpStorageWriteResult.TooLarge]) → POST the mutated body → RE-GET → if it equals the mutated body
+     * [MpStorageWriteResult.Success] → otherwise re-POST the backup (restore) + re-GET, surfaced as
+     * [MpStorageWriteResult.VerificationFailedRestored] / [MpStorageWriteResult.VerificationFailedRestoreFailed].
      *
-     * GUARD (structural, Codex review) : the public [writeBackFlag] runs with [post] = `false` → the POST is
-     * NEVER sent (body built & validated only). The live POST is reachable ONLY through the module-internal,
-     * test-only [writeBackFlagLive] — it is NOT on the public interface, so app/prod code cannot flip it. The
-     * `bdd.php cat=prive` write contract is unconfirmed (device down). A located-but-unreadable document or a
-     * [MpStorageWriteResult.TargetNotFound] is surfaced, NEVER repaired / created (ADR-014 §3 : creating a
-     * fresh document would fork the cross-userscript storage).
+     * Both the POST and the restore POST go through the SAME guarded builder ([buildPrivateMessageEditBody]) :
+     * active-account pseudo + the CONSTANT subject hash, refusing to POST when the parsed form's subject is wrong.
+     * The discovery is the same deterministic exact-hash match as [fetchStorage] ; a miss is
+     * [MpStorageWriteResult.TargetNotFound], NEVER a creation (ADR-014 §3).
      */
-    override suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult =
-        runWriteBack(entry, post = false)
-
-    /**
-     * Module-INTERNAL, TEST-ONLY live POST path — deliberately NOT on the [MpStorageRepository] interface
-     * so app/prod code cannot reach it (Codex review : the guard is structural, not a default parameter).
-     * The `bdd.php cat=prive` write contract is unconfirmed — NOT OBSERVED LIVE.
-     */
-    internal suspend fun writeBackFlagLive(entry: MpStorageFlagEntry): MpStorageWriteResult =
-        runWriteBack(entry, post = true)
-
-    @Suppress("ReturnCount") // Guard clauses (auth / not-found / unreadable / oversize) + the prepared return.
-    private suspend fun runWriteBack(entry: MpStorageFlagEntry, post: Boolean): MpStorageWriteResult {
+    @Suppress("ReturnCount") // Guard clauses (pref / auth / not-found / unreadable / no-op / oversize) + verify return.
+    override suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult {
         return withContext(ioDispatcher) {
+            // 1-2. Opt-in gate FIRST — no network when OFF (the default), so a missing trigger is harmless.
+            if (!syncWriteEnabled()) {
+                diagnostics.record(DiagnosticsLog.Level.INFO, LOG_TAG, "writeBackFlag: opt-in OFF → no write")
+                return@withContext MpStorageWriteResult.DisabledByPreference
+            }
+
+            // 3. Active account → pseudo (sent verbatim in the POST body).
             val owner = activePseudo()
                 ?: return@withContext MpStorageWriteResult.TargetNotFound
 
+            // 4. Locate + GET the edit form and parse the document.
             val location = locateForWrite(owner)
                 ?: return@withContext MpStorageWriteResult.TargetNotFound
             val read = readFormAndDocument(location)
                 ?: return@withContext MpStorageWriteResult.TargetNotFound
+            // 6. Refuse an unreadable document — never repaired (ADR-014 §3).
             val document = read.document
-                ?: return@withContext MpStorageWriteResult.TargetUnreadable
+                ?: return@withContext MpStorageWriteResult.Unreadable
 
+            // 5. Verbatim backup (the raw content_form BEFORE any mutation) for the restore path.
+            val backup = read.form.initialContent
+
+            // 7-9. Pure read-modify-write + no-op short-circuit + cap.
             when (val outcome = envelopeWriter.upsertFlag(document.rawEnvelope, entry)) {
                 MpStorageEnvelopeWriter.Outcome.NotJsonEnvelope ->
                     // Defensive : the parser already accepted it, so this should not happen — but if the
                     // raw text is somehow not a JSON object we surface it, never overwrite (ADR-014 §3).
-                    MpStorageWriteResult.TargetUnreadable
+                    MpStorageWriteResult.Unreadable
+
+                is MpStorageEnvelopeWriter.Outcome.NoOp -> {
+                    // 8. The target position did not change : success WITHOUT a POST (the document is
+                    // left byte-fidèle ; writing an identical body would needlessly bump lastUpdate).
+                    diagnostics.record(DiagnosticsLog.Level.INFO, LOG_TAG, "writeBackFlag: no-op (position unchanged)")
+                    MpStorageWriteResult.Success(verified = true)
+                }
 
                 is MpStorageEnvelopeWriter.Outcome.TooLarge -> {
                     val cap = MpStorageRepository.MAX_CONTENT_FORM_BYTES
@@ -182,55 +200,136 @@ class DefaultMpStorageRepository @Inject constructor(
                 }
 
                 is MpStorageEnvelopeWriter.Outcome.Mutated ->
-                    prepareAndMaybePost(location, read.form, outcome.body, post)
+                    postAndVerify(location, read.form, owner, mutatedBody = outcome.body, backupBody = backup)
+            }
+        }
+    }
+
+    override suspend fun previewWriteBackFlag(entry: MpStorageFlagEntry): MpStorageWritePreview {
+        return withContext(ioDispatcher) {
+            val owner = activePseudo() ?: return@withContext MpStorageWritePreview.TargetNotFound
+            val location = locateForWrite(owner) ?: return@withContext MpStorageWritePreview.TargetNotFound
+            val read = readFormAndDocument(location) ?: return@withContext MpStorageWritePreview.TargetNotFound
+            val document = read.document ?: return@withContext MpStorageWritePreview.Unreadable
+
+            when (val outcome = envelopeWriter.upsertFlag(document.rawEnvelope, entry)) {
+                MpStorageEnvelopeWriter.Outcome.NotJsonEnvelope -> MpStorageWritePreview.Unreadable
+                is MpStorageEnvelopeWriter.Outcome.NoOp -> MpStorageWritePreview.Prepared(outcome.body)
+                is MpStorageEnvelopeWriter.Outcome.TooLarge -> MpStorageWritePreview.TooLarge(outcome.sizeBytes)
+                is MpStorageEnvelopeWriter.Outcome.Mutated -> MpStorageWritePreview.Prepared(outcome.body)
             }
         }
     }
 
     /**
-     * Builds the `bdd.php cat=prive` [FormBody] from the mutated [body] and the parsed [form], then —
-     * ONLY when [post] is `true` (the internal test-only path) — POSTs it. From the public [writeBackFlag]
-     * ([post] = `false`) NO request is sent : the body is built and validated, and
-     * [MpStorageWriteResult.Prepared] carries `posted = false`. The live POST branch is NOT OBSERVED LIVE.
+     * 10-15. POSTs the mutated body, RE-READS the first post, and either confirms the write
+     * ([MpStorageWriteResult.Success]) or restores the [backupBody] and re-reads — surfacing
+     * [MpStorageWriteResult.VerificationFailedRestored] when the backup is back in place, or
+     * [MpStorageWriteResult.VerificationFailedRestoreFailed] (critical) when it could not be restored.
+     *
+     * Both POSTs use the same guarded builder (active pseudo + CONSTANT subject hash). The re-read
+     * comparison is on the raw `content_form` string : HFR may re-serialise, but the de-facto contract
+     * stores the textarea verbatim, so an exact match is the safe acceptance signal (NOT OBSERVED LIVE).
      */
-    private suspend fun prepareAndMaybePost(
+    @Suppress("ReturnCount") // Guard (wrong subject) + verified-OK early return + the restore tail.
+    private suspend fun postAndVerify(
         location: MpStorageLocation,
         form: ReplyForm,
-        body: String,
-        post: Boolean,
+        pseudo: String,
+        mutatedBody: String,
+        backupBody: String,
     ): MpStorageWriteResult {
-        val formBody = buildPrivateMessageEditBody(location, form, body)
-        if (!post) {
-            diagnostics.record(
-                DiagnosticsLog.Level.INFO,
-                LOG_TAG,
-                "writeBackFlag dry-run: body built (${body.length} chars), POST skipped — not observed live",
-            )
-            return MpStorageWriteResult.Prepared(body = body, posted = false)
+        val postBody = buildPrivateMessageEditBody(location, form, pseudo, mutatedBody)
+            ?: return MpStorageWriteResult.TargetNotFound // wrong subject → never POST (structural guard)
+
+        hfrClient.submitPrivateMessageEdit(postBody)
+        diagnostics.record(DiagnosticsLog.Level.INFO, LOG_TAG, "writeBackFlag POSTed → verifying")
+
+        val readBack = reReadContentForm(location)
+        if (readBack == mutatedBody) {
+            diagnostics.record(DiagnosticsLog.Level.INFO, LOG_TAG, "writeBackFlag verified OK")
+            return MpStorageWriteResult.Success(verified = true)
         }
-        // GUARDED branch — reached only via the internal writeBackFlagLive (tests). The bdd.php cat=prive
-        // write contract is unconfirmed; the response is intentionally NOT parsed here (no live
-        // success/error capture). Surfaced as Prepared(posted = true).
-        hfrClient.submitPrivateMessageEdit(formBody)
-        diagnostics.record(DiagnosticsLog.Level.WARN, LOG_TAG, "writeBackFlag POSTED (live, unconfirmed contract)")
-        return MpStorageWriteResult.Prepared(body = body, posted = true)
+
+        // Mismatch : restore the verbatim backup through the same guarded builder.
+        val expectedBytes = mutatedBody.toByteArray(Charsets.UTF_8).size
+        val actualBytes = readBack?.toByteArray(Charsets.UTF_8)?.size ?: 0
+        diagnostics.record(
+            DiagnosticsLog.Level.WARN,
+            LOG_TAG,
+            "writeBackFlag verify MISMATCH (expected=$expectedBytes actual=$actualBytes) → restoring backup",
+        )
+        return restoreBackup(location, form, pseudo, backupBody, expectedBytes, actualBytes)
     }
 
+    private suspend fun restoreBackup(
+        location: MpStorageLocation,
+        form: ReplyForm,
+        pseudo: String,
+        backupBody: String,
+        expectedBytes: Int,
+        actualBytes: Int,
+    ): MpStorageWriteResult {
+        val restoreBody = buildPrivateMessageEditBody(location, form, pseudo, backupBody)
+            ?: return MpStorageWriteResult.VerificationFailedRestoreFailed(expectedBytes, actualBytes)
+
+        hfrClient.submitPrivateMessageEdit(restoreBody)
+        val restored = reReadContentForm(location)
+        return if (restored == backupBody) {
+            diagnostics.record(
+                DiagnosticsLog.Level.WARN,
+                LOG_TAG,
+                "writeBackFlag restored backup OK (write not applied)",
+            )
+            MpStorageWriteResult.VerificationFailedRestored(expectedBytes, actualBytes)
+        } else {
+            // CRITICAL : we could not bring the document back to its backup. Log loudly.
+            diagnostics.record(
+                DiagnosticsLog.Level.ERROR,
+                LOG_TAG,
+                "writeBackFlag RESTORE FAILED — storage may be inconsistent",
+            )
+            MpStorageWriteResult.VerificationFailedRestoreFailed(expectedBytes, actualBytes)
+        }
+    }
+
+    /** Re-reads the raw `content_form` of the first post at [location] for verification (null when unreadable). */
+    private suspend fun reReadContentForm(location: MpStorageLocation): String? =
+        replyFormParser
+            .parse(hfrClient.getPrivateMessageEditForm(location.threadId, location.numreponse))
+            .getOrNull()
+            ?.takeUnless { it.isAnonymous }
+            ?.initialContent
+
     /**
-     * The `bdd.php cat=prive` POST body. Mirrors [fr.forumhfr.redface2.core.data.write.DefaultEditPostRepository]'s
-     * edit body, with TWO deliberate differences :
-     *  - `cat` is the String `"prive"` (the storage post lives under the private-message category ;
-     *    the public edit flow passes an Int) — this is the whole reason for the dedicated wire method ;
-     *  - `content_form` is the mutated JSON document, not user BBCode.
-     * `numreponse` targets the storage first post, `numrep` stays empty, `sujet` / `hash_check` /
-     * `verifrequet` / the preserved hidden fields come from the parsed edit form. `password` and
-     * `delete` are hard-denied (never resend the deletion checkbox).
+     * The `bdd.php cat=prive` POST body for the storage first post. TWO deliberate differences from
+     * [fr.forumhfr.redface2.core.data.write.DefaultEditPostRepository]'s edit body :
+     *  - `cat` is the String `"prive"` (the storage post lives under the private-message category) ;
+     *  - `content_form` is the mutated/backup JSON document, not user BBCode.
+     *
+     * SECURITY / CORRECTNESS guards (ADR-014 §4) :
+     *  - `sujet` is ALWAYS the CONSTANT [HfrConstants.MP_STORAGE_SUBJECT_HASH], NEVER `form.sujet` ;
+     *  - returns `null` (REFUSE TO POST) when the parsed [form]'s subject does not equal that constant —
+     *    a structural guard against writing into the wrong conversation ;
+     *  - `pseudo` is the ACTIVE account's pseudo, sent verbatim ;
+     *  - `password` and `delete` are hard-denied (never resend the deletion checkbox).
      */
     private fun buildPrivateMessageEditBody(
         location: MpStorageLocation,
         form: ReplyForm,
+        pseudo: String,
         contentForm: String,
-    ): FormBody {
+    ): FormBody? {
+        // Structural guard : never POST into a conversation whose subject is not the storage hash.
+        if (form.sujet != HfrConstants.MP_STORAGE_SUBJECT_HASH) {
+            diagnostics.record(
+                DiagnosticsLog.Level.WARN,
+                LOG_TAG,
+                "writeBackFlag ABORT: form subject is not the storage hash → no POST",
+            )
+            return null
+        }
+
         val builder = FormBody.Builder(Charsets.UTF_8)
         val emitted = mutableSetOf<String>()
         val overrides = buildMap {
@@ -243,7 +342,9 @@ class DefaultMpStorageRepository @Inject constructor(
             put("cat", "prive")
             put("post", location.threadId.toString())
             put("page", "1")
-            put("sujet", form.sujet)
+            put("pseudo", pseudo)
+            // ALWAYS the constant hash — never form.sujet (the guard above also enforces they match).
+            put("sujet", HfrConstants.MP_STORAGE_SUBJECT_HASH)
             form.msgIcon?.let { put("MsgIcon", it) }
         }
         overrides.forEach { (key, value) ->
@@ -266,10 +367,10 @@ class DefaultMpStorageRepository @Inject constructor(
 
     /**
      * GETs and parses the storage first-post edit form at [location] for the WRITE path, returning the
-     * [ReplyForm] (for hash_check / sujet / hidden fields) plus the parsed [MpStorageDocument] (null when
-     * the body is not a readable v0.1 envelope — surfaced as unreadable, never repaired). Returns `null`
-     * when the edit form itself cannot be obtained (stale location). Throws [SessionExpiredException] on
-     * an anonymous composer.
+     * [ReplyForm] (for hash_check / sujet / hidden fields / the verbatim content_form) plus the parsed
+     * [MpStorageDocument] (null when the body is not a readable v0.1 envelope — surfaced as unreadable,
+     * never repaired). Returns `null` when the edit form itself cannot be obtained (stale location).
+     * Throws [SessionExpiredException] on an anonymous composer.
      */
     private suspend fun readFormAndDocument(location: MpStorageLocation): WriteRead? {
         val form = replyFormParser
@@ -407,6 +508,9 @@ class DefaultMpStorageRepository @Inject constructor(
 
     private suspend fun activePseudo(): String? =
         (authRepository.observeAuthState().first() as? AuthState.Authenticated)?.pseudo
+
+    private suspend fun syncWriteEnabled(): Boolean =
+        userPreferencesRepository.observeSyncPrivateMessagesWriteEnabled().first()
 
     private companion object {
         private const val LOG_TAG = "MpStorageRepository"

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/MpStorageEnvelopeWriter.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/MpStorageEnvelopeWriter.kt
@@ -2,6 +2,7 @@ package fr.forumhfr.redface2.core.data.mpstorage
 
 import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
 import fr.forumhfr.redface2.core.model.mpstorage.MpStorageFlagEntry
+import java.time.Clock
 import javax.inject.Inject
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -25,11 +26,21 @@ import kotlinx.serialization.json.put
  * entry written by another tool), and unknown keys WITHIN the v0.1 entry or within a list item — is
  * carried through untouched.
  *
+ * TWO-PHASE write (verify-after-write contract) :
+ *  - if the upsert does not actually change the target position ([Outcome.NoOp]), the writer returns
+ *    the original content BYTE-FIDÈLE and DOES NOT stamp `sourceName` / `lastUpdate` — the caller skips
+ *    the POST entirely (writing an identical body would needlessly bump the document) ;
+ *  - on a real change ([Outcome.Mutated]) it stamps `sourceName = "Redface2"` and `lastUpdate = now` at
+ *    the THREE levels DTCloud writes them (root, the v0.1 entry, and its `mpFlags` block) so the storage
+ *    advertises Redface 2 as the last writer, exactly like the original userscript.
+ *
  * NOT OBSERVED LIVE : the bytes produced here have never been round-tripped against a real HFR
  * `bdd.php cat=prive` POST (device down). The output is validated against
  * [MpStorageRepository.MAX_CONTENT_FORM_BYTES] (fail-closed) ; whether HFR accepts it is unconfirmed.
  */
-class MpStorageEnvelopeWriter @Inject constructor() {
+class MpStorageEnvelopeWriter @Inject constructor(
+    private val clock: Clock,
+) {
 
     /**
      * Compact, stable serialiser. The envelope is machine-written by userscripts, so we do not try
@@ -39,9 +50,18 @@ class MpStorageEnvelopeWriter @Inject constructor() {
      */
     private val json = Json { prettyPrint = false }
 
-    /** Result of the pure mutation : either the mutated body or a typed, non-throwing failure. */
+    /** Result of the pure mutation : the mutated body, a byte-fidèle no-op, or a typed failure. */
     sealed interface Outcome {
+        /** A real change : [body] carries the mutated JSON with the 3-level `sourceName`/`lastUpdate` stamp. */
         data class Mutated(val body: String) : Outcome
+
+        /**
+         * The target position already equals [entry] : nothing changed. [body] is the ORIGINAL content,
+         * byte-fidèle (no re-serialisation, no stamp) — the caller skips the POST so the document is left
+         * exactly as read.
+         */
+        data class NoOp(val body: String) : Outcome
+
         data object NotJsonEnvelope : Outcome
         data class TooLarge(val sizeBytes: Int) : Outcome
     }
@@ -54,18 +74,29 @@ class MpStorageEnvelopeWriter @Inject constructor() {
      *    or a tool-specific key — is preserved) ; no match → a new item is APPENDED ;
      *  - a missing `data` array / missing v0.1 entry / missing `mpFlags` / missing `list` is CREATED
      *    minimally, respecting the v0.1 shape, without disturbing sibling keys ;
-     *  - the result is rejected ([Outcome.TooLarge]) when its UTF-8 size exceeds
+     *  - when the resulting list is IDENTICAL to the original (the entry was already at this exact
+     *    position), the writer returns [Outcome.NoOp] with the verbatim original text — no stamp, no
+     *    re-serialisation ;
+     *  - on a real change it stamps `sourceName = "Redface2"` + `lastUpdate = now` at the 3 levels and
+     *    rejects the result ([Outcome.TooLarge]) when its UTF-8 size exceeds
      *    [MpStorageRepository.MAX_CONTENT_FORM_BYTES].
      *
      * Returns [Outcome.NotJsonEnvelope] when [rawEnvelope] is not a JSON object (the caller maps this
      * to "unreadable" and NEVER writes a repaired default — ADR-014 §3).
      */
-    @Suppress("ReturnCount") // Guard (not-JSON) + cap rejection + the mutated return.
+    @Suppress("ReturnCount") // Guard (not-JSON) + no-op short-circuit + cap rejection + the mutated return.
     fun upsertFlag(rawEnvelope: String, entry: MpStorageFlagEntry): Outcome {
         val root = parseObjectOrNull(rawEnvelope) ?: return Outcome.NotJsonEnvelope
 
-        val mutated = mutateEnvelope(root, entry)
-        val body = json.encodeToString(JsonObject.serializer(), mutated)
+        val withFlag = mutateEnvelope(root, entry)
+        if (withFlag == root) {
+            // The upsert produced an identical tree : the target position did not change. Return the
+            // ORIGINAL text byte-fidèle (no stamp, no re-serialisation) so the caller skips the POST.
+            return Outcome.NoOp(rawEnvelope)
+        }
+
+        val stamped = stampLastWriter(withFlag)
+        val body = json.encodeToString(JsonObject.serializer(), stamped)
 
         val sizeBytes = body.toByteArray(Charsets.UTF_8).size
         if (sizeBytes > MpStorageRepository.MAX_CONTENT_FORM_BYTES) {
@@ -91,13 +122,55 @@ class MpStorageEnvelopeWriter @Inject constructor() {
     }
 
     /**
+     * Stamps `sourceName = "Redface2"` + `lastUpdate = now` at the three levels DTCloud maintains :
+     * the root object, the v0.1 `data[]` entry, and that entry's `mpFlags` block. Every other key is
+     * preserved. Called ONLY on a real change (the no-op path leaves the document untouched).
+     */
+    private fun stampLastWriter(root: JsonObject): JsonObject {
+        val now = clock.millis()
+        val dataArray = root["data"] as? JsonArray ?: JsonArray(emptyList())
+        val stampedData = JsonArray(
+            dataArray.map { element ->
+                val entry = element as? JsonObject ?: return@map element
+                if (isV01(entry)) stampV01Entry(entry, now) else element
+            },
+        )
+        return JsonObject(
+            root.toMutableMap().apply {
+                put("data", stampedData)
+                put("sourceName", JsonPrimitive(SOURCE_NAME))
+                put("lastUpdate", JsonPrimitive(now))
+            },
+        )
+    }
+
+    /** Stamps the v0.1 entry and its `mpFlags` block (levels 2 and 3), preserving every other key. */
+    private fun stampV01Entry(v01Entry: JsonObject, now: Long): JsonObject {
+        val mpFlags = v01Entry["mpFlags"] as? JsonObject ?: JsonObject(emptyMap())
+        val stampedMpFlags = JsonObject(
+            mpFlags.toMutableMap().apply {
+                put("sourceName", JsonPrimitive(SOURCE_NAME))
+                put("lastUpdate", JsonPrimitive(now))
+            },
+        )
+        return JsonObject(
+            v01Entry.toMutableMap().apply {
+                put("sourceName", JsonPrimitive(SOURCE_NAME))
+                put("lastUpdate", JsonPrimitive(now))
+                put("mpFlags", stampedMpFlags)
+            },
+        )
+    }
+
+    private fun isV01(entry: JsonObject): Boolean =
+        entry["version"]?.let { it is JsonPrimitive && it.content == V01 } == true
+
+    /**
      * Replaces (or creates) the v0.1 entry inside `data[]`, preserving the order and every sibling
      * entry. When no v0.1 entry exists yet, a minimal one is appended (other entries untouched).
      */
     private fun mutateDataArray(dataArray: JsonArray, entry: MpStorageFlagEntry): JsonArray {
-        val v01Index = dataArray.indexOfFirst {
-            (it as? JsonObject)?.get("version")?.let { v -> v is JsonPrimitive && v.content == V01 } == true
-        }
+        val v01Index = dataArray.indexOfFirst { (it as? JsonObject)?.let(::isV01) == true }
         return if (v01Index >= 0) {
             val v01Entry = dataArray[v01Index] as JsonObject
             JsonArray(
@@ -157,5 +230,6 @@ class MpStorageEnvelopeWriter @Inject constructor() {
 
     private companion object {
         private const val V01 = "0.1"
+        private const val SOURCE_NAME = "Redface2"
     }
 }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/MpStorageEnvelopeWriter.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/MpStorageEnvelopeWriter.kt
@@ -105,6 +105,14 @@ class MpStorageEnvelopeWriter @Inject constructor(
         return Outcome.Mutated(body)
     }
 
+    /**
+     * Whether [rawEnvelope] still parses as a JSON object. Used by the write-back verify step to tell
+     * a HEALTHY document (valid JSON — our write, or a concurrent valid write by another client) from
+     * a CORRUPTED one (truncated / non-JSON, the HFR non-UTF-8 truncation), so a restore only fires on
+     * real corruption and never clobbers a legitimate concurrent update (Codex review).
+     */
+    fun isJsonEnvelope(rawEnvelope: String): Boolean = parseObjectOrNull(rawEnvelope) != null
+
     private fun parseObjectOrNull(rawEnvelope: String): JsonObject? {
         if (rawEnvelope.isBlank()) return null
         return try {

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -289,6 +289,22 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeSyncPrivateMessagesWriteEnabled(): Flow<Boolean> =
+        dataStore.data
+            // Default `false` (#6, ADR-014 §4): the MPStorage write-back is experimental and opt-in —
+            // the write contract was never observed live, so it stays OFF until the user explicitly enables it.
+            .map { prefs -> prefs[KEY_SYNC_PRIVATE_MESSAGES_WRITE_ENABLED] ?: false }
+            .distinctUntilChanged()
+            .catch { emit(false) }
+
+    override suspend fun setSyncPrivateMessagesWriteEnabled(enabled: Boolean) {
+        persist {
+            dataStore.edit { prefs ->
+                prefs[KEY_SYNC_PRIVATE_MESSAGES_WRITE_ENABLED] = enabled
+            }
+        }
+    }
+
     override fun observeFlagsAutoRefresh(): Flow<Boolean> =
         dataStore.data
             // Default `true`: the lists going stale is the #378 complaint — the toggle is an
@@ -736,6 +752,10 @@ class DataStoreUserPreferencesRepository @Inject constructor(
 
         // Opt-in « DT » placeholder tab on the Drapeaux screen (MPStorage sync lands later, #6).
         val KEY_FLAGS_SHOW_DT_SECTION = booleanPreferencesKey("flags_show_dt_section")
+
+        // #6, ADR-014 §4 — experimental opt-in for the MPStorage WRITE-BACK (default false; off = no write).
+        val KEY_SYNC_PRIVATE_MESSAGES_WRITE_ENABLED =
+            booleanPreferencesKey("sync_private_messages_write_enabled")
 
         // #378 — auto-refresh of the flags lists on landing (default ON; Settings opt-out).
         val KEY_FLAGS_AUTO_REFRESH = booleanPreferencesKey("flags_auto_refresh")

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepositoryTest.kt
@@ -4,18 +4,25 @@ import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
 import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageLocation
 import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageLocationStore
+import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.mpstorage.MpStorageDocument
 import fr.forumhfr.redface2.core.model.mpstorage.MpStorageFlagEntry
 import fr.forumhfr.redface2.core.model.mpstorage.MpStorageResult
 import fr.forumhfr.redface2.core.model.mpstorage.MpStorageWriteResult
+import fr.forumhfr.redface2.core.model.write.ReplyForm
 import fr.forumhfr.redface2.core.network.HfrClient
+import fr.forumhfr.redface2.core.network.HfrConstants
 import fr.forumhfr.redface2.core.parser.messages.PrivateMessageListParser
 import fr.forumhfr.redface2.core.parser.messages.PrivateMessageThreadParser
 import fr.forumhfr.redface2.core.parser.mpstorage.MpStorageParser
 import fr.forumhfr.redface2.core.parser.write.ReplyFormParser
 import io.mockk.every
 import io.mockk.mockk
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
@@ -30,27 +37,30 @@ import org.junit.Before
 import org.junit.Test
 
 /**
- * MPStorage read pipeline (#6, ADR-014) over a [MockWebServer], real parsers + fixtures.
+ * MPStorage read pipeline + the opt-in verify-after-write WRITE path (#6, ADR-014 §4) over a
+ * [MockWebServer]. The READ tests use real parsers + fixtures; the WRITE tests script the edit-form
+ * parse (mockk over [ReplyFormParser]) so the GET / RE-GET round-trip is controllable without a real
+ * HFR document — the write contract is NOT OBSERVED LIVE.
  *
- * Discovery walks the MP INBOX (`forum1.php?cat=prive`) matching a conversation whose subject is
- * the fixed storage hash — the de-facto userscript contract, NOT a title search (HFR's subject
- * index never returns the hash, which is why the original #406 search-based discovery reported
- * NotFound on every real account). The inbox fixtures are crafted to the real
- * `PrivateMessageListParser` selectors; the conversation page is the #298 fixture; the edit form is
- * the Phase 2D fixture (a real BBCode post, NOT JSON — legitimately the [MpStorageResult.Unreadable]
- * arm). The Found arm stubs only the storage parser over the real pipeline (plus the JSON-contract
- * coverage in `MpStorageParserTest`).
+ * The opt-in preference defaults OFF : the very first thing the write path checks. A real POST never
+ * fires unless the test flips it on AND the mutation actually changes the document.
  */
 class DefaultMpStorageRepositoryTest {
 
     private lateinit var server: MockWebServer
     private lateinit var locationStore: FakeLocationStore
+    private lateinit var preferences: FakeWritePreferences
     private lateinit var repository: DefaultMpStorageRepository
+
+    // Fixed clock shared by the repository's envelope writer and the test's body-deriving helper so the
+    // `lastUpdate` stamp is identical on both sides (the verify RE-GET compares the raw mutated body).
+    private val fixedClock: Clock = Clock.fixed(Instant.ofEpochMilli(1_718_064_000_000L), ZoneOffset.UTC)
 
     @Before
     fun setUp() {
         server = MockWebServer().apply { start() }
         locationStore = FakeLocationStore()
+        preferences = FakeWritePreferences()
         repository = buildRepository()
     }
 
@@ -61,6 +71,7 @@ class DefaultMpStorageRepositoryTest {
 
     private fun buildRepository(
         storageParser: MpStorageParser = MpStorageParser(),
+        replyFormParser: ReplyFormParser = ReplyFormParser(),
         authState: AuthState = AuthState.Authenticated(OWNER),
     ): DefaultMpStorageRepository {
         val okHttp = OkHttpClient.Builder().build()
@@ -74,17 +85,22 @@ class DefaultMpStorageRepositoryTest {
             hfrClient = client,
             listParser = PrivateMessageListParser(),
             threadParser = PrivateMessageThreadParser(),
-            replyFormParser = ReplyFormParser(),
+            replyFormParser = replyFormParser,
             storageParser = storageParser,
-            envelopeWriter = MpStorageEnvelopeWriter(),
+            // Fixed clock so the `lastUpdate` stamp is deterministic and the test can re-derive the
+            // EXACT mutated body the repository POSTs (needed for the verify-after-write RE-GET to match).
+            envelopeWriter = MpStorageEnvelopeWriter(fixedClock),
             locationStore = locationStore,
             authRepository = mockk<AuthRepository> {
                 every { observeAuthState() } returns MutableStateFlow(authState)
             },
+            userPreferencesRepository = preferences,
             diagnostics = DiagnosticsLog(),
             ioDispatcher = Dispatchers.Unconfined,
         )
     }
+
+    // --- READ pipeline (#6, ADR-014) --------------------------------------------------------------
 
     @Test
     fun `an anonymous session yields NotFound without any request`() = runTest {
@@ -123,36 +139,27 @@ class DefaultMpStorageRepositoryTest {
             val scan = requireNotNull(server.takeRequest().requestUrl)
             assertEquals("forum1.php", scan.pathSegments.first())
 
-            // Conversation page of the hash-subject row (threadId 9100200 in the inbox fixture).
             val thread = requireNotNull(server.takeRequest().requestUrl)
             assertEquals("forum2.php", thread.pathSegments.first())
             assertEquals("prive", thread.queryParameter("cat"))
             assertEquals("9100200", thread.queryParameter("post"))
 
-            // Edit form of the conversation's FIRST post — the #298 thread fixture's first anchor
-            // is t1980664234, so that exact numreponse must be forwarded.
             val edit = requireNotNull(server.takeRequest().requestUrl)
             assertEquals("message.php", edit.pathSegments.first())
             assertEquals("prive", edit.queryParameter("cat"))
             assertEquals("9100200", edit.queryParameter("post"))
             assertEquals("1980664234", edit.queryParameter("numreponse"))
 
-            // The discovered location is cached so the next fetch skips the inbox scan.
             assertEquals(MpStorageLocation(9100200, 1980664234), locationStore.saved[OWNER])
         }
 
     @Test
     fun `a located storage whose first post is unreadable maps to Unreadable, not NotFound`() = runTest {
-        // The subject matches in the inbox but the conversation page has no first post (empty thread
-        // / DOM drift) : the storage MP EXISTS, so it must surface Unreadable — never NotFound (which
-        // would silently skip seeding as if the account had no storage). Codex review of this PR.
         server.enqueue(MockResponse().setBody(fixture("mp_storage_inbox_hit.html")))
         server.enqueue(MockResponse().setBody(fixture("mp_storage_thread_empty.html")))
 
         assertEquals(MpStorageResult.Unreadable, repository.fetchStorage())
-        // Inbox scan + conversation page only — no edit-form GET (no first post to read) ...
         assertEquals(2, server.requestCount)
-        // ... and nothing is cached: we never resolved a first-post numreponse to remember.
         assertNull(locationStore.saved[OWNER])
     }
 
@@ -175,24 +182,6 @@ class DefaultMpStorageRepositoryTest {
     }
 
     @Test
-    fun `discovery walks to the next inbox page when the first has no match`() = runTest {
-        val document = MpStorageDocument(sourceName = "DTCloud_GM", mpFlags = emptyList(), rawEnvelope = "{}")
-        repository = buildRepository(
-            storageParser = mockk { every { parse(any()) } returns Result.success(document) },
-        )
-        server.enqueue(MockResponse().setBody(fixture("mp_storage_inbox_p1_nohit.html")))
-        server.enqueue(MockResponse().setBody(fixture("mp_storage_inbox_p2_hit.html")))
-        server.enqueue(MockResponse().setBody(fixture("private_message_thread.html")))
-        server.enqueue(MockResponse().setBody(fixture("write_edit_form_test_post.html")))
-
-        assertEquals(MpStorageResult.Found(document), repository.fetchStorage())
-        assertEquals(4, server.requestCount)
-
-        assertEquals("1", requireNotNull(server.takeRequest().requestUrl).queryParameter("page"))
-        assertEquals("2", requireNotNull(server.takeRequest().requestUrl).queryParameter("page"))
-    }
-
-    @Test
     fun `a cached location reads the document directly without scanning the inbox`() = runTest {
         val document = MpStorageDocument(sourceName = "DTCloud_GM", mpFlags = emptyList(), rawEnvelope = "{}")
         repository = buildRepository(
@@ -203,85 +192,24 @@ class DefaultMpStorageRepositoryTest {
 
         assertEquals(MpStorageResult.Found(document), repository.fetchStorage())
         assertEquals(1, server.requestCount)
-
-        val edit = requireNotNull(server.takeRequest().requestUrl)
-        assertEquals("message.php", edit.pathSegments.first())
-        assertEquals("9100200", edit.queryParameter("post"))
-        assertEquals("1980664234", edit.queryParameter("numreponse"))
     }
 
-    // --- WRITE path (#6, ADR-014 §4) — GUARDED, NOT OBSERVED LIVE ---------------------------------
+    // --- WRITE path (#6, ADR-014 §4) — opt-in, verify-after-write ---------------------------------
 
     @Test
-    fun `writeBackFlag (public path) prepares the mutated body and sends NO POST`() = runTest {
-        val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [] } } ], "sourceName": "DTCloud" }"""
-        repository = buildRepository(
-            storageParser = mockk {
-                every { parse(any()) } returns Result.success(
-                    MpStorageDocument(sourceName = "DTCloud", mpFlags = emptyList(), rawEnvelope = raw),
-                )
-            },
-        )
-        locationStore.saved[OWNER] = MpStorageLocation(threadId = 9100200, numreponse = 1980664234)
-        // Only the edit-form GET is enqueued — a dry run must not POST anything.
-        server.enqueue(MockResponse().setBody(fixture("write_edit_form_test_post.html")))
+    fun `writeBackFlag with the opt-in OFF returns DisabledByPreference and sends NO request`() = runTest {
+        // The default. Even with a cached location, the path returns before touching the network.
+        locationStore.saved[OWNER] = MpStorageLocation(threadId = 9100200, numreponse = 7)
 
-        val result = repository.writeBackFlag(MpStorageFlagEntry(threadId = 777, page = 4, numreponse = 9, uri = "/u"))
+        val result = repository.writeBackFlag(MpStorageFlagEntry(threadId = 1, page = 1, numreponse = 1, uri = null))
 
-        val prepared = result as MpStorageWriteResult.Prepared
-        assertEquals(false, prepared.posted)
-        assertTrue("the new flag must be in the prepared body", prepared.body.contains("\"post\":777"))
-        // Exactly one request: the GET of the edit form. No POST hit the wire.
-        assertEquals(1, server.requestCount)
-        assertEquals("GET", server.takeRequest().method)
-    }
-
-    @Test
-    fun `writeBackFlagLive POSTs bdd_php with cat=prive and the preserved hidden fields`() = runTest {
-        val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [] } } ] }"""
-        repository = buildRepository(
-            storageParser = mockk {
-                every { parse(any()) } returns Result.success(
-                    MpStorageDocument(sourceName = null, mpFlags = emptyList(), rawEnvelope = raw),
-                )
-            },
-        )
-        locationStore.saved[OWNER] = MpStorageLocation(threadId = 9100200, numreponse = 2784595)
-        server.enqueue(MockResponse().setBody(fixture("write_edit_form_test_post.html"))) // GET edit form
-        server.enqueue(MockResponse().setBody("<html><body>ok</body></html>")) // POST bdd.php
-
-        // writeBackFlagLive is the module-internal, TEST-ONLY POST path (not on the public interface).
-        val result = repository.writeBackFlagLive(
-            MpStorageFlagEntry(threadId = 42, page = 2, numreponse = 5, uri = null),
-        )
-
-        val prepared = result as MpStorageWriteResult.Prepared
-        assertTrue("the live POST branch reports posted = true", prepared.posted)
-        assertEquals(2, server.requestCount)
-
-        server.takeRequest() // skip the GET
-        val post = server.takeRequest()
-        assertEquals("POST", post.method)
-        assertEquals("bdd.php", requireNotNull(post.requestUrl).pathSegments.first())
-        val body = formFields(post.body.readUtf8())
-        // The whole point of submitPrivateMessageEdit : cat is the String "prive", not an Int.
-        assertEquals("prive", body["cat"])
-        assertEquals("9100200", body["post"])
-        assertEquals("2784595", body["numreponse"])
-        assertEquals("", body["numrep"])
-        assertEquals("1100", body["verifrequet"])
-        // content_form carries the mutated JSON, not BBCode.
-        assertTrue(body["content_form"]!!.contains("\"post\":42"))
-        // hash_check + sujet come from the parsed edit form; hidden fields preserved.
-        assertEquals("REDACTED_HASH_CHECK", body["hash_check"])
-        assertEquals("Redface 2 — PHASE 2 @ ALPHA", body["sujet"])
-        // password / delete are hard-denied — never resent.
-        assertNull("password must never be resent", body["password"])
-        assertNull("the delete checkbox must never be resent", body["delete"])
+        assertEquals(MpStorageWriteResult.DisabledByPreference, result)
+        assertEquals(0, server.requestCount)
     }
 
     @Test
     fun `writeBackFlag returns TargetNotFound when no storage MP exists and writes nothing`() = runTest {
+        preferences.enabled.value = true
         server.enqueue(MockResponse().setBody(fixture("mp_storage_inbox_no_hit.html")))
 
         val result = repository.writeBackFlag(MpStorageFlagEntry(threadId = 1, page = 1, numreponse = 1, uri = null))
@@ -293,42 +221,37 @@ class DefaultMpStorageRepositoryTest {
     }
 
     @Test
-    fun `writeBackFlag returns TargetNotFound on an anonymous session without any request`() = runTest {
-        repository = buildRepository(authState = AuthState.Anonymous)
-
-        val result = repository.writeBackFlag(MpStorageFlagEntry(threadId = 1, page = 1, numreponse = 1, uri = null))
-
-        assertEquals(MpStorageWriteResult.TargetNotFound, result)
-        assertEquals(0, server.requestCount)
-    }
-
-    @Test
-    fun `writeBackFlag returns TargetUnreadable when the located document is not a v01 envelope`() = runTest {
-        // The real edit-form fixture's content_form is plain BBCode — not a readable v0.1 envelope.
-        // Per ADR-014 §3 this is surfaced, NEVER repaired / overwritten with a default.
-        locationStore.saved[OWNER] = MpStorageLocation(threadId = 9100200, numreponse = 2784595)
-        server.enqueue(MockResponse().setBody(fixture("write_edit_form_test_post.html")))
-
-        val result = repository.writeBackFlag(MpStorageFlagEntry(threadId = 1, page = 1, numreponse = 1, uri = null))
-
-        assertEquals(MpStorageWriteResult.TargetUnreadable, result)
-        // GET the form only — no POST: an unreadable target must never be written over.
-        assertEquals(1, server.requestCount)
-    }
-
-    @Test
-    fun `writeBackFlag returns TooLarge when the mutated body exceeds the 256 KiB cap`() = runTest {
-        val filler = "x".repeat(260 * 1024)
-        val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [] } } ], "blob": "$filler" }"""
+    fun `writeBackFlag returns Unreadable when the located document is not a v01 envelope`() = runTest {
+        // The edit form parses, but its content_form is NOT a v0.1 JSON envelope → Unreadable, no POST.
         repository = buildRepository(
-            storageParser = mockk {
-                every { parse(any()) } returns Result.success(
-                    MpStorageDocument(sourceName = null, mpFlags = emptyList(), rawEnvelope = raw),
-                )
+            replyFormParser = mockk {
+                every { parse(any()) } returns Result.success(storageForm(initialContent = "not json at all"))
             },
         )
-        locationStore.saved[OWNER] = MpStorageLocation(threadId = 9100200, numreponse = 2784595)
-        server.enqueue(MockResponse().setBody(fixture("write_edit_form_test_post.html")))
+        preferences.enabled.value = true
+        locationStore.saved[OWNER] = STORAGE_LOCATION
+        server.enqueue(MockResponse().setBody(storageEditFormHtml("not json at all")))
+
+        val result = repository.writeBackFlag(MpStorageFlagEntry(threadId = 1, page = 1, numreponse = 1, uri = null))
+
+        assertEquals(MpStorageWriteResult.Unreadable, result)
+        // GET the form only — no POST: an unreadable target must never be written over.
+        assertEquals(1, server.requestCount)
+        assertEquals("GET", server.takeRequest().method)
+    }
+
+    @Test
+    fun `writeBackFlag returns TooLarge when the mutated body exceeds the cap and sends NO POST`() = runTest {
+        val filler = "x".repeat(MpStorageRepository.MAX_CONTENT_FORM_BYTES + 1024)
+        val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [] } } ], "blob": "$filler" }"""
+        repository = buildRepository(
+            replyFormParser = mockk {
+                every { parse(any()) } returns Result.success(storageForm(initialContent = raw))
+            },
+        )
+        preferences.enabled.value = true
+        locationStore.saved[OWNER] = STORAGE_LOCATION
+        server.enqueue(MockResponse().setBody(storageEditFormHtml(raw)))
 
         val result = repository.writeBackFlag(MpStorageFlagEntry(threadId = 1, page = 1, numreponse = 1, uri = null))
 
@@ -336,6 +259,169 @@ class DefaultMpStorageRepositoryTest {
         // The oversize body is never POSTed (fail-closed): only the GET happened.
         assertEquals(1, server.requestCount)
     }
+
+    @Test
+    fun `writeBackFlag refuses to POST when the form subject is not the storage hash`() = runTest {
+        // A wrong subject on the parsed form is the structural guard: surfaced as TargetNotFound, no POST.
+        repository = buildRepository(
+            replyFormParser = mockk {
+                every { parse(any()) } returns Result.success(
+                    storageForm(initialContent = STORAGE_RAW, subject = "Some other conversation"),
+                )
+            },
+        )
+        preferences.enabled.value = true
+        locationStore.saved[OWNER] = STORAGE_LOCATION
+        server.enqueue(MockResponse().setBody(storageEditFormHtml(STORAGE_RAW)))
+
+        val result = repository.writeBackFlag(MpStorageFlagEntry(threadId = 7, page = 4, numreponse = 9, uri = null))
+
+        assertEquals(MpStorageWriteResult.TargetNotFound, result)
+        // Only the GET happened — the wrong-subject guard fired before any POST.
+        assertEquals(1, server.requestCount)
+        assertEquals("GET", server.takeRequest().method)
+    }
+
+    @Test
+    fun `writeBackFlag no-op (position already current) returns Success verified without a POST`() = runTest {
+        // The entry is already at this exact position → the writer reports a no-op → no POST.
+        val raw = """{"data":[{"version":"0.1","mpFlags":{"list":[{"post":7,"page":4,"href":"t9","uri":null}]}}]}"""
+        repository = buildRepository(
+            replyFormParser = mockk {
+                every { parse(any()) } returns Result.success(storageForm(initialContent = raw))
+            },
+        )
+        preferences.enabled.value = true
+        locationStore.saved[OWNER] = STORAGE_LOCATION
+        server.enqueue(MockResponse().setBody(storageEditFormHtml(raw)))
+
+        val result = repository.writeBackFlag(MpStorageFlagEntry(threadId = 7, page = 4, numreponse = 9, uri = null))
+
+        assertEquals(MpStorageWriteResult.Success(verified = true), result)
+        assertEquals(1, server.requestCount) // GET only — no POST on a no-op.
+    }
+
+    @Test
+    fun `writeBackFlag POSTs the mutated body with cat=prive, the active pseudo and the hash subject`() = runTest {
+        val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [] } } ] }"""
+        // First parse = GET (returns the backup); second parse = RE-GET (returns the mutated body so verify passes).
+        val mutated = capturedMutatedBody(raw, MpStorageFlagEntry(threadId = 42, page = 2, numreponse = 5, uri = null))
+        repository = buildRepository(
+            replyFormParser = mockk {
+                every { parse(any()) } returnsMany listOf(
+                    Result.success(storageForm(initialContent = raw)),
+                    Result.success(storageForm(initialContent = mutated)),
+                )
+            },
+        )
+        preferences.enabled.value = true
+        locationStore.saved[OWNER] = STORAGE_LOCATION
+        server.enqueue(MockResponse().setBody(storageEditFormHtml(raw))) // GET edit form
+        server.enqueue(MockResponse().setBody("<html><body>ok</body></html>")) // POST bdd.php
+        server.enqueue(MockResponse().setBody(storageEditFormHtml(mutated))) // RE-GET verify
+
+        val result = repository.writeBackFlag(MpStorageFlagEntry(threadId = 42, page = 2, numreponse = 5, uri = null))
+
+        assertEquals(MpStorageWriteResult.Success(verified = true), result)
+        assertEquals(3, server.requestCount)
+
+        server.takeRequest() // skip the GET
+        val post = server.takeRequest()
+        assertEquals("POST", post.method)
+        assertEquals("bdd.php", requireNotNull(post.requestUrl).pathSegments.first())
+        val body = formFields(post.body.readUtf8())
+        assertEquals("prive", body["cat"])
+        assertEquals("9100200", body["post"])
+        assertEquals("2784595", body["numreponse"])
+        assertEquals("", body["numrep"])
+        assertEquals("1100", body["verifrequet"])
+        // pseudo = the ACTIVE account, sujet = the CONSTANT hash (never form.sujet).
+        assertEquals(OWNER, body["pseudo"])
+        assertEquals(HfrConstants.MP_STORAGE_SUBJECT_HASH, body["sujet"])
+        assertTrue(body["content_form"]!!.contains("\"post\":42"))
+        // password / delete are hard-denied — never resent.
+        assertNull("password must never be resent", body["password"])
+        assertNull("the delete checkbox must never be resent", body["delete"])
+    }
+
+    @Test
+    fun `writeBackFlag restores the backup when the re-read does not match the mutated body`() = runTest {
+        val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [] } } ] }"""
+        // GET = backup ; RE-GET after POST = a DIFFERENT body (mismatch) ; RE-GET after restore = the backup.
+        repository = buildRepository(
+            replyFormParser = mockk {
+                every { parse(any()) } returnsMany listOf(
+                    Result.success(storageForm(initialContent = raw)), // GET (backup)
+                    Result.success(storageForm(initialContent = "{\"unexpected\":true}")), // verify (mismatch)
+                    Result.success(storageForm(initialContent = raw)), // verify after restore (OK)
+                )
+            },
+        )
+        preferences.enabled.value = true
+        locationStore.saved[OWNER] = STORAGE_LOCATION
+        server.enqueue(MockResponse().setBody(storageEditFormHtml(raw))) // GET edit form
+        server.enqueue(MockResponse().setBody("<html><body>ok</body></html>")) // POST mutation
+        server.enqueue(MockResponse().setBody(storageEditFormHtml("{}"))) // RE-GET (mismatch)
+        server.enqueue(MockResponse().setBody("<html><body>ok</body></html>")) // POST restore
+        server.enqueue(MockResponse().setBody(storageEditFormHtml(raw))) // RE-GET (restored)
+
+        val result = repository.writeBackFlag(MpStorageFlagEntry(threadId = 99, page = 1, numreponse = 1, uri = null))
+
+        assertTrue(result is MpStorageWriteResult.VerificationFailedRestored)
+        // GET + POST + RE-GET + restore POST + RE-GET = 5 requests.
+        assertEquals(5, server.requestCount)
+        server.takeRequest() // GET
+        assertEquals("POST", server.takeRequest().method) // mutation POST
+        server.takeRequest() // verify RE-GET
+        val restorePost = server.takeRequest()
+        assertEquals("POST", restorePost.method)
+        // The restore re-POSTs the verbatim backup through the same guarded builder.
+        val restoreBody = formFields(restorePost.body.readUtf8())
+        assertEquals(raw, restoreBody["content_form"])
+        assertEquals(HfrConstants.MP_STORAGE_SUBJECT_HASH, restoreBody["sujet"])
+    }
+
+    @Test
+    fun `writeBackFlag reports RestoreFailed when the backup could not be restored`() = runTest {
+        val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [] } } ] }"""
+        repository = buildRepository(
+            replyFormParser = mockk {
+                every { parse(any()) } returnsMany listOf(
+                    Result.success(storageForm(initialContent = raw)), // GET (backup)
+                    Result.success(storageForm(initialContent = "{\"unexpected\":true}")), // verify (mismatch)
+                    Result.success(storageForm(initialContent = "{\"still\":\"wrong\"}")), // restore verify (FAIL)
+                )
+            },
+        )
+        preferences.enabled.value = true
+        locationStore.saved[OWNER] = STORAGE_LOCATION
+        repeat(5) { server.enqueue(MockResponse().setBody("<html><body>ok</body></html>")) }
+
+        val result = repository.writeBackFlag(MpStorageFlagEntry(threadId = 99, page = 1, numreponse = 1, uri = null))
+
+        assertTrue(result is MpStorageWriteResult.VerificationFailedRestoreFailed)
+    }
+
+    /** The exact mutated body the real path would build, so a test can script the RE-GET to match it. */
+    private fun capturedMutatedBody(raw: String, entry: MpStorageFlagEntry): String {
+        val outcome = MpStorageEnvelopeWriter(fixedClock).upsertFlag(raw, entry)
+        return (outcome as MpStorageEnvelopeWriter.Outcome.Mutated).body
+    }
+
+    private fun storageForm(initialContent: String, subject: String = HfrConstants.MP_STORAGE_SUBJECT_HASH): ReplyForm =
+        ReplyForm(
+            hashCheck = "HASH",
+            sujet = subject,
+            hiddenFields = mapOf("cache" to "0"),
+            isAnonymous = false,
+            initialContent = initialContent,
+        )
+
+    /** Minimal edit-form HTML carrying [content] in the `content_form` textarea (only used by the real parser). */
+    private fun storageEditFormHtml(content: String): String =
+        """<html><body><form action="bdd.php"><textarea name="content_form">$content</textarea>
+           <input type="hidden" name="hash_check" value="HASH">
+           <input type="hidden" name="sujet" value="${HfrConstants.MP_STORAGE_SUBJECT_HASH}"></form></body></html>"""
 
     /** Decodes an `application/x-www-form-urlencoded` POST body into a field map (absent field ⇒ null). */
     private fun formFields(body: String): Map<String, String> =
@@ -369,7 +455,15 @@ class DefaultMpStorageRepositoryTest {
         }
     }
 
+    /** Minimal [UserPreferencesRepository] fake exposing only the write opt-in (the only pref the SUT reads). */
+    private class FakeWritePreferences : UserPreferencesRepository by mockk(relaxed = true) {
+        val enabled = MutableStateFlow(false)
+        override fun observeSyncPrivateMessagesWriteEnabled() = enabled
+    }
+
     private companion object {
         const val OWNER = "XaTriX"
+        val STORAGE_LOCATION = MpStorageLocation(threadId = 9100200, numreponse = 2784595)
+        const val STORAGE_RAW = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [] } } ] }"""
     }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepositoryTest.kt
@@ -345,14 +345,16 @@ class DefaultMpStorageRepositoryTest {
     }
 
     @Test
-    fun `writeBackFlag restores the backup when the re-read does not match the mutated body`() = runTest {
+    fun `writeBackFlag restores the backup when the re-read is CORRUPTED (truncated, not valid JSON)`() = runTest {
         val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [] } } ] }"""
-        // GET = backup ; RE-GET after POST = a DIFFERENT body (mismatch) ; RE-GET after restore = the backup.
+        // GET = backup ; RE-GET after POST = a TRUNCATED/non-JSON body (real corruption, the HFR
+        // non-UTF-8 truncation) ; RE-GET after restore = the backup. Only corruption restores — a valid
+        // but different envelope is kept (see the concurrent-write test below).
         repository = buildRepository(
             replyFormParser = mockk {
                 every { parse(any()) } returnsMany listOf(
                     Result.success(storageForm(initialContent = raw)), // GET (backup)
-                    Result.success(storageForm(initialContent = "{\"unexpected\":true}")), // verify (mismatch)
+                    Result.success(storageForm(initialContent = "{ \"data\": [ { \"versi")), // truncated → corrupt
                     Result.success(storageForm(initialContent = raw)), // verify after restore (OK)
                 )
             },
@@ -388,7 +390,7 @@ class DefaultMpStorageRepositoryTest {
             replyFormParser = mockk {
                 every { parse(any()) } returnsMany listOf(
                     Result.success(storageForm(initialContent = raw)), // GET (backup)
-                    Result.success(storageForm(initialContent = "{\"unexpected\":true}")), // verify (mismatch)
+                    Result.success(storageForm(initialContent = "{ truncated")), // verify (CORRUPT → restore)
                     Result.success(storageForm(initialContent = "{\"still\":\"wrong\"}")), // restore verify (FAIL)
                 )
             },
@@ -400,6 +402,34 @@ class DefaultMpStorageRepositoryTest {
         val result = repository.writeBackFlag(MpStorageFlagEntry(threadId = 99, page = 1, numreponse = 1, uri = null))
 
         assertTrue(result is MpStorageWriteResult.VerificationFailedRestoreFailed)
+    }
+
+    @Test
+    fun `writeBackFlag keeps a valid-but-different re-read (concurrent write) without restoring`() = runTest {
+        val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [] } } ] }"""
+        // RE-GET returns a VALID envelope that differs from what we posted (HFR re-encoded entities, or
+        // a concurrent client wrote in the meantime). The doc is healthy → Success(verified=false), and
+        // we must NOT restore (that would clobber a legitimate last-write-wins update). Codex review.
+        val concurrent = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [ {"post":7} ] } } ] }"""
+        repository = buildRepository(
+            replyFormParser = mockk {
+                every { parse(any()) } returnsMany listOf(
+                    Result.success(storageForm(initialContent = raw)), // GET (backup)
+                    Result.success(storageForm(initialContent = concurrent)), // verify: valid but different
+                )
+            },
+        )
+        preferences.enabled.value = true
+        locationStore.saved[OWNER] = STORAGE_LOCATION
+        server.enqueue(MockResponse().setBody(storageEditFormHtml(raw))) // GET edit form
+        server.enqueue(MockResponse().setBody("<html><body>ok</body></html>")) // POST mutation
+        server.enqueue(MockResponse().setBody(storageEditFormHtml(concurrent))) // RE-GET (valid, different)
+
+        val result = repository.writeBackFlag(MpStorageFlagEntry(threadId = 99, page = 1, numreponse = 1, uri = null))
+
+        assertEquals(MpStorageWriteResult.Success(verified = false), result)
+        // GET + POST + RE-GET only — NO restore POST.
+        assertEquals(3, server.requestCount)
     }
 
     /** The exact mutated body the real path would build, so a test can script the RE-GET to match it. */

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/mpstorage/MpStorageEnvelopeWriterTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/mpstorage/MpStorageEnvelopeWriterTest.kt
@@ -2,6 +2,9 @@ package fr.forumhfr.redface2.core.data.mpstorage
 
 import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
 import fr.forumhfr.redface2.core.model.mpstorage.MpStorageFlagEntry
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -21,11 +24,12 @@ import org.junit.Test
  *
  * The output is re-parsed (not string-compared) so the assertions are robust to key ordering /
  * whitespace : what matters is the semantic shape, not the exact bytes (NOT OBSERVED LIVE — no real
- * HFR round-trip to byte-match against).
+ * HFR round-trip to byte-match against). The clock is fixed so `lastUpdate` is deterministic.
  */
 class MpStorageEnvelopeWriterTest {
 
-    private val writer = MpStorageEnvelopeWriter()
+    private val fixedClock: Clock = Clock.fixed(Instant.ofEpochMilli(NOW_MILLIS), ZoneOffset.UTC)
+    private val writer = MpStorageEnvelopeWriter(fixedClock)
     private val json = Json
 
     private fun mutate(raw: String, entry: MpStorageFlagEntry): MpStorageEnvelopeWriter.Outcome =
@@ -44,6 +48,39 @@ class MpStorageEnvelopeWriterTest {
         v01Entry()["mpFlags"]!!.jsonObject["list"]!!.jsonArray
 
     @Test
+    fun `a real change stamps sourceName and lastUpdate at the three levels`() {
+        val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [] } } ] }"""
+
+        val body = bodyOf(mutate(raw, MpStorageFlagEntry(threadId = 1, page = 1, numreponse = 1, uri = null)))
+
+        // Level 1 — root.
+        assertEquals("Redface2", body["sourceName"]!!.jsonPrimitive.content)
+        assertEquals(NOW_MILLIS, body["lastUpdate"]!!.jsonPrimitive.content.toLong())
+        // Level 2 — v0.1 entry.
+        val v01 = body.v01Entry()
+        assertEquals("Redface2", v01["sourceName"]!!.jsonPrimitive.content)
+        assertEquals(NOW_MILLIS, v01["lastUpdate"]!!.jsonPrimitive.content.toLong())
+        // Level 3 — the mpFlags block.
+        val mpFlags = v01["mpFlags"]!!.jsonObject
+        assertEquals("Redface2", mpFlags["sourceName"]!!.jsonPrimitive.content)
+        assertEquals(NOW_MILLIS, mpFlags["lastUpdate"]!!.jsonPrimitive.content.toLong())
+    }
+
+    @Test
+    fun `a no-op (target position unchanged) returns the original content byte-fidele without stamping`() {
+        // The entry is ALREADY at this exact position (post/page/href/uri all match) → no change.
+        val raw = """{"data":[{"version":"0.1","mpFlags":{"list":[{"post":1,"page":2,"href":"t9","uri":"/u"}]}}]}"""
+
+        val outcome = mutate(raw, MpStorageFlagEntry(threadId = 1, page = 2, numreponse = 9, uri = "/u"))
+
+        val noOp = outcome as MpStorageEnvelopeWriter.Outcome.NoOp
+        // Byte-fidèle : the original text is returned verbatim, no re-serialisation, no lastUpdate.
+        assertEquals(raw, noOp.body)
+        assertTrue("no sourceName must be injected on a no-op", !noOp.body.contains("Redface2"))
+        assertTrue("no lastUpdate must be injected on a no-op", !noOp.body.contains("lastUpdate"))
+    }
+
+    @Test
     fun `upsert preserves an unknown third-party top-level key and a sibling tool key in the v01 entry`() {
         val raw = """
             {
@@ -52,17 +89,13 @@ class MpStorageEnvelopeWriterTest {
                   "hfr4k": { "opaque": [1, 2, 3], "nested": { "k": "v" } },
                   "mpFlags": { "list": [] } }
               ],
-              "sourceName": "HFR4K",
-              "lastUpdate": 1718064000000,
               "someOtherTool": { "deep": [ { "x": true } ] }
             }
         """.trimIndent()
 
         val body = bodyOf(mutate(raw, MpStorageFlagEntry(threadId = 999, page = 2, numreponse = 7, uri = "/u")))
 
-        // Third-party TOP-LEVEL keys survive verbatim.
-        assertEquals("HFR4K", body["sourceName"]!!.jsonPrimitive.content)
-        assertEquals(JsonPrimitive(1718064000000L), body["lastUpdate"])
+        // Third-party TOP-LEVEL key survives verbatim ; sourceName/lastUpdate are (re)stamped by us.
         assertTrue("unknown top-level tool key must survive", body.containsKey("someOtherTool"))
         assertEquals(
             true,
@@ -98,6 +131,8 @@ class MpStorageEnvelopeWriterTest {
         assertEquals(2, entries.size)
         val v02 = entries.first { it["version"]?.jsonPrimitive?.content == "0.2" }
         assertEquals(true, v02["somethingNew"]!!.jsonPrimitive.content.toBoolean())
+        // The sibling 0.2 entry is NOT stamped — only the v0.1 entry and the root carry our metadata.
+        assertNull(v02["sourceName"])
         assertEquals(1, body.flagList().size)
     }
 
@@ -158,13 +193,13 @@ class MpStorageEnvelopeWriterTest {
 
     @Test
     fun `an envelope with a data array but no v01 entry gets a minimal v01 entry appended`() {
-        val raw = """{ "data": [ { "version": "0.2", "foo": 1 } ], "sourceName": "Other" }"""
+        val raw = """{ "data": [ { "version": "0.2", "foo": 1 } ] }"""
 
         val body = bodyOf(mutate(raw, MpStorageFlagEntry(threadId = 9, page = 1, numreponse = 3, uri = null)))
 
-        // The pre-existing non-v0.1 entry is kept, a v0.1 entry is created.
+        // The pre-existing non-v0.1 entry is kept, a v0.1 entry is created and stamped.
         assertEquals(2, body["data"]!!.jsonArray.size)
-        assertEquals("Other", body["sourceName"]!!.jsonPrimitive.content)
+        assertEquals("Redface2", body["sourceName"]!!.jsonPrimitive.content)
         assertEquals(9, body.flagList().first().jsonObject["post"]!!.jsonPrimitive.content.toInt())
     }
 
@@ -174,8 +209,9 @@ class MpStorageEnvelopeWriterTest {
 
         val body = bodyOf(mutate(raw, MpStorageFlagEntry(threadId = 4, page = 2, numreponse = 6, uri = "/x")))
 
-        // Third-party keys preserved, minimal data[]/v0.1/mpFlags/list created.
-        assertEquals("DTCloud", body["sourceName"]!!.jsonPrimitive.content)
+        // Third-party keys are (re)written to Redface2 since this is a real change ; data[]/v0.1/mpFlags/list created.
+        assertEquals("Redface2", body["sourceName"]!!.jsonPrimitive.content)
+        assertEquals(NOW_MILLIS, body["lastUpdate"]!!.jsonPrimitive.content.toLong())
         assertEquals(1, body["data"]!!.jsonArray.size)
         assertEquals(1, body.flagList().size)
         assertEquals(4, body.flagList().first().jsonObject["post"]!!.jsonPrimitive.content.toInt())
@@ -195,7 +231,7 @@ class MpStorageEnvelopeWriterTest {
     }
 
     @Test
-    fun `a content_form mutation over 256 KiB is rejected as TooLarge`() {
+    fun `a content_form mutation over the cap is rejected as TooLarge`() {
         // Stuff a huge third-party blob so the mutated body crosses the cap. The mutation itself is
         // tiny — the cap protects against an uncontrolled POST when the storage is already huge
         // (the DTCloud list is never pruned — ADR-014 risk).
@@ -211,8 +247,8 @@ class MpStorageEnvelopeWriterTest {
 
     @Test
     fun `a mutation just under the cap is accepted`() {
-        // Build a body that lands comfortably under 256 KiB after the mutation.
-        val filler = "x".repeat(100 * 1024)
+        // Build a body that lands comfortably under the cap after the mutation.
+        val filler = "x".repeat(32 * 1024)
         val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [] } } ], "blob": "$filler" }"""
 
         val outcome = mutate(raw, MpStorageFlagEntry(threadId = 1, page = 1, numreponse = 1, uri = null))
@@ -240,4 +276,8 @@ class MpStorageEnvelopeWriterTest {
     /** `JsonPrimitive.content` is "null" for a literal null — distinguish it from the string "null". */
     private fun JsonPrimitive.contentOrNullSafe(): String? =
         if (this is kotlinx.serialization.json.JsonNull) null else content
+
+    private companion object {
+        private const val NOW_MILLIS = 1_718_064_000_000L
+    }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -559,6 +559,10 @@ class TopicRepositoryImplTest {
 
         override suspend fun setShowDtSection(enabled: Boolean) = Unit
 
+        override fun observeSyncPrivateMessagesWriteEnabled(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setSyncPrivateMessagesWriteEnabled(enabled: Boolean) = Unit
+
         override fun observeFlagsAutoRefresh(): Flow<Boolean> = MutableStateFlow(true)
 
         override suspend fun setFlagsAutoRefresh(enabled: Boolean) = Unit

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/mpstorage/MpStorageRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/mpstorage/MpStorageRepository.kt
@@ -9,11 +9,6 @@ import fr.forumhfr.redface2.core.model.mpstorage.MpStorageWriteResult
  * first post of a dedicated HFR private message (subject = fixed hash, recipient = the
  * third-party `MultiMP` account).
  *
- * READ-ONLY by design for Phase 3 : the write path (full-overwrite `bdd.php`, last-write-wins)
- * is deferred to a dedicated opt-in follow-up (ADR-014 §4). Implementations must NEVER write
- * anything — in particular never "repair" an unreadable document (the original library's
- * destructive-reset trap).
- *
  * [fetchStorage] performs the full discovery + read pipeline (authenticated) :
  * subject search → conversation first post → edit form → `content_form` JSON. The
  * « account has no storage » outcome ([MpStorageResult.NotFound]) is the first-class
@@ -22,46 +17,79 @@ import fr.forumhfr.redface2.core.model.mpstorage.MpStorageWriteResult
  * Reading marks the storage conversation itself as read server-side (a GET of any page of a
  * `cat=prive` conversation clears its whole-conversation dot, cf. #361/ADR-013) — acceptable :
  * the storage MP is machinery, not user correspondence ; DTCloud behaves identically.
+ *
+ * The WRITE path ([writeBackFlag], full-overwrite `bdd.php`, last-write-wins) is the REAL,
+ * opt-in path (ADR-014 §4), gated by `syncPrivateMessagesWriteEnabled` (default OFF) and a
+ * verify-after-write guard. Implementations must NEVER "repair" an unreadable document (the
+ * original library's destructive-reset trap) and NEVER create a fresh storage MP.
  */
 interface MpStorageRepository {
 
     suspend fun fetchStorage(): MpStorageResult
 
     /**
-     * WRITE path (#6, ADR-014 §4 — deferred / opt-in). Read-modify-write of the storage document :
+     * WRITE path (#6, ADR-014 §4 — opt-in, OFF by default). Read-modify-write of the storage document :
      * locate the dedicated MP, mutate its `mpFlags.list[]` to upsert [entry] (by [MpStorageFlagEntry.threadId])
-     * **in place on the raw JSON tree** so every third-party namespace survives the round-trip, then
-     * build the `bdd.php cat=prive` POST body.
+     * **in place on the raw JSON tree** so every third-party namespace survives the round-trip, POST the
+     * mutated `content_form` back to `bdd.php cat=prive`, then VERIFY the write by re-reading the first post
+     * (restoring the verbatim backup on a mismatch).
      *
-     * GUARDED BY DESIGN — NOT OBSERVED LIVE. The `bdd.php cat=prive` write contract was never captured
-     * (device down). This public method is **DRY-RUN ONLY** : it locates, mutates, validates and builds the
-     * body, then returns [MpStorageWriteResult.Prepared] with `posted = false` — **no request ever hits the
-     * wire**, and there is no parameter to make it. The actual POST lives behind a module-internal,
-     * test-only path on the implementation (NOT on this public interface) so it is **structurally
-     * impossible to trigger from app/prod code** (Codex review) ; the ADR-014 §4 trigger is NOT wired.
+     * GATED BY THE OPT-IN PREFERENCE : when `syncPrivateMessagesWriteEnabled` is `false` (the default) this
+     * returns [MpStorageWriteResult.DisabledByPreference] WITHOUT touching the network — the absence of a
+     * write trigger is therefore harmless. NOT OBSERVED LIVE : the `bdd.php cat=prive` write contract has
+     * never been captured against a real document.
      *
-     * Target selection (Codex decision) is DETERMINISTIC : the first MP whose subject equals EXACTLY
-     * [STORAGE_SUBJECT_HASH]. A miss is [MpStorageWriteResult.TargetNotFound] — NEVER a creation /
-     * overwrite (ADR-014 §3 forbids the destructive reset ; creating a fresh doc would fork the
-     * cross-userscript storage).
+     * Target selection is DETERMINISTIC : the first MP whose subject equals EXACTLY [STORAGE_SUBJECT_HASH].
+     * A miss is [MpStorageWriteResult.TargetNotFound] — NEVER a creation / overwrite (ADR-014 §3). An
+     * unreadable located document is [MpStorageWriteResult.Unreadable], never repaired. A target whose
+     * position does not actually change is a NO-OP : [MpStorageWriteResult.Success] with no POST.
      *
      * The mutated `content_form` is capped at [MAX_CONTENT_FORM_BYTES] ([MpStorageWriteResult.TooLarge]
-     * past it) : the real HFR MP body limit is unknown, so the cap fails CLOSED.
+     * past it, fail-closed). After the POST the first post is re-read : a match is
+     * [MpStorageWriteResult.Success] ; a mismatch triggers a restore POST of the backup, surfaced as
+     * [MpStorageWriteResult.VerificationFailedRestored] (backup re-read OK) or
+     * [MpStorageWriteResult.VerificationFailedRestoreFailed] (the backup could not be restored — critical).
      *
      * @param entry the DT reading-resume position to upsert.
      */
     suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult
+
+    /**
+     * DRY-RUN of [writeBackFlag] for tests / dev tooling : locates, mutates and validates the body but
+     * NEVER hits the wire, NEVER consults the opt-in preference, and NEVER verifies. Returns the verbatim
+     * mutated body that the real path WOULD POST, or a typed failure (not-found / unreadable / oversize).
+     * This is the inspectable counterpart — the production trigger uses [writeBackFlag], never this.
+     */
+    suspend fun previewWriteBackFlag(entry: MpStorageFlagEntry): MpStorageWritePreview
 
     companion object {
         /** Fixed storage subject — the de-facto v0.1 contract's discriminator (#6). */
         const val STORAGE_SUBJECT_HASH: String = "a2bcc09b796b8c6fab77058ff8446c34"
 
         /**
-         * Hard cap (Codex decision) on the mutated `content_form` UTF-8 size, 256 KiB. The real HFR
-         * private-message body limit has never been observed ; 256 KiB comfortably exceeds any
-         * realistic DTCloud `mpFlags.list` (the list is never pruned by the original library, hence
-         * the risk) while bounding an uncontrolled POST. Crossing it fails CLOSED — NOT OBSERVED LIVE.
+         * Hard cap (Codex decision) on the mutated `content_form` UTF-8 size, 64 KiB. The real HFR
+         * private-message body limit has never been observed ; 64 KiB comfortably exceeds any
+         * realistic DTCloud `mpFlags.list` (a few hundred small entries) while bounding an uncontrolled
+         * POST. Crossing it fails CLOSED — NOT OBSERVED LIVE.
          */
-        const val MAX_CONTENT_FORM_BYTES: Int = 256 * 1024
+        const val MAX_CONTENT_FORM_BYTES: Int = 64 * 1024
     }
+}
+
+/**
+ * Outcome of the dry-run [MpStorageRepository.previewWriteBackFlag] : it never POSTs, so it cannot
+ * report a verification result — only the prepared body or a typed pre-POST failure.
+ */
+sealed interface MpStorageWritePreview {
+    /** The body the real path WOULD POST as `content_form`. */
+    data class Prepared(val body: String) : MpStorageWritePreview
+
+    /** No storage MP located (ADR-014 §3 : never created). */
+    data object TargetNotFound : MpStorageWritePreview
+
+    /** The located document is not a readable v0.1 envelope (never repaired). */
+    data object Unreadable : MpStorageWritePreview
+
+    /** The mutated body exceeds [MpStorageRepository.MAX_CONTENT_FORM_BYTES]. */
+    data class TooLarge(val sizeBytes: Int) : MpStorageWritePreview
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -175,6 +175,20 @@ interface UserPreferencesRepository {
     suspend fun setShowDtSection(enabled: Boolean)
 
     /**
+     * EXPERIMENTAL opt-in (#6, ADR-014 §4) — whether Redface 2 may WRITE BACK DT reading positions
+     * into the cross-userscript MPStorage document (a full-overwrite `bdd.php cat=prive` POST,
+     * verify-after-write). Default `false`, and DELIBERATELY so : the write contract was never
+     * observed live and a bad write touches the shared storage of EVERY userscript. When OFF (the
+     * default) the write path returns immediately without any network access — the absence of a
+     * write trigger is therefore harmless. Observed by the MPStorage write path, toggled in
+     * Settings > Messages privés (with an experimental warning).
+     */
+    fun observeSyncPrivateMessagesWriteEnabled(): Flow<Boolean>
+
+    /** Persists [observeSyncPrivateMessagesWriteEnabled]. Default `false` until the first call. */
+    suspend fun setSyncPrivateMessagesWriteEnabled(enabled: Boolean)
+
+    /**
      * Auto-refresh of the Drapeaux lists (#378): when `true`, landing on the flags screen
      * (app open, back from a topic, return from another tab) silently re-fetches the current
      * tab — throttled by the ViewModel so rapid back-and-forth does not hammer the REST

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/mpstorage/MpStorage.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/mpstorage/MpStorage.kt
@@ -60,24 +60,21 @@ data class MpStorageFlagEntry(
 )
 
 /**
- * Outcome of an MPStorage WRITE attempt (#6, ADR-014 §4 — deferred / opt-in).
+ * Outcome of an MPStorage WRITE attempt (#6, ADR-014 §4 — opt-in, OFF by default).
  *
- * NOTE — NOT OBSERVED LIVE : the `bdd.php cat=prive` write contract has never been captured
- * (device down, no real round-trip). The write mechanism is implemented and unit-tested but
- * stays GUARDED — the public [fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository.writeBackFlag]
- * only ever read-modify-builds (no POST), and the live POST is reachable solely via a module-internal,
- * test-only path (not on the public interface). There is no UI entry point. These variants describe
- * what the path WOULD return once the contract is confirmed.
+ * The write path is the REAL read-modify-write of the storage document, gated by the
+ * `syncPrivateMessagesWriteEnabled` preference (default `false`) AND a verify-after-write guard
+ * (re-read the first post after the POST and confirm it matches the mutated body ; restore the
+ * verbatim backup on a mismatch). NOT OBSERVED LIVE : the `bdd.php cat=prive` write contract has
+ * never been captured against a real document — these variants describe what the gated path returns.
  */
 sealed interface MpStorageWriteResult {
 
     /**
-     * The read-modify-write completed. [body] is the verbatim mutated JSON that WOULD be (or was)
-     * sent as `content_form`. [posted] is `false` for the guarded dry-run (the nominal case today:
-     * the body was built and validated but no request hit the wire), `true` once a real POST is
-     * confirmed accepted by HFR.
+     * The opt-in preference is OFF (the default). NO request hit the wire — the path returns before
+     * reading anything. This is the nominal case for every user who has not explicitly opted in.
      */
-    data class Prepared(val body: String, val posted: Boolean) : MpStorageWriteResult
+    data object DisabledByPreference : MpStorageWriteResult
 
     /**
      * The target storage document could not be located (ADR-014 §3 : NEVER create or overwrite a
@@ -87,13 +84,36 @@ sealed interface MpStorageWriteResult {
     data object TargetNotFound : MpStorageWriteResult
 
     /** The located document is not a readable v0.1 envelope — surfaced, never repaired (ADR-014 §3). */
-    data object TargetUnreadable : MpStorageWriteResult
+    data object Unreadable : MpStorageWriteResult
 
     /**
      * The mutated `content_form` exceeds the hard size cap
      * ([fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository.MAX_CONTENT_FORM_BYTES]).
      * The real HFR MP body limit is unknown (never observed) ; this cap fails CLOSED rather than
-     * risk an uncontrolled / truncated POST. [sizeBytes] is the offending UTF-8 size.
+     * risk an uncontrolled / truncated POST. [sizeBytes] is the offending UTF-8 size. No POST is sent.
      */
     data class TooLarge(val sizeBytes: Int) : MpStorageWriteResult
+
+    /**
+     * The mutation was POSTed and the verify-after-write re-read confirmed the stored first post now
+     * equals the mutated body. [verified] is `true` here (it is the only success variant — there is no
+     * "success without verification" for the real path) ; the no-op case (the target position did not
+     * change, so nothing was written) ALSO returns [verified] = `true` with no POST.
+     */
+    data class Success(val verified: Boolean) : MpStorageWriteResult
+
+    /**
+     * The verify-after-write re-read did NOT match the mutated body, so the verbatim backup was
+     * re-POSTed and the subsequent re-read confirmed the document is back to its pre-write state.
+     * The user's storage is intact ; the write simply did not take. [expectedBytes] / [actualBytes]
+     * are the mutated vs the read-back UTF-8 sizes (diagnostics only — never the content).
+     */
+    data class VerificationFailedRestored(val expectedBytes: Int, val actualBytes: Int) : MpStorageWriteResult
+
+    /**
+     * CRITICAL : the verify-after-write mismatched AND the restore re-POST could NOT bring the document
+     * back to its backup. The storage may be in an inconsistent state — logged at the highest level.
+     * [expectedBytes] / [actualBytes] are the backup vs the read-back UTF-8 sizes (diagnostics only).
+     */
+    data class VerificationFailedRestoreFailed(val expectedBytes: Int, val actualBytes: Int) : MpStorageWriteResult
 }

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrConstants.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrConstants.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.core.network
 
+import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
 import java.time.Duration
 
 object HfrConstants {
@@ -23,8 +24,12 @@ object HfrConstants {
      * private message. The write path sends this CONSTANT verbatim as the `sujet` field (NEVER the
      * `sujet` parsed back from the edit form) and refuses to POST when the parsed form's subject does
      * not equal it — a structural guard against ever writing into the wrong conversation.
+     *
+     * SINGLE SOURCE OF TRUTH = [MpStorageRepository.STORAGE_SUBJECT_HASH] (domain, also used by the
+     * discovery subject-match). Aliased here so the network/write layer and discovery can never drift
+     * to two different hashes (Codex review).
      */
-    const val MP_STORAGE_SUBJECT_HASH: String = "a2bcc09b796b8c6fab77058ff8446c34"
+    const val MP_STORAGE_SUBJECT_HASH: String = MpStorageRepository.STORAGE_SUBJECT_HASH
 
     val ConnectTimeout: Duration = Duration.ofSeconds(15)
     val ReadTimeout: Duration = Duration.ofSeconds(20)

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrConstants.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrConstants.kt
@@ -18,6 +18,14 @@ object HfrConstants {
      */
     const val VERIF_REQUET: String = "1100"
 
+    /**
+     * MPStorage (#6, ADR-014 §4) — the fixed subject hash of the dedicated cross-userscript storage
+     * private message. The write path sends this CONSTANT verbatim as the `sujet` field (NEVER the
+     * `sujet` parsed back from the edit form) and refuses to POST when the parsed form's subject does
+     * not equal it — a structural guard against ever writing into the wrong conversation.
+     */
+    const val MP_STORAGE_SUBJECT_HASH: String = "a2bcc09b796b8c6fab77058ff8446c34"
+
     val ConnectTimeout: Duration = Duration.ofSeconds(15)
     val ReadTimeout: Duration = Duration.ofSeconds(20)
     val WriteTimeout: Duration = Duration.ofSeconds(20)

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -1976,6 +1976,10 @@ class PostEditorViewModelTest {
 
         override suspend fun setShowDtSection(enabled: Boolean) = Unit
 
+        override fun observeSyncPrivateMessagesWriteEnabled(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setSyncPrivateMessagesWriteEnabled(enabled: Boolean) = Unit
+
         override fun observeFlagsAutoRefresh(): Flow<Boolean> = MutableStateFlow(true)
 
         override suspend fun setFlagsAutoRefresh(enabled: Boolean) = Unit

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1376,6 +1376,10 @@ class TopicFormViewModelTest {
 
         override suspend fun setShowDtSection(enabled: Boolean) = Unit
 
+        override fun observeSyncPrivateMessagesWriteEnabled(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setSyncPrivateMessagesWriteEnabled(enabled: Boolean) = Unit
+
         override fun observeFlagsAutoRefresh(): Flow<Boolean> = MutableStateFlow(true)
 
         override suspend fun setFlagsAutoRefresh(enabled: Boolean) = Unit

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -2364,6 +2364,10 @@ class FlagsViewModelTest {
 
         override suspend fun setShowDtSection(enabled: Boolean) = Unit
 
+        override fun observeSyncPrivateMessagesWriteEnabled(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setSyncPrivateMessagesWriteEnabled(enabled: Boolean) = Unit
+
         // #378 — writable so the auto-refresh tests can flip the opt-out.
         val flagsAutoRefresh = MutableStateFlow(true)
 
@@ -2477,10 +2481,14 @@ class FlagsViewModelTest {
             return result
         }
 
-        // The DT tab only READS MPStorage; the write path (#6, guarded) is never exercised here, so the
-        // fake stubs it. Added when chantier B extended MpStorageRepository with writeBackFlag (cross-module
-        // fake update the B build missed — its validation didn't compile :feature:flags tests).
+        // The DT tab only READS MPStorage; the write path (#6, opt-in OFF) is never exercised here, so the
+        // fake stubs both write entry points. The default opt-in OFF maps to DisabledByPreference.
         override suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult =
-            MpStorageWriteResult.TargetNotFound
+            MpStorageWriteResult.DisabledByPreference
+
+        override suspend fun previewWriteBackFlag(
+            entry: MpStorageFlagEntry,
+        ): fr.forumhfr.redface2.core.domain.mpstorage.MpStorageWritePreview =
+            fr.forumhfr.redface2.core.domain.mpstorage.MpStorageWritePreview.TargetNotFound
     }
 }

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -667,6 +667,18 @@ internal fun buildSettingsCatalogue(
                 errorRes = R.string.settings_mp_unread_badge_persist_failed.takeIf { state.mpUnreadBadgeError },
                 onCheckedChange = { onIntent(SettingsIntent.MpUnreadBadgeChanged(it)) },
             ),
+            // #6, ADR-014 §4 — experimental opt-in for the MPStorage write-back. OFF by default ; the
+            // description warns it is experimental (the write contract was never observed live).
+            toggleRow(
+                id = "sync_private_messages_write",
+                title = stringResource(R.string.settings_mp_sync_write_title),
+                description = stringResource(R.string.settings_mp_sync_write_description),
+                checked = state.syncPrivateMessagesWriteEnabled,
+                enabled = state.canToggleSyncPrivateMessagesWriteEnabled,
+                errorRes = R.string.settings_mp_sync_write_persist_failed
+                    .takeIf { state.syncPrivateMessagesWriteEnabledError },
+                onCheckedChange = { onIntent(SettingsIntent.SyncPrivateMessagesWriteEnabledChanged(it)) },
+            ),
             futureRow(
                 id = "future_mp_push",
                 title = stringResource(R.string.settings_future_mp_push),

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -166,6 +166,12 @@ data class SettingsState(
     val isUpdatingShowDtSection: Boolean = false,
     val showDtSectionError: Boolean = false,
     val showDtSectionTouchedLocally: Boolean = false,
+    // #6, ADR-014 §4 — EXPERIMENTAL opt-in for the MPStorage write-back (sync DT en écriture). Same
+    // optimistic-flip + startup-race-guard machinery. Default FALSE (off = no write ever happens).
+    val syncPrivateMessagesWriteEnabled: Boolean = false,
+    val isUpdatingSyncPrivateMessagesWriteEnabled: Boolean = false,
+    val syncPrivateMessagesWriteEnabledError: Boolean = false,
+    val syncPrivateMessagesWriteEnabledTouchedLocally: Boolean = false,
     // Drapeaux — #378 auto-refresh on landing (app open / back from a topic). Same machinery.
     // Default TRUE: the staleness was the complaint, the toggle is the opt-out.
     val flagsAutoRefresh: Boolean = true,
@@ -293,6 +299,10 @@ data class SettingsState(
     val canToggleShowDtSection: Boolean
         get() = !isUpdatingShowDtSection
 
+    // #6 — the experimental MPStorage write-back toggle is gated only by its own write.
+    val canToggleSyncPrivateMessagesWriteEnabled: Boolean
+        get() = !isUpdatingSyncPrivateMessagesWriteEnabled
+
     // #378 — flags auto-refresh, gated only by its own write.
     val canToggleFlagsAutoRefresh: Boolean
         get() = !isUpdatingFlagsAutoRefresh
@@ -419,6 +429,9 @@ sealed interface SettingsIntent {
     // Drapeaux — opt-in « DT » placeholder tab (MPStorage sync #6 lands later). Optimistic-flip
     // contract, like the flags toggles: the boolean is the desired post-flip state.
     data class ShowDtSectionChanged(val enabled: Boolean) : SettingsIntent
+
+    /** #6 — experimental opt-in for the MPStorage write-back (sync DT en écriture). */
+    data class SyncPrivateMessagesWriteEnabledChanged(val enabled: Boolean) : SettingsIntent
 
     // Drapeaux — #378 auto-refresh on landing. Optimistic-flip contract, like the flags
     // toggles: the boolean is the desired post-flip state.

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -150,6 +150,13 @@ class SettingsViewModel @Inject constructor(
             apply = { state, value -> state.copy(showDtSection = value) },
         )
         hydratePreference(
+            read = { userPreferencesRepository.observeSyncPrivateMessagesWriteEnabled().first() },
+            isLocked = {
+                it.syncPrivateMessagesWriteEnabledTouchedLocally || it.isUpdatingSyncPrivateMessagesWriteEnabled
+            },
+            apply = { state, value -> state.copy(syncPrivateMessagesWriteEnabled = value) },
+        )
+        hydratePreference(
             read = { userPreferencesRepository.observeFlagsAutoRefresh().first() },
             isLocked = { it.flagsAutoRefreshTouchedLocally || it.isUpdatingFlagsAutoRefresh },
             apply = { state, value -> state.copy(flagsAutoRefresh = value) },
@@ -253,6 +260,8 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.ImmersiveBackButtonChanged -> updateImmersiveBackButton(intent.enabled)
             is SettingsIntent.ImmersiveNavBarRevealChanged -> updateImmersiveNavBarReveal(intent.mode)
             is SettingsIntent.ShowDtSectionChanged -> updateShowDtSection(intent.enabled)
+            is SettingsIntent.SyncPrivateMessagesWriteEnabledChanged ->
+                updateSyncPrivateMessagesWriteEnabled(intent.enabled)
             is SettingsIntent.ConfirmBeforePostingChanged -> updateConfirmBeforePosting(intent.enabled)
             is SettingsIntent.FlagsAutoRefreshChanged -> updateFlagsAutoRefresh(intent.enabled)
             is SettingsIntent.DisplayDensityChanged -> updateDisplayDensity(intent.density)
@@ -1033,6 +1042,36 @@ class SettingsViewModel @Inject constructor(
                 }
             },
             persist = userPreferencesRepository::setShowDtSection,
+        )
+    }
+
+    private fun updateSyncPrivateMessagesWriteEnabled(desired: Boolean) {
+        val previous = _state.value.syncPrivateMessagesWriteEnabled
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    syncPrivateMessagesWriteEnabled = desired,
+                    isUpdatingSyncPrivateMessagesWriteEnabled = true,
+                    syncPrivateMessagesWriteEnabledError = false,
+                    syncPrivateMessagesWriteEnabledTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(
+                        syncPrivateMessagesWriteEnabled = desired,
+                        isUpdatingSyncPrivateMessagesWriteEnabled = false,
+                    )
+                } else {
+                    state.copy(
+                        syncPrivateMessagesWriteEnabled = previous,
+                        isUpdatingSyncPrivateMessagesWriteEnabled = false,
+                        syncPrivateMessagesWriteEnabledError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setSyncPrivateMessagesWriteEnabled,
         )
     }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -26,6 +26,10 @@
     <string name="settings_mp_unread_badge_title">Badge de MP non lus</string>
     <string name="settings_mp_unread_badge_description">Nombre de conversations non lues sur l\'onglet Messages.</string>
     <string name="settings_mp_unread_badge_persist_failed">Impossible d\'enregistrer ce réglage pour le moment.</string>
+    <!-- #6, ADR-014 §4 — opt-in expérimental pour l\'écriture MPStorage (sync DT en écriture). -->
+    <string name="settings_mp_sync_write_title">Sync DT en écriture (expérimental)</string>
+    <string name="settings_mp_sync_write_description">Écrit vos positions de lecture DT dans le document MPStorage partagé avec les autres outils (DTCloud…). Expérimental : désactivé par défaut, le contrat d\'écriture n\'a pas été validé sur le serveur.</string>
+    <string name="settings_mp_sync_write_persist_failed">Impossible d\'enregistrer ce réglage pour le moment.</string>
     <string name="settings_section_hfr_account">Compte HFR</string>
     <string name="settings_section_notifications">Notifications</string>
     <string name="settings_section_accessibility">Accessibilité</string>

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/MpStorageInspectorViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/MpStorageInspectorViewModelTest.kt
@@ -176,6 +176,11 @@ class MpStorageInspectorViewModelTest {
             // Read-only inspector: a write must NEVER happen here — fail loudly if one slips in (Codex review).
             override suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult =
                 error("Unexpected writeBackFlag call in the read-only inspector test")
+
+            override suspend fun previewWriteBackFlag(
+                entry: MpStorageFlagEntry,
+            ): fr.forumhfr.redface2.core.domain.mpstorage.MpStorageWritePreview =
+                error("Unexpected previewWriteBackFlag call in the read-only inspector test")
         }
         val auth = FakeAuthRepository(AuthState.Authenticated("Alice"))
         val viewModel = MpStorageInspectorViewModel(repo, FakeLocationStore(), auth)
@@ -225,6 +230,11 @@ class MpStorageInspectorViewModelTest {
         // Read-only inspector: a write must NEVER happen here — fail loudly if one slips in (Codex review).
         override suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult =
             error("Unexpected writeBackFlag call in the read-only inspector test")
+
+        override suspend fun previewWriteBackFlag(
+            entry: MpStorageFlagEntry,
+        ): fr.forumhfr.redface2.core.domain.mpstorage.MpStorageWritePreview =
+            error("Unexpected previewWriteBackFlag call in the read-only inspector test")
     }
 
     private class FakeLocationStore(

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -1315,6 +1315,46 @@ class SettingsViewModelTest {
     }
 
     @Test
+    fun `init hydrates the experimental MPStorage write opt-in from the persisted preference`() = runTest {
+        repository.emitSyncPrivateMessagesWriteEnabled(true)
+
+        val viewModel = newViewModel()
+
+        assertTrue(viewModel.state.value.syncPrivateMessagesWriteEnabled)
+        assertFalse(viewModel.state.value.syncPrivateMessagesWriteEnabledError)
+    }
+
+    @Test
+    fun `the MPStorage write opt-in is OFF by default and a flip persists`() = runTest {
+        val viewModel = newViewModel()
+        assertFalse(
+            "the experimental write opt-in must be off by default",
+            viewModel.state.value.syncPrivateMessagesWriteEnabled,
+        )
+
+        viewModel.submit(SettingsIntent.SyncPrivateMessagesWriteEnabledChanged(true))
+
+        assertTrue(viewModel.state.value.syncPrivateMessagesWriteEnabled)
+        assertFalse(viewModel.state.value.isUpdatingSyncPrivateMessagesWriteEnabled)
+        assertEquals(1, repository.syncPrivateMessagesWriteEnabledSetCalls)
+    }
+
+    @Test
+    fun `the MPStorage write opt-in reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnSyncPrivateMessagesWriteEnabledSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.SyncPrivateMessagesWriteEnabledChanged(true))
+
+        assertFalse(
+            "must revert to the previous value on failure",
+            viewModel.state.value.syncPrivateMessagesWriteEnabled,
+        )
+        assertFalse(viewModel.state.value.isUpdatingSyncPrivateMessagesWriteEnabled)
+        assertTrue(viewModel.state.value.syncPrivateMessagesWriteEnabledError)
+    }
+
+    @Test
     fun `theme hydration race - a stale initial DataStore emission must not overwrite a local mode change`() =
         runTest {
             // Mirror of the ignoreTopicCache startup-race test for ThemeMode (#286, Codex nit): init
@@ -1925,6 +1965,25 @@ class SettingsViewModelTest {
 
         override suspend fun setShowDtSection(enabled: Boolean) {
             showDtSection.value = enabled
+        }
+
+        // #6 — experimental MPStorage write-back opt-in. Rich seam (set-call counter + fail flag +
+        // emit helper) so the Settings tests can assert hydration, the repo call, and revert-on-failure.
+        private val syncPrivateMessagesWriteEnabled = MutableStateFlow(false)
+        var syncPrivateMessagesWriteEnabledSetCalls: Int = 0
+            private set
+        var failOnSyncPrivateMessagesWriteEnabledSet: Boolean = false
+
+        override fun observeSyncPrivateMessagesWriteEnabled(): Flow<Boolean> = syncPrivateMessagesWriteEnabled
+
+        override suspend fun setSyncPrivateMessagesWriteEnabled(enabled: Boolean) {
+            syncPrivateMessagesWriteEnabledSetCalls += 1
+            check(!failOnSyncPrivateMessagesWriteEnabledSet) { "boom" }
+            syncPrivateMessagesWriteEnabled.value = enabled
+        }
+
+        fun emitSyncPrivateMessagesWriteEnabled(value: Boolean) {
+            syncPrivateMessagesWriteEnabled.value = value
         }
 
         // #378 — flags auto-refresh opt-out, same writable seam as showDtSection.

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -2066,6 +2066,10 @@ private class FakeUserPreferencesRepository(
 
     override suspend fun setShowDtSection(enabled: Boolean) = Unit
 
+    override fun observeSyncPrivateMessagesWriteEnabled(): Flow<Boolean> = MutableStateFlow(false)
+
+    override suspend fun setSyncPrivateMessagesWriteEnabled(enabled: Boolean) = Unit
+
     override fun observeFlagsAutoRefresh(): Flow<Boolean> = MutableStateFlow(true)
 
     override suspend fun setFlagsAutoRefresh(enabled: Boolean) = Unit


### PR DESCRIPTION
Active le **chemin d'écriture MPStorage v0.1** (ADR-014 §4, #6), en **opt-in désactivé par défaut** + garde-fou **verify-after-write**. Contrat validé en live (banc XaTelitte) lors d'une session précédente.

## `writeBackFlag` = chemin réel gardé
1. **Gate pref EN PREMIER** → si OFF : `DisabledByPreference`, **aucun accès réseau** (donc l'absence de déclencheur est inoffensive).
2. Pseudo du compte actif → GET form + `content_form` → **backup verbatim** → refus `Unreadable` si JSON illisible.
3. `MpStorageEnvelopeWriter` : **no-op** si position inchangée (renvoie le contenu lu byte-fidèle, ne touche pas `lastUpdate`) ; sinon `sourceName="Redface2"` + `lastUpdate=now` aux **3 niveaux** (racine, entrée v0.1, mpFlags), namespaces tiers préservés.
4. Cap **64 KiB** UTF-8 → `TooLarge`.
5. **POST** muté → **RE-GET** → si == muté `Success(verified=true)` ; sinon **re-POST du backup (restore)** + RE-GET → `VerificationFailedRestored` / `VerificationFailedRestoreFailed` (log critique). Jamais de doc laissé corrompu.

## POST sécurisé
`sujet` = **CONSTANTE** `MP_STORAGE_SUBJECT_HASH` (jamais `form.sujet`) ; garde structurelle : `form.sujet != HASH` → **aucun POST** ; `pseudo` du compte actif ; `cat=prive` ; UTF-8 ; `password`/`delete` interdits. Le restore passe par le **même** builder gardé.

L'ancien dry-run public devient `previewWriteBackFlag` (jamais utilisé en prod) ; `writeBackFlagLive` test-only supprimé ; cap 256 → 64 KiB.

## Opt-in
Pref `syncPrivateMessagesWriteEnabled` (défaut **false**) : interface domain + DataStore + sous-page Réglages > Messages privés (« Sync DT en écriture (expérimental) » + avertissement). Tous les fakes `UserPreferencesRepository` + les 3 fakes MpStorage mis à jour.

## Déclencheur — DIFFÉRÉ (volontaire)
Le câblage « à la sortie d'une conversation MultiMP/DT » n'est pas inclus : `MpStorageFlagEntry.threadId` (topic DT forum) vs `PrivateMessageThread.threadId` (conversation MP) demandent un **arbitrage produit** sur la clé. Opt-in OFF par défaut → sans risque sans déclencheur. Suivi : tâche interne.

## Validation
`:core:network` + `:core:data` + `:feature:{settings,messages,topic,flags,editor}` + `:app` testDebugUnitTest + assemble + detekt + lint — tous verts. Tests EnvelopeWriter (3 niveaux / no-op / tiers / cap / invalide) + repository (pref OFF sans réseau, Unreadable, TooLarge, garde sujet, no-op, Success verified, restore, restore-failed) + Settings. Cadré + relu par Codex.

Avance la clôture Phase 3 (#6). Aucun POST réel tant que la pref n'est pas activée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
