### PR TITLE
feat(#603): PR6 — menu config rapide + markerStyle de bout en bout

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -445,6 +445,18 @@ private fun StartScreenChoice.toTopLevelDestination(): TopLevelDestination = whe
     StartScreenChoice.MESSAGES -> TopLevelDestination.Messages
 }
 
+// #603 PR6 — a re-tap of the already-selected Drapeaux tab opens its quick-config sheet
+// ([onReselectFlags]); every other tap switches destination ([onSwitch]). Extracted from RedfaceApp's
+// bottom-bar item onClick to keep that composable's cyclomatic complexity in budget.
+private fun onTopLevelTap(
+    tapped: TopLevelDestination,
+    current: TopLevelDestination,
+    onReselectFlags: () -> Unit,
+    onSwitch: () -> Unit,
+) {
+    if (current == tapped && tapped == TopLevelDestination.Flags) onReselectFlags() else onSwitch()
+}
+
 /** #313 — badge cap : beyond this the badge shows « 9+ » (page-1 proxy, cf. MpUnreadBadgeViewModel). */
 private const val MAX_BADGE_COUNT = 9
 
@@ -648,6 +660,13 @@ fun RedfaceApp(intent: Intent?) {
             mutableStateOf(startScreen.screen.toTopLevelDestination())
         }
 
+        // #603 PR6 — re-tap of the already-selected Drapeaux tab raises this counter; threaded to
+        // FlagsRoute, which opens its quick-config sheet on each increment. Deliberately a plain
+        // `remember` (NOT rememberSaveable): a saved non-zero counter would re-open the sheet after a
+        // config change without a new tap (Codex review). Resetting to 0 on recreation is the safe
+        // event semantics — a tap mid-rotation is a negligible loss.
+        var flagsQuickConfigRequest by remember { mutableStateOf(0) }
+
         // Phase 2 finish (#208) — profile bottom sheet state, hoisted to `:app` so that
         // `:feature:topic` never depends on `:feature:profile`. The sheet is opened from
         // any TopicScreen tap on an avatar/author with a non-null profileId.
@@ -827,7 +846,16 @@ fun RedfaceApp(intent: Intent?) {
                 TopLevelDestination.entries.forEach { destination ->
                     item(
                         selected = currentDestination == destination,
-                        onClick = { currentDestination = destination },
+                        onClick = {
+                            // #603 PR6 — re-tap of the already-selected Drapeaux tab opens its
+                            // quick-config sheet (counter bump); any other tap switches destination.
+                            onTopLevelTap(
+                                tapped = destination,
+                                current = currentDestination,
+                                onReselectFlags = { flagsQuickConfigRequest++ },
+                                onSwitch = { currentDestination = destination },
+                            )
+                        },
                         icon = {
                             TopLevelDestinationIcon(
                                 destination = destination,
@@ -864,6 +892,7 @@ fun RedfaceApp(intent: Intent?) {
                     RedfaceNavHost(
                         backStack = activeBackStack,
                         accountMenu = accountMenu,
+                        flagsQuickConfigRequest = flagsQuickConfigRequest,
                         onReportContent = {
                             startReportEmail(context, reportEmailSubject, reportNoEmailClient)
                         },
@@ -1488,6 +1517,8 @@ internal fun Map<TopicTitleKey, String>.withTitle(key: TopicTitleKey, title: Str
 private fun RedfaceNavHost(
     backStack: NavBackStack<NavKey>,
     accountMenu: @Composable () -> Unit,
+    // #603 PR6 — increments on each Drapeaux-tab re-tap; FlagsRoute opens its quick-config sheet on change.
+    flagsQuickConfigRequest: Int,
     // #494 — the « Signaler un contenu » row of the settings Account/About sub-page reuses the same
     // report-email flow as the account menu (which owns `context` + the report strings).
     onReportContent: () -> Unit,
@@ -1574,6 +1605,7 @@ private fun RedfaceNavHost(
                         }
                         backStack.add(PrivateMessageThreadRoute(threadId = threadId, page = page))
                     },
+                    quickConfigRequest = flagsQuickConfigRequest,
                     topBarActions = accountMenu,
                 )
             }

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -13,6 +13,7 @@ import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
+import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
@@ -174,6 +175,15 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         persist {
             dataStore.edit { prefs ->
                 prefs[flagsUnreadOnlyKey(type)] = enabled
+            }
+        }
+    }
+
+    override suspend fun setFlagsMarkerStyle(style: MarkerStyle) {
+        // #603 PR6 — GLOBAL: a single key, no per-type variant. Persisted by name, read defensively.
+        persist {
+            dataStore.edit { prefs ->
+                prefs[KEY_FLAGS_MARKER_STYLE] = style.name
             }
         }
     }
@@ -686,19 +696,34 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         val globalHide = prefs[KEY_FLAGS_HIDE_READ_CATEGORIES] ?: false
         // #317 — unreadOnly is always per-type with a type-aware default (CYAN actionable by default).
         val unreadOnly = prefs[flagsUnreadOnlyKey(type)] ?: defaultUnreadOnly(type)
+        // #603 PR6 — marker shape is GLOBAL: resolved once, added to both return paths regardless of
+        // the per-tab override.
+        val markerStyle = readMarkerStyle(prefs)
         if (prefs[KEY_FLAGS_PER_TAB_OVERRIDE] != true) {
             return FlagsViewSettings(
                 groupByCategory = globalGroup,
                 hideReadCategories = globalHide,
                 unreadOnly = unreadOnly,
+                markerStyle = markerStyle,
             )
         }
         return FlagsViewSettings(
             groupByCategory = prefs[flagsGroupByCategoryKey(type)] ?: globalGroup,
             hideReadCategories = prefs[flagsHideReadCategoriesKey(type)] ?: globalHide,
             unreadOnly = unreadOnly,
+            markerStyle = markerStyle,
         )
     }
+
+    /**
+     * Reads [KEY_FLAGS_MARKER_STYLE] defensively (#603 PR6): an unknown / corrupt stored value falls
+     * back to [MarkerStyle.STRIPE] instead of crashing on `MarkerStyle.valueOf` — same stance as the
+     * theme / density / accent enum reads.
+     */
+    private fun readMarkerStyle(prefs: Preferences): MarkerStyle =
+        prefs[KEY_FLAGS_MARKER_STYLE]
+            ?.let { stored -> runCatching { MarkerStyle.valueOf(stored) }.getOrNull() }
+            ?: MarkerStyle.STRIPE
 
     /**
      * Type-aware default for the #317 « non-lus uniquement » filter: CYAN (« Mes sujets ») shows the
@@ -724,6 +749,9 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         val KEY_IGNORE_TOPIC_CACHE = booleanPreferencesKey("ignore_topic_cache")
         val KEY_FLAGS_GROUP_BY_CATEGORY = booleanPreferencesKey("flags_group_by_category")
         val KEY_FLAGS_HIDE_READ_CATEGORIES = booleanPreferencesKey("flags_hide_read_categories")
+        // #603 PR6 — GLOBAL Drapeaux marker shape (MarkerStyle.name, defensively parsed). No per-type
+        // variant: one shape for every tab, independent of the #309 per-tab override.
+        val KEY_FLAGS_MARKER_STYLE = stringPreferencesKey("flags_marker_style")
         // #309 — per-tab display override. The master switch plus one nullable key per FlagType for
         // each toggle; absence of a per-type key means « fall back to the global value ». Keys are
         // derived from the stable enum name (cyan/red/favorite), e.g. `flags_group_by_category_cyan`.

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -10,6 +10,7 @@ import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.AccentColor
 import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
+import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
@@ -379,6 +380,41 @@ class DataStoreUserPreferencesRepositoryTest {
         // FAVORITE untouched → still its type-aware default (false).
         repository.observeFlagsViewSettings(FlagType.FAVORITE).test {
             assertFalse("FAVORITE keeps its default, no cross-type leak", awaitItem().unreadOnly)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `markerStyle defaults to STRIPE on an empty store`() = runTest(dispatcher) {
+        repository.observeFlagsViewSettings(FlagType.CYAN).test {
+            assertEquals(MarkerStyle.STRIPE, awaitItem().markerStyle)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setFlagsMarkerStyle persists and round-trips PASTILLE then DOT for every tab`() = runTest(dispatcher) {
+        // GLOBAL: written once, observed on any tab type.
+        repository.setFlagsMarkerStyle(MarkerStyle.PASTILLE)
+        repository.observeFlagsViewSettings(FlagType.RED).test {
+            assertEquals(MarkerStyle.PASTILLE, awaitItem().markerStyle)
+            cancelAndIgnoreRemainingEvents()
+        }
+        repository.setFlagsMarkerStyle(MarkerStyle.DOT)
+        repository.observeFlagsViewSettings(FlagType.FAVORITE).test {
+            assertEquals(MarkerStyle.DOT, awaitItem().markerStyle)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `corrupt flags_marker_style value falls back to STRIPE instead of crashing`() = runTest(dispatcher) {
+        // A value from an older build / manual edit that no longer maps to a MarkerStyle must not
+        // crash observeFlagsViewSettings on MarkerStyle.valueOf — it degrades to STRIPE.
+        dataStore.edit { prefs -> prefs[stringPreferencesKey("flags_marker_style")] = "WAVY" }
+
+        repository.observeFlagsViewSettings(FlagType.CYAN).test {
+            assertEquals(MarkerStyle.STRIPE, awaitItem().markerStyle)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -14,6 +14,7 @@ import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
+import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
@@ -536,6 +537,7 @@ class TopicRepositoryImplTest {
         override suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean) = Unit
 
         override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) = Unit
+        override suspend fun setFlagsMarkerStyle(style: MarkerStyle) = Unit
 
         // #286 — theme prefs are irrelevant to TopicRepositoryImpl; stubbed at their defaults.
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FlagsViewSettings.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FlagsViewSettings.kt
@@ -31,4 +31,7 @@ data class FlagsViewSettings(
     val groupByCategory: Boolean = true,
     val hideReadCategories: Boolean = false,
     val unreadOnly: Boolean = false,
+    // #603 PR6 — left-marker shape. GLOBAL (not subject to the per-tab override): one shape for every
+    // tab. Default STRIPE (ADR-017, soberest option). Carried on every resolution path.
+    val markerStyle: MarkerStyle = MarkerStyle.STRIPE,
 )

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -109,6 +109,14 @@ interface UserPreferencesRepository {
     suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean)
 
     /**
+     * Persists the GLOBAL Drapeaux marker shape (#603 PR6). Unlike the #309 layout toggles this is
+     * NOT subject to [observeFlagsPerTabOverride] — one shape for every tab. Surfaced through
+     * [observeFlagsViewSettings] ([FlagsViewSettings.markerStyle]) so the list re-renders without a
+     * refetch. Defaults to [MarkerStyle.STRIPE] until the first call.
+     */
+    suspend fun setFlagsMarkerStyle(style: MarkerStyle)
+
+    /**
      * App theme selection (#286): [ThemeMode.SYSTEM] (default) follows the OS dark-mode setting;
      * [ThemeMode.LIGHT] / [ThemeMode.DARK] force the app theme regardless of the OS. Observed at the
      * app root ([fr.forumhfr.redface2.navigation.RedfaceApp]) to compute the effective dark theme

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -19,6 +19,7 @@ import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
+import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.ImageUpload
 import fr.forumhfr.redface2.core.domain.upload.ImageUploadReader
@@ -1961,6 +1962,7 @@ class PostEditorViewModelTest {
         override suspend fun setFlagsGroupByCategoryForType(type: FlagType, enabled: Boolean) = Unit
         override suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean) = Unit
         override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) = Unit
+        override suspend fun setFlagsMarkerStyle(style: MarkerStyle) = Unit
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
         override suspend fun setThemeMode(mode: ThemeMode) = Unit
         override fun observeAmoledEnabled(): Flow<Boolean> = MutableStateFlow(false)

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -17,6 +17,7 @@ import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
+import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.smiley.SmileyRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
@@ -1361,6 +1362,7 @@ class TopicFormViewModelTest {
         override suspend fun setFlagsGroupByCategoryForType(type: FlagType, enabled: Boolean) = Unit
         override suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean) = Unit
         override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) = Unit
+        override suspend fun setFlagsMarkerStyle(style: MarkerStyle) = Unit
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
         override suspend fun setThemeMode(mode: ThemeMode) = Unit
         override fun observeAmoledEnabled(): Flow<Boolean> = MutableStateFlow(false)

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -68,6 +68,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
+import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
@@ -81,6 +82,8 @@ import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.formatLastReplyTimestamp
 import fr.forumhfr.redface2.core.ui.icon.RedfaceVectorIcon
 import fr.forumhfr.redface2.core.ui.icon.categoryIcon
+import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsChoice
+import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsChoiceGroup
 import fr.forumhfr.redface2.core.ui.theme.FlagPalette
 import kotlinx.coroutines.launch
 
@@ -111,6 +114,7 @@ import kotlinx.coroutines.launch
 // justified inline at the content lambda usage.
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
+@Suppress("LongParameterList") // Screen route: 4 host nav callbacks + the quick-config trigger + the account slot.
 fun FlagsRoute(
     onOpenFlag: (Flag) -> Unit,
     onLoginRequested: () -> Unit,
@@ -120,6 +124,9 @@ fun FlagsRoute(
     // host decrement the MP unread badge on first read, mirroring the Messages tab's onOpenThread
     // (badge regression: the DT path never reported it, so the badge stayed stuck high).
     onOpenMultiMp: (threadId: Int, page: Int, wasUnread: Boolean) -> Unit = { _, _, _ -> },
+    // #603 PR6 — bumped by the host on each re-tap of the already-selected Drapeaux bottom-bar icon;
+    // opens the quick-config sheet (LaunchedEffect below).
+    quickConfigRequest: Int = 0,
     topBarActions: @Composable (() -> Unit)? = null,
 ) {
     val viewModel: FlagsViewModel = hiltViewModel()
@@ -216,6 +223,13 @@ fun FlagsRoute(
             sheetFlag = null
         }
     }
+
+    // #603 PR6 — open the quick-config sheet on each re-tap of the Drapeaux bottom-bar icon.
+    QuickConfigRequestEffect(
+        request = quickConfigRequest,
+        canConfigure = canConfigureView,
+        onOpen = { showViewSettingsSheet = true },
+    )
 
     DtTabFallbackEffect(
         showDtTab = showDtTab,
@@ -341,6 +355,7 @@ fun FlagsRoute(
                                 dtShowsRead = dtShowsRead,
                                 dtIsRefreshing = dtIsRefreshing,
                                 searchQuery = searchQuery,
+                                markerStyle = flagsViewSettings.markerStyle,
                             ),
                             actions = AuthenticatedActions(
                                 onSelectTab = viewModel::selectTab,
@@ -379,6 +394,7 @@ fun FlagsRoute(
                 onGroupByCategoryChange = viewModel::setFlagsGroupByCategory,
                 onHideReadCategoriesChange = viewModel::setFlagsHideReadCategories,
                 onUnreadOnlyChange = viewModel::setFlagsUnreadOnly,
+                onMarkerStyleChange = viewModel::setFlagsMarkerStyle,
                 onDismiss = { showViewSettingsSheet = false },
             ),
         )
@@ -539,6 +555,40 @@ private fun FlagsViewSettingsSheet(
                 onCheckedChange = actions.onUnreadOnlyChange,
             )
 
+            // #603 PR6 — GLOBAL marker shape selector (segmented). Shown regardless of the per-tab
+            // override (the shape is global); the write routes through the ViewModel and the list
+            // re-renders live underneath.
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = stringResource(R.string.flags_view_settings_marker_title),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = stringResource(R.string.flags_view_settings_marker_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                RedfaceSettingsChoiceGroup(
+                    options = listOf(
+                        RedfaceSettingsChoice(
+                            MarkerStyle.STRIPE,
+                            stringResource(R.string.flags_view_settings_marker_stripe),
+                        ),
+                        RedfaceSettingsChoice(
+                            MarkerStyle.PASTILLE,
+                            stringResource(R.string.flags_view_settings_marker_pastille),
+                        ),
+                        RedfaceSettingsChoice(
+                            MarkerStyle.DOT,
+                            stringResource(R.string.flags_view_settings_marker_dot),
+                        ),
+                    ),
+                    selected = settings.markerStyle,
+                    onSelected = actions.onMarkerStyleChange,
+                )
+            }
+
             TextButton(
                 // Animate the sheet out (M3 stable pattern) before removing it from composition,
                 // instead of an abrupt `if`-driven teardown. Swipe/scrim dismissals already animate
@@ -670,6 +720,17 @@ private fun flagTabEntries(
 // #603 PR4 — thin flat M3 linear progress bar shown only while [loading] (manual or auto refresh of
 // the current tab). Flat (non-wavy) indeterminate indicator; only rendered when loading — the brief
 // appearance under the app bar is the intended cue (ADR-017 decision 7).
+// #603 PR6 — opens the quick-config sheet when [request] increments (a Drapeaux bottom-bar re-tap).
+// Keyed on the counter so each re-tap re-fires; the initial 0 is skipped (no pop on fresh
+// composition) and it only opens when the screen is configurable. Extracted to keep FlagsRoute's
+// cyclomatic complexity in budget.
+@Composable
+private fun QuickConfigRequestEffect(request: Int, canConfigure: Boolean, onOpen: () -> Unit) {
+    LaunchedEffect(request) {
+        if (request > 0 && canConfigure) onOpen()
+    }
+}
+
 @Composable
 private fun FlagsLoadingBar(selectedTab: FlagTab, isRefreshing: Boolean, dtIsRefreshing: Boolean) {
     val loading = if (selectedTab == FlagTab.Dt) dtIsRefreshing else isRefreshing
@@ -875,6 +936,7 @@ private fun FlagListBody(
                             sections = content.sections,
                             selectedTab = selectedTab,
                             removalInFlight = state.removeFlagState is RemoveFlagState.Removing,
+                            markerStyle = state.markerStyle,
                             actions = actions,
                             listState = listState,
                         )
@@ -883,6 +945,7 @@ private fun FlagListBody(
                             flags = content.flags,
                             selectedTab = selectedTab,
                             removalInFlight = state.removeFlagState is RemoveFlagState.Removing,
+                            markerStyle = state.markerStyle,
                             actions = actions,
                             listState = listState,
                         )
@@ -960,10 +1023,12 @@ private const val CONTENT_TYPE_DT_FOOTER = "dt_scan_note"
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
+@Suppress("LongParameterList") // List composable: sections + tab + removal flag + marker + actions + listState.
 private fun CategorySectionedFlagList(
     sections: List<FlagCategorySection>,
     selectedTab: FlagTab,
     removalInFlight: Boolean,
+    markerStyle: MarkerStyle,
     actions: AuthenticatedActions,
     listState: LazyListState,
 ) {
@@ -1025,6 +1090,7 @@ private fun CategorySectionedFlagList(
                         flag = flag,
                         metadata = flagRowMetadata(flag),
                         removalInFlight = removalInFlight,
+                        markerStyle = markerStyle,
                         onClick = { actions.onOpenFlag(flag) },
                         onLongPress = { actions.onLongPressFlag(flag) },
                     )
@@ -1100,10 +1166,12 @@ private fun emptySectionLabel(tab: FlagTab): Int = when (tab) {
  * and accessibility action behave identically to the grouped view.
  */
 @Composable
+@Suppress("LongParameterList") // List composable: flags + tab + removal flag + marker + actions + listState.
 private fun FlatFlagList(
     flags: List<Flag>,
     selectedTab: FlagTab,
     removalInFlight: Boolean,
+    markerStyle: MarkerStyle,
     actions: AuthenticatedActions,
     listState: LazyListState,
 ) {
@@ -1132,6 +1200,7 @@ private fun FlatFlagList(
                     flag = flag,
                     metadata = flagRowMetadata(flag),
                     removalInFlight = removalInFlight,
+                    markerStyle = markerStyle,
                     onClick = { actions.onOpenFlag(flag) },
                     onLongPress = { actions.onLongPressFlag(flag) },
                 )
@@ -1198,10 +1267,12 @@ private fun flagCategoryName(catId: Int): String =
  * `Removing` is only the brief confirm→result window.
  */
 @Composable
+@Suppress("LongParameterList") // Row binding: flag + metadata + removalInFlight + marker style + 2 callbacks.
 private fun RemovableFlagItem(
     flag: Flag,
     metadata: FlagMetadata,
     removalInFlight: Boolean,
+    markerStyle: MarkerStyle,
     onClick: () -> Unit,
     onLongPress: () -> Unit,
 ) {
@@ -1211,6 +1282,7 @@ private fun RemovableFlagItem(
         flag = flag,
         metadata = metadata,
         onClick = onClick,
+        markerStyle = markerStyle,
         longPress = FlagItemLongPress(label = actionsLabel) {
             if (!removalInFlight) onLongPress()
         },
@@ -1627,6 +1699,8 @@ private data class FlagsBodyState(
     val dtIsRefreshing: Boolean,
     /** #603 PR2 — active client-side search query; empty = no filtering. */
     val searchQuery: String = "",
+    /** #603 PR6 — GLOBAL marker shape for the rows (from FlagsViewSettings). */
+    val markerStyle: MarkerStyle = MarkerStyle.STRIPE,
 )
 
 private data class AuthenticatedActions(
@@ -1655,6 +1729,7 @@ private data class FlagsViewSettingsActions(
     val onGroupByCategoryChange: (Boolean) -> Unit,
     val onHideReadCategoriesChange: (Boolean) -> Unit,
     val onUnreadOnlyChange: (Boolean) -> Unit,
+    val onMarkerStyleChange: (MarkerStyle) -> Unit,
     val onDismiss: () -> Unit,
 )
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -11,6 +11,7 @@ import fr.forumhfr.redface2.core.domain.forum.ForumResult
 import fr.forumhfr.redface2.core.domain.messages.MessagesRepository
 import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
+import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
 import fr.forumhfr.redface2.core.domain.preferences.SuperFavoriteRepository
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.model.AuthState
@@ -665,6 +666,12 @@ class FlagsViewModel @Inject constructor(
             userPreferencesRepository.setFlagsPerTabOverride(enabled)
             pendingPerTabOverride.compareAndSet(expect = enabled, update = null)
         }
+    }
+
+    /** Bottom-sheet write for the GLOBAL marker shape (#603 PR6) — one shape for every tab, so no
+     *  per-tab routing (ignores [flagsPerTabOverride]). */
+    fun setFlagsMarkerStyle(style: MarkerStyle) {
+        viewModelScope.launch { userPreferencesRepository.setFlagsMarkerStyle(style) }
     }
 
     fun refresh() {

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -129,6 +129,12 @@
          onglet » ci-dessus). Activé par défaut sur « Mes sujets », désactivé sur Lu et Favoris. -->
     <string name="flags_view_settings_unread_only_title">Non-lus uniquement</string>
     <string name="flags_view_settings_unread_only_description">N\'affiche que les sujets avec un message non lu. Propre à cet onglet.</string>
+    <!-- #603 PR6 — Forme du marqueur de gauche (barre / pastille / point). Réglage GLOBAL (tous onglets). -->
+    <string name="flags_view_settings_marker_title">Marqueur</string>
+    <string name="flags_view_settings_marker_description">Forme de l\'indicateur de couleur à gauche de chaque drapeau. S\'applique à tous les onglets.</string>
+    <string name="flags_view_settings_marker_stripe">Barre</string>
+    <string name="flags_view_settings_marker_pastille">Pastille</string>
+    <string name="flags_view_settings_marker_dot">Point</string>
     <string name="flags_view_settings_done">Fermer</string>
 
     <!-- #99 — Retirer un drapeau (delflag) : action du sheet d'appui-long (#603 PR5) + dialog de

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -20,6 +20,7 @@ import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.AccentColor
 import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
+import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.SuperFavoriteRepository
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
@@ -2248,6 +2249,8 @@ class FlagsViewModelTest {
         // #317 — per-type « non-lus uniquement », null = unset → type-aware default applied at read.
         private val perTypeUnread: Map<FlagType, MutableStateFlow<Boolean?>> =
             FlagType.entries.associateWith { MutableStateFlow<Boolean?>(null) }
+        // #603 PR6 — GLOBAL marker shape (not per-type), surfaced through observeFlagsViewSettings.
+        private val markerStyle = MutableStateFlow(MarkerStyle.STRIPE)
 
         /** When set, holds the persisted master write so a test can prove routing uses the
          * OPTIMISTIC value (the persisted `perTab` never updates while gated). */
@@ -2297,8 +2300,12 @@ class FlagsViewModelTest {
                     global to globalHide
                 }
             }
-            return combine(layout, perTypeUnread.getValue(type)) { (group, hide), unread ->
-                FlagsViewSettings(group, hide, unread ?: defaultUnreadOnly(type))
+            return combine(
+                layout,
+                perTypeUnread.getValue(type),
+                markerStyle,
+            ) { (group, hide), unread, marker ->
+                FlagsViewSettings(group, hide, unread ?: defaultUnreadOnly(type), marker)
             }
         }
 
@@ -2325,6 +2332,10 @@ class FlagsViewModelTest {
                 blockUnreadOnlySetUntil?.await()
             }
             perTypeUnread.getValue(type).value = enabled
+        }
+
+        override suspend fun setFlagsMarkerStyle(style: MarkerStyle) {
+            markerStyle.value = style
         }
 
         // #286 — theme prefs are irrelevant to FlagsViewModel; stubbed at their defaults.

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -10,6 +10,7 @@ import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
+import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
@@ -2020,6 +2021,7 @@ class SettingsViewModelTest {
         override suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean) = Unit
 
         override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) = Unit
+        override suspend fun setFlagsMarkerStyle(style: MarkerStyle) = Unit
 
         fun emit(value: ProxyConfig) {
             config.value = value

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -14,6 +14,7 @@ import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
+import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.topic.NoTopicSearchResultsException
 import fr.forumhfr.redface2.core.domain.topic.TopicRepository
@@ -2044,6 +2045,7 @@ private class FakeUserPreferencesRepository(
     override suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean) = Unit
 
     override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) = Unit
+    override suspend fun setFlagsMarkerStyle(style: MarkerStyle) = Unit
 
     override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
 


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

**PR6 — dernière PR du chantier #603** (ADR-017 décisions 5/8). Menu de config rapide + câblage du
**marqueur de bout en bout**.

## Contenu
- **`markerStyle` GLOBAL câblé end-to-end** : champ `FlagsViewSettings` + clé DataStore (persistée par
  `.name`, lecture défensive → STRIPE) + `setFlagsMarkerStyle` (interface + impl) + résolution dans
  `observeFlagsViewSettings` (les deux chemins override on/off) + setter VM + **threading**
  `FlagsRoute → listes → RemovableFlagItem → FlagItem`. Les 7 test-doubles de l'interface mis à jour.
- **Sélecteur de marqueur** (Barre / Pastille / Point, `RedfaceSettingsChoiceGroup`) ajouté au sheet
  d'affichage existant (#309) — STRIPE/PASTILLE/DOT enfin atteignables en prod.
- **Menu config rapide depuis la bottom bar** : re-tap de l'onglet **Drapeaux déjà sélectionné** →
  ouvre le sheet (compteur threadé `RedfaceApp → RedfaceNavHost → FlagsRoute`, `QuickConfigRequestEffect`).
  **SANS le hide-on-scroll** (déféré). Densité différée (`DisplayDensity` est global, concern séparé).

## Vérif
- Tests : 3 DataStore (défaut STRIPE / round-trip global tous onglets / corrupt → STRIPE) ; les 7 fakes
  compilent (6 no-op + le porteur `FlagsViewModelTest`).
- `detektAll` + `lintDebug` + **`:app:assembleProdDebug`** (graphe Hilt + wiring nav) + tests
  data/flags/editor/topic/settings **verts**.
- Review **Codex** (gpt-5.5/xhigh) : **GO** ; fix appliqué (compteur en `remember` non-saveable → pas
  de réouverture du sheet après rotation).

## Note (non bloquant, à valider)
Re-tap de l'onglet Drapeaux depuis un **sous-écran** (un topic ouvert dans l'onglet) n'est pas un
pop-to-root : le sheet s'ouvrira au retour sur la liste. Comportement conventionnel de pop-to-root =
raffinement possible ultérieur (hors scope PR6).

**Chantier #603 COMPLET** avec cette PR (PR0→PR6 + fix review). Branché sur `origin/dev`.
