### PR TITLE
chore(release): bump versionName 0.17.3 + CHANGELOG + whatsnew (titre 1 ligne #653 + bande catégorie #654)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,17 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.3` — `internal` (dev) — 2026-06-25
+
+> Suite du dogfood 0.17.2 (#653 + #654). Build dev ; versionCode au dispatch. versionName 0.17.2 → 0.17.3.
+
+**Finitions (#653, #654)**
+
+- **Option « titre sur une seule ligne »** dans le menu d'affichage des Drapeaux : tronque le titre des
+  sujets à une ligne au lieu de deux (réglage global, via CompositionLocal).
+- **Bande de catégorie allégée** (vue groupée « par catégorie ») : sous-titre minimal (nom en capitales
+  espacées + filet fin) au lieu du bloc plein `surfaceVariant`, moins lourd.
+
 ## `0.17.2` — `internal` (dev) — 2026-06-25
 
 > Polish #2 de la vue Drapeaux suite au dogfood 0.17.1 (#651). Build dev ; versionCode au dispatch.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.2"
+        versionName = "0.17.3"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,11 +1,7 @@
-Redface 2 v0.17.2 — dev.
+Redface 2 v0.17.3 — dev.
 
-Drapeaux view polish:
-- Colours retuned (less garish): lime favourite, fuchsia DT, softer cyan/red.
-- Drapeaux menu icon cleaned up.
-- Fix: the quick-config menu no longer opens by itself when switching category.
-- Cleaner « +lus » label.
-- Subtle border around the account avatar.
-- Slightly tighter category bands, correctly-sized chevron.
+Drapeaux view:
+- New "single-line titles" option (display menu): topic titles trimmed to one line instead of two.
+- Lighter category band (by-category view): a discreet subhead instead of the full block.
 
 Bugs: via dev or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,11 +1,7 @@
-Redface 2 v0.17.2 — dev.
+Redface 2 v0.17.3 — dev.
 
-Finitions de la vue Drapeaux :
-- Couleurs revues (moins criardes) : favori vert-lime, DT fuchsia, cyan/rouge adoucis.
-- Icône du menu Drapeaux remise au propre.
-- Correction : le menu de config rapide ne s'ouvre plus tout seul en changeant de catégorie.
-- Libellé « +lus » nettoyé.
-- Liseré discret autour de l'avatar.
-- Bandes de catégorie un peu plus compactes, flèche à la bonne taille.
+Vue Drapeaux :
+- Nouvelle option « titre sur une seule ligne » (menu d'affichage) : titres tronqués à une ligne au lieu de deux.
+- Bande de catégorie allégée (vue par catégorie) : un sous-titre discret au lieu du bandeau plein.
 
 Bugs : via le canal dev ou GitHub.


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaTriX)

Bump de release dev groupant **deux** suites du chantier Drapeaux (pour un seul bump) :
- **Option « titre sur une seule ligne »** (#653)
- **Bande de catégorie en sous-titre minimal** (#654)

versionName **0.17.2 → 0.17.3** (évite le doublon F-Droid .dev). versionCode au dispatch (app-v183 attendu). Guards locaux OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)