### PR TITLE
chore(release): dev 0.17.14 — Drapeaux #661 + #679 + #676

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,27 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.14` — `internal` (dev) — 2026-06-27
+
+> Refonte de la vue Drapeaux (#603), lot suivant : le menu déroulant du sélecteur d'onglet expose
+> maintenant le « +lus » et les réglages d'affichage (#661), le re-tap de l'onglet Drapeaux depuis un
+> sous-écran ramène à la racine (#679), et le sheet d'appui-long sur un sujet passe à 5 actions sur une
+> ligne (#676). Build dev ; versionCode au dispatch. versionName 0.17.13 → 0.17.14.
+
+**Drapeaux — vue (#603)**
+
+- **Menu du sélecteur d'onglet plus découvrable (#661)** : le menu déroulant (icône drapeau colorée en
+  haut à gauche) propose désormais, en plus du changement d'onglet, l'entrée contextuelle « Afficher /
+  Masquer les lus » (sur Cyan et DT) et « Réglages d'affichage » — deux actions auparavant atteignables
+  seulement par un re-tap d'onglet ou de la barre du bas.
+- **Re-tap de l'onglet Drapeaux = retour à la racine (#679)** : re-taper l'onglet Drapeaux alors qu'on
+  est dans un sous-écran (un sujet ouvert depuis un drapeau) revient à la liste des drapeaux, au lieu
+  d'armer par erreur le menu de configuration rapide.
+- **Sheet d'appui-long — 5 actions sur une ligne (#676, mockup F2)** : l'appui long sur un sujet présente
+  ses actions (Ouvrir / Super favori / Copier / Navigateur / Retirer) sur une seule rangée de boutons au
+  lieu d'une liste verticale ; « Retirer » reste rouge et passe toujours par la confirmation. Le
+  sous-titre redondant sous le titre du sujet a été retiré (l'info reste dans le bloc métadonnées).
+
 ## `0.17.13` — `internal` (dev) — 2026-06-27
 
 > Suite #666 : la barre du bas raccourcit réellement (icônes seules, 56 dp) quand les libellés sont

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.13"
+        versionName = "0.17.14"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,6 +1,8 @@
-Redface 2 v0.17.13 — dev.
+Redface 2 v0.17.14 — dev.
 
-Navigation bar:
-- Hiding the labels (Settings > Display) now actually shortens the bottom bar, which switches to icons only — on phones.
+Flags view:
+- The tab picker menu now offers "Show/Hide read" and the display settings.
+- Re-tapping the Flags tab from a topic returns to the list.
+- Long-press on a topic: 5 actions on a single row.
 
 Bugs: via dev or GitHub.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,6 +1,8 @@
-Redface 2 v0.17.13 — dev.
+Redface 2 v0.17.14 — dev.
 
-Barre de navigation :
-- Masquer les libellés (Réglages > Affichage) raccourcit maintenant vraiment la barre du bas, qui passe en icônes seules — sur téléphone.
+Vue Drapeaux :
+- Le menu du sélecteur d'onglet propose maintenant « Afficher/Masquer les lus » et les réglages d'affichage.
+- Re-taper l'onglet Drapeaux depuis un sujet revient à la liste.
+- Appui long sur un sujet : 5 actions sur une seule ligne.
 
 Bugs : via le canal dev ou GitHub.


### PR DESCRIPTION
Release dev groupée des features Drapeaux mergées depuis 0.17.13 : #661 (découvrabilité menu), #679 (re-tap → racine), #676 (sheet F2). versionName 0.17.13 → 0.17.14, versionCode au dispatch.

NB : #665 (top bar translucide, PR #688) **n'est PAS** dans cette release — sa PR attend une validation visuelle dogfood avant merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)