### PR TITLE
chore(release): bump versionName 0.17.0 + CHANGELOG + whatsnew (dev #603)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,32 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.0` — `internal` (dev) — 2026-06-25
+
+> Build dev (Play internal « Redface 2 dev » + F-Droid .dev) ; versionCode alloué au dispatch par le
+> registre de tags git. versionName bumpé 0.16.0 → 0.17.0. Chaque PR du payload : review Codex + CI
+> verte ; passe de revue à 4 agents (opus) sur le code mergé, corrections appliquées (#643).
+
+Refonte complète de la **vue Drapeaux** (#603, ADR-017) — 8 PRs.
+
+**Nouveautés**
+
+- **Search app bar** « façon Réglages » : icône drapeau de l'onglet courant (sélecteur d'onglet),
+  barre de recherche (filtre client des drapeaux), photo de profil. Remplace l'ancien header + tab row.
+- **Liste refondue** : marqueur gauche configurable (**barre de couleur** par défaut, pastille à icône,
+  ou point), pastille « pages à lire », en-têtes de catégorie à vraies icônes Material Symbols.
+- **Appui long** sur un drapeau → **bottom sheet** : métadonnées du sujet (créateur, dernier répondant,
+  dates, position, réponses, catégorie), actions (ouvrir, copier le lien, navigateur), **super-favori
+  local**, retrait. Plus de choix de couleur.
+- **Barre de progression** M3 fine sous l'app bar pendant un chargement (manuel **et** auto-refresh).
+- **Menu de config rapide** : re-tap de l'onglet Drapeaux de la barre du bas → réglages d'affichage
+  (groupement, masquer lus, non-lus, **forme du marqueur**).
+
+**Interne** : modèle de présentation pur testé en `:core:model` ; ADR-017 + rapport des 4 spikes.
+
+**Différé** : hide-on-scroll, onglets configurables, densités avancées, indicateur « cité » (aucune
+source serveur — jamais simulé).
+
 ## v179 — `0.16.0` — `open` (beta) — 2026-06-21
 
 > Shippé en bêta (Play open testing « committed » + F-Droid .beta) le 2026-06-21, tag `app-v179`.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.16.0"
+        versionName = "0.17.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,10 +1,10 @@
-Redface 2 v0.16.0 — beta.
+Redface 2 v0.17.0 — dev.
 
-New:
-- DT/MultiMP: the creator can add or remove participants (via a reply).
-- DT: participant list ("Participants" button).
-- Sync DT reading position to MPStorage (optional, off by default).
+Drapeaux view redesign:
+- Search app bar + tab picker.
+- Refonted rows: colour-bar marker (bar/pill/dot), pages-to-read pill, category icons.
+- Long-press sheet: topic metadata, actions, local super-favourite.
+- Thin loading bar (manual and auto refresh).
+- Quick-config: re-tap the Drapeaux tab.
 
-Fix: emojis that truncated a message on send.
-
-Bugs: via the beta or GitHub.
+Bugs: via dev or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,10 +1,10 @@
-Redface 2 v0.16.0 — bêta.
+Redface 2 v0.17.0 — dev.
 
-Nouveautés :
-- DT/MultiMP : le créateur peut ajouter ou retirer des participants (via une réponse).
-- DT : liste des participants (bouton « Participants »).
-- Synchro de la position de lecture des DT vers MPStorage (en option, désactivée par défaut).
+Refonte de la vue Drapeaux :
+- App bar de recherche + sélecteur d'onglet.
+- Lignes refondues : marqueur barre de couleur (barre/pastille/point), pastille « pages à lire », icônes de catégorie.
+- Appui long : métadonnées du sujet, actions, super-favori local.
+- Barre de chargement fine (refresh manuel et auto).
+- Config rapide : re-tape l'onglet Drapeaux.
 
-Correctif : les emojis qui tronquaient un message à l'envoi.
-
-Bugs : via la bêta ou GitHub.
+Bugs : via le canal dev ou GitHub.


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Prépare le **ship dev** de la refonte vue Drapeaux #603 (8 PRs déjà mergées dans `dev`).

- `versionName` **0.16.0 → 0.17.0** (distingue le build dev #603 de la bêta 0.16.0 ; `versionCode` alloué au dispatch par le registre de tags git).
- Entrée `app/CHANGELOG.md` 0.17.0 (résumé #603).
- `whatsnew-fr-FR` / `whatsnew-en-US` rafraîchis (canal dev, ≤500 car.).

Gardes `check-changelog-entry` + `check-whatsnew` **vertes** en local. Après merge : dispatch `release.yml --ref dev -f channel=dev`.

Chantier : #603.