### PR TITLE
chore(release): dev 0.17.15 — barre du bas 52 dp (#666) + bandes preset C (#671)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,23 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.15` — `internal` (dev) — 2026-06-27
+
+> Refonte de la vue Drapeaux (#603), polish : la barre du bas en mode icônes seules passe à 52 dp avec
+> un item dédié (14 dp d'air autour de l'icône, indicateur M3 actif, nom accessible des onglets corrigé),
+> et l'espacement des bandes de catégorie passe du preset D au preset C (les bandes paraissaient trop
+> serrées) (#671). Build dev ; versionCode au dispatch. versionName 0.17.14 → 0.17.15.
+
+**Drapeaux — vue (#603)**
+
+- **Barre du bas icônes seules à 52 dp (suite #666)** : quand les libellés sont masqués, la barre du bas
+  passe de 56 à 52 dp, construite à partir d'un item dédié — l'icône 24 dp est centrée avec 14 dp d'air
+  au-dessus et en dessous, l'indicateur actif (pilule M3) revient derrière l'icône sélectionnée. Corrige
+  au passage un manque d'accessibilité : en mode icônes seules les onglets n'avaient pas de nom annoncé.
+- **Espacement des bandes de catégorie — preset C (#671)** : l'air autour des bandes de catégorie passe
+  du preset D (trop serré pour la hauteur des bandes) au preset C ; un réglage utilisateur dédié arrivera
+  plus tard.
+
 ## `0.17.14` — `internal` (dev) — 2026-06-27
 
 > Refonte de la vue Drapeaux (#603), lot suivant : le menu déroulant du sélecteur d'onglet expose

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.14"
+        versionName = "0.17.15"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,8 +1,5 @@
-Redface 2 v0.17.14 — dev.
+Redface 2 v0.17.15 — dev.
 
 Flags view:
-- The tab picker menu now offers "Show/Hide read" and the display settings.
-- Re-tapping the Flags tab from a topic returns to the list.
-- Long-press on a topic: 5 actions on a single row.
-
-Bugs: via dev or GitHub.
+- More compact bottom bar (52 dp) when labels are hidden, with the active tab indicator and tab names announced for accessibility.
+- Slightly roomier category bands (preset C).

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,8 +1,5 @@
-Redface 2 v0.17.14 — dev.
+Redface 2 v0.17.15 — dev.
 
 Vue Drapeaux :
-- Le menu du sélecteur d'onglet propose maintenant « Afficher/Masquer les lus » et les réglages d'affichage.
-- Re-taper l'onglet Drapeaux depuis un sujet revient à la liste.
-- Appui long sur un sujet : 5 actions sur une seule ligne.
-
-Bugs : via le canal dev ou GitHub.
+- Barre du bas plus compacte (52 dp) quand les libellés sont masqués, avec l'indicateur d'onglet actif et le nom des onglets annoncé pour l'accessibilité.
+- Bandes de catégorie un peu plus aérées (preset C).


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Bump de release dev **0.17.15** groupant deux items de finition #603 déjà mergés sur dev :

- **Barre du bas icônes seules à 52 dp** (#666 follow-up, PR #693) — item dédié `CompactBarItem`, indicateur M3 actif, correctif a11y (nom des onglets en mode icônes seules). Gate Codex OK.
- **Espacement des bandes de catégorie preset D → C** (#671, PR #692) — les bandes paraissaient trop serrées au preset D.

`versionName` 0.17.14 → 0.17.15. `versionCode` alloué au dispatch (registre de tags). CHANGELOG + whatsnew fr/en mis à jour (gardes `check-changelog-entry` / `check-whatsnew` vertes en local).

Après merge : `gh workflow run release.yml --ref dev -f channel=dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)