### PR TITLE
fix(flags): stop pull-to-refresh amorce re-popping at end of load

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,18 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.12` — `internal` (dev) — 2026-06-26
+
+> Fix dogfood : l'amorce du pull-to-refresh ne « repop » plus en fin de chargement. Build dev ;
+> versionCode au dispatch. versionName 0.17.11 → 0.17.12.
+
+**Drapeaux (#603)**
+
+- **Amorce pull-to-refresh — plus de re-pop en fin de load** : à la fin d'un rechargement, l'indicateur
+  rond réapparaissait brièvement (puis disparaissait) pendant que la liste revenait à sa position de
+  repos — `isRefreshing` repassait à `false` alors que la distance de tirage n'était pas encore revenue
+  à 0. Une garde « settling » masque l'amorce jusqu'au retour complet au repos (signalé par XaTriX).
+
 ## `0.17.11` — `internal` (dev) — 2026-06-26
 
 > Polish dogfood : retour visuel au tirage du swipe-to-refresh. Build dev ; versionCode au dispatch.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.11"
+        versionName = "0.17.12"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,6 +1,6 @@
-Redface 2 v0.17.11 — dev.
+Redface 2 v0.17.12 — dev.
 
 Flags view:
-- Swipe-to-refresh cue: pulling the list down shows an indicator again during the gesture, which fades as the refresh starts (the top bar takes over).
+- Fix: the swipe-to-refresh indicator no longer briefly re-appears at the end of a refresh (it lingered until the list fully settled back).
 
 Bugs: via dev or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,6 +1,6 @@
-Redface 2 v0.17.11 — dev.
+Redface 2 v0.17.12 — dev.
 
 Vue Drapeaux :
-- Amorce au swipe-to-refresh : tirer la liste vers le bas réaffiche un indicateur pendant le geste, qui s'efface dès le rechargement (la barre du haut prend le relais).
+- Correctif : l'indicateur du swipe-to-refresh ne réapparaît plus brièvement à la fin du rechargement (il restait jusqu'au retour complet de la liste au repos).
 
 Bugs : via le canal dev ou GitHub.

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -57,6 +57,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -97,6 +98,7 @@ import fr.forumhfr.redface2.core.ui.icon.categoryIcon
 import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsChoice
 import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsChoiceGroup
 import fr.forumhfr.redface2.core.ui.theme.FlagPalette
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 /**
@@ -978,16 +980,34 @@ private fun ColumnScope.AuthenticatedBody(
     }
 }
 
+// #603 (XaTriX dogfood) — distance under which the pull is considered back at rest. The post-refresh
+// settle animates distanceFraction → 0; the amorce stays suppressed until it lands at ~rest.
+private const val AMORCE_REST_EPSILON = 0.001f
+
+/**
+ * Pure visibility predicate for the pull « amorce ». Shows the indicator ONLY while the user is
+ * actively pulling (`!isRefreshing && distanceFraction > 0`) AND not in the post-refresh settle
+ * ([settling]). The [settling] guard fixes the « ça repop en fin de load » bug (XaTriX): when a
+ * refresh ends, `isRefreshing` clears while `distanceFraction` is still animating back to 0, which
+ * without the guard re-pops the indicator for a frame before it dismisses.
+ */
+internal fun shouldShowPullAmorce(
+    isRefreshing: Boolean,
+    distanceFraction: Float,
+    settling: Boolean,
+): Boolean = !isRefreshing && !settling && distanceFraction > 0f
+
 /**
  * #603 (XaTriX) — « amorce seule » pull-to-refresh cue: the standard [PullToRefreshDefaults.Indicator]
- * shown ONLY while the user is actively pulling (`!isRefreshing && distanceFraction > 0`). Once the
- * refresh starts it renders NOTHING, so the thin top [FlagsLoadingBar] is the single loading cue (no
- * double indicator). The whole wrapper is gated, not just the content, per Codex (an indicator left
- * with empty content can keep its container visible). Shared by both pull-to-refresh surfaces.
+ * shown ONLY while the user is actively pulling, then NOTHING once the refresh starts so the thin top
+ * [FlagsLoadingBar] is the single loading cue (no double indicator). The whole wrapper is gated, not
+ * just the content, per Codex (an indicator left with empty content can keep its container visible).
+ * Shared by both pull-to-refresh surfaces.
  *
- * Passing `isRefreshing = false` keeps the indicator in its determinate pull state — it never reaches
- * the persistent circular spin here (the M3-expressive `LoadingIndicator` is `internal` in this BOM,
- * so the determinate default Indicator is the amorce visual).
+ * The [settling] state keeps the indicator hidden through the post-refresh return-to-rest (see
+ * [shouldShowPullAmorce]). Passing `isRefreshing = false` keeps the indicator in its determinate pull
+ * state — it never reaches the persistent circular spin here (the M3-expressive `LoadingIndicator` is
+ * `internal` in this BOM, so the determinate default Indicator is the amorce visual).
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -996,7 +1016,20 @@ private fun FlagsPullAmorce(
     isRefreshing: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    if (!isRefreshing && state.distanceFraction > 0f) {
+    var settling by remember { mutableStateOf(false) }
+    LaunchedEffect(isRefreshing) {
+        if (isRefreshing) {
+            // A refresh started: suppress the amorce until the pull settles back to rest.
+            settling = true
+        } else {
+            // Refresh ended (or never started): re-arm only once distanceFraction has animated home,
+            // so the indicator doesn't re-pop while it slides back. On first composition df is already
+            // ~0 so this resolves immediately.
+            snapshotFlow { state.distanceFraction }.first { it <= AMORCE_REST_EPSILON }
+            settling = false
+        }
+    }
+    if (shouldShowPullAmorce(isRefreshing, state.distanceFraction, settling)) {
         PullToRefreshDefaults.Indicator(
             state = state,
             isRefreshing = false,

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsPullAmorceTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsPullAmorceTest.kt
@@ -1,0 +1,42 @@
+package fr.forumhfr.redface2.feature.flags
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #603 (XaTriX dogfood) — visibility rule of the pull « amorce » indicator, including the
+ * post-refresh « settling » guard that fixes the « ça repop en fin de load » bug.
+ */
+class FlagsPullAmorceTest {
+
+    @Test
+    fun `shown while actively pulling`() {
+        assertTrue(
+            shouldShowPullAmorce(isRefreshing = false, distanceFraction = 0.5f, settling = false),
+        )
+    }
+
+    @Test
+    fun `hidden at rest`() {
+        assertFalse(
+            shouldShowPullAmorce(isRefreshing = false, distanceFraction = 0f, settling = false),
+        )
+    }
+
+    @Test
+    fun `hidden during refresh`() {
+        assertFalse(
+            shouldShowPullAmorce(isRefreshing = true, distanceFraction = 0.5f, settling = false),
+        )
+    }
+
+    @Test
+    fun `hidden while settling after refresh even with leftover pull distance`() {
+        // The bug: after a refresh, isRefreshing clears while distanceFraction is still animating back
+        // to 0. Without the settling guard the indicator re-pops for those frames.
+        assertFalse(
+            shouldShowPullAmorce(isRefreshing = false, distanceFraction = 0.5f, settling = true),
+        )
+    }
+}


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par XaTriX)

## Contexte
Régression dogfood de v191 (amorce pull-to-refresh, option C). XaTriX : *« quand ça fini de charger ça "décharge"/repop le loader rond mais en mode "fin de load"/dépop »*.

## Cause
`FlagsPullAmorce` affichait l'indicateur dès que `!isRefreshing && distanceFraction > 0`. En fin de rechargement, `isRefreshing` repasse à `false` **alors que** `distanceFraction` n'est pas encore revenu à 0 (animation de retour au repos) → l'amorce repop quelques frames puis disparaît.

## Fix
- Garde `settling` : dès qu'un refresh démarre, l'amorce reste masquée jusqu'à ce que `distanceFraction` soit revenu au repos (`snapshotFlow { … }.first { it <= ε }`).
- Prédicat pur extrait `shouldShowPullAmorce(isRefreshing, distanceFraction, settling)` — **TDD** (`FlagsPullAmorceTest`, 4 cas, RED→GREEN observés).

## Validation
`detektAll :app:lintProdDebug testDebugUnitTest :app:testProdDebugUnitTest :app:assembleProdDebug` → BUILD SUCCESSFUL.

versionName 0.17.11 → 0.17.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)