### PR TITLE
ci(release): gardes déploiement — changelog-au-bump, whatsnew, garde --ref dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,23 @@ jobs:
         uses: actions/checkout@v6
       - name: Fixture provenance (blocking)
         run: bash scripts/check-fixtures-provenance.sh
+      - name: Changelog updated on versionName bump (PR, blocking)
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git fetch --depth=1 origin "$BASE_REF"
+          old=$(git show "FETCH_HEAD:app/build.gradle.kts" 2>/dev/null | grep -E '^[[:space:]]+versionName[[:space:]]*=' | head -1 | sed -E 's/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/' || true)
+          new=$(grep -E '^[[:space:]]+versionName[[:space:]]*=' app/build.gradle.kts | head -1 | sed -E 's/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
+          echo "versionName base='${old:-?}' head='${new:-?}'"
+          if [[ -n "$new" && "$new" != "$old" ]]; then
+            echo "versionName bumpé (${old:-?} -> $new) -> entrée app/CHANGELOG.md requise"
+            bash scripts/check-changelog-entry.sh "$new"
+          else
+            echo "versionName inchangé -> pas de check changelog requis"
+          fi
       - name: Large production files report (advisory)
         run: bash scripts/report-large-files.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,12 +101,20 @@ jobs:
                 echo "::error::channel=beta must build from 'main' (effective ref='${effective_ref}'). Dispatch with --ref main (and no 'ref' override, or ref=main)."
                 exit 1
               fi
+              build_ref="$DISPATCH_REF"
               channel=beta
               app_label="Redface 2 β"
               play_upload=true; play_track=beta; play_status=completed
               fdroid_flavor=Beta; fdroid_dir=beta; fdroid_package=fr.forumhfr.redface2.beta; fdroid_channel=beta
               ;;
             dev)
+              # dev ships from `dev` ONLY. An explicit ref override pointing elsewhere is refused so a
+              # `channel=dev` dispatch never silently builds `main` (the `--ref dev` trap, app-v105).
+              if [[ -n "${DISPATCH_REF:-}" && "$DISPATCH_REF" != "dev" && "$DISPATCH_REF" != "refs/heads/dev" ]]; then
+                echo "::error::channel=dev must build from 'dev' (got ref override '${DISPATCH_REF}'). Dispatch with no ref override, or ref=dev."
+                exit 1
+              fi
+              build_ref="${DISPATCH_REF:-dev}"
               channel=dev
               app_label="Redface 2 dev"
               play_upload=true; play_track=internal; play_status=completed
@@ -128,7 +136,7 @@ jobs:
             echo "fdroid_dir=$fdroid_dir"
             echo "fdroid_package=$fdroid_package"
             echo "fdroid_channel=$fdroid_channel"
-            echo "build_ref=$DISPATCH_REF"
+            echo "build_ref=$build_ref"
           } >> "$GITHUB_OUTPUT"
           echo "::notice title=Release target::channel=$channel label='${app_label}' play=$play_upload track=$play_track fdroid=$fdroid_channel/$fdroid_package ref=${DISPATCH_REF:-<current>}"
 
@@ -250,6 +258,17 @@ jobs:
             echo "release_tag=$release_tag"
           } >> "$GITHUB_OUTPUT"
           echo "::notice title=Build::channel=${CHANNEL} versionCode=${version_code} (ledger=${ledger_code} floor=${base_code}) versionName=${version_name} tag=${release_tag} sha=${short_sha} label='${APP_LABEL:-<default>}'"
+
+      - name: Release readiness guards (changelog + whatsnew)
+        shell: bash
+        env:
+          VERSION_NAME: ${{ steps.meta.outputs.version_name }}
+        run: |
+          set -euo pipefail
+          # [enforced] fail-closed AVANT tout side-effect (build / tag-ledger / upload Play+F-Droid) :
+          # changelog applicatif à jour pour ce versionName + whatsnew frais & sous la limite Play.
+          bash scripts/check-changelog-entry.sh "$VERSION_NAME"
+          bash scripts/check-whatsnew.sh "$VERSION_NAME"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5

--- a/docs/guides/release.md
+++ b/docs/guides/release.md
@@ -105,14 +105,14 @@ Plus besoin de bumper `versionCode` à la main ni de publier une Release : le di
 
 ## Flux dev — Play internal + F-Droid `.dev` (rapide)
 
-**GitHub → Actions → Release → Run workflow → `channel = dev`** (défaut ; ou `gh workflow run release.yml -f channel=dev -f ref=<branche>`). Identique au flux beta mais :
+**GitHub → Actions → Release → Run workflow → `channel = dev`** (défaut ; ou `gh workflow run release.yml --ref dev -f channel=dev`). Identique au flux beta mais :
 
 - Play : track **`internal`** au lieu de `beta`, label « Redface 2 dev ».
 - F-Droid : `:app:assembleDevRelease` → package `fr.forumhfr.redface2.dev`.
 
-Inputs : `channel` (`dev` par défaut) et `ref` (défaut = ref courant, pour builder une branche). Les artefacts sont aussi téléchargeables depuis le run Actions (30 j) pour le sideload.
+Inputs : `channel` (`dev` par défaut) et `ref` (optionnel). **Pour `channel=dev`, le ref par défaut est désormais `dev`** (garde `resolve-target`), plus le ref courant ; un `ref` explicite ≠ `dev` est refusé. Pour `channel=beta`, le build vient de `main` (garde existante). Les artefacts sont aussi téléchargeables depuis le run Actions (30 j) pour le sideload.
 
-> ⚠️ **Toujours passer `--ref dev` ET `-f ref=dev` pour un build dev.** L'input `ref` vaut par défaut le *ref courant du dispatch* : lancer `channel=dev` depuis `main` **sans** `ref=dev` build alors **`main`**, pas `dev` (piège vécu sur `app-v105`). Commande sûre : `gh workflow run release.yml -R ForumHFR/redface2 --ref dev -f channel=dev -f ref=dev`, puis **vérifier le `headBranch` du run** juste après le dispatch.
+> ✅ **`channel=dev` builde désormais `dev` par défaut** (garde `resolve-target`) : plus besoin de forcer `-f ref=dev`, et un `ref` explicite autre que `dev` est **refusé** — fini le piège `app-v105` (`channel=dev` depuis `main` buildait `main`). Commande : `gh workflow run release.yml -R ForumHFR/redface2 --ref dev -f channel=dev`. Vérifier le `headBranch` du run reste une bonne hygiène.
 
 ## Flux prod — production (différé)
 

--- a/scripts/check-changelog-entry.sh
+++ b/scripts/check-changelog-entry.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Garde release [enforced] : app/CHANGELOG.md (canonique applicatif) doit contenir un heading
+# pour le versionName donné. Fail-closed. Appelé par la CI (au bump de versionName) et par
+# release.yml (assert final avant build/tag/upload). Aucun secret, aucun Gradle.
+set -euo pipefail
+version="${1:?usage: check-changelog-entry.sh <versionName>}"
+changelog="app/CHANGELOG.md"
+[[ -f "$changelog" ]] || { echo "::error::$changelog introuvable"; exit 1; }
+# Match en deux temps (pas de regex sur la version → aucun souci d'échappement de métacaractères) :
+# 1) isoler les lignes de heading markdown, 2) y chercher la version en chaîne LITTÉRALE (grep -F).
+if grep -E '^#{1,6}[[:space:]]' "$changelog" | grep -Fq -- "$version"; then
+  echo "CHANGELOG: entrée trouvée pour $version"
+else
+  echo "::error::Aucun heading de changelog pour la version '$version' dans $changelog (bump versionName sans entrée CHANGELOG ?)"
+  exit 1
+fi

--- a/scripts/check-whatsnew.sh
+++ b/scripts/check-whatsnew.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Garde release [enforced] : chaque fichier whatsnew-* a sa PREMIÈRE LIGNE contenant le versionName
+# courant (freshness) ET fait ≤ 500 CARACTÈRES (limite Play Console). Fail-closed.
+# Appelé par release.yml avant build/tag/upload. Aucun secret, aucun Gradle.
+set -euo pipefail
+version="${1:?usage: check-whatsnew.sh <versionName>}"
+dir="app/src/main/play/whatsnew"
+shopt -s nullglob
+files=("$dir"/whatsnew-*)
+(( ${#files[@]} > 0 )) || { echo "::error::aucun fichier whatsnew dans $dir"; exit 1; }
+for file in "${files[@]}"; do
+  first_line="$(head -n 1 "$file")"
+  [[ "$first_line" == *"$version"* ]] || {
+    echo "::error::$file : 1re ligne ne contient pas le versionName '$version' (freshness)"
+    exit 1
+  }
+  chars="$(LC_ALL=C.UTF-8 wc -m < "$file" | tr -d '[:space:]')"
+  (( chars <= 500 )) || {
+    echo "::error::$file : $chars caractères (> 500, limite Play Console)"
+    exit 1
+  }
+  echo "whatsnew OK : $(basename "$file") (${chars} car.)"
+done


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

## Summary

PR 3/5 de la consolidation **pré-#603** : fermer les **zones d'ombre du déploiement** identifiées par l'analyse fondation. Toutes les règles deviennent des **gardes machine `[enforced]`** (principe « AGENTS.md = la loi, la CI = la police »). Cadrée + gatée par Codex (gpt-5.5).

⚠️ **Touche la chaîne de publication** (`release.yml`) — à relire avant merge.

## Changes

- **`release.yml`** — step *Release readiness guards* inséré **après** `meta` et **avant** keystore/build/tag-ledger/upload (fail-closed) : exige une entrée `app/CHANGELOG.md` pour le `versionName` courant + un `whatsnew` frais. **Garde `--ref dev`** : `channel=dev` → `build_ref` par défaut `dev`, et un `ref` explicite ≠ `dev` est **refusé** (fin du piège `app-v105` où `channel=dev` depuis `main` buildait `main`). `channel=beta` inchangé (main-only).
- **`ci.yml`** — dans `repo-guards` (déjà requis), check **changelog-au-bump** (PR only) : si `versionName` change vs base, `app/CHANGELOG.md` doit contenir l'entrée.
- **`scripts/check-changelog-entry.sh`** + **`scripts/check-whatsnew.sh`** — gardes communes CI + `release.yml`, **fail-closed**, sans secret ni Gradle. whatsnew : 1re ligne contient le `versionName` + **≤ 500 caractères** (`LC_ALL=C.UTF-8 wc -m`, multi-octets fr-FR).
- **`release.md`** — obligation « toujours `--ref dev` » retirée (c'est le défaut).

## Validation

- Les 2 gardes **passent** sur `0.16.0` (whatsnew en-US 298 / fr-FR 371 car. ≤ 500) et **échouent (exit 1)** sur une version absente → fail-closed prouvé.
- YAML des 2 workflows valide (`yaml.safe_load`). Extraction `versionName` robuste (`"([^"]+)"` ancré), match changelog en **chaîne littérale** (`grep -F`, pas de souci de métacaractère).
- Cadrage + gate Codex (NO-GO → `sed` robuste + match littéral → GO).

## Hors-scope (flaggé)

- Divergence `whatsnew` beta/dev (même dossier servi aux 2 tracks) — nécessiterait des dossiers par canal.
- Non-idempotence d'un re-run après tag `app-v<N>` déjà poussé — à traiter séparément.

## Suite

PR 4 (tooling local : keystore canonique, `sync_to_b.sh`, doc machine B) · PR 5 (skills pipeline + ré-ancrage du pipeline dans `methodology.md`).
