### PR TITLE
feat(#351): primitives neutres PostCardShell/IdentityHeader/ListScaffold (:core:ui, c1)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/list/ScrollToTopOnPageChange.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/list/ScrollToTopOnPageChange.kt
@@ -1,0 +1,32 @@
+package fr.forumhfr.redface2.core.ui.list
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+
+/**
+ * #351 — land at the top when a NEW page replaces the kept-on-screen previous one (in-place
+ * pagination: the composition survives the page change, unlike the topic's route-driven model where
+ * a fresh screen starts at the top for free). Keyed on the RENDERED page: a same-page refresh keeps
+ * the read position. Only fires when a previous page was rendered in THIS composition and differs
+ * (Codex review on the first cut): on the first Content render the guard is still null, so a
+ * rotation / recreation with content already loaded keeps the position `rememberLazyListState` just
+ * restored instead of being yanked back to the top.
+ *
+ * Moved verbatim from `PrivateMessageThreadScreen` to `:core:ui` (#351): a generic
+ * [LazyListState] behaviour the private-message thread will call in c3. NOT invoked by
+ * [fr.forumhfr.redface2.core.ui.post.PostListScaffold] — the topic is route-driven and does not want
+ * it, so it stays an opt-in the call-site applies, not part of the scaffold.
+ */
+@Composable
+fun ScrollToTopOnPageChange(listState: LazyListState, renderedPage: Int) {
+    val lastRenderedPage = remember { mutableStateOf<Int?>(null) }
+    LaunchedEffect(renderedPage) {
+        if (lastRenderedPage.value != null && lastRenderedPage.value != renderedPage) {
+            listState.scrollToItem(0)
+        }
+        lastRenderedPage.value = renderedPage
+    }
+}

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostCardShell.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostCardShell.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 
 /**
  * #351 — the neutral anatomy shared by the topic post card and the private-message thread card.
@@ -64,31 +65,27 @@ fun PostCardShell(
 }
 
 /**
- * #351/#104 — the topic's tinted identity strip: a full-width [Surface] across the top of the card
- * that hosts the [content] (a [PostIdentityHeader]). Extracted as its own primitive (per the Codex
- * framing) instead of a `highlighted` flag on [PostCardShell], so the band-less private-message card
- * never inherits a strip it does not use.
+ * #351/#104 — a tinted identity strip: a full-width [Surface] across the top of the card that hosts
+ * the [content] (a [PostIdentityHeader]). Extracted as its own primitive (per the Codex framing)
+ * instead of a flag on [PostCardShell], so the band-less private-message card never inherits a strip
+ * it does not use.
  *
- * The colour switches on [highlighted]: [MaterialTheme.colorScheme.tertiaryContainer] for the
- * scroll-anchor post (#104 — quote link / deep link / last-read landing, findable without the old
- * card+band double highlight), [MaterialTheme.colorScheme.secondaryContainer] otherwise. The `Surface`
- * sets `LocalContentColor` to the matching on-container colour for the header's pseudo, and the
+ * The tint is the call-site's decision, not `:core:ui`'s: [containerColor] is passed in (the topic
+ * supplies `tertiaryContainer` for the scroll-anchor post #104 — quote link / deep link / last-read
+ * landing — and `secondaryContainer` otherwise; that semantics lives in the feature, not here). The
+ * `Surface` derives `LocalContentColor` from [containerColor] for the header's pseudo, and the
  * enclosing `Card` clips the strip to its rounded corners. The strip's inner padding is the call-site's
  * job (the topic reads it from its density preset), so the band adds none.
  */
 @Composable
 fun PostIdentityBand(
     content: @Composable () -> Unit,
+    containerColor: Color,
     modifier: Modifier = Modifier,
-    highlighted: Boolean = false,
 ) {
     Surface(
         modifier = modifier.fillMaxWidth(),
-        color = if (highlighted) {
-            MaterialTheme.colorScheme.tertiaryContainer
-        } else {
-            MaterialTheme.colorScheme.secondaryContainer
-        },
+        color = containerColor,
     ) {
         content()
     }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostCardShell.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostCardShell.kt
@@ -1,0 +1,95 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * #351 — the neutral anatomy shared by the topic post card and the private-message thread card.
+ *
+ * Both screens render the *same skeleton* — an identity header, an optional badge strip, the post
+ * body, and an optional footer of actions — but with their own labels, icons and colours. This shell
+ * is the **structure** factored out (ADR-013: share the components, not the screens); every feature
+ * fills its [header]/[badges]/[footer]/[body] slots with its own composables, so `:core:ui` never has
+ * to reach a feature string (`topic_*`/`messages_*`, which live behind each feature's own `R`) nor a
+ * material-icon (detekt `ForbiddenImport` blocks `androidx.compose.material.*`).
+ *
+ * A `Card` over [MaterialTheme.colorScheme.surfaceContainer] (the neutral card colour both screens
+ * already used) with the slots stacked top to bottom:
+ *  - [header] (mandatory) — the poster identity. The topic wraps it in a tinted [PostIdentityBand]
+ *    (full-width identity strip, anchor tint for #104); the MP passes a plain [PostIdentityHeader].
+ *    The shell does NOT draw the band itself: a band is a topic affordance, and baking it here would
+ *    force the band-less MP into a tinted-strip model it does not want.
+ *  - [badges] (optional) — citation/multi-quote pills on the topic (#239/#436); `null` on the MP.
+ *  - [body] (mandatory) — the rendered post (the call-site supplies its own [PostRenderer], choosing
+ *    `selectable` itself — selection is a topic affordance #281, off for the MP, so it is NOT decided
+ *    here).
+ *  - [footer] (optional) — the actions row (Citer/Modifier/multi-quote) on the topic; `null` on the MP.
+ *
+ * [border] is the topic's multi-quote outline (#436), `null` for the MP. Body/header padding is the
+ * slot's own job (the densities differ: the topic reads its gutters from the display-metrics preset,
+ * the MP uses a fixed 16.dp) so the shell adds no padding of its own — it is purely the vertical
+ * stack inside a `Card`. `selectable`/highlight tinting are deliberately NOT handled here.
+ */
+@Composable
+@Suppress("LongParameterList") // Slot shell: 2 mandatory slots + modifier/border + 2 optional slots.
+fun PostCardShell(
+    header: @Composable () -> Unit,
+    body: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    border: BorderStroke? = null,
+    badges: (@Composable () -> Unit)? = null,
+    footer: (@Composable () -> Unit)? = null,
+) {
+    Card(
+        modifier = modifier,
+        border = border,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        ),
+    ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            header()
+            badges?.invoke()
+            body()
+            footer?.invoke()
+        }
+    }
+}
+
+/**
+ * #351/#104 — the topic's tinted identity strip: a full-width [Surface] across the top of the card
+ * that hosts the [content] (a [PostIdentityHeader]). Extracted as its own primitive (per the Codex
+ * framing) instead of a `highlighted` flag on [PostCardShell], so the band-less private-message card
+ * never inherits a strip it does not use.
+ *
+ * The colour switches on [highlighted]: [MaterialTheme.colorScheme.tertiaryContainer] for the
+ * scroll-anchor post (#104 — quote link / deep link / last-read landing, findable without the old
+ * card+band double highlight), [MaterialTheme.colorScheme.secondaryContainer] otherwise. The `Surface`
+ * sets `LocalContentColor` to the matching on-container colour for the header's pseudo, and the
+ * enclosing `Card` clips the strip to its rounded corners. The strip's inner padding is the call-site's
+ * job (the topic reads it from its density preset), so the band adds none.
+ */
+@Composable
+fun PostIdentityBand(
+    content: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    highlighted: Boolean = false,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = if (highlighted) {
+            MaterialTheme.colorScheme.tertiaryContainer
+        } else {
+            MaterialTheme.colorScheme.secondaryContainer
+        },
+    ) {
+        content()
+    }
+}

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostIdentityHeader.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostIdentityHeader.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar
 
@@ -55,13 +56,15 @@ fun PostIdentityHeader(
     onAuthorClick: (() -> Unit)? = null,
     onAuthorClickLabel: String? = null,
     avatarContentDescription: String? = null,
+    avatarSpacing: Dp = DEFAULT_AVATAR_SPACING,
+    lineSpacing: Dp = DEFAULT_LINE_SPACING,
     pseudo: (@Composable () -> Unit)? = null,
     trailing: (@Composable () -> Unit)? = null,
     subline: (@Composable () -> Unit)? = null,
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalArrangement = Arrangement.spacedBy(avatarSpacing),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         val avatarModifier = if (onAvatarClick != null) {
@@ -83,7 +86,7 @@ fun PostIdentityHeader(
         )
         Column(
             modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(2.dp),
+            verticalArrangement = Arrangement.spacedBy(lineSpacing),
         ) {
             if (pseudo != null) {
                 pseudo()
@@ -116,3 +119,9 @@ fun PostIdentityHeader(
         trailing?.invoke()
     }
 }
+
+/** Default avatar↔identity gap. Overridable by the call-site (#351 — density stays feature-owned). */
+private val DEFAULT_AVATAR_SPACING: Dp = 12.dp
+
+/** Default pseudo↔date gap. Overridable by the call-site (#351 — density stays feature-owned). */
+private val DEFAULT_LINE_SPACING: Dp = 2.dp

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostIdentityHeader.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostIdentityHeader.kt
@@ -1,0 +1,118 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar
+
+/**
+ * #351 — the poster-identity line shared by the topic post card and the private-message thread card:
+ * an avatar, an author pseudo and a date, optionally with a contextual-menu trigger and an extra
+ * sub-line. The neutral half of the identity; the tinted strip behind it is [PostIdentityBand] (a
+ * separate primitive so the band-less MP can use this header on its own).
+ *
+ * Layout: `Row[ avatar, Column(weight 1f){ pseudo ; date + subline }, trailing ]`, centred so the
+ * avatar reads against the name+date block as one tidy unit. Slots, so each feature supplies its own
+ * labels/icons without `:core:ui` reaching a feature string or a material-icon:
+ *  - [pseudo] (optional) — overrides the default pseudo text; the topic passes its gold-sheen
+ *    `CreatorPseudoText` (#221). When `null`, a plain ellipsised [Text] of [author] is drawn. Note:
+ *    [onAuthorClick] is applied to that fallback text only — a supplied [pseudo] owns its own
+ *    interaction, the header does not wrap it.
+ *  - [subline] (optional) — extra line under the date (the topic's `· édité` marker / nothing on MP).
+ *  - [trailing] (optional) — the `⋯` per-post menu glyph (topic); `null` on the MP.
+ *
+ * Clicks: [RedfaceUserAvatar] carries no `onClick` of its own, so the avatar tap is a
+ * `Modifier.clickable` this header wraps around it (with `role = Role.Button` and a
+ * `minimumInteractiveComponentSize()` so the 40.dp avatar still meets the Material 48.dp target). The
+ * pseudo fallback gets a clickable WITHOUT the min-size box (it would inflate the line and float the
+ * text — same trade-off the topic card made: the avatar beside it is the 48.dp-compliant target for
+ * the same action). On-click labels come from the call-site ([onAvatarClickLabel]/[onAuthorClickLabel])
+ * since the labels are feature strings. [avatarContentDescription] overrides the avatar's TalkBack
+ * announcement for a non-personal avatar (e.g. a multi-recipient MP labelled « Interlocuteurs
+ * multiples »).
+ */
+@Composable
+@Suppress("LongParameterList") // Shared identity slot: avatar/pseudo/date data + 2 clicks + 3 slots.
+fun PostIdentityHeader(
+    author: String,
+    avatarUrl: String?,
+    dateText: String,
+    modifier: Modifier = Modifier,
+    onAvatarClick: (() -> Unit)? = null,
+    onAvatarClickLabel: String? = null,
+    onAuthorClick: (() -> Unit)? = null,
+    onAuthorClickLabel: String? = null,
+    avatarContentDescription: String? = null,
+    pseudo: (@Composable () -> Unit)? = null,
+    trailing: (@Composable () -> Unit)? = null,
+    subline: (@Composable () -> Unit)? = null,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        val avatarModifier = if (onAvatarClick != null) {
+            Modifier
+                .minimumInteractiveComponentSize()
+                .clickable(
+                    onClick = onAvatarClick,
+                    role = Role.Button,
+                    onClickLabel = onAvatarClickLabel,
+                )
+        } else {
+            Modifier
+        }
+        RedfaceUserAvatar(
+            avatarUrl = avatarUrl,
+            author = author,
+            modifier = avatarModifier,
+            contentDescriptionOverride = avatarContentDescription,
+        )
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            if (pseudo != null) {
+                pseudo()
+            } else {
+                val pseudoModifier = if (onAuthorClick != null) {
+                    Modifier.clickable(
+                        onClick = onAuthorClick,
+                        role = Role.Button,
+                        onClickLabel = onAuthorClickLabel,
+                    )
+                } else {
+                    Modifier
+                }
+                Text(
+                    text = author,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = pseudoModifier,
+                )
+            }
+            Text(
+                text = dateText,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            subline?.invoke()
+        }
+        trailing?.invoke()
+    }
+}

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostListScaffold.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostListScaffold.kt
@@ -1,0 +1,64 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import fr.forumhfr.redface2.core.ui.list.LazyListScrollbar
+
+/**
+ * #300/#351 — the post-list overlay shared by the topic page and the private-message thread page: a
+ * scrollable [LazyColumn] with the auto-hiding [LazyListScrollbar] riding its right edge, OUTSIDE the
+ * scrolled element so the scrollbar stays put while the list (and any swipe-follow translation on it)
+ * moves.
+ *
+ * Deliberately thin (ADR-013 — share the components, not the screens):
+ *  - [contentPadding] and [verticalArrangement] have **no defaults**: the two screens use different
+ *    densities (the topic reads 8/16/8/88-style insets from its display-metrics preset, the MP a flat
+ *    16.dp with a 12.dp gap), so forcing every call-site to pass them keeps c1 from silently changing
+ *    either screen's spacing.
+ *  - the page-swipe machinery stays in the feature (it differs by lifecycle: the topic is route-driven,
+ *    the MP paginates in place — see `PageSwipe.kt`/ADR-013) and is injected through [listModifier],
+ *    applied to the **`LazyColumn`** (so the list follows the finger) and never to the outer [Box] (so
+ *    the scrollbar overlay stays fixed). `PullToRefreshBox` is NOT absorbed here — it stays the
+ *    feature's wrapper, since its refresh state belongs to the screen's ViewModel.
+ *  - [showScrollbar] gates the scrollbar overlay off entirely. The scrollbar ALSO self-hides on the
+ *    « afficher l'ascenseur » preference (`LazyListScrollbar` reads `LocalShowScrollbar`), so this flag
+ *    is only for a call-site that wants no scrollbar at all regardless of that preference; both
+ *    consumers leave it `true`.
+ */
+@Composable
+@Suppress("LongParameterList") // List host: list state + density (padding/arrangement) + 2 modifiers + flag.
+fun PostListScaffold(
+    listState: LazyListState,
+    contentPadding: PaddingValues,
+    verticalArrangement: Arrangement.Vertical,
+    modifier: Modifier = Modifier,
+    listModifier: Modifier = Modifier,
+    showScrollbar: Boolean = true,
+    content: LazyListScope.() -> Unit,
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .fillMaxSize()
+                .then(listModifier),
+            contentPadding = contentPadding,
+            verticalArrangement = verticalArrangement,
+            content = content,
+        )
+        if (showScrollbar) {
+            LazyListScrollbar(
+                listState = listState,
+                modifier = Modifier.align(Alignment.CenterEnd),
+            )
+        }
+    }
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/list/ScrollToTopOnPageChangeTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/list/ScrollToTopOnPageChangeTest.kt
@@ -1,0 +1,111 @@
+package fr.forumhfr.redface2.core.ui.list
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * #351 — guard semantics of [ScrollToTopOnPageChange] (moved verbatim from the MP screen): the first
+ * Content render must NOT scroll (null guard preserves a restored position on rotation); a page
+ * CHANGE scrolls to item 0; a same-page recomposition does not.
+ */
+@OptIn(ExperimentalTestApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
+class ScrollToTopOnPageChangeTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `first render does not scroll (null guard)`() = runTest {
+        lateinit var listState: LazyListState
+        composeTestRule.setContent {
+            listState = rememberLazyListState(initialFirstVisibleItemIndex = 5)
+            RedfaceTheme {
+                ScrollToTopOnPageChange(listState = listState, renderedPage = 2)
+                LongList(listState)
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        // The composition starts already scrolled to item 5 (a restored position). The first render
+        // leaves the guard null, so it must NOT yank back to the top.
+        assertTrue(
+            "first render must keep the restored position, not scroll to 0",
+            listState.firstVisibleItemIndex == 5,
+        )
+    }
+
+    @Test
+    fun `a page change scrolls to item 0`() = runTest {
+        lateinit var listState: LazyListState
+        var page by mutableIntStateOf(2)
+        composeTestRule.setContent {
+            listState = rememberLazyListState(initialFirstVisibleItemIndex = 5)
+            RedfaceTheme {
+                ScrollToTopOnPageChange(listState = listState, renderedPage = page)
+                LongList(listState)
+            }
+        }
+        composeTestRule.waitForIdle()
+        assertEquals(5, listState.firstVisibleItemIndex)
+
+        page = 3
+        composeTestRule.waitForIdle()
+
+        assertEquals("a new page lands at the top", 0, listState.firstVisibleItemIndex)
+    }
+
+    @Test
+    fun `same page does not scroll`() = runTest {
+        lateinit var listState: LazyListState
+        var tick by mutableIntStateOf(0)
+        val page = 2
+        composeTestRule.setContent {
+            listState = rememberLazyListState(initialFirstVisibleItemIndex = 5)
+            RedfaceTheme {
+                // tick read so a recomposition is forced without changing renderedPage.
+                @Suppress("UNUSED_EXPRESSION") tick
+                ScrollToTopOnPageChange(listState = listState, renderedPage = page)
+                LongList(listState)
+            }
+        }
+        composeTestRule.waitForIdle()
+        assertEquals(5, listState.firstVisibleItemIndex)
+
+        tick = 1
+        composeTestRule.waitForIdle()
+
+        assertEquals("same page must keep the read position", 5, listState.firstVisibleItemIndex)
+    }
+
+    @androidx.compose.runtime.Composable
+    private fun LongList(listState: LazyListState) {
+        LazyColumn(state = listState) {
+            items((0 until 30).toList(), key = { it }) { i ->
+                Text(text = "item $i", modifier = Modifier.fillMaxWidth().height(120.dp))
+            }
+        }
+    }
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostCardShellTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostCardShellTest.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.core.ui.post
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.ExperimentalTestApi
@@ -97,17 +98,23 @@ class PostCardShellTest {
     }
 
     @Test
-    fun `identity band renders its content highlighted and not`() {
+    fun `identity band hosts its content under any caller-supplied tint`() {
         composeTestRule.setContent {
             RedfaceTheme {
-                PostIdentityBand(highlighted = true, content = { Text("highlighted band") })
-                PostIdentityBand(highlighted = false, content = { Text("normal band") })
+                // The tint is the call-site's decision (containerColor), not the band's: it hosts the
+                // content slot whatever colour it is given — the structural contract a non-pixel test pins.
+                PostIdentityBand(
+                    containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                    content = { Text("anchor band") },
+                )
+                PostIdentityBand(
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    content = { Text("normal band") },
+                )
             }
         }
 
-        // The tint differs by `highlighted` (tertiaryContainer vs secondaryContainer); both states
-        // host their content slot, which is the structural contract a non-pixel test can pin.
-        composeTestRule.onNodeWithText("highlighted band").assertIsDisplayed()
+        composeTestRule.onNodeWithText("anchor band").assertIsDisplayed()
         composeTestRule.onNodeWithText("normal band").assertIsDisplayed()
     }
 }

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostCardShellTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostCardShellTest.kt
@@ -1,0 +1,113 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.material3.Text
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * #351 — slot contract of [PostCardShell] / [PostIdentityBand]: the mandatory header/body slots
+ * always render; the optional badges/footer slots render when supplied and are absent when `null`
+ * (the MP case). Border + highlight are colour/stroke affordances (no semantics to assert on
+ * Robolectric); they are exercised here only to pin that supplying them does not drop the slots.
+ */
+@OptIn(ExperimentalTestApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class PostCardShellTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `mandatory header and body always render`() {
+        composeTestRule.setContent {
+            RedfaceTheme {
+                PostCardShell(
+                    header = { Text("header") },
+                    body = { Text("body") },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("header").assertIsDisplayed()
+        composeTestRule.onNodeWithText("body").assertIsDisplayed()
+    }
+
+    @Test
+    fun `badges and footer render when supplied`() {
+        composeTestRule.setContent {
+            RedfaceTheme {
+                PostCardShell(
+                    header = { Text("header") },
+                    body = { Text("body") },
+                    badges = { Text("badges") },
+                    footer = { Text("footer") },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("badges").assertIsDisplayed()
+        composeTestRule.onNodeWithText("footer").assertIsDisplayed()
+    }
+
+    @Test
+    fun `null badges and footer are absent (MP case)`() {
+        composeTestRule.setContent {
+            RedfaceTheme {
+                PostCardShell(
+                    header = { Text("header") },
+                    body = { Text("body") },
+                    badges = null,
+                    footer = null,
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("badges").assertDoesNotExist()
+        composeTestRule.onNodeWithText("footer").assertDoesNotExist()
+    }
+
+    @Test
+    fun `border is honoured without dropping slots`() {
+        composeTestRule.setContent {
+            RedfaceTheme {
+                PostCardShell(
+                    header = { Text("header") },
+                    body = { Text("body") },
+                    border = BorderStroke(2.dp, Color.Red),
+                )
+            }
+        }
+
+        // The bordered card still renders its mandatory slots (the stroke colour itself is not a
+        // semantics-asserted property — a Roborazzi golden would cover the pixels).
+        composeTestRule.onNodeWithText("header").assertIsDisplayed()
+        composeTestRule.onNodeWithText("body").assertIsDisplayed()
+    }
+
+    @Test
+    fun `identity band renders its content highlighted and not`() {
+        composeTestRule.setContent {
+            RedfaceTheme {
+                PostIdentityBand(highlighted = true, content = { Text("highlighted band") })
+                PostIdentityBand(highlighted = false, content = { Text("normal band") })
+            }
+        }
+
+        // The tint differs by `highlighted` (tertiaryContainer vs secondaryContainer); both states
+        // host their content slot, which is the structural contract a non-pixel test can pin.
+        composeTestRule.onNodeWithText("highlighted band").assertIsDisplayed()
+        composeTestRule.onNodeWithText("normal band").assertIsDisplayed()
+    }
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostIdentityHeaderTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostIdentityHeaderTest.kt
@@ -1,0 +1,141 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * #351 — contract of [PostIdentityHeader]: the author/date always render; the default pseudo is a
+ * plain [Text] of the author and a supplied `pseudo` slot replaces it; the optional `trailing` and
+ * `subline` slots appear only when supplied; the avatar and author-pseudo clicks fire their
+ * callbacks.
+ */
+@OptIn(ExperimentalTestApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class PostIdentityHeaderTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `avatar author and date render with default pseudo`() {
+        composeTestRule.setContent {
+            RedfaceTheme {
+                PostIdentityHeader(
+                    author = "MonPseudo",
+                    avatarUrl = null,
+                    dateText = "12/06/2026 10:00:00",
+                )
+            }
+        }
+
+        // The default pseudo is the author text; the date is its own line. The avatar (null URL)
+        // falls back to the initial-letter placeholder — its TalkBack announcement carries the author.
+        composeTestRule.onNodeWithText("MonPseudo").assertIsDisplayed()
+        composeTestRule.onNodeWithText("12/06/2026 10:00:00").assertIsDisplayed()
+    }
+
+    @Test
+    fun `supplied pseudo slot replaces the default author text`() {
+        composeTestRule.setContent {
+            RedfaceTheme {
+                PostIdentityHeader(
+                    author = "RawAuthor",
+                    avatarUrl = null,
+                    dateText = "date",
+                    pseudo = { Text("CustomPseudo") },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("CustomPseudo").assertIsDisplayed()
+        // The default author Text is NOT rendered when the pseudo slot is supplied.
+        composeTestRule.onNodeWithText("RawAuthor").assertDoesNotExist()
+    }
+
+    @Test
+    fun `trailing and subline render when supplied and are absent otherwise`() {
+        composeTestRule.setContent {
+            RedfaceTheme {
+                PostIdentityHeader(
+                    author = "author",
+                    avatarUrl = null,
+                    dateText = "date",
+                    trailing = { Text("trailing") },
+                    subline = { Text("subline") },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("trailing").assertIsDisplayed()
+        composeTestRule.onNodeWithText("subline").assertIsDisplayed()
+    }
+
+    @Test
+    fun `no trailing nor subline (MP case)`() {
+        composeTestRule.setContent {
+            RedfaceTheme {
+                PostIdentityHeader(
+                    author = "author",
+                    avatarUrl = null,
+                    dateText = "date",
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("trailing").assertDoesNotExist()
+        composeTestRule.onNodeWithText("subline").assertDoesNotExist()
+    }
+
+    @Test
+    fun `onAuthorClick fires when the default pseudo is tapped`() {
+        var clicks = 0
+        composeTestRule.setContent {
+            RedfaceTheme {
+                PostIdentityHeader(
+                    author = "Tappable",
+                    avatarUrl = null,
+                    dateText = "date",
+                    onAuthorClick = { clicks++ },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Tappable").performClick()
+        assertEquals(1, clicks)
+    }
+
+    @Test
+    fun `onAvatarClick fires when the avatar is tapped`() {
+        var clicks = 0
+        composeTestRule.setContent {
+            RedfaceTheme {
+                PostIdentityHeader(
+                    author = "Author",
+                    avatarUrl = null,
+                    dateText = "date",
+                    onAvatarClick = { clicks++ },
+                    onAvatarClickLabel = "open profile",
+                )
+            }
+        }
+
+        // The avatar (null URL) renders the initial-letter placeholder, which carries the author
+        // content description ("Avatar de <author>"); the clickable wrapper around it carries the
+        // tap. Targeting the avatar by its content description and clicking fires onAvatarClick.
+        composeTestRule.onNodeWithContentDescription("Avatar de Author").performClick()
+        assertEquals(1, clicks)
+    }
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostListScaffoldTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostListScaffoldTest.kt
@@ -1,0 +1,148 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import fr.forumhfr.redface2.core.ui.theme.LocalShowScrollbar
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * #351 — contract of [PostListScaffold]: items keyed in the [content] lambda render; the injected
+ * [listModifier] lands on the scrollable [LazyColumn] (not the outer overlay [Box]); the scrollbar
+ * overlay is gated by [showScrollbar]; [contentPadding]/[verticalArrangement] are forwarded to the
+ * list.
+ */
+@OptIn(ExperimentalTestApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
+class PostListScaffoldTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private companion object {
+        const val LIST_MODIFIER_TAG = "list_modifier"
+    }
+
+    @Composable
+    private fun Harness(
+        listState: LazyListState,
+        showScrollbar: Boolean = true,
+        listModifier: Modifier = Modifier,
+        contentPadding: PaddingValues = PaddingValues(16.dp),
+        verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(12.dp),
+    ) {
+        RedfaceTheme {
+            // The scrollbar self-hides on LocalShowScrollbar; keep it ON so showScrollbar is the only
+            // gate under test.
+            CompositionLocalProvider(LocalShowScrollbar provides true) {
+                PostListScaffold(
+                    listState = listState,
+                    contentPadding = contentPadding,
+                    verticalArrangement = verticalArrangement,
+                    listModifier = listModifier,
+                    showScrollbar = showScrollbar,
+                ) {
+                    items(listOf("first", "second", "third"), key = { it }) { label ->
+                        Text(text = label, modifier = Modifier.fillMaxWidth().height(120.dp))
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `keyed items render`() {
+        composeTestRule.setContent {
+            val state = rememberLazyListState()
+            Harness(listState = state)
+        }
+
+        composeTestRule.onNodeWithText("first").assertIsDisplayed()
+        composeTestRule.onNodeWithText("second").assertIsDisplayed()
+    }
+
+    @Test
+    fun `listModifier lands on the scrollable LazyColumn, not the Box`() {
+        composeTestRule.setContent {
+            val state = rememberLazyListState()
+            Harness(listState = state, listModifier = Modifier.testTag(LIST_MODIFIER_TAG))
+        }
+
+        // The tag travels with the LazyColumn (where listModifier is applied). That node carries the
+        // vertical scroll semantics — proving the swipe/list modifier rides the list, not the overlay
+        // Box (a Box would have no scroll-axis range).
+        val node = composeTestRule.onNodeWithTag(LIST_MODIFIER_TAG).fetchSemanticsNode()
+        assertTrue(
+            "listModifier must land on the scrollable LazyColumn",
+            node.config.contains(SemanticsProperties.VerticalScrollAxisRange),
+        )
+    }
+
+    @Test
+    fun `scrollbar gutter present when showScrollbar true`() {
+        composeTestRule.setContent {
+            val state = rememberLazyListState()
+            Harness(listState = state, showScrollbar = true)
+        }
+
+        // The scrollbar overlay is a sibling of the list inside the Box; with content taller than the
+        // viewport (3 × 120.dp) the list is scrollable, so the scrollbar machinery is active. We pin
+        // the gating contract: the list still renders normally with the overlay enabled.
+        composeTestRule.onNodeWithText("first").assertIsDisplayed()
+    }
+
+    @Test
+    fun `showScrollbar false removes the scrollbar overlay`() {
+        composeTestRule.setContent {
+            val state = rememberLazyListState()
+            Harness(listState = state, showScrollbar = false)
+        }
+
+        // The list still renders; the scrollbar overlay branch is skipped entirely (showScrollbar =
+        // false short-circuits before LazyListScrollbar even reads LocalShowScrollbar).
+        composeTestRule.onNodeWithText("first").assertIsDisplayed()
+    }
+
+    @Test
+    fun `contentPadding and verticalArrangement are forwarded to the list`() {
+        composeTestRule.setContent {
+            val state = rememberLazyListState()
+            Harness(
+                listState = state,
+                contentPadding = PaddingValues(top = 40.dp, start = 8.dp, end = 8.dp, bottom = 88.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            )
+        }
+
+        // The first item is pushed down by the 40.dp top contentPadding; a scaffold that ignored the
+        // padding (or defaulted it to zero) would place it at the very top. Bounds assert it cleared
+        // the padding.
+        val first = composeTestRule.onNodeWithText("first").fetchSemanticsNode()
+        val topPx = first.boundsInRoot.top
+        // 40.dp at xxhdpi (3×) ≈ 120px; assert it is clearly below the top edge (defensive lower bound).
+        assertTrue("first item must sit below the top contentPadding (top=$topPx)", topPx > 50f)
+    }
+}


### PR DESCRIPTION
## Quoi (#351, tranche c1)
Première tranche de la factorisation de la liste de posts topic↔MP : extraction des **primitives neutres** dans `:core:ui`, **sans migrer aucun call-site** → increment strictement **invisible** (topic et MP inchangés).

NB : les gestes de lecture MP (swipe pages, ascenseur, pull-to-refresh) sont DÉJÀ à parité sur dev (#428/#429/#335/#300) — le corps initial de #351 est périmé. Reste = factoriser l'anatomie dupliquée des cartes/listes.

## Primitives créées (`core/ui/.../post/` + `list/`)
- **`PostCardShell`** — `Card` neutre (surfaceContainer) à slots `header`/`badges?`/`body`/`footer?` + `border?`. Aucune string/icône feature, pas de padding ni de `selectable` (au call-site).
- **`PostIdentityBand`** — bande d'identité tintée ; **`containerColor` fourni par le call-site** (la sémantique d'ancre #104 reste côté topic).
- **`PostIdentityHeader`** — avatar + pseudo + date à slots (`pseudo`/`trailing`/`subline`), clics avatar/auteur, **`avatarSpacing`/`lineSpacing` paramétrables** (densité owned par la feature).
- **`PostListScaffold`** — `Box{ LazyColumn(listModifier) + LazyListScrollbar }` ; `contentPadding`/`verticalArrangement` **sans défaut** (force le call-site → pas de régression densité). `PullToRefreshBox` et la machinerie de swipe restent côté feature.
- **`ScrollToTopOnPageChange`** déplacé verbatim dans `:core:ui/list/` (guard « null au 1er render » intact).

## Validation
`BUILD SUCCESSFUL` : `:core:ui:testDebugUnitTest` (19 tests neufs : shell, header, scaffold, scroll-to-top) + `lintDebug` + `detektAll`. `:feature:topic`/`:feature:messages` compilent inchangés (aucun call-site touché).

## Revue Codex
API cadrée AVANT implémentation (band séparée du shell, avatar clickable). 2 tours de review : 2 findings « structure pas métriques » (couleur band codée en dur ; spacing header figé) → corrigés (containerColor + avatarSpacing/lineSpacing). Dernier verdict : seul un faux positif d'import (`assertDoesNotExist`, méthode chaînée — build vert le prouve) restait → GO de fait.

Avance #351 (factorisation). c2 (migration topic, diff visuel nul + golden Roborazzi) et c3 (migration MP) suivent.

---
> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
