### PR TITLE
feat(flags): sheet F2 — 5 actions sur une ligne + retrait sous-titre (#676)

### DIFF
--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagActionsSheet.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagActionsSheet.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -24,9 +25,12 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
@@ -70,50 +74,25 @@ fun FlagActionsSheet(
                 .navigationBarsPadding()
                 .padding(bottom = 12.dp),
         ) {
-            SheetHeader(flag = flag, categoryName = categoryName)
+            SheetHeader(flag = flag)
+            // #676 (mockup F2) — the actions live on a SINGLE row of icon buttons (they used to be a
+            // vertical list — « mal disposé »). « Retirer » is the 5th, error-tinted ; it still routes
+            // through the existing removal confirmation dialog (actions.onRemove), so a mis-tap is
+            // recoverable. The « catégorie · position » lives in the metadata block right below.
+            QuickActionsBar(
+                isSuperFavorite = isSuperFavorite,
+                actions = actions,
+                onCopyLink = { copyTopicLink(context, flagTopicUrl(flag), linkCopied) },
+                onOpenBrowser = { openTopicInBrowser(context, flagTopicUrl(flag), browserFailed) },
+            )
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
             FlagMetadataBlock(flag = flag, categoryName = categoryName)
-            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-
-            SheetActionRow(
-                iconRes = CoreUiR.drawable.ic_ms_forum,
-                label = stringResource(R.string.flags_sheet_open),
-                onClick = actions.onOpen,
-            )
-            SheetActionRow(
-                iconRes = CoreUiR.drawable.ic_ms_star,
-                label = stringResource(
-                    if (isSuperFavorite) {
-                        R.string.flags_sheet_super_favorite_remove
-                    } else {
-                        R.string.flags_sheet_super_favorite_add
-                    },
-                ),
-                onClick = actions.onToggleSuperFavorite,
-                contentColor = if (isSuperFavorite) FlagPalette.Favorite else MaterialTheme.colorScheme.onSurface,
-            )
-            SheetActionRow(
-                iconRes = CoreUiR.drawable.ic_ms_content_copy,
-                label = stringResource(R.string.flags_sheet_copy_link),
-                onClick = { copyTopicLink(context, flagTopicUrl(flag), linkCopied) },
-            )
-            SheetActionRow(
-                iconRes = CoreUiR.drawable.ic_ms_open_in_new,
-                label = stringResource(R.string.flags_sheet_open_browser),
-                onClick = { openTopicInBrowser(context, flagTopicUrl(flag), browserFailed) },
-            )
-            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-            SheetActionRow(
-                iconRes = CoreUiR.drawable.ic_ms_delete,
-                label = stringResource(R.string.flags_sheet_remove),
-                onClick = actions.onRemove,
-                contentColor = MaterialTheme.colorScheme.error,
-            )
         }
     }
 }
 
 @Composable
-private fun SheetHeader(flag: Flag, categoryName: String) {
+private fun SheetHeader(flag: Flag) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -128,25 +107,104 @@ private fun SheetHeader(flag: Flag, categoryName: String) {
             hasUnread = flag.hasUnread,
             categoryIconRes = categoryIcon(flag.cat),
         )
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = flag.title,
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-            )
-            val position = stringResource(
-                R.string.flags_sheet_meta_position_value,
-                flag.lastReadPage,
-                flag.totalPages,
-            )
-            Text(
-                text = "$categoryName · $position",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
+        // #676 (F2) — title only. The « catégorie · p.X/Y » subtitle was dropped: it duplicated the
+        // metadata block right below, which already lists the category and the read position.
+        Text(
+            text = flag.title,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+/**
+ * #676 (mockup F2) — the five topic actions on a single row of icon buttons (replaces the old vertical
+ * list). « Retirer » is the last button, error-tinted: removal still goes through the existing
+ * confirmation dialog ([FlagSheetActions.onRemove]), so its placement here is not a one-tap destruction.
+ * Takes the whole [actions] bundle (rather than four separate lambdas) to stay under the parameter cap.
+ */
+@Composable
+private fun QuickActionsBar(
+    isSuperFavorite: Boolean,
+    actions: FlagSheetActions,
+    onCopyLink: () -> Unit,
+    onOpenBrowser: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 4.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        // Each button takes an equal share of the row (weight 1f) so the five fit edge-to-edge and never
+        // clip on a narrow screen (~320dp), rather than a fixed width that could overflow.
+        QuickActionButton(
+            modifier = Modifier.weight(1f),
+            iconRes = CoreUiR.drawable.ic_ms_forum,
+            label = stringResource(R.string.flags_sheet_quick_open),
+            onClick = actions.onOpen,
+        )
+        QuickActionButton(
+            modifier = Modifier.weight(1f),
+            iconRes = CoreUiR.drawable.ic_ms_star,
+            label = stringResource(R.string.flags_sheet_quick_super_favorite),
+            onClick = actions.onToggleSuperFavorite,
+            tint = if (isSuperFavorite) FlagPalette.Favorite else MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        QuickActionButton(
+            modifier = Modifier.weight(1f),
+            iconRes = CoreUiR.drawable.ic_ms_content_copy,
+            label = stringResource(R.string.flags_sheet_quick_copy),
+            onClick = onCopyLink,
+        )
+        QuickActionButton(
+            modifier = Modifier.weight(1f),
+            iconRes = CoreUiR.drawable.ic_ms_open_in_new,
+            label = stringResource(R.string.flags_sheet_quick_browser),
+            onClick = onOpenBrowser,
+        )
+        QuickActionButton(
+            modifier = Modifier.weight(1f),
+            iconRes = CoreUiR.drawable.ic_ms_delete,
+            label = stringResource(R.string.flags_sheet_quick_remove),
+            onClick = actions.onRemove,
+            tint = MaterialTheme.colorScheme.error,
+        )
+    }
+}
+
+@Composable
+private fun QuickActionButton(
+    @DrawableRes iconRes: Int,
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    tint: Color = MaterialTheme.colorScheme.onSurfaceVariant,
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .clickable(role = Role.Button, onClick = onClick)
+            .padding(horizontal = 2.dp, vertical = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        // The icon carries no contentDescription: the visible [label] below is the button's accessible
+        // name (TalkBack reads the whole clickable Column, announced as a button via role), so a separate
+        // icon description would double-read.
+        RedfaceVectorIcon(resId = iconRes, contentDescription = null, tint = tint)
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = tint,
+            textAlign = TextAlign.Center,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
     }
 }
 
@@ -199,26 +257,6 @@ private fun MetaRow(key: String, value: String) {
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurface,
         )
-    }
-}
-
-@Composable
-private fun SheetActionRow(
-    @DrawableRes iconRes: Int,
-    label: String,
-    onClick: () -> Unit,
-    contentColor: Color = MaterialTheme.colorScheme.onSurface,
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(horizontal = 24.dp, vertical = 14.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(20.dp),
-    ) {
-        RedfaceVectorIcon(resId = iconRes, tint = contentColor)
-        Text(text = label, style = MaterialTheme.typography.bodyLarge, color = contentColor)
     }
 }
 

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -33,12 +33,13 @@
     <!-- #603 PR5 — bottom sheet d'appui-long sur un drapeau (métadonnées + actions + super-favori). -->
     <!-- Libellé a11y / long-press de la ligne : ouvre le sheet d'actions (remplace le « Retirer » direct). -->
     <string name="flags_row_actions_label">Actions du sujet</string>
-    <string name="flags_sheet_open">Ouvrir le sujet</string>
-    <string name="flags_sheet_super_favorite_add">Ajouter aux super-favoris</string>
-    <string name="flags_sheet_super_favorite_remove">Retirer des super-favoris</string>
-    <string name="flags_sheet_copy_link">Copier le lien</string>
-    <string name="flags_sheet_open_browser">Ouvrir dans le navigateur</string>
-    <string name="flags_sheet_remove">Retirer le drapeau</string>
+    <!-- #676 (mockup F2) — libellés courts des 5 boutons d'action sur une ligne (remplace l'ancienne
+         liste verticale). « Retirer » passe toujours par le dialog de confirmation de retrait. -->
+    <string name="flags_sheet_quick_open">Ouvrir</string>
+    <string name="flags_sheet_quick_super_favorite">Super favori</string>
+    <string name="flags_sheet_quick_copy">Copier</string>
+    <string name="flags_sheet_quick_browser">Navigateur</string>
+    <string name="flags_sheet_quick_remove">Retirer</string>
     <string name="flags_sheet_link_copied">Lien copié</string>
     <string name="flags_sheet_browser_failed">Aucune application pour ouvrir ce lien</string>
     <!-- Bloc métadonnées (clés). -->


### PR DESCRIPTION
## Drapeaux — sheet d'appui-long, mockup F2 (#676)

Itération design de la `FlagActionsSheet` (sheet ouvert à l'appui-long sur une ligne de Drapeaux), sur le mockup **F2** ([galerie](https://forumhfr.github.io/artifacts/flags-mockups-603/)).

### Ce que fait cette PR (points 1 + 2 de l'issue)

1. **Les 5 actions sur une seule ligne** (point 1) — `Ouvrir`, `Super favori`, `Copier`, `Navigateur`, `Retirer` passent d'une liste verticale empilée (« mal disposée ») à une rangée unique de boutons icône + label (`QuickActionsBar`). Chaque bouton occupe une part égale (`weight(1f)`) pour ne jamais déborder sur petit écran.
2. **Sous-titre du titre retiré** (point 2) — le « catégorie · p.X/Y » sous le titre était redondant avec le bloc métadonnées juste en dessous (qui liste déjà catégorie + position). Supprimé.

« Retirer » reste le dernier bouton, teinté `error`, et **continue de passer par le dialog de confirmation de retrait** existant — sa présence dans la rangée n'est donc pas une suppression en un tap.

Nettoyage : la liste verticale `SheetActionRow` et les 6 strings longues devenues orphelines sont supprimées (vérifiées non référencées ailleurs) ; strings courtes `flags_sheet_quick_*` ajoutées.

### Reporté (points 3 + 4) — documenté sur #676, issue laissée ouverte

3. **Sous-catégorie** — `Flag.subcat` ne porte que l'ID. Contrairement aux catégories (mapping statique `FALLBACK_CATEGORY_ORDER`, ~30 entrées), les sous-catégories sont des centaines, dynamiques par catégorie : aucun mapping id→nom disponible côté Drapeaux, et la liste ne charge pas les sous-catégories. La résolution imposerait N appels REST → l'issue marquait déjà ce point « à cadrer avant implémentation ».
4. **Nombre de vues** — confirmé absent de l'API REST JSON (existe uniquement en HTML). L'afficher imposerait un fetch hybride REST+HTML, hors scope d'une PR de layout.

### Validation

- `detektAll :app:lintProdDebug testDebugUnitTest :app:testProdDebugUnitTest :app:assembleProdDebug` → BUILD SUCCESSFUL.
- Gate Codex (gpt-5.5 xhigh) sur le diff : GO.
- Validation visuelle (rendu réel des 5 boutons / wrap du label « Super favori ») → dogfood du build dev.

Avance #676 (points 1+2). **L'issue reste OUVERTE** pour les points 3 (sous-catégorie) et 4 (vues), reportés — voir le commentaire sur l'issue pour le report justifié. Pas de mot-clé de fermeture volontairement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)