### PR TITLE
fix(flags): remove pull-to-refresh circular indicator, top bar is the sole cue (#659) + 0.17.5

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,18 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.5` — `internal` (dev) — 2026-06-26
+
+> Suite dogfood v184 : le rond de chargement persistait sur le pull-to-refresh manuel. Build dev ;
+> versionCode au dispatch. versionName 0.17.4 → 0.17.5. Codex GO + CI verte.
+
+**Drapeaux (#603, #659)**
+
+- **Plus aucun rond de chargement** : l'indicateur circulaire du pull-to-refresh est retiré
+  (`indicator = {}`) sur les onglets drapeaux ET DT. La fine barre de progression en haut devient
+  l'unique repère de chargement (manuel, auto et initial). Le geste swipe-down déclenche toujours le
+  refresh. Retrait du flag `isManualRefreshing` introduit en v184 (devenu inutile).
+
 ## `0.17.4` — `internal` (dev) — 2026-06-26
 
 > Vue Drapeaux : 4 styles de bande de catégorie au choix (#656) + correction du rond de chargement à

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.4"
+        versionName = "0.17.5"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,7 +1,6 @@
-Redface 2 v0.17.4 — dev.
+Redface 2 v0.17.5 — dev.
 
 Flags view:
-- Selectable category band styles (display menu): Minimal, Block, Accent, Chip.
-- Fix: no loading spinner during auto-refresh (only the top bar remains); manual pull-to-refresh keeps its own.
+- No more loading spinner: only the thin top bar signals a refresh (manual, auto and initial). Swipe-down still triggers the refresh.
 
 Bugs: via dev or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,7 +1,6 @@
-Redface 2 v0.17.4 — dev.
+Redface 2 v0.17.5 — dev.
 
 Vue Drapeaux :
-- Styles de bande de catégorie au choix (menu d'affichage) : Sobre, Bloc, Accent, Puce.
-- Correctif : plus de rond de chargement pendant l'auto-refresh (seule la barre du haut reste) ; le pull-to-refresh manuel garde le sien.
+- Plus de rond de chargement : seule la fine barre du haut indique le rafraîchissement (manuel, auto et initial). Le swipe-down déclenche toujours le refresh.
 
 Bugs : via le canal dev ou GitHub.

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -146,9 +146,6 @@ fun FlagsRoute(
     val selectedTab by viewModel.selectedTab.collectAsStateWithLifecycle()
     val flagsState by viewModel.flagsState.collectAsStateWithLifecycle()
     val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
-    // #603 — drives ONLY the circular PullToRefreshBox indicator (manual gesture); an auto-refresh
-    // keeps just the top linear bar via [isRefreshing], so no second rond pops on landing.
-    val isManualRefreshing by viewModel.isManualRefreshing.collectAsStateWithLifecycle()
     val removeFlagState by viewModel.removeFlagState.collectAsStateWithLifecycle()
     val removeFlagEvent by viewModel.removeFlagEvent.collectAsStateWithLifecycle()
     val flagsViewSettings by viewModel.flagsViewSettings.collectAsStateWithLifecycle()
@@ -373,7 +370,6 @@ fun FlagsRoute(
                                 flagsState = flagsState,
                                 cyanShowsRead = cyanShowsRead,
                                 isRefreshing = isRefreshing,
-                                isManualRefreshing = isManualRefreshing,
                                 removeFlagState = removeFlagState,
                                 showDtTab = showDtTab,
                                 dtListState = dtListState,
@@ -979,11 +975,14 @@ private fun FlagListBody(
     // Pull-to-refresh (swipe down) replaces the legacy header « Actualiser » button, matching
     // feature/forum. It wraps the whole flag body so the indicator stays anchored over the
     // existing content during the refresh round-trip (Material 3 stable, cf. Context7).
-    // #603 — the circular indicator is gated on the MANUAL refresh only: an auto-refresh (landing /
-    // tab switch / resume) surfaces just the top linear bar, no second rond over the list.
+    // #603 — no circular indicator: the thin top FlagsLoadingBar is the single loading cue for manual,
+    // auto AND initial loads (XaTriX dogfood — the rond was redundant with the bar). `indicator = {}`
+    // keeps the pull gesture (onRefresh still fires) but draws nothing; `isRefreshing` still drives the
+    // box state so a pull during an in-flight refresh doesn't double-trigger.
     PullToRefreshBox(
-        isRefreshing = state.isManualRefreshing,
+        isRefreshing = state.isRefreshing,
         onRefresh = actions.onRefresh,
+        indicator = {},
         modifier = Modifier.fillMaxSize(),
     ) {
         when (val current = state.flagsState) {
@@ -1646,11 +1645,13 @@ private fun DtTabOpenEffect(
 @Composable
 private fun DtListBody(state: DtListUiState, isRefreshing: Boolean, actions: AuthenticatedActions) {
     // #546 directive XaTriX — pull-to-refresh (swipe down) on the DT list, like the flag tabs. Wraps
-    // the whole body (every branch) so the indicator stays anchored over the existing content during
-    // the refresh round-trip and the gesture has a target even on the listless states (#229 pattern).
+    // the whole body (every branch) so the gesture has a target even on the listless states (#229).
+    // #603 — no circular indicator (`indicator = {}`), consistent with the flag tabs: the top
+    // FlagsLoadingBar (driven by dtIsRefreshing / DtListUiState.Loading) is the single loading cue.
     PullToRefreshBox(
         isRefreshing = isRefreshing,
         onRefresh = actions.onRefreshDt,
+        indicator = {},
         modifier = Modifier.fillMaxSize(),
     ) {
         DtListContent(state = state, actions = actions)
@@ -1949,10 +1950,8 @@ private data class FlagsBodyState(
     val flagsState: FlagsListUiState?,
     /** Whether the Cyan tab currently shows read topics (« +lus » suffix), #317. */
     val cyanShowsRead: Boolean,
-    /** Any refresh in flight (manual OR auto) — drives the top linear bar. */
+    /** Any refresh in flight (manual OR auto) — drives the top linear bar (single loading cue). */
     val isRefreshing: Boolean,
-    /** #603 — only a MANUAL refresh (pull/retry) — drives the circular PullToRefreshBox indicator. */
-    val isManualRefreshing: Boolean = false,
     val removeFlagState: RemoveFlagState,
     /** Whether the opt-in « DT » tab is shown (Settings toggle). */
     val showDtTab: Boolean,

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -490,22 +490,13 @@ class FlagsViewModel @Inject constructor(
 
     /**
      * Toggled around ANY refresh round-trip of a flag tab — manual [refresh] AND auto
-     * [maybeAutoRefresh] — so the top [FlagsLoadingBar] (the single load cue, #603/#648) shows for
-     * both. The circular `PullToRefreshBox` indicator is driven separately by [isManualRefreshing] so
-     * an auto-refresh does NOT pop a second (circular) cue over the list. Same pattern as
-     * `ForumViewModel.isRefreshing`.
+     * [maybeAutoRefresh]. Drives the top [FlagsLoadingBar], which is the SINGLE loading cue
+     * (#603/#648): the central spinner was retired and the circular `PullToRefreshBox` indicator is
+     * hidden (`indicator = {}`), so the thin top bar is the only cue for manual, auto and initial
+     * loads. Same pattern as `ForumViewModel.isRefreshing`.
      */
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
-
-    /**
-     * Toggled ONLY around the user-driven [refresh] round-trip (pull-to-refresh / retry), so the
-     * Material 3 `PullToRefreshBox` shows its circular indicator for the manual GESTURE alone. An
-     * auto-refresh ([maybeAutoRefresh]) leaves this `false` — it surfaces only the top linear bar via
-     * [isRefreshing] (#603: the central/circular cue was retired; the auto rond was the regression).
-     */
-    private val _isManualRefreshing = MutableStateFlow(false)
-    val isManualRefreshing: StateFlow<Boolean> = _isManualRefreshing.asStateFlow()
 
     /**
      * #546 — one-shot signal raised when a LANDING auto-refresh commits (app open, tab switch,
@@ -703,16 +694,10 @@ class FlagsViewModel @Inject constructor(
         // call would only duplicate the fan-out on the next landing — consume them (#378 follow-up).
         flagOpenedGenerationConsumed = flagOpenedGeneration
         viewModelScope.launch {
-            // Manual gesture: raise BOTH — the top bar ([_isRefreshing]) and the circular
-            // PullToRefreshBox indicator ([_isManualRefreshing], the gesture's own affordance).
             _isRefreshing.value = true
-            _isManualRefreshing.value = true
             try {
                 flagRepository.refresh(type)
             } finally {
-                // Drop the manual (circular) flag FIRST: were it the reverse, a frame with
-                // isRefreshing=false / isManualRefreshing=true could flash the rond alone (Codex nit).
-                _isManualRefreshing.value = false
                 _isRefreshing.value = false
             }
         }

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -222,39 +222,21 @@ class FlagsViewModelTest {
     }
 
     @Test
-    fun `a manual refresh raises BOTH isRefreshing and isManualRefreshing then clears them`() = runTest {
-        val flags = FakeFlagRepository()
-        flags.refreshGate = kotlinx.coroutines.CompletableDeferred()
-        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
-        val vm = viewModel(auth, flags, FakeForumRepository())
-
-        vm.refresh()
-        // Suspended at the gate: the manual gesture shows the top bar AND the circular indicator.
-        assertEquals(true, vm.isRefreshing.value)
-        assertEquals(true, vm.isManualRefreshing.value)
-
-        flags.refreshGate!!.complete(Unit)
-        assertEquals(false, vm.isRefreshing.value)
-        assertEquals(false, vm.isManualRefreshing.value)
-    }
-
-    @Test
-    fun `an auto-refresh raises isRefreshing only, never isManualRefreshing (no circular cue on landing)`() = runTest {
-        // #603 regression guard: the auto rond. maybeAutoRefresh must surface ONLY the top linear bar
-        // (isRefreshing) so the PullToRefreshBox circular indicator (isManualRefreshing) stays hidden.
+    fun `maybeAutoRefresh raises isRefreshing for the round-trip then clears it`() = runTest {
+        // #603 — isRefreshing is the SINGLE loading cue (it drives the top bar; the PullToRefreshBox
+        // circular indicator is hidden via indicator = {}). An auto-refresh must raise it during the
+        // round-trip and clear it after, exactly like a manual refresh.
         val flags = FakeFlagRepository()
         flags.refreshGate = kotlinx.coroutines.CompletableDeferred()
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
         val vm = viewModel(auth, flags, FakeForumRepository())
 
         vm.maybeAutoRefresh()
-        // Suspended at the gate: top bar up, but NO circular indicator.
+        // Suspended at the gate: the loading cue (top bar) is up.
         assertEquals(true, vm.isRefreshing.value)
-        assertEquals(false, vm.isManualRefreshing.value)
 
         flags.refreshGate!!.complete(Unit)
         assertEquals(false, vm.isRefreshing.value)
-        assertEquals(false, vm.isManualRefreshing.value)
     }
 
     @Test
@@ -2179,8 +2161,8 @@ class FlagsViewModelTest {
 
         /**
          * Optional gate to suspend a [refresh] round-trip so a test can assert the intermediate
-         * indicator state (isRefreshing / isManualRefreshing) before the call resolves. Null = the
-         * refresh returns immediately (the default for every test that doesn't need the gate).
+         * `isRefreshing` state before the call resolves. Null = the refresh returns immediately (the
+         * default for every test that doesn't need the gate).
          */
         var refreshGate: kotlinx.coroutines.CompletableDeferred<Unit>? = null
 


### PR DESCRIPTION
Closes #659.

## Quoi
Dogfood v184 (styx42, XaTriX) : le rond du pull-to-refresh restait sur le **geste manuel**. Décision : le retirer **partout**. La fine barre du haut devient l'unique repère de chargement (manuel + auto + initial).

## Comment
- `indicator = {}` sur les deux `PullToRefreshBox` (onglets drapeaux + DT) : le geste continue de déclencher `onRefresh`, mais aucun rond n'est dessiné (API confirmée via Context7).
- **Revert** du flag `isManualRefreshing` introduit en v184 (devenu inutile) : flow VM + câblage FlagsRoute + champ FlagsBodyState retirés. Le test à porte suspendable vérifie maintenant que `isRefreshing` bascule autour d'un auto-refresh.
- Bump versionName 0.17.4 → 0.17.5 + CHANGELOG + whatsnew.

## Validation
`detektAll` ✅ · `:app:lintProdDebug` ✅ · `:app:assembleProdDebug` ✅ · `testDebugUnitTest` ✅.

> Action par Claude Opus 4.8 (demandée par XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)