### PR TITLE
chore(repo-guards): garde TODO + provenance fixtures + rapport taille

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,20 @@ jobs:
       - name: ${{ matrix.task.name }}
         run: ./gradlew ${{ matrix.task.gradle }}
 
+  # Repo hygiene guards (no Gradle/SDK needed — pure bash). Fixture provenance is BLOCKING;
+  # the large-file report is advisory (writes to the job summary, never fails). Wired into the
+  # required aggregate check below so the guard is actually enforced on `main` (dev→main promotion).
+  repo-guards:
+    name: repo-guards
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Fixture provenance (blocking)
+        run: bash scripts/check-fixtures-provenance.sh
+      - name: Large production files report (advisory)
+        run: bash scripts/report-large-files.sh
+
   # Single aggregate check whose name is the one `main`'s branch protection requires
   # ("Build, lint and test"). Green iff every `verify` matrix entry succeeded, so the fan-out stays
   # compatible with the existing required-status-check on `main` (dev→main promotion) without having
@@ -63,14 +77,15 @@ jobs:
   build-lint-and-test:
     name: Build, lint and test
     if: always()
-    needs: [verify]
+    needs: [verify, repo-guards]
     runs-on: ubuntu-24.04
     steps:
-      - name: Require all verify jobs to pass
+      - name: Require all required jobs to pass
         run: |
-          result='${{ needs.verify.result }}'
-          echo "verify matrix result: $result"
-          if [ "$result" != "success" ]; then
-            echo "::error::One or more verify jobs did not succeed ($result)."
+          verify='${{ needs.verify.result }}'
+          guards='${{ needs.repo-guards.result }}'
+          echo "verify matrix result: $verify | repo-guards result: $guards"
+          if [ "$verify" != "success" ] || [ "$guards" != "success" ]; then
+            echo "::error::A required job did not succeed (verify=$verify, repo-guards=$guards)."
             exit 1
           fi

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -411,8 +411,7 @@ data class SettingsCategoryRoute(val categoryId: String) : RedfaceNavKey
  * the accepted MVP trade-off; no shared ViewModel or caching across the two entry points
  * is implemented yet.
  *
- * TODO(profile): caching follow-up — open a dedicated issue (none filed yet to keep this
- * PR scope-bound) and link it here. Candidate approaches: (a) shared `Singleton` Room-
+ * Caching follow-up (tracked by #625). Candidate approaches: (a) shared `Singleton` Room-
  * backed cache keyed by `userId`, (b) repository-level in-memory `Cache<Int, UserProfile>`
  * with a short TTL, (c) hoisting the ViewModel to a `LocalViewModelStoreOwner` shared by
  * the sheet and the page.

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -28,3 +28,17 @@ style:
       - androidx.compose.material.*
       - kotlinx.coroutines.GlobalScope
       - androidx.lifecycle.LiveData
+  # Pas de marqueur TODO/FIXME/STOPSHIP en code de PRODUCTION (cf. contributing.md) — ouvrir/lier
+  # une issue à la place. Scopé src/main : tests, fixtures et docs ne sont pas concernés. Redéfinir
+  # `comments:` remplace la liste par défaut, donc on répète STOPSHIP.
+  ForbiddenComment:
+    active: true
+    includes:
+      - '**/src/main/**'
+    comments:
+      - reason: 'TODO interdit en prod — ouvrir/lier une issue (cf. contributing.md).'
+        value: '\bTODO\s*(?:\(|:)'
+      - reason: 'FIXME interdit en prod — ouvrir/lier une issue (cf. contributing.md).'
+        value: '\bFIXME\b'
+      - reason: 'STOPSHIP interdit.'
+        value: '\bSTOPSHIP\b'

--- a/config/fixtures-provenance-allowlist.txt
+++ b/config/fixtures-provenance-allowlist.txt
@@ -1,0 +1,12 @@
+# Fixtures legacy sans provenance machine-détectable — backfill suivi par #630.
+# La charte interdit de fabriquer une provenance ; ces entrées sont tolérées
+# temporairement et doivent disparaître (sidecar .source.txt réel) à la clôture de #630.
+# Chemins repo exacts (pas de glob). Le script scripts/check-fixtures-provenance.sh les ignore.
+core/data/src/test/resources/fixtures/mp_storage_inbox_hit.html
+core/data/src/test/resources/fixtures/mp_storage_inbox_no_hit.html
+core/data/src/test/resources/fixtures/mp_storage_inbox_p1_nohit.html
+core/data/src/test/resources/fixtures/mp_storage_inbox_p2_hit.html
+core/data/src/test/resources/fixtures/mp_storage_thread_empty.html
+core/data/src/test/resources/fixtures/private_message_dt_owner_reply_form.html
+core/parser/src/test/resources/fixtures/private_message_dt_owner_reply_form.html
+core/parser/src/test/resources/fixtures/smileys_top100_roger21.json

--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
@@ -713,7 +713,7 @@ class PostContentParser {
         val PERSO_SMILEY_REGEX = Regex("""^\[:[^]]+]$""")
 
         // Citation header href: https://forum.hardware.fr/hfr/.../sujet_<post>_<page>.htm#t<numreponse>
-        // TODO(Phase 2): this only matches the static permalink form. In logged-in mode HFR
+        // Known limitation (tracked by #625): this only matches the static permalink form. In logged-in mode HFR
         // serves the dynamic `forum2.php?...&page=N...#t<numreponse>` form instead, which this
         // regex misses → Quote.page / Quote.numreponse stay null and scroll-to-cited-post is
         // inactive for authenticated users. Pinned by `logged-in oldcitation table …` test.

--- a/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/kotlin/fr/forumhfr/redface2/feature/profile/ProfileScreen.kt
@@ -46,10 +46,9 @@ import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
  * A [ProfileViewModel] is created via Hilt AssistedInject with a custom factory that
  * receives these arguments at construction time.
  *
- * TODO(profile): the sheet ↔ full-page transition currently builds two ProfileViewModel
- *  instances and fires two network calls — see KDoc on [fr.forumhfr.redface2.navigation
- *  .ProfileFullRoute]. A caching follow-up will land after this work (no issue opened yet
- *  to keep this PR focused).
+ * Known limitation (tracked by #625): the sheet ↔ full-page transition currently builds two
+ *  ProfileViewModel instances and fires two network calls — see KDoc on [fr.forumhfr.redface2
+ *  .navigation.ProfileFullRoute]. A caching follow-up will land after this work.
  *
  * @param onBack  Navigation callback — pops back to the previous screen.
  * @param onShowUserPosts  Navigation callback for « Derniers messages » — pushes the

--- a/scripts/check-fixtures-provenance.sh
+++ b/scripts/check-fixtures-provenance.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Garde de provenance des fixtures de test (cf. AGENTS.md § Cadence — [enforced]).
+# Toute fixture HTML/JSON sous */src/test/resources/fixtures/ doit avoir :
+#   - un sidecar `<fixture>.source.txt` OU `<fixture sans ext>.source.txt`, OU
+#   - un commentaire de provenance en tête (HTML `<!--` avec Source/Provenance/Captur…), OU
+#   - une entrée explicite dans config/fixtures-provenance-allowlist.txt (legacy, backfill suivi).
+# La charte interdit de fabriquer une provenance : les fixtures legacy non sourçables sont
+# allow-listées et suivies par une issue de backfill, jamais inventées.
+set -euo pipefail
+
+allowlist="config/fixtures-provenance-allowlist.txt"
+missing=0
+
+is_allowed() {
+  local path="$1"
+  [[ -f "$allowlist" ]] &&
+    grep -vE '^[[:space:]]*(#|$)' "$allowlist" | grep -Fxq -- "$path"
+}
+
+has_header_provenance() {
+  local file="$1"
+  [[ "$(head -c 4 "$file")" == "<!--" ]] &&
+    head -n 40 "$file" | grep -Eiq 'Source|Provenance|Captured|Captur|Origine'
+}
+
+while IFS= read -r -d '' fixture; do
+  rel="${fixture#./}"
+  sidecar_without_ext="${fixture%.*}.source.txt"
+  sidecar_with_ext="${fixture}.source.txt"
+
+  if [[ -f "$sidecar_without_ext" || -f "$sidecar_with_ext" ]]; then
+    continue
+  fi
+  if has_header_provenance "$fixture"; then
+    continue
+  fi
+  if is_allowed "$rel"; then
+    continue
+  fi
+
+  echo "::error file=$rel::Fixture sans provenance (sidecar .source.txt / header / allow-list)"
+  missing=1
+done < <(
+  # Scan global (tous modules), en élaguant les dossiers lourds non versionnés.
+  find . -type d \( -name .git -o -name build -o -name '.gradle*' -o -name '.kotlin' -o -name node_modules \) -prune -o \
+    -path '*/src/test/resources/fixtures/*' -type f \( -name '*.html' -o -name '*.json' \) -print0
+)
+
+if [[ "$missing" -eq 0 ]]; then
+  echo "Provenance fixtures : OK"
+fi
+exit "$missing"

--- a/scripts/report-large-files.sh
+++ b/scripts/report-large-files.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Rapport NON bloquant des fichiers de production Kotlin dépassant un seuil de lignes
+# (cf. AGENTS.md § Cadence — [advisory]). Écrit dans $GITHUB_STEP_SUMMARY, exit 0 toujours.
+set -euo pipefail
+threshold="${1:-800}"
+out="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+{
+  echo "## Fichiers de production Kotlin > ${threshold} lignes"
+  echo
+  found=0
+  while IFS= read -r -d '' f; do
+    n=$(wc -l < "$f")
+    if [ "$n" -gt "$threshold" ]; then
+      echo "- \`${f#./}\` — ${n} lignes"
+      found=1
+    fi
+  done < <(find app core feature build-logic -path '*/src/main/*' -name '*.kt' -type f -print0 2>/dev/null | sort -z)
+  [ "$found" -eq 0 ] && echo "_Aucun fichier au-dessus du seuil._"
+} >> "$out"
+exit 0


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

## Summary

PR 2/5 de la consolidation **pré-#603** : transformer en **gardes machine** les règles d'hygiène jusqu'ici prose-only (principe « AGENTS.md = la loi, la CI = la police », cf. #629). Cadrée + gatée par Codex (gpt-5.5).

⚠️ **Change le contrat CI** : nouveau job requis `repo-guards` + nouvelle règle detekt bloquante qui s'appliquera à toutes les PRs futures.

## Changes

- **detekt `ForbiddenComment`** (scopé `**/src/main/**`) — interdit `TODO(`/`TODO:`/`FIXME`/`STOPSHIP` en code de production. Les 3 TODO prod existants sont nettoyés (→ « tracked by #625 ») : `PostContentParser.kt`, `ProfileScreen.kt`, `RedfaceNavigation.kt`. Aucun changement de comportement (commentaires seuls).
- **Provenance fixtures** — `scripts/check-fixtures-provenance.sh` exige, pour toute fixture sous `*/src/test/resources/fixtures/` (scan global), un sidecar `.source.txt` (avec ou sans extension) **ou** un header de provenance. Les **8 fixtures legacy** sans provenance sont allow-listées (`config/fixtures-provenance-allowlist.txt`) ; backfill suivi par **#630** (la charte interdit de fabriquer une provenance).
- **Rapport taille** — `scripts/report-large-files.sh` liste les fichiers prod > 800 lignes dans `$GITHUB_STEP_SUMMARY`. **Non bloquant** (`exit 0`). Signale aujourd'hui 11 fichiers (dont `TopicScreen.kt` 2509, `RedfaceNavigation.kt` 2472).
- **CI** — job `repo-guards` (provenance **bloquant** + rapport advisory), intégré au check requis agrégé `Build, lint and test` (`needs: [verify, repo-guards]`).

## Validation

- `detektAll` local = **BUILD SUCCESSFUL** (config `ForbiddenComment` valide, 0 violation).
- 0 `TODO/FIXME/STOPSHIP` résiduel en `src/main` ; `check-fixtures-provenance.sh` exit 0 (106 fixtures scannées) ; `report-large-files.sh` exit 0.
- Cadrage + gate Codex gpt-5.5 (NO-GO → scan global au lieu de `core/` seul → GO).

## Suite

PR 3 (gardes release : changelog-au-bump, whatsnew, garde `--ref dev`) · PR 4 (tooling local : keystore, `sync_to_b.sh`, doc machine B) · PR 5 (skills pipeline + mode `--repo` de `codex-run.sh`).
