### PR TITLE
feat(#603): PR5 — bottom sheet appui-long (métadonnées API + super-favori local)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreSuperFavoriteRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreSuperFavoriteRepository.kt
@@ -1,0 +1,50 @@
+package fr.forumhfr.redface2.core.data.preferences
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import fr.forumhfr.redface2.core.domain.coroutines.ApplicationScope
+import fr.forumhfr.redface2.core.domain.preferences.SuperFavoriteRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+
+/**
+ * Local super-favorite store (#603). Reuses the shared `@UserPreferencesDataStore` Preferences store
+ * under a dedicated key (no second DataStore file). Ids are persisted as a `Set<String>` (the only
+ * set type DataStore Preferences offers) and parsed back to `Int`, tolerant of a corrupt entry.
+ */
+@Singleton
+class DataStoreSuperFavoriteRepository @Inject constructor(
+    @param:UserPreferencesDataStore private val dataStore: DataStore<Preferences>,
+    @param:ApplicationScope private val externalScope: CoroutineScope,
+) : SuperFavoriteRepository {
+
+    override fun observeSuperFavoriteTopicIds(): Flow<Set<Int>> =
+        dataStore.data
+            .map { prefs -> prefs[KEY].orEmpty().mapNotNull(String::toIntOrNull).toSet() }
+            .distinctUntilChanged()
+            .catch { emit(emptySet()) }
+
+    override suspend fun setSuperFavorite(topicId: Int, enabled: Boolean) {
+        // Parented to the process-lifetime scope (cf. DataStoreUserPreferencesRepository.persist) so a
+        // long-press sheet dismissed mid-write still commits the toggle.
+        externalScope.async {
+            dataStore.edit { prefs ->
+                val current = prefs[KEY].orEmpty().toMutableSet()
+                if (enabled) current.add(topicId.toString()) else current.remove(topicId.toString())
+                prefs[KEY] = current
+            }
+        }.await()
+    }
+
+    private companion object {
+        val KEY = stringSetPreferencesKey("super_favorite_topic_ids")
+    }
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/UserPreferencesModule.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/UserPreferencesModule.kt
@@ -12,6 +12,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenBootstrapStore
+import fr.forumhfr.redface2.core.domain.preferences.SuperFavoriteRepository
 import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import javax.inject.Singleton
@@ -52,4 +53,10 @@ abstract class UserPreferencesBindingsModule {
     abstract fun bindStartScreenBootstrapStore(
         impl: SharedPreferencesStartScreenBootstrapStore,
     ): StartScreenBootstrapStore
+
+    @Binds
+    @Singleton
+    abstract fun bindSuperFavoriteRepository(
+        impl: DataStoreSuperFavoriteRepository,
+    ): SuperFavoriteRepository
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreSuperFavoriteRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreSuperFavoriteRepositoryTest.kt
@@ -1,0 +1,75 @@
+package fr.forumhfr.redface2.core.data.preferences
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DataStoreSuperFavoriteRepositoryTest {
+
+    @get:Rule val tempFolder = TemporaryFolder()
+
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var repository: DataStoreSuperFavoriteRepository
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val externalScope = CoroutineScope(dispatcher + SupervisorJob())
+
+    @Before
+    fun setUp() {
+        dataStore = PreferenceDataStoreFactory.create(
+            produceFile = { tempFolder.newFile("super.preferences_pb") },
+        )
+        repository = DataStoreSuperFavoriteRepository(dataStore = dataStore, externalScope = externalScope)
+    }
+
+    @Test
+    fun `starts with an empty set`() = runTest(dispatcher) {
+        assertEquals(emptySet<Int>(), repository.observeSuperFavoriteTopicIds().first())
+    }
+
+    @Test
+    fun `setSuperFavorite enabled adds the topic id`() = runTest(dispatcher) {
+        repository.setSuperFavorite(42, enabled = true)
+        assertEquals(setOf(42), repository.observeSuperFavoriteTopicIds().first())
+    }
+
+    @Test
+    fun `setSuperFavorite disabled removes the topic id and keeps the others`() = runTest(dispatcher) {
+        repository.setSuperFavorite(42, enabled = true)
+        repository.setSuperFavorite(7, enabled = true)
+        repository.setSuperFavorite(42, enabled = false)
+        assertEquals(setOf(7), repository.observeSuperFavoriteTopicIds().first())
+    }
+
+    @Test
+    fun `enabling twice is idempotent`() = runTest(dispatcher) {
+        repository.setSuperFavorite(42, enabled = true)
+        repository.setSuperFavorite(42, enabled = true)
+        assertEquals(setOf(42), repository.observeSuperFavoriteTopicIds().first())
+    }
+
+    @Test
+    fun `disabling an absent id is a no-op`() = runTest(dispatcher) {
+        repository.setSuperFavorite(99, enabled = false)
+        assertEquals(emptySet<Int>(), repository.observeSuperFavoriteTopicIds().first())
+    }
+
+    @Test
+    fun `a corrupt non-numeric persisted entry is ignored`() = runTest(dispatcher) {
+        dataStore.edit { it[stringSetPreferencesKey("super_favorite_topic_ids")] = setOf("3", "boom", "5") }
+        assertEquals(setOf(3, 5), repository.observeSuperFavoriteTopicIds().first())
+    }
+}

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/SuperFavoriteRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/SuperFavoriteRepository.kt
@@ -1,0 +1,21 @@
+package fr.forumhfr.redface2.core.domain.preferences
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Local « super favori » store (#603, ADR-017 decision 5). A super favorite is a purely CLIENT-SIDE
+ * mark on a topic — a personal pin, distinct from [UserPreferencesRepository]-less of the server
+ * `isFavorite`/`flag_owntopic` decoration (there is no server equivalent). Persisted as a set of
+ * topic ids.
+ *
+ * Deliberately a SEPARATE repository (not a method on [UserPreferencesRepository]) so it carries its
+ * own responsibility and does not force every existing preferences test-double to grow a method.
+ */
+interface SuperFavoriteRepository {
+
+    /** Emits the current set of super-favorited topic ids; starts with the persisted value. */
+    fun observeSuperFavoriteTopicIds(): Flow<Set<Int>>
+
+    /** Adds ([enabled] = true) or removes the topic from the super-favorite set. Idempotent. */
+    suspend fun setSuperFavorite(topicId: Int, enabled: Boolean)
+}

--- a/core/ui/src/main/res/drawable/ic_ms_content_copy.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_content_copy.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (content_copy), grille 960 recadree via group translateY=960. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M360-240q-33 0-56.5-23.5T280-320v-480q0-33 23.5-56.5T360-880h360q33 0 56.5 23.5T800-800v480q0 33-23.5 56.5T720-240H360Zm0-80h360v-480H360v480ZM200-80q-33 0-56.5-23.5T120-160v-560h80v560h440v80H200Zm160-240v-480 480Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_delete.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_delete.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (delete), grille 960 recadree via group translateY=960. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M280-120q-33 0-56.5-23.5T200-200v-520h-40v-80h200v-40h240v40h200v80h-40v520q0 33-23.5 56.5T680-120H280Zm400-600H280v520h400v-520ZM360-280h80v-360h-80v360Zm160 0h80v-360h-80v360ZM280-720v520-520Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_open_in_new.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_open_in_new.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (open_in_new), grille 960 recadree via group translateY=960. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h280v80H200v560h560v-280h80v280q0 33-23.5 56.5T760-120H200Zm188-212-56-56 372-372H560v-80h280v280h-80v-144L388-332Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_star.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_star.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (star), grille 960 recadree via group translateY=960. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="m354-287 126-76 126 77-33-144 111-96-146-13-58-136-58 135-146 13 111 97-33 143ZM233-120l65-281L80-590l288-25 112-265 112 265 288 25-218 189 65 281-247-149-247 149Zm247-350Z" />
+    </group>
+</vector>

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagActionsSheet.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagActionsSheet.kt
@@ -1,0 +1,238 @@
+package fr.forumhfr.redface2.feature.flags
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.widget.Toast
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
+import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
+import fr.forumhfr.redface2.core.model.Flag
+import fr.forumhfr.redface2.core.model.pagesToRead
+import fr.forumhfr.redface2.core.ui.FlagMarker
+import fr.forumhfr.redface2.core.ui.formatLastReplyTimestamp
+import fr.forumhfr.redface2.core.ui.icon.RedfaceVectorIcon
+import fr.forumhfr.redface2.core.ui.icon.categoryIcon
+import fr.forumhfr.redface2.core.ui.theme.FlagPalette
+import fr.forumhfr.redface2.core.ui.R as CoreUiR
+
+/**
+ * Long-press action sheet of a Drapeaux row (#603 PR5, ADR-017 decision 6) — replaces the direct
+ * removal dialog as the long-press entry point. Shows the topic's API metadata (already in [Flag]),
+ * quick actions, the local « super favori » toggle, and the (destructive) flag removal. **No color
+ * picker** — the flag color reflects the server bucket and is not editable.
+ *
+ * « Copier le lien » / « Ouvrir dans le navigateur » are handled in-sheet via [LocalContext]
+ * ([flagTopicUrl]); the rest routes through [actions] (removal still goes through the existing
+ * confirmation dialog).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FlagActionsSheet(
+    flag: Flag,
+    categoryName: String,
+    isSuperFavorite: Boolean,
+    actions: FlagSheetActions,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val context = LocalContext.current
+    val linkCopied = stringResource(R.string.flags_sheet_link_copied)
+    val browserFailed = stringResource(R.string.flags_sheet_browser_failed)
+
+    ModalBottomSheet(onDismissRequest = actions.onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(bottom = 12.dp),
+        ) {
+            SheetHeader(flag = flag, categoryName = categoryName)
+            FlagMetadataBlock(flag = flag, categoryName = categoryName)
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+            SheetActionRow(
+                iconRes = CoreUiR.drawable.ic_ms_forum,
+                label = stringResource(R.string.flags_sheet_open),
+                onClick = actions.onOpen,
+            )
+            SheetActionRow(
+                iconRes = CoreUiR.drawable.ic_ms_star,
+                label = stringResource(
+                    if (isSuperFavorite) {
+                        R.string.flags_sheet_super_favorite_remove
+                    } else {
+                        R.string.flags_sheet_super_favorite_add
+                    },
+                ),
+                onClick = actions.onToggleSuperFavorite,
+                contentColor = if (isSuperFavorite) FlagPalette.Favorite else MaterialTheme.colorScheme.onSurface,
+            )
+            SheetActionRow(
+                iconRes = CoreUiR.drawable.ic_ms_content_copy,
+                label = stringResource(R.string.flags_sheet_copy_link),
+                onClick = { copyTopicLink(context, flagTopicUrl(flag), linkCopied) },
+            )
+            SheetActionRow(
+                iconRes = CoreUiR.drawable.ic_ms_open_in_new,
+                label = stringResource(R.string.flags_sheet_open_browser),
+                onClick = { openTopicInBrowser(context, flagTopicUrl(flag), browserFailed) },
+            )
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+            SheetActionRow(
+                iconRes = CoreUiR.drawable.ic_ms_delete,
+                label = stringResource(R.string.flags_sheet_remove),
+                onClick = actions.onRemove,
+                contentColor = MaterialTheme.colorScheme.error,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SheetHeader(flag: Flag, categoryName: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        FlagMarker(
+            style = MarkerStyle.DOT,
+            type = flag.type,
+            isFavorite = flag.isFavorite,
+            hasUnread = flag.hasUnread,
+            categoryIconRes = categoryIcon(flag.cat),
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = flag.title,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            val position = stringResource(
+                R.string.flags_sheet_meta_position_value,
+                flag.lastReadPage,
+                flag.totalPages,
+            )
+            Text(
+                text = "$categoryName · $position",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun FlagMetadataBlock(flag: Flag, categoryName: String) {
+    Column(
+        modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        MetaRow(stringResource(R.string.flags_sheet_meta_category), categoryName)
+        MetaRow(stringResource(R.string.flags_sheet_meta_author), flag.firstPostAuthor)
+        if (flag.lastReplyAuthor.isNotBlank()) {
+            MetaRow(
+                stringResource(R.string.flags_sheet_meta_last_reply),
+                stringResource(
+                    R.string.flags_sheet_meta_last_reply_value,
+                    flag.lastReplyAuthor,
+                    formatLastReplyTimestamp(flag.lastReplyAt),
+                ),
+            )
+        }
+        val pages = flag.pagesToRead()
+        val position = stringResource(R.string.flags_sheet_meta_position_value, flag.lastReadPage, flag.totalPages)
+        MetaRow(
+            stringResource(R.string.flags_sheet_meta_position),
+            if (flag.hasUnread && pages > 0) {
+                "$position · " + stringResource(R.string.flags_sheet_meta_pages_to_read, pages)
+            } else {
+                position
+            },
+        )
+        MetaRow(stringResource(R.string.flags_sheet_meta_replies), flag.replyCount.toString())
+    }
+}
+
+@Composable
+private fun MetaRow(key: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = key,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(116.dp),
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+@Composable
+private fun SheetActionRow(
+    @DrawableRes iconRes: Int,
+    label: String,
+    onClick: () -> Unit,
+    contentColor: Color = MaterialTheme.colorScheme.onSurface,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 24.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(20.dp),
+    ) {
+        RedfaceVectorIcon(resId = iconRes, tint = contentColor)
+        Text(text = label, style = MaterialTheme.typography.bodyLarge, color = contentColor)
+    }
+}
+
+/** Copies [url] to the clipboard; on pre-Android-13 (no system confirmation) shows a [feedback] toast. */
+private fun copyTopicLink(context: Context, url: String, feedback: String) {
+    val clipboard = context.getSystemService(ClipboardManager::class.java) ?: return
+    clipboard.setPrimaryClip(ClipData.newPlainText("HFR", url))
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+        Toast.makeText(context, feedback, Toast.LENGTH_SHORT).show()
+    }
+}
+
+/** Opens [url] in the browser; toasts [failureFeedback] when no app can handle the intent. */
+private fun openTopicInBrowser(context: Context, url: String, failureFeedback: String) {
+    runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, url.toUri())) }
+        .onFailure { Toast.makeText(context, failureFeedback, Toast.LENGTH_SHORT).show() }
+}

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagSheetActions.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagSheetActions.kt
@@ -1,0 +1,9 @@
+package fr.forumhfr.redface2.feature.flags
+
+/** Callbacks of the long-press [FlagActionsSheet] (copy-link / open-in-browser are handled inside). */
+data class FlagSheetActions(
+    val onOpen: () -> Unit,
+    val onToggleSuperFavorite: () -> Unit,
+    val onRemove: () -> Unit,
+    val onDismiss: () -> Unit,
+)

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagTopicUrl.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagTopicUrl.kt
@@ -1,0 +1,12 @@
+package fr.forumhfr.redface2.feature.flags
+
+import fr.forumhfr.redface2.core.model.Flag
+
+/**
+ * Canonical HFR web URL of a flagged topic (#603 PR5) — for « copier le lien » / « ouvrir dans le
+ * navigateur » from the long-press sheet. Mirrors the `forum2.php` permalink shape (cf. the topic
+ * permalink builder) and resumes at the user's last-read page. Pure, testable.
+ */
+fun flagTopicUrl(flag: Flag): String =
+    "https://forum.hardware.fr/forum2.php?config=hfr.inc" +
+        "&cat=${flag.cat}&post=${flag.topicId}&page=${flag.lastReadPage.coerceAtLeast(1)}"

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -130,6 +130,7 @@ fun FlagsRoute(
     val removeFlagEvent by viewModel.removeFlagEvent.collectAsStateWithLifecycle()
     val flagsViewSettings by viewModel.flagsViewSettings.collectAsStateWithLifecycle()
     val flagsPerTabOverride by viewModel.flagsPerTabOverride.collectAsStateWithLifecycle()
+    val superFavoriteIds by viewModel.superFavoriteTopicIds.collectAsStateWithLifecycle()
 
     // « +lus » suffix on the Cyan tab: shown when the Cyan tab is selected and CYAN's « non-lus
     // uniquement » filter is off (read participated topics are visible). The ViewModel derives this
@@ -201,13 +202,18 @@ fun FlagsRoute(
     // is only offered when there is a real list to configure (authenticated AND a real FlagType tab,
     // i.e. not the Super placeholder).
     var showViewSettingsSheet by remember { mutableStateOf(false) }
+    // #603 PR5 — the flag whose long-press actions sheet is open (null = closed).
+    var sheetFlag by remember { mutableStateOf<Flag?>(null) }
     val canConfigureView = authState is AuthState.Authenticated && selectedTab.flagType != null
 
     // If the screen stops being configurable while the sheet is open (session expired, or the user
     // lands on the Super tab), clear the flag so the sheet can't silently reappear on the next
     // configurable tab/re-auth.
     LaunchedEffect(canConfigureView) {
-        if (!canConfigureView) showViewSettingsSheet = false
+        if (!canConfigureView) {
+            showViewSettingsSheet = false
+            sheetFlag = null
+        }
     }
 
     DtTabFallbackEffect(
@@ -262,6 +268,7 @@ fun FlagsRoute(
     LaunchedEffect(selectedTab) {
         searchQuery = ""
         searchActive = false
+        sheetFlag = null
     }
 
     Scaffold(
@@ -336,7 +343,7 @@ fun FlagsRoute(
                                 },
                                 onRefresh = viewModel::refresh,
                                 onLoginRequested = onLoginRequested,
-                                onRequestRemoveFlag = viewModel::requestRemoveFlag,
+                                onLongPressFlag = { sheetFlag = it },
                                 onOpenCategory = onOpenCategory,
                                 onOpenMultiMp = onOpenMultiMp,
                                 onRefreshDt = viewModel::refreshDt,
@@ -366,6 +373,24 @@ fun FlagsRoute(
             ),
         )
     }
+
+    // #603 PR5 — long-press actions sheet: API metadata + quick actions + local super-favorite +
+    // removal (which still routes through the existing confirmation dialog). No color picker.
+    FlagActionsSheetHost(
+        flag = sheetFlag,
+        superFavoriteIds = superFavoriteIds,
+        onOpen = {
+            sheetFlag = null
+            viewModel.onFlagOpened()
+            onOpenFlag(it)
+        },
+        onToggleSuperFavorite = viewModel::toggleSuperFavorite,
+        onRemove = {
+            sheetFlag = null
+            viewModel.requestRemoveFlag(it)
+        },
+        onDismiss = { sheetFlag = null },
+    )
 
     // Confirmation gate before any network call (#99). The dialog renders only while the
     // ViewModel is in the Confirming state ; confirming moves to Removing (action disabled)
@@ -980,7 +1005,7 @@ private fun CategorySectionedFlagList(
                         metadata = flagRowMetadata(flag),
                         removalInFlight = removalInFlight,
                         onClick = { actions.onOpenFlag(flag) },
-                        onRequestRemove = { actions.onRequestRemoveFlag(flag) },
+                        onLongPress = { actions.onLongPressFlag(flag) },
                     )
                     FlagItemDivider()
                 }
@@ -1087,7 +1112,7 @@ private fun FlatFlagList(
                     metadata = flagRowMetadata(flag),
                     removalInFlight = removalInFlight,
                     onClick = { actions.onOpenFlag(flag) },
-                    onRequestRemove = { actions.onRequestRemoveFlag(flag) },
+                    onLongPress = { actions.onLongPressFlag(flag) },
                 )
                 FlagItemDivider()
             }
@@ -1105,14 +1130,46 @@ private fun flatEmptyLabel(tab: FlagTab): Int = when (tab) {
     else -> R.string.flags_list_empty
 }
 
+// #603 PR5 — hosts the long-press actions sheet; the null-check lives here (not in FlagsRoute) to keep
+// the route's cyclomatic complexity in budget. `flag == null` ⇒ nothing composed (sheet closed).
+@Composable
+@Suppress("LongParameterList") // host: the sheet flag + super-favorite set + 4 action callbacks.
+private fun FlagActionsSheetHost(
+    flag: Flag?,
+    superFavoriteIds: Set<Int>,
+    onOpen: (Flag) -> Unit,
+    onToggleSuperFavorite: (Flag) -> Unit,
+    onRemove: (Flag) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    if (flag == null) return
+    FlagActionsSheet(
+        flag = flag,
+        categoryName = flagCategoryName(flag.cat),
+        isSuperFavorite = flag.topicId in superFavoriteIds,
+        actions = FlagSheetActions(
+            onOpen = { onOpen(flag) },
+            onToggleSuperFavorite = { onToggleSuperFavorite(flag) },
+            onRemove = { onRemove(flag) },
+            onDismiss = onDismiss,
+        ),
+    )
+}
+
+// #603 PR5 — canonical category name for the sheet header, fallback « Catégorie N » for unknown ids.
+@Composable
+private fun flagCategoryName(catId: Int): String =
+    FALLBACK_CATEGORY_ORDER.firstOrNull { it.id == catId }?.name
+        ?: stringResource(R.string.flags_category_fallback, catId)
+
 /**
  * One removable flag row. The « Retirer » affordance went swipe-to-dismiss (#99) → **long-press**
  * (#457): the horizontal swipe now changes the flag tab, and a row-level `SwipeToDismissBox`
- * would consume the horizontal drag first and steal the tab gesture. The long-press only
- * *raises* the existing confirmation dialog via [onRequestRemove] — the actual removal still
- * happens after the user confirms (the repository then evicts the item from the cache, which
- * recomposes the list away). Arbitrage XaTriX (#457): the swipe-to-remove may come back later
- * in another form.
+ * would consume the horizontal drag first and steal the tab gesture. #603 PR5: the long-press now
+ * opens the rich actions sheet ([FlagActionsSheet]) via [onLongPress] — removal is one action inside
+ * it and still goes through the existing confirmation dialog (the repository then evicts the item
+ * from the cache, which recomposes the list away). Arbitrage XaTriX (#457): the swipe-to-remove may
+ * come back later in another form.
  *
  * The long-press being invisible, the row keeps the TalkBack/switch-access `customActions`
  * entry (#99) in addition to the `onLongClickLabel` semantics. While a removal is in flight
@@ -1125,23 +1182,23 @@ private fun RemovableFlagItem(
     metadata: FlagMetadata,
     removalInFlight: Boolean,
     onClick: () -> Unit,
-    onRequestRemove: () -> Unit,
+    onLongPress: () -> Unit,
 ) {
-    val removeLabel = stringResource(R.string.flags_remove_action)
+    val actionsLabel = stringResource(R.string.flags_row_actions_label)
 
     FlagItem(
         flag = flag,
         metadata = metadata,
         onClick = onClick,
-        longPress = FlagItemLongPress(label = removeLabel) {
-            if (!removalInFlight) onRequestRemove()
+        longPress = FlagItemLongPress(label = actionsLabel) {
+            if (!removalInFlight) onLongPress()
         },
         modifier = Modifier
             .background(MaterialTheme.colorScheme.surface)
             .semantics {
                 customActions = listOf(
-                    CustomAccessibilityAction(removeLabel) {
-                        onRequestRemove()
+                    CustomAccessibilityAction(actionsLabel) {
+                        if (!removalInFlight) onLongPress()
                         true
                     },
                 )
@@ -1556,7 +1613,8 @@ private data class AuthenticatedActions(
     val onOpenFlag: (Flag) -> Unit,
     val onRefresh: () -> Unit,
     val onLoginRequested: () -> Unit,
-    val onRequestRemoveFlag: (Flag) -> Unit,
+    /** #603 PR5 — long-press opens the rich actions sheet ([FlagActionsSheet]); removal moved inside it. */
+    val onLongPressFlag: (Flag) -> Unit,
     /** #414 — tap on a category band opens that category's topic listing. */
     val onOpenCategory: (Int) -> Unit,
     /** #6 — open a DT conversation (threadId, last inbox page, unread-on-open for the badge). */

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -11,6 +11,7 @@ import fr.forumhfr.redface2.core.domain.forum.ForumResult
 import fr.forumhfr.redface2.core.domain.messages.MessagesRepository
 import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
+import fr.forumhfr.redface2.core.domain.preferences.SuperFavoriteRepository
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.Category
@@ -60,6 +61,7 @@ class FlagsViewModel @Inject constructor(
     private val flagRepository: FlagRepository,
     private val forumRepository: ForumRepository,
     private val userPreferencesRepository: UserPreferencesRepository,
+    private val superFavoriteRepository: SuperFavoriteRepository,
     private val messagesRepository: MessagesRepository,
     private val mpStorageRepository: MpStorageRepository,
     private val clock: Clock,
@@ -101,6 +103,25 @@ class FlagsViewModel @Inject constructor(
             started = SharingStarted.Eagerly,
             initialValue = false,
         )
+
+    /**
+     * #603 PR5 — local « super favori » topic ids (ADR-017 decision 5), a client-side pin distinct
+     * from the server `isFavorite`. Eager so the long-press sheet reflects the current state without a
+     * subscription warm-up. Backed by [SuperFavoriteRepository] (its own store, not user prefs).
+     */
+    val superFavoriteTopicIds: StateFlow<Set<Int>> =
+        superFavoriteRepository.observeSuperFavoriteTopicIds()
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.Eagerly,
+                initialValue = emptySet(),
+            )
+
+    /** Toggles the local super-favorite mark of [flag] (long-press sheet). */
+    fun toggleSuperFavorite(flag: Flag) {
+        val enabled = flag.topicId !in superFavoriteTopicIds.value
+        viewModelScope.launch { superFavoriteRepository.setSuperFavorite(flag.topicId, enabled) }
+    }
 
     /**
      * #6 — UI state for the « DT » tab: the user's MultiMP conversations (inbox `cat=prive`,

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -26,6 +26,30 @@
     <!-- État vide d'une recherche sans résultat. %1$s = la requête saisie. -->
     <string name="flags_search_no_results">Aucun drapeau ne correspond à « %1$s »</string>
 
+    <!-- #603 PR5 — bottom sheet d'appui-long sur un drapeau (métadonnées + actions + super-favori). -->
+    <!-- Libellé a11y / long-press de la ligne : ouvre le sheet d'actions (remplace le « Retirer » direct). -->
+    <string name="flags_row_actions_label">Actions du sujet</string>
+    <string name="flags_sheet_open">Ouvrir le sujet</string>
+    <string name="flags_sheet_super_favorite_add">Ajouter aux super-favoris</string>
+    <string name="flags_sheet_super_favorite_remove">Retirer des super-favoris</string>
+    <string name="flags_sheet_copy_link">Copier le lien</string>
+    <string name="flags_sheet_open_browser">Ouvrir dans le navigateur</string>
+    <string name="flags_sheet_remove">Retirer le drapeau</string>
+    <string name="flags_sheet_link_copied">Lien copié</string>
+    <string name="flags_sheet_browser_failed">Aucune application pour ouvrir ce lien</string>
+    <!-- Bloc métadonnées (clés). -->
+    <string name="flags_sheet_meta_category">Catégorie</string>
+    <string name="flags_sheet_meta_author">Créé par</string>
+    <string name="flags_sheet_meta_last_reply">Dernier message</string>
+    <string name="flags_sheet_meta_position">Position</string>
+    <string name="flags_sheet_meta_replies">Réponses</string>
+    <!-- Valeurs métadonnées. %1$s auteur · %2$s date. -->
+    <string name="flags_sheet_meta_last_reply_value">%1$s — %2$s</string>
+    <!-- %1$d page lue · %2$d total. -->
+    <string name="flags_sheet_meta_position_value">page %1$d / %2$d</string>
+    <!-- Suffixe pages à lire, %1$d = nb. -->
+    <string name="flags_sheet_meta_pages_to_read">+%1$d à lire</string>
+
     <!-- Onglet « Super » : écran placeholder M3, futurs super favoris. Pas de fetch réseau. -->
     <string name="flags_super_placeholder_title">Super favoris — à venir</string>
     <string name="flags_super_placeholder_body">Les « super favoris » permettront d\'épingler les sujets les plus importants. Cette vue arrivera dans une prochaine version.</string>
@@ -107,9 +131,8 @@
     <string name="flags_view_settings_unread_only_description">N\'affiche que les sujets avec un message non lu. Propre à cet onglet.</string>
     <string name="flags_view_settings_done">Fermer</string>
 
-    <!-- #99 — Retirer un drapeau (delflag). Action sur chaque ligne + dialog de confirmation
-         obligatoire avant l'appel réseau, puis snackbar de résultat. -->
-    <string name="flags_remove_action">Retirer</string>
+    <!-- #99 — Retirer un drapeau (delflag) : action du sheet d'appui-long (#603 PR5) + dialog de
+         confirmation obligatoire avant l'appel réseau, puis snackbar de résultat. -->
     <string name="flags_remove_dialog_title">Retirer le drapeau ?</string>
     <!-- %1$s = titre du topic, %2$s = libellé du type de drapeau (Mes sujets / Lus uniquement / Favoris). -->
     <string name="flags_remove_dialog_message">Retirer le drapeau « %2$s » sur « %1$s » ? Cette action est définitive depuis l\'app.</string>

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagTopicUrlTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagTopicUrlTest.kt
@@ -1,0 +1,43 @@
+package fr.forumhfr.redface2.feature.flags
+
+import fr.forumhfr.redface2.core.model.Flag
+import fr.forumhfr.redface2.core.model.FlagType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Covers the pure [flagTopicUrl] builder (#603 PR5). */
+class FlagTopicUrlTest {
+
+    @Test
+    fun `builds the forum2 permalink resuming at the last-read page`() {
+        assertEquals(
+            "https://forum.hardware.fr/forum2.php?config=hfr.inc&cat=13&post=35395&page=412",
+            flagTopicUrl(flag(cat = 13, topicId = 35395, lastReadPage = 412)),
+        )
+    }
+
+    @Test
+    fun `coerces a missing last-read page (0) to page 1`() {
+        assertEquals(
+            "https://forum.hardware.fr/forum2.php?config=hfr.inc&cat=1&post=2&page=1",
+            flagTopicUrl(flag(cat = 1, topicId = 2, lastReadPage = 0)),
+        )
+    }
+
+    private fun flag(cat: Int, topicId: Int, lastReadPage: Int): Flag = Flag(
+        cat = cat,
+        subcat = null,
+        topicId = topicId,
+        title = "T",
+        totalPages = 1,
+        replyCount = 0,
+        type = FlagType.CYAN,
+        isFavorite = false,
+        hasUnread = true,
+        lastReadPage = lastReadPage,
+        lastPostReadId = null,
+        firstPostAuthor = "op",
+        lastReplyAuthor = "last",
+        lastReplyAt = "2026-06-24 12:00",
+    )
+}

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -21,6 +21,7 @@ import fr.forumhfr.redface2.core.domain.preferences.AccentColor
 import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
+import fr.forumhfr.redface2.core.domain.preferences.SuperFavoriteRepository
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
@@ -1994,6 +1995,23 @@ class FlagsViewModelTest {
         override fun instant(): Instant = now
     }
 
+    @Test
+    fun `toggleSuperFavorite adds then removes the topic in the local store`() = runTest {
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository()
+        val auth = FakeAuthRepository(AuthState.Anonymous, flagRepository = flags)
+        val vm = viewModel(auth, flags, forum)
+        val flag = stubFlag(42, FlagType.CYAN)
+
+        vm.toggleSuperFavorite(flag)
+        advanceUntilIdle()
+        assertTrue(42 in vm.superFavoriteTopicIds.value)
+
+        vm.toggleSuperFavorite(flag)
+        advanceUntilIdle()
+        assertFalse(42 in vm.superFavoriteTopicIds.value)
+    }
+
     @Suppress("LongParameterList") // test fake-builder: each repo fake is an independent collaborator
     private fun viewModel(
         auth: FakeAuthRepository,
@@ -2002,7 +2020,8 @@ class FlagsViewModelTest {
         prefs: FakeUserPreferencesRepository = FakeUserPreferencesRepository(),
         messages: FakeMessagesRepository = FakeMessagesRepository(),
         mpStorage: FakeMpStorageRepository = FakeMpStorageRepository(),
-    ): FlagsViewModel = FlagsViewModel(auth, flags, forum, prefs, messages, mpStorage, fixedClock)
+        superFavorite: SuperFavoriteRepository = FakeSuperFavoriteRepository(),
+    ): FlagsViewModel = FlagsViewModel(auth, flags, forum, prefs, superFavorite, messages, mpStorage, fixedClock)
 
     /** Builds a ViewModel with a custom [clock] for the #378 throttle tests; everything else is a
      * fresh default fake. */
@@ -2015,10 +2034,20 @@ class FlagsViewModelTest {
         flags,
         FakeForumRepository(),
         FakeUserPreferencesRepository(),
+        FakeSuperFavoriteRepository(),
         FakeMessagesRepository(),
         FakeMpStorageRepository(),
         clock,
     )
+
+    /** In-memory [SuperFavoriteRepository] (#603 PR5) — the local super-favorite set. */
+    private class FakeSuperFavoriteRepository : SuperFavoriteRepository {
+        private val ids = MutableStateFlow<Set<Int>>(emptySet())
+        override fun observeSuperFavoriteTopicIds(): Flow<Set<Int>> = ids.asStateFlow()
+        override suspend fun setSuperFavorite(topicId: Int, enabled: Boolean) {
+            ids.value = if (enabled) ids.value + topicId else ids.value - topicId
+        }
+    }
 
     /** Flattens whatever content shape into the topics order for assertions on flag content. */
     private fun flatTopics(state: FlagsListUiState.Success): List<Flag> =


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

**PR5 du chantier #603** (ADR-017 décision 6). L'appui-long d'un drapeau ouvre un **bottom sheet
riche** au lieu du retrait direct.

## Contenu
- **`SuperFavoriteRepository`** (core/domain) + **`DataStoreSuperFavoriteRepository`** (core/data) :
  store **local** des super-favoris (`Set<Int>`), réutilise le DataStore `@UserPreferencesDataStore`
  sous une clé dédiée. **Repo séparé** (pas de méthode ajoutée à `UserPreferencesRepository` → aucun
  fake de prefs cassé). Tolérant à une entrée corrompue. Testé.
- **`FlagActionsSheet`** : en-tête (marqueur + titre + catégorie · position) ; **métadonnées API**
  (catégorie, créateur, dernier répondant + date, position + pages à lire, réponses) ; actions
  **Ouvrir · Super favori (toggle) · Copier le lien · Ouvrir navigateur · Retirer**. **Pas de choix de couleur.**
- **`FlagTopicUrl`** : builder d'URL `forum2.php` (pur, testé) pour copier/ouvrir.
- **VM** : `superFavoriteTopicIds` (StateFlow eager) + `toggleSuperFavorite`, testés.
- **`FlagsRoute`** : long-press → ouvre le sheet (`onLongPressFlag`) ; le **retrait** passe toujours
  par le **dialog de confirmation** existant. `sheetFlag` reset au changement d'onglet / perte d'auth.
- 4 icônes Material Symbols officielles (star, delete, content_copy, open_in_new).

## Vérif
- Tests (store add/remove/idempotent/corruption, URL, VM toggle) + `detektAll` + `lintDebug` +
  **`:app:assembleProdDebug`** (graphe Hilt du nouveau binding) **verts**.
- Review **Codex** (gpt-5.5/xhigh) : **GO** ; fix de cohérence a11y appliqué (customAction respecte
  `removalInFlight`). Angle mort noté (non bloquant) : toggle non-atomique en cas de double-tap
  ultra-rapide — store idempotent, action issue d'un sheet (pas spam-friendly).

## Différé (noté)
Onglet « Super » alimenté par ces super-favoris (affichage) → ultérieur ; `markerStyle` PASTILLE/DOT
configurable → PR6.

Chantier : #603. Branché sur `origin/dev` (contient PR0→PR3 + fix review).
