### PR TITLE
chore(release): bump versionName 0.17.1 + CHANGELOG + whatsnew (dev #648 polish)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,24 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.1` — `internal` (dev) — 2026-06-25
+
+> Polish de la vue Drapeaux suite au dogfood (#648). Build dev ; versionCode alloué au dispatch.
+> versionName bumpé 0.17.0 → 0.17.1 (évite le doublon F-Droid). Codex GO + CI verte.
+
+**Finitions (#648)**
+
+- **Couleurs des drapeaux** alignées sur les valeurs exactes des gifs HFR : cyan `#00FFFF`, rouge
+  `#FF0000`, favori `#F0F83F` (jaune-lime) ; nouveau **DT en fuchsia** `#FF00FF`.
+- **Icône d'ouverture du menu Drapeaux** = le drapeau de Redface 2 (vectorisé, teinté selon l'onglet),
+  à la place du glyphe Material générique.
+- **Barre de recherche sur une seule ligne** (plus de retour à la ligne du contenu).
+- **Suppression du bouton d'affichage en double** dans l'app bar — le menu s'ouvre en re-tapant
+  l'onglet Drapeaux de la barre du bas.
+- **Suppression du rond de chargement central** : la barre fine du haut couvre désormais aussi le
+  chargement initial.
+- La **barre de couleur épouse la hauteur de la ligne** (correct sur les titres 2 lignes).
+
 ## `0.17.0` — `internal` (dev) — 2026-06-25
 
 > Build dev (Play internal « Redface 2 dev » + F-Droid .dev) ; versionCode alloué au dispatch par le

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.0"
+        versionName = "0.17.1"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,10 +1,11 @@
-Redface 2 v0.17.0 — dev.
+Redface 2 v0.17.1 — dev.
 
-Drapeaux view redesign:
-- Search app bar + tab picker.
-- Refonted rows: colour-bar marker (bar/pill/dot), pages-to-read pill, category icons.
-- Long-press sheet: topic metadata, actions, local super-favourite.
-- Thin loading bar (manual and auto refresh).
-- Quick-config: re-tap the Drapeaux tab.
+Drapeaux view polish:
+- Colours match HFR exactly (pure cyan/red/yellow) + DT in fuchsia.
+- Drapeaux menu icon is now the Redface 2 flag.
+- Single-line search.
+- Display menu: one entry point (re-tap the Drapeaux tab).
+- No more central spinner — the thin top bar covers it.
+- Colour bar spans the row height.
 
 Bugs: via dev or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,10 +1,11 @@
-Redface 2 v0.17.0 — dev.
+Redface 2 v0.17.1 — dev.
 
-Refonte de la vue Drapeaux :
-- App bar de recherche + sélecteur d'onglet.
-- Lignes refondues : marqueur barre de couleur (barre/pastille/point), pastille « pages à lire », icônes de catégorie.
-- Appui long : métadonnées du sujet, actions, super-favori local.
-- Barre de chargement fine (refresh manuel et auto).
-- Config rapide : re-tape l'onglet Drapeaux.
+Finitions de la vue Drapeaux :
+- Couleurs alignées sur HFR (cyan/rouge/jaune purs) + DT en fuchsia.
+- Icône du menu Drapeaux = le drapeau de Redface 2.
+- Recherche sur une seule ligne.
+- Menu d'affichage : un seul accès (re-tape l'onglet Drapeaux).
+- Plus de rond de chargement : la barre fine du haut suffit.
+- La barre de couleur épouse la hauteur de la ligne.
 
 Bugs : via le canal dev ou GitHub.


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaTriX)

Bump de release dev pour dogfooder le polish #648 (palette HFR pure + DT fuchsia, icône drapeau RF2, recherche 1 ligne, nettoyage gear/spinner, stripe pleine hauteur).

versionName **0.17.0 → 0.17.1** (évite le doublon F-Droid .dev — un 2ᵉ build dev à 0.17.0 collisionnerait). versionCode alloué au dispatch (app-v181 attendu).

Guards locaux OK : check-changelog-entry + check-whatsnew (0.17.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)