### PR TITLE
feat(flags): selectable category band style (#603)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -13,6 +13,7 @@ import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
+import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
 import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenBootstrapStore
@@ -193,6 +194,15 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         persist {
             dataStore.edit { prefs ->
                 prefs[KEY_FLAGS_SINGLE_LINE_TITLE] = enabled
+            }
+        }
+    }
+
+    override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) {
+        // #603 — GLOBAL: a single key, no per-type variant. Persisted by name, read defensively.
+        persist {
+            dataStore.edit { prefs ->
+                prefs[KEY_FLAGS_CATEGORY_BAND_STYLE] = style.name
             }
         }
     }
@@ -710,6 +720,8 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         val markerStyle = readMarkerStyle(prefs)
         // #603 — GLOBAL « single-line titles » toggle: resolved once, added to both return paths.
         val singleLineTitle = prefs[KEY_FLAGS_SINGLE_LINE_TITLE] ?: false
+        // #603 — GLOBAL category band style: resolved once (defensively), added to both return paths.
+        val categoryBandStyle = readCategoryBandStyle(prefs)
         if (prefs[KEY_FLAGS_PER_TAB_OVERRIDE] != true) {
             return FlagsViewSettings(
                 groupByCategory = globalGroup,
@@ -717,6 +729,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
                 unreadOnly = unreadOnly,
                 markerStyle = markerStyle,
                 singleLineTitle = singleLineTitle,
+                categoryBandStyle = categoryBandStyle,
             )
         }
         return FlagsViewSettings(
@@ -725,6 +738,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             unreadOnly = unreadOnly,
             markerStyle = markerStyle,
             singleLineTitle = singleLineTitle,
+            categoryBandStyle = categoryBandStyle,
         )
     }
 
@@ -737,6 +751,16 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         prefs[KEY_FLAGS_MARKER_STYLE]
             ?.let { stored -> runCatching { MarkerStyle.valueOf(stored) }.getOrNull() }
             ?: MarkerStyle.STRIPE
+
+    /**
+     * Reads [KEY_FLAGS_CATEGORY_BAND_STYLE] defensively (#603): an unknown / corrupt stored value
+     * falls back to [CategoryBandStyle.MINIMAL] instead of crashing on `CategoryBandStyle.valueOf` —
+     * same stance as [readMarkerStyle].
+     */
+    private fun readCategoryBandStyle(prefs: Preferences): CategoryBandStyle =
+        prefs[KEY_FLAGS_CATEGORY_BAND_STYLE]
+            ?.let { stored -> runCatching { CategoryBandStyle.valueOf(stored) }.getOrNull() }
+            ?: CategoryBandStyle.MINIMAL
 
     /**
      * Type-aware default for the #317 « non-lus uniquement » filter: CYAN (« Mes sujets ») shows the
@@ -767,6 +791,8 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         val KEY_FLAGS_MARKER_STYLE = stringPreferencesKey("flags_marker_style")
         // #603 — GLOBAL « single-line topic titles » toggle (one for every tab).
         val KEY_FLAGS_SINGLE_LINE_TITLE = booleanPreferencesKey("flags_single_line_title")
+        // #603 — GLOBAL grouped-view category band style (CategoryBandStyle.name, defensively parsed).
+        val KEY_FLAGS_CATEGORY_BAND_STYLE = stringPreferencesKey("flags_category_band_style")
         // #309 — per-tab display override. The master switch plus one nullable key per FlagType for
         // each toggle; absence of a per-type key means « fall back to the global value ». Keys are
         // derived from the stable enum name (cyan/red/favorite), e.g. `flags_group_by_category_cyan`.

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -9,6 +9,7 @@ import app.cash.turbine.test
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.AccentColor
+import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
 import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
@@ -415,6 +416,41 @@ class DataStoreUserPreferencesRepositoryTest {
 
         repository.observeFlagsViewSettings(FlagType.CYAN).test {
             assertEquals(MarkerStyle.STRIPE, awaitItem().markerStyle)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `categoryBandStyle defaults to MINIMAL on an empty store`() = runTest(dispatcher) {
+        repository.observeFlagsViewSettings(FlagType.CYAN).test {
+            assertEquals(CategoryBandStyle.MINIMAL, awaitItem().categoryBandStyle)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setFlagsCategoryBandStyle persists and round-trips SOFT then BULLET for every tab`() = runTest(dispatcher) {
+        // GLOBAL: written once, observed on any tab type.
+        repository.setFlagsCategoryBandStyle(CategoryBandStyle.SOFT)
+        repository.observeFlagsViewSettings(FlagType.RED).test {
+            assertEquals(CategoryBandStyle.SOFT, awaitItem().categoryBandStyle)
+            cancelAndIgnoreRemainingEvents()
+        }
+        repository.setFlagsCategoryBandStyle(CategoryBandStyle.BULLET)
+        repository.observeFlagsViewSettings(FlagType.FAVORITE).test {
+            assertEquals(CategoryBandStyle.BULLET, awaitItem().categoryBandStyle)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `corrupt flags_category_band_style value falls back to MINIMAL instead of crashing`() = runTest(dispatcher) {
+        // A value from an older build / manual edit that no longer maps to a CategoryBandStyle must
+        // not crash observeFlagsViewSettings on CategoryBandStyle.valueOf — it degrades to MINIMAL.
+        dataStore.edit { prefs -> prefs[stringPreferencesKey("flags_category_band_style")] = "RAINBOW" }
+
+        repository.observeFlagsViewSettings(FlagType.CYAN).test {
+            assertEquals(CategoryBandStyle.MINIMAL, awaitItem().categoryBandStyle)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -7,6 +7,7 @@ import fr.forumhfr.redface2.core.database.RedfaceDatabase
 import fr.forumhfr.redface2.core.database.dao.TopicDao
 import fr.forumhfr.redface2.core.database.entities.FetchMode
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
+import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.AccentColor
@@ -539,6 +540,7 @@ class TopicRepositoryImplTest {
         override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) = Unit
         override suspend fun setFlagsMarkerStyle(style: MarkerStyle) = Unit
         override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
+        override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
 
         // #286 — theme prefs are irrelevant to TopicRepositoryImpl; stubbed at their defaults.
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/CategoryBandStyle.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/CategoryBandStyle.kt
@@ -1,0 +1,28 @@
+package fr.forumhfr.redface2.core.domain.preferences
+
+/**
+ * Visual treatment of the sticky CATEGORY BAND in the grouped Drapeaux list (#603). Only the band's
+ * styling varies; its content (category icon, name, open-chevron) and its tap-to-open behaviour
+ * (#414) are identical across styles. The band only appears in the grouped view — it has no effect
+ * on the flat list.
+ *
+ * - [MINIMAL] — the **default** : an opaque subhead with an uppercase letter-spaced name and a
+ *   hairline divider below (the look shipped in 0.17.3, #654).
+ * - [SOFT] — a soft tonal block (`surfaceContainer`), no divider.
+ * - [ACCENT] — a left vertical accent bar + a tinted icon (the `primary` accent), opaque base.
+ * - [BULLET] — the category name carried in a tonal chip (`surfaceContainerHigh`), opaque base.
+ *
+ * All four render on an OPAQUE base background : the band is a `stickyHeader`, so a transparent
+ * background would let the scrolling rows bleed through. The two originally-transparent mockups
+ * ([ACCENT], [BULLET]) are therefore opacified for this sticky context.
+ *
+ * Pure domain enum (no Android / Compose), so it can be persisted in a preference and read back
+ * defensively (an unknown stored value degrades to [MINIMAL]). The colours themselves are resolved
+ * at render time from the M3 colour scheme, not by this enum.
+ */
+enum class CategoryBandStyle {
+    MINIMAL,
+    SOFT,
+    ACCENT,
+    BULLET,
+}

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FlagsViewSettings.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FlagsViewSettings.kt
@@ -37,4 +37,8 @@ data class FlagsViewSettings(
     // #603 — GLOBAL: keep topic titles on a single (ellipsised) line instead of wrapping to 2. Default
     // false = the historical 2-line wrap. Not subject to the per-tab override (like [markerStyle]).
     val singleLineTitle: Boolean = false,
+    // #603 — GLOBAL: visual treatment of the grouped-view category band. Default MINIMAL (the look
+    // shipped in 0.17.3). Not subject to the per-tab override (like [markerStyle]). Carried on every
+    // resolution path.
+    val categoryBandStyle: CategoryBandStyle = CategoryBandStyle.MINIMAL,
 )

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -124,6 +124,14 @@ interface UserPreferencesRepository {
     suspend fun setFlagsSingleLineTitle(enabled: Boolean)
 
     /**
+     * Persists the GLOBAL grouped-view category band style (#603). Like [setFlagsMarkerStyle] it is
+     * NOT subject to [observeFlagsPerTabOverride]; surfaced through [observeFlagsViewSettings]
+     * ([FlagsViewSettings.categoryBandStyle]). Defaults to [CategoryBandStyle.MINIMAL] until the
+     * first call.
+     */
+    suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle)
+
+    /**
      * App theme selection (#286): [ThemeMode.SYSTEM] (default) follows the OS dark-mode setting;
      * [ThemeMode.LIGHT] / [ThemeMode.DARK] force the app theme regardless of the OS. Observed at the
      * app root ([fr.forumhfr.redface2.navigation.RedfaceApp]) to compute the effective dark theme

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -11,6 +11,7 @@ import fr.forumhfr.redface2.core.domain.editor.BbcodeValidation
 import fr.forumhfr.redface2.core.domain.editor.EditorDraftKey
 import fr.forumhfr.redface2.core.domain.editor.EditorDraftStore
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
+import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.AccentColor
@@ -1964,6 +1965,7 @@ class PostEditorViewModelTest {
         override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) = Unit
         override suspend fun setFlagsMarkerStyle(style: MarkerStyle) = Unit
         override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
+        override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
         override suspend fun setThemeMode(mode: ThemeMode) = Unit
         override fun observeAmoledEnabled(): Flow<Boolean> = MutableStateFlow(false)

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -10,6 +10,7 @@ import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
 import fr.forumhfr.redface2.core.domain.editor.EditorDraftKey
 import fr.forumhfr.redface2.core.domain.editor.EditorDraftStore
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
+import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.AccentColor
@@ -1364,6 +1365,7 @@ class TopicFormViewModelTest {
         override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) = Unit
         override suspend fun setFlagsMarkerStyle(style: MarkerStyle) = Unit
         override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
+        override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
         override suspend fun setThemeMode(mode: ThemeMode) = Unit
         override fun observeAmoledEnabled(): Flow<Boolean> = MutableStateFlow(false)

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -10,9 +10,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -60,6 +64,7 @@ import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -68,6 +73,7 @@ import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.domain.error.classifyHfrError
+import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
 import fr.forumhfr.redface2.core.model.AuthState
@@ -371,6 +377,7 @@ fun FlagsRoute(
                                 dtIsRefreshing = dtIsRefreshing,
                                 searchQuery = searchQuery,
                                 markerStyle = flagsViewSettings.markerStyle,
+                                categoryBandStyle = flagsViewSettings.categoryBandStyle,
                             ),
                             actions = AuthenticatedActions(
                                 onSelectTab = viewModel::selectTab,
@@ -412,6 +419,7 @@ fun FlagsRoute(
                 onUnreadOnlyChange = viewModel::setFlagsUnreadOnly,
                 onMarkerStyleChange = viewModel::setFlagsMarkerStyle,
                 onSingleLineTitleChange = viewModel::setFlagsSingleLineTitle,
+                onCategoryBandStyleChange = viewModel::setFlagsCategoryBandStyle,
                 onDismiss = { showViewSettingsSheet = false },
             ),
         )
@@ -614,6 +622,45 @@ private fun FlagsViewSettingsSheet(
                 enabled = true,
                 onCheckedChange = actions.onSingleLineTitleChange,
             )
+
+            // #603 — GLOBAL grouped-view category band style selector (segmented). Only takes visual
+            // effect in the grouped view (the band is the per-category sticky header); it's disabled
+            // while « grouper par catégorie » is off so the control reflects when it actually applies.
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = stringResource(R.string.flags_view_settings_band_title),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = stringResource(R.string.flags_view_settings_band_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                RedfaceSettingsChoiceGroup(
+                    options = listOf(
+                        RedfaceSettingsChoice(
+                            CategoryBandStyle.MINIMAL,
+                            stringResource(R.string.flags_view_settings_band_minimal),
+                        ),
+                        RedfaceSettingsChoice(
+                            CategoryBandStyle.SOFT,
+                            stringResource(R.string.flags_view_settings_band_soft),
+                        ),
+                        RedfaceSettingsChoice(
+                            CategoryBandStyle.ACCENT,
+                            stringResource(R.string.flags_view_settings_band_accent),
+                        ),
+                        RedfaceSettingsChoice(
+                            CategoryBandStyle.BULLET,
+                            stringResource(R.string.flags_view_settings_band_bullet),
+                        ),
+                    ),
+                    selected = settings.categoryBandStyle,
+                    onSelected = actions.onCategoryBandStyleChange,
+                    enabled = settings.groupByCategory,
+                )
+            }
 
             TextButton(
                 // Animate the sheet out (M3 stable pattern) before removing it from composition,
@@ -998,6 +1045,7 @@ private fun FlagListBody(
                             selectedTab = selectedTab,
                             removalInFlight = state.removeFlagState is RemoveFlagState.Removing,
                             markerStyle = state.markerStyle,
+                            categoryBandStyle = state.categoryBandStyle,
                             actions = actions,
                             listState = listState,
                         )
@@ -1084,12 +1132,13 @@ private const val CONTENT_TYPE_DT_FOOTER = "dt_scan_note"
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-@Suppress("LongParameterList") // List composable: sections + tab + removal flag + marker + actions + listState.
+@Suppress("LongParameterList") // List composable: sections + tab + removal + marker + band + actions + listState.
 private fun CategorySectionedFlagList(
     sections: List<FlagCategorySection>,
     selectedTab: FlagTab,
     removalInFlight: Boolean,
     markerStyle: MarkerStyle,
+    categoryBandStyle: CategoryBandStyle,
     actions: AuthenticatedActions,
     listState: LazyListState,
 ) {
@@ -1123,6 +1172,7 @@ private fun CategorySectionedFlagList(
                     catId = section.catId,
                     label = section.catName
                         ?: stringResource(R.string.flags_category_fallback, section.catId),
+                    style = categoryBandStyle,
                     // #414 — parité RF1 : the band navigates to the category's topic listing.
                     onClick = { actions.onOpenCategory(section.catId) },
                 )
@@ -1163,29 +1213,52 @@ private fun CategorySectionedFlagList(
 }
 
 /**
- * Category separator band for the grouped list (#179). #603 — minimal SUBHEAD style: an OPAQUE
- * `surface` background (matches the list, so the sticky header never bleeds the scrolling rows through,
- * but reads as a light subhead rather than the former heavy `surfaceVariant` block), an uppercase
- * letter-spaced category name, and a hairline divider below it.
+ * Category separator band for the grouped list (#179). #603 — the visual treatment is user-selectable
+ * ([CategoryBandStyle], display sheet) ; this dispatches to the chosen leaf. ALL leaves render on an
+ * OPAQUE base background because the band is a `stickyHeader`: a transparent background would let the
+ * scrolling rows bleed through (the two originally-transparent mockups, ACCENT and BULLET, are
+ * therefore opacified — XaTriX-approved).
  *
  * #414 — the whole band is tappable and opens the category's topic listing (RF1 parity); the trailing
  * chevron vector (`ic_chevron_right`) is the affordance. Foundation [clickable] does not enforce a
- * Material touch-target minimum, hence the explicit [heightIn] (44 dp — still an acceptable target).
+ * Material touch-target minimum, hence the explicit [heightIn] (44 dp — still an acceptable target) on
+ * every leaf.
  */
 @Composable
-private fun CategoryHeaderBand(catId: Int, label: String, onClick: () -> Unit) {
+private fun CategoryHeaderBand(catId: Int, label: String, style: CategoryBandStyle, onClick: () -> Unit) {
+    when (style) {
+        CategoryBandStyle.MINIMAL -> CategoryBandMinimal(catId, label, onClick)
+        CategoryBandStyle.SOFT -> CategoryBandSoft(catId, label, onClick)
+        CategoryBandStyle.ACCENT -> CategoryBandAccent(catId, label, onClick)
+        CategoryBandStyle.BULLET -> CategoryBandBullet(catId, label, onClick)
+    }
+}
+
+/** Trailing decorative chevron shared by the band styles; the open affordance is the band's onClickLabel. */
+@Composable
+private fun CategoryBandChevron() {
+    RedfaceVectorIcon(
+        resId = CoreUiR.drawable.ic_chevron_right,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        size = 18.dp,
+    )
+}
+
+/**
+ * MINIMAL (default, #654) — an opaque `surface` subhead: uppercase letter-spaced name in
+ * `onSurfaceVariant` + a hairline divider below. Reads as a light subhead, not a heavy block.
+ */
+@Composable
+private fun CategoryBandMinimal(catId: Int, label: String, onClick: () -> Unit) {
     Column(modifier = Modifier.fillMaxWidth().background(MaterialTheme.colorScheme.surface)) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .fillMaxWidth()
                 .heightIn(min = 44.dp)
-                .clickable(onClickLabel = stringResource(R.string.flags_category_open_label)) {
-                    onClick()
-                }
+                .clickable(onClickLabel = stringResource(R.string.flags_category_open_label)) { onClick() }
                 .padding(horizontal = 24.dp, vertical = 6.dp),
         ) {
-            // Decorative category glyph (the label carries the name); generic forum glyph if unknown.
             RedfaceVectorIcon(
                 resId = categoryIcon(catId),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -1198,14 +1271,135 @@ private fun CategoryHeaderBand(catId: Int, label: String, onClick: () -> Unit) {
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.weight(1f),
             )
-            // Trailing chevron — decorative; the band's onClickLabel carries the open affordance.
-            RedfaceVectorIcon(
-                resId = CoreUiR.drawable.ic_chevron_right,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                size = 18.dp,
-            )
+            CategoryBandChevron()
         }
         FlagItemDivider()
+    }
+}
+
+/**
+ * SOFT — a soft tonal block (`surfaceContainer`, opaque), normal-case `titleSmall` name in
+ * `onSurface`, no divider: the tonal block itself is the separator.
+ */
+@Composable
+private fun CategoryBandSoft(catId: Int, label: String, onClick: () -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surfaceContainer)
+            .heightIn(min = 44.dp)
+            .clickable(onClickLabel = stringResource(R.string.flags_category_open_label)) { onClick() }
+            .padding(horizontal = 24.dp, vertical = 8.dp),
+    ) {
+        RedfaceVectorIcon(
+            resId = categoryIcon(catId),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            size = 18.dp,
+            modifier = Modifier.padding(end = 10.dp),
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f),
+        )
+        CategoryBandChevron()
+    }
+}
+
+/**
+ * ACCENT — a full-height left accent bar (`primary`) + a `primary`-tinted icon, on an opaque `surface`
+ * base, uppercase name + hairline divider. The bar uses `fillMaxHeight`, so the row is measured at its
+ * min intrinsic height (the bounded-height-parent contract the marker stripe relies on).
+ */
+@Composable
+private fun CategoryBandAccent(catId: Int, label: String, onClick: () -> Unit) {
+    Column(modifier = Modifier.fillMaxWidth().background(MaterialTheme.colorScheme.surface)) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(IntrinsicSize.Min)
+                .clickable(onClickLabel = stringResource(R.string.flags_category_open_label)) { onClick() },
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .width(3.dp)
+                    .background(MaterialTheme.colorScheme.primary),
+            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .weight(1f)
+                    .heightIn(min = 44.dp)
+                    .padding(horizontal = 20.dp, vertical = 6.dp),
+            ) {
+                RedfaceVectorIcon(
+                    resId = categoryIcon(catId),
+                    tint = MaterialTheme.colorScheme.primary,
+                    size = 18.dp,
+                    modifier = Modifier.padding(end = 10.dp),
+                )
+                Text(
+                    text = label.uppercase(),
+                    style = MaterialTheme.typography.labelMedium.copy(letterSpacing = 0.08.em),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.weight(1f),
+                )
+                CategoryBandChevron()
+            }
+        }
+        FlagItemDivider()
+    }
+}
+
+/**
+ * BULLET — the category name carried in a tonal pill chip (`surfaceContainerHigh`) on an opaque
+ * `surface` base, chevron pushed to the trailing edge. The chip wraps its content; the chip + base
+ * give the originally-transparent mockup an opaque sticky-safe ground.
+ */
+@Composable
+private fun CategoryBandBullet(catId: Int, label: String, onClick: () -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .heightIn(min = 44.dp)
+            .clickable(onClickLabel = stringResource(R.string.flags_category_open_label)) { onClick() }
+            .padding(horizontal = 20.dp, vertical = 6.dp),
+    ) {
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            shape = CircleShape,
+            // weight(fill = false): the chip hugs a short name (chevron stays right via SpaceBetween)
+            // but is capped at the available width for a long one, so it can never push the chevron off
+            // (Codex review) — the label then ellipsises inside.
+            modifier = Modifier.weight(1f, fill = false),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            ) {
+                RedfaceVectorIcon(
+                    resId = categoryIcon(catId),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    size = 16.dp,
+                    modifier = Modifier.padding(end = 8.dp),
+                )
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+        CategoryBandChevron()
     }
 }
 
@@ -1763,6 +1957,8 @@ private data class FlagsBodyState(
     val searchQuery: String = "",
     /** #603 PR6 — GLOBAL marker shape for the rows (from FlagsViewSettings). */
     val markerStyle: MarkerStyle = MarkerStyle.STRIPE,
+    /** #603 — GLOBAL category band style for the grouped view (from FlagsViewSettings). */
+    val categoryBandStyle: CategoryBandStyle = CategoryBandStyle.MINIMAL,
 )
 
 private data class AuthenticatedActions(
@@ -1793,6 +1989,7 @@ private data class FlagsViewSettingsActions(
     val onUnreadOnlyChange: (Boolean) -> Unit,
     val onMarkerStyleChange: (MarkerStyle) -> Unit,
     val onSingleLineTitleChange: (Boolean) -> Unit,
+    val onCategoryBandStyleChange: (CategoryBandStyle) -> Unit,
     val onDismiss: () -> Unit,
 )
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -10,6 +10,7 @@ import fr.forumhfr.redface2.core.domain.forum.ForumRepository
 import fr.forumhfr.redface2.core.domain.forum.ForumResult
 import fr.forumhfr.redface2.core.domain.messages.MessagesRepository
 import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
+import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
 import fr.forumhfr.redface2.core.domain.preferences.SuperFavoriteRepository
@@ -677,6 +678,11 @@ class FlagsViewModel @Inject constructor(
     /** Bottom-sheet write for the GLOBAL « single-line topic titles » toggle (#603). */
     fun setFlagsSingleLineTitle(enabled: Boolean) {
         viewModelScope.launch { userPreferencesRepository.setFlagsSingleLineTitle(enabled) }
+    }
+
+    /** Bottom-sheet write for the GLOBAL grouped-view category band style (#603). */
+    fun setFlagsCategoryBandStyle(style: CategoryBandStyle) {
+        viewModelScope.launch { userPreferencesRepository.setFlagsCategoryBandStyle(style) }
     }
 
     fun refresh() {

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -137,6 +137,14 @@
     <string name="flags_view_settings_marker_stripe">Barre</string>
     <string name="flags_view_settings_marker_pastille">Pastille</string>
     <string name="flags_view_settings_marker_dot">Point</string>
+    <!-- #603 — Style de la bande de catégorie (vue groupée) : sous-titre sobre / bloc tonal /
+         accent latéral / pastille en puce. Réglage GLOBAL (tous onglets), sans effet en vue à plat. -->
+    <string name="flags_view_settings_band_title">Bande de catégorie</string>
+    <string name="flags_view_settings_band_description">Style de l\'en-tête de catégorie dans la vue groupée. S\'applique à tous les onglets.</string>
+    <string name="flags_view_settings_band_minimal">Sobre</string>
+    <string name="flags_view_settings_band_soft">Bloc</string>
+    <string name="flags_view_settings_band_accent">Accent</string>
+    <string name="flags_view_settings_band_bullet">Puce</string>
     <string name="flags_view_settings_done">Fermer</string>
 
     <!-- #99 — Retirer un drapeau (delflag) : action du sheet d'appui-long (#603 PR5) + dialog de

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -15,6 +15,7 @@ import fr.forumhfr.redface2.core.domain.forum.ForumResult
 import fr.forumhfr.redface2.core.domain.messages.MessagesRepository
 import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
+import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.AccentColor
@@ -2339,6 +2340,7 @@ class FlagsViewModelTest {
         }
 
         override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
+        override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
 
         // #286 — theme prefs are irrelevant to FlagsViewModel; stubbed at their defaults.
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -3,6 +3,7 @@ package fr.forumhfr.redface2.feature.settings
 import fr.forumhfr.redface2.core.domain.cache.ImageCacheMaintenance
 import fr.forumhfr.redface2.core.domain.cache.TopicCacheMaintenance
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
+import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.AccentColor
@@ -2023,6 +2024,7 @@ class SettingsViewModelTest {
         override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) = Unit
         override suspend fun setFlagsMarkerStyle(style: MarkerStyle) = Unit
         override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
+        override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
 
         fun emit(value: ProxyConfig) {
             config.value = value

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -7,6 +7,7 @@ import fr.forumhfr.redface2.core.domain.blacklist.canonicalizePseudo
 import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
+import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.AccentColor
@@ -2047,6 +2048,7 @@ private class FakeUserPreferencesRepository(
     override suspend fun setFlagsUnreadOnlyForType(type: FlagType, enabled: Boolean) = Unit
     override suspend fun setFlagsMarkerStyle(style: MarkerStyle) = Unit
     override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
+    override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
 
     override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
 


### PR DESCRIPTION
## Quoi

Rend le style de la **bande de catégorie** (sticky header de la vue Drapeaux groupée) **sélectionnable** parmi 4 traitements, via une préférence GLOBALE dans le sheet d'affichage. Jusqu'ici la bande avait un seul style (le sous-titre minimal shipé en 0.17.3).

Les 4 styles :
- **Sobre** (`MINIMAL`, défaut) — sous-titre opaque, capitales espacées + filet. = le rendu actuel.
- **Bloc** (`SOFT`) — bloc tonal `surfaceContainer`, sans filet.
- **Accent** (`ACCENT`) — barre latérale `primary` pleine hauteur + icône teintée.
- **Puce** (`BULLET`) — nom dans une pastille tonale `surfaceContainerHigh`.

Demande XaTriX : les 2 maquettes d'origine transparentes (Accent / Puce) sont **opacifiées** sur fond `surface`, car la bande est un `stickyHeader` (un fond transparent laisserait transparaître les lignes qui défilent dessous).

`MINIMAL` reste le défaut → aucun changement visible pour l'existant tant qu'on ne choisit pas un autre style.

## Comment

Miroir exact du patron `markerStyle`, de bout en bout :
- `core/domain` : enum `CategoryBandStyle`, champ `FlagsViewSettings.categoryBandStyle`, setter dans `UserPreferencesRepository`.
- `core/data` : clé DataStore `flags_category_band_style` + lecture défensive (valeur inconnue → `MINIMAL`), portée sur les 2 chemins de résolution.
- `feature/flags` : setter VM, câblage `FlagsRoute` + sélecteur segmenté (désactivé en vue à plat), `CategoryHeaderBand` dispatche vers 4 leaves.

## Tests

- 3 tests de persistance DataStore (défaut, round-trip SOFT/BULLET, fallback défensif).
- 6 fakes `UserPreferencesRepository` étendus.

## Validation

- `detektAll` ✅ · `:app:lintProdDebug` ✅ · `:app:assembleProdDebug` ✅ · `testDebugUnitTest` ✅ (flake `:core:ui` smiley Roborazzi blanchi au re-run, sans rapport).
- **Codex** : GO avec réserves → la seule réserve (chip `BULLET` non borné en largeur) est corrigée (`weight(1f, fill=false)` + `maxLines=1`/ellipsis).

> Action par Claude Opus 4.8 (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)