### PR TITLE
fix(flags): loading-bar reserved slot (#671) + harmonise empty states (#662) + 0.17.6

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,19 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.6` — `internal` (dev) — 2026-06-26
+
+> Suite dogfood : la barre de chargement décalait le contenu, et les états vides étaient hétérogènes.
+> Build dev ; versionCode au dispatch. versionName 0.17.5 → 0.17.6.
+
+**Drapeaux (#603)**
+
+- **Barre de chargement** (#671) : un slot de hauteur fixe lui est réservé sous la barre du haut — elle
+  n'apparaît/disparaît plus en décalant la liste et les bandes de catégorie. Le slot fait aussi office
+  d'espace dédié entre la search bar et le début de la liste.
+- **Messages d'état vide homogénéisés** (#662) : forme courte uniforme (« Aucun(e)… », sans point ni
+  instruction collée) ; le « Aucune conversation non lue » du DT ne traîne plus son rappel « re-tape ».
+
 ## `0.17.5` — `internal` (dev) — 2026-06-26
 
 > Suite dogfood v184 : le rond de chargement persistait sur le pull-to-refresh manuel. Build dev ;

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.5"
+        versionName = "0.17.6"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,6 +1,7 @@
-Redface 2 v0.17.5 — dev.
+Redface 2 v0.17.6 — dev.
 
 Flags view:
-- No more loading spinner: only the thin top bar signals a refresh (manual, auto and initial). Swipe-down still triggers the refresh.
+- The loading bar no longer shifts the list down (reserved slot under the top bar).
+- Harmonised empty-list messages.
 
 Bugs: via dev or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,6 +1,7 @@
-Redface 2 v0.17.5 — dev.
+Redface 2 v0.17.6 — dev.
 
 Vue Drapeaux :
-- Plus de rond de chargement : seule la fine barre du haut indique le rafraîchissement (manuel, auto et initial). Le swipe-down déclenche toujours le refresh.
+- La barre de chargement ne décale plus la liste (espace réservé sous la barre du haut).
+- Messages « liste vide » harmonisés.
 
 Bugs : via le canal dev ou GitHub.

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -840,10 +840,20 @@ private fun flagsLoadingBarVisible(
 // #603 — extracted so the single-line-title branch doesn't count against FlagsRoute's cyclomatic budget.
 private fun flagTitleMaxLines(singleLineTitle: Boolean): Int = if (singleLineTitle) 1 else 2
 
+// #603 — height of the always-present loading-bar SLOT. Reserving it unconditionally (rather than
+// rendering the bar with `if (loading)`) stops the list + sticky category bands from jumping by the
+// bar's height each time a load starts/ends (XaTriX dogfood). Slightly taller than the ~4dp M3 bar so
+// it doubles as a deliberate breathing gap between the search app bar and the list; the bar sits flush
+// at the top of the slot, the gap falls between it and the first row / category band.
+private val LOADING_BAR_SLOT_HEIGHT = 10.dp
+
 @Composable
 private fun FlagsLoadingBar(loading: Boolean) {
-    if (loading) {
-        LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+    // The SLOT is always laid out; only the bar inside is conditional → toggling never reflows the list.
+    Box(modifier = Modifier.fillMaxWidth().height(LOADING_BAR_SLOT_HEIGHT)) {
+        if (loading) {
+            LinearProgressIndicator(modifier = Modifier.fillMaxWidth().align(Alignment.TopCenter))
+        }
     }
 }
 

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -65,11 +65,13 @@
          récentes) ∪ entrées connues de la synchro DT (MPStorage) — un balayage multi-pages est
          différé (cf. DT_INBOX_PAGE). Le wording assume « récente » pour ne pas affirmer qu'AUCUNE
          MultiMP n'existe ailleurs (ni en page 1, ni connue de la synchro DT). -->
-    <string name="flags_dt_empty">Aucune conversation multi-destinataires récente.</string>
+    <string name="flags_dt_empty">Aucune conversation multi-destinataires récente</string>
     <!-- #546 — état « non-lus uniquement » actif mais aucune conversation non lue (l'union n'est pas
          vide, juste filtrée). Re-taper l'onglet DT affiche aussi les lues (« +lus »). Distinct de
-         flags_dt_empty (aucune conversation du tout). -->
-    <string name="flags_dt_no_unread">Aucune conversation non lue. Re-tape l\'onglet DT pour afficher aussi les lues.</string>
+         flags_dt_empty (aucune conversation du tout). #662 — wording aligné sur les autres états vides
+         (forme courte « Aucun(e)… », sans point ni instruction collée ; la découvrabilité du « +lus »
+         est traitée à part, #661). -->
+    <string name="flags_dt_no_unread">Aucune conversation non lue</string>
     <!-- Description a11y d'une ligne DT : état lu/non-lu, annoncé par TalkBack (le point coloré
          est purement décoratif). %1$s = sujet de la conversation. -->
     <string name="flags_dt_row_unread">Non lu : %1$s</string>


### PR DESCRIPTION
Closes #671. Closes #662.

## #671 — la barre de chargement décalait le contenu
`FlagsLoadingBar` rendait la `LinearProgressIndicator` avec `if (loading)` → à chaque chargement, la barre (~4dp) apparaissait et **poussait la liste + les bandes de catégorie** vers le bas.

Fix : **slot de hauteur fixe toujours réservé** (`LOADING_BAR_SLOT_HEIGHT = 10.dp`) ; la barre se dessine dedans (flush en haut) uniquement pendant le chargement, donc plus de reflow. Le slot fait aussi office d'**espace dédié** entre la search app bar et la liste / les noms de catégories.

## #662 — états vides homogénéisés
Libellés incohérents (point final sur 2/6, et le DT « sans non-lu » traînait une instruction « re-tape » que les autres n'avaient pas). Harmonisés en forme courte « Aucun(e)… », sans point ni instruction collée : `flags_dt_empty` perd son point, `flags_dt_no_unread` → « Aucune conversation non lue » (la découvrabilité du « +lus » reste suivie dans #661).

## Validation
`detektAll` ✅ · `:app:lintProdDebug` ✅ · `:app:assembleProdDebug` ✅ (local, avant l'ajout strings — la CI rejoue tout).

> Action par Claude Opus 4.8 (demandée par XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)