### PR TITLE
feat(#603): PR3 — liste de drapeaux refondue (marqueur, pages-à-lire, icônes catégories)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
@@ -1,30 +1,26 @@
 package fr.forumhfr.redface2.core.ui
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
 import fr.forumhfr.redface2.core.model.Flag
-import fr.forumhfr.redface2.core.model.FlagType
+import fr.forumhfr.redface2.core.ui.icon.categoryIcon
 import fr.forumhfr.redface2.core.ui.theme.FlagPalette
 import fr.forumhfr.redface2.core.ui.theme.LocalDisplayMetrics
 
@@ -56,17 +52,22 @@ import fr.forumhfr.redface2.core.ui.theme.LocalDisplayMetrics
  * when null the row uses [clickable] unchanged (no long-press semantics advertised at all).
  */
 @Composable
+@Suppress("LongParameterList") // Flag row binding: flag + metadata + tap + modifier + long-press + marker style.
 fun FlagItem(
     flag: Flag,
     metadata: FlagMetadata,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     longPress: FlagItemLongPress? = null,
+    markerStyle: MarkerStyle = MarkerStyle.STRIPE,
 ) {
-    // FlagItem is now a thin `Flag`-typed binding over the shared [ForumListRow] : the bucket dot is
-    // the leading slot, the unread state drives the title emphasis. Keeping FlagItem's public
-    // signature stable means its existing callers / tests are untouched while DT (and any future
-    // forum list) renders through the SAME row primitive — change the row once, every list follows.
+    // FlagItem is a thin `Flag`-typed binding over the shared [ForumListRow]. #603 refonte: the leading
+    // slot is now the configurable [FlagMarker] (default barre de couleur, ADR-017) and the trailing
+    // slot a « pages à lire » pill when the topic is unread with pages left. DT (and any future forum
+    // list) keeps rendering through the SAME row primitive — change the row once, every list follows.
+    // pagesToRead mirrors feature/flags' Flag.pagesToRead() (the pure VM-side source of truth).
+    val pagesToRead = (flag.totalPages - flag.lastReadPage).coerceAtLeast(0)
+    val accent = if (flag.isFavorite) FlagPalette.Favorite else FlagPalette.colorFor(flag.type)
     ForumListRow(
         title = flag.title,
         metadata = metadata,
@@ -74,7 +75,20 @@ fun FlagItem(
         modifier = modifier,
         emphasized = flag.hasUnread,
         longPress = longPress,
-        leading = { FlagDot(type = flag.type, isFavorite = flag.isFavorite, hasUnread = flag.hasUnread) },
+        leading = {
+            FlagMarker(
+                style = markerStyle,
+                type = flag.type,
+                isFavorite = flag.isFavorite,
+                hasUnread = flag.hasUnread,
+                categoryIconRes = categoryIcon(flag.cat),
+            )
+        },
+        trailing = if (flag.hasUnread && pagesToRead > 0) {
+            { PagesToReadPill(count = pagesToRead, accent = accent) }
+        } else {
+            null
+        },
     )
 }
 
@@ -109,6 +123,7 @@ fun ForumListRow(
     emphasized: Boolean = false,
     longPress: FlagItemLongPress? = null,
     leading: (@Composable () -> Unit)? = null,
+    trailing: (@Composable () -> Unit)? = null,
     contentDescription: String? = null,
 ) {
     val rowInteraction = if (longPress != null) {
@@ -133,7 +148,7 @@ fun ForumListRow(
         leading?.invoke()
         Column(
             modifier = Modifier
-                .fillMaxWidth()
+                .weight(1f)
                 .then(
                     if (contentDescription != null) {
                         Modifier.clearAndSetSemantics { this.contentDescription = contentDescription }
@@ -159,6 +174,9 @@ fun ForumListRow(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
+        // #603 — optional trailing slot (the drapeaux « pages à lire » pill); pinned right after the
+        // weighted title/metadata column. Null for the other lists (DT), which keep the 2-slot layout.
+        trailing?.invoke()
     }
 }
 
@@ -180,22 +198,5 @@ fun FlagItemDivider(modifier: Modifier = Modifier) {
     HorizontalDivider(
         modifier = modifier,
         color = MaterialTheme.colorScheme.outlineVariant,
-    )
-}
-
-@Composable
-private fun FlagDot(type: FlagType, isFavorite: Boolean, hasUnread: Boolean) {
-    // #384 follow-up (dev v118 feedback) — the favori/étoile decoration WINS over the bucket
-    // color: a favorited topic listed under « Mes sujets » keeps its yellow dot, like the site.
-    // `type` stays the bucket (routing/filters); only the dot reads the decoration.
-    // Colors come from FlagPalette — the same source the Forum tab's topic rows use — instead of
-    // the local literals this dot historically duplicated (Codex review: two drifting palettes).
-    val color = if (isFavorite) FlagPalette.Favorite else FlagPalette.colorFor(type)
-    val finalColor = if (hasUnread) color else color.copy(alpha = 0.35f)
-    Box(
-        modifier = Modifier
-            .size(12.dp)
-            .clip(CircleShape)
-            .background(finalColor),
     )
 }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagMarker.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagMarker.kt
@@ -1,0 +1,102 @@
+package fr.forumhfr.redface2.core.ui
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
+import fr.forumhfr.redface2.core.model.FlagType
+import fr.forumhfr.redface2.core.ui.icon.RedfaceVectorIcon
+import fr.forumhfr.redface2.core.ui.theme.FlagPalette
+
+/** Alpha applied to a marker / pill of a fully-read flag, so unread rows visibly pop (legacy parity). */
+private const val READ_ALPHA = 0.35f
+
+/** Background alpha of the tonal PASTILLE behind the category glyph. */
+private const val PASTILLE_BG_ALPHA = 0.18f
+
+/**
+ * The left-hand marker of a Drapeaux row (#603, ADR-017). Encodes the flag color (cyan / red / favori,
+ * the favori decoration winning over the bucket — legacy parity) and the read state (desaturated when
+ * read); only the SHAPE varies with [style]:
+ *
+ * - [MarkerStyle.STRIPE] — a thin vertical color bar (the default, frees the most title width).
+ * - [MarkerStyle.PASTILLE] — a tonal circle carrying the category glyph ([categoryIconRes]).
+ * - [MarkerStyle.DOT] — the legacy minimal colored dot.
+ *
+ * The color logic mirrors the former `FlagDot` as the single rendering source of truth.
+ */
+@Composable
+// Marker primitive: shape + the 3 flag fields that drive its color/state + the category glyph +
+// modifier — kept as primitives (not a [Flag]) so non-drapeau rows can reuse it without core/model.
+@Suppress("LongParameterList")
+fun FlagMarker(
+    style: MarkerStyle,
+    type: FlagType,
+    isFavorite: Boolean,
+    hasUnread: Boolean,
+    @DrawableRes categoryIconRes: Int,
+    modifier: Modifier = Modifier,
+) {
+    val base = if (isFavorite) FlagPalette.Favorite else FlagPalette.colorFor(type)
+    val color = if (hasUnread) base else base.copy(alpha = READ_ALPHA)
+    when (style) {
+        MarkerStyle.STRIPE -> Box(
+            modifier = modifier
+                .size(width = 4.dp, height = 32.dp)
+                .clip(RoundedCornerShape(2.dp))
+                .background(color),
+        )
+
+        MarkerStyle.DOT -> Box(
+            modifier = modifier
+                .size(12.dp)
+                .clip(CircleShape)
+                .background(color),
+        )
+
+        MarkerStyle.PASTILLE -> Box(
+            modifier = modifier
+                .size(30.dp)
+                .clip(CircleShape)
+                .background(color.copy(alpha = if (hasUnread) PASTILLE_BG_ALPHA else PASTILLE_BG_ALPHA / 2)),
+            contentAlignment = Alignment.Center,
+        ) {
+            RedfaceVectorIcon(resId = categoryIconRes, tint = color, size = 18.dp)
+        }
+    }
+}
+
+/**
+ * Trailing « pages à lire » pill of a Drapeaux row (#603) — shown only when the topic is unread and
+ * has at least one page left. Reads `+N` in the flag's accent color over a tonal background.
+ */
+@Composable
+fun PagesToReadPill(count: Int, accent: Color, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(7.dp))
+            .background(accent.copy(alpha = 0.20f))
+            .padding(horizontal = 7.dp, vertical = 1.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "+$count",
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = accent,
+        )
+    }
+}

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/icon/CategoryIcon.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/icon/CategoryIcon.kt
@@ -1,0 +1,40 @@
+package fr.forumhfr.redface2.core.ui.icon
+
+import androidx.annotation.DrawableRes
+import fr.forumhfr.redface2.core.ui.R
+
+/**
+ * Maps an HFR forum category id to its Material Symbols drawable (#603, ADR-017, spike 4). The set is
+ * the 19 public categories captured from the REST catalogue; any unknown id (e.g. Blabla `24`, or a
+ * future category) falls back to [R.drawable.ic_ms_forum].
+ *
+ * Pure (returns a `@DrawableRes` id), so it is unit-testable and callable from `remember {}` blocks.
+ * Icons are local vector drawables tinted at render time (ADR-015 / `RedfaceVectorIcon`) — Material
+ * Icons imports are banned by detekt.
+ */
+@DrawableRes
+fun categoryIcon(catId: Int): Int = CATEGORY_ICONS[catId] ?: R.drawable.ic_ms_forum
+
+// catId → Material Symbol, keyed by the REST catalogue ids. A plain map (not a `when`) keeps the
+// lookup at complexity 1. Unknown ids (Blabla 24, moderation 0, future cats) fall back to forum.
+private val CATEGORY_ICONS: Map<Int, Int> = mapOf(
+    1 to R.drawable.ic_ms_memory, // Hardware
+    16 to R.drawable.ic_ms_keyboard, // Hardware - Périphériques
+    15 to R.drawable.ic_ms_laptop_chromebook, // Ordinateurs portables
+    2 to R.drawable.ic_ms_ac_unit, // Overclocking, Cooling & Modding
+    30 to R.drawable.ic_ms_build, // Electronique, domotique, DIY
+    23 to R.drawable.ic_ms_smartphone, // Technologies Mobiles
+    25 to R.drawable.ic_ms_devices, // Apple
+    3 to R.drawable.ic_ms_headphones, // Video & Son
+    14 to R.drawable.ic_ms_photo_camera, // Photo numérique
+    5 to R.drawable.ic_ms_sports_esports, // Jeux Video
+    4 to R.drawable.ic_ms_desktop_windows, // Windows & Software
+    22 to R.drawable.ic_ms_wifi, // Réseaux grand public / SoHo
+    21 to R.drawable.ic_ms_lan, // Systèmes & Réseaux Pro
+    11 to R.drawable.ic_ms_terminal, // Linux et OS Alternatifs
+    10 to R.drawable.ic_ms_code, // Programmation
+    12 to R.drawable.ic_ms_palette, // Graphisme
+    6 to R.drawable.ic_ms_shopping_cart, // Achats & Ventes
+    8 to R.drawable.ic_ms_work, // Emploi & Etudes
+    13 to R.drawable.ic_ms_forum, // Discussions
+)

--- a/core/ui/src/main/res/drawable/ic_ms_ac_unit.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_ac_unit.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (ac_unit), grille 960 (viewBox 0 -960 960 960) recadree via group translateY=960. fillColor tinte a l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M440-80v-166L310-118l-56-56 186-186v-80h-80L174-254l-56-56 128-130H80v-80h166L118-650l56-56 186 186h80v-80L254-786l56-56 130 128v-166h80v166l130-128 56 56-186 186v80h80l186-186 56 56-128 130h166v80H714l128 130-56 56-186-186h-80v80l186 186-56 56-130-128v166h-80Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_build.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_build.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (build), grille 960 (viewBox 0 -960 960 960) recadree via group translateY=960. fillColor tinte a l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M686-132 444-376q-20 8-40.5 12t-43.5 4q-100 0-170-70t-70-170q0-36 10-68.5t28-61.5l146 146 72-72-146-146q29-18 61.5-28t68.5-10q100 0 170 70t70 170q0 23-4 43.5T584-516l244 242q12 12 12 29t-12 29l-84 84q-12 12-29 12t-29-12Zm29-85 27-27-256-256q18-20 26-46.5t8-53.5q0-60-38.5-104.5T386-758l74 74q12 12 12 28t-12 28L332-500q-12 12-28 12t-28-12l-74-74q9 57 53.5 95.5T360-440q26 0 52-8t47-25l256 256ZM472-488Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_code.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_code.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (code), grille 960 (viewBox 0 -960 960 960) recadree via group translateY=960. fillColor tinte a l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M320-240 80-480l240-240 57 57-184 184 183 183-56 56Zm320 0-57-57 184-184-183-183 56-56 240 240-240 240Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_desktop_windows.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_desktop_windows.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (desktop_windows), grille 960 (viewBox 0 -960 960 960) recadree via group translateY=960. fillColor tinte a l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M320-120v-80h80v-80H160q-33 0-56.5-23.5T80-360v-400q0-33 23.5-56.5T160-840h640q33 0 56.5 23.5T880-760v400q0 33-23.5 56.5T800-280H560v80h80v80H320ZM160-360h640v-400H160v400Zm0 0v-400 400Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_devices.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_devices.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (devices), grille 960 (viewBox 0 -960 960 960) recadree via group translateY=960. fillColor tinte a l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M80-160v-120h80v-440q0-33 23.5-56.5T240-800h600v80H240v440h240v120H80Zm520 0q-17 0-28.5-11.5T560-200v-400q0-17 11.5-28.5T600-640h240q17 0 28.5 11.5T880-600v400q0 17-11.5 28.5T840-160H600Zm40-120h160v-280H640v280Zm0 0h160-160Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_headphones.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_headphones.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (headphones), grille 960 (viewBox 0 -960 960 960) recadree via group translateY=960. fillColor tinte a l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M360-120H200q-33 0-56.5-23.5T120-200v-280q0-75 28.5-140.5t77-114q48.5-48.5 114-77T480-840q75 0 140.5 28.5t114 77q48.5 48.5 77 114T840-480v280q0 33-23.5 56.5T760-120H600v-320h160v-40q0-117-81.5-198.5T480-760q-117 0-198.5 81.5T200-480v40h160v320Zm-80-240h-80v160h80v-160Zm400 0v160h80v-160h-80Zm-400 0h-80 80Zm400 0h80-80Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_keyboard.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_keyboard.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (keyboard), grille 960 (viewBox 0 -960 960 960) recadree via group translateY=960. fillColor tinte a l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M160-200q-33 0-56.5-23.5T80-280v-400q0-33 23.5-56.5T160-760h640q33 0 56.5 23.5T880-680v400q0 33-23.5 56.5T800-200H160Zm0-80h640v-400H160v400Zm160-40h320v-80H320v80ZM200-440h80v-80h-80v80Zm120 0h80v-80h-80v80Zm120 0h80v-80h-80v80Zm120 0h80v-80h-80v80Zm120 0h80v-80h-80v80ZM200-560h80v-80h-80v80Zm120 0h80v-80h-80v80Zm120 0h80v-80h-80v80Zm120 0h80v-80h-80v80Zm120 0h80v-80h-80v80ZM160-280v-400 400Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_lan.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_lan.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (lan), grille 960 (viewBox 0 -960 960 960) recadree via group translateY=960. fillColor tinte a l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M120-80v-280h120v-160h200v-80H320v-280h320v280H520v80h200v160h120v280H520v-280h120v-80H320v80h120v280H120Zm280-600h160v-120H400v120ZM200-160h160v-120H200v120Zm400 0h160v-120H600v120ZM480-680ZM360-280Zm240 0Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_laptop_chromebook.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_laptop_chromebook.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (laptop_chromebook), grille 960 (viewBox 0 -960 960 960) recadree via group translateY=960. fillColor tinte a l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M0-160v-80h80v-600h800v600h80v80H0Zm400-80h160v-40H400v40ZM160-360h640v-400H160v400Zm320-200Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_memory.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_memory.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (memory), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M360-360v-240h240v240H360Zm80-80h80v-80h-80v80Zm-80 320v-80h-80q-33 0-56.5-23.5T200-280v-80h-80v-80h80v-80h-80v-80h80v-80q0-33 23.5-56.5T280-760h80v-80h80v80h80v-80h80v80h80q33 0 56.5 23.5T760-680v80h80v80h-80v80h80v80h-80v80q0 33-23.5 56.5T680-200h-80v80h-80v-80h-80v80h-80Zm320-160v-400H280v400h400ZM480-480Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_palette.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_palette.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (palette), grille 960 (viewBox 0 -960 960 960) recadree via group translateY=960. fillColor tinte a l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M480-80q-82 0-155-31.5t-127.5-86Q143-252 111.5-325T80-480q0-83 32.5-156t88-127Q256-817 330-848.5T488-880q80 0 151 27.5t124.5 76q53.5 48.5 85 115T880-518q0 115-70 176.5T640-280h-74q-9 0-12.5 5t-3.5 11q0 12 15 34.5t15 51.5q0 50-27.5 74T480-80Zm0-400Zm-220 40q26 0 43-17t17-43q0-26-17-43t-43-17q-26 0-43 17t-17 43q0 26 17 43t43 17Zm120-160q26 0 43-17t17-43q0-26-17-43t-43-17q-26 0-43 17t-17 43q0 26 17 43t43 17Zm200 0q26 0 43-17t17-43q0-26-17-43t-43-17q-26 0-43 17t-17 43q0 26 17 43t43 17Zm120 160q26 0 43-17t17-43q0-26-17-43t-43-17q-26 0-43 17t-17 43q0 26 17 43t43 17ZM480-160q9 0 14.5-5t5.5-13q0-14-15-33t-15-57q0-42 29-67t71-25h70q66 0 113-38.5T800-518q0-121-92.5-201.5T488-800q-136 0-232 93t-96 227q0 133 93.5 226.5T480-160Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_photo_camera.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_photo_camera.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (photo_camera), grille 960 (viewBox 0 -960 960 960) recadree via group translateY=960. fillColor tinte a l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M480-260q75 0 127.5-52.5T660-440q0-75-52.5-127.5T480-620q-75 0-127.5 52.5T300-440q0 75 52.5 127.5T480-260Zm0-80q-42 0-71-29t-29-71q0-42 29-71t71-29q42 0 71 29t29 71q0 42-29 71t-71 29ZM160-120q-33 0-56.5-23.5T80-200v-480q0-33 23.5-56.5T160-760h126l74-80h240l74 80h126q33 0 56.5 23.5T880-680v480q0 33-23.5 56.5T800-120H160Zm0-80h640v-480H638l-73-80H395l-73 80H160v480Zm320-240Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_shopping_cart.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_shopping_cart.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (shopping_cart), grille 960 (viewBox 0 -960 960 960) recadree via group translateY=960. fillColor tinte a l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M280-80q-33 0-56.5-23.5T200-160q0-33 23.5-56.5T280-240q33 0 56.5 23.5T360-160q0 33-23.5 56.5T280-80Zm400 0q-33 0-56.5-23.5T600-160q0-33 23.5-56.5T680-240q33 0 56.5 23.5T760-160q0 33-23.5 56.5T680-80ZM246-720l96 200h280l110-200H246Zm-38-80h590q23 0 35 20.5t1 41.5L692-482q-11 20-29.5 31T622-440H324l-44 80h480v80H280q-45 0-68-39.5t-2-78.5l54-98-144-304H40v-80h130l38 80Zm134 280h280-280Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_smartphone.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_smartphone.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (smartphone), grille 960 (viewBox 0 -960 960 960) recadree via group translateY=960. fillColor tinte a l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M280-40q-33 0-56.5-23.5T200-120v-720q0-33 23.5-56.5T280-920h400q33 0 56.5 23.5T760-840v720q0 33-23.5 56.5T680-40H280Zm0-120v40h400v-40H280Zm0-80h400v-480H280v480Zm0-560h400v-40H280v40Zm0 0v-40 40Zm0 640v40-40Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_sports_esports.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_sports_esports.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (sports_esports / manette), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M182-200q-51 0-79-35.5T82-322l42-300q9-60 53.5-99T282-760h396q60 0 104.5 39t53.5 99l42 300q7 51-21 86.5T778-200q-21 0-39-7.5T706-230l-90-90H344l-90 90q-15 15-33 22.5t-39 7.5Zm16-86 114-114h336l114 114q2 2 16 6 11 0 17.5-6.5T800-304l-44-308q-4-29-26-48.5T678-680H282q-30 0-52 19.5T204-612l-44 308q-2 11 4.5 17.5T182-280q2 0 16-6Zm482-154q17 0 28.5-11.5T720-480q0-17-11.5-28.5T680-520q-17 0-28.5 11.5T640-480q0 17 11.5 28.5T680-440Zm-80-120q17 0 28.5-11.5T640-600q0-17-11.5-28.5T600-640q-17 0-28.5 11.5T560-600q0 17 11.5 28.5T600-560ZM310-440h60v-70h70v-60h-70v-70h-60v70h-70v60h70v70Zm170-40Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_terminal.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_terminal.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (terminal), grille 960 (viewBox 0 -960 960 960) recadree via group translateY=960. fillColor tinte a l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M160-160q-33 0-56.5-23.5T80-240v-480q0-33 23.5-56.5T160-800h640q33 0 56.5 23.5T880-720v480q0 33-23.5 56.5T800-160H160Zm0-80h640v-400H160v400Zm140-40-56-56 103-104-104-104 57-56 160 160-160 160Zm180 0v-80h240v80H480Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_wifi.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_wifi.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (wifi), grille 960 (viewBox 0 -960 960 960) recadree via group translateY=960. fillColor tinte a l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M480-120q-42 0-71-29t-29-71q0-42 29-71t71-29q42 0 71 29t29 71q0 42-29 71t-71 29ZM254-346l-84-86q59-59 138.5-93.5T480-560q92 0 171.5 35T790-430l-84 84q-44-44-102-69t-124-25q-66 0-124 25t-102 69ZM84-516 0-600q92-94 215-147t265-53q142 0 265 53t215 147l-84 84q-77-77-178.5-120.5T480-680q-116 0-217.5 43.5T84-516Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_work.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_work.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (work), grille 960 (viewBox 0 -960 960 960) recadree via group translateY=960. fillColor tinte a l'usage. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M160-120q-33 0-56.5-23.5T80-200v-440q0-33 23.5-56.5T160-720h160v-80q0-33 23.5-56.5T400-880h160q33 0 56.5 23.5T640-800v80h160q33 0 56.5 23.5T880-640v440q0 33-23.5 56.5T800-120H160Zm0-80h640v-440H160v440Zm240-520h160v-80H400v80ZM160-200v-440 440Z" />
+    </group>
+</vector>

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/FlagItemRefonteRoborazziTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/FlagItemRefonteRoborazziTest.kt
@@ -1,0 +1,144 @@
+package fr.forumhfr.redface2.core.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.unit.dp
+import com.github.takahirom.roborazzi.captureRoboImage
+import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
+import fr.forumhfr.redface2.core.model.Flag
+import fr.forumhfr.redface2.core.model.FlagType
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * #603 PR3 — showcase Roborazzi (rendu JVM, record-only) de la LIGNE de drapeau refondue (ADR-017) :
+ * marqueur configurable (barre de couleur par défaut / pastille tonale+icône catégorie / dot),
+ * désaturation des lus, décoration favori, et pastille « pages à lire » en fin de ligne. PNG sous
+ * `core/ui/build/outputs/roborazzi/` pour revue visuelle avant/après :
+ *
+ *     ./scripts/docker-dev.sh ./gradlew :core:ui:testDebugUnitTest \
+ *         --tests '*FlagItemRefonteRoborazziTest*' --console=plain
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h900dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@OptIn(ExperimentalTestApi::class)
+class FlagItemRefonteRoborazziTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Composable
+    private fun Showcase() {
+        Column(Modifier.fillMaxSize()) {
+            // Default STRIPE marker across the row states.
+            FlagRow(SAMPLE_CYAN_UNREAD, MarkerStyle.STRIPE)
+            FlagItemDivider()
+            FlagRow(SAMPLE_CYAN_READ, MarkerStyle.STRIPE)
+            FlagItemDivider()
+            FlagRow(SAMPLE_FAVORITE, MarkerStyle.STRIPE)
+            FlagItemDivider()
+            FlagRow(SAMPLE_RED_MANYPAGES, MarkerStyle.STRIPE)
+            FlagItemDivider()
+            // The three marker styles on the same unread cyan topic.
+            Row(
+                modifier = Modifier.padding(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(24.dp),
+            ) {
+                MarkerStyle.entries.forEach { style ->
+                    FlagMarker(
+                        style = style,
+                        type = FlagType.CYAN,
+                        isFavorite = false,
+                        hasUnread = true,
+                        categoryIconRes = fr.forumhfr.redface2.core.ui.icon.categoryIcon(1),
+                    )
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun FlagRow(flag: Flag, style: MarkerStyle) {
+        FlagItem(
+            flag = flag,
+            metadata = FlagMetadata(start = flag.lastReplyAuthor, end = "01-05-2026 à 17:07"),
+            onClick = {},
+            markerStyle = style,
+        )
+    }
+
+    @Test
+    fun flagListRefonteLight() {
+        capture(darkTheme = false, amoled = false, name = "flags_pr3_row_light")
+    }
+
+    @Test
+    fun flagListRefonteDark() {
+        capture(darkTheme = true, amoled = false, name = "flags_pr3_row_dark")
+    }
+
+    @Test
+    fun flagListRefonteAmoled() {
+        capture(darkTheme = true, amoled = true, name = "flags_pr3_row_amoled")
+    }
+
+    private fun capture(darkTheme: Boolean, amoled: Boolean, name: String) {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = darkTheme, amoledTheme = amoled, dynamicColor = false) {
+                Surface(color = MaterialTheme.colorScheme.surface) { Showcase() }
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage(filePath = "build/outputs/roborazzi/$name.png")
+    }
+
+    private companion object {
+        private val BASE = Flag(
+            cat = 1,
+            subcat = null,
+            topicId = 0,
+            title = "",
+            totalPages = 1,
+            replyCount = 0,
+            type = FlagType.CYAN,
+            isFavorite = false,
+            hasUnread = true,
+            lastReadPage = 1,
+            lastPostReadId = null,
+            firstPostAuthor = "OP",
+            lastReplyAuthor = "",
+            lastReplyAt = "2026-05-01 17:07",
+        )
+
+        val SAMPLE_CYAN_UNREAD = BASE.copy(
+            topicId = 1, cat = 1, totalPages = 431, lastReadPage = 429,
+            title = "[Topic] Hardware — config du moment et retours", lastReplyAuthor = "Kermine",
+        )
+        val SAMPLE_CYAN_READ = BASE.copy(
+            topicId = 2, cat = 10, hasUnread = false, totalPages = 12, lastReadPage = 12,
+            title = "Kotlin / Compose — questions diverses", lastReplyAuthor = "Shaad",
+        )
+        val SAMPLE_FAVORITE = BASE.copy(
+            topicId = 3, cat = 5, isFavorite = true, totalPages = 88, lastReadPage = 80,
+            title = "Le topic des jeux indé à suivre", lastReplyAuthor = "tinc",
+        )
+        val SAMPLE_RED_MANYPAGES = BASE.copy(
+            topicId = 4, cat = 13, type = FlagType.RED, totalPages = 1726, lastReadPage = 1700,
+            title = "Le topic de la blague Carambar et autres réjouissances", lastReplyAuthor = "Lt Ripley",
+        )
+    }
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/icon/CategoryIconTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/icon/CategoryIconTest.kt
@@ -1,0 +1,41 @@
+package fr.forumhfr.redface2.core.ui.icon
+
+import fr.forumhfr.redface2.core.ui.R
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Covers the pure [categoryIcon] mapping (#603, spike 4). Comparisons are `R.drawable.X` vs
+ * `R.drawable.X` so the test is robust to the actual generated resource ids.
+ */
+class CategoryIconTest {
+
+    @Test
+    fun `known categories map to their dedicated Material Symbol`() {
+        assertEquals(R.drawable.ic_ms_memory, categoryIcon(1)) // Hardware
+        assertEquals(R.drawable.ic_ms_sports_esports, categoryIcon(5)) // Jeux Video
+        assertEquals(R.drawable.ic_ms_code, categoryIcon(10)) // Programmation
+        assertEquals(R.drawable.ic_ms_terminal, categoryIcon(11)) // Linux et OS Alternatifs
+        assertEquals(R.drawable.ic_ms_shopping_cart, categoryIcon(6)) // Achats & Ventes
+        assertEquals(R.drawable.ic_ms_forum, categoryIcon(13)) // Discussions
+    }
+
+    @Test
+    fun `an unknown category falls back to the generic forum glyph`() {
+        assertEquals(R.drawable.ic_ms_forum, categoryIcon(24)) // Blabla — not in the REST catalogue
+        assertEquals(R.drawable.ic_ms_forum, categoryIcon(0)) // moderation space
+        assertEquals(R.drawable.ic_ms_forum, categoryIcon(9999)) // arbitrary unknown
+    }
+
+    @Test
+    fun `every public category resolves to a non-zero drawable`() {
+        val publicCats = listOf(1, 16, 15, 2, 30, 23, 25, 3, 14, 5, 4, 22, 21, 11, 10, 12, 6, 8, 13)
+        publicCats.forEach { catId ->
+            assertEquals(
+                "cat $catId must resolve",
+                true,
+                categoryIcon(catId) != 0,
+            )
+        }
+    }
+}

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -78,6 +78,8 @@ import fr.forumhfr.redface2.core.ui.FlagMetadata
 import fr.forumhfr.redface2.core.ui.ForumListRow
 import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.formatLastReplyTimestamp
+import fr.forumhfr.redface2.core.ui.icon.RedfaceVectorIcon
+import fr.forumhfr.redface2.core.ui.icon.categoryIcon
 import fr.forumhfr.redface2.core.ui.theme.FlagPalette
 import kotlinx.coroutines.launch
 
@@ -943,6 +945,7 @@ private fun CategorySectionedFlagList(
             // recycles a row slot for a row instead of recreating the node from a header slot.
             stickyHeader(key = "cat-${section.catId}-header", contentType = CONTENT_TYPE_HEADER) {
                 CategoryHeaderBand(
+                    catId = section.catId,
                     label = section.catName
                         ?: stringResource(R.string.flags_category_fallback, section.catId),
                     // #414 — parité RF1 : the band navigates to the category's topic listing.
@@ -994,7 +997,7 @@ private fun CategorySectionedFlagList(
  * explicit [heightIn].
  */
 @Composable
-private fun CategoryHeaderBand(label: String, onClick: () -> Unit) {
+private fun CategoryHeaderBand(catId: Int, label: String, onClick: () -> Unit) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
@@ -1006,6 +1009,14 @@ private fun CategoryHeaderBand(label: String, onClick: () -> Unit) {
             }
             .padding(horizontal = 24.dp, vertical = 8.dp),
     ) {
+        // #603 — Material Symbols glyph per category (spike 4, ADR-017); decorative (the label carries
+        // the name), so no contentDescription. Generic forum glyph for unknown categories.
+        RedfaceVectorIcon(
+            resId = categoryIcon(catId),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            size = 20.dp,
+            modifier = Modifier.padding(end = 12.dp),
+        )
         Text(
             text = label,
             style = MaterialTheme.typography.titleSmall,
@@ -1566,29 +1577,12 @@ private data class FlagsViewSettingsActions(
 )
 
 /**
- * Builds the two-segment footer of a drapeau row ([FlagMetadata]). Dogfooding feedback on
- * v102: the single-string footer (`author · N rép. · p.X/Y · timestamp`) truncated its
- * tail — the #325 timestamp — on narrow screens. `start` is `author · p.X/Y` (the only
- * segment allowed to ellipsise; the reply count is dropped, redundant with the page count
- * for a quick scan) and `end` is the last-reply timestamp, formatted web-style
- * (`01-05-2026 à 17:07`) by [formatLastReplyTimestamp] from the raw REST string — rendered
- * end-aligned and never truncated by [FlagItem]. Blank when REST omits it.
+ * Builds the two-segment footer of a drapeau row ([FlagMetadata]). #603 refonte (ADR-017): `start`
+ * is the last poster (the only segment allowed to ellipsise) and `end` is the last-reply timestamp,
+ * formatted web-style (`01-05-2026 à 17:07`) by [formatLastReplyTimestamp], end-aligned and never
+ * truncated by [FlagItem]. The page position (« p.X/Y ») left the footer: the pages-à-lire count is
+ * now the trailing [fr.forumhfr.redface2.core.ui.PagesToReadPill] of the row. Blank when REST omits
+ * a field.
  */
-@Composable
-private fun flagRowMetadata(flag: Flag): FlagMetadata {
-    val start = if (flag.lastReplyAuthor.isNotBlank()) {
-        stringResource(
-            R.string.flags_item_metadata_with_author,
-            flag.lastReplyAuthor,
-            flag.lastReadPage,
-            flag.totalPages,
-        )
-    } else {
-        stringResource(
-            R.string.flags_item_metadata_no_author,
-            flag.lastReadPage,
-            flag.totalPages,
-        )
-    }
-    return FlagMetadata(start = start, end = formatLastReplyTimestamp(flag.lastReplyAt))
-}
+private fun flagRowMetadata(flag: Flag): FlagMetadata =
+    FlagMetadata(start = flag.lastReplyAuthor, end = formatLastReplyTimestamp(flag.lastReplyAt))

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -87,15 +87,6 @@
     <string name="flags_session_expired">Session HFR expirée. Reconnecte-toi pour recharger tes drapeaux.</string>
     <string name="flags_retry">Réessayer</string>
 
-    <!-- Footer metadata formats. The `*_at` variants (#325) carry the last-reply timestamp
-         already formatted web-style by :core:ui (`01-05-2026 à 17:07`), placed LAST so that
-         on narrow screens the ellipsis eats the added data first and never the pre-existing
-         read-progress « p.X/Y » (review #325):
-         "Shaad · 69017 rép. · p.1725/1726 · 01-05-2026 à 17:07". The timestamp-less variants
-         remain as fallbacks when REST omits `last_post_date`. Without author (HFR returns no
-         last replier on brand new topics): "69017 rép. · p.1/1". -->
-    <string name="flags_item_metadata_with_author">%1$s · p.%2$d/%3$d</string>
-    <string name="flags_item_metadata_no_author">p.%1$d/%2$d</string>
 
     <!-- #309 — Menu d'affichage des drapeaux (bottom sheet M3 ouvert depuis l'en-tête). Reflète et
          modifie les réglages d'affichage de l'onglet courant (ou globaux selon « par onglet »). -->


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

**PR3 du chantier #603** (refonte vue Drapeaux), run autonome. Refonte visuelle de la **ligne** et de
l'**en-tête de catégorie** (ADR-017), sur le modèle pur livré par PR1 (#640).

## Contenu
- **`FlagMarker`** (core/ui) : marqueur gauche **configurable** — **barre de couleur** (défaut, ADR-017)
  / pastille tonale + icône catégorie / dot. Couleur = bucket (favori gagne), désaturée si lu.
  Remplace l'ancien `FlagDot`.
- **`PagesToReadPill`** : pastille **« +N »** en fin de ligne (non-lus avec pages restantes).
- **`ForumListRow`** : slot `trailing` optionnel (la pill) ; colonne titre/meta en `weight(1f)`.
- **`FlagItem`** : marqueur STRIPE par défaut + pill ; metadata simplifiée en **auteur · date**.
- **En-tête de catégorie** : vraie **icône Material Symbols** (`categoryIcon`) + chevron « ouvrir ».
- **Set d'icônes** : **16 vector drawables Material Symbols Outlined officiels** (récupérés du dépôt
  Google, grille 960) + mapping pur `categoryIcon(catId)→drawable` (fallback forum), **TDD**.
- **Roborazzi** (record) : `FlagItemRefonteRoborazziTest` (light/dark/amoled) — rendu **vérifié
  visuellement** (barres de couleur, pill +N, pastille à icône CPU).

## Décision à confirmer en revue
- **`p.X/Y` retiré du footer** : la position (page courante/total) quitte la metadata au profit du
  signal actionnable **« +N pages à lire »** (pill), conforme au mockup. **Perte d'info assumée** —
  veto possible si tu préfères réafficher la position.

## Vérif
- `detektAll` + `lintDebug` + `:core:ui:testDebugUnitTest` + `:feature:flags:testDebugUnitTest` **verts**.
- Review **Codex** (gpt-5.5/xhigh) : **GO**, aucun bloquant (DT non régressé par `weight(1f)`, FlagMarker
  fidèle à FlagDot, mapping/fallback sains).

Chantier de référence : #603. **Aucune merge** — attend ta revue. Branché sur `origin/dev` (contient PR0/1/2).
