### PR TITLE
feat(flags): amorce « pull-to-refresh » au tirage (#603) + 0.17.11

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,17 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.11` — `internal` (dev) — 2026-06-26
+
+> Polish dogfood : retour visuel au tirage du swipe-to-refresh. Build dev ; versionCode au dispatch.
+> versionName 0.17.10 → 0.17.11.
+
+**Drapeaux (#603)**
+
+- **Amorce au pull-to-refresh** : tirer la liste vers le bas affiche de nouveau un indicateur pendant
+  le geste (il avait été retiré), puis il s'efface dès que le rechargement démarre — la fine barre du
+  haut prend le relais (plus de double indicateur). Vaut pour les onglets de drapeaux et la liste DT.
+
 ## `0.17.10` — `internal` (dev) — 2026-06-26
 
 > Lot 1 dogfood (4 sur 4) : le réglage des libellés de la barre du bas, dernier item du lot. Build dev ;

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.10"
+        versionName = "0.17.11"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,6 +1,6 @@
-Redface 2 v0.17.10 — dev.
+Redface 2 v0.17.11 — dev.
 
-Settings:
-- New Display > Navigation bar setting: show or hide the labels under the bottom-bar icons (icon-only, more compact).
+Flags view:
+- Swipe-to-refresh cue: pulling the list down shows an indicator again during the gesture, which fades as the refresh starts (the top bar takes over).
 
 Bugs: via dev or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,6 +1,6 @@
-Redface 2 v0.17.10 — dev.
+Redface 2 v0.17.11 — dev.
 
-Réglages :
-- Nouveau réglage Affichage > Barre de navigation : afficher ou masquer les libellés sous les icônes de la barre du bas (barre à icônes seules, plus compacte).
+Vue Drapeaux :
+- Amorce au swipe-to-refresh : tirer la liste vers le bas réaffiche un indicateur pendant le geste, qui s'efface dès le rechargement (la barre du haut prend le relais).
 
 Bugs : via le canal dev ou GitHub.

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -43,6 +43,9 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
+import androidx.compose.material3.pulltorefresh.PullToRefreshState
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -976,6 +979,33 @@ private fun ColumnScope.AuthenticatedBody(
 }
 
 /**
+ * #603 (XaTriX) — « amorce seule » pull-to-refresh cue: the standard [PullToRefreshDefaults.Indicator]
+ * shown ONLY while the user is actively pulling (`!isRefreshing && distanceFraction > 0`). Once the
+ * refresh starts it renders NOTHING, so the thin top [FlagsLoadingBar] is the single loading cue (no
+ * double indicator). The whole wrapper is gated, not just the content, per Codex (an indicator left
+ * with empty content can keep its container visible). Shared by both pull-to-refresh surfaces.
+ *
+ * Passing `isRefreshing = false` keeps the indicator in its determinate pull state — it never reaches
+ * the persistent circular spin here (the M3-expressive `LoadingIndicator` is `internal` in this BOM,
+ * so the determinate default Indicator is the amorce visual).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun FlagsPullAmorce(
+    state: PullToRefreshState,
+    isRefreshing: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    if (!isRefreshing && state.distanceFraction > 0f) {
+        PullToRefreshDefaults.Indicator(
+            state = state,
+            isRefreshing = false,
+            modifier = modifier,
+        )
+    }
+}
+
+/**
  * The real flag-list body of a [FlagTab] with a backend (Cyan/Red/Favorite) — extracted from
  * [AuthenticatedBody] when the #457 tab-swipe wrapper landed, so the swipe surface (placeholders
  * included) and the pull-to-refresh surface stay two distinct layers.
@@ -991,14 +1021,18 @@ private fun FlagListBody(
     // Pull-to-refresh (swipe down) replaces the legacy header « Actualiser » button, matching
     // feature/forum. It wraps the whole flag body so the indicator stays anchored over the
     // existing content during the refresh round-trip (Material 3 stable, cf. Context7).
-    // #603 — no circular indicator: the thin top FlagsLoadingBar is the single loading cue for manual,
-    // auto AND initial loads (XaTriX dogfood — the rond was redundant with the bar). `indicator = {}`
-    // keeps the pull gesture (onRefresh still fires) but draws nothing; `isRefreshing` still drives the
-    // box state so a pull during an in-flight refresh doesn't double-trigger.
+    // #603 — « amorce seule » (XaTriX): a pull cue while dragging, then NOTHING during the refresh —
+    // the thin top FlagsLoadingBar is the single loading cue (manual, auto and initial loads), so no
+    // double indicator. The pull gesture still fires onRefresh; isRefreshing drives the box state so a
+    // pull mid-refresh doesn't double-trigger.
+    val pullState = rememberPullToRefreshState()
     PullToRefreshBox(
         isRefreshing = state.isRefreshing,
         onRefresh = actions.onRefresh,
-        indicator = {},
+        state = pullState,
+        indicator = {
+            FlagsPullAmorce(pullState, state.isRefreshing, Modifier.align(Alignment.TopCenter))
+        },
         modifier = Modifier.fillMaxSize(),
     ) {
         when (val current = state.flagsState) {
@@ -1663,12 +1697,16 @@ private fun DtTabOpenEffect(
 private fun DtListBody(state: DtListUiState, isRefreshing: Boolean, actions: AuthenticatedActions) {
     // #546 directive XaTriX — pull-to-refresh (swipe down) on the DT list, like the flag tabs. Wraps
     // the whole body (every branch) so the gesture has a target even on the listless states (#229).
-    // #603 — no circular indicator (`indicator = {}`), consistent with the flag tabs: the top
+    // #603 — « amorce seule » (XaTriX): pull cue while dragging, nothing during the refresh; the top
     // FlagsLoadingBar (driven by dtIsRefreshing / DtListUiState.Loading) is the single loading cue.
+    val pullState = rememberPullToRefreshState()
     PullToRefreshBox(
         isRefreshing = isRefreshing,
         onRefresh = actions.onRefreshDt,
-        indicator = {},
+        state = pullState,
+        indicator = {
+            FlagsPullAmorce(pullState, isRefreshing, Modifier.align(Alignment.TopCenter))
+        },
         modifier = Modifier.fillMaxSize(),
     ) {
         DtListContent(state = state, actions = actions)


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaTriX)

Retour visuel au tirage du swipe-to-refresh de la vue Drapeaux. Depuis v185 c'était `indicator = {}` (zéro retour pendant le geste) ; XaTriX voulait **amorcer au tirage puis laisser la barre du haut prendre le relais**.

## Quoi (option 4 « amorce seule »)

Nouveau helper partagé `FlagsPullAmorce` : affiche `PullToRefreshDefaults.Indicator` **uniquement pendant le tirage** (`!isRefreshing && state.distanceFraction > 0f`), et **ne rend rien dès que le rechargement démarre** → la fine `FlagsLoadingBar` du haut reste le **seul** indicateur de chargement (plus de double indicateur). Le **wrapper entier** est gaté (pas juste le contenu), aligné `TopCenter` (formulation validée par Codex). Les 2 surfaces (FlagListBody + DtListBody) hoistent `rememberPullToRefreshState()` pour lire `distanceFraction`.

## Choix d'API

L'expressive `PullToRefreshDefaults.LoadingIndicator` (le look préféré de XaTriX) est **`internal` dans la BOM 2026.05.01** (annotation `ExperimentalMaterial3ExpressiveApi` inaccessible) → repli sur le `Indicator` déterminé standard. Le comportement des indicateurs (le rond ET l'expressive animent pendant TOUT `isRefreshing`, pas « amorce seule » ; `distanceFraction` = nom exact ; pas de modifier `pullToRefreshIndicator`) a été **vérifié par Codex contre la doc officielle AndroidX** avant de coder.

## Validation

`detektAll` + `:app:lintProdDebug` + `testDebugUnitTest` + `:app:assembleProdDebug` → **BUILD SUCCESSFUL**. Guards changelog + whatsnew (0.17.11) verts. Comparateur visuel des 4 indicateurs publié (https://forumhfr.github.io/artifacts/flags-603-pull-to-refresh/).

L'amorce est un geste/UI → validation par dogfood (pas de test unitaire pour l'indicateur, cohérent avec le traitement PTR existant). versionName 0.17.10 → 0.17.11 ; versionCode au dispatch.