### PR TITLE
feat(flags): resserrage espacement bandes de catégorie (#603, preset D) + 0.17.8

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,20 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.8` — `internal` (dev) — 2026-06-26
+
+> Polish dogfood : resserrage de l'espacement entre la barre de recherche et les bandes de catégorie
+> (preset D « minimal » validé par XaTriX sur l'inspecteur d'espacement). Build dev ; versionCode au
+> dispatch. versionName 0.17.7 → 0.17.8.
+
+**Drapeaux (#603)**
+
+- **Espacement resserré (vue groupée)** : l'air au-dessus et autour des bandes de catégorie était jugé
+  trop grand. Slot de la barre de chargement 10 → 4 dp, marge basse de la barre de recherche 8 → 2 dp
+  (la bande remonte sous la barre), hauteur min des bandes 44 → 34 dp et padding vertical → 4 dp.
+  La cible tactile de la bande passe sous la reco Material 48 dp / WCAG AAA 44 dp mais reste au-dessus
+  du plancher WCAG 2.2 AA (24 dp) — compromis densité assumé.
+
 ## `0.17.7` — `internal` (dev) — 2026-06-26
 
 > Hotfix dogfood : le menu de réglages rapides ne défilait pas, rendant le sélecteur de style de bande

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.7"
+        versionName = "0.17.8"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,6 +1,6 @@
-Redface 2 v0.17.7 — dev.
+Redface 2 v0.17.8 — dev.
 
 Flags view:
-- The quick-settings menu now scrolls: every option (including the category band style) stays reachable, even on small screens.
+- Tighter spacing between the search bar and the category bands: less air above and around categories, denser list (the "minimal" preset).
 
 Bugs: via dev or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,6 +1,6 @@
-Redface 2 v0.17.7 — dev.
+Redface 2 v0.17.8 — dev.
 
 Vue Drapeaux :
-- Le menu de réglages rapides défile désormais : toutes les options (dont le style de bande) restent accessibles, même sur petit écran.
+- Espacement resserré entre la barre de recherche et les bandes de catégorie : moins d'air au-dessus et autour des catégories, liste plus dense (preset « minimal »).
 
 Bugs : via le canal dev ou GitHub.

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -848,10 +848,10 @@ private fun flagTitleMaxLines(singleLineTitle: Boolean): Int = if (singleLineTit
 
 // #603 — height of the always-present loading-bar SLOT. Reserving it unconditionally (rather than
 // rendering the bar with `if (loading)`) stops the list + sticky category bands from jumping by the
-// bar's height each time a load starts/ends (XaTriX dogfood). Slightly taller than the ~4dp M3 bar so
-// it doubles as a deliberate breathing gap between the search app bar and the list; the bar sits flush
-// at the top of the slot, the gap falls between it and the first row / category band.
-private val LOADING_BAR_SLOT_HEIGHT = 10.dp
+// bar's height each time a load starts/ends (XaTriX dogfood). Sized to the ~4dp M3 bar itself with no
+// extra air (preset D, XaTriX): the bar sits flush at the top of the slot and the list/first band follow
+// immediately, so the slot costs no visible gap when idle.
+private val LOADING_BAR_SLOT_HEIGHT = 4.dp
 
 @Composable
 private fun FlagsLoadingBar(loading: Boolean) {
@@ -1242,8 +1242,9 @@ private fun CategorySectionedFlagList(
  *
  * #414 — the whole band is tappable and opens the category's topic listing (RF1 parity); the trailing
  * chevron vector (`ic_chevron_right`) is the affordance. Foundation [clickable] does not enforce a
- * Material touch-target minimum, hence the explicit [heightIn] (44 dp — still an acceptable target) on
- * every leaf.
+ * Material touch-target minimum, hence the explicit [heightIn] on every leaf. #603 (preset D, XaTriX)
+ * trimmed that min to 34 dp for a denser band: below Material's 48 dp / WCAG AAA 44 dp recommendation
+ * but still above the WCAG 2.2 AA 24 dp floor — a deliberate density-over-target-size trade-off.
  */
 @Composable
 private fun CategoryHeaderBand(catId: Int, label: String, style: CategoryBandStyle, onClick: () -> Unit) {
@@ -1276,9 +1277,9 @@ private fun CategoryBandMinimal(catId: Int, label: String, onClick: () -> Unit) 
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .fillMaxWidth()
-                .heightIn(min = 44.dp)
+                .heightIn(min = 34.dp)
                 .clickable(onClickLabel = stringResource(R.string.flags_category_open_label)) { onClick() }
-                .padding(horizontal = 24.dp, vertical = 6.dp),
+                .padding(horizontal = 24.dp, vertical = 4.dp),
         ) {
             RedfaceVectorIcon(
                 resId = categoryIcon(catId),
@@ -1309,9 +1310,9 @@ private fun CategoryBandSoft(catId: Int, label: String, onClick: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.surfaceContainer)
-            .heightIn(min = 44.dp)
+            .heightIn(min = 34.dp)
             .clickable(onClickLabel = stringResource(R.string.flags_category_open_label)) { onClick() }
-            .padding(horizontal = 24.dp, vertical = 8.dp),
+            .padding(horizontal = 24.dp, vertical = 4.dp),
     ) {
         RedfaceVectorIcon(
             resId = categoryIcon(catId),
@@ -1354,8 +1355,8 @@ private fun CategoryBandAccent(catId: Int, label: String, onClick: () -> Unit) {
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier
                     .weight(1f)
-                    .heightIn(min = 44.dp)
-                    .padding(horizontal = 20.dp, vertical = 6.dp),
+                    .heightIn(min = 34.dp)
+                    .padding(horizontal = 20.dp, vertical = 4.dp),
             ) {
                 RedfaceVectorIcon(
                     resId = categoryIcon(catId),
@@ -1389,9 +1390,9 @@ private fun CategoryBandBullet(catId: Int, label: String, onClick: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.surface)
-            .heightIn(min = 44.dp)
+            .heightIn(min = 34.dp)
             .clickable(onClickLabel = stringResource(R.string.flags_category_open_label)) { onClick() }
-            .padding(horizontal = 20.dp, vertical = 6.dp),
+            .padding(horizontal = 20.dp, vertical = 4.dp),
     ) {
         Surface(
             color = MaterialTheme.colorScheme.surfaceContainerHigh,

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsSearchAppBar.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsSearchAppBar.kt
@@ -75,7 +75,10 @@ fun FlagsSearchAppBar(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 8.dp, vertical = 8.dp),
+                // Asymmetric vertical padding (#603, XaTriX preset D): the bottom is trimmed to 2.dp so
+                // the category band tucks up close under the search bar; the top keeps 8.dp of breathing
+                // room below the status bar.
+                .padding(start = 8.dp, end = 8.dp, top = 8.dp, bottom = 2.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaTriX)

## Quoi

XaTriX a choisi le **preset D (« minimal »)** sur l'inspecteur d'espacement publié pour la vue Drapeaux ([artefact](https://forumhfr.github.io/artifacts/flags-603-band-spacing/)). On resserre l'air **au-dessus et autour** des bandes de catégorie (vue groupée) :

| Lever | Avant | Après |
|---|---|---|
| Slot barre de chargement (`LOADING_BAR_SLOT_HEIGHT`) | 10 dp | 4 dp |
| Bas de la barre de recherche (`FlagsSearchAppBar`) | 8 dp | 2 dp |
| Hauteur min des bandes (`heightIn`, 4 styles) | 44 dp | 34 dp |
| Padding vertical des bandes | 6 / 8 dp | 4 dp |

Net : l'air pastille de recherche → bande passe de **18 dp à 6 dp**, et chaque bande perd ~10 dp de hauteur. Le padding du haut de la barre reste à 8 dp (respiration sous la status bar), d'où le padding asymétrique. Le chip interne du style BULLET garde son padding de 6 dp.

## Accessibilité (assumé)

La bande entière est la cible tactile (#414, ouvre la catégorie). 34 dp passe **sous** la reco Material (48 dp) et WCAG AAA (44 dp), mais reste **au-dessus** du plancher WCAG 2.2 AA (24 dp). Compromis densité validé par XaTriX, documenté dans le KDoc de `CategoryHeaderBand`.

## Validation

- `detektAll` + `:app:lintProdDebug` + `testDebugUnitTest` + `:app:assembleProdDebug` → **BUILD SUCCESSFUL** (le 34 dp ne déclenche aucun lint touch-target).
- Guards `check-changelog-entry.sh 0.17.8` + `check-whatsnew.sh 0.17.8` verts.

versionName 0.17.7 → 0.17.8 ; versionCode alloué au dispatch.