### PR TITLE
feat(flags): option « titre sur une seule ligne » (GLOBAL, via CompositionLocal)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -188,6 +188,15 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override suspend fun setFlagsSingleLineTitle(enabled: Boolean) {
+        // #603 — GLOBAL toggle, a single key (mirrors the marker shape).
+        persist {
+            dataStore.edit { prefs ->
+                prefs[KEY_FLAGS_SINGLE_LINE_TITLE] = enabled
+            }
+        }
+    }
+
     override fun observeThemeMode(): Flow<ThemeMode> =
         dataStore.data
             // Default SYSTEM: follow the OS dark-mode setting unless the user picked otherwise (#286).
@@ -699,12 +708,15 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         // #603 PR6 — marker shape is GLOBAL: resolved once, added to both return paths regardless of
         // the per-tab override.
         val markerStyle = readMarkerStyle(prefs)
+        // #603 — GLOBAL « single-line titles » toggle: resolved once, added to both return paths.
+        val singleLineTitle = prefs[KEY_FLAGS_SINGLE_LINE_TITLE] ?: false
         if (prefs[KEY_FLAGS_PER_TAB_OVERRIDE] != true) {
             return FlagsViewSettings(
                 groupByCategory = globalGroup,
                 hideReadCategories = globalHide,
                 unreadOnly = unreadOnly,
                 markerStyle = markerStyle,
+                singleLineTitle = singleLineTitle,
             )
         }
         return FlagsViewSettings(
@@ -712,6 +724,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             hideReadCategories = prefs[flagsHideReadCategoriesKey(type)] ?: globalHide,
             unreadOnly = unreadOnly,
             markerStyle = markerStyle,
+            singleLineTitle = singleLineTitle,
         )
     }
 
@@ -752,6 +765,8 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         // #603 PR6 — GLOBAL Drapeaux marker shape (MarkerStyle.name, defensively parsed). No per-type
         // variant: one shape for every tab, independent of the #309 per-tab override.
         val KEY_FLAGS_MARKER_STYLE = stringPreferencesKey("flags_marker_style")
+        // #603 — GLOBAL « single-line topic titles » toggle (one for every tab).
+        val KEY_FLAGS_SINGLE_LINE_TITLE = booleanPreferencesKey("flags_single_line_title")
         // #309 — per-tab display override. The master switch plus one nullable key per FlagType for
         // each toggle; absence of a per-type key means « fall back to the global value ». Keys are
         // derived from the stable enum name (cyan/red/favorite), e.g. `flags_group_by_category_cyan`.

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -538,6 +538,7 @@ class TopicRepositoryImplTest {
 
         override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) = Unit
         override suspend fun setFlagsMarkerStyle(style: MarkerStyle) = Unit
+        override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
 
         // #286 — theme prefs are irrelevant to TopicRepositoryImpl; stubbed at their defaults.
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FlagsViewSettings.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FlagsViewSettings.kt
@@ -34,4 +34,7 @@ data class FlagsViewSettings(
     // #603 PR6 — left-marker shape. GLOBAL (not subject to the per-tab override): one shape for every
     // tab. Default STRIPE (ADR-017, soberest option). Carried on every resolution path.
     val markerStyle: MarkerStyle = MarkerStyle.STRIPE,
+    // #603 — GLOBAL: keep topic titles on a single (ellipsised) line instead of wrapping to 2. Default
+    // false = the historical 2-line wrap. Not subject to the per-tab override (like [markerStyle]).
+    val singleLineTitle: Boolean = false,
 )

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -117,6 +117,13 @@ interface UserPreferencesRepository {
     suspend fun setFlagsMarkerStyle(style: MarkerStyle)
 
     /**
+     * Persists the GLOBAL « single-line topic titles » toggle (#603). Like [setFlagsMarkerStyle] it is
+     * NOT subject to [observeFlagsPerTabOverride]; surfaced through [observeFlagsViewSettings]
+     * ([FlagsViewSettings.singleLineTitle]). Defaults to `false` (2-line wrap) until the first call.
+     */
+    suspend fun setFlagsSingleLineTitle(enabled: Boolean)
+
+    /**
      * App theme selection (#286): [ThemeMode.SYSTEM] (default) follows the OS dark-mode setting;
      * [ThemeMode.LIGHT] / [ThemeMode.DARK] force the app theme regardless of the OS. Observed at the
      * app root ([fr.forumhfr.redface2.navigation.RedfaceApp]) to compute the effective dark theme

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.clearAndSetSemantics
@@ -27,6 +28,14 @@ import fr.forumhfr.redface2.core.model.pagesToRead
 import fr.forumhfr.redface2.core.ui.icon.categoryIcon
 import fr.forumhfr.redface2.core.ui.theme.FlagPalette
 import fr.forumhfr.redface2.core.ui.theme.LocalDisplayMetrics
+
+/**
+ * #603 — GLOBAL « single-line topic titles » preference, surfaced as a CompositionLocal so the leaf
+ * [ForumListRow] reads it WITHOUT threading the flag through every list composable. Default 2 (the
+ * historical 2-line wrap); FlagsRoute provides 1 when the user enables single-line titles. Other
+ * [ForumListRow] consumers (forum / search / DT) keep the default unless they provide their own.
+ */
+val LocalForumRowTitleMaxLines = compositionLocalOf { 2 }
 
 /**
  * Renders one row of the user's drapeaux list.
@@ -172,7 +181,8 @@ fun ForumListRow(
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurface,
                 fontWeight = if (emphasized) FontWeight.SemiBold else FontWeight.Normal,
-                maxLines = 2,
+                // #603 — GLOBAL single-line-title pref via CompositionLocal (default = 2-line wrap).
+                maxLines = LocalForumRowTitleMaxLines.current,
                 overflow = TextOverflow.Ellipsis,
             )
             // #376 — shared two-segment metadata line (start truncatable + end pinned right),

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -1963,6 +1963,7 @@ class PostEditorViewModelTest {
         override suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean) = Unit
         override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) = Unit
         override suspend fun setFlagsMarkerStyle(style: MarkerStyle) = Unit
+        override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
         override suspend fun setThemeMode(mode: ThemeMode) = Unit
         override fun observeAmoledEnabled(): Flow<Boolean> = MutableStateFlow(false)

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1363,6 +1363,7 @@ class TopicFormViewModelTest {
         override suspend fun setFlagsHideReadCategoriesForType(type: FlagType, enabled: Boolean) = Unit
         override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) = Unit
         override suspend fun setFlagsMarkerStyle(style: MarkerStyle) = Unit
+        override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
         override suspend fun setThemeMode(mode: ThemeMode) = Unit
         override fun observeAmoledEnabled(): Flow<Boolean> = MutableStateFlow(false)

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -41,6 +41,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -77,6 +78,7 @@ import fr.forumhfr.redface2.core.ui.FlagItemDivider
 import fr.forumhfr.redface2.core.ui.FlagItemLongPress
 import fr.forumhfr.redface2.core.ui.FlagMetadata
 import fr.forumhfr.redface2.core.ui.ForumListRow
+import fr.forumhfr.redface2.core.ui.LocalForumRowTitleMaxLines
 import fr.forumhfr.redface2.core.ui.R as CoreUiR
 import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.formatLastReplyTimestamp
@@ -349,7 +351,13 @@ fun FlagsRoute(
                 authState?.let { state ->
                     when (state) {
                         AuthState.Anonymous -> AnonymousBody(onLoginRequested)
-                        is AuthState.Authenticated -> AuthenticatedBody(
+                        is AuthState.Authenticated -> CompositionLocalProvider(
+                            // #603 — single-line topic titles when enabled (GLOBAL pref); the leaf
+                            // ForumListRow reads this local, so no threading through list composables.
+                            LocalForumRowTitleMaxLines provides
+                                flagTitleMaxLines(flagsViewSettings.singleLineTitle),
+                        ) {
+                            AuthenticatedBody(
                             state = FlagsBodyState(
                                 selectedTab = selectedTab,
                                 flagsState = flagsState,
@@ -380,7 +388,8 @@ fun FlagsRoute(
                                 onRefreshDt = viewModel::refreshDt,
                             ),
                             listState = flagsListState,
-                        )
+                            )
+                        }
                     }
                 }
             }
@@ -401,6 +410,7 @@ fun FlagsRoute(
                 onHideReadCategoriesChange = viewModel::setFlagsHideReadCategories,
                 onUnreadOnlyChange = viewModel::setFlagsUnreadOnly,
                 onMarkerStyleChange = viewModel::setFlagsMarkerStyle,
+                onSingleLineTitleChange = viewModel::setFlagsSingleLineTitle,
                 onDismiss = { showViewSettingsSheet = false },
             ),
         )
@@ -595,6 +605,15 @@ private fun FlagsViewSettingsSheet(
                 )
             }
 
+            // #603 — GLOBAL « single-line topic titles » toggle (not per-tab, like the marker shape).
+            ViewSettingsSwitchRow(
+                title = stringResource(R.string.flags_view_settings_single_line_title_title),
+                description = stringResource(R.string.flags_view_settings_single_line_title_description),
+                checked = settings.singleLineTitle,
+                enabled = true,
+                onCheckedChange = actions.onSingleLineTitleChange,
+            )
+
             TextButton(
                 // Animate the sheet out (M3 stable pattern) before removing it from composition,
                 // instead of an abrupt `if`-driven teardown. Swipe/scrim dismissals already animate
@@ -769,6 +788,9 @@ private fun flagsLoadingBarVisible(
     FlagTab.Super -> false
     else -> isRefreshing || flagsState == null || flagsState == FlagsListUiState.Loading
 }
+
+// #603 — extracted so the single-line-title branch doesn't count against FlagsRoute's cyclomatic budget.
+private fun flagTitleMaxLines(singleLineTitle: Boolean): Int = if (singleLineTitle) 1 else 2
 
 @Composable
 private fun FlagsLoadingBar(loading: Boolean) {
@@ -1769,6 +1791,7 @@ private data class FlagsViewSettingsActions(
     val onHideReadCategoriesChange: (Boolean) -> Unit,
     val onUnreadOnlyChange: (Boolean) -> Unit,
     val onMarkerStyleChange: (MarkerStyle) -> Unit,
+    val onSingleLineTitleChange: (Boolean) -> Unit,
     val onDismiss: () -> Unit,
 )
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -674,6 +674,11 @@ class FlagsViewModel @Inject constructor(
         viewModelScope.launch { userPreferencesRepository.setFlagsMarkerStyle(style) }
     }
 
+    /** Bottom-sheet write for the GLOBAL « single-line topic titles » toggle (#603). */
+    fun setFlagsSingleLineTitle(enabled: Boolean) {
+        viewModelScope.launch { userPreferencesRepository.setFlagsSingleLineTitle(enabled) }
+    }
+
     fun refresh() {
         // Super is a placeholder with no backing FlagType — pull-to-refresh is a no-op there.
         val type = _selectedTab.value.flagType ?: return

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -131,6 +131,9 @@
     <!-- #603 PR6 — Forme du marqueur de gauche (barre / pastille / point). Réglage GLOBAL (tous onglets). -->
     <string name="flags_view_settings_marker_title">Marqueur</string>
     <string name="flags_view_settings_marker_description">Forme de l\'indicateur de couleur à gauche de chaque drapeau. S\'applique à tous les onglets.</string>
+    <!-- #603 — bascule GLOBALE : titre des sujets sur une seule ligne (tronqué) plutôt que deux. -->
+    <string name="flags_view_settings_single_line_title_title">Titre sur une seule ligne</string>
+    <string name="flags_view_settings_single_line_title_description">Tronque le titre des sujets à une ligne au lieu de deux. S\'applique à tous les onglets.</string>
     <string name="flags_view_settings_marker_stripe">Barre</string>
     <string name="flags_view_settings_marker_pastille">Pastille</string>
     <string name="flags_view_settings_marker_dot">Point</string>

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -2338,6 +2338,8 @@ class FlagsViewModelTest {
             markerStyle.value = style
         }
 
+        override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
+
         // #286 — theme prefs are irrelevant to FlagsViewModel; stubbed at their defaults.
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
 

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -2022,6 +2022,7 @@ class SettingsViewModelTest {
 
         override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) = Unit
         override suspend fun setFlagsMarkerStyle(style: MarkerStyle) = Unit
+        override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
 
         fun emit(value: ProxyConfig) {
             config.value = value

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -2046,6 +2046,7 @@ private class FakeUserPreferencesRepository(
 
     override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) = Unit
     override suspend fun setFlagsMarkerStyle(style: MarkerStyle) = Unit
+    override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
 
     override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
 


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaTriX)

Nouvelle option d'affichage demandée au dogfood : garder le titre des sujets **sur une seule ligne** (tronqué) au lieu de passer sur deux. GLOBALE (comme la forme de marqueur), pas par onglet.

## Implémentation
- `FlagsViewSettings.singleLineTitle` + `KEY_FLAGS_SINGLE_LINE_TITLE` + `setFlagsSingleLineTitle` (interface repo, impl DataStore — résolution + les 2 chemins de retour, ViewModel). Mirror exact de `markerStyle`.
- Rendu via un **CompositionLocal** `LocalForumRowTitleMaxLines` (core/ui, défaut 2) lu par le composant feuille `ForumListRow` → **pas de threading** à travers les composables de liste. `FlagsRoute` fournit 1 autour de l'`AuthenticatedBody` quand l'option est active. Les autres consommateurs de `ForumListRow` gardent le défaut 2 lignes.
- `ViewSettingsSwitchRow` ajouté dans le menu d'affichage (#309). Les 6 fakes `UserPreferencesRepository` de test mis à jour.

## Validation
`detektAll` + `:app:lintProdDebug` + `testDebugUnitTest` + `:app:assembleProdDebug` → **BUILD SUCCESSFUL** (podman). (1ʳᵉ passe : CyclomaticComplexMethod sur FlagsRoute corrigé en extrayant `flagTitleMaxLines`.)

Suite de #651 / référence #603 (polish). Déploiement (release dev) au choix de XaTriX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)