### PR TITLE
docs(reality): aligner README/index/stack sur Phase 4 / bêta 0.16.0 / Roborazzi

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Les spécifications complètes sont disponibles sur le site du projet :
 
 ## État
 
-Phase courante : **Phase 1 — Core lecture** ([roadmap](https://forumhfr.github.io/redface2/specs/roadmap)). La Phase 0 (bootstrap : Gradle multi-modules, CI, thème Material 3, navigation, Hilt, AAB stamping) est livrée. Slice topic fixe + AST `PostContent` + `PostRenderer` Compose en cours d'intégration via [#3](https://github.com/ForumHFR/redface2/issues/3) et la série de PRs [#78](https://github.com/ForumHFR/redface2/pull/78) / [#80](https://github.com/ForumHFR/redface2/pull/80).
+Phase courante : **Phase 4 — Extensions + refonte UI** ([roadmap](https://forumhfr.github.io/redface2/specs/roadmap)). Phases 0 à 3 livrées (bootstrap ; lecture du forum ; écriture poster/citer/upload/smileys ; messages MP + DT/MultiMP + recherche), bêta **0.16.0** publiée (Play open testing + F-Droid). En cours : refonte des vues Drapeaux ([#603](https://github.com/ForumHFR/redface2/issues/603)) et Topic ([#604](https://github.com/ForumHFR/redface2/issues/604)), architecture d'extensions ([#6](https://github.com/ForumHFR/redface2/issues/6)/[#7](https://github.com/ForumHFR/redface2/issues/7)).
 
 ## Pourquoi réécrire ?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,7 +71,7 @@ graph TB
 
 ## État du projet
 
-Phase courante : **Phase 4 — Extensions** ([roadmap]({{ site.baseurl }}/specs/roadmap)). Phases 1 (lecture), 2 (écriture) et 3 (messages) sont **livrées** : login, drapeaux, forum, topics, cache, deep links, recherche, écriture/édition/citation/création, MPs classiques et MultiMPs (lecture, reply, quote, onglet DT). Seule la synchronisation/écriture MPStorage reste reportée (#6, Phase 4). Le dev (canal interne) accumule en `0.14.0` avant la prochaine bêta.
+Phase courante : **Phase 4 — Extensions + refonte UI** ([roadmap]({{ site.baseurl }}/specs/roadmap)). Phases 1 (lecture), 2 (écriture) et 3 (messages) sont **livrées** : login, drapeaux, forum, topics, cache, deep links, recherche, écriture/édition/citation/création, MPs classiques et MultiMPs (lecture, reply, quote, onglet DT), MPStorage lecture **et écriture** (opt-in). La **bêta 0.16.0** (clôture Phase 3) est publiée (Play open testing + F-Droid) ; seule la sync MPStorage bidirectionnelle complète reste reportée (#6). En cours : refonte UI Drapeaux (#603) / Topic (#604).
 
 Les specs restent la source de vérité du projet, mais elles doivent désormais refléter le code réel : tout écart entre une page canonique et le repo est traité comme un bug de spec, pas comme une dette future. Voir [`/spec-reality`](https://github.com/ForumHFR/redface2/blob/main/.agents/skills/spec-reality/SKILL.md) pour la procédure d'audit cross-fichier.
 

--- a/docs/specs/stack.md
+++ b/docs/specs/stack.md
@@ -33,7 +33,7 @@ Chaque choix a été évalué, comparé et verrouillé. Voici le détail.
 | Enforcement archi | **Konsist** | ArchUnit | Kotlin-first, voit les sealed/data/internal ; ArchUnit = bytecode-only, perd la finesse Kotlin |
 | Style + deprecations | **Detekt** | ktlint | Plus riche, règles custom possibles |
 | A11y + i18n + correctness | **Android Lint** (natif) | — | Déjà présent, config `lintOptions` |
-| Screenshot testing | **Non retenu MVP** (Roborazzi reconsidéré Phase 4+) | — | Compose Preview + review manuelle suffisent en Phase 1-3 |
+| Screenshot testing | **Roborazzi adopté (Phase 4)** | [ADR-016]({{ site.baseurl }}/adr/016-roborazzi-screenshot-testing) | JVM via Robolectric, sans device ; **record-only** (record + inspection, pas de `verify` sous AGP 9) ; Compose Preview pour le design |
 | minSdk | **29** | 26, 31 | Android 10 : Scoped Storage, TLS 1.3, dark thème natif, ~88-90% parc 04/2026 |
 
 > **Versions précises** : le Gradle version catalog `gradle/libs.versions.toml` sera créé en Phase 0 comme source de vérité unique. Ce tableau garde les versions **major.minor** quand elles sont structurelles (Material 3 Adaptive 1.2+ pour les canonical layouts, Compose Navigation 3 pour les back stacks en state, OkHttp 5 pour le client HTTP + `CookieJar`). Les patches stables 2026 sont à résoudre via Context7/Docfork quand on interroge les docs officielles (cf. [#19](https://github.com/ForumHFR/redface2/issues/19)).


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Aligne les 3 pages vitrine sur la réalité (l'item « reality docs » du plan, qui avait été absorbé par la PR charte) : README (Phase 1→4), index (0.14.0→0.16.0 + MPStorage write opt-in), stack (Roborazzi non-retenu→adopté record-only, ADR-016). Diff 3 lignes ; faits vérifiés (CHANGELOG v179, #593, ADR-016) ; gate Codex GO. Clôt le volet « docs publiques périmées » du diagnostic.