### PR TITLE
feat(#603): PR2 — search app bar « façon Réglages » + filtre client

### DIFF
--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagSearch.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagSearch.kt
@@ -1,0 +1,47 @@
+package fr.forumhfr.redface2.feature.flags
+
+import fr.forumhfr.redface2.core.model.Flag
+
+/**
+ * Pure client-side Drapeaux search (#603, PR2). HFR exposes no server-side search (cf.
+ * [ADR-003]) and the flagged topics of the current tab are already loaded, so « rechercher dans les
+ * drapeaux » is a title filter applied to the rendered [FlagsContent] — it never touches the
+ * fetch/cache pipeline. Pure and testable without Android.
+ */
+
+/**
+ * Keeps the flags whose [Flag.title] contains [query] (case-insensitive, trimmed). A blank query is
+ * a no-op (returns [flags] unchanged).
+ */
+fun filterFlagsByQuery(flags: List<Flag>, query: String): List<Flag> {
+    val q = query.trim()
+    if (q.isEmpty()) return flags
+    return flags.filter { it.title.contains(q, ignoreCase = true) }
+}
+
+/**
+ * Applies [filterFlagsByQuery] to a whole [FlagsContent].
+ *
+ * - Blank query → unchanged (the grouped view keeps its web-parity empty sections).
+ * - [FlagsContent.Flat] → the matching flags only.
+ * - [FlagsContent.Grouped] → each section is filtered and a section that ends up empty is DROPPED,
+ *   so an active search shows only categories with a hit instead of a wall of empty placeholders.
+ */
+fun FlagsContent.filteredBy(query: String): FlagsContent {
+    if (query.isBlank()) return this
+    return when (this) {
+        is FlagsContent.Flat -> FlagsContent.Flat(filterFlagsByQuery(flags, query))
+        is FlagsContent.Grouped -> FlagsContent.Grouped(
+            sections.mapNotNull { section ->
+                val kept = filterFlagsByQuery(section.topics, query)
+                if (kept.isEmpty()) null else section.copy(topics = kept)
+            },
+        )
+    }
+}
+
+/** True when this content holds no topic at all (every section empty, or a flat empty list). */
+fun FlagsContent.isEmpty(): Boolean = when (this) {
+    is FlagsContent.Flat -> flags.isEmpty()
+    is FlagsContent.Grouped -> sections.all { it.topics.isEmpty() }
+}

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -12,10 +12,8 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -33,13 +31,11 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
-import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -56,13 +52,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -82,6 +78,7 @@ import fr.forumhfr.redface2.core.ui.FlagMetadata
 import fr.forumhfr.redface2.core.ui.ForumListRow
 import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.formatLastReplyTimestamp
+import fr.forumhfr.redface2.core.ui.theme.FlagPalette
 import kotlinx.coroutines.launch
 
 /**
@@ -255,6 +252,16 @@ fun FlagsRoute(
         }
     }
 
+    // #603 PR2 — client-side search over the loaded flags + the app-bar tab picker. The query is
+    // hoisted here (the app bar edits it, the body filters with it) and reset on a tab change so a
+    // query never carries silently from one tab to another.
+    var searchQuery by remember { mutableStateOf("") }
+    var searchActive by remember { mutableStateOf(false) }
+    LaunchedEffect(selectedTab) {
+        searchQuery = ""
+        searchActive = false
+    }
+
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         containerColor = MaterialTheme.colorScheme.surface,
@@ -273,13 +280,28 @@ fun FlagsRoute(
                     .statusBarsPadding()
                     .navigationBarsPadding(),
             ) {
-                FlagsHeader(
-                    topBarActions = topBarActions,
+                FlagsSearchAppBar(
+                    state = FlagsAppBarState(
+                        currentTabColor = flagTabColor(selectedTab),
+                        tabs = flagAppBarTabs(
+                            authState = authState,
+                            showDtTab = showDtTab,
+                            cyanShowsRead = cyanShowsRead,
+                            dtShowsRead = dtShowsRead,
+                        ),
+                        searchEnabled = canConfigureView,
+                        query = searchQuery,
+                        searchActive = searchActive,
+                    ),
+                    onSelectTab = viewModel::selectTab,
+                    onQueryChange = { searchQuery = it },
+                    onSearchActiveChange = { searchActive = it },
                     onOpenViewSettings = if (canConfigureView) {
                         { showViewSettingsSheet = true }
                     } else {
                         null
                     },
+                    accountMenu = { topBarActions?.invoke() },
                 )
 
                 // Render nothing while authState is null (cookie jar warming up). Same
@@ -299,6 +321,7 @@ fun FlagsRoute(
                                 dtListState = dtListState,
                                 dtShowsRead = dtShowsRead,
                                 dtIsRefreshing = dtIsRefreshing,
+                                searchQuery = searchQuery,
                             ),
                             actions = AuthenticatedActions(
                                 onSelectTab = viewModel::selectTab,
@@ -392,51 +415,6 @@ private fun flagTypeLabel(type: FlagType): Int = when (type) {
     FlagType.CYAN -> R.string.flags_tab_my_topics
     FlagType.RED -> R.string.flags_type_read_only
     FlagType.FAVORITE -> R.string.flags_tab_favorite
-}
-
-@Composable
-private fun FlagsHeader(
-    topBarActions: @Composable (() -> Unit)?,
-    onOpenViewSettings: (() -> Unit)?,
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 24.dp, vertical = 12.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween,
-    ) {
-        Text(
-            text = stringResource(R.string.flags_title),
-            style = MaterialTheme.typography.headlineMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
-        // Refresh moved to a PullToRefreshBox (swipe down) on the list — the header now carries the
-        // display-settings trigger (#309) and the global account menu slot.
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-            onOpenViewSettings?.let { open ->
-                // Gear glyph instead of the « Affichage » text label (dogfooding v102: the word
-                // crowded the header). Text glyph because ForbiddenImport bans material icons
-                // (cf. the Text("←") precedent); U+FE0E pins the monochrome text rendition over
-                // the emoji one. The wording survives as the TalkBack label.
-                val viewSettingsLabel = stringResource(R.string.flags_view_settings_action)
-                IconButton(
-                    onClick = open,
-                    modifier = Modifier.semantics { contentDescription = viewSettingsLabel },
-                ) {
-                    Text(
-                        text = "\u2699\uFE0E",
-                        style = MaterialTheme.typography.titleLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-            topBarActions?.invoke()
-        }
-    }
 }
 
 /**
@@ -594,6 +572,83 @@ private fun flagTabLabel(tab: FlagTab): Int = when (tab) {
     FlagTab.Dt -> R.string.flags_tab_dt
 }
 
+// #603 PR2 — flag color of the current tab for the app-bar indicator glyph; the Super/DT placeholders
+// have no flag color so they fall back to a neutral on-surface tint.
+@Composable
+private fun flagTabColor(tab: FlagTab): Color = when (tab.flagType) {
+    FlagType.CYAN -> FlagPalette.Cyan
+    FlagType.RED -> FlagPalette.Red
+    FlagType.FAVORITE -> FlagPalette.Favorite
+    null -> MaterialTheme.colorScheme.onSurfaceVariant
+}
+
+// #603 PR2 — app-bar tab entries, or an empty list when anonymous (no flags ⇒ the flag glyph is a
+// static indicator with no picker). Extracted so the auth branch stays out of FlagsRoute's
+// cyclomatic-complexity budget.
+@Composable
+private fun flagAppBarTabs(
+    authState: AuthState?,
+    showDtTab: Boolean,
+    cyanShowsRead: Boolean,
+    dtShowsRead: Boolean,
+): List<FlagTabEntry> = if (authState is AuthState.Authenticated) {
+    flagTabEntries(showDtTab = showDtTab, cyanShowsRead = cyanShowsRead, dtShowsRead = dtShowsRead)
+} else {
+    emptyList()
+}
+
+// #603 PR2 — the entries of the app-bar tab picker (FlagsSearchAppBar). Labels carry the « +lus »
+// suffix exactly like the retired tab row; order MUST match the swipe `tabs` list in AuthenticatedBody.
+@Composable
+private fun flagTabEntries(
+    showDtTab: Boolean,
+    cyanShowsRead: Boolean,
+    dtShowsRead: Boolean,
+): List<FlagTabEntry> {
+    val readSuffix = stringResource(R.string.flags_tab_cyan_read_shown_suffix)
+    val neutral = MaterialTheme.colorScheme.onSurfaceVariant
+    return buildList {
+        add(
+            FlagTabEntry(
+                FlagTab.Cyan,
+                stringResource(R.string.flags_tab_my_topics) + if (cyanShowsRead) readSuffix else "",
+                FlagPalette.Cyan,
+            ),
+        )
+        add(FlagTabEntry(FlagTab.Red, stringResource(R.string.flags_tab_read_only), FlagPalette.Red))
+        add(FlagTabEntry(FlagTab.Favorite, stringResource(R.string.flags_tab_favorite), FlagPalette.Favorite))
+        if (showDtTab) {
+            add(
+                FlagTabEntry(
+                    FlagTab.Dt,
+                    stringResource(R.string.flags_tab_dt) + if (dtShowsRead) readSuffix else "",
+                    neutral,
+                ),
+            )
+        }
+        add(FlagTabEntry(FlagTab.Super, stringResource(R.string.flags_tab_super), neutral))
+    }
+}
+
+// #603 PR2 — empty state of an active search with no match. Scrollable so the surrounding
+// PullToRefreshBox keeps a swipe target on this listless state (#229).
+@Composable
+private fun NoFlagsSearchResults(query: String) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(R.string.flags_search_no_results, query),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
 @Composable
 private fun AnonymousBody(onLoginRequested: () -> Unit) {
     Column(
@@ -626,58 +681,21 @@ private fun ColumnScope.AuthenticatedBody(
     listState: LazyListState,
 ) {
     val selectedTab = state.selectedTab
-    val cyanShowsRead = state.cyanShowsRead
-    val dtShowsRead = state.dtShowsRead
+    // #603 PR2 — the text PrimaryTabRow is gone: the app-bar flag picker (FlagsSearchAppBar) now
+    // both indicates the current tab and switches it, and the « +lus » re-tap survives there
+    // (re-selecting Cyan/DT routes through the same onSelectTab). This list is kept ONLY to map the
+    // committed horizontal-swipe index back to a FlagTab (placeholders included, so a swipe can
+    // leave Super/DT too). Its order MUST match the picker's (flagTabEntries).
     val tabs = buildList {
-        add(FlagTab.Cyan to stringResource(R.string.flags_tab_my_topics))
-        add(FlagTab.Red to stringResource(R.string.flags_tab_read_only))
-        add(FlagTab.Favorite to stringResource(R.string.flags_tab_favorite))
-        // Opt-in placeholder (Settings toggle) — sits before Super : DT is closer to the
-        // real flag lists it will eventually join (MPStorage sync, #6).
-        if (state.showDtTab) add(FlagTab.Dt to stringResource(R.string.flags_tab_dt))
-        add(FlagTab.Super to stringResource(R.string.flags_tab_super))
+        add(FlagTab.Cyan)
+        add(FlagTab.Red)
+        add(FlagTab.Favorite)
+        if (state.showDtTab) add(FlagTab.Dt)
+        add(FlagTab.Super)
     }
-    val selectedIndex = tabs.indexOfFirst { it.first == selectedTab }.coerceAtLeast(0)
-    // Discreet « +lus » suffix on the Cyan label so the user knows read participated topics
-    // are currently shown — re-tapping the (already selected) Cyan tab toggles it. #546 directive
-    // XaTriX — the SAME suffix marks the DT tab when its read conversations are shown (mirror).
-    val readSuffix = stringResource(R.string.flags_tab_cyan_read_shown_suffix)
+    val selectedIndex = tabs.indexOf(selectedTab).coerceAtLeast(0)
 
-    PrimaryTabRow(selectedTabIndex = selectedIndex) {
-        tabs.forEachIndexed { index, (tab, label) ->
-            val displayLabel = when {
-                tab == FlagTab.Cyan && cyanShowsRead -> label + readSuffix
-                tab == FlagTab.Dt && dtShowsRead -> label + readSuffix
-                else -> label
-            }
-            // Low-level `content` overload INSTEAD of the `text` slot : the text slot pads a
-            // non-configurable 16 dp each side, which left « Mes sujets » with exactly its own
-            // measured width in a 4-tab equal-width PrimaryTabRow — wrapping it to two lines
-            // on a density-dependent pixel boundary. 8 dp gutters + single line + ellipsis
-            // (the « +lus » suffixed label ellipsizes by design — arbitrage XaTriX 2026-06-12).
-            // Colors are passed explicitly because this overload defaults BOTH states to
-            // LocalContentColor (no selected/unselected distinction out of the box).
-            Tab(
-                selected = index == selectedIndex,
-                onClick = { actions.onSelectTab(tab) },
-                selectedContentColor = MaterialTheme.colorScheme.primary,
-                unselectedContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-            ) {
-                Text(
-                    text = displayLabel,
-                    style = MaterialTheme.typography.labelLarge,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier
-                        .height(48.dp)
-                        .wrapContentHeight()
-                        .padding(horizontal = 8.dp),
-                )
-            }
-        }
-    }
-
-    // #457 — horizontal swipe between flag tabs, carried by the whole body under the tab row
+    // #457 — horizontal swipe between flag tabs, carried by the whole body under the app bar
     // (placeholders included, so a swipe can leave Super/DT too). The committed target INDEX is
     // mapped back to a FlagTab against the same `tabs` list the row renders — read through
     // rememberUpdatedState because the gesture is keyed on Unit and never restarts, while the
@@ -692,7 +710,7 @@ private fun ColumnScope.AuthenticatedBody(
             haptics = haptics,
             onSelectTab = { index ->
                 updatedTabs.value.getOrNull(index)
-                    ?.let { (tab, _) -> updatedActions.value.onSelectTab(tab) }
+                    ?.let { tab -> updatedActions.value.onSelectTab(tab) }
             },
         )
     }
@@ -793,22 +811,32 @@ private fun FlagListBody(
                 }
             }
 
-            is FlagsListUiState.Success -> when (val content = current.content) {
-                is FlagsContent.Grouped -> CategorySectionedFlagList(
-                    sections = content.sections,
-                    selectedTab = selectedTab,
-                    removalInFlight = state.removeFlagState is RemoveFlagState.Removing,
-                    actions = actions,
-                    listState = listState,
-                )
+            is FlagsListUiState.Success -> {
+                // #603 PR2 — apply the client-side search filter (no-op on a blank query) before
+                // rendering. An active query that matches nothing shows a scrollable empty state so
+                // the pull-to-refresh still has a target (#229).
+                val content = current.content.filteredBy(state.searchQuery)
+                if (state.searchQuery.isNotBlank() && content.isEmpty()) {
+                    NoFlagsSearchResults(query = state.searchQuery)
+                } else {
+                    when (content) {
+                        is FlagsContent.Grouped -> CategorySectionedFlagList(
+                            sections = content.sections,
+                            selectedTab = selectedTab,
+                            removalInFlight = state.removeFlagState is RemoveFlagState.Removing,
+                            actions = actions,
+                            listState = listState,
+                        )
 
-                is FlagsContent.Flat -> FlatFlagList(
-                    flags = content.flags,
-                    selectedTab = selectedTab,
-                    removalInFlight = state.removeFlagState is RemoveFlagState.Removing,
-                    actions = actions,
-                    listState = listState,
-                )
+                        is FlagsContent.Flat -> FlatFlagList(
+                            flags = content.flags,
+                            selectedTab = selectedTab,
+                            removalInFlight = state.removeFlagState is RemoveFlagState.Removing,
+                            actions = actions,
+                            listState = listState,
+                        )
+                    }
+                }
             }
         }
     }
@@ -1505,6 +1533,8 @@ private data class FlagsBodyState(
     val dtShowsRead: Boolean,
     /** #546 — toggled around the DT pull-to-refresh round-trip (anchors the indicator). */
     val dtIsRefreshing: Boolean,
+    /** #603 PR2 — active client-side search query; empty = no filtering. */
+    val searchQuery: String = "",
 )
 
 private data class AuthenticatedActions(

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsSearchAppBar.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsSearchAppBar.kt
@@ -1,0 +1,231 @@
+package fr.forumhfr.redface2.feature.flags
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.ui.icon.RedfaceVectorIcon
+import fr.forumhfr.redface2.core.ui.R as CoreUiR
+
+/** One selectable tab of the Drapeaux app bar picker. [label] already carries the « +lus » suffix. */
+data class FlagTabEntry(val tab: FlagTab, val label: String, val color: Color)
+
+/**
+ * Drapeaux search app bar (#603 PR2, ADR-017) — replaces the old `FlagsHeader` + text `PrimaryTabRow`
+ * with the « façon Réglages » app bar of the vision:
+ *
+ * - **left** : a colored flag glyph for the CURRENT tab (its flag color), tappable → a tab picker
+ *   dropdown. The picker keeps tab switching discoverable now that the text tab row is gone (swipe
+ *   between tabs is preserved separately); re-selecting the current Cyan/DT tab toggles « +lus »
+ *   exactly like the old re-tap, since it routes back through the same `onSelectTab`.
+ * - **center** : a search pill that expands to an inline filter of the loaded flags
+ *   ([filterFlagsByQuery]) — HFR has no server search, the flags are already in hand.
+ * - **right** : the display-settings action (when configurable) + the shared account menu (whose
+ *   avatar doubles as the « photo de profil » of the vision).
+ *
+ * The scroll-coupled translucency (elevated app bar + content gliding underneath) is intentionally
+ * NOT wired here: it belongs to the deferred scroll-chrome work (cf. the hide-on-scroll deferral),
+ * so PR2 keeps the simple top-of-column layout and ships the structure + interactions first.
+ */
+@Composable
+@Suppress("LongParameterList") // App-bar API: state + 3 callbacks + optional action + the @Composable account slot.
+fun FlagsSearchAppBar(
+    state: FlagsAppBarState,
+    onSelectTab: (FlagTab) -> Unit,
+    onQueryChange: (String) -> Unit,
+    onSearchActiveChange: (Boolean) -> Unit,
+    onOpenViewSettings: (() -> Unit)?,
+    accountMenu: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(modifier = modifier.fillMaxWidth(), color = MaterialTheme.colorScheme.surface) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            FlagTabPickerButton(
+                currentTabColor = state.currentTabColor,
+                tabs = state.tabs,
+                onSelectTab = onSelectTab,
+            )
+            SearchField(
+                state = SearchFieldState(state.searchEnabled, state.query, state.searchActive),
+                onQueryChange = onQueryChange,
+                onActiveChange = onSearchActiveChange,
+                modifier = Modifier.weight(1f),
+            )
+            onOpenViewSettings?.let { open ->
+                val viewSettingsLabel = stringResource(R.string.flags_view_settings_action)
+                IconButton(
+                    onClick = open,
+                    modifier = Modifier.semantics { contentDescription = viewSettingsLabel },
+                ) {
+                    // U+FE0E pins the monochrome gear glyph (ForbiddenImport bans material icons),
+                    // matching the legacy header's affordance until it migrates to the bottom-bar
+                    // quick-config (#603 PR6).
+                    Text(
+                        text = "⚙︎",
+                        style = MaterialTheme.typography.titleLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            accountMenu()
+        }
+    }
+}
+
+/** State of [FlagsSearchAppBar]. [tabs] empty ⇒ the flag glyph is a static indicator (no picker). */
+data class FlagsAppBarState(
+    val currentTabColor: Color,
+    val tabs: List<FlagTabEntry>,
+    val searchEnabled: Boolean,
+    val query: String,
+    val searchActive: Boolean,
+)
+
+@Composable
+private fun FlagTabPickerButton(
+    currentTabColor: Color,
+    tabs: List<FlagTabEntry>,
+    onSelectTab: (FlagTab) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val pickerLabel = stringResource(R.string.flags_appbar_tab_picker)
+    Box {
+        IconButton(
+            onClick = { if (tabs.isNotEmpty()) expanded = true },
+            enabled = tabs.isNotEmpty(),
+            modifier = Modifier.semantics { contentDescription = pickerLabel },
+        ) {
+            RedfaceVectorIcon(resId = CoreUiR.drawable.ic_ms_flag, tint = currentTabColor)
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            tabs.forEach { entry ->
+                DropdownMenuItem(
+                    text = { Text(entry.label) },
+                    leadingIcon = { ColorDot(entry.color) },
+                    onClick = {
+                        expanded = false
+                        onSelectTab(entry.tab)
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ColorDot(color: Color) {
+    Box(
+        modifier = Modifier
+            .size(12.dp)
+            .clip(CircleShape)
+            .background(color),
+    )
+}
+
+/** State of the app-bar [SearchField]: whether searching is available, the query, and the open state. */
+data class SearchFieldState(val enabled: Boolean, val query: String, val active: Boolean)
+
+@Composable
+private fun SearchField(
+    state: SearchFieldState,
+    onQueryChange: (String) -> Unit,
+    onActiveChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val placeholder = stringResource(R.string.flags_search_placeholder)
+    val clearLabel = stringResource(R.string.flags_search_clear)
+    val query = state.query
+    Surface(
+        onClick = { if (state.enabled) onActiveChange(true) },
+        enabled = state.enabled,
+        modifier = modifier.height(48.dp),
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Icon(
+                painter = painterResource(CoreUiR.drawable.ic_ms_search),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (state.active && state.enabled) {
+                val focusRequester = remember { FocusRequester() }
+                LaunchedEffect(Unit) { focusRequester.requestFocus() }
+                BasicTextField(
+                    value = query,
+                    onValueChange = onQueryChange,
+                    singleLine = true,
+                    textStyle = LocalTextStyle.current.copy(color = MaterialTheme.colorScheme.onSurface),
+                    cursorBrush = androidx.compose.ui.graphics.SolidColor(MaterialTheme.colorScheme.primary),
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(imeAction = ImeAction.Search),
+                    modifier = Modifier
+                        .weight(1f)
+                        .focusRequester(focusRequester),
+                )
+                IconButton(
+                    onClick = {
+                        onQueryChange("")
+                        onActiveChange(false)
+                    },
+                    modifier = Modifier
+                        .size(24.dp)
+                        .semantics { contentDescription = clearLabel },
+                ) {
+                    Text(text = "✕", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            } else {
+                Text(
+                    text = query.ifEmpty { placeholder },
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = if (query.isEmpty()) {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    } else {
+                        MaterialTheme.colorScheme.onSurface
+                    },
+                )
+            }
+        }
+    }
+}

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -17,6 +17,15 @@
          déjà lus sont affichés (re-tap de l'onglet Cyan déjà sélectionné). -->
     <string name="flags_tab_cyan_read_shown_suffix"> · +lus</string>
 
+    <!-- #603 PR2 — search app bar (façon Réglages) qui remplace l'ancien header + le tab row texte. -->
+    <string name="flags_search_placeholder">Rechercher dans les drapeaux</string>
+    <!-- a11y : l'icône drapeau colorée à gauche indique l'onglet courant et ouvre le sélecteur d'onglet. -->
+    <string name="flags_appbar_tab_picker">Onglet courant — changer d\'onglet</string>
+    <!-- a11y : action d'effacement du champ de recherche. -->
+    <string name="flags_search_clear">Effacer la recherche</string>
+    <!-- État vide d'une recherche sans résultat. %1$s = la requête saisie. -->
+    <string name="flags_search_no_results">Aucun drapeau ne correspond à « %1$s »</string>
+
     <!-- Onglet « Super » : écran placeholder M3, futurs super favoris. Pas de fetch réseau. -->
     <string name="flags_super_placeholder_title">Super favoris — à venir</string>
     <string name="flags_super_placeholder_body">Les « super favoris » permettront d\'épingler les sujets les plus importants. Cette vue arrivera dans une prochaine version.</string>

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagSearchTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagSearchTest.kt
@@ -1,0 +1,113 @@
+package fr.forumhfr.redface2.feature.flags
+
+import fr.forumhfr.redface2.core.model.Flag
+import fr.forumhfr.redface2.core.model.FlagType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * 100% coverage of the pure client-side Drapeaux search (#603, PR2). The flagged topics are already
+ * loaded (HFR has no server search, cf. ADR-003), so « rechercher dans les drapeaux » is a pure
+ * title filter applied to the rendered [FlagsContent] — no ViewModel pipeline change. Blank query is
+ * a no-op (the grouped view keeps its web-parity empty sections); a real query drops non-matching
+ * sections so the result is not a wall of empty placeholders.
+ */
+class FlagSearchTest {
+
+    // --- filterFlagsByQuery ------------------------------------------------------------------
+
+    @Test
+    fun `a blank query returns the list unchanged`() {
+        val flags = listOf(flag("Kotlin"), flag("Compose"))
+        assertEquals(flags, filterFlagsByQuery(flags, "   "))
+    }
+
+    @Test
+    fun `the query matches the title case-insensitively`() {
+        val flags = listOf(flag("Kotlin Multiplatform"), flag("Jetpack Compose"), flag("Rust"))
+        assertEquals(
+            listOf("Kotlin Multiplatform"),
+            filterFlagsByQuery(flags, "kotlin").map { it.title },
+        )
+    }
+
+    @Test
+    fun `the query is trimmed before matching`() {
+        val flags = listOf(flag("Compose"), flag("Rust"))
+        assertEquals(listOf("Compose"), filterFlagsByQuery(flags, "  compose  ").map { it.title })
+    }
+
+    @Test
+    fun `a substring anywhere in the title matches`() {
+        val flags = listOf(flag("Le topic des montres"), flag("Le topic des PC"))
+        assertEquals(listOf("Le topic des montres"), filterFlagsByQuery(flags, "montre").map { it.title })
+    }
+
+    @Test
+    fun `no match yields an empty list`() {
+        val flags = listOf(flag("A"), flag("B"))
+        assertEquals(emptyList<Flag>(), filterFlagsByQuery(flags, "zzz"))
+    }
+
+    // --- FlagsContent.filteredBy (flat) ------------------------------------------------------
+
+    @Test
+    fun `flat content with a blank query is unchanged`() {
+        val content = FlagsContent.Flat(listOf(flag("A"), flag("B")))
+        assertEquals(content, content.filteredBy(""))
+    }
+
+    @Test
+    fun `flat content keeps only the matching flags`() {
+        val content = FlagsContent.Flat(listOf(flag("Kotlin"), flag("Rust")))
+        val filtered = content.filteredBy("kotlin") as FlagsContent.Flat
+        assertEquals(listOf("Kotlin"), filtered.flags.map { it.title })
+    }
+
+    // --- FlagsContent.filteredBy (grouped) ---------------------------------------------------
+
+    @Test
+    fun `grouped content with a blank query keeps its sections (web-parity empties)`() {
+        val content = FlagsContent.Grouped(
+            listOf(
+                FlagCategorySection(1, "Hardware", listOf(flag("CPU"))),
+                FlagCategorySection(10, "Programmation", emptyList()),
+            ),
+        )
+        assertEquals(content, content.filteredBy("  "))
+    }
+
+    @Test
+    fun `grouped content filters within sections and drops the empty ones`() {
+        val content = FlagsContent.Grouped(
+            listOf(
+                FlagCategorySection(1, "Hardware", listOf(flag("Carte mère"), flag("CPU"))),
+                FlagCategorySection(10, "Programmation", listOf(flag("Kotlin"))),
+                FlagCategorySection(13, "Discussions", emptyList()),
+            ),
+        )
+
+        val filtered = content.filteredBy("c") as FlagsContent.Grouped
+
+        // « Carte mère » + « CPU » match in Hardware ; nothing in Programmation/Discussions → dropped.
+        assertEquals(listOf(1), filtered.sections.map { it.catId })
+        assertEquals(listOf("Carte mère", "CPU"), filtered.sections.single().topics.map { it.title })
+    }
+
+    private fun flag(title: String): Flag = Flag(
+        cat = 1,
+        subcat = null,
+        topicId = title.hashCode(),
+        title = title,
+        totalPages = 1,
+        replyCount = 0,
+        type = FlagType.CYAN,
+        isFavorite = false,
+        hasUnread = true,
+        lastReadPage = 1,
+        lastPostReadId = null,
+        firstPostAuthor = "op",
+        lastReplyAuthor = "last",
+        lastReplyAt = "2026-06-24 12:00",
+    )
+}


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

**PR2 du chantier #603** (refonte vue Drapeaux), run autonome « mode nuit ». Remplace l'ancien
`FlagsHeader` (titre + gear + account) **et** le `PrimaryTabRow` texte par la **search app bar
« façon Réglages »** de la vision (ADR-017).

## Contenu
- **Gauche** : icône drapeau colorée de l'onglet courant ; tap → **picker d'onglet** (`DropdownMenu`).
- **Centre** : pill de recherche → **filtre client pur** des drapeaux chargés (`filterFlagsByQuery`).
- **Droite** : action « Affichage » (#309) + account menu (dont l'avatar = la « photo de profil »).
- `PrimaryTabRow` texte supprimé ; **swipe inter-onglets et pull-to-refresh conservés**.

## Décisions de jugement (prototype-driven — à confirmer en revue)
- **Switch d'onglet** : le tab row texte est retiré ; le switch passe par le **picker** (tap icône
  drapeau) **+ le swipe**. Le re-tap « +lus » (Cyan/DT) est préservé (route via le même `selectTab`).
  ⚠️ La découvrabilité du changement d'onglet repose désormais sur le picker + le swipe (assumé par la
  vision / mockups). À valider.
- **Recherche** : HFR n'a pas de recherche serveur (ADR-003) → filtre **client** sur les drapeaux déjà
  chargés, limité aux onglets configurables (Cyan/Red/Favorite). État vide géré (scrollable).
- **Translucidité couplée au scroll** (contenu glissant sous l'app bar) : **DÉFÉRÉE** (même famille que
  le hide-on-scroll déjà différé) ; PR2 garde le layout Column simple.
- L'ordre du picker (`flagTabEntries`) et de la liste de swipe (`tabs`) est **volontairement aligné**
  (mapping index→FlagTab).

## Tests & vérif
- `FlagSearchTest` (filtre pur, TDD red→green) : 9 cas (blank no-op, case-insensitive, trim, substring,
  Flat/Grouped, drop des sections vides).
- `detektAll` + `lintDebug` + `:feature:flags:testDebugUnitTest` **verts** (conteneur podman).
- Review **Codex** (gpt-5.5/xhigh) : **GO**, aucune régression détectée (swipe, +lus, auto-refresh,
  reset recherche, sheet #309, pull-to-refresh), filtre correct.

Chantier de référence : #603. **Aucune merge** — attend ta revue. Branché sur `origin/dev`.
