### PR TITLE
feat(skills): pipeline skills techno-check / roborazzi / codex-review

### DIFF
--- a/.agents/skills/codex-review/SKILL.md
+++ b/.agents/skills/codex-review/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: codex-review
+description: Fait cadrer/relire/valider un plan, un diff ou un prompt par un agent distinct (Codex) hors-bande, et intègre le verdict. Use for the project's separate-validator cadence (framing before a non-trivial change, diff review, gate before merge).
+argument-hint: "<plan|diff|prompt à reviewer> + la question précise à trancher"
+disable-model-invocation: true
+---
+
+# /codex-review — validation par un agent distinct (Codex)
+
+Matérialise la cadence projet « le même agent ne produit + valide pas seul » ([AGENTS.md] § Cadence de validation). L'agent producteur (ex. Claude) fait **cadrer** l'approche (avant un chantier non-trivial), **relire** le diff, et **gater** avant merge par un agent distinct.
+
+> ⚠️ **Dépendance hors-repo, par conception.** L'implémentation de référence repose sur le CLI `codex` (harness-side, **non versionné** dans ce repo). Sur un agent qui n'a pas Codex, **dégrader** vers : un autre LLM distinct, une review humaine, ou `/code-review`. Ce skill décrit le **flow** (et la discipline), pas un binaire garanti présent.
+
+## Flow A — dossier de faits (reviewer un plan / diff / prompt collé)
+
+1. Écrire un **dossier de faits** : contexte (résumé, pas d'exploration attendue) + l'objet collé (diff / plan / prompt) + la **question précise** à trancher. **Aucun secret.**
+2. Lancer Codex (réf. wrapper `codex-run.sh` côté harness ; modèle/effort = ceux que le harness fournit).
+3. Lire le **VERDICT**, l'intégrer, re-soumettre si une 2ᵉ passe est demandée.
+
+## Flow B — repo-context (confronter au code vivant)
+
+Quand la review doit vérifier des affirmations contre le **code réel** : lancer `codex exec` **dans** le repo (lecture autorisée, ne PAS interdire l'exploration), sans modifier ni builder.
+
+## Règles
+
+- Les verdicts Codex se **recoupent au code** — ils ne font pas autorité seuls (Codex se trompe aussi : exemple vécu, un `runBlocking` prod manqué).
+- Préfixer « NE MODIFIE RIEN » pour une review pure.
+- Toujours **intégrer** le verdict avant de conclure (cycle NO-GO → fix → GO).
+- Mode dossier-de-faits = pas d'exploration (anti-timeout) ; mode repo-context = exploration voulue. Choisir selon la question.

--- a/.agents/skills/roborazzi/SKILL.md
+++ b/.agents/skills/roborazzi/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: roborazzi
+description: Capture (record) et inspecte le rendu Compose via Roborazzi en JVM (sans device) pour un changement de rendu UI. Use when changing PostRenderer or refactoring a screen's rendering and you need to eyeball the result.
+argument-hint: "[module] (défaut :core:ui ; ex :feature:topic)"
+disable-model-invocation: true
+---
+
+# /roborazzi — capture & inspection du rendu (record-only)
+
+Screenshot testing JVM (Robolectric, sans device). **Record-only** : le plugin Gradle Roborazzi n'est pas applicable sous AGP 9 → il n'existe **pas** de tâche `recordRoborazzi` / `verifyRoborazzi` ; le record est forcé via `roborazzi.test.record=true` (cf. `core/ui/build.gradle.kts`, [ADR-016]).
+
+## Argument
+
+`$ARGUMENTS` = module (défaut `:core:ui`).
+
+## Étapes
+
+1. Lancer les tests du module dans l'env Docker :
+
+   ```bash
+   # remplacer :core:ui par le module ciblé (ex. :feature:topic)
+   ./scripts/docker-dev.sh ./gradlew :core:ui:testDebugUnitTest --rerun-tasks
+   ```
+
+2. Les PNG sont générés dans `<module>/build/outputs/roborazzi/` (**non versionnés**).
+3. **Inspecter visuellement** les PNG (le but est l'œil humain/agent, pas un diff automatique).
+
+## Quand l'utiliser
+
+- Changement intentionnel de rendu (`PostRenderer`, écran refondu #603/#604).
+- Capturer une **baseline avant** une refonte, ré-inspecter **après** (le pipeline méthodo le prévoit pour une refonte d'écran existant).
+
+## Limites (assumées)
+
+- **Pas de `verify`** (comparaison auto) ni de gate CI tant que le plugin reste inapplicable sous AGP 9. La bascule record→verify + baselines versionnées fera l'objet d'une décision après stabilisation #603/#604 (ADR-016).
+- Les nodes async (Coil `AsyncImage`) restent sur leur placeholder sous Robolectric → asserter la structure du layout, pas le bitmap rendu.

--- a/.agents/skills/techno-check/SKILL.md
+++ b/.agents/skills/techno-check/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: techno-check
+description: Vérifie le statut actuel d'une API/lib (existe ? dépréciée ? version stable ?) via Context7/Docfork et produit un rapport décision/ADR. Use before writing prod code or a spec snippet with an API whose status is uncertain.
+argument-hint: "<lib/API> (ex: 'androidx.compose.material3 PullToRefreshBox' ou 'OkHttp 5 CookieJar')"
+disable-model-invocation: true
+---
+
+# /techno-check — vérification d'API actuelle
+
+Évite les pièges « API inexistante / dépréciée / pré-release » (SwipeRefresh, EncryptedSharedPreferences, Kotlin 2.4-SNAPSHOT pris pour la stable). Produit un **rapport vérifiable**, pas un rappel de prose.
+
+## Argument
+
+`$ARGUMENTS` = la lib / l'API à vérifier.
+
+## Étapes
+
+1. Résoudre la lib via Context7 (`resolve-library-id`) ou Docfork.
+2. Interroger la doc en précisant **« stable release »** (Context7 indexe aussi snapshots / pre-release).
+3. Confronter à la stack verrouillée (`gradle/libs.versions.toml`, `docs/specs/stack.md`).
+4. Si la décision est structurante → scaffolder un ADR (`docs/adr/NNN-*.md`) ; sinon, pas d'ADR.
+
+## Sortie (rapport)
+
+```
+API            : <nom>
+Statut         : existe / dépréciée / inexistante
+Version stable : <x.y.z> (source : Context7/Docfork, consulté le <date>)
+Aligné stack   : oui/non (libs.versions.toml = <…>)
+Décision       : <à utiliser / alternative <…> / ne pas utiliser>
+ADR nécessaire : oui (scaffold #/chemin) / non
+```
+
+## Règles
+
+- Ne jamais conclure sans avoir **réellement** interrogé la doc (pas depuis la mémoire).
+- « stable release » obligatoire dans la requête.
+- Pas d'ADR pour un choix non structurant (méthodo : ADR a posteriori, pas spéculatif).
+- Un seul artefact = le rapport ci-dessus ; s'il n'apporte rien de vérifiable, ne pas lancer le skill (rester sur la règle prose de `methodology.md`).

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -21,6 +21,9 @@ Le source of truth des règles projet est [`AGENTS.md`](AGENTS.md).
 | `radar` | Scanne issues/PRs/branches/CI/roadmap et produit un rapport en 4 buckets (urgent / court terme / roadmap / gros chantiers). Modes collecte (objectif) ou score (subjectif). | Toute phase | [.agents/skills/radar/SKILL.md](.agents/skills/radar/SKILL.md) |
 | `spec-reality` | Vérifie l'alignement specs + ADR ↔ code réel (modules Gradle, libs.versions.toml, modèles Kotlin, dépréciations). Sortie par sévérité. | Avant bump version, refacto structurelle | [.agents/skills/spec-reality/SKILL.md](.agents/skills/spec-reality/SKILL.md) |
 | `validate` | Validation locale canonique (reproduit la CI, env Docker) + rapport ; interdit `:app:testDevDebugUnitTest` seul | Avant PR / gate | [.agents/skills/validate/SKILL.md](.agents/skills/validate/SKILL.md) |
+| `techno-check` | Vérifie une API/lib (existe/dépréciée/version stable) via Context7/Docfork + rapport décision/ADR | Avant code/snippet sur API incertaine | [.agents/skills/techno-check/SKILL.md](.agents/skills/techno-check/SKILL.md) |
+| `roborazzi` | Capture (record-only) + inspection du rendu Compose en JVM, sans device | Changement de rendu / refonte écran | [.agents/skills/roborazzi/SKILL.md](.agents/skills/roborazzi/SKILL.md) |
+| `codex-review` | Cadrage/relecture/gate par un agent distinct (Codex) hors-bande ; dégradation gracieuse si pas de Codex | Chantier non-trivial / avant merge | [.agents/skills/codex-review/SKILL.md](.agents/skills/codex-review/SKILL.md) |
 
 ---
 


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

## Summary

Crée les 3 skills du pipeline **différés en #634** — à la demande explicite du mainteneur. **Right-sizés** : chacun a de vraies dents (artefact vérifiable ou flow réel), pas un alias creux (on évite de recréer le cycle #24 sous forme de skills).

## Changes

- **`techno-check`** — vérif d'API via Context7/Docfork (« stable release ») → rapport `API / statut / version stable / source / décision / ADR`. Dry-run : `PullToRefreshBox` confirmé stable (material3 1.3.0+).
- **`roborazzi`** — capture **record-only** + inspection du rendu Compose (JVM, sans device). Honnête : pas de `recordRoborazzi`/`verifyRoborazzi` ni de gate (plugin inapplicable AGP 9). Dry-run : 16 PNG générés.
- **`codex-review`** — cadrage/relecture/gate par un agent distinct. **Caveat assumé** : le CLI `codex` est harness-side / non versionné → dégradation gracieuse (autre LLM, review humaine, `/code-review`). Dry-run : flow exercé ~10× cette session (gates NO-GO→fix→GO).
- **`SKILLS.md`** — 3 lignes ajoutées.

## Validation

Règle « créer un skill = tester avant la PR » satisfaite (3 dry-runs ci-dessus). Gate Codex : **GO** (« pas un retour du cycle #24 »), 2 micro-retouches appliquées (commande roborazzi par module, défauts Codex non figés).

`Closes #634`.
