### PR TITLE
docs: aligner la doc dev Phase 4 + acter l'adoption de Roborazzi

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Voir SKILLS.md à la racine pour l'index humain des skills.
 
 ## Projet
 
-- Phase actuelle : **Phase 1 — Core lecture** ([roadmap](docs/specs/roadmap.md)). Phase 0 bootstrap livrée (Gradle multi-modules, CI, thème M3, navigation, Hilt). Slice topic fixe + AST `PostContent` + `PostRenderer` Compose en cours d'intégration.
+- Phase actuelle : **Phase 4 — UI & hygiène + Extensions** ([roadmap](docs/specs/roadmap.md)). Phases 0 à 3 livrées (bootstrap ; lecture du forum ; écriture poster/citer/upload ; messages MP + DT/MultiMP), bêta **0.16.0** publiée (Play open testing + F-Droid). En cours : refontes UI (vue Drapeaux #603, vue Topic #604), aide & réglages, architecture d'extensions (#6 MPStorage, #7).
 - Licence : GPL-3.0-only
 - Documentation : GitHub Pages via `docs/` (Jekyll + just-the-docs)
 - Langue : code en anglais, issues et docs en francais

--- a/docs/adr/016-roborazzi-screenshot-testing.md
+++ b/docs/adr/016-roborazzi-screenshot-testing.md
@@ -1,0 +1,66 @@
+---
+title: ADR-016
+parent: ADRs
+grand_parent: Spécifications
+nav_order: 16
+permalink: /adr/016-roborazzi-screenshot-testing
+---
+
+# ADR-016 — Roborazzi pour le rendu visuel (screenshot testing JVM), mode record en Phase 4
+
+## Statut
+
+Accepté — 2026-06-21
+
+## Contexte
+
+La méthodologie ([ADR-000]({{ site.baseurl }}/adr/000-methodologie-triple-hybride)) prototype l'UI Compose
+et exclut le TDD red-green dessus ; en MVP, Roborazzi avait été **écarté** (Compose Preview + review
+visuelle, cf. `contributing.md` « à reconsidérer Phase 4+ »).
+
+La situation a changé en Phase 4 :
+- des **régressions visuelles** réelles ont été vécues sur le rendu (smileys intrinsèques #175, citations,
+  blocs de code, AMOLED) — détectables seulement à l'œil, tard ;
+- les **refontes UI multi-features** arrivent (Drapeaux #603, Topic #604, refonte réglages v2) — surface
+  visuelle large, plusieurs modules ;
+- on veut une boucle de vérification **rapide et sans device** (l'émulateur/adb est lent et non
+  reproductible en CI).
+
+Roborazzi 1.63 (sur Robolectric, rendu JVM) a été introduit de fait sur `:core:ui` (PostRenderer :
+code, smiley, citation) et la coquille réglages v2. Il est consommé comme **artefact de test simple**
+(sans le plugin Gradle), avec `roborazzi.test.record=true` forcé.
+
+## Décision
+
+Adopter **Roborazzi comme test de rendu visuel JVM** en Phase 4, en **mode `record`** :
+- les tests `captureRoboImage` génèrent des PNG dans `<module>/build/outputs/roborazzi/` (non versionnés)
+  pour **inspection visuelle** rapide, sans device ;
+- **recommandé** pour tout changement de rendu UI structurant (PostRenderer, écrans refondus) ;
+- **pas encore un gate CI dur** : le mode `verify`/baselines committées est différé tant que les
+  refontes #603/#604 font bouger le rendu (baselines instables = bruit) ;
+- `docs/guides/contributing.md` porte le **mode opératoire** (commandes, quand record vs compare) ; cet
+  ADR porte la décision et le pourquoi.
+
+Couverture initiale : `:core:ui` (PostRenderer) + `:feature:topic` + coquille réglages. La couverture
+s'étend au cas par cas — **pas** d'obligation « tout écran doit avoir un snapshot ».
+
+## Conséquences
+
+- **+** Filet visuel reproductible (~40 s, JVM, sans device) qui complète Compose Preview ; capture
+  inspectable hors IDE et en revue.
+- **+** Détecte tôt les régressions de rendu sur les modules couverts.
+- **−** En mode `record`, pas de diff automatique contre une baseline : l'inspection reste manuelle ; les
+  images ne sont pas versionnées.
+- **−** Coût de maintenance : régénérer (`record`) lors d'un changement visuel intentionnel.
+- **Étape ultérieure** (hors de cet ADR) : passer en `verify` + baselines committées + gate CI une fois
+  les refontes UI stabilisées ; cette bascule fera l'objet d'une décision dédiée.
+
+## Alternatives considérées
+
+- **Compose Preview seul** (statu quo MVP) : pratique en design, mais pas de capture reproductible ni
+  inspectable en CI/revue → insuffisant face aux régressions multi-features.
+- **Tests instrumentés sur device/émulateur** : lents, flaky, exigent un appareil → inadaptés à une
+  boucle rapide et à la CI.
+- **`verify` + baselines committées dès maintenant** : rejeté en V1 — baselines instables tant que
+  #603/#604 retravaillent le rendu (génère du bruit de diff sans valeur).
+- **Paparazzi** : alternative JVM, mais moins alignée sur la stack Robolectric/Compose déjà en place.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,3 +43,4 @@ Les numéros `004` à `007` sont volontairement laissés libres pour des décisi
 | [ADR-013]({{ site.baseurl }}/adr/013-mp-lecture-cache-prefetch) | Lecture MP : partage topic↔MP, cache à trois étages, prefetch borné |
 | [ADR-014]({{ site.baseurl }}/adr/014-mpstorage-v01-de-facto) | MPStorage : enveloppe v0.1 de facto, lecture d'abord, écriture opt-in (OFF par défaut) |
 | [ADR-015]({{ site.baseurl }}/adr/015-iconographie-boutons-icones) | Iconographie des boutons-icônes : vector drawables stroke locaux, primitive `RedfaceVectorIcon` |
+| [ADR-016]({{ site.baseurl }}/adr/016-roborazzi-screenshot-testing) | Roborazzi pour le rendu visuel (screenshot testing JVM), mode record en Phase 4 |

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -13,15 +13,16 @@ Comment participer au projet.
 
 ---
 
-## Phase actuelle : Phase 1 — Core lecture
+## Phase actuelle : Phase 4 — UI & extensions
 
-Phase 0 (bootstrap Gradle multi-modules, CI, thème M3, navigation, Hilt) est livrée. Phase 1 — lecture du forum (drapeaux, topics, forum, deep links, `PostRenderer` Compose) est en cours, voir [roadmap]({{ site.baseurl }}/specs/roadmap). Les contributions utiles maintenant :
+Phases 0 à 3 sont livrées (bootstrap ; lecture du forum ; écriture : poster/citer/`[img]`/upload ; messages : MP + DT/MultiMP), bêta **0.16.0** publiée (Play open testing + F-Droid). Phase 4 en cours : refontes UI (vue Drapeaux [#603](https://github.com/ForumHFR/redface2/issues/603), vue Topic [#604](https://github.com/ForumHFR/redface2/issues/604)), aide & réglages, et architecture d'extensions ([#6](https://github.com/ForumHFR/redface2/issues/6), [#7](https://github.com/ForumHFR/redface2/issues/7)). Voir [roadmap]({{ site.baseurl }}/specs/roadmap). Les contributions utiles maintenant :
 
-- **Implémenter une issue Phase 1** ouverte (drapeaux, login HFR, écran forum, cache Room…)
+- **Implémenter une issue Phase 4** ouverte (refonte Drapeaux/Topic, extensions, polish UX)
 - **Proposer des features** : ouvrir une issue avec le label `feature`
 - **Signaler des oublis ou divergences spec/code** : skill `/spec-reality` ou commentaire d'issue
 - **Capturer des fixtures HFR réelles** via `hfr-mcp` (skill `/parse-fixture`)
-- **Proposer un nom** d'app : voir la [page nommage]({{ site.baseurl }}/guides/naming)
+
+> Ce guide est la **source canonique du workflow opérationnel** (environnement, tests, rendu visuel, Git). La *méthode* (quoi spécifier / prototyper / TDD) vit dans [methodology.md]({{ site.baseurl }}/specs/methodology) ; la *promotion / release* dans [release.md]({{ site.baseurl }}/guides/release). Ne pas dupliquer le cycle ailleurs.
 
 ---
 
@@ -227,9 +228,19 @@ Cette page décrit **comment** contribuer ; elle ne redéfinit pas la méthode d
 **Stratégie :**
 - **TDD sélectif** sur fonctions pures (parser, PostContent AST, ViewModels, helpers, mappers) — red → green → refactor
 - **Test-after** sur intégrations (repositories cache/network, deep linking)
-- **Pas de TDD** sur UI Compose (Compose Preview + review visuelle suffisent ; Roborazzi non retenu en MVP, à reconsidérer Phase 4+ si régressions visuelles multi-features)
+- **Pas de TDD red-green** sur UI Compose, mais **rendu visuel Roborazzi adopté en Phase 4** (cf. sous-section ci-dessous + [ADR-016]({{ site.baseurl }}/adr/016-roborazzi-screenshot-testing)) : Compose Preview pour le design, Roborazzi pour **capturer et inspecter** le rendu sans device.
 
-**Smoke test mensuel HFR (Phase 1 fin) :**
+**Rendu visuel (Roborazzi) :**
+
+Screenshot testing **JVM** (sur Robolectric, sans device) via Roborazzi 1.63, consommé comme artefact de test simple (pas le plugin Gradle), avec `roborazzi.test.record=true` forcé.
+
+- **Mode `record`** (par défaut ici) : un test `captureRoboImage` génère un PNG dans `<module>/build/outputs/roborazzi/` (non versionné) → **inspection visuelle** rapide (~40 s). Lancer via l'env Docker, ex. `./scripts/docker-dev.sh ./gradlew :core:ui:testDebugUnitTest` (ou la tâche `recordRoborazzi`).
+- **Quand l'utiliser** : `record` est réservé aux **changements de rendu intentionnels** (PostRenderer, écrans refondus) — on régénère puis on regarde l'image. `verifyRoborazzi` (compare) existe mais les **baselines ne sont pas versionnées** en V1 (elles bougeraient à chaque itération des refontes #603/#604).
+- **Statut** : **recommandé** pour tout changement de rendu UI structurant, **pas encore un gate CI dur**. Le passage en `verify` + baselines committées + gate fera l'objet d'une décision dédiée une fois les refontes UI stabilisées.
+- **Couverture actuelle** : `:core:ui` (PostRenderer — code, smiley, citation) + `:feature:topic` + coquille réglages. Elle s'étend au cas par cas — **pas** d'obligation « tout écran doit avoir un snapshot ».
+- Décision et rationale : [ADR-016]({{ site.baseurl }}/adr/016-roborazzi-screenshot-testing).
+
+**Smoke test mensuel HFR (fin de phase de lecture) :**
 
 Workflow GitHub Actions (`cron: '0 2 1 * *'`, 1er du mois, 2h UTC) qui vérifie contre HFR réel :
 


### PR DESCRIPTION
> Action par Claude Opus 4.8 (1M context) (demandée par @XaTriX)

Aligne la doc de développement sur la réalité Phase 4 et **acte l'adoption de Roborazzi** (jusqu'ici la doc disait « Roborazzi non retenu en MVP »).

## Changements
- **ADR-016** — Roborazzi screenshot testing JVM (Robolectric, sans device), **mode `record`**, adopté en Phase 4. Décision + conséquences (pas de baselines versionnées en V1) + alternatives.
- **`contributing.md`** :
  - nouvelle sous-section **« Rendu visuel (Roborazzi) »** (mode record, quand l'utiliser, couverture actuelle `:core:ui`+`:feature:topic`, **recommandé pas gate CI dur**) ;
  - corrige la ligne périmée « Roborazzi non retenu en MVP » ;
  - **déclare le guide source canonique du workflow opérationnel** (méthode → `methodology.md`, release → `release.md`, pas de duplication).
- **`contributing.md` + `AGENTS.md`** : phase actuelle **Phase 1 → Phase 4** (dérive doc/réalité).
- **README adr** : index ADR-016.

## Méthode
Cadré et **validé par Codex gpt-5.5 (xhigh) avant rédaction** : inventaire anti-duplication d'abord → décision de **ne pas créer un `dev-loop.md` séparé** (aurait dupliqué methodology/contributing/release) mais d'**enrichir l'existant**. Self-review : 0 fichier parasite, liens ADR cohérents, plus aucune mention « Phase 1 — Core lecture ».

Doc-only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)