### PR TITLE
feat(#618): recipient-manager sheet + manage-from-thread + non-owner roster

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -169,6 +169,14 @@ data class PrivateMessageThreadRoute(
 data class PrivateMessageReplyRoute(
     val threadId: Int,
     val page: Int = 1,
+    /**
+     * #618 — when true, the reply composer auto-opens its « Gérer les destinataires » bottom sheet on
+     * mount (once the form has loaded and the owner-only member editor is available). Set by the
+     * « Gérer les destinataires » entry of the conversation's Participants sheet; `false` on the
+     * normal « Répondre » path. A plain serializable Boolean — kotlinx-serialization handles it with
+     * no custom NavType.
+     */
+    val openRecipientManager: Boolean = false,
 ) : RedfaceNavKey
 
 /**
@@ -1714,6 +1722,17 @@ private fun RedfaceNavHost(
                     onReply = { threadId, page ->
                         backStack.add(PrivateMessageReplyRoute(threadId = threadId, page = page))
                     },
+                    // #618 — owner-only « Gérer les destinataires » entry from the Participants sheet:
+                    // open the reply composer with its recipient-manager sheet auto-opened.
+                    onManageRecipients = { threadId, page ->
+                        backStack.add(
+                            PrivateMessageReplyRoute(
+                                threadId = threadId,
+                                page = page,
+                                openRecipientManager = true,
+                            ),
+                        )
+                    },
                     topBarActions = accountMenu,
                 )
             }
@@ -1722,6 +1741,7 @@ private fun RedfaceNavHost(
                     request = PrivateMessageReplyRequest(
                         threadId = route.threadId,
                         page = route.page,
+                        openRecipientManager = route.openRecipientManager,
                     ),
                     onSubmitSucceeded = { threadId, page ->
                         // Pop the editor, then replace the conversation entry with a fresh key

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/write/ReplyForm.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/write/ReplyForm.kt
@@ -75,6 +75,22 @@ data class ReplyForm(
      * unparseable forms — the repository falls back to `user_id=0`.
      */
     val userId: Int? = null,
+    /**
+     * #618 — read-only roster CSV of a DT/MultiMP, surfaced for the « Participants » sheet of EVERY
+     * member, not just the owner. HFR exposes the full member list (minus the viewer) in two shapes
+     * on `message.php` :
+     *  - OWNER : the editable `<input name="newdest">` value → identical to [manageableRecipients].
+     *  - NON-OWNER : the read-only text of the « Destinataires » row (`<td class="repCase2">`'s
+     *    `<span>`), since HFR serves no `newdest` to a simple participant.
+     *
+     * `null` when the form carries no « Destinataires » row at all — a one-to-one MP or a topic
+     * reply. Defaulted to `null` so the dozens of [ReplyForm] construction sites (fakes, repository
+     * tests) keep compiling unchanged ; the parser is the single producer of a non-null value.
+     *
+     * [canManageRecipients] (the EDIT permission) stays tied to the owner-only `newdest` input — a
+     * non-owner gets a roster to read but never the member editor.
+     */
+    val recipientsRoster: String? = null,
 ) {
     /**
      * #606 — CSV of the DT/MultiMP members HFR prefills inside `<input name="newdest">`, served

--- a/core/model/src/test/kotlin/fr/forumhfr/redface2/core/model/write/ReplyFormTest.kt
+++ b/core/model/src/test/kotlin/fr/forumhfr/redface2/core/model/write/ReplyFormTest.kt
@@ -40,4 +40,29 @@ class ReplyFormTest {
         assertTrue(replyForm.canManageRecipients)
         assertEquals("alice, bob, Bébé Yoda, stitch+, Administration", replyForm.manageableRecipients)
     }
+
+    @Test
+    fun `recipientsRoster defaults to null and is independent of canManageRecipients`() {
+        // #618 — recipientsRoster is the parser-supplied read-only roster; on a hand-built form it
+        // defaults to null and does NOT affect the owner-detection contract.
+        val replyForm = form(mapOf("newdest" to "alice, bob"))
+        assertNull(replyForm.recipientsRoster)
+        assertTrue("newdest still drives manageability", replyForm.canManageRecipients)
+    }
+
+    @Test
+    fun `a non-owner form can carry a roster without being manageable`() {
+        // #618 — the parser sets recipientsRoster from a read-only span for a participant: roster
+        // present, but no newdest → not manageable.
+        val replyForm = ReplyForm(
+            hashCheck = "h",
+            sujet = "s",
+            hiddenFields = mapOf("cat" to "prive", "post" to "4242424"),
+            isAnonymous = false,
+            recipientsRoster = "TestOwner, alice, bob",
+        )
+        assertEquals("TestOwner, alice, bob", replyForm.recipientsRoster)
+        assertFalse("no newdest input → cannot manage", replyForm.canManageRecipients)
+        assertNull(replyForm.manageableRecipients)
+    }
 }

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/write/ReplyFormParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/write/ReplyFormParser.kt
@@ -81,8 +81,32 @@ class ReplyFormParser {
                 options = parseOptions(replyForm),
                 msgIcon = parseMsgIcon(replyForm),
                 userId = SmileyUserIdExtractor.extract(html),
+                recipientsRoster = parseRecipientsRoster(replyForm, collection.fields["newdest"]),
             ),
         )
+    }
+
+    /**
+     * #618 — read-only roster CSV for the « Participants » sheet of EVERY member of a DT/MultiMP.
+     *
+     * - OWNER : HFR serves the editable `<input name="newdest">`; we reuse its value (already in
+     *   [hiddenFields], passed as [newdest]) so the owner roster matches the editor exactly.
+     * - NON-OWNER : HFR serves no `newdest` but still renders the « Destinataires » row as read-only
+     *   text inside `<td class="repCase2">` (a `<span>`); we take that cell's text (entities decoded,
+     *   whitespace collapsed by Jsoup) trimmed.
+     * - Neither (one-to-one MP / topic reply) : `null`.
+     *
+     * The row is located by its `<th>` label rather than a structural index so an HFR layout shuffle
+     * does not silently grab the wrong cell.
+     */
+    private fun parseRecipientsRoster(replyForm: Element, newdest: String?): String? {
+        if (newdest != null) return newdest
+        // The owner branch above already handled the editable-input case; here the cell is read-only
+        // text. Resolve the « Destinataires » cell by its `<th>` label rather than a positional index.
+        val recipientsCell = replyForm.select("th.repCase1").firstOrNull { th ->
+            th.text().trim().equals(DESTINATAIRES_LABEL, ignoreCase = true)
+        }?.nextElementSibling()
+        return recipientsCell?.text()?.trim()?.takeIf { it.isNotEmpty() }
     }
 
     /**
@@ -174,4 +198,9 @@ class ReplyFormParser {
         val fields: Map<String, String>,
         val hashCheck: String?,
     )
+
+    private companion object {
+        /** #618 — HFR's `<th class="repCase1">` label for the recipients row of a DT/MultiMP. */
+        private const val DESTINATAIRES_LABEL = "Destinataires"
+    }
 }

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/write/PrivateMessageReplyFormParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/write/PrivateMessageReplyFormParserTest.kt
@@ -84,6 +84,29 @@ class PrivateMessageReplyFormParserTest {
         // The message.php form renders options as real checkboxes — signature is the checked default.
         assertTrue("signature is the checked default on the message.php form", form.options.signatureEnabled)
         assertEquals("1", form.msgIcon)
+        // #618 — the owner roster mirrors the editable newdest value verbatim.
+        assertEquals("alice, bob, Bébé Yoda, stitch+, Administration", form.recipientsRoster)
+    }
+
+    @Test
+    fun `a non-owner DT message_php form exposes the read-only roster but no member editor`() {
+        // #618 — a simple participant gets the « Destinataires » row as READ-ONLY text (a <span>),
+        // with NO <input name="newdest">. The roster is still readable for the « Participants » sheet,
+        // but the member editor stays owner-only.
+        val form = parser.parse(fixture("private_message_dt_participant_reply_form.html")).getOrThrow()
+
+        assertFalse("a non-owner has no editable newdest input", form.canManageRecipients)
+        assertEquals(null, form.manageableRecipients)
+        // The full roster (minus self) is parsed from the read-only span, trimmed.
+        assertEquals("TestOwner, alice, bob, Bébé Yoda, stitch+, Administration", form.recipientsRoster)
+    }
+
+    @Test
+    fun `a reply form without a Destinataires row exposes no roster`() {
+        // #618 — a one-to-one MP / topic reply has no « Destinataires » row at all → null roster.
+        val form = parser.parse(fixture("private_message_thread.html")).getOrThrow()
+
+        assertEquals(null, form.recipientsRoster)
     }
 
     private fun fixture(name: String): String {

--- a/core/parser/src/test/resources/fixtures/private_message_dt_participant_reply_form.html
+++ b/core/parser/src/test/resources/fixtures/private_message_dt_participant_reply_form.html
@@ -1,0 +1,60 @@
+<!--
+  #618 — SANITISED fixture : the `message.php` reply form HFR serves to a NON-OWNER (simple
+  participant) of a DT / MultiMP. Unlike the owner form, HFR renders the « Destinataires » row as
+  READ-ONLY text — a `<span>` inside `<td class="repCase2">`, with NO `<input name="newdest">`. The
+  participant therefore cannot edit the member list (canManageRecipients=false) but the full roster
+  (minus themselves) is still readable from that span (#618 recipientsRoster).
+
+  Everything here is fake : bogus pseudos (TestOwner, alice, bob, "Bébé Yoda", "stitch+",
+  Administration), no real private content, no real hash_check (value="TESTHASH").
+-->
+<html><body>
+<a name="formulaire"></a>
+<form name="hop" action="/bddpost.php?config=hfr.inc" method="post" onsubmit="document.hop.submit.style.visibility='hidden';">
+<input type="hidden" name="hash_check" value="TESTHASH" />
+<table class="main" cellspacing="0" cellpadding="4">
+  <tr class="cBackHeader fondForum2Title"><th class="padding" colspan="2">Répondre</th></tr>
+  <tr class="reponse">
+    <th class="repCase1">Destinataires</th>
+    <td class="repCase2"><span style="font-size:12px;">TestOwner, alice, bob, Bébé Yoda, stitch+, Administration</span></td>
+  </tr>
+  <tr class="reponse">
+    <th class="repCase1">Votre message</th>
+    <td class="repCase2"><textarea rows="15" cols="75" name="content_form" id="content_form" accesskey="c"></textarea></td>
+  </tr>
+  <tr class="reponse">
+    <th class="repCase1">Ton du message</th>
+    <td class="repCase2">
+      <input type="radio" name="MsgIcon" value="20" id="MsgIcon20" />
+      <input type="radio" name="MsgIcon" value="1" id="MsgIcon1" checked="checked" />
+      <input type="radio" name="MsgIcon" value="16" id="MsgIcon16" />
+    </td>
+  </tr>
+  <tr class="reponse">
+    <th class="repCase1">Options</th>
+    <td class="repCase2">
+      <input class="checkbox" type="checkbox" name="signature" value="1" id="signature" checked="checked" /><label for="signature">Activer votre signature</label>
+      <input class="checkbox" type="checkbox" name="smiley" value="1" id="smiley" /><label for="smiley">Désactiver les smilies</label>
+      <input class="checkbox" type="checkbox" name="emaill" value="1" id="emaill" /><label for="emaill">Activer la notification par email du sujet</label>
+    </td>
+  </tr>
+</table>
+<input type="submit" accesskey="s" value="Valider votre message" name="submit" id="submitreprap"/>
+<input type="hidden" name="new" value="0" />
+<input type="hidden" name="post" value="4242424" />
+<input type="hidden" name="numrep" value="1990000222" />
+<input type="hidden" name="ref" value="0" />
+<input type="hidden" name="cat" value="prive" />
+<input type="hidden" name="subcat" value="0" />
+<input type="hidden" name="page" value="3" />
+<input type="hidden" name="verifrequet" value="1100" />
+<input type="hidden" name="p" value="1" />
+<input type="hidden" name="sondage" value="0" />
+<input type="hidden" name="cache" value="" />
+<input type="hidden" name="config" value="hfr.inc" />
+<input type="hidden" name="pseudo" value="TestParticipant" />
+<input type="password" name="password" value="" />
+<input type="hidden" name="sujet" value="Discussion de groupe de test" />
+</form>
+<script type="text/javascript">find_smilies_timer('hfr.inc', 990456);</script>
+</body></html>

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessageEditorComponents.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/MessageEditorComponents.kt
@@ -9,8 +9,11 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -18,19 +21,24 @@ import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.InputChip
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -358,6 +366,70 @@ private fun MessageOptionToggle(
             modifier = Modifier.padding(end = 16.dp),
         )
         Switch(checked = checked, enabled = enabled, onCheckedChange = onCheckedChange)
+    }
+}
+
+/**
+ * #618 (Bug 1) — compact owner-only recipients summary shown in the reply composer in place of the
+ * old inline editor. « Destinataires : N » + a « Gérer » action; the tap opens the dedicated
+ * [RecipientManagerSheet] so the message body and the send bar stay reachable (the inline editor used
+ * to crowd them out, especially for a 29+-member DT). Gated by `canManageRecipients` at the call site.
+ */
+@Composable
+internal fun MessageRecipientsSummary(count: Int, onManage: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = stringResource(R.string.messages_recipients_summary, count),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        TextButton(onClick = onManage) {
+            Text(text = stringResource(R.string.messages_recipients_manage))
+        }
+    }
+}
+
+/**
+ * #618 (Bug 1) — bottom sheet hosting the DT/MultiMP member editor, moved out of the composer flow.
+ * Wraps the existing [MessageRecipientsEditor] (chips + add field) in a height-capped, scrollable
+ * column so a 29+-member DT scrolls inside the sheet instead of pushing the composer off-screen. The
+ * change still ships with the reply (HFR mutates members only via a posted reply, #606 wiring
+ * unchanged) — closing the sheet just returns to the composer. `navigationBarsPadding()` + the sheet's
+ * own IME handling keep the add field above the keyboard.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+@Suppress("LongParameterList") // List + 2 edit callbacks + enabled + dismiss — each call-site distinct.
+internal fun RecipientManagerSheet(
+    recipients: List<String>,
+    enabled: Boolean,
+    onAddRecipient: (String) -> Unit,
+    onRemoveRecipient: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 480.dp)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .imePadding()
+                .navigationBarsPadding(),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            MessageRecipientsEditor(
+                recipients = recipients,
+                enabled = enabled,
+                onAddRecipient = onAddRecipient,
+                onRemoveRecipient = onRemoveRecipient,
+            )
+        }
     }
 }
 

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/ParticipantRosterSheet.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/ParticipantRosterSheet.kt
@@ -44,6 +44,9 @@ internal fun ParticipantRosterSheet(
     roster: PrivateMessageThreadUiState.Roster,
     onDismiss: () -> Unit,
     onRetry: () -> Unit,
+    // #618 — owner-only « Gérer les destinataires » entry. Closes the sheet then navigates to the
+    // reply composer with the recipient-manager sheet auto-opened. Null = entry not wired (defensive).
+    onManageRecipients: () -> Unit = {},
 ) {
     // Hidden = the sheet is closed; render nothing.
     if (roster is PrivateMessageThreadUiState.Roster.Hidden) return
@@ -66,7 +69,11 @@ internal fun ParticipantRosterSheet(
                 // Already handled by the early return, but the `when` must be exhaustive.
                 PrivateMessageThreadUiState.Roster.Hidden -> Unit
                 PrivateMessageThreadUiState.Roster.Loading -> RosterLoading()
-                is PrivateMessageThreadUiState.Roster.Loaded -> RosterList(members = roster.members)
+                is PrivateMessageThreadUiState.Roster.Loaded -> RosterList(
+                    members = roster.members,
+                    canManageRecipients = roster.canManageRecipients,
+                    onManageRecipients = onManageRecipients,
+                )
                 PrivateMessageThreadUiState.Roster.Unavailable -> RosterUnavailable()
                 is PrivateMessageThreadUiState.Roster.Error -> RosterError(roster = roster, onRetry = onRetry)
             }
@@ -89,7 +96,11 @@ private fun RosterLoading() {
 }
 
 @Composable
-private fun RosterList(members: List<String>) {
+private fun RosterList(
+    members: List<String>,
+    canManageRecipients: Boolean,
+    onManageRecipients: () -> Unit,
+) {
     Text(
         text = pluralStringResource(R.plurals.messages_roster_count, members.size, members.size),
         style = MaterialTheme.typography.labelLarge,
@@ -116,6 +127,13 @@ private fun RosterList(members: List<String>) {
                     overflow = TextOverflow.Ellipsis,
                 )
             }
+        }
+    }
+    // #618 — owner-only entry to the member editor. A participant reads the roster but cannot edit it
+    // (HFR mutates members only via an owner reply), so the button is gated on canManageRecipients.
+    if (canManageRecipients) {
+        Button(onClick = onManageRecipients, modifier = Modifier.fillMaxWidth()) {
+            Text(text = stringResource(R.string.messages_roster_manage))
         }
     }
 }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyRequest.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyRequest.kt
@@ -11,4 +11,10 @@ package fr.forumhfr.redface2.feature.messages
 data class PrivateMessageReplyRequest(
     val threadId: Int,
     val page: Int = 1,
+    /**
+     * #618 — when true, the screen auto-opens the « Gérer les destinataires » bottom sheet once the
+     * form has loaded and the owner-only member editor is available. Carried from
+     * `PrivateMessageReplyRoute.openRecipientManager`; `false` on the normal « Répondre » path.
+     */
+    val openRecipientManager: Boolean = false,
 )

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -64,6 +65,8 @@ fun PrivateMessageReplyScreen(
     }
     PrivateMessageReplyContent(
         state = state,
+        // #618 — auto-open the recipient-manager sheet when entered from the Participants sheet.
+        autoOpenRecipientManager = request.openRecipientManager,
         onBack = onBack,
         onContentChanged = viewModel::onContentChanged,
         onToolbarAction = viewModel::onToolbarAction,
@@ -90,6 +93,7 @@ fun PrivateMessageReplyScreen(
 @Suppress("LongParameterList") // One callback per editor action — each is wired to a distinct VM method.
 private fun PrivateMessageReplyContent(
     state: PrivateMessageReplyUiState,
+    autoOpenRecipientManager: Boolean,
     onBack: () -> Unit,
     onContentChanged: (TextFieldValue) -> Unit,
     onToolbarAction: (BbcodeAction) -> Unit,
@@ -111,6 +115,20 @@ private fun PrivateMessageReplyContent(
     modifier: Modifier = Modifier,
 ) {
     var optionsSheetOpen by remember { mutableStateOf(false) }
+    // #618 — the « Gérer les destinataires » bottom sheet (Bug 1: the member editor no longer stacks
+    // inline above the composer). Opened by the compact summary button below, or auto-opened on entry
+    // from the conversation's Participants sheet.
+    var recipientManagerOpen by remember { mutableStateOf(false) }
+    // One-shot auto-open (Codex framing): fire once the form has loaded AND the owner-only editor is
+    // available, never before (canManageRecipients arrives after the async form GET). `autoOpened`
+    // survives recomposition / config changes so the sheet is never re-opened after the user closes it.
+    var autoOpened by rememberSaveable { mutableStateOf(false) }
+    LaunchedEffect(autoOpenRecipientManager, state.canManageRecipients) {
+        if (autoOpenRecipientManager && state.canManageRecipients && !autoOpened) {
+            autoOpened = true
+            recipientManagerOpen = true
+        }
+    }
     Surface(modifier = modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surface) {
         Column(modifier = Modifier.fillMaxSize().statusBarsPadding()) {
             MessageEditorHeader(title = stringResource(R.string.messages_reply_title), onBack = onBack)
@@ -126,8 +144,7 @@ private fun PrivateMessageReplyContent(
                         onErrorDismissed = onErrorDismissed,
                         onDraftRestore = onDraftRestore,
                         onDraftDiscard = onDraftDiscard,
-                        onAddRecipient = onAddRecipient,
-                        onRemoveRecipient = onRemoveRecipient,
+                        onManageRecipients = { recipientManagerOpen = true },
                         modifier = Modifier.weight(1f),
                     )
                     MessageSubmitBar(
@@ -158,6 +175,17 @@ private fun PrivateMessageReplyContent(
                 )
             }
         }
+        // #618 — recipient manager bottom sheet (Bug 1: was an inline editor stacked above the body).
+        // Owner-only; the compact summary button can only arm it when canManageRecipients is true.
+        if (recipientManagerOpen && state.canManageRecipients) {
+            RecipientManagerSheet(
+                recipients = state.recipients,
+                enabled = !state.isSubmitting,
+                onAddRecipient = onAddRecipient,
+                onRemoveRecipient = onRemoveRecipient,
+                onDismiss = { recipientManagerOpen = false },
+            )
+        }
         // #387 — smiley picker sheet (Standard + Wiki), same component as the post editors.
         val pickerState by smileyPicker.state.collectAsStateWithLifecycle()
         (pickerState as? SmileyPickerState.Open)?.let { open ->
@@ -181,8 +209,7 @@ private fun ReplyEditorBody(
     onErrorDismissed: () -> Unit,
     onDraftRestore: () -> Unit,
     onDraftDiscard: () -> Unit,
-    onAddRecipient: (String) -> Unit,
-    onRemoveRecipient: (String) -> Unit,
+    onManageRecipients: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     // No outer scroll : the draft field is weighted so it stretches down to the bar (same
@@ -194,14 +221,14 @@ private fun ReplyEditorBody(
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        // #606 — owner-only member editor, above the body. Hidden for a simple participant /
-        // one-to-one MP (canManageRecipients is false).
+        // #618 (Bug 1) — owner-only COMPACT summary, replacing the inline member editor that used to
+        // stack above the body and crowd the composer (unscrollable for a 29+-member DT). A tap opens
+        // the dedicated RecipientManagerSheet; the body + send bar stay reachable. Hidden for a simple
+        // participant / one-to-one MP (canManageRecipients is false).
         if (state.canManageRecipients) {
-            MessageRecipientsEditor(
-                recipients = state.recipients,
-                enabled = !state.isSubmitting,
-                onAddRecipient = onAddRecipient,
-                onRemoveRecipient = onRemoveRecipient,
+            MessageRecipientsSummary(
+                count = state.recipients.size,
+                onManage = onManageRecipients,
             )
             HorizontalDivider()
         }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadScreen.kt
@@ -71,6 +71,9 @@ fun PrivateMessageThreadScreen(
     onLoaded: () -> Unit,
     onBack: () -> Unit,
     onReply: (threadId: Int, page: Int) -> Unit,
+    // #618 — owner-only entry to the recipient editor, from the « Participants » sheet. Navigates to
+    // the reply composer with the recipient-manager sheet auto-opened (member changes ship as a reply).
+    onManageRecipients: (threadId: Int, page: Int) -> Unit = { _, _ -> },
     topBarActions: @Composable (() -> Unit)? = null,
 ) {
     val viewModel = hiltViewModel<PrivateMessageThreadViewModel, PrivateMessageThreadViewModel.Factory>(
@@ -266,6 +269,12 @@ fun PrivateMessageThreadScreen(
         roster = state.roster,
         onDismiss = viewModel::dismissRoster,
         onRetry = viewModel::retryRoster,
+        // #618 — close the roster sheet BEFORE navigating (Codex framing) so it does not reappear when
+        // the composer pops back, then open the composer with the recipient manager auto-opened.
+        onManageRecipients = {
+            viewModel.dismissRoster()
+            onManageRecipients(request.threadId, state.page)
+        },
     )
 }
 

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadUiState.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadUiState.kt
@@ -47,13 +47,24 @@ data class PrivateMessageThreadUiState(
         /** The sheet is open and the reply form GET is in flight. */
         data object Loading : Roster
 
-        /** The owner's full member list, parsed from `newdest` (HFR's `, ` separator). */
-        data class Loaded(val members: List<String>) : Roster
+        /**
+         * The full member list, parsed from the form's recipients roster (#618 — `newdest` for the
+         * owner, the read-only « Destinataires » span for a participant ; HFR's `, ` separator). The
+         * viewer is prepended so the sheet shows the whole group.
+         *
+         * [canManageRecipients] (#618) — true only for the owner (HFR served the editable `newdest`).
+         * Gates the « Gérer les destinataires » entry in the sheet: a participant reads the roster but
+         * cannot edit it (HFR mutates members only via an owner reply).
+         */
+        data class Loaded(
+            val members: List<String>,
+            val canManageRecipients: Boolean = false,
+        ) : Roster
 
         /**
-         * The reply form loaded but carried no `newdest` — the user is a participant, not the owner.
-         * HFR has no authoritative roster to show; the sheet surfaces a sober « non disponible »
-         * note rather than a partial author list.
+         * The reply form loaded but exposed no roster at all (#618 — neither an editable `newdest`
+         * nor a read-only « Destinataires » row): a one-to-one MP. The sheet surfaces a sober « non
+         * disponible » note rather than a partial author list.
          */
         data object Unavailable : Roster
 

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModel.kt
@@ -168,24 +168,34 @@ class PrivateMessageThreadViewModel @AssistedInject constructor(
     }
 
     /**
-     * #612 — maps a loaded reply form to a roster state. An owner form carries `newdest` (the member
-     * list MINUS the owner — HFR never lists the creator in their own `newdest`) → the roster prepends
-     * [owner] so the « Participants » sheet shows the FULL group including the viewer (Codex). Otherwise
-     * the user is a simple participant and HFR exposes no authoritative roster →
-     * [PrivateMessageThreadUiState.Roster.Unavailable] (no misleading partial list of visible authors).
+     * #612 / #618 — maps a loaded reply form to a roster state. HFR ships the member list (MINUS the
+     * viewer — it never lists you in your own row) two ways on message.php:
+     *  - OWNER : the editable `newdest` input → `canManageRecipients` true, roster from
+     *    [ReplyForm.recipientsRoster] (falls back to [manageableRecipients] for a form built before
+     *    #618 / a test fake that only sets `newdest`).
+     *  - NON-OWNER : the read-only « Destinataires » span → `canManageRecipients` false, roster from
+     *    [ReplyForm.recipientsRoster].
+     *
+     * Either way the roster prepends [owner] so the sheet shows the FULL group including the viewer
+     * (Codex). Only a form with NO roster at all (a one-to-one MP) maps to
+     * [PrivateMessageThreadUiState.Roster.Unavailable]. The `canManageRecipients` flag is forwarded so
+     * the sheet offers the owner-only « Gérer les destinataires » entry to the owner alone.
      */
-    private fun ReplyForm.toRoster(owner: String?): PrivateMessageThreadUiState.Roster =
-        if (canManageRecipients) {
-            val members = RecipientCsv.parse(manageableRecipients)
-            val full = if (owner != null && members.none { it == owner.trim() }) {
-                listOf(owner.trim()) + members
-            } else {
-                members
-            }
-            PrivateMessageThreadUiState.Roster.Loaded(full)
+    private fun ReplyForm.toRoster(owner: String?): PrivateMessageThreadUiState.Roster {
+        val rosterCsv = recipientsRoster
+            ?: manageableRecipients
+            ?: return PrivateMessageThreadUiState.Roster.Unavailable
+        val members = RecipientCsv.parse(rosterCsv)
+        val full = if (owner != null && members.none { it == owner.trim() }) {
+            listOf(owner.trim()) + members
         } else {
-            PrivateMessageThreadUiState.Roster.Unavailable
+            members
         }
+        return PrivateMessageThreadUiState.Roster.Loaded(
+            members = full,
+            canManageRecipients = canManageRecipients,
+        )
+    }
 
     private fun clearPrivateState() {
         authenticatedPseudo = null

--- a/feature/messages/src/main/res/values/strings.xml
+++ b/feature/messages/src/main/res/values/strings.xml
@@ -72,10 +72,18 @@
     <string name="messages_roster_title">Participants</string>
     <string name="messages_roster_loading">Chargement des participants…</string>
     <string name="messages_roster_unavailable_title">Liste indisponible</string>
-    <string name="messages_roster_unavailable_body">Seul le créateur de la discussion peut voir la liste complète des participants.</string>
+    <!-- #618 — n'apparaît plus que pour un MP individuel (pas de ligne « Destinataires ») : un
+         participant d'une discussion de groupe voit désormais la liste complète. -->
+    <string name="messages_roster_unavailable_body">Cette conversation ne comporte pas de liste de participants.</string>
     <string name="messages_roster_error">Impossible de charger les participants.</string>
+    <!-- #618 — entrée vers l'éditeur de membres, réservée au créateur. -->
+    <string name="messages_roster_manage">Gérer les destinataires</string>
     <plurals name="messages_roster_count">
         <item quantity="one">%1$d participant</item>
         <item quantity="other">%1$d participants</item>
     </plurals>
+
+    <!-- #618 — bouton compact « Destinataires : N — Gérer » au-dessus du corps du composer (créateur). -->
+    <string name="messages_recipients_summary">Destinataires : %1$d</string>
+    <string name="messages_recipients_manage">Gérer</string>
 </resources>

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageThreadViewModelTest.kt
@@ -527,20 +527,67 @@ class PrivateMessageThreadViewModelTest {
     }
 
     @Test
-    fun `openRoster maps a non-owner form to Unavailable`() = runTest {
+    fun `openRoster maps a one-to-one MP (no roster) to Unavailable`() = runTest {
+        // #618 — only a form with NO « Destinataires » row at all (recipientsRoster == null AND no
+        // newdest) maps to Unavailable: a one-to-one MP. A non-owner DT now resolves to Loaded.
         val repository = mockk<MessagesRepository>()
         coEvery {
             repository.getPrivateMessageThread(threadId = 42, page = 1, fallbackCorrespondent = null)
         } returns thread(page = 1, totalPages = 1)
         val write = mockk<PrivateMessageWriteRepository>()
-        // No newdest → a simple participant, not the owner.
-        coEvery { write.fetchReplyForm(any(), any()) } returns replyForm(newdest = null)
+        // Neither newdest nor a read-only roster → a one-to-one MP.
+        coEvery { write.fetchReplyForm(any(), any()) } returns replyForm(newdest = null, roster = null)
 
         val viewModel = threadViewModel(repository, writeRepository = write)
         viewModel.openRoster()
         advanceUntilIdle()
 
         assertEquals(PrivateMessageThreadUiState.Roster.Unavailable, viewModel.state.value.roster)
+    }
+
+    @Test
+    fun `openRoster exposes the full roster of a NON-owner DT and marks it non-manageable`() = runTest {
+        // #618 — a participant's message.php form carries the roster as a read-only span (no newdest).
+        // The sheet must still show the FULL group (viewer prepended), but flag it as not manageable.
+        val repository = mockk<MessagesRepository>()
+        coEvery {
+            repository.getPrivateMessageThread(threadId = 42, page = 1, fallbackCorrespondent = null)
+        } returns thread(page = 1, totalPages = 1)
+        val write = mockk<PrivateMessageWriteRepository>()
+        // No newdest (not the owner) but a read-only roster CSV (minus the viewer « xaat »).
+        coEvery {
+            write.fetchReplyForm(any(), any())
+        } returns replyForm(newdest = null, roster = "alice, bob, TestOwner")
+
+        val viewModel = threadViewModel(repository, writeRepository = write)
+        viewModel.openRoster()
+        advanceUntilIdle()
+
+        val roster = viewModel.state.value.roster
+        assertTrue("expected Loaded, got $roster", roster is PrivateMessageThreadUiState.Roster.Loaded)
+        roster as PrivateMessageThreadUiState.Roster.Loaded
+        assertEquals(listOf("xaat", "alice", "bob", "TestOwner"), roster.members)
+        assertFalse("a non-owner cannot manage the recipients", roster.canManageRecipients)
+    }
+
+    @Test
+    fun `openRoster marks the owner roster as manageable`() = runTest {
+        // #618 — an owner form (newdest present) → the roster is editable, so canManageRecipients=true
+        // and the « Gérer les destinataires » entry is offered.
+        val repository = mockk<MessagesRepository>()
+        coEvery {
+            repository.getPrivateMessageThread(threadId = 42, page = 1, fallbackCorrespondent = null)
+        } returns thread(page = 1, totalPages = 1)
+        val write = mockk<PrivateMessageWriteRepository>()
+        coEvery { write.fetchReplyForm(any(), any()) } returns replyForm(newdest = "alice, bob")
+
+        val viewModel = threadViewModel(repository, writeRepository = write)
+        viewModel.openRoster()
+        advanceUntilIdle()
+
+        val roster = viewModel.state.value.roster
+        assertTrue("expected Loaded, got $roster", roster is PrivateMessageThreadUiState.Roster.Loaded)
+        assertTrue((roster as PrivateMessageThreadUiState.Roster.Loaded).canManageRecipients)
     }
 
     @Test
@@ -591,7 +638,10 @@ class PrivateMessageThreadViewModelTest {
         assertTrue(viewModel.state.value.roster is PrivateMessageThreadUiState.Roster.Loaded)
     }
 
-    private fun replyForm(newdest: String?) = ReplyForm(
+    // #618 — `newdest` = the owner's editable input (drives canManageRecipients) ; `roster` = the
+    // read-only roster CSV the parser surfaces for EVERY member. An owner form sets both to the same
+    // value (parser reuses newdest) ; a non-owner form sets only `roster` (read-only span, no newdest).
+    private fun replyForm(newdest: String?, roster: String? = newdest) = ReplyForm(
         hashCheck = "h",
         sujet = "Sujet",
         hiddenFields = buildMap {
@@ -600,6 +650,7 @@ class PrivateMessageThreadViewModelTest {
             if (newdest != null) put("newdest", newdest)
         },
         isAnonymous = false,
+        recipientsRoster = roster,
     )
 
     private fun thread(


### PR DESCRIPTION
## Quoi (#618 — retour dev v177 de XaTriX)
Refonte de la gestion des destinataires DT + correction du roster non-owner.

- **Bouton « Gérer » → feuille dédiée** (au lieu de chips inline) : l'éditeur de membres était empilé au-dessus du corps → sur un gros DT (29 chips) le corps + Envoyer devenaient inaccessibles (composer non scrollable). Désormais : ligne compacte « Destinataires : N — Gérer » (owner) → `ModalBottomSheet` scrollable (gère 29+ membres). Corps + Envoyer toujours atteignables. Câblage #606 (`recipientsOverride`/`recipientsDirty`) inchangé — l'envoi de la réponse porte le changement.
- **Entrée depuis le topic** : action owner « Gérer les destinataires » (feuille Participants) → ouvre le composer avec la feuille de gestion (param de nav `openRecipientManager`, auto-ouverture one-shot). Rappel contrat HFR : changer les membres = poster une réponse (pas d'édition séparée).
- **Roster non-owner (Bug 2)** : la liste était dite « indisponible si pas créateur » — FAUX. `message.php` porte la liste complète : owner = `<input name="newdest">`, non-owner = `<td><span>CSV</span></td>` (lecture seule). Nouveau `ReplyForm.recipientsRoster` → roster `Loaded` pour owner ET non-owner (l'inbox `title` est tronquée par HFR, non utilisée). `canManageRecipients` (édition) reste owner-only.

## Validation
`BUILD SUCCESSFUL` : `:feature:messages` + `:core:parser` + `:core:model` + `:core:data` + `:app:testDevDebugUnitTest` + `lintDebug` + `detektAll`. Fixtures owner + non-owner + tests parser/modèle/VM.

## Revue Codex
Cadrage avant impl + 2 reviews du diff (agent + finale) : aucun bloquant — #606/#612/#351 non régressés, auto-ouverture one-shot, nav param propagé, pas de double-sheet, canManageRecipients owner-only.

Closes #618.

---
> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
