### PR TITLE
fix(flags): no circular pull-to-refresh indicator on auto-refresh (#603)

### DIFF
--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -146,6 +146,9 @@ fun FlagsRoute(
     val selectedTab by viewModel.selectedTab.collectAsStateWithLifecycle()
     val flagsState by viewModel.flagsState.collectAsStateWithLifecycle()
     val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
+    // #603 — drives ONLY the circular PullToRefreshBox indicator (manual gesture); an auto-refresh
+    // keeps just the top linear bar via [isRefreshing], so no second rond pops on landing.
+    val isManualRefreshing by viewModel.isManualRefreshing.collectAsStateWithLifecycle()
     val removeFlagState by viewModel.removeFlagState.collectAsStateWithLifecycle()
     val removeFlagEvent by viewModel.removeFlagEvent.collectAsStateWithLifecycle()
     val flagsViewSettings by viewModel.flagsViewSettings.collectAsStateWithLifecycle()
@@ -370,6 +373,7 @@ fun FlagsRoute(
                                 flagsState = flagsState,
                                 cyanShowsRead = cyanShowsRead,
                                 isRefreshing = isRefreshing,
+                                isManualRefreshing = isManualRefreshing,
                                 removeFlagState = removeFlagState,
                                 showDtTab = showDtTab,
                                 dtListState = dtListState,
@@ -975,8 +979,10 @@ private fun FlagListBody(
     // Pull-to-refresh (swipe down) replaces the legacy header « Actualiser » button, matching
     // feature/forum. It wraps the whole flag body so the indicator stays anchored over the
     // existing content during the refresh round-trip (Material 3 stable, cf. Context7).
+    // #603 — the circular indicator is gated on the MANUAL refresh only: an auto-refresh (landing /
+    // tab switch / resume) surfaces just the top linear bar, no second rond over the list.
     PullToRefreshBox(
-        isRefreshing = state.isRefreshing,
+        isRefreshing = state.isManualRefreshing,
         onRefresh = actions.onRefresh,
         modifier = Modifier.fillMaxSize(),
     ) {
@@ -1943,7 +1949,10 @@ private data class FlagsBodyState(
     val flagsState: FlagsListUiState?,
     /** Whether the Cyan tab currently shows read topics (« +lus » suffix), #317. */
     val cyanShowsRead: Boolean,
+    /** Any refresh in flight (manual OR auto) — drives the top linear bar. */
     val isRefreshing: Boolean,
+    /** #603 — only a MANUAL refresh (pull/retry) — drives the circular PullToRefreshBox indicator. */
+    val isManualRefreshing: Boolean = false,
     val removeFlagState: RemoveFlagState,
     /** Whether the opt-in « DT » tab is shown (Settings toggle). */
     val showDtTab: Boolean,

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -489,12 +489,23 @@ class FlagsViewModel @Inject constructor(
     val removeFlagEvent: StateFlow<RemoveFlagEvent?> = _removeFlagEvent.asStateFlow()
 
     /**
-     * Toggled around the user-driven [refresh] round-trip so the Material 3
-     * `PullToRefreshBox` indicator can stay anchored over the existing list instead of
-     * blanking it back to a cold spinner. Same pattern as `ForumViewModel.isRefreshing`.
+     * Toggled around ANY refresh round-trip of a flag tab — manual [refresh] AND auto
+     * [maybeAutoRefresh] — so the top [FlagsLoadingBar] (the single load cue, #603/#648) shows for
+     * both. The circular `PullToRefreshBox` indicator is driven separately by [isManualRefreshing] so
+     * an auto-refresh does NOT pop a second (circular) cue over the list. Same pattern as
+     * `ForumViewModel.isRefreshing`.
      */
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
+    /**
+     * Toggled ONLY around the user-driven [refresh] round-trip (pull-to-refresh / retry), so the
+     * Material 3 `PullToRefreshBox` shows its circular indicator for the manual GESTURE alone. An
+     * auto-refresh ([maybeAutoRefresh]) leaves this `false` — it surfaces only the top linear bar via
+     * [isRefreshing] (#603: the central/circular cue was retired; the auto rond was the regression).
+     */
+    private val _isManualRefreshing = MutableStateFlow(false)
+    val isManualRefreshing: StateFlow<Boolean> = _isManualRefreshing.asStateFlow()
 
     /**
      * #546 — one-shot signal raised when a LANDING auto-refresh commits (app open, tab switch,
@@ -692,10 +703,16 @@ class FlagsViewModel @Inject constructor(
         // call would only duplicate the fan-out on the next landing — consume them (#378 follow-up).
         flagOpenedGenerationConsumed = flagOpenedGeneration
         viewModelScope.launch {
+            // Manual gesture: raise BOTH — the top bar ([_isRefreshing]) and the circular
+            // PullToRefreshBox indicator ([_isManualRefreshing], the gesture's own affordance).
             _isRefreshing.value = true
+            _isManualRefreshing.value = true
             try {
                 flagRepository.refresh(type)
             } finally {
+                // Drop the manual (circular) flag FIRST: were it the reverse, a frame with
+                // isRefreshing=false / isManualRefreshing=true could flash the rond alone (Codex nit).
+                _isManualRefreshing.value = false
                 _isRefreshing.value = false
             }
         }

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -222,6 +222,42 @@ class FlagsViewModelTest {
     }
 
     @Test
+    fun `a manual refresh raises BOTH isRefreshing and isManualRefreshing then clears them`() = runTest {
+        val flags = FakeFlagRepository()
+        flags.refreshGate = kotlinx.coroutines.CompletableDeferred()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val vm = viewModel(auth, flags, FakeForumRepository())
+
+        vm.refresh()
+        // Suspended at the gate: the manual gesture shows the top bar AND the circular indicator.
+        assertEquals(true, vm.isRefreshing.value)
+        assertEquals(true, vm.isManualRefreshing.value)
+
+        flags.refreshGate!!.complete(Unit)
+        assertEquals(false, vm.isRefreshing.value)
+        assertEquals(false, vm.isManualRefreshing.value)
+    }
+
+    @Test
+    fun `an auto-refresh raises isRefreshing only, never isManualRefreshing (no circular cue on landing)`() = runTest {
+        // #603 regression guard: the auto rond. maybeAutoRefresh must surface ONLY the top linear bar
+        // (isRefreshing) so the PullToRefreshBox circular indicator (isManualRefreshing) stays hidden.
+        val flags = FakeFlagRepository()
+        flags.refreshGate = kotlinx.coroutines.CompletableDeferred()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val vm = viewModel(auth, flags, FakeForumRepository())
+
+        vm.maybeAutoRefresh()
+        // Suspended at the gate: top bar up, but NO circular indicator.
+        assertEquals(true, vm.isRefreshing.value)
+        assertEquals(false, vm.isManualRefreshing.value)
+
+        flags.refreshGate!!.complete(Unit)
+        assertEquals(false, vm.isRefreshing.value)
+        assertEquals(false, vm.isManualRefreshing.value)
+    }
+
+    @Test
     fun `selecting the Super tab is a placeholder with no fetch and null state`() = runTest {
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository(catIds = listOf(1))
@@ -2141,8 +2177,16 @@ class FlagsViewModelTest {
         override fun observe(type: FlagType): Flow<FlagsResult> =
             perType.getValue(type).asSharedFlow()
 
+        /**
+         * Optional gate to suspend a [refresh] round-trip so a test can assert the intermediate
+         * indicator state (isRefreshing / isManualRefreshing) before the call resolves. Null = the
+         * refresh returns immediately (the default for every test that doesn't need the gate).
+         */
+        var refreshGate: kotlinx.coroutines.CompletableDeferred<Unit>? = null
+
         override suspend fun refresh(type: FlagType) {
             refreshCalls = refreshCalls + type
+            refreshGate?.await()
         }
 
         override fun clearSessionCache() {


### PR DESCRIPTION
## Bug

Le spinner **central** a été retiré au #648 (barre linéaire en haut = cue unique). Mais l'indicateur **circulaire** du `PullToRefreshBox` continuait de s'afficher à **chaque auto-refresh** (atterrissage / changement d'onglet / retour au premier plan) : `refresh()` (manuel) et `maybeAutoRefresh()` (auto) lèvent le même `isRefreshing`, et le `PullToRefreshBox` y était branché. Résultat : un rond circulaire en plus de la barre du haut sur chaque atterrissage — exactement le doublon que le #648 devait éliminer.

## Fix

Découplage des deux indicateurs :
- `isRefreshing` (inchangé) → barre linéaire du haut, pour **tout** refresh (manuel + auto) + le load initial.
- `isManualRefreshing` (nouveau) → levé **uniquement** par `refresh()` (geste pull / retry) → pilote le rond du `PullToRefreshBox`. Un auto-refresh le laisse `false` → atterrissage = barre du haut seule, **plus de rond**.

Le geste manuel garde son rond (attendu). **DT inchangé** : son `dtIsRefreshing` n'est levé que par `refreshDt()` manuel.

## Tests

- Un refresh manuel lève les deux indicateurs puis les remet à false.
- Un auto-refresh ne lève **que** `isRefreshing`, jamais `isManualRefreshing` (garde de régression).
- Ajout d'une porte suspendable à `FakeFlagRepository.refresh` pour observer l'état mi-round-trip.

## Validation

`detektAll` ✅ · `:app:lintProdDebug` ✅ · `:app:assembleProdDebug` ✅ · `testDebugUnitTest` ✅ (dont les 2 nouveaux). Codex : review en cours.

> Action par Claude Opus 4.8 (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)