### PR TITLE
feat(settings): toggle libellés de la barre du bas (#666) + 0.17.10

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,17 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.10` — `internal` (dev) — 2026-06-26
+
+> Lot 1 dogfood (4 sur 4) : le réglage des libellés de la barre du bas, dernier item du lot. Build dev ;
+> versionCode au dispatch. versionName 0.17.9 → 0.17.10.
+
+**Réglages / Navigation (#666)**
+
+- **Afficher / masquer les libellés de la barre du bas** : nouveau réglage dans *Réglages > Affichage >
+  Barre de navigation* (activé par défaut). Désactivé, la barre du bas n'affiche que les icônes (plus
+  compacte). Réglage global, persistant.
+
 ## `0.17.9` — `internal` (dev) — 2026-06-26
 
 > Lot 1 dogfood (3 sur 4) : bugs swipe + navigation et icône de catégorie. Le réglage des libellés de

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.9"
+        versionName = "0.17.10"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModel.kt
@@ -73,6 +73,12 @@ class AppThemeViewModel @Inject constructor(
         userPreferencesRepository.observeShowScrollbar()
             .stateIn(viewModelScope, SharingStarted.Eagerly, true)
 
+    // #666 — show the labels under the bottom-nav icons. Eagerly collected at the shell so the
+    // NavigationSuiteScaffold can drop the labels. No bootstrap mirror; seed = the `true` default.
+    val navBarLabels: StateFlow<Boolean> =
+        userPreferencesRepository.observeNavBarLabels()
+            .stateIn(viewModelScope, SharingStarted.Eagerly, true)
+
     // #445 — debug bounds overlay toggle (dev channel only; the channel gate lives in RedfaceApp).
     // No bootstrap mirror: it does not paint the pre-first-frame window, so the seed is the `false`
     // default and DataStore resolves on the first Eagerly read.

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -458,6 +458,15 @@ private fun onTopLevelTap(
     if (current == tapped && tapped == TopLevelDestination.Flags) onReselectFlags() else onSwitch()
 }
 
+/**
+ * #666 — the bottom-nav item label, or null (icon-only) when the user turned labels off. A plain
+ * helper (not in [RedfaceApp]) so the toggle adds no branch to the host's cyclomatic-complexity budget.
+ */
+private fun navItemLabel(
+    show: Boolean,
+    content: @Composable () -> Unit,
+): (@Composable () -> Unit)? = content.takeIf { show }
+
 /** #667 — target tab + remaining history when back is pressed at a secondary tab's root. */
 internal data class TabBackResult(
     val target: TopLevelDestination,
@@ -616,6 +625,8 @@ fun RedfaceApp(intent: Intent?) {
     val foldLongQuotes by themeViewModel.foldLongQuotes.collectAsStateWithLifecycle()
     // #105 — « afficher l'ascenseur » reading preference, provided to the reading scrollbar via RedfaceTheme.
     val showScrollbar by themeViewModel.showScrollbar.collectAsStateWithLifecycle()
+    // #666 — show/hide the labels under the bottom-nav icons (resolved at the shell for the suite below).
+    val navBarLabels by themeViewModel.navBarLabels.collectAsStateWithLifecycle()
     // #445 — debug bounds overlay preference (the dev-channel gate + render live in
     // [DevDebugBoundsOverlay], emitted last so it paints over everything; off by default).
     val debugBoundsOverlay by themeViewModel.debugBoundsOverlay.collectAsStateWithLifecycle()
@@ -943,7 +954,11 @@ fun RedfaceApp(intent: Intent?) {
                                 mpUnreadCount = mpUnreadCount,
                             )
                         },
-                        label = { Text(text = stringResource(destination.labelRes)) },
+                        // #666 — null label = icon-only bar when the user disabled labels. The helper
+                        // (via takeIf) keeps this off RedfaceApp's cyclomatic-complexity budget.
+                        label = navItemLabel(navBarLabels) {
+                            Text(text = stringResource(destination.labelRes))
+                        },
                     )
                 }
             },

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,10 +1,6 @@
-Redface 2 v0.17.9 — dev.
+Redface 2 v0.17.10 — dev.
 
-Flags view:
-- Tab swipe fixed (the new tab no longer slides in from the wrong side) and now cyclic (last wraps to first).
-- Dedicated icon for the Intelligence Artificielle category.
-
-Navigation:
-- Back from Settings (or another tab) returns to the previous tab instead of closing the app.
+Settings:
+- New Display > Navigation bar setting: show or hide the labels under the bottom-bar icons (icon-only, more compact).
 
 Bugs: via dev or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,10 +1,6 @@
-Redface 2 v0.17.9 — dev.
+Redface 2 v0.17.10 — dev.
 
-Vue Drapeaux :
-- Swipe entre onglets corrigé (le nouvel onglet n'arrive plus du mauvais côté) et désormais cyclique (du dernier au premier).
-- Icône dédiée pour la catégorie Intelligence Artificielle.
-
-Navigation :
-- Le retour depuis les Réglages (ou un autre onglet) revient à l'onglet précédent au lieu de fermer l'appli.
+Réglages :
+- Nouveau réglage Affichage > Barre de navigation : afficher ou masquer les libellés sous les icônes de la barre du bas (barre à icônes seules, plus compacte).
 
 Bugs : via le canal dev ou GitHub.

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModelTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppThemeViewModelTest.kt
@@ -60,6 +60,8 @@ class AppThemeViewModelTest {
             every { observeFoldLongQuotes() } returns MutableStateFlow(true)
             // #105 — eagerly collected by the VM constructor; default on is enough here.
             every { observeShowScrollbar() } returns MutableStateFlow(true)
+            // #666 — eagerly collected by the VM constructor; default on is enough here.
+            every { observeNavBarLabels() } returns MutableStateFlow(true)
             // #518 — eagerly collected by the VM constructor; default off is enough here.
             every { observeHideSystemNavBar() } returns MutableStateFlow(false)
             // #518 follow-up — eagerly collected by the VM constructor; default on is enough here.
@@ -91,6 +93,8 @@ class AppThemeViewModelTest {
             every { observeFoldLongQuotes() } returns MutableStateFlow(true)
             // #105 — eagerly collected by the VM constructor; default on is enough here.
             every { observeShowScrollbar() } returns MutableStateFlow(true)
+            // #666 — eagerly collected by the VM constructor; default on is enough here.
+            every { observeNavBarLabels() } returns MutableStateFlow(true)
             // #518 — eagerly collected by the VM constructor; default off is enough here.
             every { observeHideSystemNavBar() } returns MutableStateFlow(false)
             // #518 follow-up — eagerly collected by the VM constructor; default on is enough here.

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -429,6 +429,22 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeNavBarLabels(): Flow<Boolean> =
+        dataStore.data
+            // Default `true` (#666): labels under the bottom-nav icons are the historical M3
+            // behaviour; hiding them is the opt-out to an icon-only bar.
+            .map { prefs -> prefs[KEY_NAV_BAR_LABELS] ?: true }
+            .distinctUntilChanged()
+            .catch { emit(true) }
+
+    override suspend fun setNavBarLabels(enabled: Boolean) {
+        persist {
+            dataStore.edit { prefs ->
+                prefs[KEY_NAV_BAR_LABELS] = enabled
+            }
+        }
+    }
+
     override fun observeStartScreen(): Flow<StartScreenPreference> =
         dataStore.data
             .map(::readStartScreen)
@@ -842,6 +858,9 @@ class DataStoreUserPreferencesRepository @Inject constructor(
 
         // #105 — show the intra-page reading scrollbar (default true = historical; opt-out).
         val KEY_SHOW_SCROLLBAR = booleanPreferencesKey("show_scrollbar")
+
+        // #666 — show the labels under the bottom-nav icons (default true = historical; opt-out).
+        val KEY_NAV_BAR_LABELS = booleanPreferencesKey("nav_bar_labels")
 
         // #458 — cold-start tab (StartScreenChoice.name, defensively parsed) + optional Forum
         // category id (absent unless screen == FORUM and a category was picked).

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -680,6 +680,27 @@ class DataStoreUserPreferencesRepositoryTest {
     }
 
     @Test
+    fun `observeNavBarLabels defaults to true then persists false and true`() = runTest(dispatcher) {
+        // #666 — labels under the bottom-nav icons are the historical M3 behaviour; hiding them is the opt-out.
+        repository.observeNavBarLabels().test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setNavBarLabels(false)
+        repository.observeNavBarLabels().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setNavBarLabels(true)
+        repository.observeNavBarLabels().test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `observeConfirmBeforePosting defaults to false then persists true and false`() = runTest(dispatcher) {
         // #312 — publishing stays one-tap by default; the guard is strictly opt-in.
         repository.observeConfirmBeforePosting().test {

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -596,6 +596,10 @@ class TopicRepositoryImplTest {
 
         override suspend fun setShowScrollbar(enabled: Boolean) = Unit
 
+        override fun observeNavBarLabels(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setNavBarLabels(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -287,6 +287,15 @@ interface UserPreferencesRepository {
     suspend fun setShowScrollbar(enabled: Boolean)
 
     /**
+     * #666 — show the text labels under the bottom navigation bar icons. Default `true` (labels shown,
+     * the historical Material 3 behaviour); the toggle is the opt-out to an icon-only bar.
+     */
+    fun observeNavBarLabels(): Flow<Boolean>
+
+    /** Persists [observeNavBarLabels]. Default `true` until the first call. */
+    suspend fun setNavBarLabels(enabled: Boolean)
+
+    /**
      * #458 — which top-level tab (and optional Forum category) a cold start opens on. Default
      * [StartScreenChoice.FLAGS] (historical behaviour). The navigation reads the SYNCHRONOUS
      * [StartScreenBootstrapStore] mirror at cold start; this flow is the source of truth and

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -2013,6 +2013,10 @@ class PostEditorViewModelTest {
 
         override suspend fun setShowScrollbar(enabled: Boolean) = Unit
 
+        override fun observeNavBarLabels(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setNavBarLabels(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1413,6 +1413,10 @@ class TopicFormViewModelTest {
 
         override suspend fun setShowScrollbar(enabled: Boolean) = Unit
 
+        override fun observeNavBarLabels(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setNavBarLabels(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -2405,6 +2405,10 @@ class FlagsViewModelTest {
 
         override suspend fun setShowScrollbar(enabled: Boolean) = Unit
 
+        override fun observeNavBarLabels(): Flow<Boolean> = MutableStateFlow(true)
+
+        override suspend fun setNavBarLabels(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsDisplayScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsDisplayScreen.kt
@@ -216,7 +216,45 @@ fun SettingsDisplayScreen(
             if (state.immersiveNavBarRevealError) {
                 PreferencePersistError(R.string.settings_display_nav_bar_reveal_persist_failed)
             }
+
+            // #666 — bottom navigation bar labels. Extracted to keep SettingsDisplayScreen under
+            // detekt's cyclomatic-complexity budget (same rationale as AccentColorSetting).
+            NavBarLabelsSetting(
+                checked = state.navBarLabels,
+                enabled = state.canToggleNavBarLabels,
+                error = state.navBarLabelsError,
+                onCheckedChange = { viewModel.submit(SettingsIntent.NavBarLabelsChanged(it)) },
+            )
         }
+    }
+}
+
+/**
+ * #666 — bottom navigation bar labels toggle. Extracted from [SettingsDisplayScreen] so the host stays
+ * under detekt's cyclomatic-complexity budget; emits a section title, the toggle and the persist-error
+ * line into the caller's Column.
+ */
+@Composable
+private fun NavBarLabelsSetting(
+    checked: Boolean,
+    enabled: Boolean,
+    error: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Text(
+        text = stringResource(R.string.settings_display_nav_bar_section_title),
+        style = MaterialTheme.typography.titleMedium,
+        color = MaterialTheme.colorScheme.onSurface,
+    )
+    DisplayToggleRow(
+        title = stringResource(R.string.settings_display_nav_bar_labels_title),
+        description = stringResource(R.string.settings_display_nav_bar_labels_description),
+        checked = checked,
+        enabled = enabled,
+        onCheckedChange = onCheckedChange,
+    )
+    if (error) {
+        PreferencePersistError(R.string.settings_display_nav_bar_labels_persist_failed)
     }
 }
 

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -133,6 +133,12 @@ data class SettingsState(
     val isUpdatingShowScrollbar: Boolean = false,
     val showScrollbarError: Boolean = false,
     val showScrollbarTouchedLocally: Boolean = false,
+    // #666 — afficher les libellés sous les icônes de la barre du bas. Même machinerie optimistic-flip
+    // + garde de course. Default TRUE (libellés affichés = comportement M3 historique) : l'opt-out.
+    val navBarLabels: Boolean = true,
+    val isUpdatingNavBarLabels: Boolean = false,
+    val navBarLabelsError: Boolean = false,
+    val navBarLabelsTouchedLocally: Boolean = false,
     // #518 — masquer la barre de navigation système Android (plein écran immersif). Même machinerie
     // optimistic-flip + garde de course. Default FALSE (opt-in).
     val hideSystemNavBar: Boolean = false,
@@ -279,6 +285,10 @@ data class SettingsState(
     val canToggleShowScrollbar: Boolean
         get() = !isUpdatingShowScrollbar
 
+    // #666 — the nav-bar-labels toggle is gated only by its own write.
+    val canToggleNavBarLabels: Boolean
+        get() = !isUpdatingNavBarLabels
+
     // #518 — the hide-system-nav-bar toggle is gated only by its own write.
     val canToggleHideSystemNavBar: Boolean
         get() = !isUpdatingHideSystemNavBar
@@ -412,6 +422,9 @@ sealed interface SettingsIntent {
 
     /** #105 — afficher l'ascenseur de lecture (sujets et MP). */
     data class ShowScrollbarChanged(val enabled: Boolean) : SettingsIntent
+
+    /** #666 — afficher les libellés sous les icônes de la barre du bas. */
+    data class NavBarLabelsChanged(val enabled: Boolean) : SettingsIntent
 
     /** #518 — masquer la barre de navigation système Android (plein écran immersif). */
     data class HideSystemNavBarChanged(val enabled: Boolean) : SettingsIntent

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -120,6 +120,11 @@ class SettingsViewModel @Inject constructor(
             apply = { state, value -> state.copy(showScrollbar = value) },
         )
         hydratePreference(
+            read = { userPreferencesRepository.observeNavBarLabels().first() },
+            isLocked = { it.navBarLabelsTouchedLocally || it.isUpdatingNavBarLabels },
+            apply = { state, value -> state.copy(navBarLabels = value) },
+        )
+        hydratePreference(
             read = { userPreferencesRepository.observeHideSystemNavBar().first() },
             isLocked = { it.hideSystemNavBarTouchedLocally || it.isUpdatingHideSystemNavBar },
             apply = { state, value -> state.copy(hideSystemNavBar = value) },
@@ -256,6 +261,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.TopicSignaturesChanged -> updateTopicSignatures(intent.enabled)
             is SettingsIntent.FoldLongQuotesChanged -> updateFoldLongQuotes(intent.enabled)
             is SettingsIntent.ShowScrollbarChanged -> updateShowScrollbar(intent.enabled)
+            is SettingsIntent.NavBarLabelsChanged -> updateNavBarLabels(intent.enabled)
             is SettingsIntent.HideSystemNavBarChanged -> updateHideSystemNavBar(intent.enabled)
             is SettingsIntent.ImmersiveBackButtonChanged -> updateImmersiveBackButton(intent.enabled)
             is SettingsIntent.ImmersiveNavBarRevealChanged -> updateImmersiveNavBarReveal(intent.mode)
@@ -874,6 +880,33 @@ class SettingsViewModel @Inject constructor(
                 }
             },
             persist = userPreferencesRepository::setShowScrollbar,
+        )
+    }
+
+    private fun updateNavBarLabels(desired: Boolean) {
+        val previous = _state.value.navBarLabels
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    navBarLabels = desired,
+                    isUpdatingNavBarLabels = true,
+                    navBarLabelsError = false,
+                    navBarLabelsTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(navBarLabels = desired, isUpdatingNavBarLabels = false)
+                } else {
+                    state.copy(
+                        navBarLabels = previous,
+                        isUpdatingNavBarLabels = false,
+                        navBarLabelsError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setNavBarLabels,
         )
     }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -289,6 +289,11 @@
     <string name="settings_display_font_scale_large">Grande</string>
     <string name="settings_display_font_scale_persist_failed">Impossible de mémoriser la taille de police. Réessayez.</string>
     <!-- #518 — plein écran immersif : masquer la barre de navigation système Android (boutons ou barre gestuelle). -->
+    <!-- #666 — afficher/masquer les libellés sous les icônes de la barre de navigation du bas. -->
+    <string name="settings_display_nav_bar_section_title">Barre de navigation</string>
+    <string name="settings_display_nav_bar_labels_title">Afficher les libellés</string>
+    <string name="settings_display_nav_bar_labels_description">Affiche le texte sous les icônes de la barre du bas (Drapeaux, Forum…). Désactivez pour une barre à icônes seules, plus compacte.</string>
+    <string name="settings_display_nav_bar_labels_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
     <string name="settings_display_fullscreen_title">Plein écran</string>
     <string name="settings_display_hide_nav_bar_title">Masquer la barre de navigation Android</string>
     <string name="settings_display_hide_nav_bar_description">Masque la barre de navigation système du bas (les 3 boutons, ou la barre gestuelle selon votre appareil). La barre du haut et les onglets de l\'app restent affichés. Elle peut réapparaître temporairement avec un geste depuis le bas de l\'écran.</string>

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -1880,6 +1880,24 @@ class SettingsViewModelTest {
             showScrollbar.value = value
         }
 
+        // #666 — afficher les libellés de la barre du bas. Même seam optimistic-flip ; default TRUE.
+        private val navBarLabels = MutableStateFlow(true)
+        var navBarLabelsSetCalls: Int = 0
+            private set
+        var failOnNavBarLabelsSet: Boolean = false
+
+        override fun observeNavBarLabels(): Flow<Boolean> = navBarLabels
+
+        override suspend fun setNavBarLabels(enabled: Boolean) {
+            navBarLabelsSetCalls += 1
+            check(!failOnNavBarLabelsSet) { "boom" }
+            navBarLabels.value = enabled
+        }
+
+        fun emitNavBarLabels(value: Boolean) {
+            navBarLabels.value = value
+        }
+
         // #458 — start screen lives on its own StartScreenSettingsViewModel; this fake only
         // satisfies the interface for the main Settings ViewModel under test.
         override fun observeStartScreen(): Flow<StartScreenPreference> =

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -2103,6 +2103,10 @@ private class FakeUserPreferencesRepository(
 
     override suspend fun setShowScrollbar(enabled: Boolean) = Unit
 
+    override fun observeNavBarLabels(): Flow<Boolean> = MutableStateFlow(true)
+
+    override suspend fun setNavBarLabels(enabled: Boolean) = Unit
+
     override fun observeStartScreen(): Flow<StartScreenPreference> =
         MutableStateFlow(StartScreenPreference())
 


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaTriX)

Dernier item du Lot 1 de la phase Drapeaux (#603). Réglage demandé par XaTriX.

## Quoi

Nouveau réglage **global** (défaut **activé** = comportement actuel) : afficher / masquer les **libellés sous les icônes de la barre de navigation du bas**. Désactivé → barre à icônes seules (plus compacte). Vit dans **Réglages > Affichage > Barre de navigation**.

## Comment (miroir exact du pattern `showScrollbar`)

- **Domaine** : `UserPreferencesRepository.observeNavBarLabels()` / `setNavBarLabels()` (défaut `true`).
- **Données** : `DataStoreUserPreferencesRepository` — clé `nav_bar_labels`, lecture défensive (`?: true` + `catch { emit(true) }`).
- **Shell** : `AppThemeViewModel.navBarLabels: StateFlow<Boolean>` (Eagerly) ; `RedfaceApp` le collecte et le passe au `NavigationSuiteScaffold` : `label = navItemLabel(navBarLabels) { Text(…) }`.
- **`navItemLabel`** (helper `takeIf`) et **`NavBarLabelsSetting`** (section d'écran extraite) : tous deux extraits pour garder `RedfaceApp` et `SettingsDisplayScreen` **sous le seuil de complexité cyclomatique detekt** (même idiome que les helpers existants).
- **Réglages** : `SettingsState` (champs + `canToggleNavBarLabels` + intent `NavBarLabelsChanged`), `SettingsViewModel` (`hydratePreference` + `updateNavBarLabels` via le seam `updateBooleanPreference` optimiste), `SettingsDisplayScreen` (toggle), strings FR.

## Tests
- Round-trip DataStore (`observeNavBarLabels defaults to true then persists false and true`).
- Les **6 fakes** `UserPreferencesRepository` écrits à la main + le mock **AppThemeViewModelTest** mis à jour pour les 2 nouvelles méthodes (piège connu de l'ajout à l'interface).

## Validation
`detektAll` + `:app:lintProdDebug` + `testDebugUnitTest` + `:app:testProdDebugUnitTest` + `:app:assembleProdDebug` → **BUILD SUCCESSFUL**. Guards changelog + whatsnew (0.17.10) verts.

Pas de review Codex : clone mécanique fidèle d'un pattern existant et validé (exception « edit mécanique » de la cadence) ; la CI complète couvre le contrat.

versionName 0.17.9 → 0.17.10 ; versionCode au dispatch. Closes #666.