### PR TITLE
chore(release): 0.17.4 dev (band styles #656 + spinner fix #657)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,19 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.4` — `internal` (dev) — 2026-06-26
+
+> Vue Drapeaux : 4 styles de bande de catégorie au choix (#656) + correction du rond de chargement à
+> l'auto-refresh (#657). Build dev ; versionCode au dispatch. versionName 0.17.3 → 0.17.4. Codex GO + CI verte.
+
+**Drapeaux (#603)**
+
+- **Styles de bande de catégorie au choix** (menu d'affichage, vue groupée) : Sobre (défaut, = l'actuel),
+  Bloc (bloc tonal), Accent (barre latérale + icône teintée), Puce (nom dans une pastille). Réglage global ;
+  les 2 styles d'origine transparents sont opacifiés pour le sticky header.
+- **Bug corrigé** : le rond de chargement (pull-to-refresh) ne s'affiche plus pendant l'auto-refresh
+  (atterrissage / changement d'onglet / retour) — seule la barre du haut reste. Le geste manuel garde son rond.
+
 ## `0.17.3` — `internal` (dev) — 2026-06-25
 
 > Suite du dogfood 0.17.2 (#653 + #654). Build dev ; versionCode au dispatch. versionName 0.17.2 → 0.17.3.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.3"
+        versionName = "0.17.4"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,7 +1,7 @@
-Redface 2 v0.17.3 — dev.
+Redface 2 v0.17.4 — dev.
 
-Drapeaux view:
-- New "single-line titles" option (display menu): topic titles trimmed to one line instead of two.
-- Lighter category band (by-category view): a discreet subhead instead of the full block.
+Flags view:
+- Selectable category band styles (display menu): Minimal, Block, Accent, Chip.
+- Fix: no loading spinner during auto-refresh (only the top bar remains); manual pull-to-refresh keeps its own.
 
 Bugs: via dev or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,7 +1,7 @@
-Redface 2 v0.17.3 — dev.
+Redface 2 v0.17.4 — dev.
 
 Vue Drapeaux :
-- Nouvelle option « titre sur une seule ligne » (menu d'affichage) : titres tronqués à une ligne au lieu de deux.
-- Bande de catégorie allégée (vue par catégorie) : un sous-titre discret au lieu du bandeau plein.
+- Styles de bande de catégorie au choix (menu d'affichage) : Sobre, Bloc, Accent, Puce.
+- Correctif : plus de rond de chargement pendant l'auto-refresh (seule la barre du haut reste) ; le pull-to-refresh manuel garde le sien.
 
 Bugs : via le canal dev ou GitHub.


### PR DESCRIPTION
Bump de version groupant les deux suites #603 déjà mergées dans `dev` en **une seule release dev** :

- **#656** — styles de bande de catégorie au choix (Sobre / Bloc / Accent / Puce).
- **#657** — plus de rond de chargement pendant l'auto-refresh (seule la barre du haut reste).

`versionName` 0.17.3 → 0.17.4 (évite le doublon F-Droid `.dev`). `versionCode` alloué au dispatch. CHANGELOG + whatsnew fr/en (guards verts).

> Action par Claude Opus 4.8 (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)