### PR TITLE
fix(beta-0.16.0): 4-flavor review MAJORs (read-mark/badge, MPStorage session+non-BMP, #316)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -877,12 +877,20 @@ fun RedfaceApp(intent: Intent?) {
                                 if (decrement) {
                                     mpBadgeViewModel.onThreadRead(threadId)
                                 }
+                                // (C1, 4-flavor MAJOR) the per-open unread flag is a PER-OPEN pending
+                                // too: CONSUME it here once the decrement decision is made. Without
+                                // this, a later re-fire / re-open keeps `threadId in unreadOnOpen`,
+                                // and after #531 drops the read mark the thread re-decrements the
+                                // badge from a stale unread state. A genuinely-unread re-open rearms
+                                // it via onThreadOpenedUnread.
+                                unreadOnOpenThreadIds = unreadOnOpenThreadIds - threadId
                                 // #531 — record the mark keyed by the conversation date captured at
                                 // open-time (openThreadDates). reconcileReadMarks later compares the
                                 // server date against it. (Codex MAJOR 3) the open-time date is a
                                 // PER-OPEN pending: CONSUME it here so a later re-open of the same
                                 // thread WITHOUT a fresh inbox date can't reuse this stale baseline —
-                                // it falls back to the MAX sentinel (never reconciled) instead.
+                                // (W1) but withReadMark now preserves an already-stored real baseline
+                                // before falling back to the MAX sentinel.
                                 readPrivateMessageThreadIds = readPrivateMessageThreadIds
                                     .withReadMark(threadId, openThreadDates)
                                 openThreadDates = openThreadDates - threadId
@@ -1168,9 +1176,10 @@ private data class PrivateMessageNavState(
  * when that thread was actually unread when opened ([unreadOnOpen]). Opening an already-read
  * conversation subtracts nothing, and re-opening one ([alreadyRead]) must not subtract twice.
  * Extracted from [onThreadLoaded] so the boolean connective stays out of RedfaceApp's cyclomatic
- * complexity budget.
+ * complexity budget. `internal` (like the other nav-state helpers) so the [ReadMarkReconcileTest]
+ * can model the C1 consume-on-load sequence without a Compose host.
  */
-private fun shouldDecrementUnreadBadge(
+internal fun shouldDecrementUnreadBadge(
     threadId: Int,
     unreadOnOpen: Set<Int>,
     alreadyRead: Set<Int>,
@@ -1264,11 +1273,18 @@ private val NO_RECONCILE_BASELINE: Instant = Instant.MAX
  * open-time ([openDates]). A thread with no captured date falls back to [NO_RECONCILE_BASELINE]
  * ([Instant.MAX]), so it is never reconciled back to unread (see that constant). Extracted to keep
  * [RedfaceApp]'s Elvis out of its cyclomatic-complexity budget.
+ *
+ * (W1, 4-flavor MAJOR) — `onThreadLoaded` re-fires for EVERY Content emission (page change, PTR),
+ * not once per visit, and the per-open [openDates] entry is consumed after the first fire. A later
+ * re-fire in the SAME visit must NOT clobber a real baseline already stored for this thread: prefer
+ * an existing real mark ([this] [threadId]) before falling back to the MAX sentinel. Order:
+ * fresh open-time date → already-stored mark → sentinel.
  */
 internal fun Map<Int, Instant>.withReadMark(
     threadId: Int,
     openDates: Map<Int, Instant>,
-): Map<Int, Instant> = this + (threadId to (openDates[threadId] ?: NO_RECONCILE_BASELINE))
+): Map<Int, Instant> =
+    this + (threadId to (openDates[threadId] ?: this[threadId] ?: NO_RECONCILE_BASELINE))
 
 /**
  * Bug fix (build 89) — per-topic title cache plumbed into [RedfaceNavHost]. A topic page change

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/ReadMarkReconcileTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/ReadMarkReconcileTest.kt
@@ -185,30 +185,83 @@ class ReadMarkReconcileTest {
     }
 
     @Test
-    fun `the open-time date is consumed on load so a re-open without a fresh date falls back to MAX`() {
+    fun `the open-time date is consumed on load (a fresh open with no pending and no mark falls back to MAX)`() {
         // #531 (Codex MAJOR 3) — the date captured at open-time is a PER-OPEN pending : onThreadLoaded
-        // reads it to build the mark, then removes it from openThreadDates. A later re-open of the same
-        // thread WITHOUT a fresh inbox date must therefore NOT reuse the old date — it falls back to the
-        // MAX sentinel. This models the host's onThreadLoaded sequence with the pure helpers.
+        // reads it to build the mark, then removes it from openThreadDates. (W1, 4-flavor MAJOR) — the
+        // earlier revision of this test wrongly modelled the SECOND onThreadLoaded as building the mark
+        // from an EMPTY marks map, so it expected MAX. In the real host the first load has ALREADY
+        // stored the mark, so the only way to reach the MAX fallback is when there is neither a fresh
+        // open date NOR an existing real mark (a genuine first-ever read via DT / deep-link). That is
+        // what this test now models.
 
-        // 1st open from the inbox : the row date is recorded as a pending open date.
-        var openDates = mapOf(10 to opened)
+        // First-ever read with no captured open date (DT / deep-link, marks still empty for this id).
+        var openDates = emptyMap<Int, Instant>()
         var marks = emptyMap<Int, Instant>()
 
-        // onThreadLoaded #1 : build the mark from the captured date, THEN consume the date.
         marks = marks.withReadMark(10, openDates)
         openDates = openDates - 10
-        assertEquals("first load keys the mark on the captured open date", opened, marks[10])
-        assertTrue("the open date is consumed after load", openDates.isEmpty())
-
-        // 2nd open of the SAME thread NOT from the inbox (deep-link / DT) : no fresh date captured.
-        // onThreadLoaded #2 : with the pending consumed, the mark falls back to the MAX sentinel.
-        marks = marks.withReadMark(10, openDates)
-        assertEquals("a re-open without a fresh date must not reuse the stale date", Instant.MAX, marks[10])
+        assertEquals("no pending and no existing mark falls back to the MAX sentinel", Instant.MAX, marks[10])
 
         // And that MAX-baseline mark is never reconciled, even if the server still shows it unread.
         val fresh = listOf(conversation(threadId = 10, date = opened.plusSeconds(120), hasUnread = true))
-        assertTrue("the re-keyed MAX mark must survive reconcile", reconcileReadMarks(marks, fresh).isEmpty())
+        assertTrue("the MAX mark must survive reconcile", reconcileReadMarks(marks, fresh).isEmpty())
+    }
+
+    @Test
+    fun `W1 - a re-fired onThreadLoaded in the same visit keeps the real captured baseline`() {
+        // (W1, 4-flavor MAJOR) — onThreadLoaded re-fires for every Content emission (page change, PTR),
+        // not once per visit, and the per-open date is consumed after the FIRST fire. A later re-fire in
+        // the SAME visit must NOT clobber the real baseline already stored on the first fire : the real
+        // date has to survive, otherwise reconcileReadMarks loses its baseline and can never re-flag a
+        // genuinely new MP (the reconcile-to-unread path is silently neutralised).
+
+        // 1st fire : capture the real inbox date, build the mark, then consume the pending open date.
+        var openDates = mapOf(10 to opened)
+        var marks = emptyMap<Int, Instant>()
+        marks = marks.withReadMark(10, openDates)
+        openDates = openDates - 10
+        assertEquals("first fire keys the mark on the captured open date", opened, marks[10])
+        assertTrue("the open date is consumed after the first fire", openDates.isEmpty())
+
+        // 2nd fire SAME visit (page change / PTR) : pending already consumed → withReadMark must reuse
+        // the already-stored REAL baseline, NOT the MAX sentinel.
+        marks = marks.withReadMark(10, openDates)
+        assertEquals("a re-fired load must preserve the real baseline, not clobber it with MAX", opened, marks[10])
+
+        // Proof the reconcile-to-unread path still works : a genuinely-newer server date drops the mark.
+        val newMp = listOf(conversation(threadId = 10, date = opened.plusSeconds(30), hasUnread = true))
+        assertEquals("the kept baseline still reconciles a new MP", setOf(10), reconcileReadMarks(marks, newMp))
+    }
+
+    @Test
+    fun `C1 - a re-open does not re-decrement the badge once the unread-on-open flag is consumed`() {
+        // (C1, 4-flavor MAJOR) — unreadOnOpenThreadIds is a PER-OPEN pending : onThreadLoaded consumes
+        // it once the decrement decision is made. Without that, after #531 drops the read mark a re-open
+        // would keep `threadId in unreadOnOpen` and re-decrement the badge from a stale unread state.
+        // This models the host's shouldDecrementUnreadBadge + consume sequence with the pure helpers.
+        val threadId = 10
+
+        // 1st open : the thread was unread on open and not yet read → it decrements.
+        var unreadOnOpen = setOf(threadId)
+        var alreadyRead = emptySet<Int>()
+        val decrement1 = shouldDecrementUnreadBadge(threadId, unreadOnOpen, alreadyRead)
+        assertTrue("first read of an unread thread decrements", decrement1)
+        // Consume the per-open pending (C1) and record the read.
+        unreadOnOpen = unreadOnOpen - threadId
+        alreadyRead = alreadyRead + threadId
+
+        // #531 later reconciles the mark away (server still reports it unread on a stale echo path): the
+        // thread is no longer in alreadyRead, but the per-open unread pending has been consumed.
+        alreadyRead = alreadyRead - threadId
+
+        // Re-open / re-fire WITHOUT a genuine unread signal : must NOT decrement again.
+        val decrement2 = shouldDecrementUnreadBadge(threadId, unreadOnOpen, alreadyRead)
+        assertTrue("a stale re-open must not re-decrement once the unread pending is consumed", !decrement2)
+
+        // A genuinely-unread re-open rearms via onThreadOpenedUnread and decrements again, as intended.
+        unreadOnOpen = unreadOnOpen + threadId
+        val decrement3 = shouldDecrementUnreadBadge(threadId, unreadOnOpen, alreadyRead)
+        assertTrue("a genuinely-unread re-open rearms the decrement", decrement3)
     }
 
     @Test

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepository.kt
@@ -183,13 +183,13 @@ class DefaultMpStorageRepository @Inject constructor(
                 return@withContext MpStorageWriteResult.DisabledByPreference
             }
 
-            // 3. Active account → pseudo (sent verbatim in the POST body).
-            val owner = activePseudo()
-                ?: return@withContext MpStorageWriteResult.TargetNotFound
-
-            // 3b. IDENTITY GUARD (C2) — refuse to write under an account different from the one the
-            // caller resolved and decided to write under (a switch since the caller's check). No POST.
-            if (expectedPseudo != null && owner != expectedPseudo) {
+            // 3. IDENTITY GUARD (C2) FIRST — resolve the active account, then refuse (SessionChanged,
+            // no POST) when it no longer matches the account the caller resolved and decided to write
+            // under. This INCLUDES the active session now being null (logged out) while the caller had
+            // one — the contract is « active != expected ⇒ SessionChanged », checked before any other
+            // not-found mapping.
+            val active = activePseudo()
+            if (expectedPseudo != null && active != expectedPseudo) {
                 diagnostics.record(
                     DiagnosticsLog.Level.WARN,
                     LOG_TAG,
@@ -197,6 +197,9 @@ class DefaultMpStorageRepository @Inject constructor(
                 )
                 return@withContext MpStorageWriteResult.SessionChanged
             }
+            // No expected pseudo (manual / dev path) and no active session → nothing to write under.
+            val owner = active
+                ?: return@withContext MpStorageWriteResult.TargetNotFound
 
             // 4. Locate + GET the edit form and parse the document.
             val location = locateForWrite(owner)
@@ -349,6 +352,9 @@ class DefaultMpStorageRepository @Inject constructor(
         return restoreBackup(location, form, pseudo, backupBody, expectedBytes, actualBytes)
     }
 
+    // ReturnCount: the session guard (C2), the build-failure guard, and the restored/failed outcome are
+    // three legitimate exits; splitting would obscure the restore's linear flow.
+    @Suppress("ReturnCount")
     private suspend fun restoreBackup(
         location: MpStorageLocation,
         form: ReplyForm,
@@ -357,6 +363,19 @@ class DefaultMpStorageRepository @Inject constructor(
         expectedBytes: Int,
         actualBytes: Int,
     ): MpStorageWriteResult {
+        // IDENTITY GUARD (C2) — the verify GET above suspended ; re-check before the restore POST so a
+        // mid-operation account switch can never POST the restore under a different session (it would
+        // hit the new account's storage). Declining is the lesser evil : we surface a possibly
+        // un-restored document (loud) rather than write it to the wrong place.
+        if (activePseudo() != pseudo) {
+            diagnostics.record(
+                DiagnosticsLog.Level.ERROR,
+                LOG_TAG,
+                "writeBackFlag: active account changed before restore → no restore POST (document may be inconsistent)",
+            )
+            return MpStorageWriteResult.VerificationFailedRestoreFailed(expectedBytes, actualBytes)
+        }
+
         // Reuse the initial edit form: HFR's hash_check is session-stable (verified live, NOT rotated
         // per-request), so the original form is valid for the restore. The guarded builder still
         // refuses if its subject is not the storage hash.

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepository.kt
@@ -151,19 +151,31 @@ class DefaultMpStorageRepository @Inject constructor(
      * [MpStorageWriteResult.TargetNotFound], NEVER a creation (ADR-014 §3).
      */
     override suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult =
-        writeBack(entry, updateOnly = false)
+        writeBack(entry, updateOnly = false, expectedPseudo = null)
 
     /**
      * UPDATE-ONLY write path (#597) — the AUTO reading-position trigger. Same pipeline / gates as
      * [writeBackFlag] but constrains the upsert to entries already present : an absent `threadId` is
      * declined with [MpStorageWriteResult.SkippedNotPresent] (no POST), so a passive page land never
      * pollutes the shared cross-userscript document with a Redface-2-invented entry (ADR-014 anti-doublon).
+     *
+     * IDENTITY GUARD (C2) — [expectedPseudo] is the account the caller decided to write under. After
+     * re-resolving the active pseudo here, the write is DECLINED ([MpStorageWriteResult.SessionChanged],
+     * no POST) when it no longer matches : the active account switched between the caller's check and
+     * this call.
      */
-    override suspend fun writeBackFlagIfPresent(entry: MpStorageFlagEntry): MpStorageWriteResult =
-        writeBack(entry, updateOnly = true)
+    override suspend fun writeBackFlagIfPresent(
+        entry: MpStorageFlagEntry,
+        expectedPseudo: String,
+    ): MpStorageWriteResult = writeBack(entry, updateOnly = true, expectedPseudo = expectedPseudo)
 
-    @Suppress("ReturnCount") // Guard clauses (pref / auth / not-found / unreadable / skip / no-op / oversize) + verify.
-    private suspend fun writeBack(entry: MpStorageFlagEntry, updateOnly: Boolean): MpStorageWriteResult {
+    // ReturnCount: guard clauses (pref / auth / identity / not-found / unreadable / skip / no-op / oversize / unsafe).
+    @Suppress("ReturnCount")
+    private suspend fun writeBack(
+        entry: MpStorageFlagEntry,
+        updateOnly: Boolean,
+        expectedPseudo: String?,
+    ): MpStorageWriteResult {
         return withContext(ioDispatcher) {
             // 1-2. Opt-in gate FIRST — no network when OFF (the default), so a missing trigger is harmless.
             if (!syncWriteEnabled()) {
@@ -174,6 +186,17 @@ class DefaultMpStorageRepository @Inject constructor(
             // 3. Active account → pseudo (sent verbatim in the POST body).
             val owner = activePseudo()
                 ?: return@withContext MpStorageWriteResult.TargetNotFound
+
+            // 3b. IDENTITY GUARD (C2) — refuse to write under an account different from the one the
+            // caller resolved and decided to write under (a switch since the caller's check). No POST.
+            if (expectedPseudo != null && owner != expectedPseudo) {
+                diagnostics.record(
+                    DiagnosticsLog.Level.WARN,
+                    LOG_TAG,
+                    "writeBackFlag: active account changed since caller's check → no write",
+                )
+                return@withContext MpStorageWriteResult.SessionChanged
+            }
 
             // 4. Locate + GET the edit form and parse the document.
             val location = locateForWrite(owner)
@@ -222,6 +245,18 @@ class DefaultMpStorageRepository @Inject constructor(
                     MpStorageWriteResult.TooLarge(outcome.sizeBytes)
                 }
 
+                MpStorageEnvelopeWriter.Outcome.UnsafeContent -> {
+                    // FAIL-CLOSED (C4) : the mutated body carries a non-BMP / lone-surrogate code point
+                    // HFR would truncate at — POSTing it would corrupt the shared third-party document.
+                    // Refuse the write (no POST) ; the document is left byte-fidèle (never stripped).
+                    diagnostics.record(
+                        DiagnosticsLog.Level.WARN,
+                        LOG_TAG,
+                        "writeBackFlag UNSAFE content (non-BMP / surrogate) → no write",
+                    )
+                    MpStorageWriteResult.UnsafeContent
+                }
+
                 is MpStorageEnvelopeWriter.Outcome.Mutated ->
                     postAndVerify(location, read.form, owner, mutatedBody = outcome.body, backupBody = backup)
             }
@@ -242,6 +277,7 @@ class DefaultMpStorageRepository @Inject constructor(
                 is MpStorageEnvelopeWriter.Outcome.SkippedNotPresent -> MpStorageWritePreview.Prepared(outcome.body)
                 is MpStorageEnvelopeWriter.Outcome.NoOp -> MpStorageWritePreview.Prepared(outcome.body)
                 is MpStorageEnvelopeWriter.Outcome.TooLarge -> MpStorageWritePreview.TooLarge(outcome.sizeBytes)
+                MpStorageEnvelopeWriter.Outcome.UnsafeContent -> MpStorageWritePreview.UnsafeContent
                 is MpStorageEnvelopeWriter.Outcome.Mutated -> MpStorageWritePreview.Prepared(outcome.body)
             }
         }
@@ -257,7 +293,7 @@ class DefaultMpStorageRepository @Inject constructor(
      * comparison is on the raw `content_form` string : HFR may re-serialise, but the de-facto contract
      * stores the textarea verbatim, so an exact match is the safe acceptance signal (NOT OBSERVED LIVE).
      */
-    @Suppress("ReturnCount") // Guard (wrong subject) + verified-OK early return + the restore tail.
+    @Suppress("ReturnCount") // Guard (wrong subject / session) + verified-OK early return + the restore tail.
     private suspend fun postAndVerify(
         location: MpStorageLocation,
         form: ReplyForm,
@@ -265,6 +301,18 @@ class DefaultMpStorageRepository @Inject constructor(
         mutatedBody: String,
         backupBody: String,
     ): MpStorageWriteResult {
+        // IDENTITY GUARD (C2, Codex hardening) — the locate + GET above suspend ; re-resolve the active
+        // pseudo IMMEDIATELY before the POST and abort if the account switched in between, so neither
+        // the POST nor the restore can run under a different session than the one that read the document.
+        if (activePseudo() != pseudo) {
+            diagnostics.record(
+                DiagnosticsLog.Level.WARN,
+                LOG_TAG,
+                "writeBackFlag: active account changed before POST → no write",
+            )
+            return MpStorageWriteResult.SessionChanged
+        }
+
         val postBody = buildPrivateMessageEditBody(location, form, pseudo, mutatedBody)
             ?: return MpStorageWriteResult.TargetNotFound // wrong subject → never POST (structural guard)
 

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/MpStorageEnvelopeWriter.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/MpStorageEnvelopeWriter.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.core.data.mpstorage
 
+import fr.forumhfr.redface2.core.data.write.containsUnstorableContent
 import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
 import fr.forumhfr.redface2.core.model.mpstorage.MpStorageFlagEntry
 import java.time.Clock
@@ -74,6 +75,14 @@ class MpStorageEnvelopeWriter @Inject constructor(
 
         data object NotJsonEnvelope : Outcome
         data class TooLarge(val sizeBytes: Int) : Outcome
+
+        /**
+         * FAIL-CLOSED (C4) : the mutated body holds a code point HFR truncates at (astral / lone
+         * surrogate, #114). The caller must NOT POST it — the shared third-party document would be
+         * corrupted — and must NOT strip it either (that would destroy third-party data). The document
+         * is left byte-fidèle.
+         */
+        data object UnsafeContent : Outcome
     }
 
     /**
@@ -123,6 +132,14 @@ class MpStorageEnvelopeWriter @Inject constructor(
 
         val stamped = stampLastWriter(withFlag)
         val body = json.encodeToString(JsonObject.serializer(), stamped)
+
+        // FAIL-CLOSED (C4) : the re-emitted JSON can carry an astral / lone-surrogate code point HFR
+        // silently truncates at (e.g. a third-party value the source escaped as \uXXXX, re-emitted as a
+        // real character). POSTing it would corrupt the shared document ; stripping it would destroy
+        // third-party data. Refuse the write instead — the document stays byte-fidèle.
+        if (containsUnstorableContent(body)) {
+            return Outcome.UnsafeContent
+        }
 
         val sizeBytes = body.toByteArray(Charsets.UTF_8).size
         if (sizeBytes > MpStorageRepository.MAX_CONTENT_FORM_BYTES) {

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/ContentFormSanitizer.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/ContentFormSanitizer.kt
@@ -55,6 +55,29 @@ internal fun sanitizeContentForm(content: String): String {
     }
 }
 
+/**
+ * DETECTION twin of [sanitizeContentForm] (#114 logic, #C4) — reports whether [content] holds any
+ * code point HFR would silently truncate at : an astral (non-BMP, `>= U+10000`) scalar value OR a
+ * lone / unpaired UTF-16 surrogate. Returns `false` for any pure-BMP string (BBCode, accented Latin,
+ * high-BMP chars `U+E000..U+FFFF`, CR/LF, tabs).
+ *
+ * This is the NON-DESTRUCTIVE companion : where [sanitizeContentForm] STRIPS the offending code
+ * points from a freshly-typed user post (losing an emoji beats losing the whole post), this only
+ * DETECTS them. The MPStorage write path (ADR-014) must NOT strip — the body is a SHARED third-party
+ * document — so it uses this to FAIL CLOSED (refuse the POST) instead, leaving the document untouched.
+ *
+ * Pure and side-effect-free (unit-tested in `ContentFormSanitizerTest`). Shares the exact code-unit
+ * scan / boundary semantics of [sanitizeContentForm] so the two never disagree on what HFR truncates.
+ */
+internal fun containsUnstorableContent(content: String): Boolean {
+    // Fast path: every astral pair AND every lone surrogate has at least one code unit >= 0xD800, so
+    // the absence of any such unit proves the string is pure BMP — nothing HFR truncates on. The
+    // common ASCII/Latin/BBCode body returns false without a code-point walk. Otherwise scan the code
+    // units: any unit in the surrogate range is either an astral pair's half or a lone surrogate, and
+    // both are unstorable (same boundary semantics as sanitizeContentForm, which drops exactly these).
+    return content.any { it.code in SURROGATE_RANGE_START..SURROGATE_RANGE_END }
+}
+
 /** First code point of the astral planes (UTF-16 surrogate-pair territory). */
 private const val ASTRAL_PLANE_START = 0x10000
 

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultPrivateMessageWriteRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/write/DefaultPrivateMessageWriteRepository.kt
@@ -66,7 +66,9 @@ class DefaultPrivateMessageWriteRepository @Inject constructor(
         diagnostics.record(
             DiagnosticsLog.Level.INFO,
             LOG_TAG,
-            "GET MP reply form post=${context.threadId} page=${context.page} fallback=$allowEmbeddedFallback",
+            // #316 (C3) — never log post=threadId / page : a private-conversation id reconstructs the
+            // private URL. Operation + the non-identifying fallback flag only.
+            "GET MP reply form fallback=$allowEmbeddedFallback",
         )
         return try {
             withContext(ioDispatcher) {
@@ -185,7 +187,9 @@ class DefaultPrivateMessageWriteRepository @Inject constructor(
         diagnostics.record(
             DiagnosticsLog.Level.INFO,
             LOG_TAG,
-            "POST MP reply post=${context.threadId} page=${context.page} bbcode.length=${bbcodeContent.length}",
+            // #316 (C3) — never log post=threadId / page (reconstructs the private URL). Operation +
+            // the non-identifying content length only.
+            "POST MP reply bbcode.length=${bbcodeContent.length}",
         )
         val formBody = buildFormBody(form, bbcodeContent, options, recipientsOverride)
         return try {

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepositoryTest.kt
@@ -309,7 +309,7 @@ class DefaultMpStorageRepositoryTest {
         locationStore.saved[OWNER] = MpStorageLocation(threadId = 9100200, numreponse = 7)
 
         val entry = MpStorageFlagEntry(threadId = 1, page = 1, numreponse = 1, uri = null)
-        val result = repository.writeBackFlagIfPresent(entry)
+        val result = repository.writeBackFlagIfPresent(entry, expectedPseudo = OWNER)
 
         assertEquals(MpStorageWriteResult.DisabledByPreference, result)
         assertEquals(0, server.requestCount)
@@ -331,7 +331,7 @@ class DefaultMpStorageRepositoryTest {
         server.enqueue(MockResponse().setBody(storageEditFormHtml(raw)))
 
         val entry = MpStorageFlagEntry(threadId = 42, page = 2, numreponse = 5, uri = "/u")
-        val result = repository.writeBackFlagIfPresent(entry)
+        val result = repository.writeBackFlagIfPresent(entry, expectedPseudo = OWNER)
 
         assertEquals(MpStorageWriteResult.SkippedNotPresent, result)
         // GET the form only — no POST: the absent threadId is never appended (anti-doublon, ADR-014 §3).
@@ -362,7 +362,7 @@ class DefaultMpStorageRepositoryTest {
         server.enqueue(MockResponse().setBody("<html><body>ok</body></html>")) // POST bdd.php
         server.enqueue(MockResponse().setBody(storageEditFormHtml(mutated))) // RE-GET verify
 
-        val result = repository.writeBackFlagIfPresent(entry)
+        val result = repository.writeBackFlagIfPresent(entry, expectedPseudo = OWNER)
 
         assertEquals(MpStorageWriteResult.Success(verified = true), result)
         assertEquals(3, server.requestCount)
@@ -371,6 +371,51 @@ class DefaultMpStorageRepositoryTest {
         assertEquals("prive", body["cat"])
         assertTrue(body["content_form"]!!.contains("\"page\":2"))
     }
+
+    @Test
+    fun `writeBackFlagIfPresent declines (SessionChanged, no POST) when the active account differs from expected`() =
+        runTest {
+            // C2 — the active account (OWNER) is not the one the caller snapshotted and asked to write
+            // under (expectedPseudo = "alice"). The repo must refuse BEFORE any POST so the shared
+            // MPStorage document is never written under a session other than the one that read the page.
+            preferences.enabled.value = true
+            locationStore.saved[OWNER] = STORAGE_LOCATION
+
+            val entry = MpStorageFlagEntry(threadId = 42, page = 2, numreponse = 5, uri = "/u")
+            val result = repository.writeBackFlagIfPresent(entry, expectedPseudo = "alice")
+
+            assertEquals(MpStorageWriteResult.SessionChanged, result)
+            // The guard fires after the opt-in + active-pseudo resolution but BEFORE locating / GETting.
+            assertEquals(0, server.requestCount)
+        }
+
+    @Test
+    fun `writeBackFlagIfPresent fails closed (UnsafeContent, no POST) when the mutated body has an astral char`() =
+        runTest {
+            // C4 — a third-party key in the located document holds an emoji (astral code point). The
+            // mutation re-emits it ; HFR would truncate the POST there (#114) and corrupt the shared
+            // document. The repo must map the writer's UnsafeContent to MpStorageWriteResult.UnsafeContent
+            // and send NO POST (GET the edit form only) — never strip third-party data.
+            val raw = """{ "data": [ { "version": "0.1", "hfr4k": "note 😀", "mpFlags": { "list": [
+                { "post": 42, "page": 1, "href": "t1" }
+            ] } } ] }"""
+            repository = buildRepository(
+                replyFormParser = mockk {
+                    every { parse(any()) } returns Result.success(storageForm(initialContent = raw))
+                },
+            )
+            preferences.enabled.value = true
+            locationStore.saved[OWNER] = STORAGE_LOCATION
+            server.enqueue(MockResponse().setBody(storageEditFormHtml(raw)))
+
+            val entry = MpStorageFlagEntry(threadId = 42, page = 2, numreponse = 5, uri = "/u")
+            val result = repository.writeBackFlagIfPresent(entry, expectedPseudo = OWNER)
+
+            assertEquals(MpStorageWriteResult.UnsafeContent, result)
+            // GET the edit form only — the unsafe re-emit is refused before any POST.
+            assertEquals(1, server.requestCount)
+            assertEquals("GET", server.takeRequest().method)
+        }
 
     @Test
     fun `writeBackFlag POSTs the mutated body with cat=prive, the active pseudo and the hash subject`() = runTest {

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/mpstorage/MpStorageEnvelopeWriterTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/mpstorage/MpStorageEnvelopeWriterTest.kt
@@ -363,6 +363,36 @@ class MpStorageEnvelopeWriterTest {
         assertNull(item["uri"]!!.jsonPrimitive.contentOrNullSafe())
     }
 
+    @Test
+    fun `C4 - a mutated body carrying an astral code point fails closed (UnsafeContent, no Mutated)`() {
+        // C4 — a third-party key holds an emoji (an astral, non-BMP code point). HFR silently truncates
+        // a posted body at the first such character (#114), so POSTing the re-emitted document would
+        // CORRUPT the shared cross-userscript storage. MPStorage must NOT strip (third-party data) →
+        // the writer fails closed with UnsafeContent so the caller refuses the POST and leaves the
+        // document byte-fidèle.
+        val raw = """{ "data": [ { "version": "0.1", "hfr4k": "note 😀", "mpFlags": { "list": [
+            { "post": 42, "page": 1, "href": "t1" }
+        ] } } ] }"""
+
+        // A real change (page 1 → 2) so the writer reaches the re-emit + detection, not the no-op path.
+        val outcome = mutate(raw, MpStorageFlagEntry(threadId = 42, page = 2, numreponse = 5, uri = null))
+
+        assertEquals(MpStorageEnvelopeWriter.Outcome.UnsafeContent, outcome)
+    }
+
+    @Test
+    fun `C4 - a pure-BMP body (accents, BBCode) is never flagged unsafe`() {
+        // Belt-and-braces: the detection must not over-trigger on legitimate BMP content (accented
+        // Latin, high-BMP private-use chars) — only astral / lone surrogates fail closed.
+        val raw = """{ "data": [ { "version": "0.1", "hfr4k": "café œuvre ", "mpFlags": { "list": [
+            { "post": 42, "page": 1, "href": "t1" }
+        ] } } ] }"""
+
+        val outcome = mutate(raw, MpStorageFlagEntry(threadId = 42, page = 2, numreponse = 5, uri = null))
+
+        assertTrue("pure-BMP content must mutate normally", outcome is MpStorageEnvelopeWriter.Outcome.Mutated)
+    }
+
     /** `JsonPrimitive.content` is "null" for a literal null — distinguish it from the string "null". */
     private fun JsonPrimitive.contentOrNullSafe(): String? =
         if (this is kotlinx.serialization.json.JsonNull) null else content

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/write/ContentFormSanitizerTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/write/ContentFormSanitizerTest.kt
@@ -1,6 +1,8 @@
 package fr.forumhfr.redface2.core.data.write
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -92,5 +94,30 @@ class ContentFormSanitizerTest {
     fun `string made only of astral code points becomes empty`() {
         // U+1F600 + U+1F601, nothing else.
         assertEquals("", sanitizeContentForm(cp(0x1F600) + cp(0x1F601)))
+    }
+
+    // --- containsUnstorableContent : the DETECTION twin used by MPStorage's fail-closed path (C4) ----
+
+    @Test
+    fun `containsUnstorableContent is false for pure-BMP content (no truncation vector)`() {
+        // Same BMP scope sanitizeContentForm preserves: BBCode, accents, high-BMP selectors → all safe.
+        assertFalse(containsUnstorableContent("café [b]œuvre[/b] ! 12345"))
+        val highBmp = "a" + cp(0xE000) + cp(0xFE0F) + cp(0xFF21) + cp(0x2764) + "b"
+        assertFalse(containsUnstorableContent(highBmp))
+        assertFalse(containsUnstorableContent(""))
+    }
+
+    @Test
+    fun `containsUnstorableContent is true for an astral code point (emoji)`() {
+        // U+1F600 — the exact vector HFR truncates at. MPStorage fails closed rather than strip it.
+        assertTrue(containsUnstorableContent("note " + cp(0x1F600) + " end"))
+        assertTrue(containsUnstorableContent(cp(0x1F642) + cp(0xFE0F))) // astral base + BMP selector
+    }
+
+    @Test
+    fun `containsUnstorableContent is true for a lone unpaired surrogate`() {
+        // A lone high surrogate (U+D800) is < U+10000 yet never a valid scalar value — must be detected,
+        // mirroring sanitizeContentForm's explicit surrogate-range test.
+        assertTrue(containsUnstorableContent("x" + cp(0xD800) + "y"))
     }
 }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/mpstorage/MpStorageRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/mpstorage/MpStorageRepository.kt
@@ -69,8 +69,15 @@ interface MpStorageRepository {
      * existing anchor / uri of the matched entry rather than nulling it (the trigger always knows the
      * landed page but not always the current anchor). The MANUAL path ([writeBackFlag] / [previewWriteBackFlag])
      * keeps the historical add-or-update + null-erase behaviour, unchanged.
+     *
+     * IDENTITY GUARD (C2, 4-flavor MAJOR) — [expectedPseudo] is the account the CALLER resolved and
+     * decided to write under (snapshotted before its own suspension points). The repository re-resolves
+     * the active pseudo and, if it no longer equals [expectedPseudo], DECLINES the write
+     * ([MpStorageWriteResult.SessionChanged]) WITHOUT a POST : the active account switched between the
+     * caller's check and this call, so the shared MPStorage document must never be written under a
+     * different session than the one that actually read the page.
      */
-    suspend fun writeBackFlagIfPresent(entry: MpStorageFlagEntry): MpStorageWriteResult
+    suspend fun writeBackFlagIfPresent(entry: MpStorageFlagEntry, expectedPseudo: String): MpStorageWriteResult
 
     /**
      * DRY-RUN of [writeBackFlag] for tests / dev tooling : locates, mutates and validates the body but
@@ -110,4 +117,11 @@ sealed interface MpStorageWritePreview {
 
     /** The mutated body exceeds [MpStorageRepository.MAX_CONTENT_FORM_BYTES]. */
     data class TooLarge(val sizeBytes: Int) : MpStorageWritePreview
+
+    /**
+     * FAIL-CLOSED (C4) : the mutated body would carry a non-BMP / lone-surrogate code point HFR
+     * truncates at. The real write refuses to POST it ; the dry-run surfaces it so dev tooling can
+     * see the path would be declined (never stripped — the body is a shared third-party document).
+     */
+    data object UnsafeContent : MpStorageWritePreview
 }

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/mpstorage/MpStorage.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/mpstorage/MpStorage.kt
@@ -87,6 +87,14 @@ sealed interface MpStorageWriteResult {
     data object SkippedNotPresent : MpStorageWriteResult
 
     /**
+     * IDENTITY GUARD (C2, 4-flavor MAJOR) : the active account no longer matches the `expectedPseudo`
+     * the caller decided to write under (an account switch happened between the caller's check and the
+     * repository's own re-resolution of the active pseudo). NO POST was sent — the shared MPStorage
+     * document is never written under a session other than the one that actually read the page.
+     */
+    data object SessionChanged : MpStorageWriteResult
+
+    /**
      * The target storage document could not be located (ADR-014 §3 : NEVER create or overwrite a
      * fresh document — that would fork the cross-userscript storage / spawn a duplicate). The
      * caller must surface this, not "repair" it.
@@ -103,6 +111,16 @@ sealed interface MpStorageWriteResult {
      * risk an uncontrolled / truncated POST. [sizeBytes] is the offending UTF-8 size. No POST is sent.
      */
     data class TooLarge(val sizeBytes: Int) : MpStorageWriteResult
+
+    /**
+     * FAIL-CLOSED (C4, 4-flavor MAJOR) : the mutated `content_form` would carry a code point HFR
+     * silently truncates at — an astral (non-BMP) scalar value or a lone UTF-16 surrogate. HFR stores
+     * a posted body only up to that first character (answering HTTP 200 anyway, #114), so POSTing it
+     * would CORRUPT the shared cross-userscript document. Unlike a user post (#114 STRIPS the emoji),
+     * MPStorage MUST NOT strip — the body is THIRD-PARTY data (DTCloud / HFR4K) — so the write is
+     * REFUSED instead, leaving the document byte-fidèle. NO POST is sent. NOT OBSERVED LIVE.
+     */
+    data object UnsafeContent : MpStorageWriteResult
 
     /**
      * The mutation was POSTed and the verify-after-write re-read confirmed the stored first post now

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -2486,7 +2486,10 @@ class FlagsViewModelTest {
         override suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult =
             MpStorageWriteResult.DisabledByPreference
 
-        override suspend fun writeBackFlagIfPresent(entry: MpStorageFlagEntry): MpStorageWriteResult =
+        override suspend fun writeBackFlagIfPresent(
+            entry: MpStorageFlagEntry,
+            expectedPseudo: String,
+        ): MpStorageWriteResult =
             MpStorageWriteResult.DisabledByPreference
 
         override suspend fun previewWriteBackFlag(

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModel.kt
@@ -361,6 +361,10 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
                     // PRESERVES both the existing href AND uri rather than minting an anchorless / stale uri.
                     uri = numreponse?.let { buildDesktopUri(request.threadId, page, it) },
                 ),
+                // IDENTITY GUARD (C2) — the owner we snapshotted for THIS read. The repo re-resolves the
+                // active pseudo and refuses (no POST) if it switched since this VM's own session re-check
+                // above, closing the account-switch race across the repository's own suspension points.
+                expectedPseudo = owner,
             )
         } catch (cancellation: CancellationException) {
             throw cancellation

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModelTest.kt
@@ -411,6 +411,9 @@ class PrivateMessageThreadViewModelTest {
         assertEquals(2784595, entry.numreponse)
         // Canonical DTCloud desktop uri, with the #t<anchor> fragment matching the page.
         assertEquals("/forum2.php?config=hfr.inc&cat=prive&post=42&page=1#t2784595", entry.uri)
+        // C2 — the VM passes the owner it snapshotted for THIS read as expectedPseudo, so the repo can
+        // refuse the write if the active account switched across its own suspension points.
+        assertEquals("xaat", mpStorage.ifPresentPseudos.single())
     }
 
     @Test
@@ -471,6 +474,9 @@ class PrivateMessageThreadViewModelTest {
         // Only bob's landing reached the MPStorage sync — alice's sealed (cancelled) job never did.
         assertEquals(1, mpStorage.ifPresentCalls.size)
         assertEquals(1, mpStorage.ifPresentCalls.single().page)
+        // C2 — and the expectedPseudo passed is bob's (the session that actually read the page), so
+        // the repo's identity guard compares against the right account.
+        assertEquals("bob", mpStorage.ifPresentPseudos.single())
     }
 
     // #612 — participant roster.
@@ -677,13 +683,20 @@ class PrivateMessageThreadViewModelTest {
     ) : MpStorageRepository {
         val ifPresentCalls = mutableListOf<MpStorageFlagEntry>()
 
+        /** C2 — the `expectedPseudo` the VM snapshotted and passed for each call, in order. */
+        val ifPresentPseudos = mutableListOf<String>()
+
         override suspend fun fetchStorage() = error("read path not used by the thread VM")
 
         override suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult =
             error("the auto trigger uses writeBackFlagIfPresent, never writeBackFlag")
 
-        override suspend fun writeBackFlagIfPresent(entry: MpStorageFlagEntry): MpStorageWriteResult {
+        override suspend fun writeBackFlagIfPresent(
+            entry: MpStorageFlagEntry,
+            expectedPseudo: String,
+        ): MpStorageWriteResult {
             ifPresentCalls += entry
+            ifPresentPseudos += expectedPseudo
             thrown?.let { throw it }
             return result
         }

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/MpStorageInspectorViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/MpStorageInspectorViewModelTest.kt
@@ -177,7 +177,10 @@ class MpStorageInspectorViewModelTest {
             override suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult =
                 error("Unexpected writeBackFlag call in the read-only inspector test")
 
-            override suspend fun writeBackFlagIfPresent(entry: MpStorageFlagEntry): MpStorageWriteResult =
+            override suspend fun writeBackFlagIfPresent(
+                entry: MpStorageFlagEntry,
+                expectedPseudo: String,
+            ): MpStorageWriteResult =
                 error("Unexpected writeBackFlagIfPresent call in the read-only inspector test")
 
             override suspend fun previewWriteBackFlag(
@@ -234,7 +237,10 @@ class MpStorageInspectorViewModelTest {
         override suspend fun writeBackFlag(entry: MpStorageFlagEntry): MpStorageWriteResult =
             error("Unexpected writeBackFlag call in the read-only inspector test")
 
-        override suspend fun writeBackFlagIfPresent(entry: MpStorageFlagEntry): MpStorageWriteResult =
+        override suspend fun writeBackFlagIfPresent(
+            entry: MpStorageFlagEntry,
+            expectedPseudo: String,
+        ): MpStorageWriteResult =
             error("Unexpected writeBackFlagIfPresent call in the read-only inspector test")
 
         override suspend fun previewWriteBackFlag(


### PR DESCRIPTION
## Quoi
Corrige les **5 MAJOR** remontés par la revue 4-flavor (Codex + workflow) du payload bêta 0.16.0 — des bugs d'INTÉGRATION invisibles aux reviews par-PR.

- **W1** (#531 × multi-fire onThreadLoaded) : `withReadMark` préserve une baseline réelle existante (`openDates ?: this[id] ?: MAX`) → un re-fire (changement de page/PTR) ne dégrade plus la date en `Instant.MAX` (la réconciliation re-non-lu n'est plus neutralisée).
- **C1** : `onThreadLoaded` consomme `unreadOnOpenThreadIds` per-open → plus de re-décrément du badge MP après qu'#531 a retiré un read-mark.
- **C2** : `writeBackFlagIfPresent(entry, expectedPseudo)` + garde session — refuse (`SessionChanged`, no POST) si l'actif diffère (y compris null/logged-out), re-check avant le POST principal ET avant le restore-POST (fenêtres locate/GET/verify).
- **C3** : logs MP reply ne contiennent plus `post=threadId/page` (#316).
- **C4** : avant POST MPStorage, body muté contenant du non-BMP/surrogate → `UnsafeContent` (no POST, **pas de strip** — données tierces du doc partagé préservées).

## Validation
`BUILD SUCCESSFUL` : `:app:testDevDebugUnitTest` + `:feature:messages` + `:core:data` + `:core:network` + `lintDebug` + `detektAll`. Tests de régression ajoutés (ReadMarkReconcile W1/C1, MpStorage SessionChanged/UnsafeContent).

## Revue Codex
3 tours. Findings successifs corrigés ; dernier tour : W1/C1/C3/C4 OK, 2 résidus C2 (null-active → SessionChanged ; re-check avant restore-POST) corrigés dans ce commit.

Part of #598 (gate revue bêta 0.16.0).

---
> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
