### PR TITLE
fix(flags): scrollable quick-config sheet (#673) + 0.17.7

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,17 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.7` — `internal` (dev) — 2026-06-26
+
+> Hotfix dogfood : le menu de réglages rapides ne défilait pas, rendant le sélecteur de style de bande
+> inaccessible. Build dev ; versionCode au dispatch. versionName 0.17.6 → 0.17.7.
+
+**Drapeaux (#603, #673)**
+
+- **Menu de réglages rapides scrollable** : le bottom sheet a grossi (marqueur, titre 1 ligne, style de
+  bande…) et débordait sans défiler — les options du bas (dont le style de bande) étaient injoignables sur
+  petits écrans. Le contenu défile désormais ; tout reste accessible.
+
 ## `0.17.6` — `internal` (dev) — 2026-06-26
 
 > Suite dogfood : la barre de chargement décalait le contenu, et les états vides étaient hétérogènes.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.6"
+        versionName = "0.17.7"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,7 +1,6 @@
-Redface 2 v0.17.6 — dev.
+Redface 2 v0.17.7 — dev.
 
 Flags view:
-- The loading bar no longer shifts the list down (reserved slot under the top bar).
-- Harmonised empty-list messages.
+- The quick-settings menu now scrolls: every option (including the category band style) stays reachable, even on small screens.
 
 Bugs: via dev or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,7 +1,6 @@
-Redface 2 v0.17.6 — dev.
+Redface 2 v0.17.7 — dev.
 
 Vue Drapeaux :
-- La barre de chargement ne décale plus la liste (espace réservé sous la barre du haut).
-- Messages « liste vide » harmonisés.
+- Le menu de réglages rapides défile désormais : toutes les options (dont le style de bande) restent accessibles, même sur petit écran.
 
 Bugs : via le canal dev ou GitHub.

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -522,6 +522,12 @@ private fun FlagsViewSettingsSheet(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                // #673 — the sheet grew (override + grouper + masquer lues + non-lus + marqueur + titre
+                // 1 ligne + style de bande + Fermer) and overflowed without scrolling, hiding the bottom
+                // options (band-style selector) on short screens. Make the content scrollable so every
+                // option stays reachable; navigationBarsPadding scrolls with it so the last row clears
+                // the system bar.
+                .verticalScroll(rememberScrollState())
                 .navigationBarsPadding()
                 .padding(horizontal = 24.dp)
                 .padding(bottom = 24.dp),


### PR DESCRIPTION
Closes #673.

## Bug
Le bottom sheet de réglages rapides (`FlagsViewSettingsSheet`) était une `Column` **non scrollable**. À force de grossir (marqueur, titre 1 ligne, **style de bande**…), il débordait sur petit écran et les options du bas — dont le **sélecteur de style de bande** ajouté en v184 — devenaient **injoignables** (nicko, confirmé XaTriX, v184/v185).

## Fix
`verticalScroll(rememberScrollState())` sur la Column du sheet → tout reste accessible ; `navigationBarsPadding` défile avec le contenu.

Bump 0.17.6 → 0.17.7. (Le retour « réglages rapides trop gros / ranger l'avancé dans les Réglages » est suivi à part, #661.)

## Validation
`detektAll` ✅ · `:app:lintProdDebug` ✅ · `:app:assembleProdDebug` ✅.

> Action par Claude Opus 4.8 (demandée par XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)