### PR TITLE
feat(#606): DT/MultiMP — l'owner peut ajouter/retirer des membres (override newdest)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultPrivateMessageWriteRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultPrivateMessageWriteRepository.kt
@@ -105,6 +105,7 @@ class DefaultPrivateMessageWriteRepository @Inject constructor(
         form: ReplyForm,
         bbcodeContent: String,
         options: ReplyFormOptions,
+        recipientsOverride: String?,
     ): ReplySubmitResult {
         guardAgainstInvalidSubmission(form, bbcodeContent)?.let { early ->
             diagnostics.record(
@@ -120,7 +121,7 @@ class DefaultPrivateMessageWriteRepository @Inject constructor(
             LOG_TAG,
             "POST MP reply post=${context.threadId} page=${context.page} bbcode.length=${bbcodeContent.length}",
         )
-        val formBody = buildFormBody(form, bbcodeContent, options)
+        val formBody = buildFormBody(form, bbcodeContent, options, recipientsOverride)
         return try {
             withContext(ioDispatcher) {
                 // Same endpoint as a topic reply: bddpost.php?config=hfr.inc. All MP routing
@@ -289,11 +290,19 @@ class DefaultPrivateMessageWriteRepository @Inject constructor(
      * as-is — it is NOT a quote reference), `subcat=0`, `page`, `sujet`, `pseudo`. `password` is never
      * relayed. This deliberately does not reuse [DefaultReplyRepository.buildFormBody], whose typed
      * `cat`/`numrep` overrides would corrupt the private-message contract.
+     *
+     * #606 — [recipientsOverride] mutates the DT/MultiMP member list **only when the form already
+     * carries a `newdest` key** (HFR serves it to the conversation's owner alone). The override
+     * value replaces HFR's prefilled `newdest` and the key is marked emitted up front, so the
+     * verbatim loop never appends a second `newdest`. Without that guard — a simple participant,
+     * a one-to-one MP, a topic reply — no `newdest` exists, the override is ignored, and any
+     * `newdest` HFR did send is forwarded verbatim (members unchanged).
      */
     private fun buildFormBody(
         form: ReplyForm,
         bbcodeContent: String,
         options: ReplyFormOptions,
+        recipientsOverride: String?,
     ): FormBody {
         val builder = FormBody.Builder(Charsets.UTF_8)
         builder.add("hash_check", form.hashCheck)
@@ -307,6 +316,13 @@ class DefaultPrivateMessageWriteRepository @Inject constructor(
         if (options.smileyDisabled) builder.add("smiley", "1")
         if (options.emailNotificationEnabled) builder.add("emaill", "1")
         val emitted = mutableSetOf("hash_check", "verifrequet", "content_form", "signature", "smiley", "emaill")
+        // #606 — owner-only member edit. The `newdest` key presence is the owner guard ; only then
+        // does a non-null override win over the prefill. Mark it emitted so the verbatim loop below
+        // can never duplicate it.
+        if (recipientsOverride != null && form.hiddenFields.containsKey("newdest")) {
+            builder.add("newdest", recipientsOverride)
+            emitted += "newdest"
+        }
         form.hiddenFields.forEach { (key, value) ->
             if (key in emitted) return@forEach
             // Belt-and-braces: ReplyFormParser already drops `password`, never relay it.

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/write/DefaultPrivateMessageWriteRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/write/DefaultPrivateMessageWriteRepositoryTest.kt
@@ -180,6 +180,81 @@ class DefaultPrivateMessageWriteRepositoryTest {
         assertEquals(0, server.requestCount)
     }
 
+    // #606 — owner manages DT/MultiMP members via a `newdest` override on the reply.
+
+    @Test
+    fun `submitReply forwards newdest verbatim when the owner passes no override`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("write_reply_success_response.html")))
+
+        val form = ReplyForm(
+            hashCheck = "h",
+            sujet = "s",
+            hiddenFields = mapOf(
+                "cat" to "prive",
+                "post" to "4242424",
+                "newdest" to "alice, bob, Administration",
+            ),
+            isAnonymous = false,
+        )
+        repository.submitReply(context, form, bbcodeContent = "hi") // recipientsOverride defaults to null
+
+        val raw = server.takeRequest().body.readUtf8()
+        val body = parseFormBody(raw)
+        // No edit → HFR's prefilled member list is reposted unchanged, exactly once.
+        assertEquals("alice, bob, Administration", body["newdest"])
+        assertEquals(1, raw.split('&').count { it.startsWith("newdest=") })
+    }
+
+    @Test
+    fun `submitReply ignores a recipientsOverride on a form without newdest (participant)`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("write_reply_success_response.html")))
+
+        // A simple participant's form has NO `newdest` key — the owner guard blocks the override.
+        val form = ReplyForm(
+            hashCheck = "h",
+            sujet = "s",
+            hiddenFields = mapOf("cat" to "prive", "post" to "4242424"),
+            isAnonymous = false,
+        )
+        repository.submitReply(
+            context,
+            form,
+            bbcodeContent = "hi",
+            recipientsOverride = "alice, intruder",
+        )
+
+        val body = parseFormBody(server.takeRequest().body.readUtf8())
+        assertFalse("a participant override must never introduce newdest", body.containsKey("newdest"))
+    }
+
+    @Test
+    fun `submitReply applies the owner override as a single modified newdest field`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("write_reply_success_response.html")))
+
+        val form = ReplyForm(
+            hashCheck = "h",
+            sujet = "s",
+            hiddenFields = mapOf(
+                "cat" to "prive",
+                "post" to "4242424",
+                "newdest" to "alice, bob, Administration",
+            ),
+            isAnonymous = false,
+        )
+        repository.submitReply(
+            context,
+            form,
+            bbcodeContent = "hi",
+            recipientsOverride = "bob, Bébé Yoda",
+        )
+
+        val raw = server.takeRequest().body.readUtf8()
+        val body = parseFormBody(raw)
+        // The override wins over the prefill, and exactly one `newdest` is emitted (no duplicate).
+        assertEquals("bob, Bébé Yoda", body["newdest"])
+        assertEquals(1, raw.split('&').count { it.startsWith("newdest=") })
+    }
+
     @Test
     fun `submitReply classifies the empty-message error response`() = runTest {
         server.enqueue(MockResponse().setBody(fixture("write_empty_message_error.html")))

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/write/PrivateMessageWriteRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/write/PrivateMessageWriteRepository.kt
@@ -36,11 +36,20 @@ interface PrivateMessageWriteRepository {
 
     suspend fun fetchReplyForm(context: PrivateMessageReplyContext): ReplyForm
 
+    /**
+     * POSTs a reply to the conversation. [recipientsOverride] (#606) is honoured **only when the
+     * form is an owner's DT/MultiMP** — i.e. [ReplyForm.canManageRecipients] is true (HFR served
+     * the `newdest` field). When non-null on such a form, the new CSV replaces HFR's prefilled
+     * `newdest`, adding / removing members alongside the posted reply. On any other form (a simple
+     * participant, a one-to-one MP, a topic reply) the override is ignored and `newdest`, if any,
+     * is forwarded verbatim — the safe default that never mutates the member list.
+     */
     suspend fun submitReply(
         context: PrivateMessageReplyContext,
         form: ReplyForm,
         bbcodeContent: String,
         options: ReplyFormOptions = ReplyFormOptions(),
+        recipientsOverride: String? = null,
     ): ReplySubmitResult
 
     /**

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/write/ReplyForm.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/write/ReplyForm.kt
@@ -75,7 +75,23 @@ data class ReplyForm(
      * unparseable forms — the repository falls back to `user_id=0`.
      */
     val userId: Int? = null,
-)
+) {
+    /**
+     * #606 — CSV of the DT/MultiMP members HFR prefills inside `<input name="newdest">`, served
+     * **only to the owner** of a group conversation (all current members minus the owner). `null`
+     * when the form has no `newdest` field — i.e. a one-to-one MP, a topic reply, or a group
+     * conversation where the logged-in user is a simple participant (not the owner).
+     *
+     * Read straight off [hiddenFields] (the parser already collects `newdest` in its `else`
+     * branch) rather than from any local source : the owner-only presence of the key is the
+     * single source of truth. The repository re-posts this value verbatim by default
+     * (members unchanged) ; an owner edit overrides it explicitly via `recipientsOverride`.
+     */
+    val manageableRecipients: String? get() = hiddenFields["newdest"]
+
+    /** #606 — true only when HFR served the owner-only `newdest` field (see [manageableRecipients]). */
+    val canManageRecipients: Boolean get() = manageableRecipients != null
+}
 
 /**
  * Per-post options HFR exposes as three checkboxes on the reply form. Captured

--- a/core/model/src/test/kotlin/fr/forumhfr/redface2/core/model/write/ReplyFormTest.kt
+++ b/core/model/src/test/kotlin/fr/forumhfr/redface2/core/model/write/ReplyFormTest.kt
@@ -1,0 +1,43 @@
+package fr.forumhfr.redface2.core.model.write
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #606 — pins the owner-detection contract on [ReplyForm]. HFR serves `<input name="newdest">`
+ * only to the owner of a DT/MultiMP, so [ReplyForm.manageableRecipients] / [canManageRecipients]
+ * read straight off the parsed hidden fields : present ⇒ owner can manage members, absent ⇒ a
+ * one-to-one MP / topic reply / simple participant.
+ */
+class ReplyFormTest {
+
+    private fun form(hiddenFields: Map<String, String>): ReplyForm = ReplyForm(
+        hashCheck = "h",
+        sujet = "s",
+        hiddenFields = hiddenFields,
+        isAnonymous = false,
+    )
+
+    @Test
+    fun `a form without newdest exposes no manageable recipients`() {
+        val replyForm = form(mapOf("cat" to "prive", "post" to "4242424"))
+        assertNull(replyForm.manageableRecipients)
+        assertFalse(replyForm.canManageRecipients)
+    }
+
+    @Test
+    fun `a form with newdest surfaces the prefilled CSV verbatim`() {
+        val replyForm = form(
+            mapOf(
+                "cat" to "prive",
+                "post" to "4242424",
+                "newdest" to "alice, bob, Bébé Yoda, stitch+, Administration",
+            ),
+        )
+        assertTrue(replyForm.canManageRecipients)
+        assertEquals("alice, bob, Bébé Yoda, stitch+, Administration", replyForm.manageableRecipients)
+    }
+}

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/write/PrivateMessageReplyFormParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/write/PrivateMessageReplyFormParserTest.kt
@@ -46,6 +46,31 @@ class PrivateMessageReplyFormParserTest {
         assertTrue("hidden fields should not be empty", form.hiddenFields.isNotEmpty())
     }
 
+    @Test
+    fun `a one-to-one MP form is not an owner-managed DT (no newdest)`() {
+        val form = parser.parse(fixture("private_message_thread.html")).getOrThrow()
+
+        // #606 — a regular conversation has no `newdest` field, so the user can't manage members.
+        assertFalse("a one-to-one MP exposes no member editor", form.canManageRecipients)
+        assertEquals(null, form.manageableRecipients)
+    }
+
+    @Test
+    fun `an owner DT form exposes the prefilled member CSV via newdest`() {
+        val form = parser.parse(fixture("private_message_dt_owner_reply_form.html")).getOrThrow()
+
+        assertFalse("authenticated owner form is never anonymous", form.isAnonymous)
+        // #606 — HFR serves `newdest` only to the owner ; the parser already collects it verbatim.
+        assertTrue("owner DT form must expose the member editor", form.canManageRecipients)
+        assertEquals(
+            "alice, bob, Bébé Yoda, stitch+, Administration",
+            form.manageableRecipients,
+        )
+        // The owner-only DT carries owntopic=1 and cat=prive, forwarded verbatim on POST.
+        assertEquals("prive", form.hiddenFields["cat"])
+        assertEquals("1", form.hiddenFields["owntopic"])
+    }
+
     private fun fixture(name: String): String {
         val stream = requireNotNull(
             PrivateMessageReplyFormParserTest::class.java.classLoader?.getResourceAsStream("fixtures/$name"),

--- a/core/parser/src/test/resources/fixtures/private_message_dt_owner_reply_form.html
+++ b/core/parser/src/test/resources/fixtures/private_message_dt_owner_reply_form.html
@@ -1,0 +1,35 @@
+<!--
+  #606 — SANITISED fixture : reply form of a DT/MultiMP where the logged-in user is the OWNER.
+  HFR serves an extra `<input name="newdest">` (text input, prefilled with the CSV of all current
+  members minus the owner) ONLY to the owner of a group conversation. Everything here is fake:
+  bogus pseudos (alice, bob, "Bébé Yoda", "stitch+"), no real private content, no real hash_check
+  (value="TESTHASH"). Reduced to the bddpost.php reply form so the parser test has the smallest
+  faithful shape carrying `newdest`. cf. /work/xaat/spec-dt-membership.md
+-->
+<html><body>
+<form name="hop" action="/bddpost.php" method="post" onsubmit="document.hop.submit.style.visibility='hidden';">
+<input type="hidden" name="hash_check" value="TESTHASH" />
+<div class="s2Ext"><b>Réponse rapide</b>
+<tr class="reponse">
+  <th class="repCase1">Destinataires</th>
+  <td class="repCase2"><input size="25" name="newdest" value="alice, bob, Bébé Yoda, stitch+, Administration" id="newdest" />
+   Vous pouvez ajouter ou supprimer des destinataires (un destinataire au minimum !)</td>
+</tr>
+<textarea rows="5" cols="60" name="content_form" class="reponserapide" id="content_form" accesskey="c"></textarea>
+<input type="submit" accesskey="s" value="Valider votre message" name="submit" id="submitreprap"/>
+<input type="hidden" name="new" value="0" />
+<input type="hidden" name="post" value="4242424" /><input type="hidden" name="numrep" value="1990000111" /><input type="hidden" name="cat" value="prive" />
+<input type="hidden" name="subcat" value="0" />
+<input type="hidden" name="page" value="1" />
+<input type="hidden" name="verifrequet" value="1100" />
+<input type="hidden" name="p" value="1" />
+<input type="hidden" name="sondage" value="0" />
+<input type="hidden" name="cache" value="" />
+<input type="hidden" name="owntopic" value="1" />
+<input type="hidden" name="config" value="hfr.inc" />
+<input type="hidden" name="emaill" value="" />
+<input type="hidden" name="pseudo" value="TestOwner" />
+<input type="hidden" name="sujet" value="Discussion de groupe de test" />
+<input type="hidden" value="1" name="signature" />
+</div></form>
+</body></html>

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessageEditorComponents.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessageEditorComponents.kt
@@ -17,18 +17,25 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.InputChip
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -105,6 +112,92 @@ internal fun MessageDraftRestoreBanner(
                     Text(text = stringResource(R.string.messages_draft_discard))
                 }
             }
+        }
+    }
+}
+
+/**
+ * #606 — DT/MultiMP member editor, shown only to the conversation OWNER (gated by
+ * `state.canManageRecipients` at the call site). Renders each current member as an [InputChip] with
+ * a remove affordance, plus a text field + button to append a new member. The change is sent with
+ * the reply (HFR mutates the member list only via a posted reply). Removing « Administration »
+ * raises an inline warning but is not blocked. The last remaining member can't be removed — the VM
+ * enforces « un destinataire au minimum », so its remove chip is disabled here too.
+ */
+@Composable
+@Suppress("LongParameterList") // List + 2 callbacks + enabled — each call-site distinct.
+internal fun MessageRecipientsEditor(
+    recipients: List<String>,
+    enabled: Boolean,
+    onAddRecipient: (String) -> Unit,
+    onRemoveRecipient: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var pendingPseudo by remember { mutableStateOf("") }
+    val canRemove = recipients.size > 1
+    val showsAdminWarning = recipients.none { it.equals(ADMIN_PSEUDO, ignoreCase = true) }
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.messages_members_title),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = stringResource(R.string.messages_members_help),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            recipients.forEach { pseudo ->
+                val removeLabel = stringResource(R.string.messages_members_remove, pseudo)
+                InputChip(
+                    selected = false,
+                    enabled = enabled && canRemove,
+                    onClick = { onRemoveRecipient(pseudo) },
+                    label = { Text(pseudo) },
+                    trailingIcon = {
+                        Icon(
+                            painter = painterResource(fr.forumhfr.redface2.core.ui.R.drawable.ic_close),
+                            contentDescription = removeLabel,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    },
+                )
+            }
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            OutlinedTextField(
+                value = pendingPseudo,
+                onValueChange = { pendingPseudo = it },
+                singleLine = true,
+                enabled = enabled,
+                label = { Text(stringResource(R.string.messages_members_add_label)) },
+                placeholder = { Text(stringResource(R.string.messages_members_add_placeholder)) },
+                modifier = Modifier.weight(1f),
+            )
+            FilledTonalButton(
+                onClick = {
+                    onAddRecipient(pendingPseudo)
+                    pendingPseudo = ""
+                },
+                enabled = enabled && pendingPseudo.isNotBlank(),
+            ) {
+                Text(text = stringResource(R.string.messages_members_add))
+            }
+        }
+        if (showsAdminWarning) {
+            Text(
+                text = stringResource(R.string.messages_members_admin_warning),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+            )
         }
     }
 }
@@ -267,6 +360,9 @@ private fun MessageOptionToggle(
         Switch(checked = checked, enabled = enabled, onCheckedChange = onCheckedChange)
     }
 }
+
+/** #606 — HFR's system member of a group conversation ; removing it warrants a warning, not a block. */
+private const val ADMIN_PSEUDO = "Administration"
 
 internal val PrivateMessageReplyError.bannerResId: Int
     get() = when (this) {

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeScreen.kt
@@ -211,8 +211,10 @@ private fun ComposeEditorBody(
             onValueChange = onRecipientsChanged,
             singleLine = true,
             enabled = !state.isSubmitting,
-            label = { Text(stringResource(R.string.messages_compose_recipients_label)) },
+            // #606 — clearer label + a one-liner that explains a CSV makes a group conversation.
+            label = { Text(stringResource(R.string.messages_compose_recipients_label_v2)) },
             placeholder = { Text(stringResource(R.string.messages_compose_recipients_placeholder)) },
+            supportingText = { Text(stringResource(R.string.messages_compose_recipients_help)) },
             modifier = Modifier.fillMaxWidth(),
         )
 

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
@@ -78,6 +78,8 @@ fun PrivateMessageReplyScreen(
         onRetryFormLoad = viewModel::retryFormLoad,
         onDraftRestore = viewModel::onDraftRestoreRequested,
         onDraftDiscard = viewModel::onDraftDiscardRequested,
+        onAddRecipient = viewModel::onAddRecipient,
+        onRemoveRecipient = viewModel::onRemoveRecipient,
         smileyPicker = viewModel.smileyPicker,
         onSmileySelected = viewModel::onSmileySelected,
         modifier = modifier,
@@ -102,6 +104,8 @@ private fun PrivateMessageReplyContent(
     onRetryFormLoad: () -> Unit,
     onDraftRestore: () -> Unit,
     onDraftDiscard: () -> Unit,
+    onAddRecipient: (String) -> Unit,
+    onRemoveRecipient: (String) -> Unit,
     smileyPicker: SmileyPickerController,
     onSmileySelected: (String) -> Unit,
     modifier: Modifier = Modifier,
@@ -122,6 +126,8 @@ private fun PrivateMessageReplyContent(
                         onErrorDismissed = onErrorDismissed,
                         onDraftRestore = onDraftRestore,
                         onDraftDiscard = onDraftDiscard,
+                        onAddRecipient = onAddRecipient,
+                        onRemoveRecipient = onRemoveRecipient,
                         modifier = Modifier.weight(1f),
                     )
                     MessageSubmitBar(
@@ -175,6 +181,8 @@ private fun ReplyEditorBody(
     onErrorDismissed: () -> Unit,
     onDraftRestore: () -> Unit,
     onDraftDiscard: () -> Unit,
+    onAddRecipient: (String) -> Unit,
+    onRemoveRecipient: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     // No outer scroll : the draft field is weighted so it stretches down to the bar (same
@@ -186,6 +194,18 @@ private fun ReplyEditorBody(
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
+        // #606 — owner-only member editor, above the body. Hidden for a simple participant /
+        // one-to-one MP (canManageRecipients is false).
+        if (state.canManageRecipients) {
+            MessageRecipientsEditor(
+                recipients = state.recipients,
+                enabled = !state.isSubmitting,
+                onAddRecipient = onAddRecipient,
+                onRemoveRecipient = onRemoveRecipient,
+            )
+            HorizontalDivider()
+        }
+
         BbcodeToolbar(onAction = onToolbarAction)
 
         BbcodeTextField(

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyUiState.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyUiState.kt
@@ -46,6 +46,19 @@ data class PrivateMessageReplyUiState(
      * the editor, « Ignorer » deletes the cached row. Never silently applied nor lost.
      */
     val restorableDraft: String? = null,
+    /**
+     * #606 — true only when the loaded form is the OWNER's DT/MultiMP (HFR served the `newdest`
+     * field). Gates the member editor in the UI ; a simple participant / one-to-one MP keeps it
+     * false and never sees the editor.
+     */
+    val canManageRecipients: Boolean = false,
+    /**
+     * #606 — current working list of DT/MultiMP members (owner view), parsed from HFR's `newdest`
+     * CSV on form load and mutated by add / remove. Order, case, accents, `+` and internal spaces
+     * are preserved verbatim (« Bébé Yoda », « stitch+ ») ; only the leading / trailing whitespace
+     * of each CSV element is trimmed. Empty when [canManageRecipients] is false.
+     */
+    val recipients: List<String> = emptyList(),
 ) {
     val canSubmit: Boolean
         get() = formAvailable && !isLoadingForm && !isSubmitting && draft.text.isNotBlank()

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyUiState.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyUiState.kt
@@ -59,6 +59,13 @@ data class PrivateMessageReplyUiState(
      * of each CSV element is trimmed. Empty when [canManageRecipients] is false.
      */
     val recipients: List<String> = emptyList(),
+    /**
+     * #606 — true once the owner has actually added / removed a member. Until then the submit sends
+     * `recipientsOverride = null` so the repository forwards HFR's original `newdest` **verbatim**
+     * (a normal owner reply must never round-trip the member list through parse → join, which would
+     * normalise whitespace / drop entries and risk losing members). Only an explicit edit arms it.
+     */
+    val recipientsDirty: Boolean = false,
 ) {
     val canSubmit: Boolean
         get() = formAvailable && !isLoadingForm && !isSubmitting && draft.text.isNotBlank()

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
@@ -196,6 +196,16 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
                             current.emailNotificationEnabled
                         },
                         optionsHydratedFromForm = true,
+                        // #606 — owner-only member editor. Hydrate the working list from HFR's
+                        // `newdest` CSV on the FIRST load only : a silent refetch after an expired
+                        // hash_check (InvalidHashCheck) must not clobber a member the user added /
+                        // removed in between — same `hydrateOptions` guard as the option toggles.
+                        canManageRecipients = form.canManageRecipients,
+                        recipients = if (hydrateOptions) {
+                            RecipientCsv.parse(form.manageableRecipients)
+                        } else {
+                            current.recipients
+                        },
                     )
                 }
             } catch (cancellation: CancellationException) {
@@ -283,6 +293,42 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
     fun onToggleEmailNotification(enabled: Boolean) =
         _state.update { it.copy(emailNotificationEnabled = enabled) }
 
+    /**
+     * #606 — owner adds a member to the DT/MultiMP. The pseudo is appended at the end (HFR keeps
+     * insertion order), trimmed of leading / trailing whitespace but otherwise verbatim (case,
+     * accents, `+`, internal spaces preserved). A blank entry or an exact-trimmed duplicate of an
+     * existing member is refused (no-op). Ignored entirely when the user is not the owner.
+     */
+    fun onAddRecipient(pseudo: String) {
+        if (!_state.value.canManageRecipients) return
+        val trimmed = pseudo.trim()
+        if (trimmed.isEmpty()) return
+        _state.update { current ->
+            if (current.recipients.any { it == trimmed }) {
+                current
+            } else {
+                current.copy(recipients = current.recipients + trimmed)
+            }
+        }
+    }
+
+    /**
+     * #606 — owner removes a member. Exact match after trim (`bob` never removes `bob2`). The last
+     * remaining member can't be removed — HFR enforces « un destinataire au minimum ». Ignored when
+     * the user is not the owner.
+     */
+    fun onRemoveRecipient(pseudo: String) {
+        if (!_state.value.canManageRecipients) return
+        val target = pseudo.trim()
+        _state.update { current ->
+            if (current.recipients.size <= 1 || current.recipients.none { it == target }) {
+                current
+            } else {
+                current.copy(recipients = current.recipients.filterNot { it == target })
+            }
+        }
+    }
+
     fun onErrorDismissed() = _state.update { it.copy(submitError = null) }
 
     /**
@@ -327,6 +373,14 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
             smileyDisabled = snapshot.smileyDisabled,
             emailNotificationEnabled = snapshot.emailNotificationEnabled,
         )
+        // #606 — only an owner (canManageRecipients) overrides the member list ; a simple
+        // participant always passes null so the repository forwards HFR's `newdest`, if any,
+        // verbatim. The CSV is recomposed with HFR's own `, ` separator.
+        val recipientsOverride = if (snapshot.canManageRecipients) {
+            RecipientCsv.join(snapshot.recipients)
+        } else {
+            null
+        }
         _state.update { it.copy(isSubmitting = true, submitError = null) }
         submitJob = viewModelScope.launch {
             val outcome = runCatching {
@@ -335,6 +389,7 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
                     form = form,
                     bbcodeContent = snapshot.draft.text,
                     options = options,
+                    recipientsOverride = recipientsOverride,
                 )
             }
             outcome.fold(
@@ -428,4 +483,26 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
  */
 sealed interface PrivateMessageReplyEffect {
     data class SubmitSucceeded(val threadId: Int, val page: Int) : PrivateMessageReplyEffect
+}
+
+/**
+ * #606 — pure CSV codec for the DT/MultiMP member list HFR ships in `newdest`. Kept separate from
+ * the ViewModel so it is trivially unit-testable and shares no mutable state.
+ *
+ * - [parse] splits on `,`, trims each element's surrounding whitespace and drops empties, while
+ *   preserving order, case, accents, `+` and any internal spaces (« Bébé Yoda », « stitch+ »). A
+ *   null / blank CSV (a non-owner form, or HFR sending an empty value) yields an empty list.
+ * - [join] recomposes with HFR's own `, ` separator so the POST `newdest` mirrors the field HFR
+ *   prefills.
+ */
+internal object RecipientCsv {
+    private const val SEPARATOR = ", "
+
+    fun parse(csv: String?): List<String> =
+        csv.orEmpty()
+            .split(',')
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+
+    fun join(recipients: List<String>): String = recipients.joinToString(SEPARATOR)
 }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
@@ -201,7 +201,13 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
                         // hash_check (InvalidHashCheck) must not clobber a member the user added /
                         // removed in between — same `hydrateOptions` guard as the option toggles.
                         canManageRecipients = form.canManageRecipients,
-                        recipients = if (hydrateOptions) {
+                        // Re-hydrate from the freshly-parsed `newdest` on the first load AND on any
+                        // silent refetch where the user has NOT edited the list : that way a
+                        // concurrent membership change made elsewhere is picked up, and — since a
+                        // non-dirty submit sends `recipientsOverride = null` — the original `newdest`
+                        // is still forwarded verbatim. Only an in-progress edit (`recipientsDirty`)
+                        // is preserved across the refetch.
+                        recipients = if (hydrateOptions || !current.recipientsDirty) {
                             RecipientCsv.parse(form.manageableRecipients)
                         } else {
                             current.recipients
@@ -307,7 +313,7 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
             if (current.recipients.any { it == trimmed }) {
                 current
             } else {
-                current.copy(recipients = current.recipients + trimmed)
+                current.copy(recipients = current.recipients + trimmed, recipientsDirty = true)
             }
         }
     }
@@ -324,7 +330,10 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
             if (current.recipients.size <= 1 || current.recipients.none { it == target }) {
                 current
             } else {
-                current.copy(recipients = current.recipients.filterNot { it == target })
+                current.copy(
+                    recipients = current.recipients.filterNot { it == target },
+                    recipientsDirty = true,
+                )
             }
         }
     }
@@ -373,10 +382,12 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
             smileyDisabled = snapshot.smileyDisabled,
             emailNotificationEnabled = snapshot.emailNotificationEnabled,
         )
-        // #606 — only an owner (canManageRecipients) overrides the member list ; a simple
-        // participant always passes null so the repository forwards HFR's `newdest`, if any,
-        // verbatim. The CSV is recomposed with HFR's own `, ` separator.
-        val recipientsOverride = if (snapshot.canManageRecipients) {
+        // #606 — only an owner who ACTUALLY edited the member list overrides it. Without an edit
+        // (`recipientsDirty == false`) — including every non-owner reply — we pass null so the
+        // repository forwards HFR's original `newdest` VERBATIM : a normal owner reply must never
+        // round-trip the list through parse → join (which normalises whitespace / drops entries and
+        // could silently lose members). The CSV is recomposed with HFR's own `, ` separator.
+        val recipientsOverride = if (snapshot.canManageRecipients && snapshot.recipientsDirty) {
             RecipientCsv.join(snapshot.recipients)
         } else {
             null

--- a/feature/messages/src/main/res/values/strings.xml
+++ b/feature/messages/src/main/res/values/strings.xml
@@ -22,7 +22,6 @@
     <string name="messages_reply_title">Répondre</string>
     <string name="messages_compose_title">Nouveau message</string>
     <string name="messages_compose_new">Nouveau</string>
-    <string name="messages_compose_recipients_label">Destinataire(s)</string>
     <string name="messages_compose_recipients_placeholder">Pseudo(s), séparés par des virgules…</string>
     <string name="messages_compose_subject_label">Sujet</string>
     <string name="messages_compose_subject_counter">%1$d/%2$d</string>
@@ -54,4 +53,17 @@
     <string name="messages_draft_restore_message">Un brouillon non envoyé a été retrouvé.</string>
     <string name="messages_draft_restore">Restaurer</string>
     <string name="messages_draft_discard">Ignorer</string>
+
+    <!-- #606 — gestion des membres d'une discussion de groupe (réservé au créateur). -->
+    <string name="messages_members_title">Membres de la discussion</string>
+    <string name="messages_members_help">Vous êtes le créateur : vous pouvez ajouter ou retirer des membres (un destinataire au minimum). La modification est envoyée avec votre réponse.</string>
+    <string name="messages_members_add_label">Ajouter un membre</string>
+    <string name="messages_members_add_placeholder">Pseudo à ajouter…</string>
+    <string name="messages_members_add">Ajouter</string>
+    <string name="messages_members_remove">Retirer %1$s</string>
+    <string name="messages_members_admin_warning">Retirer « Administration » d\'une discussion de groupe est déconseillé.</string>
+
+    <!-- #606 — libellé du champ destinataires du nouveau message (compose). -->
+    <string name="messages_compose_recipients_label_v2">Pseudo des destinataires</string>
+    <string name="messages_compose_recipients_help">Plusieurs pseudos séparés par des virgules = discussion de groupe.</string>
 </resources>

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
@@ -88,6 +88,20 @@ class PrivateMessageReplyViewModelTest {
         isAnonymous = isAnonymous,
     )
 
+    /** #606 — owner DT/MultiMP form: HFR serves the `newdest` CSV (members minus the owner). */
+    private fun ownerForm(
+        newdest: String = "alice, bob, Bébé Yoda, stitch+, Administration",
+    ): ReplyForm = form(
+        hiddenFields = mapOf(
+            "cat" to "prive",
+            "post" to "4242424",
+            "numrep" to "1990000111",
+            "owntopic" to "1",
+            "signature" to "1",
+            "newdest" to newdest,
+        ),
+    )
+
     @Test
     fun `loads the form on init and hydrates signature from the hidden field`() = runTest {
         val repository = mockk<PrivateMessageWriteRepository>()
@@ -126,7 +140,7 @@ class PrivateMessageReplyViewModelTest {
     fun `submit success raises SubmitSucceeded for the conversation`() = runTest {
         val repository = mockk<PrivateMessageWriteRepository>()
         coEvery { repository.fetchReplyForm(any()) } returns form()
-        coEvery { repository.submitReply(any(), any(), any(), any()) } returns
+        coEvery { repository.submitReply(any(), any(), any(), any(), any()) } returns
             ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
 
         val viewModel = PrivateMessageReplyViewModel(
@@ -150,7 +164,7 @@ class PrivateMessageReplyViewModelTest {
     fun `empty-message failure shows the banner and keeps the draft`() = runTest {
         val repository = mockk<PrivateMessageWriteRepository>()
         coEvery { repository.fetchReplyForm(any()) } returns form()
-        coEvery { repository.submitReply(any(), any(), any(), any()) } returns
+        coEvery { repository.submitReply(any(), any(), any(), any(), any()) } returns
             ReplySubmitResult.Failure(ReplyFailureReason.EmptyMessage)
 
         val viewModel = PrivateMessageReplyViewModel(
@@ -169,7 +183,7 @@ class PrivateMessageReplyViewModelTest {
     fun `invalid hash check refetches the form silently`() = runTest {
         val repository = mockk<PrivateMessageWriteRepository>()
         coEvery { repository.fetchReplyForm(any()) } returns form()
-        coEvery { repository.submitReply(any(), any(), any(), any()) } returns
+        coEvery { repository.submitReply(any(), any(), any(), any(), any()) } returns
             ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)
 
         val viewModel = PrivateMessageReplyViewModel(
@@ -187,7 +201,7 @@ class PrivateMessageReplyViewModelTest {
     fun `invalid hash check refetch preserves the user option toggles`() = runTest {
         val repository = mockk<PrivateMessageWriteRepository>()
         coEvery { repository.fetchReplyForm(any()) } returns form()
-        coEvery { repository.submitReply(any(), any(), any(), any()) } returns
+        coEvery { repository.submitReply(any(), any(), any(), any(), any()) } returns
             ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)
 
         val viewModel = PrivateMessageReplyViewModel(
@@ -211,7 +225,7 @@ class PrivateMessageReplyViewModelTest {
     fun `unknown response maps to the non-destructive unexpected banner`() = runTest {
         val repository = mockk<PrivateMessageWriteRepository>()
         coEvery { repository.fetchReplyForm(any()) } returns form()
-        coEvery { repository.submitReply(any(), any(), any(), any()) } returns
+        coEvery { repository.submitReply(any(), any(), any(), any(), any()) } returns
             ReplySubmitResult.Failure(ReplyFailureReason.Unknown)
 
         val viewModel = PrivateMessageReplyViewModel(
@@ -268,7 +282,7 @@ class PrivateMessageReplyViewModelTest {
     fun `confirm-before-posting OFF keeps the one-tap submit unchanged`() = runTest {
         val repository = mockk<PrivateMessageWriteRepository>()
         coEvery { repository.fetchReplyForm(any()) } returns form()
-        coEvery { repository.submitReply(any(), any(), any(), any()) } returns
+        coEvery { repository.submitReply(any(), any(), any(), any(), any()) } returns
             ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
 
         val viewModel = PrivateMessageReplyViewModel(
@@ -277,7 +291,7 @@ class PrivateMessageReplyViewModelTest {
         viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
         viewModel.onSubmit()
 
-        coVerify(exactly = 1) { repository.submitReply(any(), any(), any(), any()) }
+        coVerify(exactly = 1) { repository.submitReply(any(), any(), any(), any(), any()) }
         assertFalse(viewModel.state.value.showSubmitConfirmation)
     }
 
@@ -299,14 +313,14 @@ class PrivateMessageReplyViewModelTest {
 
         assertTrue("the confirmation dialog must be armed", viewModel.state.value.showSubmitConfirmation)
         assertFalse("nothing is in flight while the dialog is up", viewModel.state.value.isSubmitting)
-        coVerify(exactly = 0) { repository.submitReply(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { repository.submitReply(any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `confirm-before-posting ON onSubmitConfirmed executes the real submission without re-confirming`() = runTest {
         val repository = mockk<PrivateMessageWriteRepository>()
         coEvery { repository.fetchReplyForm(any()) } returns form()
-        coEvery { repository.submitReply(any(), any(), any(), any()) } returns
+        coEvery { repository.submitReply(any(), any(), any(), any(), any()) } returns
             ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
 
         val viewModel = PrivateMessageReplyViewModel(
@@ -319,7 +333,7 @@ class PrivateMessageReplyViewModelTest {
         )
         viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
         viewModel.onSubmit()
-        coVerify(exactly = 0) { repository.submitReply(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { repository.submitReply(any(), any(), any(), any(), any()) }
 
         viewModel.effects.test {
             viewModel.onSubmitConfirmed()
@@ -330,7 +344,7 @@ class PrivateMessageReplyViewModelTest {
             cancelAndIgnoreRemainingEvents()
         }
         // Confirm bypasses the preference re-check : exactly one POST, no dialog re-arm.
-        coVerify(exactly = 1) { repository.submitReply(any(), any(), any(), any()) }
+        coVerify(exactly = 1) { repository.submitReply(any(), any(), any(), any(), any()) }
         assertFalse(viewModel.state.value.showSubmitConfirmation)
     }
 
@@ -355,7 +369,7 @@ class PrivateMessageReplyViewModelTest {
         assertFalse(viewModel.state.value.showSubmitConfirmation)
         assertEquals("the draft survives the dismissal", "Coucou en privé.", viewModel.state.value.draft.text)
         assertNull(viewModel.state.value.submitError)
-        coVerify(exactly = 0) { repository.submitReply(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { repository.submitReply(any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -376,7 +390,7 @@ class PrivateMessageReplyViewModelTest {
         viewModel.onSubmit()
 
         assertFalse("invalid form must not raise the dialog", viewModel.state.value.showSubmitConfirmation)
-        coVerify(exactly = 0) { repository.submitReply(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { repository.submitReply(any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -402,7 +416,7 @@ class PrivateMessageReplyViewModelTest {
 
         assertTrue("the dialog must stay armed", viewModel.state.value.showSubmitConfirmation)
         assertFalse("nothing is in flight while the dialog is up", viewModel.state.value.isSubmitting)
-        coVerify(exactly = 0) { repository.submitReply(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { repository.submitReply(any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -413,7 +427,7 @@ class PrivateMessageReplyViewModelTest {
         // non-suspending mock would complete synchronously and the second confirm would
         // legitimately re-fire. The gate keeps `submitJob` active across both confirms.
         val gate = CompletableDeferred<Unit>()
-        coEvery { repository.submitReply(any(), any(), any(), any()) } coAnswers {
+        coEvery { repository.submitReply(any(), any(), any(), any(), any()) } coAnswers {
             gate.await()
             ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
         }
@@ -435,7 +449,7 @@ class PrivateMessageReplyViewModelTest {
 
         gate.complete(Unit)
 
-        coVerify(exactly = 1) { repository.submitReply(any(), any(), any(), any()) }
+        coVerify(exactly = 1) { repository.submitReply(any(), any(), any(), any(), any()) }
         assertFalse(viewModel.state.value.showSubmitConfirmation)
         assertFalse(viewModel.state.value.isSubmitting)
     }
@@ -499,7 +513,7 @@ class PrivateMessageReplyViewModelTest {
     fun `a successful MP reply submit deletes the cached draft`() = runTest {
         val repository = mockk<PrivateMessageWriteRepository>()
         coEvery { repository.fetchReplyForm(any()) } returns form()
-        coEvery { repository.submitReply(any(), any(), any(), any()) } returns
+        coEvery { repository.submitReply(any(), any(), any(), any(), any()) } returns
             ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
         val viewModel = PrivateMessageReplyViewModel(
             request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
@@ -510,6 +524,200 @@ class PrivateMessageReplyViewModelTest {
         advanceUntilIdle()
 
         assertTrue(draftStore.deletedKeys.contains(EditorDraftKey.mpReply(request.threadId)))
+    }
+
+    // ----- #606 : owner manages DT/MultiMP members --------------------------------
+
+    @Test
+    fun `a non-owner form exposes no member editor and never overrides newdest`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns form() // no newdest
+        coEvery { repository.submitReply(any(), any(), any(), any(), any()) } returns
+            ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
+
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+        )
+
+        assertFalse(viewModel.state.value.canManageRecipients)
+        assertTrue(viewModel.state.value.recipients.isEmpty())
+
+        // Even if add/remove are called on a participant form, they no-op.
+        viewModel.onAddRecipient("intruder")
+        viewModel.onRemoveRecipient("anyone")
+        assertTrue(viewModel.state.value.recipients.isEmpty())
+
+        viewModel.onContentChanged(TextFieldValue("hello"))
+        viewModel.onSubmit()
+        // A participant never overrides the member list — recipientsOverride stays null.
+        coVerify {
+            repository.submitReply(
+                context = any(),
+                form = any(),
+                bbcodeContent = any(),
+                options = any(),
+                recipientsOverride = null,
+            )
+        }
+    }
+
+    @Test
+    fun `an owner form hydrates the members CSV preserving order, accents, plus and spaces`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns ownerForm()
+
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+        )
+
+        assertTrue(viewModel.state.value.canManageRecipients)
+        assertEquals(
+            listOf("alice", "bob", "Bébé Yoda", "stitch+", "Administration"),
+            viewModel.state.value.recipients,
+        )
+    }
+
+    @Test
+    fun `owner submit without edits reposts the member CSV verbatim`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns ownerForm()
+        coEvery { repository.submitReply(any(), any(), any(), any(), any()) } returns
+            ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
+
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+        )
+        viewModel.onContentChanged(TextFieldValue("hello"))
+
+        viewModel.onSubmit()
+        // Round-trip is loss-less: same members, HFR's own `, ` separator.
+        coVerify {
+            repository.submitReply(
+                context = any(),
+                form = any(),
+                bbcodeContent = any(),
+                options = any(),
+                recipientsOverride = "alice, bob, Bébé Yoda, stitch+, Administration",
+            )
+        }
+    }
+
+    @Test
+    fun `owner adds a member appended at the end`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns ownerForm(newdest = "alice, bob")
+
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+        )
+
+        viewModel.onAddRecipient("  charlie  ") // trimmed before insertion
+        assertEquals(listOf("alice", "bob", "charlie"), viewModel.state.value.recipients)
+    }
+
+    @Test
+    fun `owner add refuses an exact-trimmed duplicate`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns ownerForm(newdest = "alice, bob")
+
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+        )
+
+        viewModel.onAddRecipient(" alice ")
+        assertEquals("no duplicate appended", listOf("alice", "bob"), viewModel.state.value.recipients)
+    }
+
+    @Test
+    fun `owner remove is exact-match so bob does not delete bob2`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns ownerForm(newdest = "alice, bob, bob2")
+
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+        )
+
+        viewModel.onRemoveRecipient("bob")
+        assertEquals(listOf("alice", "bob2"), viewModel.state.value.recipients)
+    }
+
+    @Test
+    fun `owner can remove down to one but never the last member`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns ownerForm(newdest = "alice, bob")
+
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+        )
+
+        viewModel.onRemoveRecipient("alice")
+        assertEquals("down to one is allowed", listOf("bob"), viewModel.state.value.recipients)
+
+        viewModel.onRemoveRecipient("bob")
+        assertEquals("the last member can't be removed", listOf("bob"), viewModel.state.value.recipients)
+    }
+
+    @Test
+    fun `owner edits travel to the repository as the recomposed CSV`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns ownerForm(newdest = "alice, bob")
+        coEvery { repository.submitReply(any(), any(), any(), any(), any()) } returns
+            ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
+
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+        )
+        viewModel.onRemoveRecipient("alice")
+        viewModel.onAddRecipient("Bébé Yoda")
+        viewModel.onContentChanged(TextFieldValue("hello"))
+
+        viewModel.onSubmit()
+        coVerify {
+            repository.submitReply(
+                context = any(),
+                form = any(),
+                bbcodeContent = any(),
+                options = any(),
+                recipientsOverride = "bob, Bébé Yoda",
+            )
+        }
+    }
+
+    @Test
+    fun `the member list survives a silent hash-check refetch`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any()) } returns ownerForm(newdest = "alice, bob")
+        coEvery { repository.submitReply(any(), any(), any(), any(), any()) } returns
+            ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)
+
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+        )
+        viewModel.onRemoveRecipient("alice") // user edit before the failed submit
+        viewModel.onContentChanged(TextFieldValue("hello"))
+        viewModel.onSubmit()
+
+        // The silent refetch after the expired hash_check must NOT re-hydrate the member list back
+        // to HFR's prefill — the user's removal survives.
+        assertEquals(listOf("bob"), viewModel.state.value.recipients)
+        coVerify(exactly = 2) { repository.fetchReplyForm(any()) }
+    }
+
+    // ----- #606 : RecipientCsv codec ----------------------------------------------
+
+    @Test
+    fun `RecipientCsv parse trims each element, drops empties and preserves order`() {
+        assertEquals(
+            listOf("alice", "bob", "Bébé Yoda", "stitch+"),
+            RecipientCsv.parse(" alice ,bob,  Bébé Yoda , stitch+ , "),
+        )
+        assertTrue(RecipientCsv.parse(null).isEmpty())
+        assertTrue(RecipientCsv.parse("").isEmpty())
+    }
+
+    @Test
+    fun `RecipientCsv join uses HFR's comma-space separator`() {
+        assertEquals("alice, bob, stitch+", RecipientCsv.join(listOf("alice", "bob", "stitch+")))
     }
 
     /** #405 — in-memory fake [EditorDraftStore], same shape as the one in `PostEditorViewModelTest`. */

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
@@ -590,14 +590,17 @@ class PrivateMessageReplyViewModelTest {
         viewModel.onContentChanged(TextFieldValue("hello"))
 
         viewModel.onSubmit()
-        // Round-trip is loss-less: same members, HFR's own `, ` separator.
+        // No edit was made, so the VM passes `recipientsOverride = null`: the repository then
+        // forwards HFR's original `newdest` hidden field VERBATIM (covered by the repo test), never
+        // round-tripping the list through parse → join. This is the loss-less invariant for a normal
+        // owner reply — the member list must not change just because the owner replied.
         coVerify {
             repository.submitReply(
                 context = any(),
                 form = any(),
                 bbcodeContent = any(),
                 options = any(),
-                recipientsOverride = "alice, bob, Bébé Yoda, stitch+, Administration",
+                recipientsOverride = null,
             )
         }
     }
@@ -701,6 +704,28 @@ class PrivateMessageReplyViewModelTest {
         // to HFR's prefill — the user's removal survives.
         assertEquals(listOf("bob"), viewModel.state.value.recipients)
         coVerify(exactly = 2) { repository.fetchReplyForm(any()) }
+    }
+
+    @Test
+    fun `an unedited list re-hydrates from a fresher form on a silent refetch`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        // 1st load: alice, bob. The silent refetch after InvalidHashCheck returns a fresher form
+        // where a member changed elsewhere (charlie added). With no local edit (recipientsDirty
+        // false), the VM must pick up the fresher list rather than keep the stale prefill.
+        coEvery { repository.fetchReplyForm(any()) } returnsMany listOf(
+            ownerForm(newdest = "alice, bob"),
+            ownerForm(newdest = "alice, bob, charlie"),
+        )
+        coEvery { repository.submitReply(any(), any(), any(), any(), any()) } returns
+            ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)
+
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+        )
+        viewModel.onContentChanged(TextFieldValue("hello")) // no member edit
+        viewModel.onSubmit()
+
+        assertEquals(listOf("alice", "bob", "charlie"), viewModel.state.value.recipients)
     }
 
     // ----- #606 : RecipientCsv codec ----------------------------------------------


### PR DESCRIPTION
## Quoi
Permet à l'**owner** d'un DT/MultiMP d'**ajouter / retirer des membres**, via le champ HFR `newdest` du formulaire de réponse (présent uniquement pour l'owner). La mutation passe par un post de réponse (contrat HFR) ; HFR conserve le post et ajoute un message « Modération ».

## Comment
- `ReplyForm.manageableRecipients` / `canManageRecipients` (lus depuis `hiddenFields["newdest"]`, jamais recalculés).
- Repo : `submitReply(..., recipientsOverride)` override `newdest` **uniquement si la clé existe déjà** (guard owner) et **seulement après une édition réelle** (`recipientsDirty`) → un owner qui répond sans toucher aux membres reposte le `newdest` **verbatim** (aucune perte). Un seul champ `newdest` émis. `dest` (compose) et `newdest` (reply) restent séparés. `cat=prive` relayé tel quel.
- ViewModel : liste éditable (ajout en fin, refus doublon match-exact, retrait exact, **min 1**), ordre/casse/accents/`+`/espaces préservés, re-hydratation depuis le form frais sur refetch silencieux tant que non-édité (anti-race).
- UI reply : éditeur de membres (chips + ajout) au-dessus du corps, owner-only, avertissement si « Administration » retiré.
- Compose : libellé « Pseudo des destinataires » + aide « >1 = discussion de groupe ».
- Message « Modération » : rendu comme post normal (pas de fixture → styling différé).

## Validation
`BUILD SUCCESSFUL` : `:feature:messages`, `:core:data`, `:core:parser`, `:core:model` tests + `lintDebug` + `detektAll`. Fixture de test **sanitisée** (pseudos bidons, `value="TESTHASH"`, aucun contenu privé).

## Revue Codex
2 tours. 1er : BLOCKER (override envoyé sans édition → perte possible de membres) + MAJOR (refetch écrasant un changement concurrent) → corrigés par le flag `recipientsDirty`. 2e tour : **GO**, BLOCKER + MAJOR résolus, pas de régression.

Closes #606.

---
> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
