### PR TITLE
feat(#351): migrate MP thread card + list onto shell primitives (c3)

### DIFF
--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
@@ -8,13 +8,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
@@ -29,7 +26,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
@@ -40,17 +36,18 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.model.Post
-import fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar
 import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.icon.RedfaceVectorIcon
-import fr.forumhfr.redface2.core.ui.list.LazyListScrollbar
+import fr.forumhfr.redface2.core.ui.list.ScrollToTopOnPageChange
 import fr.forumhfr.redface2.core.ui.pager.pageSwipeEdgeHint
+import fr.forumhfr.redface2.core.ui.post.PostCardShell
+import fr.forumhfr.redface2.core.ui.post.PostIdentityHeader
+import fr.forumhfr.redface2.core.ui.post.PostListScaffold
 import fr.forumhfr.redface2.core.ui.post.PostRenderer
 import java.time.Instant
 import java.time.ZoneId
@@ -223,6 +220,9 @@ fun PrivateMessageThreadScreen(
                 }
 
                 is PrivateMessageThreadUiState.Mode.Content -> {
+                    // #351c — moved to :core:ui (was a local copy here). Lands at the top when a NEW
+                    // page replaces the kept-on-screen one; the null guard on the first render keeps a
+                    // restored position on rotation/recreation.
                     ScrollToTopOnPageChange(listState = listState, renderedPage = mode.thread.page)
                     // #335/#351 — pull-to-refresh re-fetches the displayed page; the indicator also
                     // covers the keep-content page changes (same isRefreshing flag).
@@ -231,34 +231,29 @@ fun PrivateMessageThreadScreen(
                         onRefresh = viewModel::refresh,
                         modifier = Modifier.fillMaxSize(),
                     ) {
-                        // #300/#351 — same overlay layout as the topic page: the shared scrollbar
-                        // rides the right edge of the message list, OUTSIDE the swiped element so
-                        // it stays put while the page follows the finger.
-                        Box(modifier = Modifier.fillMaxSize()) {
-                            ThreadMessages(
-                                messages = mode.thread.messages,
-                                page = state.page,
+                        // #300/#351c — the list overlay (LazyColumn + auto-hiding scrollbar) is now the
+                        // shared PostListScaffold; the swipe chain rides the inner list via listModifier
+                        // (so the scrollbar stays fixed while the page follows the finger) and the MP
+                        // density (16.dp padding, 12.dp gap) is passed unchanged.
+                        ThreadMessages(
+                            messages = mode.thread.messages,
+                            page = state.page,
+                            totalPages = state.totalPages,
+                            onSelectPage = viewModel::selectPage,
+                            // Codex review — gate the pager buttons with the same condition as
+                            // the swipe: re-tapping during a keep-content load would only cancel
+                            // and restart the round-trip (supersede), never advance faster.
+                            pagerEnabled = !state.isRefreshing,
+                            listState = listState,
+                            // #351b — horizontal swipe changes page in place (same thresholds
+                            // and feel as the topic via the shared :core:ui geometry).
+                            swipeModifier = rememberThreadSwipeModifier(
+                                renderedPage = mode.thread.page,
                                 totalPages = state.totalPages,
+                                isRefreshing = state.isRefreshing,
                                 onSelectPage = viewModel::selectPage,
-                                // Codex review — gate the pager buttons with the same condition as
-                                // the swipe: re-tapping during a keep-content load would only cancel
-                                // and restart the round-trip (supersede), never advance faster.
-                                pagerEnabled = !state.isRefreshing,
-                                listState = listState,
-                                // #351b — horizontal swipe changes page in place (same thresholds
-                                // and feel as the topic via the shared :core:ui geometry).
-                                swipeModifier = rememberThreadSwipeModifier(
-                                    renderedPage = mode.thread.page,
-                                    totalPages = state.totalPages,
-                                    isRefreshing = state.isRefreshing,
-                                    onSelectPage = viewModel::selectPage,
-                                ),
-                            )
-                            LazyListScrollbar(
-                                listState = listState,
-                                modifier = Modifier.align(Alignment.CenterEnd),
-                            )
-                        }
+                            ),
+                        )
                     }
                 }
             }
@@ -318,27 +313,6 @@ private fun ThreadReplyFab(canReply: Boolean, onReply: () -> Unit) {
         icon = { RedfaceVectorIcon(resId = fr.forumhfr.redface2.core.ui.R.drawable.ic_edit) },
         onClick = onReply,
     )
-}
-
-/**
- * #351 — land at the top when a NEW page replaces the kept-on-screen previous one (in-place
- * pagination: the composition survives the page change, unlike the topic's route-driven model where
- * a fresh screen starts at the top for free). Keyed on the RENDERED page: a same-page refresh keeps
- * the read position. Only fires when a previous page was rendered in THIS composition and differs
- * (Codex review on the first cut): on the first Content render the guard is still null, so a
- * rotation / recreation with content already loaded keeps the position `rememberLazyListState` just
- * restored instead of being yanked back to the top. Extracted from the screen host to keep it under
- * detekt's cyclomatic-complexity threshold.
- */
-@Composable
-private fun ScrollToTopOnPageChange(listState: LazyListState, renderedPage: Int) {
-    val lastRenderedPage = remember { mutableStateOf<Int?>(null) }
-    LaunchedEffect(renderedPage) {
-        if (lastRenderedPage.value != null && lastRenderedPage.value != renderedPage) {
-            listState.scrollToItem(0)
-        }
-        lastRenderedPage.value = renderedPage
-    }
 }
 
 /**
@@ -417,15 +391,17 @@ private fun ThreadMessages(
     listState: LazyListState,
     swipeModifier: Modifier = Modifier,
 ) {
-    LazyColumn(
-        state = listState,
-        // #351b — the swipe chain (edge glow + gesture + graphicsLayer follow) applies to the list
-        // itself, like the topic's LazyColumn: the scrollbar overlay outside stays fixed on screen.
-        modifier = Modifier
-            .fillMaxSize()
-            .then(swipeModifier),
+    // #351c — the shared list overlay (LazyColumn + auto-hiding scrollbar). The MP density stays
+    // feature-owned (16.dp padding, 12.dp gap, distinct from the topic's display-metrics preset) so
+    // it is passed explicitly. The swipe chain (edge glow + gesture + graphicsLayer follow) goes on
+    // the inner LazyColumn via [PostListScaffold.listModifier], like the topic's LazyColumn: the
+    // scrollbar overlay outside stays fixed on screen. [LocalShowScrollbar] (#105) is honoured by the
+    // scaffold's scrollbar, so the call leaves showScrollbar at its default.
+    PostListScaffold(
+        listState = listState,
         contentPadding = PaddingValues(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
+        listModifier = swipeModifier,
     ) {
         items(messages, key = { it.numreponse }) { message ->
             MessageCard(message = message)
@@ -461,46 +437,36 @@ private fun ThreadMessages(
     }
 }
 
+/**
+ * #351c — one private-message rendered onto the shared [PostCardShell]. Unlike the topic card it has
+ * no tinted [PostIdentityBand] (MP has no anchor/category tint), no badges, no footer (the « Répondre »
+ * affordance is the screen FAB #301, not a per-card action) and no multi-quote border. The MP density
+ * (16.dp around the card content, 8.dp between the identity header and the body) is feature-owned and
+ * reinjected via the slots' own padding — the shell adds none. The body stays NON-selectable (#281
+ * is a topic affordance; PostRenderer defaults selection OFF, the MP keeps it).
+ */
 @Composable
 private fun MessageCard(message: Post) {
-    Card(
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                RedfaceUserAvatar(
-                    avatarUrl = message.avatarUrl,
-                    author = message.author,
-                )
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(2.dp),
-                ) {
-                    Text(
-                        text = message.author,
-                        style = MaterialTheme.typography.titleSmall,
-                        fontWeight = FontWeight.SemiBold,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    Text(
-                        text = message.date.asMessageDate(),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-            PostRenderer(content = message.content)
-        }
-    }
+    PostCardShell(
+        header = {
+            PostIdentityHeader(
+                author = message.author,
+                avatarUrl = message.avatarUrl,
+                dateText = message.date.asMessageDate(),
+                // MP density (#351c): 16.dp around the card content; the 8.dp gap to the body rides on
+                // the body slot's top padding so the header↔body spacing matches the pre-shell layout.
+                modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
+            )
+        },
+        body = {
+            // Body slot owns the side + bottom gutters (16.dp) and the 8.dp gap below the header, so the
+            // overall card padding/spacing is byte-identical to the pre-shell MessageCard.
+            PostRenderer(
+                content = message.content,
+                modifier = Modifier.padding(start = 16.dp, top = 8.dp, end = 16.dp, bottom = 16.dp),
+            )
+        },
+    )
 }
 
 // #351b — same blend as the topic edge glow (#282): a full-primary glow read as an imposing panel.


### PR DESCRIPTION
## Quoi (#351, tranche c3 — dernière)
Migre la carte (`MessageCard`) + la liste (`ThreadMessages`) du thread MP sur les primitives `PostCardShell` / `PostIdentityHeader` / `PostListScaffold`. Clôt la factorisation #351 (la liste de posts topic↔MP partage désormais l'anatomie).

## Report (rendu MP préservé)
- `MessageCard` → `PostCardShell(header = PostIdentityHeader(author/avatarUrl/dateText), body = PostRenderer)`. Pas de `PostIdentityBand`/badges/footer/border (spécifiques topic). `selectable=false` (défaut, contrat MP). Densité MP **16.dp + 8.dp** header/body réinjectée via les `modifier` des slots (pas la densité topic).
- `ThreadMessages` → `PostListScaffold(contentPadding=16.dp, verticalArrangement=spacedBy(12.dp), listModifier=swipeModifier)`. Scrollbar manuelle retirée (gérée par le scaffold, `LocalShowScrollbar` #105 respecté). `PullToRefreshBox` + `pagerEnabled=!isRefreshing` + reset `dragOffset(renderedPage)` conservés.
- `ScrollToTopOnPageChange` : copie locale supprimée → appel redirigé vers `:core:ui` (guard 1er render intact).
- **Roster #612** (`ThreadTopBarActions`/`ParticipantRosterSheet`) et `threadPageSwipe` : non touchés.
- Net : 1 fichier, −99/+65 (simplification).

## Validation
`BUILD SUCCESSFUL` : `:feature:messages:testDebugUnitTest` (VM + roster #612 verts) + `:core:ui:testDebugUnitTest` + `lintDebug` + `detektAll`.

## Revue Codex
GO, aucun finding (densité préservée, scaffold/scrollbar/PTR/swipe corrects, ScrollToTop redirigé, roster intact).

Clôt #351 (factorisation liste de posts topic↔MP). Connexe c1 (#611), c2 (#613).

---
> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
