### PR TITLE
feat(flags): Lot 1 vue Drapeaux — swipe (#660/#663), icône IA (#664), retour onglet (#667) + 0.17.9

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,25 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.9` — `internal` (dev) — 2026-06-26
+
+> Lot 1 dogfood (3 sur 4) : bugs swipe + navigation et icône de catégorie. Le réglage des libellés de
+> la barre du bas (#666) suivra dans une release dédiée. Build dev ; versionCode au dispatch.
+> versionName 0.17.8 → 0.17.9.
+
+**Drapeaux (#603)**
+
+- **Swipe entre onglets — animation du bon côté (#660)** : au changement d'onglet validé, le nouvel
+  onglet apparaît centré net au lieu de glisser depuis le mauvais côté.
+- **Swipe cyclique (#663)** : balayer au-delà du dernier onglet revient au premier (et inversement).
+- **Icône Intelligence Artificielle (#664)** : la catégorie IA (nouvelle sur HFR) a enfin son icône au
+  lieu du glyphe générique.
+
+**Navigation (#667)**
+
+- **Retour depuis un onglet secondaire** : à la racine des Réglages (ou Forum/Recherche/Messages), le
+  bouton retour revient à l'onglet précédent au lieu de fermer l'application.
+
 ## `0.17.8` — `internal` (dev) — 2026-06-26
 
 > Polish dogfood : resserrage de l'espacement entre la barre de recherche et les bandes de catégorie

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.8"
+        versionName = "0.17.9"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -496,6 +496,22 @@ internal fun tabBackTarget(
         TabBackResult(history.last(), history.dropLast(1))
     }
 
+/**
+ * #667 — back at a secondary tab's root returns to the previous tab instead of letting the system
+ * finish the Activity. Extracted from [RedfaceApp] to keep it under detekt's complexity threshold.
+ * Enabled only at the ROOT (size == 1) of a tab other than the home Flags tab.
+ */
+@Composable
+private fun TabRootBackHandler(
+    currentDestination: TopLevelDestination,
+    activeBackStackSize: Int,
+    onRootBack: () -> Unit,
+) {
+    BackHandler(
+        enabled = currentDestination != TopLevelDestination.Flags && activeBackStackSize == 1,
+    ) { onRootBack() }
+}
+
 /** #313 — badge cap : beyond this the badge shows « 9+ » (page-1 proxy, cf. MpUnreadBadgeViewModel). */
 private const val MAX_BADGE_COUNT = 9
 
@@ -705,7 +721,9 @@ fun RedfaceApp(intent: Intent?) {
         var tabHistory by rememberSaveable(
             stateSaver = listSaver(
                 save = { it.map(TopLevelDestination::name) },
-                restore = { it.map(TopLevelDestination::valueOf) },
+                // Defensive restore (Codex review): drop names that no longer resolve so a renamed/removed
+                // tab in a future version cannot crash the process-death restore.
+                restore = { names -> names.mapNotNull { runCatching { TopLevelDestination.valueOf(it) }.getOrNull() } },
             ),
         ) { mutableStateOf(emptyList<TopLevelDestination>()) }
 
@@ -942,9 +960,11 @@ fun RedfaceApp(intent: Intent?) {
             // still wins while it can pop (size > 1); the immersive back FAB (#518) routes through the
             // same dispatcher, so it is covered. RedfaceNavHost.onRootBack is a belt-and-suspenders for a
             // future nav3 that might invoke onBack at the root.
-            BackHandler(
-                enabled = currentDestination != TopLevelDestination.Flags && activeBackStack.size == 1,
-            ) { onRootTabBack() }
+            TabRootBackHandler(
+                currentDestination = currentDestination,
+                activeBackStackSize = activeBackStack.size,
+                onRootBack = onRootTabBack,
+            )
             Box(modifier = Modifier.fillMaxSize()) {
                 Surface(modifier = contentInsetModifier) {
                     val accountMenu: @Composable () -> Unit = {

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
@@ -457,6 +458,44 @@ private fun onTopLevelTap(
     if (current == tapped && tapped == TopLevelDestination.Flags) onReselectFlags() else onSwitch()
 }
 
+/** #667 — target tab + remaining history when back is pressed at a secondary tab's root. */
+internal data class TabBackResult(
+    val target: TopLevelDestination,
+    val history: List<TopLevelDestination>,
+)
+
+/**
+ * #667 — visited-tab history (MRU stack of top-level tabs, most-recently-left LAST, excluding the
+ * current tab). New history after switching the active tab from [current] to [target]: a reselect
+ * (target == current) is a no-op; otherwise the left tab becomes the most-recent previous and any
+ * stale occurrence of either tab is dropped so the history stays a deduplicated MRU. Pure → tested.
+ */
+internal fun tabHistoryOnSwitch(
+    history: List<TopLevelDestination>,
+    current: TopLevelDestination,
+    target: TopLevelDestination,
+): List<TopLevelDestination> =
+    if (target == current) {
+        history
+    } else {
+        history.filterNot { it == current || it == target } + current
+    }
+
+/**
+ * #667 — target + remaining history when back is pressed at a secondary tab's root: pop the
+ * most-recent visited tab (the popped tab is NOT re-pushed — back is a pop, not a forward nav, which
+ * is what avoids the ping-pong Codex flagged), or [fallback] (Flags) when the history is empty.
+ */
+internal fun tabBackTarget(
+    history: List<TopLevelDestination>,
+    fallback: TopLevelDestination,
+): TabBackResult =
+    if (history.isEmpty()) {
+        TabBackResult(fallback, emptyList())
+    } else {
+        TabBackResult(history.last(), history.dropLast(1))
+    }
+
 /** #313 — badge cap : beyond this the badge shows « 9+ » (page-1 proxy, cf. MpUnreadBadgeViewModel). */
 private const val MAX_BADGE_COUNT = 9
 
@@ -660,6 +699,16 @@ fun RedfaceApp(intent: Intent?) {
             mutableStateOf(startScreen.screen.toTopLevelDestination())
         }
 
+        // #667 — visited-tab history (MRU) so back at a secondary tab's root returns to the previously
+        // visited tab instead of falling through to the system (which closed the app). Saveable across
+        // rotation/process death; stored as enum names.
+        var tabHistory by rememberSaveable(
+            stateSaver = listSaver(
+                save = { it.map(TopLevelDestination::name) },
+                restore = { it.map(TopLevelDestination::valueOf) },
+            ),
+        ) { mutableStateOf(emptyList<TopLevelDestination>()) }
+
         // #603 PR6 — re-tap of the already-selected Drapeaux tab raises this counter; threaded to
         // FlagsRoute, which opens its quick-config sheet on each increment. Deliberately a plain
         // `remember` (NOT rememberSaveable): a saved non-zero counter would re-open the sheet after a
@@ -692,9 +741,23 @@ fun RedfaceApp(intent: Intent?) {
             )
         }
 
+        // #667 — single entry point for every tab change (tap, deep link, root-back) so the visited-tab
+        // history stays consistent. A reselect of the current tab leaves the history untouched.
+        val switchTab: (TopLevelDestination) -> Unit = { target ->
+            tabHistory = tabHistoryOnSwitch(tabHistory, currentDestination, target)
+            currentDestination = target
+        }
+        // #667 — back at a secondary tab's root: pop the most-recent visited tab (fallback Flags). A pop,
+        // NOT a forward switch (no re-push), so successive backs walk the history out without oscillating.
+        val onRootTabBack: () -> Unit = {
+            val result = tabBackTarget(tabHistory, TopLevelDestination.Flags)
+            tabHistory = result.history
+            currentDestination = result.target
+        }
+
         LaunchedEffect(intent) {
             val parsed = intent?.data?.let(::parseHfrDeepLink) ?: return@LaunchedEffect
-            currentDestination = parsed.destination
+            switchTab(parsed.destination)
             resetStack(
                 backStack = backStacks.getValue(parsed.destination),
                 root = parsed.destination.rootRoute,
@@ -853,7 +916,7 @@ fun RedfaceApp(intent: Intent?) {
                                 tapped = destination,
                                 current = currentDestination,
                                 onReselectFlags = { flagsQuickConfigRequest++ },
-                                onSwitch = { currentDestination = destination },
+                                onSwitch = { switchTab(destination) },
                             )
                         },
                         icon = {
@@ -873,6 +936,15 @@ fun RedfaceApp(intent: Intent?) {
             // for the theme background/elevation; only its horizontal padding was removed.
             // #529 — consumes the bottom nav-bar inset under a bottom-bar layout (no-op otherwise).
             val activeBackStack = backStacks.getValue(currentDestination)
+            // #667 — at a secondary tab's ROOT, NavDisplay's own back handler is disabled (size == 1)
+            // and the back would finish the Activity (bug). Intercept here to return to the previous
+            // tab instead; Flags (home) keeps the default exit. Composed ABOVE NavDisplay, so NavDisplay
+            // still wins while it can pop (size > 1); the immersive back FAB (#518) routes through the
+            // same dispatcher, so it is covered. RedfaceNavHost.onRootBack is a belt-and-suspenders for a
+            // future nav3 that might invoke onBack at the root.
+            BackHandler(
+                enabled = currentDestination != TopLevelDestination.Flags && activeBackStack.size == 1,
+            ) { onRootTabBack() }
             Box(modifier = Modifier.fillMaxSize()) {
                 Surface(modifier = contentInsetModifier) {
                     val accountMenu: @Composable () -> Unit = {
@@ -891,6 +963,9 @@ fun RedfaceApp(intent: Intent?) {
                     }
                     RedfaceNavHost(
                         backStack = activeBackStack,
+                        // #667 — invoked if NavDisplay ever calls onBack at the root (defensive; the
+                        // parent BackHandler above handles it in the current nav3 where it does not).
+                        onRootBack = onRootTabBack,
                         accountMenu = accountMenu,
                         flagsQuickConfigRequest = flagsQuickConfigRequest,
                         // #603 bug fix — reset the counter once FlagsRoute handled it, so a re-mount
@@ -1519,6 +1594,10 @@ internal fun Map<TopicTitleKey, String>.withTitle(key: TopicTitleKey, title: Str
 // without reducing complexity. Param count: each nav-state bundle has a distinct owner/call-site.
 private fun RedfaceNavHost(
     backStack: NavBackStack<NavKey>,
+    // #667 — called when back is pressed at the active tab's root (size == 1). Defensive: in the current
+    // nav3 NavDisplay disables its own back handler at the root, so RedfaceApp's parent BackHandler
+    // fires instead; this keeps the behaviour correct if a future nav3 invokes onBack at the root.
+    onRootBack: () -> Unit,
     accountMenu: @Composable () -> Unit,
     // #603 PR6 — increments on each Drapeaux-tab re-tap; FlagsRoute opens its quick-config sheet on change.
     flagsQuickConfigRequest: Int,
@@ -1547,6 +1626,8 @@ private fun RedfaceNavHost(
         onBack = {
             if (backStack.size > 1) {
                 backStack.removeAt(backStack.lastIndex)
+            } else {
+                onRootBack()
             }
         },
         // Transitions (Claude + Codex, remplace le crossfade 700 ms global) : shared-axis X léger pour le

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,6 +1,10 @@
-Redface 2 v0.17.8 — dev.
+Redface 2 v0.17.9 — dev.
 
 Flags view:
-- Tighter spacing between the search bar and the category bands: less air above and around categories, denser list (the "minimal" preset).
+- Tab swipe fixed (the new tab no longer slides in from the wrong side) and now cyclic (last wraps to first).
+- Dedicated icon for the Intelligence Artificielle category.
+
+Navigation:
+- Back from Settings (or another tab) returns to the previous tab instead of closing the app.
 
 Bugs: via dev or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,6 +1,10 @@
-Redface 2 v0.17.8 — dev.
+Redface 2 v0.17.9 — dev.
 
 Vue Drapeaux :
-- Espacement resserré entre la barre de recherche et les bandes de catégorie : moins d'air au-dessus et autour des catégories, liste plus dense (preset « minimal »).
+- Swipe entre onglets corrigé (le nouvel onglet n'arrive plus du mauvais côté) et désormais cyclique (du dernier au premier).
+- Icône dédiée pour la catégorie Intelligence Artificielle.
+
+Navigation :
+- Le retour depuis les Réglages (ou un autre onglet) revient à l'onglet précédent au lieu de fermer l'appli.
 
 Bugs : via le canal dev ou GitHub.

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/TabBackStackTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/TabBackStackTest.kt
@@ -1,0 +1,65 @@
+package fr.forumhfr.redface2.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure visited-tab history for #667 (back at a secondary tab's root returns to the previously-visited
+ * tab, not the system → no more app-exit). The history is an MRU stack of top-level tabs, the
+ * most-recently-left LAST, excluding the current tab. Switching pushes the left tab; back pops it.
+ * Codex flagged the oscillation risk — these tests pin the no-ping-pong contract.
+ */
+class TabBackStackTest {
+
+    private val flags = TopLevelDestination.Flags
+    private val forum = TopLevelDestination.Forum
+    private val settings = TopLevelDestination.Settings
+
+    @Test
+    fun `switching pushes the left tab as the most-recent previous`() {
+        assertEquals(listOf(flags), tabHistoryOnSwitch(emptyList(), current = flags, target = settings))
+    }
+
+    @Test
+    fun `reselecting the current tab leaves the history unchanged`() {
+        assertEquals(
+            listOf(flags),
+            tabHistoryOnSwitch(listOf(flags), current = settings, target = settings),
+        )
+    }
+
+    @Test
+    fun `switching dedups so a revisited tab is not duplicated`() {
+        // On Forum with history [Flags, Settings], going (back forward) to Settings must not duplicate it.
+        assertEquals(
+            listOf(flags, forum),
+            tabHistoryOnSwitch(listOf(flags, settings), current = forum, target = settings),
+        )
+    }
+
+    @Test
+    fun `back at a secondary root pops the most-recent visited tab`() {
+        val result = tabBackTarget(listOf(flags, forum), fallback = flags)
+        assertEquals(forum, result.target)
+        assertEquals(listOf(flags), result.history)
+    }
+
+    @Test
+    fun `back with an empty history falls back to Flags`() {
+        val result = tabBackTarget(emptyList(), fallback = flags)
+        assertEquals(flags, result.target)
+        assertEquals(emptyList<TopLevelDestination>(), result.history)
+    }
+
+    @Test
+    fun `successive backs walk the history without oscillating`() {
+        var history = emptyList<TopLevelDestination>()
+        history = tabHistoryOnSwitch(history, current = flags, target = forum) // [Flags]
+        history = tabHistoryOnSwitch(history, current = forum, target = settings) // [Flags, Forum]
+        val back1 = tabBackTarget(history, fallback = flags) // → Forum, [Flags]
+        val back2 = tabBackTarget(back1.history, fallback = flags) // → Flags, []
+        assertEquals(forum, back1.target)
+        assertEquals(flags, back2.target)
+        assertEquals(emptyList<TopLevelDestination>(), back2.history)
+    }
+}

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/icon/CategoryIcon.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/icon/CategoryIcon.kt
@@ -5,8 +5,9 @@ import fr.forumhfr.redface2.core.ui.R
 
 /**
  * Maps an HFR forum category id to its Material Symbols drawable (#603, ADR-017, spike 4). The set is
- * the 19 public categories captured from the REST catalogue; any unknown id (e.g. Blabla `24`, or a
- * future category) falls back to [R.drawable.ic_ms_forum].
+ * the public categories captured from the REST catalogue (20 as of 2026-06, incl. Intelligence
+ * Artificielle `32`); any unknown id (e.g. Blabla `24`, which 403s on REST, or a future category)
+ * falls back to [R.drawable.ic_ms_forum].
  *
  * Pure (returns a `@DrawableRes` id), so it is unit-testable and callable from `remember {}` blocks.
  * Icons are local vector drawables tinted at render time (ADR-015 / `RedfaceVectorIcon`) — Material
@@ -37,4 +38,5 @@ private val CATEGORY_ICONS: Map<Int, Int> = mapOf(
     6 to R.drawable.ic_ms_shopping_cart, // Achats & Ventes
     8 to R.drawable.ic_ms_work, // Emploi & Etudes
     13 to R.drawable.ic_ms_forum, // Discussions
+    32 to R.drawable.ic_ms_smart_toy, // Intelligence Artificielle
 )

--- a/core/ui/src/main/res/drawable/ic_ms_smart_toy.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_smart_toy.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #603 — Material Symbols Outlined (smart_toy / robot), grille 960 (viewBox 0 -960 960 960) recadrée via group translateY=960. fillColor tinté à l'usage. Catégorie Intelligence Artificielle (cat 32). -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M160-360q-50 0-85-35t-35-85q0-50 35-85t85-35v-80q0-33 23.5-56.5T240-760h120q0-50 35-85t85-35q50 0 85 35t35 85h120q33 0 56.5 23.5T800-680v80q50 0 85 35t35 85q0 50-35 85t-85 35v160q0 33-23.5 56.5T720-120H240q-33 0-56.5-23.5T160-200v-160Zm200-80q25 0 42.5-17.5T420-500q0-25-17.5-42.5T360-560q-25 0-42.5 17.5T300-500q0 25 17.5 42.5T360-440Zm240 0q25 0 42.5-17.5T660-500q0-25-17.5-42.5T600-560q-25 0-42.5 17.5T540-500q0 25 17.5 42.5T600-440ZM320-280h320v-80H320v80Zm-80 80h480v-480H240v480Zm240-240Z" />
+    </group>
+</vector>

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/icon/CategoryIconTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/icon/CategoryIconTest.kt
@@ -18,6 +18,7 @@ class CategoryIconTest {
         assertEquals(R.drawable.ic_ms_terminal, categoryIcon(11)) // Linux et OS Alternatifs
         assertEquals(R.drawable.ic_ms_shopping_cart, categoryIcon(6)) // Achats & Ventes
         assertEquals(R.drawable.ic_ms_forum, categoryIcon(13)) // Discussions
+        assertEquals(R.drawable.ic_ms_smart_toy, categoryIcon(32)) // Intelligence Artificielle
     }
 
     @Test
@@ -29,7 +30,7 @@ class CategoryIconTest {
 
     @Test
     fun `every public category resolves to a non-zero drawable`() {
-        val publicCats = listOf(1, 16, 15, 2, 30, 23, 25, 3, 14, 5, 4, 22, 21, 11, 10, 12, 6, 8, 13)
+        val publicCats = listOf(1, 16, 15, 2, 30, 23, 25, 3, 14, 5, 4, 22, 21, 11, 10, 12, 6, 8, 13, 32)
         publicCats.forEach { catId ->
             assertEquals(
                 "cat $catId must resolve",

--- a/docs/specs/navigation.md
+++ b/docs/specs/navigation.md
@@ -479,6 +479,8 @@ private fun RedfaceNavHost(backStack: NavBackStack<NavKey>) {
 
 `NavigationSuiteScaffold` (Material 3 Adaptive) commute la `currentDestination` (état `rememberSaveable`) et passe le back stack actif à `RedfaceNavHost`. Les autres back stacks restent en mémoire — quand l'utilisateur revient sur l'onglet Forum, il retombe à l'écran où il l'a quitté.
 
+**Retour à la racine d'un onglet (#667)** : à la racine d'un onglet **secondaire** (≠ Drapeaux, back stack de taille 1), le `BackHandler` interne de `NavDisplay` est désactivé et le retour fermait l'application (bug #667). `RedfaceApp` intercepte ce cas via un `BackHandler` parent (`enabled = currentDestination != Flags && activeBackStack.size == 1`) qui **revient à l'onglet précédemment visité**, à défaut Drapeaux. L'historique d'onglets est un **MRU** (`tabHistory`, `rememberSaveable`) alimenté par un point d'entrée unique (`switchTab`, partagé par le tap de barre, le deep link et le retour-racine) ; les helpers purs `tabHistoryOnSwitch` / `tabBackTarget` (testés, `TabBackStackTest`) garantissent l'absence d'oscillation (le retour **dépile** sans réempiler). À la racine de **Drapeaux** (accueil), le retour garde le comportement par défaut (quitter/mettre en arrière-plan). `RedfaceNavHost.onRootBack` double le mécanisme par sécurité si une future version de nav3 invoquait `onBack` à la racine. Le FAB de retour immersif (#518) passe par le même `OnBackPressedDispatcher`, donc il est couvert.
+
 **Avantages Nav 3 vs Nav 2.x pour Redface 2** :
 - Le back stack est du **state observable standard** — facile à persister/restaurer, à inspecter pour debug, à manipuler dans des tests
 - Plusieurs back stacks indépendants (un par onglet) sans avoir à hiérarchiser un nav graph

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTabSwipe.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTabSwipe.kt
@@ -22,7 +22,6 @@ import fr.forumhfr.redface2.core.ui.pager.swipeArmed
 import fr.forumhfr.redface2.core.ui.pager.swipeCommitDirection
 import fr.forumhfr.redface2.core.ui.pager.swipeCommitDistancePx
 import fr.forumhfr.redface2.core.ui.pager.swipeFollowOffset
-import fr.forumhfr.redface2.core.ui.pager.swipeTargetPage
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -35,14 +34,14 @@ import kotlinx.coroutines.launch
  * swiping the content left commits to the tab on the right, exactly like turning to the next
  * page. The tab row itself is NOT part of the gesture surface — it already has taps.
  *
- * In-place mechanics mirror the thread gesture (the composition survives the tab change, so a
- * committed swipe springs back to rest while the new tab's content swaps in — instantly on a
- * cache hit, behind the existing loading state otherwise):
+ * In-place mechanics (the composition survives the tab change). On commit the offset is snapped to
+ * rest and the new tab's content swaps in centred — #660: springing back from the released drag
+ * offset made the incoming tab slide in from the wrong side. Only a sub-threshold drag springs back:
  *
  * - **Commit → [FlagsTabSwipeHandlers.onSelectTab]** with the target index; the caller maps it
  *   back to a `FlagTab` (the DT tab is conditional, so the index↔tab mapping lives where the tab
  *   list is built). The ViewModel's re-tap toggle (Cyan « +lus ») is unreachable by construction:
- *   [swipeTargetPage] never returns the current index.
+ *   [swipeTargetIndex] never returns the current index (≥2 tabs).
  * - [currentIndex] and [tabCount] are lambdas: the selected tab changes UNDER this live
  *   composition (gesture keyed on `Unit`, never re-keyed), both must be read fresh per frame.
  * - No re-entrance latch and no enabled-gate: a tab switch is local state + cached list, there
@@ -51,7 +50,8 @@ import kotlinx.coroutines.launch
  * Coexistence contract: horizontal slop only — the vertical list scroll and the pull-to-refresh
  * nested-scroll are never stolen. This gesture only became possible once the rows' horizontal
  * `SwipeToDismissBox` (#99) was retired in this same change: a child consuming the horizontal
- * drag first cancels ours. Edges (first/last tab) are a damped no-op wall.
+ * drag first cancels ours. Tabs are cyclic (#663): swiping past the last tab wraps to the first and
+ * vice-versa, so there is no edge wall (every direction has a target).
  */
 internal fun Modifier.flagsTabSwipe(
     currentIndex: () -> Int,
@@ -101,6 +101,7 @@ internal fun Modifier.flagsTabSwipe(
                     armed = nowArmed
                     change.consume()
                 }
+                var committed = false
                 if (completed) {
                     val velocityX = velocityTracker.calculateVelocity().x
                     val forward =
@@ -109,13 +110,23 @@ internal fun Modifier.flagsTabSwipe(
                     if (forward != null && target != null) {
                         handlers.haptics.performHapticFeedback(HapticFeedbackType.Confirm)
                         handlers.onSelectTab(target)
+                        committed = true
                     }
                 }
-                // ALWAYS spring back — commit included: the composition is kept, the new tab's
-                // content swaps in at rest (cache hit = instant, otherwise the loading state).
-                releaseJob = animationScope.launch {
-                    release.snapTo(dragOffset.floatValue)
-                    release.animateTo(0f, TAB_SPRING_BACK) { dragOffset.floatValue = value }
+                if (committed) {
+                    // #660 — on commit, snap straight to rest: the new tab swaps in centred. The old
+                    // code sprang `dragOffset` back to 0 from the RELEASED offset, but that offset was
+                    // the OUTGOING tab's displacement — so the INCOMING tab rode it and slid in from
+                    // the wrong side (swipe left → next tab entered from the left). The drag-follow
+                    // already conveyed the direction; the swap itself needs no slide.
+                    dragOffset.floatValue = 0f
+                } else {
+                    // Sub-threshold drag (no commit): spring the current tab back so the damped
+                    // over-pull settles to rest.
+                    releaseJob = animationScope.launch {
+                        release.snapTo(dragOffset.floatValue)
+                        release.animateTo(0f, TAB_SPRING_BACK) { dragOffset.floatValue = value }
+                    }
                 }
             }
         }
@@ -141,11 +152,21 @@ internal class FlagsTabSwipeHandlers(
 )
 
 /**
- * The shared pager geometry speaks 1-based pages; tabs are 0-based indices. Shift by one for
- * [swipeTargetPage] so its `1..totalPages` bounds check becomes a `0..tabCount-1` check.
+ * Cyclic tab target (#663): flag tabs form a ring, so a forward swipe past the last tab lands on the
+ * first and a backward swipe before the first lands on the last. This deliberately does NOT reuse the
+ * shared `core.ui.pager.swipeTargetPage` geometry: the topic/MP pagers are hard-bounded (a topic must
+ * never wrap page N → page 1), tabs wrap. Returns `null` only when there is nowhere to go (0 or 1
+ * tab); with ≥2 tabs the result is never [currentIndex] (so the re-tap «+lus» toggle stays unreachable
+ * by swipe, by construction).
  */
-private fun swipeTargetIndex(currentIndex: Int, tabCount: Int, forward: Boolean): Int? =
-    swipeTargetPage(currentIndex + 1, tabCount, forward)?.minus(1)
+internal fun swipeTargetIndex(currentIndex: Int, tabCount: Int, forward: Boolean): Int? {
+    if (tabCount <= 1) return null
+    return if (forward) {
+        (currentIndex + 1) % tabCount
+    } else {
+        (currentIndex - 1 + tabCount) % tabCount
+    }
+}
 
 private fun tabFollowOffset(
     totalDx: Float,

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTabSwipeTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTabSwipeTest.kt
@@ -1,0 +1,53 @@
+package fr.forumhfr.redface2.feature.flags
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pure cyclic tab-target geometry for the flags tab swipe (#663). Unlike the shared
+ * [fr.forumhfr.redface2.core.ui.pager.swipeTargetPage] used by the topic/MP pagers (hard-bounded — a
+ * topic must never wrap page N → page 1), flag tabs form a ring: swiping past the last tab lands on
+ * the first and vice-versa. `null` only when there is nowhere to go (0 or 1 tab).
+ */
+class FlagsTabSwipeTest {
+
+    @Test
+    fun `forward from a middle tab advances by one`() {
+        assertEquals(2, swipeTargetIndex(currentIndex = 1, tabCount = 4, forward = true))
+    }
+
+    @Test
+    fun `backward from a middle tab steps back by one`() {
+        assertEquals(1, swipeTargetIndex(currentIndex = 2, tabCount = 4, forward = false))
+    }
+
+    @Test
+    fun `forward past the last tab wraps to the first`() {
+        assertEquals(0, swipeTargetIndex(currentIndex = 3, tabCount = 4, forward = true))
+    }
+
+    @Test
+    fun `backward before the first tab wraps to the last`() {
+        assertEquals(3, swipeTargetIndex(currentIndex = 0, tabCount = 4, forward = false))
+    }
+
+    @Test
+    fun `the wrap target is never the current tab`() {
+        // Two tabs: both directions cross to the other tab, never re-select the current one (which
+        // would shadow the re-tap «+lus» toggle).
+        assertEquals(1, swipeTargetIndex(currentIndex = 0, tabCount = 2, forward = true))
+        assertEquals(1, swipeTargetIndex(currentIndex = 0, tabCount = 2, forward = false))
+    }
+
+    @Test
+    fun `a single tab has no swipe target in either direction`() {
+        assertNull(swipeTargetIndex(currentIndex = 0, tabCount = 1, forward = true))
+        assertNull(swipeTargetIndex(currentIndex = 0, tabCount = 1, forward = false))
+    }
+
+    @Test
+    fun `an empty tab list has no swipe target`() {
+        assertNull(swipeTargetIndex(currentIndex = 0, tabCount = 0, forward = true))
+    }
+}


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaTriX)

Premier lot du « reste » de la phase Drapeaux (#603), 3 des 4 items validés avec XaTriX (le 4ᵉ, #666 labels de la barre du bas, suit dans une PR dédiée). Diagnostics préalables par 5 agents d'exploration, scope tranché par XaTriX, approche nav cadrée + diff relu par Codex.

## Changements

### Swipe entre onglets — #660 + #663 (`FlagsTabSwipe.kt`)
- **#660 (bug)** : au changement d'onglet validé, on `snapTo(0)` au lieu de faire revenir `dragOffset` par ressort depuis l'offset de l'**ancien** onglet — qui faisait glisser le nouveau contenu **du mauvais côté**. Le nouvel onglet apparaît centré net (l'intention « instantané » déjà présente). Le ressort ne sert plus que pour un drag non-validé (bounce d'extrémité / sub-threshold).
- **#663** : `swipeTargetIndex` calcule un **wrap cyclique local** (dernier ↔ premier) au lieu de déléguer au `swipeTargetPage` partagé borné (utilisé par les pagers Topic/MP qui **ne doivent pas** boucler). Pour ≥2 onglets, jamais l'index courant (le toggle re-tap « +lus » reste inatteignable au swipe).

### Icône de catégorie — #664a (`CategoryIcon.kt`)
- La catégorie **Intelligence Artificielle** (cat 32, nouvelle au catalogue REST — vérifié en live) tombait sur l'icône générique `forum`. Mapping ajouté vers un nouveau drawable `ic_ms_smart_toy` (Material Symbols robot). Blabla (cat 24) reste sur le fallback (403 en REST, déjà documenté).

### Retour depuis un onglet secondaire — #667 (`RedfaceNavigation.kt`)
- À la racine d'un onglet secondaire (back stack size == 1), le `BackHandler` interne de `NavDisplay` est désactivé → le retour **fermait l'appli** (tinc, v180). `RedfaceApp` tient désormais un **historique MRU d'onglets** (`tabHistory`, saveable) alimenté par un point d'entrée unique `switchTab` (tap, deep link, retour-racine). Un `BackHandler` parent (helper `TabRootBackHandler`) revient à **l'onglet précédemment visité** (fallback Flags) ; **Flags** (accueil) garde la sortie par défaut. `RedfaceNavHost.onRootBack` double le mécanisme par sécurité. Le FAB de retour immersif (#518) passe par le même dispatcher → couvert. Doc `navigation.md` mise à jour.

## Tests
- **TDD** sur les fonctions pures : `FlagsTabSwipeTest` (wrap cyclique), `CategoryIconTest` (cat 32), `TabBackStackTest` (historique MRU, contrat no-ping-pong).
- Le snap (#660) et le câblage nav sont du test-after/dogfood (geste / intégration Compose).

## Codex
- **Cadrage** de l'approche nav #667 (BackHandler parent + historique) **avant** implémentation.
- **Review** du diff : OK, aucun finding bloquant. Intégré : extraction `TabRootBackHandler` (complexité detekt) + restore `tabHistory` défensif (`mapNotNull`/`runCatching`). Finding mineur non retenu (reset historique sur Flags) : le back renvoie toujours à l'onglet immédiatement précédent (MRU-last), comportement déjà conforme à l'intention « onglet précédent ».

## Validation
`detektAll` + `:app:lintProdDebug` + `testDebugUnitTest` + `:app:testProdDebugUnitTest` + `:app:assembleProdDebug` → **BUILD SUCCESSFUL**. Guards changelog + whatsnew (0.17.9) verts.

versionName 0.17.8 → 0.17.9 ; versionCode au dispatch.

Closes #660, closes #663, closes #667. Avance #664 (volet icônes ; pastille agrandie = volet b à venir).