### PR TITLE
docs(methodo): pipeline canonique dans methodology.md + skill /validate

### DIFF
--- a/.agents/skills/validate/SKILL.md
+++ b/.agents/skills/validate/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: validate
+description: Exécute la validation locale canonique Redface 2 (reproduit la CI) dans l'environnement Docker de référence et produit un rapport commandes/résultats. Use before opening or updating a PR with code changes that must reproduce CI locally.
+argument-hint: "[module] — sans argument : validation complète canonique (= CI)"
+disable-model-invocation: true
+---
+
+# /validate — validation locale canonique
+
+Reproduit la CI Redface 2 en local pour éviter le « build local vert / CI rouge ».
+
+## Objectif
+
+Lancer la validation dans l'environnement Docker épinglé (même image que la CI) et **lire le résultat** avant d'ouvrir ou de mettre à jour une PR.
+
+## Quand l'invoquer
+
+- Avant d'ouvrir une PR avec des changements de code.
+- Après une review qui touche un test ou la source qu'il couvre (ajouter `--rerun-tasks`).
+- En gate final avant un déploiement émulateur.
+
+## Commande canonique (= CI, cf. `.github/workflows/ci.yml`)
+
+```bash
+./scripts/docker-dev.sh ./gradlew \
+  :app:assembleProdDebug test testDebugUnitTest lintDebug :app:lintProdDebug detektAll \
+  --console=plain --no-daemon
+```
+
+Itératif (modules touchés seulement, plus rapide) :
+
+```bash
+./scripts/docker-dev.sh ./gradlew \
+  detektAll :feature:<module>:testDebugUnitTest :feature:<module>:lintDebug --rerun-tasks
+```
+
+## Règles
+
+- **Jamais `:app:testDevDebugUnitTest` seul** : il COMPILE mais n'EXÉCUTE PAS les tests des modules `feature`/`core` (la CI lance `testDebugUnitTest` global). Vécu sur #588.
+- `detektAll` est une tâche **racine** (pas `:core:ui:detektAll`) ; `lintDebug` peut être ciblé par module.
+- `--rerun-tasks` dès qu'on touche un test ou sa source : le cache Docker peut renvoyer un faux-vert.
+- Ne jamais conclure « vert » sans avoir lu `BUILD SUCCESSFUL` / `BUILD FAILED` dans le log (un `; echo "$?"` en arrière-plan masque l'exit code de Gradle).
+
+## Format de sortie
+
+```
+Commande(s) lancée(s) : <…>
+Résultat            : BUILD SUCCESSFUL | BUILD FAILED in <durée>
+Échecs              : <tâche:test ou "aucun">
+Non exécuté (env)   : <… ou "rien">
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,16 +104,14 @@ Codex n'a pas de runner CI : c'est une **discipline**, signalée (pas imposée) 
 - **Validation séparée** (cf. § Charte anti-derive) : Codex est le validateur distinct par défaut ;
   ses verdicts se recoupent au code, ils ne font pas autorité seuls.
 
-### Pipeline de développement `[advisory]`
+### Pipeline de développement
 
-`choix techno → (roborazzi baseline si refonte) → développement → validation → (roborazzi verify si refonte) → review`
-- **Neuf** : techno → dev → validation → review. **Refonte d'écran existant** : capturer le rendu
-  Roborazzi *avant* (baseline) et le vérifier *après*.
-- **Choix techno** : sur une API incertaine, vérifier la doc officielle actuelle (Context7/Docfork,
-  « stable release ») ; ADR seulement pour une décision structurante.
-- **Validation** : reproduire la CI — `:app:assembleProdDebug test testDebugUnitTest lintDebug :app:lintProdDebug detektAll` ;
-  **jamais `:app:testDevDebugUnitTest` seul** (il compile mais n'exécute pas les tests des modules `feature`/`core`).
-- **Review** : Codex (cf. cadence) + `/code-review`.
+Le pipeline canonique (`choix techno → … → review`, `[advisory]`) est défini dans
+**`docs/specs/methodology.md` § Pipeline de développement** (source canonique) — `AGENTS.md` ne le
+redéfinit pas. Conséquences opérationnelles pour les agents :
+- **Validation** = reproduire la CI via le skill **`/validate`** ; **jamais `:app:testDevDebugUnitTest`
+  seul** (il compile mais n'exécute pas les tests des modules `feature`/`core`).
+- **Review** = Codex (cf. § Cadence Codex ci-dessus) + `/code-review`.
 
 ---
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -20,6 +20,7 @@ Le source of truth des règles projet est [`AGENTS.md`](AGENTS.md).
 | `preflight` | Vérifie l'environnement de l'agent (MCP, comptes, CLI, repo) avant une session structurante | Toute phase | [.agents/skills/preflight/SKILL.md](.agents/skills/preflight/SKILL.md) |
 | `radar` | Scanne issues/PRs/branches/CI/roadmap et produit un rapport en 4 buckets (urgent / court terme / roadmap / gros chantiers). Modes collecte (objectif) ou score (subjectif). | Toute phase | [.agents/skills/radar/SKILL.md](.agents/skills/radar/SKILL.md) |
 | `spec-reality` | Vérifie l'alignement specs + ADR ↔ code réel (modules Gradle, libs.versions.toml, modèles Kotlin, dépréciations). Sortie par sévérité. | Avant bump version, refacto structurelle | [.agents/skills/spec-reality/SKILL.md](.agents/skills/spec-reality/SKILL.md) |
+| `validate` | Validation locale canonique (reproduit la CI, env Docker) + rapport ; interdit `:app:testDevDebugUnitTest` seul | Avant PR / gate | [.agents/skills/validate/SKILL.md](.agents/skills/validate/SKILL.md) |
 
 ---
 

--- a/docs/specs/methodology.md
+++ b/docs/specs/methodology.md
@@ -66,6 +66,20 @@ Quand un nouveau sujet arrive, commencer par cette question :
 | Logique pure et déterministe | **TDD-first** |
 | Orchestration réelle entre composants | **Impl puis test d'intégration** |
 
+## Pipeline de développement
+
+Une fois le mode de travail choisi (matrice ci-dessus), l'ordre d'exécution canonique est :
+
+`choix techno → (Roborazzi baseline si refonte d'un écran existant) → développement → validation → (Roborazzi record/inspection si rendu UI) → review`
+
+C'est `[advisory]` (une discipline, pas un gate dur — aucun runner CI ne l'impose) :
+
+- **Neuf** : techno (si API incertaine) → dev → validation → review.
+- **Refonte d'un écran existant** : capturer le rendu Roborazzi *avant* le changement (si un test existe déjà), puis record/inspection *après*. Le setup actuel est **record-only** (le plugin Gradle Roborazzi n'est pas applicable sous AGP 9 ; pas de `verify`) — cf. [contributing.md]({{ site.baseurl }}/guides/contributing#tests) et [ADR-016]({{ site.baseurl }}/adr/016-roborazzi-screenshot-testing).
+- **Choix techno** : sur une API au statut incertain, consulter la doc officielle actuelle (Context7/Docfork, mot-clé *stable release*) ; ADR seulement pour une décision structurante.
+- **Validation** : reproduire la CI canonique en local via le skill **`/validate`** — la commande exacte et ses garde-fous (env Docker, `--rerun-tasks`, et « jamais `:app:testDevDebugUnitTest` seul ») y sont définis comme **source unique**, pour éviter deux formulations divergentes.
+- **Review** : un agent distinct du producteur (cf. § Rôle du LLM) — en pratique Codex (cadrage avant un chantier non-trivial + relecture du diff + gate avant merge) puis `/code-review`. Les conséquences opérationnelles pour les agents (cadence Codex, méta-règle `[enforced]`/`[advisory]`) vivent dans [`AGENTS.md`](https://github.com/ForumHFR/redface2/blob/main/AGENTS.md) § Cadence de validation, qui pointe vers cette page comme source canonique.
+
 ## Exemples concrets
 
 | Sujet | Approche | Pourquoi |


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

## Summary

PR **5/5** (dernière) de la consolidation **pré-#603** : ancrer le pipeline de développement dans la **source canonique** (`docs/specs/methodology.md`) et matérialiser le premier skill du pipeline (`validate`). Cadrée + gatée Codex (gpt-5.5), avec **right-sizing explicite** : pas de skills spéculatifs.

## Changes

- **`docs/specs/methodology.md`** — nouvelle section « Pipeline de développement » (canonique), après la matrice de décision : `techno → (Roborazzi baseline si refonte) → dev → validation → (Roborazzi record si UI) → review`, `[advisory]`, record-only assumé (plugin non applicable AGP 9).
- **`AGENTS.md`** — sous-section pipeline réduite à un **pointeur** vers `methodology.md` (fin de la duplication méthodo que la page interdit) ; la cadence Codex et la méta-règle `[enforced]`/`[advisory]` restent (opérationnelles).
- **`.agents/skills/validate/SKILL.md`** + **`SKILLS.md`** — skill de validation locale canonique : reproduit la CI dans l'env Docker, interdit `:app:testDevDebugUnitTest` seul, impose `--rerun-tasks` et la lecture du résultat, format de rapport. **Source unique** de la commande de validation.
- **Skills différés** `roborazzi` / `techno-check` / `codex-review` → **#634** (creux ou prématurés aujourd'hui : Roborazzi sans `verify` sous AGP 9, `codex-run.sh` harness-side, techno-check = prose).

## Validation

- **Dry-run du skill `/validate`** (la commande canonique complète) = **BUILD SUCCESSFUL** (1m50) → règle « créer un skill = tester avant la PR » satisfaite.
- Vérifié : la commande gradle canonique n'apparaît **que** dans `/validate` (source unique), pas de duplication divergente.
- Cadrage + gate Codex (NO-GO sur une duplication de commande → corrigé → GO).

## Clôture de la série

PR1 charte/docs (#629) · PR2 repo-guards (#631) · PR3 gardes release (#632) · PR4 keystore (#633) · **PR5 (celle-ci)**. Reste hors-repo : ops workspace (`sync_to_b.sh` durci + doc machine B) + swap-log/quota-preflight (déjà faits). Ensuite : **#603 refonte Drapeaux** sur base saine.
