### PR TITLE
fix(#531): réconcilier l'état lu/non-lu MP avec le serveur (re-unread, gaté par date)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -719,6 +719,15 @@ fun RedfaceApp(intent: Intent?) {
         // page only) and the date is private metadata, so it is held here in memory — purged on every
         // auth transition like the hints above — rather than carried in PrivateMessageThreadRoute.
         var openThreadDates by remember { mutableStateOf(emptyMap<Int, Instant>()) }
+        // #531 (Codex BLOCKER 1) — highest inbox load generation already reconciled, held OUTSIDE the
+        // MessagesScreen composition so the once-per-fetch guarantee survives the screen re-entering
+        // composition (thread → back re-runs the reconcile effect on a stale page-1 Content for the
+        // SAME generation). The handler ignores `generation <= lastReconciledGeneration`. Reset to 0
+        // on every auth transition, in lockstep with the read-mark purge and with the ViewModel's own
+        // generation reset (clearPrivateState rebuilds the state, so the generation restarts at 0 on
+        // Anonymous) — keeping a positive value here would then silently swallow the next session's
+        // first reconcile.
+        var lastReconciledGeneration by remember { mutableStateOf(0) }
         // #301 follow-up — bumped when the new-conversation composer pops back after a successful
         // send. The MP list collects the signal and refreshes itself so the created conversation
         // appears at the top (its thread id is unknown — the bddpost success response of a new MP
@@ -765,6 +774,8 @@ fun RedfaceApp(intent: Intent?) {
                     multiRecipientThreadIds = emptySet()
                     unreadOnOpenThreadIds = emptySet()
                     openThreadDates = emptyMap()
+                    // #531 — stay in lockstep with the VM's generation reset (clearPrivateState).
+                    lastReconciledGeneration = 0
                     privateMessageSentSignal = null
                     // #291 — a write intention armed under another session must not survive the
                     // transition (Codex review: stale « Citer N » after logout/login).
@@ -776,6 +787,9 @@ fun RedfaceApp(intent: Intent?) {
                     multiRecipientThreadIds = emptySet()
                     unreadOnOpenThreadIds = emptySet()
                     openThreadDates = emptyMap()
+                    // #531 — the VM reloads page 1 (generation back to 1) on a fresh authentication;
+                    // resetting here lets that first reconcile run.
+                    lastReconciledGeneration = 0
                     privateMessageSentSignal = null
                     multiQuoteBasket = null
                     resetStack(messagesBackStack, MessagesRoute, MessagesRoute)
@@ -865,16 +879,29 @@ fun RedfaceApp(intent: Intent?) {
                                 }
                                 // #531 — record the mark keyed by the conversation date captured at
                                 // open-time (openThreadDates). reconcileReadMarks later compares the
-                                // server date against it; a thread with no captured date (DT/deep-link
-                                // path) falls back to EPOCH so any later server date reconciles it.
+                                // server date against it. (Codex MAJOR 3) the open-time date is a
+                                // PER-OPEN pending: CONSUME it here so a later re-open of the same
+                                // thread WITHOUT a fresh inbox date can't reuse this stale baseline —
+                                // it falls back to the MAX sentinel (never reconciled) instead.
                                 readPrivateMessageThreadIds = readPrivateMessageThreadIds
                                     .withReadMark(threadId, openThreadDates)
+                                openThreadDates = openThreadDates - threadId
                             },
                             // #531 — fresh page-1 network result: drop the marks HFR now reports as
                             // genuinely unread again (server date strictly newer than the open-time date).
-                            onReconcileReadMarks = { conversations ->
-                                readPrivateMessageThreadIds =
-                                    readPrivateMessageThreadIds.withoutReconciled(conversations)
+                            // (Codex BLOCKER 1) dedupe by generation OUTSIDE the screen composition: the
+                            // reconcile effect can refire for the same generation on a stale page-1
+                            // Content, so ignore an already-reconciled generation; otherwise record it
+                            // BEFORE reconciling.
+                            onReconcileReadMarks = { generation, conversations ->
+                                val pass = reconcilePass(
+                                    marks = readPrivateMessageThreadIds,
+                                    lastReconciled = lastReconciledGeneration,
+                                    generation = generation,
+                                    freshConversations = conversations,
+                                )
+                                lastReconciledGeneration = pass.lastReconciled
+                                readPrivateMessageThreadIds = pass.marks
                             },
                             onThreadOpenedAsMulti = { threadId ->
                                 multiRecipientThreadIds = multiRecipientThreadIds + threadId
@@ -1116,8 +1143,10 @@ private const val DEV_CHANNEL: String = "dev"
  * @property onThreadOpenedAt #531 — records the conversation date seen when a thread is opened from
  *   the inbox; that date becomes the read mark's value so a later, strictly-newer server date can
  *   reconcile (re-unread) it (see [reconcileReadMarks]).
- * @property onReconcileReadMarks #531 — invoked once per fresh page-1 network result with the server
- *   conversations; drops the optimistic read marks HFR now reports as genuinely unread again.
+ * @property onReconcileReadMarks #531 — invoked on each fresh page-1 network result with the load
+ *   GENERATION and the server conversations; drops the optimistic read marks HFR now reports as
+ *   genuinely unread again. Deduped by generation in the host (Codex BLOCKER 1) so a re-fired effect
+ *   on the same generation reconciles at most once.
  */
 private data class PrivateMessageNavState(
     val readThreadIds: Set<Int>,
@@ -1126,7 +1155,8 @@ private data class PrivateMessageNavState(
     val onThreadOpenedAsMulti: (Int) -> Unit,
     val onThreadOpenedUnread: (Int) -> Unit = {},
     val onThreadOpenedAt: (threadId: Int, date: Instant) -> Unit = { _, _ -> },
-    val onReconcileReadMarks: (List<PrivateMessageSummary>) -> Unit = {},
+    val onReconcileReadMarks: (generation: Int, conversations: List<PrivateMessageSummary>) -> Unit =
+        { _, _ -> },
     /** #301 follow-up — last successful new-conversation send ; the MP list refreshes on change. */
     val sentSignal: Long? = null,
     /** #301 follow-up — bumps [sentSignal] when the composer reports a successful send. */
@@ -1187,16 +1217,58 @@ internal fun Map<Int, Instant>.withoutReconciled(
 }
 
 /**
+ * #531 (Codex BLOCKER 1) — result of a generation-deduped reconcile pass. Both fields are returned so
+ * the caller updates its two pieces of state atomically (the high-water generation and the read-mark
+ * map). When [generation] is not newer than [lastReconciled], [marks] is the input map unchanged and
+ * [lastReconciled] is unchanged too — the pass was a no-op.
+ */
+internal data class ReconcilePass(
+    val marks: Map<Int, Instant>,
+    val lastReconciled: Int,
+)
+
+/**
+ * #531 (Codex BLOCKER 1) — once-per-generation reconciliation, hoisted OUT of the MessagesScreen
+ * composition. The reconcile effect can re-fire for the SAME [generation] when the screen re-enters
+ * composition (thread → back lands on a stale page-1 [MessagesUiState.Mode.Content]); keying the
+ * effect alone does not guard that. So the host keeps a high-water mark ([lastReconciled]) and this
+ * pure function:
+ *  - ignores `generation <= lastReconciled` (returns the inputs untouched → idempotent re-fire), else
+ *  - advances the high-water mark to [generation] AND applies [withoutReconciled].
+ *
+ * Compose-free so the dedupe + idempotence are unit-testable without a UI host.
+ */
+internal fun reconcilePass(
+    marks: Map<Int, Instant>,
+    lastReconciled: Int,
+    generation: Int,
+    freshConversations: List<PrivateMessageSummary>,
+): ReconcilePass = if (generation <= lastReconciled) {
+    ReconcilePass(marks, lastReconciled)
+} else {
+    ReconcilePass(marks.withoutReconciled(freshConversations), generation)
+}
+
+/**
+ * #531 (Codex BLOCKER 2) — baseline used for a read mark when NO real open-time date was captured (the
+ * DT / deep-link open path never records one). It is [Instant.MAX] on purpose: `serverDate.isAfter(MAX)`
+ * is ALWAYS false, so such a mark is NEVER dropped by [reconcileReadMarks] — it only ever clears on the
+ * auth purge. This is the conservative choice: a just-read thread with no baseline must never be
+ * re-flagged unread on a mere echo of its dot. (The original [Instant.EPOCH] was the inverse: every
+ * server date exceeded it, so any dot echo re-unread the thread.)
+ */
+private val NO_RECONCILE_BASELINE: Instant = Instant.MAX
+
+/**
  * #531 — adds an optimistic read mark for [threadId], keyed by the conversation date captured at
- * open-time ([openDates]). A thread with no captured date (the DT / deep-link open path never records
- * one) falls back to [Instant.EPOCH], so any later server date reconciles it (the conservative choice:
- * a missing baseline never blocks a re-unread). Extracted to keep [RedfaceApp]'s Elvis out of its
- * cyclomatic-complexity budget.
+ * open-time ([openDates]). A thread with no captured date falls back to [NO_RECONCILE_BASELINE]
+ * ([Instant.MAX]), so it is never reconciled back to unread (see that constant). Extracted to keep
+ * [RedfaceApp]'s Elvis out of its cyclomatic-complexity budget.
  */
 internal fun Map<Int, Instant>.withReadMark(
     threadId: Int,
     openDates: Map<Int, Instant>,
-): Map<Int, Instant> = this + (threadId to (openDates[threadId] ?: Instant.EPOCH))
+): Map<Int, Instant> = this + (threadId to (openDates[threadId] ?: NO_RECONCILE_BASELINE))
 
 /**
  * Bug fix (build 89) — per-topic title cache plumbed into [RedfaceNavHost]. A topic page change

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -79,6 +79,7 @@ import fr.forumhfr.redface2.BuildConfig
 import fr.forumhfr.redface2.R
 import fr.forumhfr.redface2.core.ui.R as CoreUiR
 import fr.forumhfr.redface2.core.model.AuthState
+import fr.forumhfr.redface2.core.model.messages.PrivateMessageSummary
 import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.shouldRevealNavBar
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
@@ -120,6 +121,7 @@ import fr.forumhfr.redface2.feature.settings.SettingsScreen
 import fr.forumhfr.redface2.feature.topic.TopicRequest
 import fr.forumhfr.redface2.feature.topic.TopicScreen
 import fr.forumhfr.redface2.feature.topic.TopicScrollAnchor
+import java.time.Instant
 import kotlinx.serialization.Serializable
 import androidx.compose.material3.ExperimentalMaterial3Api
 
@@ -693,7 +695,13 @@ fun RedfaceApp(intent: Intent?) {
         val reportEmailSubject = stringResource(fr.forumhfr.redface2.core.ui.R.string.account_menu_report_email_subject)
         val reportNoEmailClient = stringResource(fr.forumhfr.redface2.core.ui.R.string.account_menu_no_email_client)
         val context = LocalContext.current
-        var readPrivateMessageThreadIds by remember { mutableStateOf(emptySet<Int>()) }
+        // #531 — optimistic « read » marks of the inbox, now keyed by the conversation DATE seen at
+        // open-time (was a bare Set<Int>). Storing the date lets a fresh page-1 network result RECONCILE
+        // the mark: HFR re-flagging a thread unread is only honoured when its server date is STRICTLY
+        // newer than the date recorded here (a true new MP), never on an identical date (an echo of the
+        // pre-read dot — see reconcileReadMarks). Same lifecycle as before: in-memory only, purged on
+        // every auth transition; membership (`threadId in map`) drives the list read-override.
+        var readPrivateMessageThreadIds by remember { mutableStateOf(emptyMap<Int, Instant>()) }
         // Ephemeral, in-memory only (NOT persisted in any Navigation route): threads the user
         // opened from the inbox as multi-recipient (MultiMP / "DT"). Lets the thread screen show
         // "Interlocuteurs multiples" even when the current page reveals a single other author.
@@ -706,6 +714,11 @@ fun RedfaceApp(intent: Intent?) {
         // it is private metadata (it reveals a conversation carried an unread message) and must never
         // outlive the session, hence it stays OUT of the opaque PrivateMessageThreadRoute.
         var unreadOnOpenThreadIds by remember { mutableStateOf(emptySet<Int>()) }
+        // #531 — conversation DATE captured at the moment a thread is opened from the inbox, used as
+        // the read-mark value once the thread loads (onThreadLoaded). The route is opaque (threadId +
+        // page only) and the date is private metadata, so it is held here in memory — purged on every
+        // auth transition like the hints above — rather than carried in PrivateMessageThreadRoute.
+        var openThreadDates by remember { mutableStateOf(emptyMap<Int, Instant>()) }
         // #301 follow-up — bumped when the new-conversation composer pops back after a successful
         // send. The MP list collects the signal and refreshes itself so the created conversation
         // appears at the top (its thread id is unknown — the bddpost success response of a new MP
@@ -748,9 +761,10 @@ fun RedfaceApp(intent: Intent?) {
             when (authState) {
                 null -> Unit
                 AuthState.Anonymous -> {
-                    readPrivateMessageThreadIds = emptySet()
+                    readPrivateMessageThreadIds = emptyMap()
                     multiRecipientThreadIds = emptySet()
                     unreadOnOpenThreadIds = emptySet()
+                    openThreadDates = emptyMap()
                     privateMessageSentSignal = null
                     // #291 — a write intention armed under another session must not survive the
                     // transition (Codex review: stale « Citer N » after logout/login).
@@ -758,9 +772,10 @@ fun RedfaceApp(intent: Intent?) {
                     resetStack(messagesBackStack, MessagesRoute, MessagesRoute)
                 }
                 is AuthState.Authenticated -> {
-                    readPrivateMessageThreadIds = emptySet()
+                    readPrivateMessageThreadIds = emptyMap()
                     multiRecipientThreadIds = emptySet()
                     unreadOnOpenThreadIds = emptySet()
+                    openThreadDates = emptyMap()
                     privateMessageSentSignal = null
                     multiQuoteBasket = null
                     resetStack(messagesBackStack, MessagesRoute, MessagesRoute)
@@ -832,7 +847,9 @@ fun RedfaceApp(intent: Intent?) {
                             startReportEmail(context, reportEmailSubject, reportNoEmailClient)
                         },
                         privateMessageNavState = PrivateMessageNavState(
-                            readThreadIds = readPrivateMessageThreadIds,
+                            // #531 — the screen only needs membership, so it gets the marked thread ids;
+                            // the dates stay nav-internal, consumed by reconcileReadMarks below.
+                            readThreadIds = readPrivateMessageThreadIds.keys,
                             multiRecipientThreadIds = multiRecipientThreadIds,
                             onThreadLoaded = { threadId ->
                                 // #453 (Codex review) — decrement the badge ONLY when the conversation was
@@ -841,18 +858,32 @@ fun RedfaceApp(intent: Intent?) {
                                 val decrement = shouldDecrementUnreadBadge(
                                     threadId = threadId,
                                     unreadOnOpen = unreadOnOpenThreadIds,
-                                    alreadyRead = readPrivateMessageThreadIds,
+                                    alreadyRead = readPrivateMessageThreadIds.keys,
                                 )
                                 if (decrement) {
                                     mpBadgeViewModel.onThreadRead(threadId)
                                 }
-                                readPrivateMessageThreadIds = readPrivateMessageThreadIds + threadId
+                                // #531 — record the mark keyed by the conversation date captured at
+                                // open-time (openThreadDates). reconcileReadMarks later compares the
+                                // server date against it; a thread with no captured date (DT/deep-link
+                                // path) falls back to EPOCH so any later server date reconciles it.
+                                readPrivateMessageThreadIds = readPrivateMessageThreadIds
+                                    .withReadMark(threadId, openThreadDates)
+                            },
+                            // #531 — fresh page-1 network result: drop the marks HFR now reports as
+                            // genuinely unread again (server date strictly newer than the open-time date).
+                            onReconcileReadMarks = { conversations ->
+                                readPrivateMessageThreadIds =
+                                    readPrivateMessageThreadIds.withoutReconciled(conversations)
                             },
                             onThreadOpenedAsMulti = { threadId ->
                                 multiRecipientThreadIds = multiRecipientThreadIds + threadId
                             },
                             onThreadOpenedUnread = { threadId ->
                                 unreadOnOpenThreadIds = unreadOnOpenThreadIds + threadId
+                            },
+                            onThreadOpenedAt = { threadId, date ->
+                                openThreadDates = openThreadDates + (threadId to date)
                             },
                             sentSignal = privateMessageSentSignal,
                             onConversationSent = {
@@ -1082,6 +1113,11 @@ private const val DEV_CHANNEL: String = "dev"
  * @property onThreadOpenedAsMulti records that a thread was opened from a multi-recipient row.
  * @property onThreadOpenedUnread records that a thread was UNREAD when opened, so [onThreadLoaded]
  *   knows it may decrement the unread badge (an already-read conversation must not, #453).
+ * @property onThreadOpenedAt #531 — records the conversation date seen when a thread is opened from
+ *   the inbox; that date becomes the read mark's value so a later, strictly-newer server date can
+ *   reconcile (re-unread) it (see [reconcileReadMarks]).
+ * @property onReconcileReadMarks #531 — invoked once per fresh page-1 network result with the server
+ *   conversations; drops the optimistic read marks HFR now reports as genuinely unread again.
  */
 private data class PrivateMessageNavState(
     val readThreadIds: Set<Int>,
@@ -1089,6 +1125,8 @@ private data class PrivateMessageNavState(
     val onThreadLoaded: (Int) -> Unit,
     val onThreadOpenedAsMulti: (Int) -> Unit,
     val onThreadOpenedUnread: (Int) -> Unit = {},
+    val onThreadOpenedAt: (threadId: Int, date: Instant) -> Unit = { _, _ -> },
+    val onReconcileReadMarks: (List<PrivateMessageSummary>) -> Unit = {},
     /** #301 follow-up — last successful new-conversation send ; the MP list refreshes on change. */
     val sentSignal: Long? = null,
     /** #301 follow-up — bumps [sentSignal] when the composer reports a successful send. */
@@ -1107,6 +1145,58 @@ private fun shouldDecrementUnreadBadge(
     unreadOnOpen: Set<Int>,
     alreadyRead: Set<Int>,
 ): Boolean = threadId in unreadOnOpen && threadId !in alreadyRead
+
+/**
+ * #531 — reconciles the optimistic inbox read marks ([marks]: threadId → date seen at open-time)
+ * against a FRESH page-1 network result ([freshConversations]). Returns the set of marked thread ids
+ * to DROP: a conversation that the server still reports unread, that we had marked read, AND whose
+ * server date is STRICTLY after the recorded open-time date — i.e. a genuine new MP arrived after the
+ * user last read it, so the server's "unread" must win over our optimistic mark.
+ *
+ * Gating rationale (Codex): the comparison is `isAfter`, never `>=`. An identical date is the echo of
+ * the pre-read dot (the server response that motivated the read, observed again on refresh) — dropping
+ * the mark there would make a just-read thread re-blink unread (a regression). A conversation absent
+ * from [freshConversations] is never inferred unread (no page-1 entry, no decision). A conversation the
+ * server reports read (`!hasUnread`) leaves its mark untouched (it would be redundant anyway).
+ *
+ * Pure and Compose-free so it is unit-testable; the caller only runs it on a genuine network success
+ * (not a recomposition / cached page), driven by [MessagesUiState.networkLoadGeneration].
+ */
+internal fun reconcileReadMarks(
+    marks: Map<Int, Instant>,
+    freshConversations: List<PrivateMessageSummary>,
+): Set<Int> = freshConversations.asSequence()
+    .filter { conversation ->
+        conversation.hasUnread &&
+            marks[conversation.threadId]?.let { conversation.date.isAfter(it) } == true
+    }
+    .map { it.threadId }
+    .toSet()
+
+/**
+ * #531 — applies [reconcileReadMarks] to drop the now-genuinely-unread marks from this read-mark map.
+ * Returns the SAME instance when nothing is reconciled, so a routine page-1 refresh (the common case:
+ * no new MP) neither allocates a new map nor triggers a [RedfaceApp] recomposition. Folds the empty-set
+ * guard out of the composable to keep it under detekt's cyclomatic-complexity budget.
+ */
+internal fun Map<Int, Instant>.withoutReconciled(
+    freshConversations: List<PrivateMessageSummary>,
+): Map<Int, Instant> {
+    val stale = reconcileReadMarks(this, freshConversations)
+    return if (stale.isEmpty()) this else this - stale
+}
+
+/**
+ * #531 — adds an optimistic read mark for [threadId], keyed by the conversation date captured at
+ * open-time ([openDates]). A thread with no captured date (the DT / deep-link open path never records
+ * one) falls back to [Instant.EPOCH], so any later server date reconciles it (the conservative choice:
+ * a missing baseline never blocks a re-unread). Extracted to keep [RedfaceApp]'s Elvis out of its
+ * cyclomatic-complexity budget.
+ */
+internal fun Map<Int, Instant>.withReadMark(
+    threadId: Int,
+    openDates: Map<Int, Instant>,
+): Map<Int, Instant> = this + (threadId to (openDates[threadId] ?: Instant.EPOCH))
 
 /**
  * Bug fix (build 89) — per-topic title cache plumbed into [RedfaceNavHost]. A topic page change
@@ -1470,7 +1560,7 @@ private fun RedfaceNavHost(
             entry<MessagesRoute> {
                 MessagesScreen(
                     readThreadIds = privateMessageNavState.readThreadIds,
-                    onOpenThread = { threadId, isMultiRecipient, openAtPage, wasUnread ->
+                    onOpenThread = { threadId, isMultiRecipient, openAtPage, wasUnread, openedAtDate ->
                         // Record the multi-recipient hint in memory only; the route stays opaque.
                         if (isMultiRecipient) {
                             privateMessageNavState.onThreadOpenedAsMulti(threadId)
@@ -1480,6 +1570,9 @@ private fun RedfaceNavHost(
                         if (wasUnread) {
                             privateMessageNavState.onThreadOpenedUnread(threadId)
                         }
+                        // #531 — capture the conversation date seen now, so the read mark recorded on
+                        // load can later be reconciled against a strictly-newer server date.
+                        privateMessageNavState.onThreadOpenedAt(threadId, openedAtDate)
                         backStack.add(
                             PrivateMessageThreadRoute(
                                 threadId = threadId,
@@ -1490,6 +1583,7 @@ private fun RedfaceNavHost(
                             ),
                         )
                     },
+                    onReconcileReadMarks = privateMessageNavState.onReconcileReadMarks,
                     onComposeNew = { backStack.add(PrivateMessageComposeRoute()) },
                     sentSignal = privateMessageNavState.sentSignal,
                     topBarActions = accountMenu,

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/ReadMarkReconcileTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/ReadMarkReconcileTest.kt
@@ -1,0 +1,144 @@
+package fr.forumhfr.redface2.navigation
+
+import fr.forumhfr.redface2.core.model.messages.PrivateMessageSummary
+import java.time.Instant
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #531 — covers the [reconcileReadMarks] pure helper that reconciles the optimistic inbox read marks
+ * (threadId → date seen at open-time) against a fresh page-1 network result. Compose-free, like the
+ * other nav-state helper tests ([TopicScrollCacheTest], [TopicTitleCacheTest]).
+ *
+ * Invariant: a mark is dropped ONLY when the server still reports the thread unread AND its server
+ * date is STRICTLY after the recorded open-time date (a genuine new MP). An identical date is the echo
+ * of the pre-read dot and must keep the mark, or a just-read thread would re-blink unread.
+ */
+class ReadMarkReconcileTest {
+
+    private val opened = Instant.parse("2026-06-18T10:00:00Z")
+
+    private fun conversation(
+        threadId: Int,
+        date: Instant,
+        hasUnread: Boolean,
+    ) = PrivateMessageSummary(
+        threadId = threadId,
+        correspondent = "Corr$threadId",
+        subject = "Sujet $threadId",
+        date = date,
+        hasUnread = hasUnread,
+    )
+
+    @Test
+    fun `keeps the mark when the server date equals the open-time date (echo of the pre-read dot)`() {
+        val marks = mapOf(10 to opened)
+        val fresh = listOf(conversation(threadId = 10, date = opened, hasUnread = true))
+
+        assertTrue("same-date unread is an echo, mark must survive", reconcileReadMarks(marks, fresh).isEmpty())
+    }
+
+    @Test
+    fun `drops the mark when the server date is strictly after the open-time date (real new MP)`() {
+        val marks = mapOf(10 to opened)
+        val fresh = listOf(conversation(threadId = 10, date = opened.plusSeconds(1), hasUnread = true))
+
+        assertEquals(setOf(10), reconcileReadMarks(marks, fresh))
+    }
+
+    @Test
+    fun `does not drop a mark for a conversation absent from page 1`() {
+        val marks = mapOf(10 to opened, 20 to opened)
+        // Only thread 10 is on the fresh page, and it is unchanged (read). Thread 20 is absent: no
+        // page-1 entry means no signal, so its mark must NOT be inferred stale.
+        val fresh = listOf(conversation(threadId = 10, date = opened, hasUnread = false))
+
+        assertTrue(reconcileReadMarks(marks, fresh).isEmpty())
+    }
+
+    @Test
+    fun `leaves the mark untouched when the server reports the thread read`() {
+        val marks = mapOf(10 to opened)
+        // hasUnread = false : the server agrees the thread is read, even with a newer date — there is
+        // nothing to reconcile (the read override is already consistent with the server).
+        val fresh = listOf(conversation(threadId = 10, date = opened.plusSeconds(60), hasUnread = false))
+
+        assertTrue(reconcileReadMarks(marks, fresh).isEmpty())
+    }
+
+    @Test
+    fun `ignores a fresh unread conversation that was never marked read`() {
+        // No mark for thread 30 : a normally-unread inbox row is not our concern (the list already
+        // shows it unread). reconcileReadMarks only ever removes EXISTING marks.
+        val marks = mapOf(10 to opened)
+        val fresh = listOf(conversation(threadId = 30, date = opened.plusSeconds(99), hasUnread = true))
+
+        assertTrue(reconcileReadMarks(marks, fresh).isEmpty())
+    }
+
+    @Test
+    fun `comparison is strict (after), not greater-or-equal`() {
+        // Belt-and-braces twin of the echo case: the boundary (exactly equal) must NOT drop. A single
+        // nanosecond later must drop. Guards against a future >= regression.
+        val marks = mapOf(10 to opened)
+        val equalDate = listOf(conversation(threadId = 10, date = opened, hasUnread = true))
+        val oneNanoLater = listOf(conversation(threadId = 10, date = opened.plusNanos(1), hasUnread = true))
+
+        assertTrue("exactly equal must keep the mark", reconcileReadMarks(marks, equalDate).isEmpty())
+        assertEquals("one nanosecond later must drop", setOf(10), reconcileReadMarks(marks, oneNanoLater))
+    }
+
+    @Test
+    fun `withoutReconciled returns the same instance when nothing is stale (no recomposition)`() {
+        val marks = mapOf(10 to opened)
+        val fresh = listOf(conversation(threadId = 10, date = opened, hasUnread = true)) // echo → keep
+
+        assertSame("a no-op reconciliation must not allocate a new map", marks, marks.withoutReconciled(fresh))
+    }
+
+    @Test
+    fun `withoutReconciled removes the genuinely-newer mark`() {
+        val marks = mapOf(10 to opened, 20 to opened)
+        val fresh = listOf(
+            conversation(threadId = 10, date = opened.plusSeconds(1), hasUnread = true), // real new MP → drop
+            conversation(threadId = 20, date = opened, hasUnread = true), // echo → keep
+        )
+
+        assertEquals(mapOf(20 to opened), marks.withoutReconciled(fresh))
+    }
+
+    @Test
+    fun `withReadMark records the captured open-time date`() {
+        val marks = emptyMap<Int, Instant>().withReadMark(10, openDates = mapOf(10 to opened))
+
+        assertEquals(opened, marks[10])
+    }
+
+    @Test
+    fun `withReadMark falls back to EPOCH when no open-time date was captured`() {
+        // DT / deep-link open path never records an open date: the mark falls back to EPOCH so any
+        // later server date strictly exceeds it and can reconcile the thread back to unread.
+        val marks = emptyMap<Int, Instant>().withReadMark(10, openDates = emptyMap())
+
+        assertEquals(Instant.EPOCH, marks[10])
+    }
+
+    @Test
+    fun `drops only the genuinely-newer marks in a mixed page`() {
+        val marks = mapOf(
+            10 to opened, // echo (same date) → keep
+            20 to opened, // real new MP (later) → drop
+            30 to opened, // server reports read → keep
+        )
+        val fresh = listOf(
+            conversation(threadId = 10, date = opened, hasUnread = true),
+            conversation(threadId = 20, date = opened.plusSeconds(5), hasUnread = true),
+            conversation(threadId = 30, date = opened.plusSeconds(5), hasUnread = false),
+            conversation(threadId = 40, date = opened.plusSeconds(5), hasUnread = true), // unmarked → ignore
+        )
+
+        assertEquals(setOf(20), reconcileReadMarks(marks, fresh))
+    }
+}

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/ReadMarkReconcileTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/ReadMarkReconcileTest.kt
@@ -117,12 +117,98 @@ class ReadMarkReconcileTest {
     }
 
     @Test
-    fun `withReadMark falls back to EPOCH when no open-time date was captured`() {
-        // DT / deep-link open path never records an open date: the mark falls back to EPOCH so any
-        // later server date strictly exceeds it and can reconcile the thread back to unread.
+    fun `withReadMark falls back to the MAX sentinel when no open-time date was captured`() {
+        // #531 (Codex BLOCKER 2) — DT / deep-link open path never records an open date: the mark
+        // falls back to Instant.MAX (NO_RECONCILE_BASELINE), NOT EPOCH. With EPOCH any server date
+        // exceeded the baseline and a dot echo re-unread a just-read thread; with MAX no server date
+        // is ever strictly after it, so the mark is never reconciled away (conservative).
         val marks = emptyMap<Int, Instant>().withReadMark(10, openDates = emptyMap())
 
-        assertEquals(Instant.EPOCH, marks[10])
+        assertEquals(Instant.MAX, marks[10])
+    }
+
+    @Test
+    fun `a mark with no open-time baseline (MAX sentinel) is never reconciled, even when shown unread`() {
+        // #531 (Codex BLOCKER 2) — a thread read via the DT / deep-link path (no captured open date)
+        // gets the MAX sentinel. No server date can be strictly after MAX, so even a fresh page-1
+        // result still reporting it unread leaves the mark in place (it clears only on the auth purge).
+        val marks = emptyMap<Int, Instant>().withReadMark(10, openDates = emptyMap())
+        val fresh = listOf(conversation(threadId = 10, date = opened.plusSeconds(999), hasUnread = true))
+
+        assertTrue("a MAX-baseline mark must survive any server date", reconcileReadMarks(marks, fresh).isEmpty())
+        assertSame("a no-op reconciliation must not allocate", marks, marks.withoutReconciled(fresh))
+    }
+
+    @Test
+    fun `reconcilePass ignores a generation already reconciled (idempotent re-fire)`() {
+        // #531 (Codex BLOCKER 1) — the reconcile effect can re-fire for the SAME generation when the
+        // screen re-enters composition (thread → back on a stale page-1 Content). The dedupe must
+        // make the second pass a no-op : same marks, same high-water mark, regardless of content.
+        val marks = mapOf(10 to opened)
+        val realNewMp = listOf(conversation(threadId = 10, date = opened.plusSeconds(1), hasUnread = true))
+
+        // First pass at generation 5 reconciles : the genuinely-newer mark is dropped, high-water → 5.
+        val first = reconcilePass(marks, lastReconciled = 0, generation = 5, freshConversations = realNewMp)
+        assertEquals(emptyMap<Int, Instant>(), first.marks)
+        assertEquals(5, first.lastReconciled)
+
+        // Re-fire at the SAME generation 5 : ignored. The mark map (now empty) is returned untouched,
+        // and even feeding it back the original (still-marked) map must not re-reconcile it.
+        val refire = reconcilePass(marks, lastReconciled = 5, generation = 5, freshConversations = realNewMp)
+        assertSame("a re-fired generation must return the inputs untouched", marks, refire.marks)
+        assertEquals(5, refire.lastReconciled)
+
+        // A strictly newer generation (6) reconciles again.
+        val next = reconcilePass(marks, lastReconciled = 5, generation = 6, freshConversations = realNewMp)
+        assertEquals(emptyMap<Int, Instant>(), next.marks)
+        assertEquals(6, next.lastReconciled)
+    }
+
+    @Test
+    fun `reconcilePass reconciles at most once across a repeated generation`() {
+        // #531 (Codex BLOCKER 1) — two reconcile calls for the same generation drop the mark exactly
+        // once : the first removes it, the second (same generation) is a no-op, so the effect is
+        // idempotent end-to-end. Mirrors the host loop : (marks, lastReconciled) fed back in.
+        val realNewMp = listOf(conversation(threadId = 10, date = opened.plusSeconds(1), hasUnread = true))
+
+        var marks = mapOf(10 to opened)
+        var lastReconciled = 0
+
+        repeat(3) {
+            val pass = reconcilePass(marks, lastReconciled, generation = 7, freshConversations = realNewMp)
+            marks = pass.marks
+            lastReconciled = pass.lastReconciled
+        }
+
+        assertTrue("the mark is dropped once and stays dropped", marks.isEmpty())
+        assertEquals(7, lastReconciled)
+    }
+
+    @Test
+    fun `the open-time date is consumed on load so a re-open without a fresh date falls back to MAX`() {
+        // #531 (Codex MAJOR 3) — the date captured at open-time is a PER-OPEN pending : onThreadLoaded
+        // reads it to build the mark, then removes it from openThreadDates. A later re-open of the same
+        // thread WITHOUT a fresh inbox date must therefore NOT reuse the old date — it falls back to the
+        // MAX sentinel. This models the host's onThreadLoaded sequence with the pure helpers.
+
+        // 1st open from the inbox : the row date is recorded as a pending open date.
+        var openDates = mapOf(10 to opened)
+        var marks = emptyMap<Int, Instant>()
+
+        // onThreadLoaded #1 : build the mark from the captured date, THEN consume the date.
+        marks = marks.withReadMark(10, openDates)
+        openDates = openDates - 10
+        assertEquals("first load keys the mark on the captured open date", opened, marks[10])
+        assertTrue("the open date is consumed after load", openDates.isEmpty())
+
+        // 2nd open of the SAME thread NOT from the inbox (deep-link / DT) : no fresh date captured.
+        // onThreadLoaded #2 : with the pending consumed, the mark falls back to the MAX sentinel.
+        marks = marks.withReadMark(10, openDates)
+        assertEquals("a re-open without a fresh date must not reuse the stale date", Instant.MAX, marks[10])
+
+        // And that MAX-baseline mark is never reconciled, even if the server still shows it unread.
+        val fresh = listOf(conversation(threadId = 10, date = opened.plusSeconds(120), hasUnread = true))
+        assertTrue("the re-keyed MAX mark must survive reconcile", reconcileReadMarks(marks, fresh).isEmpty())
     }
 
     @Test

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessagesScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessagesScreen.kt
@@ -65,8 +65,19 @@ fun MessagesScreen(
     // wasUnread is the row's unread state at open-time (#453) : the nav host decrements the unread
     // badge only for a conversation that was actually unread. Not private metadata persisted in any
     // route — a transient signal consumed by the ephemeral nav state.
-    onOpenThread: (threadId: Int, isMultiRecipient: Boolean, openAtPage: Int, wasUnread: Boolean) -> Unit,
+    // openedAtDate is the conversation's last-activity date seen at open-time (#531) : the nav host
+    // keys the read mark on it so a strictly-newer server date can later reconcile (re-unread) it.
+    onOpenThread: (
+        threadId: Int,
+        isMultiRecipient: Boolean,
+        openAtPage: Int,
+        wasUnread: Boolean,
+        openedAtDate: Instant,
+    ) -> Unit,
     readThreadIds: Set<Int> = emptySet(),
+    // #531 — invoked once per fresh page-1 network result with the server conversations, so the host
+    // can drop the optimistic read marks HFR now reports as genuinely unread again (gated by date).
+    onReconcileReadMarks: (List<PrivateMessageSummary>) -> Unit = {},
     topBarActions: @Composable (() -> Unit)? = null,
     // #301 follow-up — opens the new-conversation composer. Null hides the button.
     onComposeNew: (() -> Unit)? = null,
@@ -81,6 +92,17 @@ fun MessagesScreen(
             // Page 1 always : the created conversation lands at the top of the inbox, and a
             // plain current-page refresh from page 2+ would never surface it.
             viewModel.showFreshInbox()
+        }
+    }
+    // #531 — reconcile optimistic read marks on a genuine page-1 network success. Keyed on the
+    // ViewModel's load generation (not the conversation list) so it fires exactly once per fetch and
+    // never on a bare recomposition. Page 1 only: it is where HFR re-signals a thread unread, and a
+    // conversation appears on a single inbox page so reconciling elsewhere has nothing to add.
+    val currentMode = state.mode
+    LaunchedEffect(state.networkLoadGeneration) {
+        val freshContent = currentMode as? MessagesUiState.Mode.Content
+        if (state.networkLoadGeneration > 0 && state.page == 1 && freshContent != null) {
+            onReconcileReadMarks(freshContent.conversations)
         }
     }
 
@@ -190,6 +212,9 @@ fun MessagesScreen(
                                 // effectiveConversation already folds the local read override, so a
                                 // re-opened (now read) row correctly reports wasUnread = false (#453).
                                 conversation.hasUnread,
+                                // #531 — the conversation's last-activity date seen now: the host keys
+                                // the read mark on it for the strictly-newer-date reconciliation.
+                                conversation.date,
                             )
                         },
                     )

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessagesScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessagesScreen.kt
@@ -75,9 +75,13 @@ fun MessagesScreen(
         openedAtDate: Instant,
     ) -> Unit,
     readThreadIds: Set<Int> = emptySet(),
-    // #531 — invoked once per fresh page-1 network result with the server conversations, so the host
-    // can drop the optimistic read marks HFR now reports as genuinely unread again (gated by date).
-    onReconcileReadMarks: (List<PrivateMessageSummary>) -> Unit = {},
+    // #531 — invoked on each fresh page-1 network result with the LOAD GENERATION and the server
+    // conversations, so the host can drop the optimistic read marks HFR now reports as genuinely
+    // unread again (gated by date). The generation lets the host dedupe out-of-composition: the
+    // effect below can refire for the SAME generation when the screen re-enters composition (e.g.
+    // returning from a thread on a stale page-1 Content), so the host ignores a generation it has
+    // already reconciled instead of relying on the effect key alone (Codex BLOCKER 1).
+    onReconcileReadMarks: (generation: Int, conversations: List<PrivateMessageSummary>) -> Unit = { _, _ -> },
     topBarActions: @Composable (() -> Unit)? = null,
     // #301 follow-up — opens the new-conversation composer. Null hides the button.
     onComposeNew: (() -> Unit)? = null,
@@ -95,14 +99,18 @@ fun MessagesScreen(
         }
     }
     // #531 — reconcile optimistic read marks on a genuine page-1 network success. Keyed on the
-    // ViewModel's load generation (not the conversation list) so it fires exactly once per fetch and
-    // never on a bare recomposition. Page 1 only: it is where HFR re-signals a thread unread, and a
-    // conversation appears on a single inbox page so reconciling elsewhere has nothing to add.
+    // ViewModel's load generation (not the conversation list) so it fires once per fetch and never on
+    // a bare recomposition. The effect can still REFIRE for the same generation when the screen
+    // re-enters composition (thread → back lands on a stale page-1 Content), so the actual once-per-
+    // generation guarantee lives in the host (Codex BLOCKER 1): the generation is forwarded and the
+    // host ignores any generation it has already reconciled. Page 1 only: it is where HFR re-signals a
+    // thread unread, and a conversation appears on a single inbox page so reconciling elsewhere adds
+    // nothing.
     val currentMode = state.mode
     LaunchedEffect(state.networkLoadGeneration) {
         val freshContent = currentMode as? MessagesUiState.Mode.Content
         if (state.networkLoadGeneration > 0 && state.page == 1 && freshContent != null) {
-            onReconcileReadMarks(freshContent.conversations)
+            onReconcileReadMarks(state.networkLoadGeneration, freshContent.conversations)
         }
     }
 

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessagesUiState.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessagesUiState.kt
@@ -13,6 +13,15 @@ data class MessagesUiState(
     val page: Int = 1,
     val totalPages: Int = 1,
     val isRefreshing: Boolean = false,
+    /**
+     * #531 — monotonic counter bumped on every SUCCESSFUL network load of the inbox (initial,
+     * page change, retry, refresh). The inbox has no cache layer (#298 MVP), so each successful
+     * [Mode.Content] emission is a genuine fresh network result. The screen keys a `LaunchedEffect`
+     * on this value to run the read-mark reconciliation exactly once per fetch — not on every
+     * recomposition (a plain effect keyed on the conversation list could refire on unrelated state
+     * changes that re-emit the same list). Starts at `0` (no fetch yet); the screen ignores `0`.
+     */
+    val networkLoadGeneration: Int = 0,
 ) {
     /** `true` when a previous inbox page exists (enables the "Précédent" pager control). */
     val canGoPrevious: Boolean get() = page > 1

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessagesViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessagesViewModel.kt
@@ -138,6 +138,9 @@ class MessagesViewModel @Inject constructor(
                         page = result.page,
                         totalPages = result.totalPages,
                         isRefreshing = false,
+                        // #531 — a genuine network success (no cache layer here): bump the generation
+                        // so the screen reconciles the optimistic read marks exactly once per fetch.
+                        networkLoadGeneration = it.networkLoadGeneration + 1,
                     )
                 }
             } catch (cancellation: CancellationException) {

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/MessagesViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/MessagesViewModelTest.kt
@@ -139,6 +139,41 @@ class MessagesViewModelTest {
     }
 
     @Test
+    fun `networkLoadGeneration bumps on every successful network load`() = runTest {
+        // #531 — the inbox has no cache layer, so every successful Content is a fresh network result.
+        // The generation counter (which the screen keys its read-mark reconciliation on) must advance
+        // once per fetch: init (1), then refresh (2). It never advances on a failed load.
+        val repository = mockk<MessagesRepository>()
+        coEvery { repository.getPrivateMessageList(page = 1) } returns
+            PrivateMessageListPage(page = 1, totalPages = 1, items = listOf(summary(1)))
+
+        val viewModel = viewModel(repository, FakeAuthRepository())
+        assertEquals(1, viewModel.state.value.networkLoadGeneration)
+
+        viewModel.refresh()
+        advanceUntilIdle()
+        assertEquals(2, viewModel.state.value.networkLoadGeneration)
+    }
+
+    @Test
+    fun `networkLoadGeneration does not advance on a failed refresh`() = runTest {
+        // #531 — a failed pull-to-refresh keeps the existing content and must NOT bump the generation
+        // (no fresh server data to reconcile against — reconciling on stale content could wrongly drop
+        // marks). The successful init load is generation 1; the failed refresh leaves it at 1.
+        val repository = mockk<MessagesRepository>()
+        coEvery { repository.getPrivateMessageList(page = 1) } returns
+            PrivateMessageListPage(page = 1, totalPages = 1, items = listOf(summary(1))) andThenThrows
+            IOException("offline")
+
+        val viewModel = viewModel(repository, FakeAuthRepository())
+        assertEquals(1, viewModel.state.value.networkLoadGeneration)
+
+        viewModel.refresh()
+        advanceUntilIdle()
+        assertEquals(1, viewModel.state.value.networkLoadGeneration)
+    }
+
+    @Test
     fun `selectPage loads the requested page`() = runTest {
         val repository = mockk<MessagesRepository>()
         coEvery { repository.getPrivateMessageList(page = 1) } returns


### PR DESCRIPTION
## Quoi
Réconcilie le marquage optimiste « lu » de l'inbox MP avec le serveur (#531) : quand un fetch page 1 frais re-signale un thread NON-LU (nouveau MP arrivé), on retire le mark local pour que la ligne repasse « non-lue » et que le badge se ré-arme — au lieu de masquer la donnée serveur jusqu'au prochain refresh.

## Design (cadré + relu 2× par Codex) — gaté par la date, conservateur
- Marks `Set<Int>` → **`Map<Int, Instant>`** (threadId → date d'activité vue à l'ouverture).
- On ne retire un mark QUE si `conversation.date.isAfter(openDate)` STRICTEMENT (vrai nouveau MP) — jamais sur un écho du dot (même date) : un thread juste lu ne re-clignote pas non-lu.
- Helper pur `reconcileReadMarks` (testable hors UI).
- Réconciliation déclenchée par `MessagesViewModel.networkLoadGeneration` (bump sur succès réseau uniquement ; pas de cache → chaque Content = réseau frais), **dédupé hors composition** : `reconcilePass` + `lastReconciledGeneration` dans le nav host → fire exactement une fois par fetch, même si l'écran re-rentre en composition (thread→back).
- Fallback **`Instant.MAX`** quand aucune date d'ouverture réelle (DT/deep-link) → un tel mark n'est jamais réconcilié (ne part qu'à la purge d'auth). Conservateur.
- Date d'ouverture **consommée** après usage → une ré-ouverture sans date inbox fraîche retombe sur la sentinelle, jamais sur une date périmée.
- Purge `marks + openThreadDates + lastReconciledGeneration` aux 2 transitions d'auth.
- Badge (fold séparé) **hors scope** ; effet bonus gratuit : après retrait, ré-ouvrir envoie wasUnread=true → badge ré-armé.

## Validation
`BUILD SUCCESSFUL` : `:feature:messages:testDebugUnitTest`, `:app:testDevDebugUnitTest`, `:app:lintDevDebug`, `detektAll`. Tests (ReadMarkReconcileTest + MessagesViewModelTest) : même date→conservé, date+1→retiré, +1ns→retiré (strict), absent page 1→pas de retrait, hasUnread=false→inchangé, purge auth, sentinelle MAX jamais retirée, dédup idempotent, date consommée.

## Revue Codex
2 tours. 1er : 2 BLOCKER (replay réconciliation sur génération périmée ; fallback EPOCH non conservateur) + 1 MAJOR (date réutilisable) → corrigés. 2e tour : **GO**, B1/B2/M3 résolus, pas de régression.

Closes #531.

---
> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
