### PR TITLE
docs(methodo): charte cadence/pipeline + corrige les faux-enforced

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,16 +12,23 @@
 
 ## Validation Run
 
-- [ ] `./gradlew detektAll`
-- [ ] `./gradlew lintDebug`
-- [ ] `./gradlew testDebugUnitTest`
-- [ ] `./gradlew :app:assembleDebug`
+- [ ] Branché depuis `origin/dev` frais
+- [ ] `./scripts/docker-dev.sh ./gradlew detektAll :app:lintProdDebug` (detekt racine + lint flavoré)
+- [ ] `./gradlew :feature:<module>:testDebugUnitTest` — modules touchés **exécutés** (pas `:app:testDevDebugUnitTest` seul, qui ne lance pas les tests feature/core)
+- [ ] `./gradlew :app:assembleProdDebug` (avant push/PR)
+- [ ] Fixtures ajoutées accompagnées d'un `.source.txt`/header
+- [ ] `app/CHANGELOG.md` mis à jour si `versionName` change
 - [ ] Autre validation utile décrite ci-dessous
 
 ## Docs / Specs Impact
 
 - [ ] Aucun
 - [ ] Oui, docs/specs mises à jour
+
+## Review
+
+- [ ] Review Codex jointe (cadrage si non-trivial + relecture du diff) — label `codex-reviewed`
+- [ ] Validation par un agent/relecteur distinct du producteur
 
 ## AI Attribution
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,8 @@ Voir SKILLS.md à la racine pour l'index humain des skills.
 
 ```bash
 # Build applicatif local — image Docker pin (cf. .devcontainer/devcontainer.json)
-./gradlew :app:assembleDebug
+# Variantes dev/prod (#233) : le :app:assembleDebug non flavoré ne résout plus.
+./gradlew :app:assembleProdDebug
 
 # Preview Jekyll (necessite Ruby + Bundler)
 cd docs && bundle install && bundle exec jekyll serve
@@ -75,10 +76,44 @@ Strategie complete (TDD/spec/prototype par sous-chantier, fixtures, couverture d
 
 - Issues et commentaires : toujours mentionner qui a demande l'action si generee par IA
 - Conventional Commits : `feat:`, `fix:`, `docs:`, `chore:`, `test:`
-- Branche principale : `main`
+- Branche principale : `main` (branche de **release**). **Branche d'intégration : `dev`** — les branches de feature partent de `origin/dev` (fraîchement pull) et y sont mergées ; promotion `dev → main` à la release. Ne jamais brancher depuis une branche feature locale non squashée.
 - **Pas de push direct sur `main`** : toute modification (code, doc, skill, ADR, fixture) passe par une **pull request** avec CI verte avant merge. Cette règle vaut aussi pour les changements jugés triviaux (typo, ajout d'une ligne dans une table) : la PR donne un point d'historique reviewable et fait tourner la CI. La branch protection actuelle n'enforce pas techniquement cette règle (`enforce_admins: false` pour garder un échappatoire d'urgence), c'est une discipline de projet. Toute exception (revert critique, hotfix bloquant, ou absence prolongée de reviewer humain) doit être : (1) justifiée dans le message du commit ou du merge, et (2) tracée dans une issue post-mortem ouverte le jour même si l'exception devient récurrente.
 - **Review en mono-maintainer** : si le maintainer principal opère sous deux comptes GitHub (alias dédié au projet + autre compte) **et que les deux comptes sont publiquement associables sans fuite d'information personnelle**, les PR du compte projet peuvent être approuvées depuis l'autre compte pour satisfaire la règle "1 review approuvée + CI verte" sans bloquer le workflow. **Si l'autre compte porte une identité que le maintainer ne souhaite pas publiquement lier au projet** (typiquement un projet sous pseudonyme), ne **jamais** l'utiliser pour une review, un commentaire ou tout artefact public sur ce repo — la trace est immuable côté GitHub. Si aucun reviewer "sûr" n'est disponible (autre compte du maintainer associable, ou contributeur communautaire), le merge `--admin` est acceptable comme exception au sens du point précédent ; il vaut mieux un `--admin` justifié dans le message de merge qu'une review qui crée un lien d'identité non voulu.
 - **Modifier un skill = tester avant la PR** : toute modification d'un skill `.agents/skills/<name>/SKILL.md` doit être exécutée dans la session courante (dry-run) pour valider que les commandes documentées marchent et que le rapport produit colle aux checks. Le rapport (ou le bug trouvé) est mentionné dans la description de la PR. Voir `SKILLS.md` § "Créer ou modifier un skill".
+
+---
+
+## Cadence de validation & pipeline
+
+> **Méta-règle : AGENTS.md = la loi, la CI = la police.** Une règle « stricte » est soit
+> `[enforced]` (garde machine bloquante : CI / Konsist / Detekt / lint / hook), soit
+> `[advisory]` (discipline, au mieux rappelée par le template PR). **Ne jamais présenter une
+> règle comme `[enforced]` sans garde réelle** — le statut de chaque garde vit dans
+> `docs/guides/contributing.md`.
+
+### Cadence Codex `[advisory]`
+
+Codex n'a pas de runner CI : c'est une **discipline**, signalée (pas imposée) par le template PR
+(case « review Codex », label `codex-reviewed`).
+- **Cadrage** — avant un chantier non-trivial (nouvelle archi, changement cross-cutting, design à
+  forks réels), faire cadrer l'approche par Codex *avant* d'implémenter (`NE MODIFIE RIEN` ;
+  lecture du repo autorisée).
+- **Review** — après chaque diff non-trivial, faire relire le diff par Codex.
+- **Gate** — Codex en bout de chaîne avant merge / release.
+- **Exception** — edit purement mécanique (typo, rename, bump de version).
+- **Validation séparée** (cf. § Charte anti-derive) : Codex est le validateur distinct par défaut ;
+  ses verdicts se recoupent au code, ils ne font pas autorité seuls.
+
+### Pipeline de développement `[advisory]`
+
+`choix techno → (roborazzi baseline si refonte) → développement → validation → (roborazzi verify si refonte) → review`
+- **Neuf** : techno → dev → validation → review. **Refonte d'écran existant** : capturer le rendu
+  Roborazzi *avant* (baseline) et le vérifier *après*.
+- **Choix techno** : sur une API incertaine, vérifier la doc officielle actuelle (Context7/Docfork,
+  « stable release ») ; ADR seulement pour une décision structurante.
+- **Validation** : reproduire la CI — `:app:assembleProdDebug test testDebugUnitTest lintDebug :app:lintProdDebug detektAll` ;
+  **jamais `:app:testDevDebugUnitTest` seul** (il compile mais n'exécute pas les tests des modules `feature`/`core`).
+- **Review** : Codex (cf. cadence) + `/code-review`.
 
 ---
 

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -211,13 +211,13 @@ Cette page décrit **comment** contribuer ; elle ne redéfinit pas la méthode d
 
 **Enforcement au build (Phase 0) :**
 - **Konsist** — règles d'architecture (imports inter-modules, `:core:extension` limité à `topic/editor`, tokens M3 centralisés dans `:core:ui`). Voir [architecture.md]({{ site.baseurl }}/specs/architecture) pour les règles. La règle `@AnonymousClient` sur prefetch sera activée dès que le code réseau/prefetch existera réellement.
-- **Detekt** — style Kotlin + deprecations (`runBlocking`, `GlobalScope`, `LiveData`, imports dépréciés).
-- **Android Lint** — a11y + i18n + correctness. `MissingContentDescription`, `TouchTargetSizeCheck`, `HardcodedText` en `error` (abort build). Config `lintOptions` dans `build.gradle.kts`.
+- **Detekt** — style Kotlin + imports interdits (`ForbiddenImport` : `GlobalScope`, `LiveData`, `material.*`). NB : `runBlocking` n'est **pas** attrapé par Detekt aujourd'hui. L'interdiction de **nouveaux** `runBlocking` en prod (allow-list des 2 sites existants : `DataStoreUserPreferencesRepository.kt`, `PersistentCookieJar.kt`) est une garde dédiée à ajouter, pas un défaut Detekt.
+- **Android Lint** — a11y + i18n + correctness. Lint tourne avec `abortOnError = true` (convention plugin dans `build-logic/`). NB : `MissingContentDescription`/`TouchTargetSizeCheck`/`HardcodedText` restent à leur **sévérité par défaut (warning)** — ils ne font pas échouer le build tant qu'ils ne sont pas promus en `error` (`lint { error += listOf(...) }`), ce qui n'est pas le cas actuellement.
 
 **CI Phase 0 :**
 - workflow GitHub Actions sur push `main` et PR
 - exécution dans le même env Docker de référence, épinglé par digest
-- pipeline actuelle : `detektAll`, `lintDebug`, `testDebugUnitTest` (inclut les checks Konsist), `:app:assembleDebug`
+- pipeline actuelle (CI) : `detektAll`, `lintDebug` + `:app:lintProdDebug`, `test` + `testDebugUnitTest` (inclut les checks Konsist), `:app:assembleProdDebug` — le `:app:assembleDebug` **non flavoré ne résout plus** (variantes `dev`/`prod`, [#233](https://github.com/ForumHFR/redface2/issues/233))
 - **Dependabot** configuré pour `gradle` et `github-actions`
 
 **Couverture (hybride différenciée) :**
@@ -234,7 +234,7 @@ Cette page décrit **comment** contribuer ; elle ne redéfinit pas la méthode d
 
 Screenshot testing **JVM** (sur Robolectric, sans device) via Roborazzi 1.63, consommé comme artefact de test simple (pas le plugin Gradle), avec `roborazzi.test.record=true` forcé.
 
-- **Mode `record`** (par défaut ici) : un test `captureRoboImage` génère un PNG dans `<module>/build/outputs/roborazzi/` (non versionné) → **inspection visuelle** rapide (~40 s). Lancer via l'env Docker, ex. `./scripts/docker-dev.sh ./gradlew :core:ui:testDebugUnitTest` (ou la tâche `recordRoborazzi`).
+- **Mode `record`** (par défaut ici) : un test `captureRoboImage` génère un PNG dans `<module>/build/outputs/roborazzi/` (non versionné) → **inspection visuelle** rapide (~40 s). Lancer via l'env Docker, ex. `./scripts/docker-dev.sh ./gradlew :core:ui:testDebugUnitTest`. (Il n'existe **pas** de tâche `recordRoborazzi` : le plugin Gradle Roborazzi n'est pas appliqué — record forcé via `roborazzi.test.record=true`.)
 - **Quand l'utiliser** : `record` est réservé aux **changements de rendu intentionnels** (PostRenderer, écrans refondus) — on régénère puis on regarde l'image. `verifyRoborazzi` (compare) existe mais les **baselines ne sont pas versionnées** en V1 (elles bougeraient à chaque itération des refontes #603/#604).
 - **Statut** : **recommandé** pour tout changement de rendu UI structurant, **pas encore un gate CI dur**. Le passage en `verify` + baselines committées + gate fera l'objet d'une décision dédiée une fois les refontes UI stabilisées.
 - **Couverture actuelle** : `:core:ui` (PostRenderer — code, smiley, citation) + `:feature:topic` + coquille réglages. Elle s'étend au cas par cas — **pas** d'obligation « tout écran doit avoir un snapshot ».
@@ -242,7 +242,7 @@ Screenshot testing **JVM** (sur Robolectric, sans device) via Roborazzi 1.63, co
 
 **Smoke test mensuel HFR (fin de phase de lecture) :**
 
-Workflow GitHub Actions (`cron: '0 2 1 * *'`, 1er du mois, 2h UTC) qui vérifie contre HFR réel :
+**Prévu — pas encore implémenté** (aucun workflow `cron` n'existe à ce jour dans `.github/workflows/`). Conception : un workflow GitHub Actions (`cron: '0 2 1 * *'`, 1er du mois, 2h UTC) qui vérifierait, **sans authentification** (cf. règle prefetch non-authentifié), contre HFR réel :
 
 - Sélecteurs CSS critiques (`HfrSelectors`) matchent toujours
 - Liste catégories + sous-catégories (`HfrCategories.ALL` hardcodée) matche le HTML de la page d'accueil — détecte les ajouts/renommages HFR rares mais impactants
@@ -365,7 +365,7 @@ Mêmes règles que les fixtures HTML : capturées live, **jamais inventées**, n
 - Exception contrôlée : les pseudos et profils des comptes de test dédiés publics (`XaTelitte` / `xatelitte`, profil HFR `1214571`) peuvent rester en clair pour conserver la fidélité parser. Ne jamais appliquer cette exception à un compte personnel non dédié.
 - Ne pas reformatter les fixtures HTML : elles doivent rester proches de la réponse HFR. Un nettoyage minimal des fins de ligne/trailing whitespace est acceptable pour satisfaire `git diff --check`, sans modifier la structure DOM.
 - Quand un bug de parsing est corrigé, le HTML problématique est ajouté aux fixtures avec un test de non-régression.
-- Un **smoke test CI mensuel** (cf. cron `0 2 1 * *` ci-dessus) vérifie que les sélecteurs CSS critiques matchent toujours sur une vraie page HFR publique.
+- Un **smoke test CI mensuel** (cf. cron `0 2 1 * *` ci-dessus, **prévu**) vérifiera que les sélecteurs CSS critiques matchent toujours sur une vraie page HFR publique.
 
 ---
 

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -503,13 +503,13 @@ Interceptor OkHttp avec détection des réponses HTTP 429 et des patterns de blo
 
 ### Breakage du parser
 
-`HfrParser` wrappe chaque méthode dans `runCatching`. Sur échec, le HTML brut est loggé en mode debug pour diagnostic. Un smoke test CI hebdomadaire vérifie que les sélecteurs CSS critiques (`HfrSelectors`) matchent toujours sur une vraie page HFR publique.
+`HfrParser` wrappe chaque méthode dans `runCatching`. Sur échec, le HTML brut est loggé en mode debug pour diagnostic. Un smoke test CI (mensuel, cf. [contributing.md]({{ site.baseurl }}/guides/contributing#tests)) est **prévu** — il vérifierait que les sélecteurs CSS critiques (`HfrSelectors`) matchent toujours sur une vraie page HFR publique. **Pas encore implémenté** (aucun workflow `cron` à ce jour).
 
 ---
 
 ## Enforcement architecture au build
 
-Les règles d'architecture décrites plus haut (3 couches strictes, features → `:core:domain` + `:core:ui` uniquement, tokens M3 centralisés dans `:core:ui`) sont **enforcées mécaniquement** par **[Konsist](https://docs.konsist.lemonappdev.com/)** (Kotlin-first, AST parsing) — pas par une convention markdown.
+Une **partie** des règles d'architecture décrites plus haut est **enforcée mécaniquement** par **[Konsist](https://docs.konsist.lemonappdev.com/)** (Kotlin-first, AST parsing) — pas par une simple convention markdown. Couverture actuelle (6 règles) : la garde « features → pas de couche d'implémentation `:core:*` » (slice `/feature/`), les tokens M3 instanciés hors `:core:ui` (imports nommés `ColorScheme`/`Typography`/`Shapes`), `:core:extension` limité à `topic`/`editor`. **Non couverts à ce jour** : les dépendances autorisées **inter-`core`**, le module `:app`, et l'instanciation M3 via fabriques (`lightColorScheme()`) ou usage pleinement qualifié. À étendre (cf. charte méthodo) — la prose ne doit pas affirmer plus que ce que Konsist vérifie réellement.
 
 Choix Konsist plutôt que ArchUnit :
 - Konsist voit les spécificités Kotlin : `sealed`/`data`/`internal`/`object`, extensions, expect/actual KMP.


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

## Summary

PR 1/5 du chantier de consolidation **pré-#603** : poser la **charte méthodo/workflow** comme loi écrite (`AGENTS.md`) et corriger la doc qui se présentait à tort comme « enforced ». Issue d'une analyse multi-agents read-only + double gate Codex (cf. `drafts/methodo-charter-2026-06-22.md`, non versionné).

## Changes

- **AGENTS.md** — nouvelle section « Cadence de validation & pipeline » : méta-règle `[enforced]`/`[advisory]` (« AGENTS.md = la loi, la CI = la police »), cadence Codex (cadrage/review/gate, `[advisory]` car pas de runner CI), pipeline de dev. Clarifie `dev` = branche d'**intégration** / `main` = **release**. Commande build → `:app:assembleProdDebug` (#233).
- **contributing.md** — 4 « faux enforced » corrigés : Detekt n'attrape **pas** `runBlocking` ; lint a11y **non** promu en `error` ; smoke-test HFR « **prévu** » (aucun cron n'existe) ; **pas** de tâche `recordRoborazzi` (plugin non appliqué). Commandes CI flavorées.
- **architecture.md** — smoke-test « prévu » ; Konsist présenté comme couverture **partielle** (ne survend plus « 3 couches enforcées mécaniquement » ; inter-`core` et `:app` non couverts).
- **pull_request_template.md** — checklist durcie : branche `origin/dev`, modules **exécutés** (pas `:app:testDevDebugUnitTest` seul), fixtures sourcées, `app/CHANGELOG.md` au bump, review Codex.

## Validation

Docs-only (aucun Kotlin touché) → la CI (`assemble`/`test`/`lint`/`detekt`) valide. Faits vérifiés contre `.github/workflows/ci.yml` et `config/detekt/detekt.yml`. Revue + gate par Codex gpt-5.5 (NO-GO → retouches → GO).

## Suite

PR 2 (gardes repo : cleanup TODO + `ForbiddenComment`, provenance fixtures + check CI, rapport taille) · PR 3 (gardes release : changelog-au-bump, whatsnew, garde `--ref dev`) · PR 4 (tooling local : keystore canonique, `sync_to_b.sh`, doc machine B) · PR 5 (skills pipeline + mode `--repo` de `codex-run.sh`).
