### PR TITLE
fix(beta-0.16.0): double-review MAJORs (manager no-fallback, MPStorage verify guard, roster fixture provenance)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/mpstorage/DefaultMpStorageRepository.kt
@@ -322,6 +322,22 @@ class DefaultMpStorageRepository @Inject constructor(
         hfrClient.submitPrivateMessageEdit(postBody)
         diagnostics.record(DiagnosticsLog.Level.INFO, LOG_TAG, "writeBackFlag POSTed → verifying")
 
+        // IDENTITY GUARD (C2) — the POST suspends ; re-check before the verify re-read so the GET does
+        // not run under a switched session (it would re-read the wrong account's document with this
+        // thread's id and could mislabel the result). The write itself already happened under the right
+        // session ; if the account changed now, surface it loud rather than verify against the wrong one.
+        if (activePseudo() != pseudo) {
+            diagnostics.record(
+                DiagnosticsLog.Level.ERROR,
+                LOG_TAG,
+                "writeBackFlag: active account changed after POST, before verify → unverifiable",
+            )
+            return MpStorageWriteResult.VerificationFailedRestoreFailed(
+                mutatedBody.toByteArray(Charsets.UTF_8).size,
+                actualBytes = 0,
+            )
+        }
+
         val readBack = reReadContentForm(location)
         if (readBack == mutatedBody) {
             diagnostics.record(DiagnosticsLog.Level.INFO, LOG_TAG, "writeBackFlag verified OK")

--- a/core/parser/src/test/resources/fixtures/private_message_dt_participant_reply_form.source.txt
+++ b/core/parser/src/test/resources/fixtures/private_message_dt_participant_reply_form.source.txt
@@ -1,0 +1,19 @@
+Provenance — private_message_dt_participant_reply_form.html (#618 / #612)
+
+STRUCTURE VÉRIFIÉE LIVE (capture authentifiée d'un DT dont le compte n'est PAS le créateur,
+2026-06-21). Le HTML de cette fixture est MODELÉ sur cette capture réelle puis SANITISÉ — il n'est
+pas une supposition.
+
+Fait structurel reproduit fidèlement (ce qui distingue le non-owner de l'owner) :
+- la ligne « Destinataires » du formulaire message.php d'un NON-OWNER est rendue en LECTURE SEULE :
+    <th class="repCase1">Destinataires</th>
+    <td class="repCase2"><span style="font-size:12px;">{liste CSV, hors soi}</span></td>
+  AUCUN <input name="newdest"> (réservé à l'owner, qui a un champ éditable au même endroit).
+- la liste exclut le lecteur (soi), exactement comme le `newdest` de l'owner.
+
+Le parser (ReplyFormParser.parseRecipientsRoster) résout la cellule par le label « Destinataires »
+du <th>, pas par un index positionnel — robuste aux colonnes voisines.
+
+SANITISATION : tous les pseudos sont bidons (TestOwner, alice, bob, « Bébé Yoda », « stitch+ »,
+Administration), hash_check = "TESTHASH", aucun contenu de message privé réel. Le brut de la capture
+live (pseudos + hash de session réels) n'est PAS conservé (PII).

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
@@ -156,7 +156,14 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
         _state.update { it.copy(isLoadingForm = true, formError = false) }
         formJob = viewModelScope.launch {
             try {
-                val form = repository.fetchReplyForm(context)
+                // #618 — when the user came specifically to MANAGE recipients, the form MUST be the
+                // message.php one carrying `newdest` (owner) ; refuse the forum2.php quick-reply
+                // fallback (no newdest → no member editor → silently lands on a plain composer). A
+                // failed message.php GET then surfaces as a form error (retry) rather than a dead end.
+                val form = repository.fetchReplyForm(
+                    context,
+                    allowEmbeddedFallback = !request.openRecipientManager,
+                )
                 if (form.isAnonymous) {
                     // Session vanished between opening the thread and replying — treat like a form
                     // error so the user re-authenticates (the reply route is only reachable while


### PR DESCRIPTION
## Quoi
Corrige les findings de la **double review pré-promotion** de la bêta 0.16.0 (Codex + workflow, sur le payload complet main..dev).

- **#618 — entrée « Gérer »** : `loadForm` fetche désormais `allowEmbeddedFallback = !openRecipientManager`. Si on vient gérer les destinataires et que `message.php` échoue, on n'atterrit plus silencieusement sur un composer normal (sans `newdest`) → erreur/retry. Le reply normal garde le fallback (#301 non régressé).
- **MPStorage** : garde de session ajoutée AVANT le re-read de vérification (en plus de celles avant le POST et avant le restore-POST) — la vérif ne peut plus tourner sous une session changée.
- **Roster non-owner** : ajout du `.source.txt` de provenance — la structure « Destinataires » en lecture seule (`<span>` dans `td.repCase2`, sans `newdest`) a été **vérifiée live** (DT non-owner, sanitisée) ; la fixture est modelée dessus, pas une supposition synthétique.

## Validation
`BUILD SUCCESSFUL` : `:feature:messages` + `:core:data` + `:core:parser` + `:app:testDevDebugUnitTest` + `lintDebug` + `detektAll`. Codex re-review du fix : GO, 0 finding.

Dernier lot avant le cut bêta 0.16.0.

---
> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
