### PR TITLE
feat(flags): surface display settings + « +lus » toggle in the tab picker (#661)

### DIFF
--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -334,10 +334,20 @@ fun FlagsRoute(
                         searchEnabled = canConfigureView,
                         query = searchQuery,
                         searchActive = searchActive,
+                        // #661 — the picker dropdown surfaces a contextual « +lus » toggle (Cyan/DT) and
+                        // the display-settings sheet for discoverability.
+                        currentTab = selectedTab,
+                        readFilterShowsRead = flagsReadFilterShowsRead(
+                            tab = selectedTab,
+                            cyanShowsRead = cyanShowsRead,
+                            dtShowsRead = dtShowsRead,
+                        ),
                     ),
                     onSelectTab = viewModel::selectTab,
                     onQueryChange = { searchQuery = it },
                     onSearchActiveChange = { searchActive = it },
+                    // #661 — open the quick-config sheet from the picker (same sheet as the bottom-bar re-tap).
+                    onOpenViewSettings = { showViewSettingsSheet = true },
                     accountMenu = { topBarActions?.invoke() },
                 )
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsSearchAppBar.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsSearchAppBar.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalTextStyle
@@ -62,12 +63,13 @@ data class FlagTabEntry(val tab: FlagTab, val label: String, val color: Color)
  * so PR2 keeps the simple top-of-column layout and ships the structure + interactions first.
  */
 @Composable
-@Suppress("LongParameterList") // App-bar API: state + 3 callbacks + the @Composable account slot + modifier.
+@Suppress("LongParameterList") // App-bar API: state + 4 callbacks + the @Composable account slot + modifier.
 fun FlagsSearchAppBar(
     state: FlagsAppBarState,
     onSelectTab: (FlagTab) -> Unit,
     onQueryChange: (String) -> Unit,
     onSearchActiveChange: (Boolean) -> Unit,
+    onOpenViewSettings: () -> Unit,
     accountMenu: @Composable () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -83,9 +85,9 @@ fun FlagsSearchAppBar(
             horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             FlagTabPickerButton(
-                currentTabColor = state.currentTabColor,
-                tabs = state.tabs,
+                state = state,
                 onSelectTab = onSelectTab,
+                onOpenViewSettings = onOpenViewSettings,
             )
             SearchField(
                 state = SearchFieldState(state.searchEnabled, state.query, state.searchActive),
@@ -105,34 +107,93 @@ data class FlagsAppBarState(
     val searchEnabled: Boolean,
     val query: String,
     val searchActive: Boolean,
+    /** #661 — the active tab, so the picker can offer the contextual « +lus » toggle. */
+    val currentTab: FlagTab,
+    /**
+     * #661 — whether the active tab currently shows read items (« +lus ») : `true`/`false` on the tabs
+     * that have the toggle (Cyan / DT), `null` on the others (Red / Favori / Super) → no « +lus » entry.
+     */
+    val readFilterShowsRead: Boolean?,
 )
+
+/**
+ * #661 — read-filter state for the picker's contextual « +lus » entry: `null` when the active tab has
+ * no such toggle (Red / Favori / Super), otherwise whether read items are currently shown (Cyan / DT).
+ * Pure → unit-tested.
+ */
+internal fun flagsReadFilterShowsRead(
+    tab: FlagTab,
+    cyanShowsRead: Boolean,
+    dtShowsRead: Boolean,
+): Boolean? = when (tab) {
+    FlagTab.Cyan -> cyanShowsRead
+    FlagTab.Dt -> dtShowsRead
+    else -> null
+}
 
 @Composable
 private fun FlagTabPickerButton(
-    currentTabColor: Color,
-    tabs: List<FlagTabEntry>,
+    state: FlagsAppBarState,
     onSelectTab: (FlagTab) -> Unit,
+    onOpenViewSettings: () -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
     val pickerLabel = stringResource(R.string.flags_appbar_tab_picker)
     Box {
         IconButton(
-            onClick = { if (tabs.isNotEmpty()) expanded = true },
-            enabled = tabs.isNotEmpty(),
+            onClick = { if (state.tabs.isNotEmpty()) expanded = true },
+            enabled = state.tabs.isNotEmpty(),
             modifier = Modifier.semantics { contentDescription = pickerLabel },
         ) {
             // Flag glyph of the current tab, tinted with its color (cyan/red/favori/fuchsia). (The
             // pixel-art RF2 brand flag was rolled back — too crude at 24dp ; awaiting a proper vector.)
-            RedfaceVectorIcon(resId = CoreUiR.drawable.ic_ms_flag, tint = currentTabColor)
+            RedfaceVectorIcon(resId = CoreUiR.drawable.ic_ms_flag, tint = state.currentTabColor)
         }
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-            tabs.forEach { entry ->
+            state.tabs.forEach { entry ->
                 DropdownMenuItem(
                     text = { Text(entry.label) },
                     leadingIcon = { ColorDot(entry.color) },
                     onClick = {
                         expanded = false
                         onSelectTab(entry.tab)
+                    },
+                )
+            }
+            // #661 — discoverability: the « +lus » toggle (otherwise reachable only by re-tapping a tab)
+            // and the display-settings sheet (otherwise only via the bottom-bar re-tap — the header gear
+            // was retired, #648) get explicit entries under a divider.
+            val showsRead = state.readFilterShowsRead
+            if (showsRead != null || state.searchEnabled) {
+                HorizontalDivider()
+            }
+            if (showsRead != null) {
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            stringResource(
+                                if (showsRead) {
+                                    R.string.flags_appbar_menu_hide_read
+                                } else {
+                                    R.string.flags_appbar_menu_show_read
+                                },
+                            ),
+                        )
+                    },
+                    // Re-selecting the active Cyan/DT tab toggles its « +lus » filter — the same path as a
+                    // tab re-tap (FlagsViewModel.selectTab -> handleReTap).
+                    onClick = {
+                        expanded = false
+                        onSelectTab(state.currentTab)
+                    },
+                )
+            }
+            if (state.searchEnabled) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.flags_appbar_menu_display_settings)) },
+                    onClick = {
+                        expanded = false
+                        onOpenViewSettings()
                     },
                 )
             }

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -21,6 +21,10 @@
     <string name="flags_search_placeholder">Rechercher dans les drapeaux</string>
     <!-- a11y : l'icône drapeau colorée à gauche indique l'onglet courant et ouvre le sélecteur d'onglet. -->
     <string name="flags_appbar_tab_picker">Onglet courant — changer d\'onglet</string>
+    <!-- #661 — entrées de découvrabilité du menu déroulant du sélecteur d'onglet. -->
+    <string name="flags_appbar_menu_display_settings">Réglages d\'affichage</string>
+    <string name="flags_appbar_menu_show_read">Afficher les lus</string>
+    <string name="flags_appbar_menu_hide_read">Masquer les lus</string>
     <!-- a11y : action d'effacement du champ de recherche. -->
     <string name="flags_search_clear">Effacer la recherche</string>
     <!-- État vide d'une recherche sans résultat. %1$s = la requête saisie. -->

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsReadFilterShowsReadTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsReadFilterShowsReadTest.kt
@@ -1,0 +1,32 @@
+package fr.forumhfr.redface2.feature.flags
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #661 — the picker dropdown's contextual « +lus » entry exists ONLY for the tabs that carry a read
+ * filter (Cyan / DT) and its label follows their current state; the other tabs (Red / Favori / Super)
+ * get no entry (null). Pure mapping → unit-tested.
+ */
+class FlagsReadFilterShowsReadTest {
+
+    @Test
+    fun `cyan reflects its read-shortcut state`() {
+        assertEquals(true, flagsReadFilterShowsRead(FlagTab.Cyan, cyanShowsRead = true, dtShowsRead = false))
+        assertEquals(false, flagsReadFilterShowsRead(FlagTab.Cyan, cyanShowsRead = false, dtShowsRead = true))
+    }
+
+    @Test
+    fun `dt reflects its own read state`() {
+        assertEquals(true, flagsReadFilterShowsRead(FlagTab.Dt, cyanShowsRead = false, dtShowsRead = true))
+        assertEquals(false, flagsReadFilterShowsRead(FlagTab.Dt, cyanShowsRead = true, dtShowsRead = false))
+    }
+
+    @Test
+    fun `tabs without a read filter have no entry`() {
+        assertNull(flagsReadFilterShowsRead(FlagTab.Red, cyanShowsRead = true, dtShowsRead = true))
+        assertNull(flagsReadFilterShowsRead(FlagTab.Favorite, cyanShowsRead = true, dtShowsRead = true))
+        assertNull(flagsReadFilterShowsRead(FlagTab.Super, cyanShowsRead = true, dtShowsRead = true))
+    }
+}


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Closes #661.

## Problème (découvrabilité)
- Le sheet de réglages d'affichage n'était ouvrable que par re-tap de l'icône Drapeaux de la barre du bas (la roue dentée de l'en-tête a été retirée #648).
- La bascule « +lus » n'était accessible que par re-tap d'un onglet.
Ni l'un ni l'autre n'étaient découvrables (retours nicko/thibw/CharLee).

## Changement
Le menu déroulant du sélecteur d'onglet (`FlagTabPickerButton`) affiche désormais, **sous un séparateur** :
- une entrée contextuelle **« Afficher / Masquer les lus »** (uniquement Cyan/DT, libellé selon l'état courant) — route via `onSelectTab(currentTab)`, exactement le même toggle qu'un re-tap d'onglet ;
- une entrée **« Réglages d'affichage »** (si configurable) qui ouvre le sheet de réglages rapides.

## Conception
- `flagsReadFilterShowsRead(tab, cyanShowsRead, dtShowsRead) : Boolean?` = mapping pur (null pour Red/Favori/Super), **testé** (`FlagsReadFilterShowsReadTest`).
- `FlagsAppBarState` gagne `currentTab` + `readFilterShowsRead` ; `FlagsSearchAppBar` gagne le callback `onOpenViewSettings` (→ `showViewSettingsSheet = true`).
- Pas d'overflow ⋮ séparé (les entrées vont dans le picker existant, comme convenu).

## Validation
CI-équiv locale verte (detektAll + lintProdDebug + tests + assembleProdDebug). Gate Codex en cours.
Visuel : dogfood (émulateur indisponible dans l'env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)