### PR TITLE
fix(#114): sanitize non-BMP code points (emojis) avant POST — anti-troncation HFR

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/ContentFormSanitizer.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/ContentFormSanitizer.kt
@@ -1,0 +1,63 @@
+package fr.forumhfr.redface2.core.data.write
+
+/**
+ * Strips code points HFR cannot store from the `content_form` body of a post before it is
+ * POSTed (#114).
+ *
+ * ## Why
+ *
+ * HFR silently truncates a posted message at the FIRST character it cannot store and STILL
+ * answers HTTP 200 « success » — so the user loses everything after that character with no
+ * error. Verified live, the trigger in practice is any code point outside the Basic
+ * Multilingual Plane (`>= U+10000`, encoded as a UTF-16 surrogate pair) — chiefly **emojis**
+ * pasted into the editor. The app itself posts valid UTF-8 (`FormBody.Builder(Charsets.UTF_8)`),
+ * so the bad byte never comes from our encoding; it comes from the content the user typed.
+ *
+ * ## What it does
+ *
+ * Removes every astral (non-BMP) code point AND every lone/unpaired UTF-16 surrogate, keeping
+ * everything in the BMP intact: BBCode tags (`[b]…[/b]`), accented Latin (é, à, ç, œ…),
+ * combining marks, CR/LF, tabs and all ordinary punctuation are preserved verbatim. Losing the
+ * emoji is far better than losing the whole post.
+ *
+ * Deliberately scoped to non-BMP / surrogate removal only — no control-byte stripping — because
+ * that is the single truncation vector observed live (do not broaden without fresh evidence).
+ *
+ * Pure and side-effect-free so it can be unit-tested in isolation (see
+ * `ContentFormSanitizerTest`), mirroring the [redactHashCheckForDiagnostics] precedent. Applied
+ * at every user-authored `content_form` write site (reply / quote / edit / new-topic /
+ * edit-first-post / MP reply / MP compose). The delete-post path is excluded on purpose: it
+ * re-posts `ReplyForm.initialContent`, i.e. content HFR already accepted, never freshly typed.
+ */
+internal fun sanitizeContentForm(content: String): String {
+    // Fast path: a single `Char` (UTF-16 code unit) scan. Every astral pair AND every lone
+    // surrogate has at least one code unit >= 0xD800, so the absence of any such unit proves the
+    // string is pure BMP scalar values — nothing to strip — and the common ASCII/Latin/BBCode
+    // post returns without allocating. High-BMP chars (U+E000..U+FFFF) are < 0xD800 so they take
+    // this path too and are preserved.
+    if (content.all { it.code < SURROGATE_RANGE_START }) return content
+    return buildString(content.length) {
+        var index = 0
+        while (index < content.length) {
+            val codePoint = content.codePointAt(index)
+            val charCount = Character.charCount(codePoint)
+            // Keep only valid BMP scalar values. `codePointAt` returns the raw surrogate value
+            // (0xD800..0xDFFF, charCount 1) for an UNPAIRED surrogate — those are < 0x10000 yet
+            // must still be dropped, so test the surrogate range explicitly. A well-formed
+            // astral pair decodes to a single codePoint >= 0x10000 with charCount 2.
+            val isAstral = codePoint >= ASTRAL_PLANE_START
+            val isLoneSurrogate = codePoint in SURROGATE_RANGE_START..SURROGATE_RANGE_END
+            if (!isAstral && !isLoneSurrogate) {
+                append(content, index, index + charCount)
+            }
+            index += charCount
+        }
+    }
+}
+
+/** First code point of the astral planes (UTF-16 surrogate-pair territory). */
+private const val ASTRAL_PLANE_START = 0x10000
+
+/** Inclusive bounds of the UTF-16 surrogate range — never valid as standalone scalar values. */
+private const val SURROGATE_RANGE_START = 0xD800
+private const val SURROGATE_RANGE_END = 0xDFFF

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultEditPostRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultEditPostRepository.kt
@@ -200,7 +200,8 @@ class DefaultEditPostRepository @Inject constructor(
         val overrides = buildMap {
             put("hash_check", form.hashCheck)
             put("verifrequet", HfrConstants.VERIF_REQUET)
-            put("content_form", bbcodeContent)
+            // #114 — strip non-BMP code points (emojis) HFR would silently truncate the post at.
+            put("content_form", sanitizeContentForm(bbcodeContent))
             // Edit : numreponse identifies the post being edited. numrep stays
             // empty (only quote uses it, and quote always goes through the
             // reply repository).

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultPrivateMessageWriteRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultPrivateMessageWriteRepository.kt
@@ -298,7 +298,8 @@ class DefaultPrivateMessageWriteRepository @Inject constructor(
         val builder = FormBody.Builder(Charsets.UTF_8)
         builder.add("hash_check", form.hashCheck)
         builder.add("verifrequet", HfrConstants.VERIF_REQUET)
-        builder.add("content_form", bbcodeContent)
+        // #114 — strip non-BMP code points (emojis) HFR would silently truncate the message at.
+        builder.add("content_form", sanitizeContentForm(bbcodeContent))
         // Browser-style opt-in: a field is only present when the user enabled it (`emaill` keeps
         // HFR's own two-`l` spelling). The matching keys are marked emitted so the verbatim
         // forwarder below cannot resurrect a stale `value="1"` default from the parsed checkbox.
@@ -337,7 +338,8 @@ class DefaultPrivateMessageWriteRepository @Inject constructor(
         val builder = FormBody.Builder(Charsets.UTF_8)
         builder.add("hash_check", form.hashCheck)
         builder.add("verifrequet", HfrConstants.VERIF_REQUET)
-        builder.add("content_form", bbcodeContent)
+        // #114 — strip non-BMP code points (emojis) HFR would silently truncate the message at.
+        builder.add("content_form", sanitizeContentForm(bbcodeContent))
         builder.add("dest", recipients)
         builder.add("sujet", subject)
         if (options.signatureEnabled) builder.add("signature", "1")

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultReplyRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultReplyRepository.kt
@@ -235,7 +235,8 @@ class DefaultReplyRepository @Inject constructor(
         val overrides = buildMap {
             put("hash_check", form.hashCheck)
             put("verifrequet", HfrConstants.VERIF_REQUET)
-            put("content_form", bbcodeContent)
+            // #114 — strip non-BMP code points (emojis) HFR would silently truncate the post at.
+            put("content_form", sanitizeContentForm(bbcodeContent))
             put("numreponse", "")
             // Quote: HFR identifies the cited post via `numrep`. Reply: empty.
             // The form's own hidden `numrep` (if any) is already echoed correctly

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultTopicFormRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultTopicFormRepository.kt
@@ -204,7 +204,8 @@ class DefaultTopicFormRepository @Inject constructor(
         val overrides = buildMap {
             put("hash_check", form.hashCheck)
             put("verifrequet", HfrConstants.VERIF_REQUET)
-            put("content_form", bbcodeContent)
+            // #114 — strip non-BMP code points (emojis) HFR would silently truncate the post at.
+            put("content_form", sanitizeContentForm(bbcodeContent))
             put("sujet", subject)
             put("numreponse", context.numreponse.toString())
             put("numrep", "")
@@ -391,7 +392,8 @@ class DefaultTopicFormRepository @Inject constructor(
         val overrides = buildMap {
             put("hash_check", form.hashCheck)
             put("verifrequet", HfrConstants.VERIF_REQUET)
-            put("content_form", bbcodeContent)
+            // #114 — strip non-BMP code points (emojis) HFR would silently truncate the post at.
+            put("content_form", sanitizeContentForm(bbcodeContent))
             put("sujet", subject)
             put("cat", context.cat.toString())
             // User's dropdown choice — always > 0 thanks to guardAgainstInvalidSubmission.

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/write/ContentFormSanitizerTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/write/ContentFormSanitizerTest.kt
@@ -1,0 +1,96 @@
+package fr.forumhfr.redface2.core.data.write
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the [sanitizeContentForm] contract (#114). HFR silently truncates a post at the first
+ * code point it cannot store (non-BMP / emoji), so the helper must drop every astral code point
+ * and every lone surrogate while leaving the whole BMP — BBCode, accents, combining marks,
+ * whitespace, punctuation, high-BMP selectors — untouched.
+ *
+ * Astral and invisible code points are written with explicit escapes / [Character.toChars] so the
+ * test source stays unambiguous (no relying on the editor to preserve a raw emoji or a zero-width
+ * selector verbatim).
+ */
+class ContentFormSanitizerTest {
+
+    /** Renders a single code point (BMP or astral) to its String form. */
+    private fun cp(codePoint: Int): String = String(Character.toChars(codePoint))
+
+    @Test
+    fun `emoji between text is removed and surrounding text preserved`() {
+        // U+1F600 GRINNING FACE.
+        assertEquals("beforeafter", sanitizeContentForm("before" + cp(0x1F600) + "after"))
+    }
+
+    @Test
+    fun `multiple emojis and a ZWJ sequence are fully stripped of astral parts`() {
+        // Family ZWJ sequence: man + ZWJ(U+200D, BMP) + woman + ZWJ + girl. The astral faces go,
+        // the BMP zero-width joiners between them stay (valid BMP scalar values).
+        val zwj = cp(0x200D)
+        val family = cp(0x1F468) + zwj + cp(0x1F469) + zwj + cp(0x1F467)
+        assertEquals("a$zwj${zwj}b", sanitizeContentForm("a${family}b"))
+    }
+
+    @Test
+    fun `bbcode tags and accented latin are left untouched`() {
+        val bbcode = "[b]éà œ ÿ ç[/b] [url=http://x]lien[/url]"
+        assertEquals(bbcode, sanitizeContentForm(bbcode))
+    }
+
+    @Test
+    fun `combining marks (BMP) survive`() {
+        // 'e' + U+0301 COMBINING ACUTE ACCENT — both BMP, must be kept verbatim.
+        val combining = "e" + cp(0x0301) + "galite"
+        assertEquals(combining, sanitizeContentForm(combining))
+    }
+
+    @Test
+    fun `lone high surrogate is removed`() {
+        assertEquals("ab", sanitizeContentForm("a\uD83Db"))
+    }
+
+    @Test
+    fun `lone low surrogate is removed`() {
+        assertEquals("ab", sanitizeContentForm("a\uDE00b"))
+    }
+
+    @Test
+    fun `whitespace tabs and newlines are preserved`() {
+        val text = "line1\nline2\r\n\tindented  spaced"
+        assertEquals(text, sanitizeContentForm(text))
+    }
+
+    @Test
+    fun `empty string is unchanged`() {
+        assertEquals("", sanitizeContentForm(""))
+    }
+
+    @Test
+    fun `pure BMP content takes the fast path unchanged`() {
+        val text = "Tout en BMP : ponctuation ! ? ; : , 12345 #@%"
+        assertEquals(text, sanitizeContentForm(text))
+    }
+
+    @Test
+    fun `high-BMP characters above the surrogate range are preserved`() {
+        // Valid BMP scalar values just above the surrogate range that must survive the slow path:
+        // U+E000 private-use, U+FE0F VARIATION SELECTOR-16, U+FF21 FULLWIDTH LATIN A,
+        // U+20E3 COMBINING ENCLOSING KEYCAP, U+2764 HEAVY BLACK HEART.
+        val highBmp = "a" + cp(0xE000) + cp(0xFE0F) + cp(0xFF21) + cp(0x20E3) + cp(0x2764) + "b"
+        assertEquals(highBmp, sanitizeContentForm(highBmp))
+    }
+
+    @Test
+    fun `astral base with a BMP variation selector keeps only the selector`() {
+        // U+1F642 SLIGHTLY SMILING FACE (astral) + U+FE0F (BMP selector): astral dropped, selector kept.
+        assertEquals(cp(0xFE0F), sanitizeContentForm(cp(0x1F642) + cp(0xFE0F)))
+    }
+
+    @Test
+    fun `string made only of astral code points becomes empty`() {
+        // U+1F600 + U+1F601, nothing else.
+        assertEquals("", sanitizeContentForm(cp(0x1F600) + cp(0x1F601)))
+    }
+}


### PR DESCRIPTION
**#114 — post tronqué.** Cause vérifiée live : HFR tronque silencieusement un post au 1er octet non-UTF-8 ; en pratique = caractères non supportés (emojis / code points astraux ≥ U+10000). Le contenu tapé par l'utilisateur (emoji) fait tronquer HFR (réponse 200 « succès » trompeuse).

**Fix** (décision cadrée + relue Codex) : `ContentFormSanitizer` (core/data/write) — strip silencieux des code points hors BMP (≥ U+10000) **et des surrogates orphelins** (0xD800–0xDFFF), tout le BMP préservé (BBCode, accents, combining marks, U+FE0F, whitespace), fast-path ASCII. Câblé aux **6 sites `content_form`** user-authored (reply, quote, edit, new-topic, edit-first-post, MP reply, MP compose). **Delete exclu** (re-poste un contenu déjà accepté). Mieux vaut perdre l'emoji que tout le post.

12 tests (`ContentFormSanitizerTest`). Build : core:data + assemble + detekt + lint verts. Cadré + relu par Codex.

Connexes investigués (rapport, non corrigés cette nuit) : #122 interligne (cause = encodage lignes vides 8.dp vs 20.sp ; besoin golden Roborazzi), #545 (isEditable, sélecteur toolbar), #555 (focus éditeur manquant), #583 (repro live requis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)