### PR TITLE
feat(flags): palette HFR pure + DT fuchsia, icône drapeau RF2, recherche 1 ligne, nettoyage spinner/gear, stripe pleine hauteur

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
@@ -4,8 +4,10 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -144,6 +146,10 @@ fun ForumListRow(
         modifier = modifier
             .fillMaxWidth()
             .then(rowInteraction)
+            // #603 — IntrinsicSize.Min lets a fillMaxHeight leading marker (the STRIPE « barre de
+            // couleur ») span the row's content height (1- or 2-line title) instead of a fixed 32 dp
+            // that fell short on 2-line titles. Per-row intrinsic pass, negligible cost.
+            .height(IntrinsicSize.Min)
             .padding(horizontal = 16.dp, vertical = m.listRowVertical),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagMarker.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagMarker.kt
@@ -3,8 +3,10 @@ package fr.forumhfr.redface2.core.ui
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -57,8 +59,11 @@ fun FlagMarker(
     val color = if (hasUnread) base else base.copy(alpha = READ_ALPHA)
     when (style) {
         MarkerStyle.STRIPE -> Box(
+            // #603 — the bar spans the row's content height (fillMaxHeight within ForumListRow's
+            // IntrinsicSize.Min) instead of a fixed 32 dp that fell short on 2-line titles.
             modifier = modifier
-                .size(width = 4.dp, height = 32.dp)
+                .fillMaxHeight()
+                .width(4.dp)
                 .clip(RoundedCornerShape(2.dp))
                 .background(color),
         )

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagMarker.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagMarker.kt
@@ -36,6 +36,9 @@ private const val PASTILLE_BG_ALPHA = 0.18f
  * read); only the SHAPE varies with [style]:
  *
  * - [MarkerStyle.STRIPE] — a thin vertical color bar (the default, frees the most title width).
+ *   IMPORTANT: STRIPE uses `fillMaxHeight` to span the row, so it MUST sit in a bounded-height parent
+ *   (e.g. [ForumListRow]'s `IntrinsicSize.Min` Row). In an unbounded-height context it would stretch
+ *   to fill all available height — wrap it in `Modifier.height(IntrinsicSize.Min)` or give it a height.
  * - [MarkerStyle.PASTILLE] — a tonal circle carrying the category glyph ([categoryIconRes]).
  * - [MarkerStyle.DOT] — the legacy minimal colored dot.
  *

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/FlagPalette.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/FlagPalette.kt
@@ -4,9 +4,10 @@ import androidx.compose.ui.graphics.Color
 import fr.forumhfr.redface2.core.model.FlagType
 
 /**
- * Drapeau bucket palette. The colors mirror the legacy HFR palette
- * (`flag1.gif` cyan / `flag0.gif` red / `favoris.gif` yellow) so a user reading the
- * forum on the web and on Redface 2 sees the same visual mapping :
+ * Drapeau bucket palette. The colors are the EXACT fill values of the legacy HFR flag gifs
+ * (`flag1.gif` cyan `#00FFFF` / `flag0.gif` red `#FF0000` / `favoris.gif` yellow `#F0F83F`, relevés
+ * sur les gifs réels), so a user reading the forum on the web and on Redface 2 sees the same colors,
+ * not just the same hue mapping :
  *
  * - [FlagType.CYAN] → cyan, sujets participés
  * - [FlagType.RED] → rouge, lus uniquement
@@ -20,9 +21,17 @@ import fr.forumhfr.redface2.core.model.FlagType
  */
 object FlagPalette {
 
-    val Cyan: Color = Color(0xFF00BCD4)
-    val Red: Color = Color(0xFFD32F2F)
-    val Favorite: Color = Color(0xFFF9A825)
+    val Cyan: Color = Color(0xFF00FFFF)
+    val Red: Color = Color(0xFFFF0000)
+    val Favorite: Color = Color(0xFFF0F83F)
+
+    /**
+     * #603 — the « DT » (MultiMP) bucket marker. Fuchsia completes the pure cyan/red trio with the
+     * CGA/EGA magenta primary (`#FF00FF`), assorti aux fills purs des gifs HFR. DT is NOT a [FlagType]
+     * (it is an opt-in tab fed by MPStorage #6), so this color is read directly by the app-bar tab
+     * indicator / picker, never via [colorFor].
+     */
+    val Dt: Color = Color(0xFFFF00FF)
 
     /**
      * Resolves the bucket color for a non-null [FlagType]. Plain Kotlin function — not

--- a/core/ui/src/main/res/drawable/ic_rf2_flag.xml
+++ b/core/ui/src/main/res/drawable/ic_rf2_flag.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- RF2 brand flag (drapeau cyan du launcher), pixel-art silhouette vectorisée pour
+     l'icône du picker d'onglet Drapeaux (#603). Mono-couleur => tintable (tint = couleur d'onglet). -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="22"
+    android:viewportHeight="22">
+    <path android:fillColor="#FF000000" android:pathData="M0,0h4v1h-4zM9,0h4v1h-4zM0,1h4v1h-4zM9,1h4v1h-4zM0,2h22v1h-22zM0,3h22v1h-22zM2,4h18v1h-18zM2,5h18v1h-18zM2,6h18v1h-18zM2,7h16v1h-16zM2,8h16v1h-16zM4,9h11v1h-11zM4,10h11v1h-11zM4,11h7v1h-7zM4,12h7v1h-7zM6,13h3v1h-3zM6,14h3v1h-3zM6,15h3v1h-3zM6,16h3v1h-3zM7,17h2v1h-2zM9,18h2v1h-2zM9,19h2v1h-2zM9,20h2v1h-2zM9,21h2v1h-2z" />
+</vector>

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/FlagItemRefonteRoborazziTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/FlagItemRefonteRoborazziTest.kt
@@ -2,8 +2,10 @@ package fr.forumhfr.redface2.core.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -56,7 +58,11 @@ class FlagItemRefonteRoborazziTest {
             FlagItemDivider()
             // The three marker styles on the same unread cyan topic.
             Row(
-                modifier = Modifier.padding(16.dp),
+                // #603 — STRIPE marker is now fillMaxHeight; bound it with IntrinsicSize.Min so the
+                // standalone showcase row sizes to the tallest marker (PASTILLE), not the screen.
+                modifier = Modifier
+                    .padding(16.dp)
+                    .height(IntrinsicSize.Min),
                 horizontalArrangement = Arrangement.spacedBy(24.dp),
             ) {
                 MarkerStyle.entries.forEach { style ->

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -320,21 +319,20 @@ fun FlagsRoute(
                     onSelectTab = viewModel::selectTab,
                     onQueryChange = { searchQuery = it },
                     onSearchActiveChange = { searchActive = it },
-                    onOpenViewSettings = if (canConfigureView) {
-                        { showViewSettingsSheet = true }
-                    } else {
-                        null
-                    },
                     accountMenu = { topBarActions?.invoke() },
                 )
 
-                // #603 PR4 — thin, flat (non-wavy) M3 progress bar under the app bar, shown during any
-                // load of the current tab: manual pull-to-refresh AND auto-refresh — the auto-refresh
-                // finally gets a visual (ADR-017 decision 7; signal = the existing isRefreshing).
+                // #603 — thin, flat (non-wavy) M3 progress bar under the app bar, shown during any load
+                // of the current tab: manual pull-to-refresh, auto-refresh AND the initial cold load —
+                // it is now the single loading cue (the central spinner was retired). ADR-017 decision 7.
                 FlagsLoadingBar(
-                    selectedTab = selectedTab,
-                    isRefreshing = isRefreshing,
-                    dtIsRefreshing = dtIsRefreshing,
+                    loading = flagsLoadingBarVisible(
+                        selectedTab = selectedTab,
+                        flagsState = flagsState,
+                        isRefreshing = isRefreshing,
+                        dtListState = dtListState,
+                        dtIsRefreshing = dtIsRefreshing,
+                    ),
                 )
 
                 // Render nothing while authState is null (cookie jar warming up). Same
@@ -659,14 +657,15 @@ private fun flagTabLabel(tab: FlagTab): Int = when (tab) {
     FlagTab.Dt -> R.string.flags_tab_dt
 }
 
-// #603 PR2 — flag color of the current tab for the app-bar indicator glyph; the Super/DT placeholders
-// have no flag color so they fall back to a neutral on-surface tint.
+// #603 PR2 — flag color of the current tab for the app-bar indicator glyph. DT (MultiMP) uses fuchsia
+// (#603 polish, the 4th flag color); only the Super placeholder falls back to a neutral on-surface tint.
 @Composable
-private fun flagTabColor(tab: FlagTab): Color = when (tab.flagType) {
-    FlagType.CYAN -> FlagPalette.Cyan
-    FlagType.RED -> FlagPalette.Red
-    FlagType.FAVORITE -> FlagPalette.Favorite
-    null -> MaterialTheme.colorScheme.onSurfaceVariant
+private fun flagTabColor(tab: FlagTab): Color = when (tab) {
+    FlagTab.Cyan -> FlagPalette.Cyan
+    FlagTab.Red -> FlagPalette.Red
+    FlagTab.Favorite -> FlagPalette.Favorite
+    FlagTab.Dt -> FlagPalette.Dt
+    FlagTab.Super -> MaterialTheme.colorScheme.onSurfaceVariant
 }
 
 // #603 PR2 — app-bar tab entries, or an empty list when anonymous (no flags ⇒ the flag glyph is a
@@ -709,7 +708,7 @@ private fun flagTabEntries(
                 FlagTabEntry(
                     FlagTab.Dt,
                     stringResource(R.string.flags_tab_dt) + if (dtShowsRead) readSuffix else "",
-                    neutral,
+                    FlagPalette.Dt,
                 ),
             )
         }
@@ -731,9 +730,24 @@ private fun QuickConfigRequestEffect(request: Int, canConfigure: Boolean, onOpen
     }
 }
 
+// #603 — the top loading bar is shown during a refresh OR the INITIAL load (no content yet) of the
+// current tab, so the central CircularProgressIndicator could be retired: the bar is the single loading
+// cue (manual + auto refresh + cold load). Plain function (no composition) — keeps FlagsRoute's
+// cyclomatic complexity in budget.
+private fun flagsLoadingBarVisible(
+    selectedTab: FlagTab,
+    flagsState: FlagsListUiState?,
+    isRefreshing: Boolean,
+    dtListState: DtListUiState,
+    dtIsRefreshing: Boolean,
+): Boolean = when (selectedTab) {
+    FlagTab.Dt -> dtIsRefreshing || dtListState is DtListUiState.Loading
+    FlagTab.Super -> false
+    else -> isRefreshing || flagsState == null || flagsState == FlagsListUiState.Loading
+}
+
 @Composable
-private fun FlagsLoadingBar(selectedTab: FlagTab, isRefreshing: Boolean, dtIsRefreshing: Boolean) {
-    val loading = if (selectedTab == FlagTab.Dt) dtIsRefreshing else isRefreshing
+private fun FlagsLoadingBar(loading: Boolean) {
     if (loading) {
         LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
     }
@@ -874,13 +888,13 @@ private fun FlagListBody(
     ) {
         when (val current = state.flagsState) {
             null, FlagsListUiState.Loading -> Box(
+                // #603 — central spinner retired: the top FlagsLoadingBar is now the single loading cue
+                // (it covers the initial load too). An empty but scrollable box keeps the surrounding
+                // PullToRefreshBox a swipe target (#229).
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(vertical = 32.dp),
-                contentAlignment = Alignment.Center,
-            ) {
-                CircularProgressIndicator()
-            }
+                    .verticalScroll(rememberScrollState()),
+            )
 
             is FlagsListUiState.Failure -> Column(
                 // #229 — scrollable so the PullToRefreshBox still captures a swipe-to-refresh
@@ -1403,13 +1417,12 @@ private fun DtListBody(state: DtListUiState, isRefreshing: Boolean, actions: Aut
 private fun DtListContent(state: DtListUiState, actions: AuthenticatedActions) {
     when (state) {
         DtListUiState.Loading -> Box(
+            // #603 — central spinner retired (cf. FlagListBody); the top FlagsLoadingBar covers the DT
+            // initial load too. Empty but scrollable so the PullToRefreshBox keeps a target (#229).
             modifier = Modifier
                 .fillMaxSize()
-                .padding(vertical = 32.dp),
-            contentAlignment = Alignment.Center,
-        ) {
-            CircularProgressIndicator()
-        }
+                .verticalScroll(rememberScrollState()),
+        )
 
         DtListUiState.Empty -> DtMessageBody(text = stringResource(R.string.flags_dt_empty))
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -326,9 +326,11 @@ fun FlagsRoute(
                 // of the current tab: manual pull-to-refresh, auto-refresh AND the initial cold load —
                 // it is now the single loading cue (the central spinner was retired). ADR-017 decision 7.
                 FlagsLoadingBar(
-                    loading = flagsLoadingBarVisible(
+                    // Anonymous gate: when not authenticated, flagsState stays null and we must NOT show
+                    // the bar over the « Se connecter » prompt (Codex review #648) — short-circuit here
+                    // so the helper stays at 5 params (detekt LongParameterList).
+                    loading = authState is AuthState.Authenticated && flagsLoadingBarVisible(
                         selectedTab = selectedTab,
-                        isAuthenticated = authState is AuthState.Authenticated,
                         flagsState = flagsState,
                         isRefreshing = isRefreshing,
                         dtListState = dtListState,
@@ -735,23 +737,19 @@ private fun QuickConfigRequestEffect(request: Int, canConfigure: Boolean, onOpen
 // current tab, so the central CircularProgressIndicator could be retired: the bar is the single loading
 // cue (manual + auto refresh + cold load). Plain function (no composition) — keeps FlagsRoute's
 // cyclomatic complexity in budget.
+// NB: the anonymous gate (`authState is Authenticated`) lives at the CALL SITE — when anonymous,
+// flagsState stays null and this would otherwise keep the bar up forever over the « Se connecter »
+// prompt (Codex review #648). Kept at 5 params here (detekt LongParameterList threshold = 6).
 private fun flagsLoadingBarVisible(
     selectedTab: FlagTab,
-    isAuthenticated: Boolean,
     flagsState: FlagsListUiState?,
     isRefreshing: Boolean,
     dtListState: DtListUiState,
     dtIsRefreshing: Boolean,
-): Boolean {
-    // Authenticated-screen affordance only: when anonymous, flagsState stays null and the AnonymousBody
-    // (login prompt) is shown — without this gate `flagsState == null` would keep the bar up forever on
-    // the « Se connecter » screen (Codex review #648).
-    if (!isAuthenticated) return false
-    return when (selectedTab) {
-        FlagTab.Dt -> dtIsRefreshing || dtListState is DtListUiState.Loading
-        FlagTab.Super -> false
-        else -> isRefreshing || flagsState == null || flagsState == FlagsListUiState.Loading
-    }
+): Boolean = when (selectedTab) {
+    FlagTab.Dt -> dtIsRefreshing || dtListState is DtListUiState.Loading
+    FlagTab.Super -> false
+    else -> isRefreshing || flagsState == null || flagsState == FlagsListUiState.Loading
 }
 
 @Composable

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -328,6 +328,7 @@ fun FlagsRoute(
                 FlagsLoadingBar(
                     loading = flagsLoadingBarVisible(
                         selectedTab = selectedTab,
+                        isAuthenticated = authState is AuthState.Authenticated,
                         flagsState = flagsState,
                         isRefreshing = isRefreshing,
                         dtListState = dtListState,
@@ -736,14 +737,21 @@ private fun QuickConfigRequestEffect(request: Int, canConfigure: Boolean, onOpen
 // cyclomatic complexity in budget.
 private fun flagsLoadingBarVisible(
     selectedTab: FlagTab,
+    isAuthenticated: Boolean,
     flagsState: FlagsListUiState?,
     isRefreshing: Boolean,
     dtListState: DtListUiState,
     dtIsRefreshing: Boolean,
-): Boolean = when (selectedTab) {
-    FlagTab.Dt -> dtIsRefreshing || dtListState is DtListUiState.Loading
-    FlagTab.Super -> false
-    else -> isRefreshing || flagsState == null || flagsState == FlagsListUiState.Loading
+): Boolean {
+    // Authenticated-screen affordance only: when anonymous, flagsState stays null and the AnonymousBody
+    // (login prompt) is shown — without this gate `flagsState == null` would keep the bar up forever on
+    // the « Se connecter » screen (Codex review #648).
+    if (!isAuthenticated) return false
+    return when (selectedTab) {
+        FlagTab.Dt -> dtIsRefreshing || dtListState is DtListUiState.Loading
+        FlagTab.Super -> false
+        else -> isRefreshing || flagsState == null || flagsState == FlagsListUiState.Loading
+    }
 }
 
 @Composable

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsSearchAppBar.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsSearchAppBar.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.ui.icon.RedfaceVectorIcon
 import fr.forumhfr.redface2.core.ui.R as CoreUiR
@@ -52,21 +53,21 @@ data class FlagTabEntry(val tab: FlagTab, val label: String, val color: Color)
  *   exactly like the old re-tap, since it routes back through the same `onSelectTab`.
  * - **center** : a search pill that expands to an inline filter of the loaded flags
  *   ([filterFlagsByQuery]) — HFR has no server search, the flags are already in hand.
- * - **right** : the display-settings action (when configurable) + the shared account menu (whose
- *   avatar doubles as the « photo de profil » of the vision).
+ * - **right** : the shared account menu (whose avatar doubles as the « photo de profil » of the
+ *   vision). The display-settings gear was retired (#603 polish) — the quick-config sheet is now
+ *   opened by re-tapping the Drapeaux bottom-bar icon (#603 PR6), so a duplicate header trigger is gone.
  *
  * The scroll-coupled translucency (elevated app bar + content gliding underneath) is intentionally
  * NOT wired here: it belongs to the deferred scroll-chrome work (cf. the hide-on-scroll deferral),
  * so PR2 keeps the simple top-of-column layout and ships the structure + interactions first.
  */
 @Composable
-@Suppress("LongParameterList") // App-bar API: state + 3 callbacks + optional action + the @Composable account slot.
+@Suppress("LongParameterList") // App-bar API: state + 3 callbacks + the @Composable account slot + modifier.
 fun FlagsSearchAppBar(
     state: FlagsAppBarState,
     onSelectTab: (FlagTab) -> Unit,
     onQueryChange: (String) -> Unit,
     onSearchActiveChange: (Boolean) -> Unit,
-    onOpenViewSettings: (() -> Unit)?,
     accountMenu: @Composable () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -89,22 +90,6 @@ fun FlagsSearchAppBar(
                 onActiveChange = onSearchActiveChange,
                 modifier = Modifier.weight(1f),
             )
-            onOpenViewSettings?.let { open ->
-                val viewSettingsLabel = stringResource(R.string.flags_view_settings_action)
-                IconButton(
-                    onClick = open,
-                    modifier = Modifier.semantics { contentDescription = viewSettingsLabel },
-                ) {
-                    // U+FE0E pins the monochrome gear glyph (ForbiddenImport bans material icons),
-                    // matching the legacy header's affordance until it migrates to the bottom-bar
-                    // quick-config (#603 PR6).
-                    Text(
-                        text = "⚙︎",
-                        style = MaterialTheme.typography.titleLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
             accountMenu()
         }
     }
@@ -133,7 +118,9 @@ private fun FlagTabPickerButton(
             enabled = tabs.isNotEmpty(),
             modifier = Modifier.semantics { contentDescription = pickerLabel },
         ) {
-            RedfaceVectorIcon(resId = CoreUiR.drawable.ic_ms_flag, tint = currentTabColor)
+            // #603 polish — the RF2 brand flag (drapeau cyan du launcher, vectorisé) instead of the
+            // generic Material flag glyph; tinted with the current tab color (cyan/red/favori/fuchsia).
+            RedfaceVectorIcon(resId = CoreUiR.drawable.ic_rf2_flag, tint = currentTabColor)
         }
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             tabs.forEach { entry ->
@@ -224,6 +211,11 @@ private fun SearchField(
                     } else {
                         MaterialTheme.colorScheme.onSurface
                     },
+                    // No wrap in the search pill — a long query/placeholder stays on one line and
+                    // ellipsises instead of pushing the bar to a second row.
+                    maxLines = 1,
+                    softWrap = false,
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
         }

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -112,9 +112,8 @@
     <string name="flags_retry">Réessayer</string>
 
 
-    <!-- #309 — Menu d'affichage des drapeaux (bottom sheet M3 ouvert depuis l'en-tête). Reflète et
-         modifie les réglages d'affichage de l'onglet courant (ou globaux selon « par onglet »). -->
-    <string name="flags_view_settings_action">Affichage</string>
+    <!-- #309 — Menu d'affichage des drapeaux (bottom sheet M3 ouvert via re-tap de l'onglet
+         Drapeaux de la barre du bas, #603 PR6). -->
     <string name="flags_view_settings_title">Affichage des drapeaux</string>
     <!-- Portée affichée sous le titre : globale, ou onglet courant. %1$s = libellé de l'onglet. -->
     <string name="flags_view_settings_scope_global">S\'applique à tous les onglets</string>


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaTriX)

Polish de la vue Drapeaux (#603), suite au dogfood : couleurs, icône de marque, et nettoyage UI.

## Changements

1. **Palette HFR pure** — les 3 buckets prennent les valeurs EXACTES des gifs HFR d'origine (relevées sur `flag1.gif`/`flag0.gif`/`favoris.gif`) : Cyan `#00FFFF`, Rouge `#FF0000`, Favori `#F0F83F` (jaune-lime, et non l'ambre Material). Le commentaire de `FlagPalette` mentait (« mirror the legacy palette ») — corrigé.
2. **DT en fuchsia** `#FF00FF` (magenta CGA/EGA, le pur qui complète cyan/rouge). 4ᵉ couleur de bucket pour l'onglet MultiMP (indicateur + picker + pastille du menu). DT n'étant pas un `FlagType`, la couleur est lue directement par l'app bar.
3. **Icône du picker = drapeau RF2** — le glyphe Material générique est remplacé par le drapeau de marque (pixel-art cyan du launcher, **vectorisé en silhouette mono-couleur tintable**), teinté avec la couleur de l'onglet courant.
4. **Recherche sur une seule ligne** — `maxLines=1` + ellipsis + `softWrap=false` (plus de retour à la ligne du contenu dans la pill).
5. **Suppression du gear de réglages rapides** dans l'app bar (doublon : le menu d'affichage s'ouvre désormais via le re-tap de l'onglet Drapeaux de la barre du bas, #603 PR6). String orpheline retirée.
6. **Spinner rond central retiré** (listes Cyan/Red/Fav + DT) : la `LinearProgressIndicator` du haut est étendue au **chargement initial** et devient l'unique indicateur de chargement. Le body de chargement reste scrollable (cible pull-to-refresh, #229).
7. **Le stripe épouse la ligne** — le marqueur barre passe d'une hauteur fixe 32dp à `fillMaxHeight` dans un `ForumListRow` en `IntrinsicSize.Min`, donc la barre couvre toute la hauteur de la ligne (titres 1 ou 2 lignes). Audit container : OK par ailleurs (padding centralisé #287/#398, tap target inclut le padding).

## Décisions (arbitrages XaTriX)

- Palette : **HFR pure** (vs Material) — choix assumé, plus criard mais fidèle web.
- Icône : **teintée par onglet** (vs cyan fixe).
- Stripe : **épouse la ligne** (vs 32dp fixe).
- Progress bar : **gardée plate par défaut M3** — pas de variante plate plus fine en standard (seule l'épaisseur custom `Modifier.height` ou le `LinearWavyProgressIndicator` ondulé exposent l'épaisseur ; vérifié Context7 sur M3 BOM 2026.05.01).

## Validation

`detektAll` + `:app:lintProdDebug` + `testDebugUnitTest` + `:app:assembleProdDebug` → **BUILD SUCCESSFUL** (podman). Le showcase Roborazzi `flags_pr3_row_*` re-rendu confirme palette pure + stripe pleine hauteur.

Référence #603 (polish, ne ferme pas l'umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
