### PR TITLE
chore(release): bump versionName 0.17.2 + CHANGELOG + whatsnew (dev #651 polish #2)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,21 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.2` — `internal` (dev) — 2026-06-25
+
+> Polish #2 de la vue Drapeaux suite au dogfood 0.17.1 (#651). Build dev ; versionCode au dispatch.
+> versionName 0.17.1 → 0.17.2. Bug du menu rapide analysé + corrigé (Codex). CI verte.
+
+**Finitions (#651)**
+
+- **Couleurs retonées** (les valeurs HFR pures étaient criardes) : favori → vert-lime `#CDDC39`, DT →
+  fuchsia `#D500F9`, cyan/rouge reviennent aux tons Material.
+- **Icône du menu Drapeaux** : retour au glyphe propre (le drapeau pixel-art était trop brut à petite taille).
+- **Bug corrigé** : le menu de config rapide s'ouvrait tout seul en changeant de catégorie ou au retour.
+- « +lus » : libellé nettoyé (plus de point médian).
+- Liseré discret autour de l'avatar du compte.
+- Bandes de catégorie un peu moins hautes ; flèche « › » de catégorie à la bonne taille (était un bug).
+
 ## `0.17.1` — `internal` (dev) — 2026-06-25
 
 > Polish de la vue Drapeaux suite au dogfood (#648). Build dev ; versionCode alloué au dispatch.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.1"
+        versionName = "0.17.2"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,11 +1,11 @@
-Redface 2 v0.17.1 — dev.
+Redface 2 v0.17.2 — dev.
 
 Drapeaux view polish:
-- Colours match HFR exactly (pure cyan/red/yellow) + DT in fuchsia.
-- Drapeaux menu icon is now the Redface 2 flag.
-- Single-line search.
-- Display menu: one entry point (re-tap the Drapeaux tab).
-- No more central spinner — the thin top bar covers it.
-- Colour bar spans the row height.
+- Colours retuned (less garish): lime favourite, fuchsia DT, softer cyan/red.
+- Drapeaux menu icon cleaned up.
+- Fix: the quick-config menu no longer opens by itself when switching category.
+- Cleaner « +lus » label.
+- Subtle border around the account avatar.
+- Slightly tighter category bands, correctly-sized chevron.
 
 Bugs: via dev or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,11 +1,11 @@
-Redface 2 v0.17.1 — dev.
+Redface 2 v0.17.2 — dev.
 
 Finitions de la vue Drapeaux :
-- Couleurs alignées sur HFR (cyan/rouge/jaune purs) + DT en fuchsia.
-- Icône du menu Drapeaux = le drapeau de Redface 2.
-- Recherche sur une seule ligne.
-- Menu d'affichage : un seul accès (re-tape l'onglet Drapeaux).
-- Plus de rond de chargement : la barre fine du haut suffit.
-- La barre de couleur épouse la hauteur de la ligne.
+- Couleurs revues (moins criardes) : favori vert-lime, DT fuchsia, cyan/rouge adoucis.
+- Icône du menu Drapeaux remise au propre.
+- Correction : le menu de config rapide ne s'ouvre plus tout seul en changeant de catégorie.
+- Libellé « +lus » nettoyé.
+- Liseré discret autour de l'avatar.
+- Bandes de catégorie un peu plus compactes, flèche à la bonne taille.
 
 Bugs : via le canal dev ou GitHub.


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaTriX)

Bump de release dev pour dogfooder le polish #2 (#651) : palette Material, rollback icône drapeau, **fix du bug menu rapide** qui s'ouvrait à la nav, +lus nettoyé, liseré avatar, bande catégorie, chevron.

versionName **0.17.1 → 0.17.2** (évite le doublon F-Droid .dev). versionCode au dispatch (app-v182 attendu). Guards locaux OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)