### PR TITLE
feat(#603): PR1 — modèle de présentation Drapeaux + fonctions pures (TDD)

### DIFF
--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/MarkerStyle.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/MarkerStyle.kt
@@ -1,0 +1,21 @@
+package fr.forumhfr.redface2.core.domain.preferences
+
+/**
+ * Visual style of the left-hand marker of a Drapeaux list row (#603, ADR-017). The marker encodes
+ * the flag color (cyan / red / favori) and the read state; only its SHAPE varies:
+ *
+ * - [STRIPE] — a thin vertical color bar at the left edge (the **default**: the soberest option,
+ *   frees the most width for the title).
+ * - [PASTILLE] — a tonal circle carrying the category icon.
+ * - [DOT] — a minimal colored dot (the legacy `FlagDot`).
+ *
+ * Pure domain enum (no Android / Compose), so it can be persisted in a preference and consumed by a
+ * pure mapper ([fr.forumhfr.redface2.feature.flags] `toFlagRowUiModel`) without dragging UI types
+ * into the model layer. The color itself is resolved at render time from the row's effective flag
+ * color (`FlagPalette`), not by this enum.
+ */
+enum class MarkerStyle {
+    STRIPE,
+    PASTILLE,
+    DOT,
+}

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagPresentation.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagPresentation.kt
@@ -1,0 +1,58 @@
+package fr.forumhfr.redface2.feature.flags
+
+import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
+import fr.forumhfr.redface2.core.model.Flag
+import fr.forumhfr.redface2.core.model.FlagType
+
+/**
+ * Pure presentation derivations for the #603 Drapeaux refonte (ADR-017). They turn a raw [Flag]
+ * into the values the list row renders, so the computation lives OFF the composition (ViewModel /
+ * mapper) and the LazyColumn never recomputes it. No Android / Compose types here — colors are
+ * resolved at render time from [effectiveColor] via `FlagPalette`.
+ */
+
+/**
+ * Number of pages the user has left to read on a topic: `max(totalPages - lastReadPage, 0)`.
+ *
+ * Clamped at 0 (a stale cache can carry a [Flag.lastReadPage] past a shrunk [Flag.totalPages]).
+ *
+ * This is a DISPLAY counter, not an unread oracle: it can be `0` while [Flag.hasUnread] is `true`
+ * (unread posts on the last-read page). [Flag.hasUnread] stays the source of truth for read state.
+ */
+fun Flag.pagesToRead(): Int = (totalPages - lastReadPage).coerceAtLeast(0)
+
+/**
+ * The flag color actually shown for this row. The favori/étoile decoration WINS over the bucket
+ * color (#384 / dev v118 web parity: a favorited topic listed under « Mes sujets » keeps its yellow
+ * marker), so a favorited row reads [FlagType.FAVORITE] regardless of which bucket [Flag.type] it
+ * was fetched from. Mirrors the legacy `FlagDot` logic as a single pure source of truth.
+ */
+fun Flag.effectiveFlagColor(): FlagType = if (isFavorite) FlagType.FAVORITE else type
+
+/**
+ * Precomputed presentation bundle for one Drapeaux list row — the "FlagUiModel" of the refonte.
+ * Built once per flag in the data/VM layer ([toFlagRowUiModel]); the composition reads these values
+ * directly instead of deriving them on each recomposition.
+ *
+ * @property flag the source domain row (title, authors, ids… consumed as-is by the row).
+ * @property pagesToRead see [Flag.pagesToRead] — a display counter, not an unread oracle.
+ * @property effectiveColor see [Flag.effectiveFlagColor] — the bucket color, favori-overridden.
+ * @property dimmed `true` for a fully-read flag (`!hasUnread`): the marker is rendered desaturated.
+ * @property markerStyle the configured marker shape for this view ([MarkerStyle], default STRIPE).
+ */
+data class FlagRowUiModel(
+    val flag: Flag,
+    val pagesToRead: Int,
+    val effectiveColor: FlagType,
+    val dimmed: Boolean,
+    val markerStyle: MarkerStyle,
+)
+
+/** Builds the [FlagRowUiModel] for this flag under the given [markerStyle]. Pure. */
+fun Flag.toFlagRowUiModel(markerStyle: MarkerStyle): FlagRowUiModel = FlagRowUiModel(
+    flag = this,
+    pagesToRead = pagesToRead(),
+    effectiveColor = effectiveFlagColor(),
+    dimmed = !hasUnread,
+    markerStyle = markerStyle,
+)

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagPresentationTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagPresentationTest.kt
@@ -1,0 +1,121 @@
+package fr.forumhfr.redface2.feature.flags
+
+import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
+import fr.forumhfr.redface2.core.model.Flag
+import fr.forumhfr.redface2.core.model.FlagType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * 100% coverage of the pure presentation helpers introduced for the #603 Drapeaux refonte
+ * (ADR-017): [pagesToRead], [effectiveFlagColor] and [toFlagRowUiModel]. No Android dependency —
+ * raw [Flag] in, plain values out, so the list/marker rendering (PR3) never recomputes them in
+ * composition.
+ */
+class FlagPresentationTest {
+
+    // --- pagesToRead -------------------------------------------------------------------------
+
+    @Test
+    fun `pagesToRead is the number of pages after the last read one`() {
+        assertEquals(3, baseFlag.copy(totalPages = 10, lastReadPage = 7).pagesToRead())
+    }
+
+    @Test
+    fun `pagesToRead is zero when the topic is fully read`() {
+        assertEquals(0, baseFlag.copy(totalPages = 10, lastReadPage = 10).pagesToRead())
+    }
+
+    @Test
+    fun `pagesToRead clamps to zero when lastReadPage exceeds totalPages (stale data)`() {
+        // Defensive: a stale cache could carry a lastReadPage past a shrunk totalPages.
+        assertEquals(0, baseFlag.copy(totalPages = 5, lastReadPage = 8).pagesToRead())
+    }
+
+    @Test
+    fun `pagesToRead on a barely-read long topic`() {
+        assertEquals(40, baseFlag.copy(totalPages = 41, lastReadPage = 1).pagesToRead())
+    }
+
+    @Test
+    fun `pagesToRead with an unset last-read page (0) returns the full page count`() {
+        // Defensive boundary: REST defaults lastReadPage to 1, but a missing marker (0) must not
+        // over-count — totalPages - 0 = totalPages, never more.
+        assertEquals(7, baseFlag.copy(totalPages = 7, lastReadPage = 0).pagesToRead())
+    }
+
+    // --- effectiveFlagColor ------------------------------------------------------------------
+
+    @Test
+    fun `effective color is the bucket type when the topic is not a favorite`() {
+        assertEquals(FlagType.CYAN, baseFlag.copy(type = FlagType.CYAN, isFavorite = false).effectiveFlagColor())
+        assertEquals(FlagType.RED, baseFlag.copy(type = FlagType.RED, isFavorite = false).effectiveFlagColor())
+    }
+
+    @Test
+    fun `effective color is FAVORITE when the topic is favorited regardless of bucket`() {
+        // #384/dev v118 parity: a favorited topic listed under « Mes sujets » keeps its yellow marker.
+        assertEquals(FlagType.FAVORITE, baseFlag.copy(type = FlagType.CYAN, isFavorite = true).effectiveFlagColor())
+        assertEquals(FlagType.FAVORITE, baseFlag.copy(type = FlagType.RED, isFavorite = true).effectiveFlagColor())
+    }
+
+    @Test
+    fun `effective color of a FAVORITE bucket flag is FAVORITE`() {
+        assertEquals(FlagType.FAVORITE, baseFlag.copy(type = FlagType.FAVORITE).effectiveFlagColor())
+    }
+
+    // --- toFlagRowUiModel --------------------------------------------------------------------
+
+    @Test
+    fun `row ui model bundles the derived presentation values`() {
+        val f = baseFlag.copy(
+            type = FlagType.CYAN,
+            isFavorite = false,
+            hasUnread = true,
+            totalPages = 12,
+            lastReadPage = 9,
+        )
+
+        val ui = f.toFlagRowUiModel(MarkerStyle.STRIPE)
+
+        assertEquals(f, ui.flag)
+        assertEquals(3, ui.pagesToRead)
+        assertEquals(FlagType.CYAN, ui.effectiveColor)
+        assertEquals(MarkerStyle.STRIPE, ui.markerStyle)
+        assertFalse("an unread flag is not dimmed", ui.dimmed)
+    }
+
+    @Test
+    fun `row ui model is dimmed for a read flag`() {
+        val ui = baseFlag.copy(hasUnread = false).toFlagRowUiModel(MarkerStyle.DOT)
+
+        assertTrue("a fully-read flag is dimmed", ui.dimmed)
+    }
+
+    @Test
+    fun `row ui model carries the requested marker style and favorite color`() {
+        val ui = baseFlag.copy(type = FlagType.CYAN, isFavorite = true).toFlagRowUiModel(MarkerStyle.PASTILLE)
+
+        assertEquals(MarkerStyle.PASTILLE, ui.markerStyle)
+        assertEquals(FlagType.FAVORITE, ui.effectiveColor)
+    }
+
+    private val baseFlag = Flag(
+        cat = 1,
+        subcat = null,
+        topicId = 1,
+        title = "Topic",
+        totalPages = 1,
+        replyCount = 0,
+        type = FlagType.CYAN,
+        isFavorite = false,
+        hasUnread = true,
+        lastReadPage = 1,
+        lastPostReadId = null,
+        firstPostAuthor = "op",
+        lastReplyAuthor = "last",
+        lastReplyAt = "2026-06-24 12:00",
+    )
+}


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

**PR1 du chantier #603** (refonte vue Drapeaux), run autonome « mode nuit ». Pose la **couche de
présentation pure** (ADR-017), calculée hors composition et testée à 100% en TDD. **Pas d'UI.**

## Contenu
- `Flag.pagesToRead()` = `max(totalPages - lastReadPage, 0)` — compteur d'affichage, **pas** un
  oracle de non-lu (`hasUnread` reste la source de vérité ; peut valoir 0 alors que `hasUnread`).
- `Flag.effectiveFlagColor()` — la décoration **favori gagne** sur le bucket (parité #384 / dev
  v118), source pure unique alignée sur la logique de `FlagDot`.
- `FlagRowUiModel` + `Flag.toFlagRowUiModel(markerStyle)` — bundle précalculé
  (`pagesToRead`, `effectiveColor`, `dimmed`, `markerStyle`) que la liste (PR3) consomme tel quel,
  sans recalcul en composition (piège sticky-headers / recompo identifié au cadrage).
- `MarkerStyle { STRIPE (défaut), PASTILLE, DOT }` dans `core/domain/preferences` — futur champ de
  `FlagsViewSettings` ; **câblage settings/DataStore en PR3 (lecture) et PR6 (écriture)**.

Le regroupement / en-têtes / filtres par catégorie existaient **déjà** (`groupFlagsByCategory`,
`filterCategoriesWithUnread`, purs et testés) — non touchés ici.

## Tests (TDD red→green)
`FlagPresentationTest` — 11 cas : `pagesToRead` (nominal, fully-read, clamp sur données périmées,
gros delta, borne `lastReadPage=0`) ; `effectiveFlagColor` (bucket vs favori-gagne, les 3 types) ;
`toFlagRowUiModel` (bundle, `dimmed = !hasUnread`, style porté, couleur favorite).

## Vérification
- `detektAll` + `lintDebug` + `:feature:flags:testDebugUnitTest` **verts** (reproduction CI locale,
  conteneur podman).
- Review **Codex** (gpt-5.5/xhigh) : **GO** ; recommandation mineure (cas `lastReadPage=0`) appliquée.

Chantier de référence : #603. **Aucune merge** — attend ta revue. Dépend conceptuellement de PR0
(#639, ADR-017) mais branché sur `origin/dev` (indépendant au merge).
