### PR TITLE
fix(flags): favori lisible #FFB300 (#690) + scroll par onglet (#695)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,22 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.17` — `internal` (dev) — 2026-06-27
+
+> Vue Drapeaux (#603) : la couleur du drapeau favori passe à un jaune-ambre lisible sur clair comme sur
+> sombre (#690, choix « D » des testeurs), et le défilement de chaque onglet (Mes sujets / Lu / Favoris)
+> est désormais indépendant — il ne « bave » plus d'un onglet à l'autre (#695). versionName 0.17.16 → 0.17.17.
+
+**Drapeaux — vue (#603)**
+
+- **Couleur du favori lisible sur fond clair (#690)** : le jaune Material Yellow 600 (`#FDD835`) se
+  noyait sur le thème clair (fond crème, contraste ~1,2:1). Il passe à Material Amber 600 (`#FFB300`),
+  un jaune-ambre qui tient sur clair comme sur sombre (choix « D » des testeurs CharLee/thibw/XaTriX),
+  sans aller jusqu'à l'ambre `#F9A825` jugé trop loin de l'identité du favori. Cyan et rouge inchangés.
+- **Défilement indépendant par onglet (#695)** : les onglets Mes sujets / Lu / Favoris partageaient un
+  seul état de liste, donc la position de défilement « bavait » d'un onglet à l'autre. Chaque onglet a
+  désormais son propre état de liste (préservé au changement d'onglet et à la rotation).
+
 ## `0.17.16` — `internal` (dev) — 2026-06-27
 
 > Vue Drapeaux (#603), correctifs : les sujets cyan d'une catégorie ajoutée récemment sur HFR (ex. « IA »)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.16"
+        versionName = "0.17.17"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,5 +1,5 @@
-Redface 2 v0.17.16 — dev.
+Redface 2 v0.17.17 — dev.
 
 Flags view:
-- Cyan topics from a recently added HFR category (e.g. "AI") show up again in the list.
-- The favorite flag colour is yellow again (it had drifted to green).
+- The favorite flag colour is now an amber-yellow that stays legible on the light theme too.
+- Each tab (My topics / Read / Favorites) keeps its own scroll position instead of bleeding across tabs.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,5 +1,5 @@
-Redface 2 v0.17.16 — dev.
+Redface 2 v0.17.17 — dev.
 
 Vue Drapeaux :
-- Les sujets cyan d'une catégorie ajoutée récemment sur HFR (ex. « IA ») réapparaissent dans la liste.
-- La couleur du drapeau favori repasse au jaune (elle virait au vert).
+- La couleur du drapeau favori devient un jaune-ambre lisible aussi sur le thème clair.
+- Le défilement de chaque onglet (Mes sujets / Lu / Favoris) est indépendant : il ne saute plus d'un onglet à l'autre.

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/FlagPalette.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/FlagPalette.kt
@@ -13,9 +13,11 @@ import fr.forumhfr.redface2.core.model.FlagType
  * - [FlagType.RED] → rouge, lus uniquement
  * - [FlagType.FAVORITE] → jaune, favoris
  *
- * #690 — [FAVORITE] was Material Lime 500 (`#CDDC39`) but on screen it read GREEN, not yellow, so it
- * moved to Material Yellow 600 (`#FDD835`) : unmistakably yellow without the amber drift (`#F9A825`)
- * that loses the HFR favourite identity. Cyan/Red stay in their Material tones.
+ * #690 — [FAVORITE] history: Material Lime 500 (`#CDDC39`) read GREEN on screen; Material Yellow 600
+ * (`#FDD835`, v196) was unmistakably yellow on dark but washed out on the light theme's cream surface
+ * (~1.2:1, illegible). It is now Material Amber 600 (`#FFB300`) — a warm yellow-gold that holds on
+ * BOTH light and dark (community pick « D »), without going all the way to the amber (`#F9A825`) the
+ * team rejected as too far from the HFR favourite identity. Cyan/Red stay in their Material tones.
  *
  * Kept distinct from the Material 3 `error` / `tertiary` roles on purpose : mapping
  * the buckets to roles would either introduce ambiguity (red flag ↔ error state) or
@@ -27,7 +29,7 @@ object FlagPalette {
 
     val Cyan: Color = Color(0xFF00BCD4)
     val Red: Color = Color(0xFFD32F2F)
-    val Favorite: Color = Color(0xFFFDD835)
+    val Favorite: Color = Color(0xFFFFB300)
 
     /**
      * #603 — the « DT » (MultiMP) bucket marker, in a Material-toned fuchsia (`#D500F9`, Material

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -191,7 +191,11 @@ fun FlagsRoute(
 
     // #385 — hoisted list state + scroll-to-top when the unread filter flips (cf.
     // FilterFlipScrollResetEffect).
-    val flagsListState = rememberLazyListState()
+    // #695 — ONE LazyListState per flag tab (helper below) so a single shared state no longer carries
+    // Cyan's scroll index onto Favori/Rouge when switching tabs. The current tab's state drives the
+    // filter-flip reset (#385) and the landing recall-to-top (#546) below, both already scoped to the
+    // active tab.
+    val flagsListState = rememberFlagTabListState(selectedTab.flagType)
     val tabUnreadFilter by viewModel.tabUnreadFilter.collectAsStateWithLifecycle()
     FilterFlipScrollResetEffect(
         tabUnreadFilter = tabUnreadFilter,
@@ -1160,6 +1164,25 @@ private fun FlagListBody(
                 }
             }
         }
+    }
+}
+
+/**
+ * #695 — one [LazyListState] per flag tab so the scroll position of Mes sujets / Lu / Favoris does not
+ * bleed across tabs (a single shared state carried one tab's index onto another). The three states are
+ * remembered + saveable, so each tab keeps its own position across switches and rotation; the active
+ * tab's state is returned. Super has no list — it reuses the Cyan state harmlessly (never rendered).
+ * Extracted from [FlagsRoute] to keep its cyclomatic complexity under the detekt threshold.
+ */
+@Composable
+private fun rememberFlagTabListState(flagType: FlagType?): LazyListState {
+    val cyanListState = rememberLazyListState()
+    val redListState = rememberLazyListState()
+    val favoriteListState = rememberLazyListState()
+    return when (flagType) {
+        FlagType.RED -> redListState
+        FlagType.FAVORITE -> favoriteListState
+        FlagType.CYAN, null -> cyanListState
     }
 }
 

--- a/scripts/check-changelog-entry.sh
+++ b/scripts/check-changelog-entry.sh
@@ -7,10 +7,19 @@ version="${1:?usage: check-changelog-entry.sh <versionName>}"
 changelog="app/CHANGELOG.md"
 [[ -f "$changelog" ]] || { echo "::error::$changelog introuvable"; exit 1; }
 # Match en deux temps (pas de regex sur la version → aucun souci d'échappement de métacaractères) :
-# 1) isoler les lignes de heading markdown, 2) y chercher la version en chaîne LITTÉRALE (grep -F).
-if grep -E '^#{1,6}[[:space:]]' "$changelog" | grep -Fq -- "$version"; then
-  echo "CHANGELOG: entrée trouvée pour $version"
-else
-  echo "::error::Aucun heading de changelog pour la version '$version' dans $changelog (bump versionName sans entrée CHANGELOG ?)"
-  exit 1
-fi
+# 1) isoler les lignes de heading markdown, 2) y chercher la version en chaîne LITTÉRALE.
+# NB : surtout PAS de pipe « grep | grep -Fq » ici. Sous `set -o pipefail`, le `-q` sort au
+# premier match et ferme le pipe ; le grep amont reçoit alors un SIGPIPE (exit 141) que pipefail
+# propage comme échec du pipeline → faux négatif intermittent selon le timing du runner
+# (« grep: write error: Broken pipe »). On capture d'abord les headings, puis on teste en
+# substring littérale via `case`, sans pipe ni sous-processus à fermeture anticipée.
+headings="$(grep -E '^#{1,6}[[:space:]]' "$changelog" || true)"
+case "$headings" in
+  *"$version"*)
+    echo "CHANGELOG: entrée trouvée pour $version"
+    ;;
+  *)
+    echo "::error::Aucun heading de changelog pour la version '$version' dans $changelog (bump versionName sans entrée CHANGELOG ?)"
+    exit 1
+    ;;
+esac

--- a/scripts/check-fixtures-provenance.sh
+++ b/scripts/check-fixtures-provenance.sh
@@ -11,16 +11,20 @@ set -euo pipefail
 allowlist="config/fixtures-provenance-allowlist.txt"
 missing=0
 
+# NB : pas de `grep -q` / `grep -Fxq` en aval d'un pipe ici. Sous `set -o pipefail`, le `-q`
+# sort au premier match et ferme le pipe → SIGPIPE (exit 141) sur la commande amont, que pipefail
+# propage comme échec → faux négatif intermittent. On retire le `-q` (grep consomme alors toute son
+# entrée, l'amont finit proprement) et on jette la sortie via `>/dev/null`.
 is_allowed() {
   local path="$1"
   [[ -f "$allowlist" ]] &&
-    grep -vE '^[[:space:]]*(#|$)' "$allowlist" | grep -Fxq -- "$path"
+    grep -vE '^[[:space:]]*(#|$)' "$allowlist" | grep -Fx -- "$path" >/dev/null
 }
 
 has_header_provenance() {
   local file="$1"
   [[ "$(head -c 4 "$file")" == "<!--" ]] &&
-    head -n 40 "$file" | grep -Eiq 'Source|Provenance|Captured|Captur|Origine'
+    head -n 40 "$file" | grep -Ei 'Source|Provenance|Captured|Captur|Origine' >/dev/null
 }
 
 while IFS= read -r -d '' fixture; do


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Deux correctifs vue Drapeaux (#603), gate Codex GO + CI.

## #690 — couleur du favori lisible sur fond clair
`FlagPalette.Favorite` : Yellow 600 `#FDD835` (illisible sur le thème clair, crème ~1,2:1) → **Amber 600 `#FFB300`**, jaune-ambre lisible sur clair ET sombre — **choix « D »** plébiscité par les testeurs (CharLee, thibw, XaTriX), sans aller jusqu'à l'ambre `#F9A825` jugé trop loin. Cyan/rouge inchangés. `colorFor(FAVORITE)` inchangé, `FlagPaletteTest` référentiel.

## #695 — défilement indépendant par onglet
La vue partageait un seul `LazyListState` entre Mes sujets / Lu / Favoris → le scroll « bavait » d'un onglet à l'autre. Helper `rememberFlagTabListState(flagType)` : un état remembered+saveable par onglet, l'actif renvoyé. `FilterFlipScrollResetEffect` (#385) et le recall-to-top (#546) restent scopés à l'onglet actif (reset seulement au flip filtre même onglet). Helper extrait pour garder `FlagsRoute` sous le seuil detekt.

Validé : detektAll, lintProdDebug, tests, assembleProdDebug (BUILD SUCCESSFUL). Gate Codex (gpt-5.5 xhigh) GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141E4fPEy9rnw5zCbpv4Aq1
