### PR TITLE
feat(nav): shorter icon-only bottom bar when labels off (#666) + 0.17.13

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,20 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.13` — `internal` (dev) — 2026-06-27
+
+> Suite #666 : la barre du bas raccourcit réellement (icônes seules, 56 dp) quand les libellés sont
+> masqués — auparavant elle conservait la hauteur réservée aux libellés. Build dev ; versionCode au
+> dispatch. versionName 0.17.12 → 0.17.13.
+
+**Réglages / Navigation (#666)**
+
+- **Barre du bas plus courte sans les libellés** : libellés masqués (*Réglages > Affichage > Barre de
+  navigation*), la barre du bas passe à 56 dp en icônes seules au lieu de garder les ~64 dp réservés à la
+  rangée de libellés (téléphone uniquement ; rail / tiroir des écrans larges inchangés). Cible tactile
+  conservée ≥ 48 dp. Le « short bar » expressif Material 3 étant `internal` dans le BOM courant, la barre
+  compacte est bâtie sur le `NavigationBarItem` stable. Signalé par XaTriX.
+
 ## `0.17.12` — `internal` (dev) — 2026-06-26
 
 > Fix dogfood : l'amorce du pull-to-refresh ne « repop » plus en fin de chargement. Build dev ;

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.12"
+        versionName = "0.17.13"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -21,6 +21,8 @@ import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SmallFloatingActionButton
+import androidx.compose.material3.NavigationBarDefaults
+import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -44,18 +46,24 @@ import androidx.compose.ui.unit.dp
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
-import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuite
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldDefaults
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldLayout
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.core.net.toUri
 import androidx.core.view.WindowCompat
@@ -200,7 +208,7 @@ private fun NavKey?.hidesNavigationSuite(): Boolean =
         this is PrivateMessageComposeRoute
 
 /**
- * #494 — type de barre de navigation à passer au [NavigationSuiteScaffold]. Sur téléphone l'adaptatif
+ * #494 — type de barre de navigation à passer au [NavigationSuiteScaffoldLayout]. Sur téléphone l'adaptatif
  * renvoie `NavigationBar` (80dp) ; on lui substitue `ShortNavigationBarCompact` (M3 Expressive, ~64dp,
  * icône au-dessus du label, labels conservés, cible tactile ≥48dp). Les autres formes (rail/drawer sur
  * largeur medium/expanded) restent telles quelles ; la navigation est masquée (`None`) sur les routes
@@ -218,7 +226,7 @@ private fun resolveNavLayoutType(
 }
 
 /**
- * #529 — modifier appliqué au CONTENU du [NavigationSuiteScaffold]. Quand la suite est une barre du
+ * #529 — modifier appliqué au CONTENU du [NavigationSuiteScaffoldLayout]. Quand la suite est une barre du
  * BAS (téléphone), cette barre possède déjà `WindowInsets.navigationBars` : on consomme l'inset pour
  * le sous-arbre de contenu, de sorte que les `.navigationBarsPadding()` des écrans (toujours requis
  * pour les dispositions rail/drawer, où la suite est sur le côté et laisse l'inset bas) se résolvent
@@ -466,6 +474,128 @@ private fun navItemLabel(
     show: Boolean,
     content: @Composable () -> Unit,
 ): (@Composable () -> Unit)? = content.takeIf { show }
+
+/**
+ * #666 follow-up — height of the icon-only compact bottom bar. The adaptive
+ * [NavigationSuiteType.ShortNavigationBarCompact] keeps reserving the label-row height (~64 dp) even with
+ * labels hidden, so the bar looked needlessly tall in icon-only mode (« ça sert à rien », XaTriX). Dropping
+ * to a label-less bar at this height reclaims that band while staying ≥ 48 dp (Material's minimum touch
+ * target). Phone bottom-bar + labels-off only; rail / drawer / None layouts are untouched.
+ */
+private val CompactIconBarHeight = 56.dp
+
+/**
+ * #666 follow-up — true only for the phone bottom-bar layout ([NavigationSuiteType.ShortNavigationBarCompact])
+ * with the labels hidden; that is the single case where the suite is swapped for the shorter icon-only bar.
+ * Every other layout (rail / drawer on wide windows, or labels still on) keeps the adaptive suite. Pure →
+ * unit-tested (`ShouldUseCompactIconBarTest`).
+ */
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+internal fun shouldUseCompactIconBar(
+    navBarLabels: Boolean,
+    navLayoutType: NavigationSuiteType,
+): Boolean = !navBarLabels && navLayoutType == NavigationSuiteType.ShortNavigationBarCompact
+
+/**
+ * #666 follow-up — the bottom navigation suite slot. When the phone bottom-bar layout has its labels turned
+ * off (see [shouldUseCompactIconBar]) it renders the shorter icon-only [IconOnlyBottomBar]; every other case defers to
+ * the adaptive [NavigationSuite] (bottom bar with labels on phones, rail / drawer on wider windows),
+ * preserving the previous behaviour exactly. Extracted from [RedfaceApp] so the extra branch stays off that
+ * composable's cyclomatic-complexity budget (it sits at detekt's ceiling).
+ *
+ * NB — the icon-only bar is built from the **stable** [NavigationBarItem] (not the expressive
+ * `ShortNavigationBar`): in the compose-bom 2026.05.01 the whole `ExperimentalMaterial3ExpressiveApi`
+ * surface is `internal`, so the expressive short bar cannot be opted into from app code (same gotcha as
+ * `PullToRefreshDefaults.LoadingIndicator`). The labels-on branch keeps the adaptive suite's short bar.
+ */
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+@Composable
+private fun RedfaceBottomNavigationSuite(
+    navLayoutType: NavigationSuiteType,
+    navBarLabels: Boolean,
+    currentDestination: TopLevelDestination,
+    mpUnreadCount: Int?,
+    onItemClick: (TopLevelDestination) -> Unit,
+) {
+    val compactIconOnly = shouldUseCompactIconBar(navBarLabels, navLayoutType)
+    if (compactIconOnly) {
+        IconOnlyBottomBar(
+            currentDestination = currentDestination,
+            mpUnreadCount = mpUnreadCount,
+            onItemClick = onItemClick,
+        )
+    } else {
+        NavigationSuite(layoutType = navLayoutType) {
+            TopLevelDestination.entries.forEach { destination ->
+                item(
+                    selected = currentDestination == destination,
+                    onClick = { onItemClick(destination) },
+                    icon = {
+                        TopLevelDestinationIcon(
+                            destination = destination,
+                            mpUnreadCount = mpUnreadCount,
+                        )
+                    },
+                    // #666 — null label = icon-only items when labels are off (helper keeps this off
+                    // RedfaceApp's cyclomatic-complexity budget via takeIf).
+                    label = navItemLabel(navBarLabels) {
+                        Text(text = stringResource(destination.labelRes))
+                    },
+                )
+            }
+        }
+    }
+}
+
+/**
+ * #666 follow-up — the label-less compact bottom bar, [CompactIconBarHeight] tall. Phone + labels-off only.
+ * Built from the stable [NavigationBarItem] laid out in a fixed-height [Row] (the standard
+ * [androidx.compose.material3.NavigationBar] hard-codes its own ~80 dp height, and the expressive short bar
+ * is `internal` in this bom — see [RedfaceBottomNavigationSuite]). Window-inset handling mirrors the
+ * standard suite so #529 (no dark band) still holds: the [Surface] paints the container colour across the
+ * whole region — including behind the system navigation bar — while the [Row] is pushed above the system
+ * insets via [windowInsetsPadding] (bottom + horizontal: a landscape / multi-window side bar also reports a
+ * horizontal inset). [selectableGroup] keeps the items a single a11y tab group (as the real nav bar does).
+ */
+@Composable
+private fun IconOnlyBottomBar(
+    currentDestination: TopLevelDestination,
+    mpUnreadCount: Int?,
+    onItemClick: (TopLevelDestination) -> Unit,
+) {
+    Surface(
+        color = NavigationBarDefaults.containerColor,
+        tonalElevation = NavigationBarDefaults.Elevation,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .windowInsetsPadding(
+                    WindowInsets.navigationBars.only(
+                        WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
+                    ),
+                )
+                .height(CompactIconBarHeight)
+                .selectableGroup(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            TopLevelDestination.entries.forEach { destination ->
+                NavigationBarItem(
+                    selected = currentDestination == destination,
+                    onClick = { onItemClick(destination) },
+                    icon = {
+                        TopLevelDestinationIcon(
+                            destination = destination,
+                            mpUnreadCount = mpUnreadCount,
+                        )
+                    },
+                    label = null,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}
 
 /** #667 — target tab + remaining history when back is pressed at a secondary tab's root. */
 internal data class TabBackResult(
@@ -932,36 +1062,31 @@ fun RedfaceApp(intent: Intent?) {
         // (see navSuiteContentInsetModifier). Read in composable scope, branch lives in the helper.
         val contentInsetModifier = navSuiteContentInsetModifier(navLayoutType, WindowInsets.navigationBars)
 
-        NavigationSuiteScaffold(
-            layoutType = navLayoutType,
-            navigationSuiteItems = {
-                TopLevelDestination.entries.forEach { destination ->
-                    item(
-                        selected = currentDestination == destination,
-                        onClick = {
-                            // #603 PR6 — re-tap of the already-selected Drapeaux tab opens its
-                            // quick-config sheet (counter bump); any other tap switches destination.
-                            onTopLevelTap(
-                                tapped = destination,
-                                current = currentDestination,
-                                onReselectFlags = { flagsQuickConfigRequest++ },
-                                onSwitch = { switchTab(destination) },
-                            )
-                        },
-                        icon = {
-                            TopLevelDestinationIcon(
-                                destination = destination,
-                                mpUnreadCount = mpUnreadCount,
-                            )
-                        },
-                        // #666 — null label = icon-only bar when the user disabled labels. The helper
-                        // (via takeIf) keeps this off RedfaceApp's cyclomatic-complexity budget.
-                        label = navItemLabel(navBarLabels) {
-                            Text(text = stringResource(destination.labelRes))
-                        },
-                    )
-                }
+        // #603 PR6 — re-tap of the already-selected Drapeaux tab opens its quick-config sheet (counter
+        // bump); any other tap switches destination. Hoisted to a val so the per-item onClick in
+        // RedfaceBottomNavigationSuite carries no extra branch and RedfaceApp stays under detekt's ceiling.
+        val onNavItemClick: (TopLevelDestination) -> Unit = { destination ->
+            onTopLevelTap(
+                tapped = destination,
+                current = currentDestination,
+                onReselectFlags = { flagsQuickConfigRequest++ },
+                onSwitch = { switchTab(destination) },
+            )
+        }
+        // #666 follow-up — NavigationSuiteScaffoldLayout (not the higher-level NavigationSuiteScaffold) so
+        // the navigationSuite slot can swap a shorter icon-only bar in when labels are off (Option A). The
+        // content slot below is unchanged (#529 content-inset handling stays put).
+        NavigationSuiteScaffoldLayout(
+            navigationSuite = {
+                RedfaceBottomNavigationSuite(
+                    navLayoutType = navLayoutType,
+                    navBarLabels = navBarLabels,
+                    currentDestination = currentDestination,
+                    mpUnreadCount = mpUnreadCount,
+                    onItemClick = onNavItemClick,
+                )
             },
+            layoutType = navLayoutType,
         ) {
             // #398 — no global side gutter here. Each screen owns its own lateral rhythm
             // (listings keep their 16/24 dp content padding, readers compensate explicitly),

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,6 +1,6 @@
-Redface 2 v0.17.12 — dev.
+Redface 2 v0.17.13 — dev.
 
-Flags view:
-- Fix: the swipe-to-refresh indicator no longer briefly re-appears at the end of a refresh (it lingered until the list fully settled back).
+Navigation bar:
+- Hiding the labels (Settings > Display) now actually shortens the bottom bar, which switches to icons only — on phones.
 
 Bugs: via dev or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,6 +1,6 @@
-Redface 2 v0.17.12 — dev.
+Redface 2 v0.17.13 — dev.
 
-Vue Drapeaux :
-- Correctif : l'indicateur du swipe-to-refresh ne réapparaît plus brièvement à la fin du rechargement (il restait jusqu'au retour complet de la liste au repos).
+Barre de navigation :
+- Masquer les libellés (Réglages > Affichage) raccourcit maintenant vraiment la barre du bas, qui passe en icônes seules — sur téléphone.
 
 Bugs : via le canal dev ou GitHub.

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/ShouldUseCompactIconBarTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/ShouldUseCompactIconBarTest.kt
@@ -1,0 +1,67 @@
+package fr.forumhfr.redface2.navigation
+
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #666 follow-up — the shorter icon-only bottom bar is used in exactly ONE case: the phone bottom-bar
+ * layout ([NavigationSuiteType.ShortNavigationBarCompact]) with the nav labels hidden. Every other layout
+ * (rail / drawer on wide windows, or the suite hidden) and the labels-on case keep the adaptive suite. These
+ * pin that single-case contract so a future layout-type tweak cannot silently shrink the rail/drawer.
+ */
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+class ShouldUseCompactIconBarTest {
+
+    @Test
+    fun `compact phone bar with labels off uses the short icon-only bar`() {
+        assertTrue(
+            shouldUseCompactIconBar(
+                navBarLabels = false,
+                navLayoutType = NavigationSuiteType.ShortNavigationBarCompact,
+            ),
+        )
+    }
+
+    @Test
+    fun `compact phone bar with labels on keeps the adaptive suite`() {
+        assertFalse(
+            shouldUseCompactIconBar(
+                navBarLabels = true,
+                navLayoutType = NavigationSuiteType.ShortNavigationBarCompact,
+            ),
+        )
+    }
+
+    @Test
+    fun `rail layout with labels off keeps the adaptive suite`() {
+        assertFalse(
+            shouldUseCompactIconBar(
+                navBarLabels = false,
+                navLayoutType = NavigationSuiteType.NavigationRail,
+            ),
+        )
+    }
+
+    @Test
+    fun `drawer layout with labels off keeps the adaptive suite`() {
+        assertFalse(
+            shouldUseCompactIconBar(
+                navBarLabels = false,
+                navLayoutType = NavigationSuiteType.NavigationDrawer,
+            ),
+        )
+    }
+
+    @Test
+    fun `hidden suite with labels off keeps the adaptive suite`() {
+        assertFalse(
+            shouldUseCompactIconBar(
+                navBarLabels = false,
+                navLayoutType = NavigationSuiteType.None,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Suite de **#666** (toggle des libellés de la barre du bas, livré en 0.17.10/v190). Retour dogfood XaTriX : masquer les libellés ne réduisait pas la hauteur (~64 dp réservés à la rangée de libellés) — « ça sert à rien ».

## Changement
Quand les libellés sont masqués **et** sur la disposition téléphone (`ShortNavigationBarCompact`), la barre du bas passe à **56 dp en icônes seules**. Rail / tiroir (écrans larges) et la barre labels-on sont **inchangés**.

## Implémentation
- `NavigationSuiteScaffold` → `NavigationSuiteScaffoldLayout` + slot `navigationSuite` custom (`RedfaceBottomNavigationSuite`) qui choisit la barre selon layout + état des libellés.
- Barre compacte (`IconOnlyBottomBar`) : `Row(height=56.dp)` + `NavigationBarItem` **stables**. L'API expressive `ShortNavigationBar` est `internal` dans la compose-bom 2026.05.01 (même piège que `PullToRefreshDefaults.LoadingIndicator`) → repli sur le composant stable.
- Ordre des modifiers `windowInsetsPadding(...).height(56.dp)` = ordre **canonique du `NavigationBar` Material3** (contenu 56 dp + inset système ; inverser écraserait le contenu sur nav 3-boutons).
- `#529` préservé (`navSuiteContentInsetModifier` inchangé) ; `selectableGroup()` pour l'a11y.
- Prédicat pur `shouldUseCompactIconBar` extrait + test unitaire `ShouldUseCompactIconBarTest` (5 cas).

## Validation
- CI-équiv locale **verte** (detektAll + lintProdDebug + tests + assembleProdDebug), 2×.
- **Codex gpt-5.5 xhigh : GO** (cadrage + gate diff) ; confirme l'ordre des modifiers.
- **Code-review 8 finders (opus)** : 0 bug de correction (1 lien KDoc corrigé).
- ⚠️ **Validation visuelle déléguée au dogfood** : l'émulateur ne boote pas dans l'env. À surveiller : nav 3-boutons + gesture (clip éventuel du pill).

versionName 0.17.12 → 0.17.13 ; CHANGELOG + whatsnew à jour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)