### PR TITLE
feat(#597): déclencheur auto MPStorage — sync position de lecture DT (update-only, opt-in OFF)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepository.kt
@@ -150,8 +150,20 @@ class DefaultMpStorageRepository @Inject constructor(
      * The discovery is the same deterministic exact-hash match as [fetchStorage] ; a miss is
      * [MpStorageWriteResult.TargetNotFound], NEVER a creation (ADR-014 §3).
      */
-    @Suppress("ReturnCount") // Guard clauses (pref / auth / not-found / unreadable / no-op / oversize) + verify return.
-    override suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult {
+    override suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult =
+        writeBack(entry, updateOnly = false)
+
+    /**
+     * UPDATE-ONLY write path (#597) — the AUTO reading-position trigger. Same pipeline / gates as
+     * [writeBackFlag] but constrains the upsert to entries already present : an absent `threadId` is
+     * declined with [MpStorageWriteResult.SkippedNotPresent] (no POST), so a passive page land never
+     * pollutes the shared cross-userscript document with a Redface-2-invented entry (ADR-014 anti-doublon).
+     */
+    override suspend fun writeBackFlagIfPresent(entry: MpStorageFlagEntry): MpStorageWriteResult =
+        writeBack(entry, updateOnly = true)
+
+    @Suppress("ReturnCount") // Guard clauses (pref / auth / not-found / unreadable / skip / no-op / oversize) + verify.
+    private suspend fun writeBack(entry: MpStorageFlagEntry, updateOnly: Boolean): MpStorageWriteResult {
         return withContext(ioDispatcher) {
             // 1-2. Opt-in gate FIRST — no network when OFF (the default), so a missing trigger is harmless.
             if (!syncWriteEnabled()) {
@@ -175,12 +187,23 @@ class DefaultMpStorageRepository @Inject constructor(
             // 5. Verbatim backup (the raw content_form BEFORE any mutation) for the restore path.
             val backup = read.form.initialContent
 
-            // 7-9. Pure read-modify-write + no-op short-circuit + cap.
-            when (val outcome = envelopeWriter.upsertFlag(document.rawEnvelope, entry)) {
+            // 7-9. Pure read-modify-write + skip / no-op short-circuit + cap.
+            when (val outcome = envelopeWriter.upsertFlag(document.rawEnvelope, entry, updateOnly = updateOnly)) {
                 MpStorageEnvelopeWriter.Outcome.NotJsonEnvelope ->
                     // Defensive : the parser already accepted it, so this should not happen — but if the
                     // raw text is somehow not a JSON object we surface it, never overwrite (ADR-014 §3).
                     MpStorageWriteResult.Unreadable
+
+                is MpStorageEnvelopeWriter.Outcome.SkippedNotPresent -> {
+                    // #597 UPDATE-ONLY : the threadId is not already tracked → never add it (anti-pollution
+                    // of the shared document). No POST; the document is left byte-fidèle.
+                    diagnostics.record(
+                        DiagnosticsLog.Level.INFO,
+                        LOG_TAG,
+                        "writeBackFlag: skipped (threadId not present, update-only)",
+                    )
+                    MpStorageWriteResult.SkippedNotPresent
+                }
 
                 is MpStorageEnvelopeWriter.Outcome.NoOp -> {
                     // 8. The target position did not change : success WITHOUT a POST (the document is
@@ -212,8 +235,11 @@ class DefaultMpStorageRepository @Inject constructor(
             val read = readFormAndDocument(location) ?: return@withContext MpStorageWritePreview.TargetNotFound
             val document = read.document ?: return@withContext MpStorageWritePreview.Unreadable
 
+            // Preview is the MANUAL path : upsert add-or-update (updateOnly = false), so SkippedNotPresent
+            // is never produced here — mapped to Prepared(verbatim) for an exhaustive `when` regardless.
             when (val outcome = envelopeWriter.upsertFlag(document.rawEnvelope, entry)) {
                 MpStorageEnvelopeWriter.Outcome.NotJsonEnvelope -> MpStorageWritePreview.Unreadable
+                is MpStorageEnvelopeWriter.Outcome.SkippedNotPresent -> MpStorageWritePreview.Prepared(outcome.body)
                 is MpStorageEnvelopeWriter.Outcome.NoOp -> MpStorageWritePreview.Prepared(outcome.body)
                 is MpStorageEnvelopeWriter.Outcome.TooLarge -> MpStorageWritePreview.TooLarge(outcome.sizeBytes)
                 is MpStorageEnvelopeWriter.Outcome.Mutated -> MpStorageWritePreview.Prepared(outcome.body)

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/MpStorageEnvelopeWriter.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/MpStorageEnvelopeWriter.kt
@@ -62,6 +62,16 @@ class MpStorageEnvelopeWriter @Inject constructor(
          */
         data class NoOp(val body: String) : Outcome
 
+        /**
+         * UPDATE-ONLY mode only (#597) : [entry]'s `threadId` is ABSENT from the list and `updateOnly`
+         * was set, so the writer declined to APPEND a new item. [body] is the ORIGINAL content,
+         * byte-fidèle (no re-serialisation, no stamp) — the caller skips the POST entirely. This is the
+         * anti-pollution skip of the auto reading-position trigger : a shared cross-userscript document
+         * must never gain a Redface-2-invented entry from a page land. Never returned when `updateOnly`
+         * is `false` (the manual / preview path appends as before).
+         */
+        data class SkippedNotPresent(val body: String) : Outcome
+
         data object NotJsonEnvelope : Outcome
         data class TooLarge(val sizeBytes: Int) : Outcome
     }
@@ -81,14 +91,30 @@ class MpStorageEnvelopeWriter @Inject constructor(
      *    rejects the result ([Outcome.TooLarge]) when its UTF-8 size exceeds
      *    [MpStorageRepository.MAX_CONTENT_FORM_BYTES].
      *
+     * UPDATE-ONLY mode ([updateOnly] = `true`, #597 auto trigger) changes two things versus the default
+     * manual/preview behaviour :
+     *  - an ABSENT `threadId` is NOT appended — the writer returns [Outcome.SkippedNotPresent] with the
+     *    verbatim original (anti-pollution of the shared cross-userscript document) ; nothing is created
+     *    when there is no v0.1 entry / no list either ;
+     *  - on an UPDATE, a `null` [MpStorageFlagEntry.numreponse] / [MpStorageFlagEntry.uri] PRESERVES the
+     *    existing `href` / `uri` of the matched item instead of nulling them (the auto trigger never
+     *    erases a known anchor when the current page anchor is unknown).
+     * The default ([updateOnly] = `false`) keeps the historical add-or-update + null-erases semantics.
+     *
      * Returns [Outcome.NotJsonEnvelope] when [rawEnvelope] is not a JSON object (the caller maps this
      * to "unreadable" and NEVER writes a repaired default — ADR-014 §3).
      */
-    @Suppress("ReturnCount") // Guard (not-JSON) + no-op short-circuit + cap rejection + the mutated return.
-    fun upsertFlag(rawEnvelope: String, entry: MpStorageFlagEntry): Outcome {
+    @Suppress("ReturnCount") // Guard (not-JSON) + not-present skip + no-op short-circuit + cap + mutated return.
+    fun upsertFlag(rawEnvelope: String, entry: MpStorageFlagEntry, updateOnly: Boolean = false): Outcome {
         val root = parseObjectOrNull(rawEnvelope) ?: return Outcome.NotJsonEnvelope
 
-        val withFlag = mutateEnvelope(root, entry)
+        if (updateOnly && !containsThread(root, entry.threadId)) {
+            // UPDATE-ONLY : the threadId is not already tracked → never add it. Return the verbatim
+            // original so the caller skips the POST (anti-pollution of the shared document).
+            return Outcome.SkippedNotPresent(rawEnvelope)
+        }
+
+        val withFlag = mutateEnvelope(root, entry, updateOnly)
         if (withFlag == root) {
             // The upsert produced an identical tree : the target position did not change. Return the
             // ORIGINAL text byte-fidèle (no stamp, no re-serialisation) so the caller skips the POST.
@@ -122,10 +148,21 @@ class MpStorageEnvelopeWriter @Inject constructor(
         }
     }
 
+    /**
+     * Whether the v0.1 `mpFlags.list[]` already holds an item whose `post` matches [threadId]. The
+     * UPDATE-ONLY guard (#597) : a `false` here means the auto trigger must NOT add the entry.
+     */
+    private fun containsThread(root: JsonObject, threadId: Int): Boolean {
+        val dataArray = root["data"] as? JsonArray
+        val v01Entry = dataArray?.firstOrNull { (it as? JsonObject)?.let(::isV01) == true } as? JsonObject
+        val list = (v01Entry?.get("mpFlags") as? JsonObject)?.get("list") as? JsonArray
+        return list?.any { (it as? JsonObject)?.get("post")?.asIntOrNull() == threadId } == true
+    }
+
     /** Rebuilds the top-level object preserving every key, replacing only `data` with the mutated array. */
-    private fun mutateEnvelope(root: JsonObject, entry: MpStorageFlagEntry): JsonObject {
+    private fun mutateEnvelope(root: JsonObject, entry: MpStorageFlagEntry, updateOnly: Boolean): JsonObject {
         val dataArray = root["data"] as? JsonArray ?: JsonArray(emptyList())
-        val mutatedData = mutateDataArray(dataArray, entry)
+        val mutatedData = mutateDataArray(dataArray, entry, updateOnly)
         return JsonObject(root.toMutableMap().apply { put("data", mutatedData) })
     }
 
@@ -177,62 +214,88 @@ class MpStorageEnvelopeWriter @Inject constructor(
      * Replaces (or creates) the v0.1 entry inside `data[]`, preserving the order and every sibling
      * entry. When no v0.1 entry exists yet, a minimal one is appended (other entries untouched).
      */
-    private fun mutateDataArray(dataArray: JsonArray, entry: MpStorageFlagEntry): JsonArray {
+    private fun mutateDataArray(dataArray: JsonArray, entry: MpStorageFlagEntry, updateOnly: Boolean): JsonArray {
         val v01Index = dataArray.indexOfFirst { (it as? JsonObject)?.let(::isV01) == true }
         return if (v01Index >= 0) {
             val v01Entry = dataArray[v01Index] as JsonObject
             JsonArray(
-                dataArray.toMutableList().apply { this[v01Index] = mutateV01Entry(v01Entry, entry) },
+                dataArray.toMutableList().apply { this[v01Index] = mutateV01Entry(v01Entry, entry, updateOnly) },
             )
         } else {
-            JsonArray(dataArray + mutateV01Entry(emptyV01Entry(), entry))
+            JsonArray(dataArray + mutateV01Entry(emptyV01Entry(), entry, updateOnly))
         }
     }
 
     private fun emptyV01Entry(): JsonObject = buildJsonObject { put("version", V01) }
 
     /** Preserves every key of the v0.1 entry, replacing only its `mpFlags` (itself merged, not clobbered). */
-    private fun mutateV01Entry(v01Entry: JsonObject, entry: MpStorageFlagEntry): JsonObject {
+    private fun mutateV01Entry(v01Entry: JsonObject, entry: MpStorageFlagEntry, updateOnly: Boolean): JsonObject {
         val mpFlags = v01Entry["mpFlags"] as? JsonObject ?: JsonObject(emptyMap())
         val list = mpFlags["list"] as? JsonArray ?: JsonArray(emptyList())
-        val mutatedList = upsertList(list, entry)
+        val mutatedList = upsertList(list, entry, updateOnly)
         val mutatedMpFlags = JsonObject(mpFlags.toMutableMap().apply { put("list", mutatedList) })
         return JsonObject(v01Entry.toMutableMap().apply { put("mpFlags", mutatedMpFlags) })
     }
 
     /**
      * Upserts the item whose `post` matches [MpStorageFlagEntry.threadId]. On an UPDATE, only the
-     * four owned wire fields are written ; all other keys on the matched item survive verbatim.
+     * owned wire fields are written ; all other keys on the matched item survive verbatim. In
+     * UPDATE-ONLY mode an absent threadId is never reached here (the caller short-circuits to
+     * [Outcome.SkippedNotPresent]) — the append branch is dead in that mode, kept only for the
+     * manual/preview path.
      */
-    private fun upsertList(list: JsonArray, entry: MpStorageFlagEntry): JsonArray {
+    private fun upsertList(list: JsonArray, entry: MpStorageFlagEntry, updateOnly: Boolean): JsonArray {
         val matchIndex = list.indexOfFirst { item ->
             (item as? JsonObject)?.get("post")?.asIntOrNull() == entry.threadId
         }
         return if (matchIndex >= 0) {
             val existing = list[matchIndex] as JsonObject
             JsonArray(
-                list.toMutableList().apply { this[matchIndex] = writeWireFields(existing, entry) },
+                list.toMutableList().apply { this[matchIndex] = writeWireFields(existing, entry, updateOnly) },
             )
         } else {
-            JsonArray(list + writeWireFields(JsonObject(emptyMap()), entry))
+            JsonArray(list + writeWireFields(JsonObject(emptyMap()), entry, updateOnly = false))
         }
     }
 
     /**
-     * Overwrites the four owned wire fields on [base] (preserving any other key, e.g. `p`):
-     * `post`, `page`, `href` (= `"t<numreponse>"`, omitted/null when [MpStorageFlagEntry.numreponse]
-     * is null), `uri` (omitted/null when absent). Numbers are emitted as JSON numbers (the read parser
-     * tolerates both, the original userscript writes numbers).
+     * Overwrites the owned wire fields on [base] (preserving any other key, e.g. `p`):
+     * `post`, `page`, `href` (= `"t<numreponse>"`), `uri`. Numbers are emitted as JSON numbers (the
+     * read parser tolerates both, the original userscript writes numbers).
+     *
+     * When [MpStorageFlagEntry.numreponse] / [MpStorageFlagEntry.uri] is null :
+     *  - [preserveAbsent] = `false` (manual/preview) → the field is written as JSON `null` (historical) ;
+     *  - [preserveAbsent] = `true` (#597 auto UPDATE) → the field is LEFT AS-IS on [base] (the existing
+     *    anchor / uri is kept, never erased — the auto trigger only knows page, not always the anchor).
      */
-    private fun writeWireFields(base: JsonObject, entry: MpStorageFlagEntry): JsonObject =
+    private fun writeWireFields(base: JsonObject, entry: MpStorageFlagEntry, updateOnly: Boolean): JsonObject =
         JsonObject(
             base.toMutableMap().apply {
                 put("post", JsonPrimitive(entry.threadId))
                 put("page", JsonPrimitive(entry.page))
-                put("href", entry.numreponse?.let { JsonPrimitive("t$it") } ?: JsonNull)
-                put("uri", entry.uri?.let { JsonPrimitive(it) } ?: JsonNull)
+                putAnchorField("href", entry.numreponse?.let { "t$it" }, base, updateOnly)
+                putAnchorField("uri", entry.uri, base, updateOnly)
             },
         )
+
+    /**
+     * Writes [value] under [key], or — when [value] is null — either preserves the existing key from
+     * [base] ([preserveAbsent] = `true`, the #597 auto path) or emits JSON `null` ([preserveAbsent] =
+     * `false`, the historical manual/preview path). Preserving leaves [base]'s key untouched in the
+     * mutable copy (it is already present), or omits it entirely when [base] had none.
+     */
+    private fun MutableMap<String, JsonElement>.putAnchorField(
+        key: String,
+        value: String?,
+        base: JsonObject,
+        preserveAbsent: Boolean,
+    ) {
+        when {
+            value != null -> put(key, JsonPrimitive(value))
+            preserveAbsent -> base[key]?.let { put(key, it) } // keep the existing anchor/uri verbatim, never null it
+            else -> put(key, JsonNull)
+        }
+    }
 
     private fun JsonElement.asIntOrNull(): Int? = (this as? JsonPrimitive)?.content?.toIntOrNull()
 

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepositoryTest.kt
@@ -301,6 +301,77 @@ class DefaultMpStorageRepositoryTest {
         assertEquals(1, server.requestCount) // GET only — no POST on a no-op.
     }
 
+    // --- UPDATE-ONLY auto trigger (#597) ----------------------------------------------------------
+
+    @Test
+    fun `writeBackFlagIfPresent with the opt-in OFF returns DisabledByPreference and sends NO request`() = runTest {
+        // The default. The auto trigger never touches the network when the user has not opted in.
+        locationStore.saved[OWNER] = MpStorageLocation(threadId = 9100200, numreponse = 7)
+
+        val entry = MpStorageFlagEntry(threadId = 1, page = 1, numreponse = 1, uri = null)
+        val result = repository.writeBackFlagIfPresent(entry)
+
+        assertEquals(MpStorageWriteResult.DisabledByPreference, result)
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun `writeBackFlagIfPresent skips (no POST) when the threadId is absent from the document`() = runTest {
+        // UPDATE-ONLY anti-pollution: a threadId not already tracked is never added from the trigger.
+        val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [
+            { "post": 555, "page": 1, "href": "t1" }
+        ] } } ] }"""
+        repository = buildRepository(
+            replyFormParser = mockk {
+                every { parse(any()) } returns Result.success(storageForm(initialContent = raw))
+            },
+        )
+        preferences.enabled.value = true
+        locationStore.saved[OWNER] = STORAGE_LOCATION
+        server.enqueue(MockResponse().setBody(storageEditFormHtml(raw)))
+
+        val entry = MpStorageFlagEntry(threadId = 42, page = 2, numreponse = 5, uri = "/u")
+        val result = repository.writeBackFlagIfPresent(entry)
+
+        assertEquals(MpStorageWriteResult.SkippedNotPresent, result)
+        // GET the form only — no POST: the absent threadId is never appended (anti-doublon, ADR-014 §3).
+        assertEquals(1, server.requestCount)
+        assertEquals("GET", server.takeRequest().method)
+    }
+
+    @Test
+    fun `writeBackFlagIfPresent updates a present threadId end-to-end (POST + verify)`() = runTest {
+        val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [
+            { "post": 42, "page": 1, "href": "t1", "uri": "/old" }
+        ] } } ] }"""
+        val entry = MpStorageFlagEntry(threadId = 42, page = 2, numreponse = 5, uri = "/forum2.php?post=42&page=2#t5")
+        // The exact body the update-only path POSTs (matched by the verify RE-GET).
+        val mutated = MpStorageEnvelopeWriter(fixedClock).upsertFlag(raw, entry, updateOnly = true)
+            .let { (it as MpStorageEnvelopeWriter.Outcome.Mutated).body }
+        repository = buildRepository(
+            replyFormParser = mockk {
+                every { parse(any()) } returnsMany listOf(
+                    Result.success(storageForm(initialContent = raw)),
+                    Result.success(storageForm(initialContent = mutated)),
+                )
+            },
+        )
+        preferences.enabled.value = true
+        locationStore.saved[OWNER] = STORAGE_LOCATION
+        server.enqueue(MockResponse().setBody(storageEditFormHtml(raw))) // GET edit form
+        server.enqueue(MockResponse().setBody("<html><body>ok</body></html>")) // POST bdd.php
+        server.enqueue(MockResponse().setBody(storageEditFormHtml(mutated))) // RE-GET verify
+
+        val result = repository.writeBackFlagIfPresent(entry)
+
+        assertEquals(MpStorageWriteResult.Success(verified = true), result)
+        assertEquals(3, server.requestCount)
+        server.takeRequest() // GET
+        val body = formFields(server.takeRequest().body.readUtf8())
+        assertEquals("prive", body["cat"])
+        assertTrue(body["content_form"]!!.contains("\"page\":2"))
+    }
+
     @Test
     fun `writeBackFlag POSTs the mutated body with cat=prive, the active pseudo and the hash subject`() = runTest {
         val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [] } } ] }"""

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/mpstorage/MpStorageEnvelopeWriterTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/mpstorage/MpStorageEnvelopeWriterTest.kt
@@ -273,6 +273,96 @@ class MpStorageEnvelopeWriterTest {
         )
     }
 
+    // --- UPDATE-ONLY mode (#597 auto trigger) -----------------------------------------------------
+
+    @Test
+    fun `updateOnly skips an absent threadId without appending — anti-pollution`() {
+        val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [
+            { "post": 111, "page": 1, "href": "t1" }
+        ] } } ] }"""
+
+        val entry = MpStorageFlagEntry(threadId = 999, page = 4, numreponse = 2, uri = "/u")
+        val outcome = writer.upsertFlag(raw, entry, updateOnly = true)
+
+        // The unknown threadId is NOT added; the verbatim original is returned for the caller to skip the POST.
+        val skipped = outcome as MpStorageEnvelopeWriter.Outcome.SkippedNotPresent
+        assertEquals(raw, skipped.body)
+    }
+
+    @Test
+    fun `updateOnly skips when there is no v01 entry or list at all (never creates)`() {
+        assertTrue(
+            writer.upsertFlag(
+                """{ "sourceName": "DTCloud" }""",
+                MpStorageFlagEntry(threadId = 1, page = 1, numreponse = 1, uri = null),
+                updateOnly = true,
+            ) is MpStorageEnvelopeWriter.Outcome.SkippedNotPresent,
+        )
+        assertTrue(
+            writer.upsertFlag(
+                """{ "data": [ { "version": "0.2", "foo": 1 } ] }""",
+                MpStorageFlagEntry(threadId = 1, page = 1, numreponse = 1, uri = null),
+                updateOnly = true,
+            ) is MpStorageEnvelopeWriter.Outcome.SkippedNotPresent,
+        )
+    }
+
+    @Test
+    fun `updateOnly updates a present threadId (page, anchor, uri) and preserves third-party keys`() {
+        val raw = """
+            { "data": [ { "version": "0.1",
+                "hfr4k": { "opaque": 1 },
+                "mpFlags": { "list": [
+                    { "post": 12345, "page": 3, "href": "t1", "uri": "/old", "p": 2 }
+                ] } } ],
+              "someOtherTool": { "deep": true } }
+        """.trimIndent()
+
+        val entry = MpStorageFlagEntry(threadId = 12345, page = 7, numreponse = 555, uri = "/new")
+        val body = bodyOf(writer.upsertFlag(raw, entry, updateOnly = true))
+
+        val updated = body.flagList().first().jsonObject
+        assertEquals(7, updated["page"]!!.jsonPrimitive.content.toInt())
+        assertEquals("t555", updated["href"]!!.jsonPrimitive.content)
+        assertEquals("/new", updated["uri"]!!.jsonPrimitive.content)
+        assertEquals("2", updated["p"]!!.jsonPrimitive.content)
+        // Third-party keys survive both at the v0.1 entry and the top level.
+        assertTrue(body.v01Entry().containsKey("hfr4k"))
+        assertTrue(body.containsKey("someOtherTool"))
+    }
+
+    @Test
+    fun `updateOnly with a null anchor PRESERVES the existing href and uri (never nulls them)`() {
+        // The auto trigger landed on a page but has no current anchor → it must keep the known anchor/uri.
+        val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [
+            { "post": 7, "page": 2, "href": "t99", "uri": "/keep" }
+        ] } } ] }"""
+
+        val entry = MpStorageFlagEntry(threadId = 7, page = 5, numreponse = null, uri = null)
+        val body = bodyOf(writer.upsertFlag(raw, entry, updateOnly = true))
+
+        val updated = body.flagList().first().jsonObject
+        // Page advanced…
+        assertEquals(5, updated["page"]!!.jsonPrimitive.content.toInt())
+        // …but the existing anchor and uri are kept verbatim, NOT nulled.
+        assertEquals("t99", updated["href"]!!.jsonPrimitive.content)
+        assertEquals("/keep", updated["uri"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `the manual path (updateOnly = false) still appends an absent threadId and nulls absent fields`() {
+        // Regression guard: the default behaviour is unchanged by #597.
+        val raw = """{ "data": [ { "version": "0.1", "mpFlags": { "list": [] } } ] }"""
+
+        val body = bodyOf(mutate(raw, MpStorageFlagEntry(threadId = 222, page = 1, numreponse = null, uri = null)))
+
+        // Appended (not skipped), and the absent anchor/uri are written as JSON null (historical).
+        val item = body.flagList().single().jsonObject
+        assertEquals(222, item["post"]!!.jsonPrimitive.content.toInt())
+        assertNull(item["href"]!!.jsonPrimitive.contentOrNullSafe())
+        assertNull(item["uri"]!!.jsonPrimitive.contentOrNullSafe())
+    }
+
     /** `JsonPrimitive.content` is "null" for a literal null — distinguish it from the string "null". */
     private fun JsonPrimitive.contentOrNullSafe(): String? =
         if (this is kotlinx.serialization.json.JsonNull) null else content

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/mpstorage/MpStorageRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/mpstorage/MpStorageRepository.kt
@@ -55,6 +55,24 @@ interface MpStorageRepository {
     suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult
 
     /**
+     * UPDATE-ONLY variant of [writeBackFlag] (#597) — the AUTO reading-position trigger.
+     *
+     * Identical to [writeBackFlag] (same opt-in gate, same session guard, same locate / verify-after-write
+     * pipeline, same third-party-key preservation) EXCEPT the upsert is constrained to entries ALREADY
+     * present in the document : if no `mpFlags.list[]` item matches [MpStorageFlagEntry.threadId], the
+     * write is DECLINED with [MpStorageWriteResult.SkippedNotPresent] and NO POST is sent. This is the
+     * anti-pollution guarantee of the page-land hook — a shared cross-userscript document (DTCloud /
+     * HFR4K) must never gain a Redface-2-invented entry from a passive page land (a 1-to-1 MP wrongly
+     * recorded as a DT would corrupt the shared storage).
+     *
+     * On an UPDATE, a null [MpStorageFlagEntry.numreponse] / [MpStorageFlagEntry.uri] PRESERVES the
+     * existing anchor / uri of the matched entry rather than nulling it (the trigger always knows the
+     * landed page but not always the current anchor). The MANUAL path ([writeBackFlag] / [previewWriteBackFlag])
+     * keeps the historical add-or-update + null-erase behaviour, unchanged.
+     */
+    suspend fun writeBackFlagIfPresent(entry: MpStorageFlagEntry): MpStorageWriteResult
+
+    /**
      * DRY-RUN of [writeBackFlag] for tests / dev tooling : locates, mutates and validates the body but
      * NEVER hits the wire, NEVER consults the opt-in preference, and NEVER verifies. Returns the verbatim
      * mutated body that the real path WOULD POST, or a typed failure (not-found / unreadable / oversize).

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/mpstorage/MpStorage.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/mpstorage/MpStorage.kt
@@ -77,6 +77,16 @@ sealed interface MpStorageWriteResult {
     data object DisabledByPreference : MpStorageWriteResult
 
     /**
+     * UPDATE-ONLY path only (#597) : the storage document was located and read, but its
+     * `mpFlags.list[]` holds NO entry for this `threadId`, so the auto reading-position trigger
+     * declined to ADD a new one. This is the anti-pollution guarantee of the AUTO hook — a shared
+     * cross-userscript document (DTCloud / HFR4K) must never gain a Redface-2-invented entry from a
+     * mere page land (a 1-to-1 MP wrongly recorded as a DT would corrupt the storage). No POST was
+     * sent. The MANUAL / preview path never returns this (it upserts add-or-update).
+     */
+    data object SkippedNotPresent : MpStorageWriteResult
+
+    /**
      * The target storage document could not be located (ADR-014 §3 : NEVER create or overwrite a
      * fresh document — that would fork the cross-userscript storage / spawn a duplicate). The
      * caller must surface this, not "repair" it.

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -2482,8 +2482,11 @@ class FlagsViewModelTest {
         }
 
         // The DT tab only READS MPStorage; the write path (#6, opt-in OFF) is never exercised here, so the
-        // fake stubs both write entry points. The default opt-in OFF maps to DisabledByPreference.
+        // fake stubs the write entry points. The default opt-in OFF maps to DisabledByPreference.
         override suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult =
+            MpStorageWriteResult.DisabledByPreference
+
+        override suspend fun writeBackFlagIfPresent(entry: MpStorageFlagEntry): MpStorageWriteResult =
             MpStorageWriteResult.DisabledByPreference
 
         override suspend fun previewWriteBackFlag(

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModel.kt
@@ -10,7 +10,9 @@ import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.messages.MessagesRepository
 import fr.forumhfr.redface2.core.domain.messages.PrivateMessageReadPositionStore
+import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
 import fr.forumhfr.redface2.core.model.AuthState
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageFlagEntry
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -35,6 +37,7 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
     private val repository: MessagesRepository,
     private val authRepository: AuthRepository,
     private val readPositionStore: PrivateMessageReadPositionStore,
+    private val mpStorageRepository: MpStorageRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(PrivateMessageThreadUiState.initial(request))
@@ -168,7 +171,10 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
                     isRefreshing = false,
                 )
             }
-            savePosition(thread.page, owner)
+            // The anchor of the LAST post on the landed page — the furthest the reader can have reached
+            // on it. Null when the page has no posts (defensive); the auto MPStorage update then keeps
+            // any existing anchor rather than nulling it.
+            savePosition(thread.page, owner, lastPostNumreponse = thread.messages.lastOrNull()?.numreponse)
         } catch (cancellation: CancellationException) {
             // Deliberately does NOT clear isRefreshing: a cancellation only comes from a
             // superseding load() (which owns the flag from its own start) or from
@@ -210,7 +216,7 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
      *   started; if the active session changed before this write fires, it is dropped (the
      *   store also re-resolves the active session and no-ops when none is left).
      */
-    private fun savePosition(page: Int, owner: String) {
+    private fun savePosition(page: Int, owner: String, lastPostNumreponse: Int?) {
         saveJob?.cancel()
         saveJob = viewModelScope.launch {
             if (owner != authenticatedPseudo) return@launch
@@ -221,6 +227,40 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
             } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
                 // Swallowed: the resume position is a nicety, never worth surfacing an error.
             }
+            syncMpStoragePosition(page, lastPostNumreponse)
+        }
+    }
+
+    /**
+     * #597 — best-effort AUTO sync of the landed reading position to the shared MPStorage document,
+     * inside the SAME [saveJob] launch as the local save (so it shares its serialize-latest-wins and
+     * session guards) and AFTER it (the local write is the source of truth ; the remote sync is a
+     * bonus that must never delay or break the local save).
+     *
+     * UPDATE-ONLY ([MpStorageRepository.writeBackFlagIfPresent]) : it only refreshes a `threadId` the
+     * document ALREADY tracks (DTCloud's DT conversations) and NEVER adds a new entry from a passive
+     * page land (anti-pollution of the cross-userscript storage). The whole call is silent : the opt-in
+     * is OFF by default (no network then), and any failure — transport, session, an unwritable document —
+     * is swallowed. A null [numreponse] preserves the entry's existing anchor (the repository keeps it).
+     */
+    private suspend fun syncMpStoragePosition(page: Int, numreponse: Int?) {
+        try {
+            mpStorageRepository.writeBackFlagIfPresent(
+                MpStorageFlagEntry(
+                    threadId = request.threadId,
+                    page = page,
+                    numreponse = numreponse,
+                    // uri↔page coherence: only emit a fresh desktop uri when the anchor is known (so the
+                    // uri's #t<anchor> matches the page). With no anchor, pass null → the update-only path
+                    // PRESERVES both the existing href AND uri rather than minting an anchorless / stale uri.
+                    uri = numreponse?.let { buildDesktopUri(request.threadId, page, it) },
+                ),
+            )
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
+            // Swallowed: the MPStorage sync is a bonus on top of the (already done) local save. A failure
+            // must never break the reading session — the local resume position is the source of truth.
         }
     }
 
@@ -229,3 +269,13 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
         fun create(request: PrivateMessageThreadRequest): PrivateMessageThreadViewModel
     }
 }
+
+/**
+ * Rebuilds the canonical DTCloud desktop URI for an MPStorage `mpFlags.list[]` entry (#597) :
+ * `/forum2.php?config=hfr.inc&cat=prive&post=<threadId>&page=<page>#t<numreponse>`. This is the exact
+ * shape DTCloud stores (cf. the MpStorage parser fixtures) — relative path, the `t<numreponse>` anchor
+ * as a fragment. The caller only builds it when the anchor is known, so the `#t…` fragment always
+ * matches the page (uri↔page coherence); with no anchor the entry keeps its existing uri instead.
+ */
+internal fun buildDesktopUri(threadId: Int, page: Int, numreponse: Int): String =
+    "/forum2.php?config=hfr.inc&cat=prive&post=$threadId&page=$page#t$numreponse"

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModel.kt
@@ -227,7 +227,7 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
             } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
                 // Swallowed: the resume position is a nicety, never worth surfacing an error.
             }
-            syncMpStoragePosition(page, lastPostNumreponse)
+            syncMpStoragePosition(page, owner, lastPostNumreponse)
         }
     }
 
@@ -242,8 +242,14 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
      * page land (anti-pollution of the cross-userscript storage). The whole call is silent : the opt-in
      * is OFF by default (no network then), and any failure — transport, session, an unwritable document —
      * is swallowed. A null [numreponse] preserves the entry's existing anchor (the repository keeps it).
+     *
+     * Re-checks the session AFTER the local save's suspension point: the launch's initial
+     * `owner == authenticatedPseudo` guard only held when the job started, but `savePage` suspends, so
+     * the active account may have changed in between. We must never write the shared MPStorage document
+     * under a session other than the one that actually read this page (invariant: authenticated user only).
      */
-    private suspend fun syncMpStoragePosition(page: Int, numreponse: Int?) {
+    private suspend fun syncMpStoragePosition(page: Int, owner: String, numreponse: Int?) {
+        if (owner != authenticatedPseudo) return
         try {
             mpStorageRepository.writeBackFlagIfPresent(
                 MpStorageFlagEntry(

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModelTest.kt
@@ -5,12 +5,19 @@ import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.domain.messages.MessagesRepository
 import fr.forumhfr.redface2.core.domain.messages.PrivateMessageReadPositionStore
+import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
+import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageWritePreview
 import fr.forumhfr.redface2.core.model.AuthState
+import fr.forumhfr.redface2.core.model.Post
+import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.messages.PrivateMessageThread
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageFlagEntry
+import fr.forumhfr.redface2.core.model.mpstorage.MpStorageWriteResult
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import java.io.IOException
+import java.time.Instant
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -52,7 +59,10 @@ class PrivateMessageThreadViewModelTest {
         repository: MessagesRepository,
         authRepository: AuthRepository = FakeAuthRepository(),
         readPositionStore: PrivateMessageReadPositionStore = FakeReadPositionStore(),
-    ) = PrivateMessageThreadViewModel(request, repository, authRepository, readPositionStore)
+        mpStorageRepository: MpStorageRepository = FakeMpStorageRepository(),
+    ) = PrivateMessageThreadViewModel(
+        request, repository, authRepository, readPositionStore, mpStorageRepository,
+    )
 
     @Test
     fun `loads the thread on init without private route metadata fallback`() = runTest {
@@ -83,6 +93,7 @@ class PrivateMessageThreadViewModelTest {
             repository = repository,
             authRepository = FakeAuthRepository(AuthState.Anonymous),
             readPositionStore = FakeReadPositionStore(),
+            mpStorageRepository = FakeMpStorageRepository(),
         )
 
         assertEquals(PrivateMessageThreadUiState.Mode.RequiresLogin, viewModel.state.value.mode)
@@ -267,6 +278,7 @@ class PrivateMessageThreadViewModelTest {
             repository = repository,
             authRepository = FakeAuthRepository(),
             readPositionStore = FakeReadPositionStore(initial = mapOf(42 to 7)),
+            mpStorageRepository = FakeMpStorageRepository(),
         )
 
         coVerify(exactly = 1) {
@@ -288,6 +300,7 @@ class PrivateMessageThreadViewModelTest {
             repository = repository,
             authRepository = FakeAuthRepository(),
             readPositionStore = FakeReadPositionStore(initial = mapOf(42 to 3)),
+            mpStorageRepository = FakeMpStorageRepository(),
         )
 
         coVerify(exactly = 1) {
@@ -307,7 +320,9 @@ class PrivateMessageThreadViewModelTest {
         val store = FakeReadPositionStore()
 
         val viewModel =
-            PrivateMessageThreadViewModel(request, repository, FakeAuthRepository(), store)
+            PrivateMessageThreadViewModel(
+                request, repository, FakeAuthRepository(), store, FakeMpStorageRepository(),
+            )
         assertEquals(1, store.saved[42])
 
         viewModel.selectPage(5)
@@ -368,14 +383,113 @@ class PrivateMessageThreadViewModelTest {
         assertEquals(5, store.saved[42])
     }
 
-    private fun thread(page: Int, totalPages: Int) = PrivateMessageThread(
+    @Test
+    fun `a landed page triggers the update-only MPStorage sync with page, anchor and desktop uri (#597)`() = runTest {
+        // The auto trigger fires AFTER the local save, in the same launch. It builds the entry from the
+        // landed page + the last post's anchor and the canonical DTCloud desktop uri.
+        val repository = mockk<MessagesRepository>()
+        coEvery {
+            repository.getPrivateMessageThread(threadId = 42, page = 1, fallbackCorrespondent = null)
+        } returns thread(page = 1, totalPages = 3, messages = listOf(post(1000), post(2784595)))
+        val mpStorage = FakeMpStorageRepository()
+
+        threadViewModel(repository, mpStorageRepository = mpStorage)
+        advanceUntilIdle()
+
+        assertEquals(1, mpStorage.ifPresentCalls.size)
+        val entry = mpStorage.ifPresentCalls.single()
+        assertEquals(42, entry.threadId)
+        assertEquals(1, entry.page)
+        // Anchor = the LAST post on the page (the furthest the reader reached).
+        assertEquals(2784595, entry.numreponse)
+        // Canonical DTCloud desktop uri, with the #t<anchor> fragment matching the page.
+        assertEquals("/forum2.php?config=hfr.inc&cat=prive&post=42&page=1#t2784595", entry.uri)
+    }
+
+    @Test
+    fun `the MPStorage sync omits the uri and anchor when the page has no posts (#597)`() = runTest {
+        // No anchor available → numreponse null AND uri null, so the update-only path preserves the
+        // entry's existing href/uri rather than nulling them (the repository keeps the absent fields).
+        val repository = mockk<MessagesRepository>()
+        coEvery {
+            repository.getPrivateMessageThread(threadId = 42, page = 1, fallbackCorrespondent = null)
+        } returns thread(page = 1, totalPages = 1, messages = emptyList())
+        val mpStorage = FakeMpStorageRepository()
+
+        threadViewModel(repository, mpStorageRepository = mpStorage)
+        advanceUntilIdle()
+
+        val entry = mpStorage.ifPresentCalls.single()
+        assertEquals(null, entry.numreponse)
+        assertEquals(null, entry.uri)
+    }
+
+    @Test
+    fun `a failing MPStorage sync is swallowed and never breaks the local save (#597)`() = runTest {
+        val repository = mockk<MessagesRepository>()
+        coEvery {
+            repository.getPrivateMessageThread(threadId = 42, page = 1, fallbackCorrespondent = null)
+        } returns thread(page = 1, totalPages = 1, messages = listOf(post(7)))
+        val store = FakeReadPositionStore()
+        val mpStorage = FakeMpStorageRepository(thrown = IOException("storage write down"))
+
+        val viewModel = threadViewModel(repository, readPositionStore = store, mpStorageRepository = mpStorage)
+        advanceUntilIdle()
+
+        // The thrown sync did not break the session: content is loaded and the local position is saved.
+        assertTrue(viewModel.state.value.mode is PrivateMessageThreadUiState.Mode.Content)
+        assertEquals(1, store.saved[42])
+        assertEquals(1, mpStorage.ifPresentCalls.size)
+    }
+
+    @Test
+    fun `an account switch seals the MPStorage sync to the reading session (#597 + #462)`() = runTest {
+        // The sync lives in the same saveJob/session guard as the local save: a save attributed to a
+        // session that changed before it fires is dropped before any MPStorage call.
+        val repository = mockk<MessagesRepository>()
+        val gate = CompletableDeferred<PrivateMessageThread>()
+        var calls = 0
+        coEvery {
+            repository.getPrivateMessageThread(threadId = 42, page = 1, fallbackCorrespondent = null)
+        } coAnswers { if (calls++ == 0) gate.await() else thread(page = 1, totalPages = 1, messages = listOf(post(9))) }
+        val authRepository = FakeAuthRepository(AuthState.Authenticated("alice"))
+        val mpStorage = FakeMpStorageRepository()
+
+        threadViewModel(repository, authRepository, mpStorageRepository = mpStorage)
+        authRepository.emit(AuthState.Authenticated("bob"))
+        advanceUntilIdle()
+        gate.complete(thread(page = 3, totalPages = 9, messages = listOf(post(123))))
+        advanceUntilIdle()
+
+        // Only bob's landing reached the MPStorage sync — alice's sealed (cancelled) job never did.
+        assertEquals(1, mpStorage.ifPresentCalls.size)
+        assertEquals(1, mpStorage.ifPresentCalls.single().page)
+    }
+
+    private fun thread(
+        page: Int,
+        totalPages: Int,
+        messages: List<Post> = emptyList(),
+    ) = PrivateMessageThread(
         threadId = 42,
         subject = "Sujet",
         correspondent = "Correspondant",
-        messages = emptyList(),
+        messages = messages,
         page = page,
         totalPages = totalPages,
         canReply = true,
+    )
+
+    private fun post(numreponse: Int) = Post(
+        numreponse = numreponse,
+        author = "auteur",
+        date = Instant.EPOCH,
+        content = PostContent(blocks = emptyList()),
+        avatarUrl = null,
+        isEditable = false,
+        isOwnPost = false,
+        quotedAuthors = emptyList(),
+        postIndex = null,
     )
 
     private class FakeAuthRepository(
@@ -419,5 +533,32 @@ class PrivateMessageThreadViewModelTest {
             lastSaveOwner = owner?.lowercase()
             saved[threadId] = page
         }
+    }
+
+    /**
+     * Fake [MpStorageRepository] for the #597 auto-sync trigger. Records every
+     * [writeBackFlagIfPresent] entry (so a test can assert the page/anchor/uri the trigger built),
+     * returns [result] (default = the opt-in-OFF nominal case), or throws [thrown] to prove the sync
+     * failure is swallowed. The read / manual-write paths are never exercised by the thread VM.
+     */
+    private class FakeMpStorageRepository(
+        private val result: MpStorageWriteResult = MpStorageWriteResult.DisabledByPreference,
+        private val thrown: Throwable? = null,
+    ) : MpStorageRepository {
+        val ifPresentCalls = mutableListOf<MpStorageFlagEntry>()
+
+        override suspend fun fetchStorage() = error("read path not used by the thread VM")
+
+        override suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult =
+            error("the auto trigger uses writeBackFlagIfPresent, never writeBackFlag")
+
+        override suspend fun writeBackFlagIfPresent(entry: MpStorageFlagEntry): MpStorageWriteResult {
+            ifPresentCalls += entry
+            thrown?.let { throw it }
+            return result
+        }
+
+        override suspend fun previewWriteBackFlag(entry: MpStorageFlagEntry): MpStorageWritePreview =
+            error("preview path not used by the thread VM")
     }
 }

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/MpStorageInspectorViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/MpStorageInspectorViewModelTest.kt
@@ -177,6 +177,9 @@ class MpStorageInspectorViewModelTest {
             override suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult =
                 error("Unexpected writeBackFlag call in the read-only inspector test")
 
+            override suspend fun writeBackFlagIfPresent(entry: MpStorageFlagEntry): MpStorageWriteResult =
+                error("Unexpected writeBackFlagIfPresent call in the read-only inspector test")
+
             override suspend fun previewWriteBackFlag(
                 entry: MpStorageFlagEntry,
             ): fr.forumhfr.redface2.core.domain.mpstorage.MpStorageWritePreview =
@@ -230,6 +233,9 @@ class MpStorageInspectorViewModelTest {
         // Read-only inspector: a write must NEVER happen here — fail loudly if one slips in (Codex review).
         override suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult =
             error("Unexpected writeBackFlag call in the read-only inspector test")
+
+        override suspend fun writeBackFlagIfPresent(entry: MpStorageFlagEntry): MpStorageWriteResult =
+            error("Unexpected writeBackFlagIfPresent call in the read-only inspector test")
 
         override suspend fun previewWriteBackFlag(
             entry: MpStorageFlagEntry,


### PR DESCRIPTION
## Quoi
Câble le **déclencheur automatique** de l'écriture MPStorage (#597) : quand une page de conversation MP est atteinte, la position de lecture est synchronisée vers le document MPStorage partagé (DTCloud), pour que le desktop reprenne où le mobile s'est arrêté.

## Design (cadré + relu par Codex) — UPDATE-ONLY, sûr par construction
- **Hook** : dans `PrivateMessageThreadViewModel.savePosition`, APRÈS la sauvegarde locale (#430), dans le même `saveJob` (latest-wins, scellé à la session), en **échec silencieux** (ne casse jamais la lecture).
- **UPDATE-ONLY** (`writeBackFlagIfPresent`, nouvelle politique) : ne met à jour QUE les `threadId` déjà présents dans le doc (DT suivis par DTCloud). **Aucun ajout** depuis ce hook → zéro pollution du document partagé avec des MP 1-1. `upsertFlag` gagne un param `updateOnly` ; le chemin manuel/preview garde l'upsert add-or-update.
- **Opt-in `syncPrivateMessagesWriteEnabled` reste OFF par défaut** — le trigger n'active jamais la sync (no réseau quand OFF).
- **Jamais de création** de document (`TargetNotFound` → no-op).
- **Garde session double** : au lancement du job ET re-vérifiée après le `suspend savePage`, avant l'écriture (corrige un BLOCKER Codex — un changement de compte pendant le save ne peut pas écrire sous la mauvaise session).
- **Entrée** : `numreponse` = dernier post de la page atteinte (ancre déterministe) ; `uri` = URI desktop canonique reconstruite (`/forum2.php?...&post=&page=#t<n>`, format DTCloud) **uniquement si l'ancre est connue** (cohérence uri↔page) ; sans ancre → l'update-only **préserve** href ET uri existants (jamais nullés).

## Validation
`BUILD SUCCESSFUL` : `:feature:messages:testDebugUnitTest`, `:core:data:test`, `:core:model:test`, `lintDebug`, `detektAll`. Tests : opt-in OFF→no-op, threadId présent→update (champs tiers préservés), threadId absent→aucun ajout, garde session (lancement + post-suspend), ancre indispo→préservée, échec→swallowed.

## Revue Codex
2 tours. BLOCKER (garde session post-suspension) corrigé → **GO**, pas de régression.

Closes #597.

---
> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
