### PR TITLE
feat(flags): visual empty states with opt-in funny smiley (#662)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -445,6 +445,22 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeFunnyEmptyState(): Flow<Boolean> =
+        dataStore.data
+            // Default `false` (#662): the sober style-A empty state is the default; the smiley wink
+            // is an explicit opt-in.
+            .map { prefs -> prefs[KEY_FLAGS_FUNNY_EMPTY_STATE] ?: false }
+            .distinctUntilChanged()
+            .catch { emit(false) }
+
+    override suspend fun setFunnyEmptyState(enabled: Boolean) {
+        persist {
+            dataStore.edit { prefs ->
+                prefs[KEY_FLAGS_FUNNY_EMPTY_STATE] = enabled
+            }
+        }
+    }
+
     override fun observeStartScreen(): Flow<StartScreenPreference> =
         dataStore.data
             .map(::readStartScreen)
@@ -809,6 +825,8 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         val KEY_FLAGS_SINGLE_LINE_TITLE = booleanPreferencesKey("flags_single_line_title")
         // #603 — GLOBAL grouped-view category band style (CategoryBandStyle.name, defensively parsed).
         val KEY_FLAGS_CATEGORY_BAND_STYLE = stringPreferencesKey("flags_category_band_style")
+        // #662 — « états vides humoristiques » opt-in (smiley empty state instead of the sober icon).
+        val KEY_FLAGS_FUNNY_EMPTY_STATE = booleanPreferencesKey("flags_funny_empty_state")
         // #309 — per-tab display override. The master switch plus one nullable key per FlagType for
         // each toggle; absence of a per-type key means « fall back to the global value ». Keys are
         // derived from the stable enum name (cyan/red/favorite), e.g. `flags_group_by_category_cyan`.

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -701,6 +701,27 @@ class DataStoreUserPreferencesRepositoryTest {
     }
 
     @Test
+    fun `observeFunnyEmptyState defaults to false then persists true and false`() = runTest(dispatcher) {
+        // #662 — the sober style-A empty state is the default; the smiley wink is strictly opt-in.
+        repository.observeFunnyEmptyState().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setFunnyEmptyState(true)
+        repository.observeFunnyEmptyState().test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setFunnyEmptyState(false)
+        repository.observeFunnyEmptyState().test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `observeConfirmBeforePosting defaults to false then persists true and false`() = runTest(dispatcher) {
         // #312 — publishing stays one-tap by default; the guard is strictly opt-in.
         repository.observeConfirmBeforePosting().test {

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -600,6 +600,10 @@ class TopicRepositoryImplTest {
 
         override suspend fun setNavBarLabels(enabled: Boolean) = Unit
 
+        override fun observeFunnyEmptyState(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setFunnyEmptyState(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -296,6 +296,18 @@ interface UserPreferencesRepository {
     suspend fun setNavBarLabels(enabled: Boolean)
 
     /**
+     * #662 — « états vides humoristiques » on the Drapeaux screen. When `false` (default), an empty
+     * tab shows the sober style A visual empty state (a thin icon + contextual title + subtext). When
+     * `true`, the same contextual text is shown under a HFR perso smiley instead of the icon (style C,
+     * a light forum wink). Opt-in by design: TalkBack reads the same text either way, and the smiley
+     * is never imposed. Observed by `:feature:flags`, toggled in Settings > Affichage.
+     */
+    fun observeFunnyEmptyState(): Flow<Boolean>
+
+    /** Persists [observeFunnyEmptyState]. Default `false` until the first call. */
+    suspend fun setFunnyEmptyState(enabled: Boolean)
+
+    /**
      * #458 — which top-level tab (and optional Forum category) a cold start opens on. Default
      * [StartScreenChoice.FLAGS] (historical behaviour). The navigation reads the SYNCHRONOUS
      * [StartScreenBootstrapStore] mirror at cold start; this flow is the source of truth and

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -2017,6 +2017,10 @@ class PostEditorViewModelTest {
 
         override suspend fun setNavBarLabels(enabled: Boolean) = Unit
 
+        override fun observeFunnyEmptyState(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setFunnyEmptyState(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1417,6 +1417,10 @@ class TopicFormViewModelTest {
 
         override suspend fun setNavBarLabels(enabled: Boolean) = Unit
 
+        override fun observeFunnyEmptyState(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setFunnyEmptyState(enabled: Boolean) = Unit
+
         override fun observeStartScreen(): Flow<StartScreenPreference> =
             MutableStateFlow(StartScreenPreference())
 

--- a/feature/flags/build.gradle.kts
+++ b/feature/flags/build.gradle.kts
@@ -15,6 +15,9 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.kotlinx.coroutines.android)
+    // #662 — AsyncImage for the opt-in perso-smiley empty state. The network fetcher
+    // (coil-network-okhttp) is provided app-wide via :core:ui; same direct dep pattern as :feature:editor.
+    implementation(libs.coil.compose)
 
     testImplementation(libs.junit4)
     testImplementation(libs.mockk)

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -62,12 +63,15 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
@@ -75,6 +79,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil3.compose.AsyncImage
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
@@ -165,6 +170,8 @@ fun FlagsRoute(
 
     // Opt-in « DT » tab (Settings toggle). Its MultiMP list is fetched on tab open (#6).
     val showDtTab by viewModel.showDtTab.collectAsStateWithLifecycle()
+    // #662 — « états vides humoristiques » opt-in (smiley empty state).
+    val funnyEmptyState by viewModel.funnyEmptyState.collectAsStateWithLifecycle()
     // #546 directive XaTriX — the screen consumes the FILTERED DT state (dtDisplayState), not the raw
     // union: DT defaults to « non-lus uniquement » and a re-tap of the DT tab toggles « +lus ».
     val dtListState by viewModel.dtDisplayState.collectAsStateWithLifecycle()
@@ -397,6 +404,8 @@ fun FlagsRoute(
                                 searchQuery = searchQuery,
                                 markerStyle = flagsViewSettings.markerStyle,
                                 categoryBandStyle = flagsViewSettings.categoryBandStyle,
+                                funnyEmptyState = funnyEmptyState,
+                                hideReadActive = flagsViewSettings.hideReadCategories,
                             ),
                             actions = AuthenticatedActions(
                                 onSelectTab = viewModel::selectTab,
@@ -1148,6 +1157,8 @@ private fun FlagListBody(
                             removalInFlight = state.removeFlagState is RemoveFlagState.Removing,
                             markerStyle = state.markerStyle,
                             categoryBandStyle = state.categoryBandStyle,
+                            funnyEmptyState = state.funnyEmptyState,
+                            hideReadActive = state.hideReadActive,
                             actions = actions,
                             listState = listState,
                         )
@@ -1157,6 +1168,7 @@ private fun FlagListBody(
                             selectedTab = selectedTab,
                             removalInFlight = state.removeFlagState is RemoveFlagState.Removing,
                             markerStyle = state.markerStyle,
+                            funnyEmptyState = state.funnyEmptyState,
                             actions = actions,
                             listState = listState,
                         )
@@ -1253,13 +1265,16 @@ private const val CONTENT_TYPE_DT_FOOTER = "dt_scan_note"
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-@Suppress("LongParameterList") // List composable: sections + tab + removal + marker + band + actions + listState.
+// List composable: sections + tab + removal + marker + band + funny + hideRead + actions + listState.
+@Suppress("LongParameterList")
 private fun CategorySectionedFlagList(
     sections: List<FlagCategorySection>,
     selectedTab: FlagTab,
     removalInFlight: Boolean,
     markerStyle: MarkerStyle,
     categoryBandStyle: CategoryBandStyle,
+    funnyEmptyState: Boolean,
+    hideReadActive: Boolean,
     actions: AuthenticatedActions,
     listState: LazyListState,
 ) {
@@ -1272,15 +1287,27 @@ private fun CategorySectionedFlagList(
         // « Masquer les catégories sans non-lu » can filter every section out (no unread anywhere,
         // or all-read CYAN with « +lus » off). Without this guard the LazyColumn would render an
         // empty body — a blank screen with no scrollable target for the PullToRefreshBox (#229).
-        // A single placeholder item keeps the body informative and the pull gesture anchored.
+        // #662 — a real visual empty state (icon/smiley + contextual text) keeps the body informative
+        // and the pull gesture anchored (fillParentMaxSize centers it). When the hide-read filter is
+        // active, empty sections do NOT mean « no topic » (read topics may exist) — show a distinct,
+        // factual wording instead of the per-tab « aucun … » that would be misleading (#662 Codex).
         if (sections.isEmpty()) {
             item(key = "grouped-empty", contentType = CONTENT_TYPE_EMPTY) {
-                Text(
-                    text = stringResource(R.string.flags_no_unread_category),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
-                )
+                if (hideReadActive) {
+                    FlagsEmptyState(
+                        iconRes = fr.forumhfr.redface2.core.ui.R.drawable.ic_ms_flag,
+                        title = stringResource(R.string.flags_no_unread_category),
+                        subtitle = stringResource(R.string.flags_no_unread_category_subtitle),
+                        funny = funnyEmptyState,
+                        modifier = Modifier.fillParentMaxSize(),
+                    )
+                } else {
+                    FlagsTabEmptyState(
+                        tab = selectedTab,
+                        funny = funnyEmptyState,
+                        modifier = Modifier.fillParentMaxSize(),
+                    )
+                }
             }
         }
 
@@ -1546,12 +1573,13 @@ private fun emptySectionLabel(tab: FlagTab): Int = when (tab) {
  * and accessibility action behave identically to the grouped view.
  */
 @Composable
-@Suppress("LongParameterList") // List composable: flags + tab + removal flag + marker + actions + listState.
+@Suppress("LongParameterList") // List composable: flags + tab + removal flag + marker + funny + actions + listState.
 private fun FlatFlagList(
     flags: List<Flag>,
     selectedTab: FlagTab,
     removalInFlight: Boolean,
     markerStyle: MarkerStyle,
+    funnyEmptyState: Boolean,
     actions: AuthenticatedActions,
     listState: LazyListState,
 ) {
@@ -1563,11 +1591,12 @@ private fun FlatFlagList(
     ) {
         if (flags.isEmpty()) {
             item(key = "flat-empty", contentType = CONTENT_TYPE_EMPTY) {
-                Text(
-                    text = stringResource(flatEmptyLabel(selectedTab)),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
+                // Flat view ignores « masquer les catégories sans non-lu », so an empty list always
+                // means the tab genuinely has no flag → the per-tab empty state is correct.
+                FlagsTabEmptyState(
+                    tab = selectedTab,
+                    funny = funnyEmptyState,
+                    modifier = Modifier.fillParentMaxSize(),
                 )
             }
         } else {
@@ -1591,14 +1620,113 @@ private fun FlatFlagList(
 }
 
 /**
- * Empty-list wording per tab for the FLAT view (#179 follow-up). Mirrors [emptySectionLabel] but
- * without the « catégorie » noun, which would be misleading in a flat list. Cyan keeps the « aucun
- * nouveau message » parity wording.
+ * #662 — per-tab visual empty state for a fully-empty Drapeaux tab. Resolves the tab's icon, title
+ * and subtitle, then delegates to [FlagsEmptyState]. Used for the genuinely-empty case (the tab has
+ * no flag at all). The grouped « masquer les catégories sans non-lu » case uses [FlagsEmptyState]
+ * directly with a distinct, factual wording (cf. #662 Codex review).
  */
-private fun flatEmptyLabel(tab: FlagTab): Int = when (tab) {
-    FlagTab.Cyan -> R.string.flags_list_empty_cyan
-    else -> R.string.flags_list_empty
+@Composable
+private fun FlagsTabEmptyState(
+    tab: FlagTab,
+    funny: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    FlagsEmptyState(
+        iconRes = emptyStateIcon(tab),
+        title = stringResource(emptyStateTitle(tab)),
+        subtitle = emptyStateSubtitle(tab)?.let { stringResource(it) },
+        funny = funny,
+        modifier = modifier,
+    )
 }
+
+/**
+ * #662 — visual empty state renderer for a fully-empty Drapeaux tab (grouped or flat). Default
+ * (style A) shows a thin icon; with the « états vides humoristiques » opt-in ([funny], style C) the
+ * same contextual text appears under a HFR perso smiley instead. The title + subtitle carry all the
+ * meaning, so TalkBack reads an identical state either way — the visual is decorative
+ * (`contentDescription = null`). Centered via [fillParentMaxSize] from the calling lazy item so the
+ * surrounding `PullToRefreshBox` keeps a swipe target (#229).
+ */
+@Composable
+private fun FlagsEmptyState(
+    iconRes: Int,
+    title: String,
+    subtitle: String?,
+    funny: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.padding(horizontal = 32.dp, vertical = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        if (funny) {
+            AsyncImage(
+                model = FUNNY_EMPTY_SMILEY_URL,
+                // Decorative: the title/subtitle below carry the meaning (a11y). FilterQuality.None
+                // keeps the pixel-art smiley crisp (same stance as the smiley picker, #236). The
+                // app-wide ImageLoader registers AnimatedImageDecoder, so the .gif animates.
+                contentDescription = null,
+                modifier = Modifier.size(72.dp),
+                contentScale = ContentScale.Fit,
+                filterQuality = FilterQuality.None,
+            )
+        } else {
+            RedfaceVectorIcon(
+                resId = iconRes,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                size = 48.dp,
+            )
+        }
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+        )
+        if (subtitle != null) {
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+/** #662 — per-tab style-A icon (local vector drawable; the project forbids Material `Icons.*`). */
+private fun emptyStateIcon(tab: FlagTab): Int = when (tab) {
+    FlagTab.Cyan -> fr.forumhfr.redface2.core.ui.R.drawable.ic_ms_forum
+    FlagTab.Red -> fr.forumhfr.redface2.core.ui.R.drawable.ic_ms_flag
+    FlagTab.Favorite -> fr.forumhfr.redface2.core.ui.R.drawable.ic_ms_star
+    else -> fr.forumhfr.redface2.core.ui.R.drawable.ic_ms_flag
+}
+
+/** #662 — per-tab empty-state title. */
+private fun emptyStateTitle(tab: FlagTab): Int = when (tab) {
+    FlagTab.Cyan -> R.string.flags_empty_title_cyan
+    FlagTab.Red -> R.string.flags_empty_title_red
+    FlagTab.Favorite -> R.string.flags_empty_title_favorite
+    else -> R.string.flags_empty_title_generic
+}
+
+/** #662 — per-tab empty-state subtitle (null = title only, e.g. the placeholder tabs). */
+private fun emptyStateSubtitle(tab: FlagTab): Int? = when (tab) {
+    FlagTab.Cyan -> R.string.flags_empty_subtitle_cyan
+    FlagTab.Red -> R.string.flags_empty_subtitle_red
+    FlagTab.Favorite -> R.string.flags_empty_subtitle_favorite
+    else -> null
+}
+
+// #662 — perso smiley for the « états vides humoristiques » opt-in (style C). The space in the HFR
+// perso filename is percent-encoded so the request URL is well-formed.
+private const val FUNNY_EMPTY_SMILEY_URL =
+    "https://forum-images.hardware.fr/images/perso/eric%20le%20looser.gif"
 
 // #603 PR5 — hosts the long-press actions sheet; the null-check lives here (not in FlagsRoute) to keep
 // the route's cyclomatic complexity in budget. `flag == null` ⇒ nothing composed (sheet closed).
@@ -2089,6 +2217,14 @@ private data class FlagsBodyState(
     val markerStyle: MarkerStyle = MarkerStyle.STRIPE,
     /** #603 — GLOBAL category band style for the grouped view (from FlagsViewSettings). */
     val categoryBandStyle: CategoryBandStyle = CategoryBandStyle.MINIMAL,
+    /** #662 — « états vides humoristiques » opt-in: smiley empty state instead of the sober icon. */
+    val funnyEmptyState: Boolean = false,
+    /**
+     * #662 (Codex) — whether « masquer les catégories sans non-lu » is active for the current tab.
+     * When true, an empty grouped list means « no category with unread », NOT « no topic », so the
+     * empty state uses a distinct factual wording instead of the per-tab « aucun … ».
+     */
+    val hideReadActive: Boolean = false,
 )
 
 private data class AuthenticatedActions(

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -107,6 +107,18 @@ class FlagsViewModel @Inject constructor(
         )
 
     /**
+     * #662 — « états vides humoristiques » opt-in. When `true`, an empty tab swaps the sober
+     * style-A icon for a HFR perso smiley (style C); the contextual text is unchanged. Eager so the
+     * empty state renders the right visual without a subscription warm-up flash.
+     */
+    val funnyEmptyState: StateFlow<Boolean> = userPreferencesRepository.observeFunnyEmptyState()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = false,
+        )
+
+    /**
      * #603 PR5 — local « super favori » topic ids (ADR-017 decision 5), a client-side pin distinct
      * from the server `isFavorite`. Eager so the long-press sheet reflects the current state without a
      * subscription warm-up. Backed by [SuperFavoriteRepository] (its own store, not user prefs).

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -106,17 +106,29 @@
     <string name="flags_category_fallback">Catégorie %1$d</string>
     <!-- #414 — libellé d'action (a11y) du bandeau de catégorie cliquable. -->
     <string name="flags_category_open_label">Ouvrir la catégorie</string>
-    <!-- #179 follow-up — Vue à plat (legacy) : message quand la liste est vide. Sans le mot
-         « catégorie » (il n'y a pas de regroupement dans cette vue). -->
-    <string name="flags_list_empty_cyan">Aucun nouveau message</string>
-    <string name="flags_list_empty">Aucun drapeau à afficher</string>
-    <!-- #179 follow-up — Vue groupée AVEC « masquer les catégories sans non-lu » : quand aucune
-         catégorie n'a de message non lu, toutes les sections sont masquées. Message + item unique
-         pour ne pas laisser un corps blanc et garder une cible scrollable au pull-to-refresh (#229). -->
+    <!-- #662 — les états vides plein-onglet (vue groupée sans section, vue à plat sans drapeau) sont
+         désormais rendus par FlagsEmptyState (visuel + titre + sous-texte par onglet), cf. les chaînes
+         flags_empty_* plus bas. Les anciens libellés courts flags_list_empty* ont été retirés. Le
+         libellé per-section (flags_category_empty*) reste utilisé. -->
+    <!-- #662 (Codex) — vue groupée AVEC « masquer les catégories sans non-lu » : sections vides ≠
+         onglet vide (il peut rester des sujets lus, juste aucun non-lu). On garde donc un état vide
+         distinct, factuel, plutôt que le « Aucun favori » trompeur. -->
     <string name="flags_no_unread_category">Aucune catégorie avec un message non lu</string>
+    <string name="flags_no_unread_category_subtitle">Désactive « Masquer les catégories sans non-lu » pour revoir les sujets lus.</string>
     <string name="flags_error">Impossible de récupérer les drapeaux. Vérifie ta connexion ou réessaie.</string>
     <string name="flags_session_expired">Session HFR expirée. Reconnecte-toi pour recharger tes drapeaux.</string>
     <string name="flags_retry">Réessayer</string>
+
+    <!-- #662 — état vide visuel d'un onglet entièrement vide : un visuel (icône fine en défaut, ou un
+         smiley perso HFR si « états vides humoristiques » est activé) + un titre + un sous-texte propres
+         à l'onglet. Le texte porte tout le sens (le visuel est décoratif pour TalkBack). -->
+    <string name="flags_empty_title_cyan">Aucun sujet suivi</string>
+    <string name="flags_empty_subtitle_cyan">Les sujets où tu interviens apparaissent ici.</string>
+    <string name="flags_empty_title_red">Aucun sujet lu</string>
+    <string name="flags_empty_subtitle_red">Les sujets que tu as marqués comme lus apparaissent ici.</string>
+    <string name="flags_empty_title_favorite">Aucun favori</string>
+    <string name="flags_empty_subtitle_favorite">Touche l\'étoile sur un sujet pour le retrouver ici.</string>
+    <string name="flags_empty_title_generic">Rien à afficher</string>
 
 
     <!-- #309 — Menu d'affichage des drapeaux (bottom sheet M3 ouvert via re-tap de l'onglet

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -330,6 +330,20 @@ class FlagsViewModelTest {
     }
 
     @Test
+    fun `funnyEmptyState reflects the persisted preference`() = runTest {
+        // #662 — the opt-in smiley empty state surfaces through an eager StateFlow; default is sober.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+
+        val sober = viewModel(auth, flags, forum, FakeUserPreferencesRepository())
+        assertFalse("default empty state is sober", sober.funnyEmptyState.value)
+
+        val funny = viewModel(auth, flags, forum, FakeUserPreferencesRepository(funnyEmptyState = true))
+        assertTrue("opt-in surfaces the funny empty state", funny.funnyEmptyState.value)
+    }
+
+    @Test
     fun `an in-flight RED write never clobbers the CYAN re-tap shim`() = runTest {
         // #317 Codex review: the optimistic shim is CYAN-scoped, so a concurrent (or late-completing)
         // RED/FAVORITE write must never touch — let alone clear — CYAN's pending flip. Gate ONLY the
@@ -2269,10 +2283,12 @@ class FlagsViewModelTest {
         groupByCategory: Boolean = true,
         hideReadCategories: Boolean = false,
         perTabOverride: Boolean = false,
+        funnyEmptyState: Boolean = false,
     ) : UserPreferencesRepository {
         private val groupBy = MutableStateFlow(groupByCategory)
         private val hideRead = MutableStateFlow(hideReadCategories)
         private val perTab = MutableStateFlow(perTabOverride)
+        private val funnyEmpty = MutableStateFlow(funnyEmptyState)
         private val perTypeGroup: Map<FlagType, MutableStateFlow<Boolean?>> =
             FlagType.entries.associateWith { MutableStateFlow<Boolean?>(null) }
         private val perTypeHide: Map<FlagType, MutableStateFlow<Boolean?>> =
@@ -2410,6 +2426,11 @@ class FlagsViewModelTest {
         override suspend fun setShowScrollbar(enabled: Boolean) = Unit
 
         override fun observeNavBarLabels(): Flow<Boolean> = MutableStateFlow(true)
+
+        override fun observeFunnyEmptyState(): Flow<Boolean> = funnyEmpty
+        override suspend fun setFunnyEmptyState(enabled: Boolean) {
+            funnyEmpty.value = enabled
+        }
 
         override suspend fun setNavBarLabels(enabled: Boolean) = Unit
 

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -463,6 +463,16 @@ internal fun buildSettingsCatalogue(
                     .takeIf { state.flagsAutoRefreshError },
                 onCheckedChange = { onIntent(SettingsIntent.FlagsAutoRefreshChanged(it)) },
             ),
+            toggleRow(
+                id = "flags_funny_empty_state",
+                title = stringResource(R.string.settings_flags_funny_empty_state_title),
+                description = stringResource(R.string.settings_flags_funny_empty_state_description),
+                checked = state.funnyEmptyState,
+                enabled = state.canToggleFunnyEmptyState,
+                errorRes = R.string.settings_flags_funny_empty_state_persist_failed
+                    .takeIf { state.funnyEmptyStateError },
+                onCheckedChange = { onIntent(SettingsIntent.FunnyEmptyStateChanged(it)) },
+            ),
             futureRow(
                 id = "future_flags_sort",
                 title = stringResource(R.string.settings_future_flags_sort),

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -139,6 +139,12 @@ data class SettingsState(
     val isUpdatingNavBarLabels: Boolean = false,
     val navBarLabelsError: Boolean = false,
     val navBarLabelsTouchedLocally: Boolean = false,
+    // #662 — états vides humoristiques de la vue Drapeaux (smiley perso au lieu de l'icône sobre).
+    // Même machinerie optimistic-flip + garde de course. Default FALSE (opt-in).
+    val funnyEmptyState: Boolean = false,
+    val isUpdatingFunnyEmptyState: Boolean = false,
+    val funnyEmptyStateError: Boolean = false,
+    val funnyEmptyStateTouchedLocally: Boolean = false,
     // #518 — masquer la barre de navigation système Android (plein écran immersif). Même machinerie
     // optimistic-flip + garde de course. Default FALSE (opt-in).
     val hideSystemNavBar: Boolean = false,
@@ -289,6 +295,10 @@ data class SettingsState(
     val canToggleNavBarLabels: Boolean
         get() = !isUpdatingNavBarLabels
 
+    // #662 — the funny-empty-state toggle is gated only by its own write.
+    val canToggleFunnyEmptyState: Boolean
+        get() = !isUpdatingFunnyEmptyState
+
     // #518 — the hide-system-nav-bar toggle is gated only by its own write.
     val canToggleHideSystemNavBar: Boolean
         get() = !isUpdatingHideSystemNavBar
@@ -425,6 +435,9 @@ sealed interface SettingsIntent {
 
     /** #666 — afficher les libellés sous les icônes de la barre du bas. */
     data class NavBarLabelsChanged(val enabled: Boolean) : SettingsIntent
+
+    /** #662 — états vides humoristiques de la vue Drapeaux (smiley perso). */
+    data class FunnyEmptyStateChanged(val enabled: Boolean) : SettingsIntent
 
     /** #518 — masquer la barre de navigation système Android (plein écran immersif). */
     data class HideSystemNavBarChanged(val enabled: Boolean) : SettingsIntent

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -125,6 +125,11 @@ class SettingsViewModel @Inject constructor(
             apply = { state, value -> state.copy(navBarLabels = value) },
         )
         hydratePreference(
+            read = { userPreferencesRepository.observeFunnyEmptyState().first() },
+            isLocked = { it.funnyEmptyStateTouchedLocally || it.isUpdatingFunnyEmptyState },
+            apply = { state, value -> state.copy(funnyEmptyState = value) },
+        )
+        hydratePreference(
             read = { userPreferencesRepository.observeHideSystemNavBar().first() },
             isLocked = { it.hideSystemNavBarTouchedLocally || it.isUpdatingHideSystemNavBar },
             apply = { state, value -> state.copy(hideSystemNavBar = value) },
@@ -262,6 +267,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.FoldLongQuotesChanged -> updateFoldLongQuotes(intent.enabled)
             is SettingsIntent.ShowScrollbarChanged -> updateShowScrollbar(intent.enabled)
             is SettingsIntent.NavBarLabelsChanged -> updateNavBarLabels(intent.enabled)
+            is SettingsIntent.FunnyEmptyStateChanged -> updateFunnyEmptyState(intent.enabled)
             is SettingsIntent.HideSystemNavBarChanged -> updateHideSystemNavBar(intent.enabled)
             is SettingsIntent.ImmersiveBackButtonChanged -> updateImmersiveBackButton(intent.enabled)
             is SettingsIntent.ImmersiveNavBarRevealChanged -> updateImmersiveNavBarReveal(intent.mode)
@@ -907,6 +913,33 @@ class SettingsViewModel @Inject constructor(
                 }
             },
             persist = userPreferencesRepository::setNavBarLabels,
+        )
+    }
+
+    private fun updateFunnyEmptyState(desired: Boolean) {
+        val previous = _state.value.funnyEmptyState
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    funnyEmptyState = desired,
+                    isUpdatingFunnyEmptyState = true,
+                    funnyEmptyStateError = false,
+                    funnyEmptyStateTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(funnyEmptyState = desired, isUpdatingFunnyEmptyState = false)
+                } else {
+                    state.copy(
+                        funnyEmptyState = previous,
+                        isUpdatingFunnyEmptyState = false,
+                        funnyEmptyStateError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setFunnyEmptyState,
         )
     }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -257,6 +257,10 @@
     <string name="settings_flags_auto_refresh_title">Actualisation automatique</string>
     <string name="settings_flags_auto_refresh_description">Rafraîchit la liste à l\'ouverture de l\'app et au retour d\'un sujet.</string>
     <string name="settings_flags_auto_refresh_persist_failed">Impossible de mémoriser l\'actualisation automatique. Réessayez.</string>
+    <!-- #662 — états vides humoristiques (smiley perso au lieu de l'icône sobre). Opt-in. -->
+    <string name="settings_flags_funny_empty_state_title">États vides humoristiques</string>
+    <string name="settings_flags_funny_empty_state_description">Affiche un smiley perso HFR quand un onglet est vide, au lieu de l\'icône sobre.</string>
+    <string name="settings_flags_funny_empty_state_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
 
     <!-- #286 — Thème. Sélecteur Clair/Système/Sombre (Système = suit l'OS) + thème AMOLED (vrai
          noir), persistés en DataStore et appliqués à toute l'app en direct. -->

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -568,6 +568,20 @@ class SettingsViewModelTest {
     }
 
     @Test
+    fun `FunnyEmptyStateChanged persists the flip and clears the updating flag`() = runTest {
+        // #662 — the smiley empty state is opt-in (default off); toggling persists and settles.
+        val viewModel = newViewModel()
+        assertFalse("sober empty state is the default", viewModel.state.value.funnyEmptyState)
+
+        viewModel.submit(SettingsIntent.FunnyEmptyStateChanged(true))
+
+        assertTrue(viewModel.state.value.funnyEmptyState)
+        assertFalse(viewModel.state.value.isUpdatingFunnyEmptyState)
+        assertFalse(viewModel.state.value.funnyEmptyStateError)
+        assertEquals(1, repository.funnyEmptyStateSetCalls)
+    }
+
+    @Test
     fun `hide-read categories switch is disabled while the flat flags view is selected`() = runTest {
         val viewModel = newViewModel()
         assertTrue(viewModel.state.value.canToggleFlagsHideReadCategories)
@@ -1896,6 +1910,21 @@ class SettingsViewModelTest {
 
         fun emitNavBarLabels(value: Boolean) {
             navBarLabels.value = value
+        }
+
+        private val funnyEmptyState = MutableStateFlow(false)
+        var funnyEmptyStateSetCalls: Int = 0
+            private set
+
+        override fun observeFunnyEmptyState(): Flow<Boolean> = funnyEmptyState
+
+        override suspend fun setFunnyEmptyState(enabled: Boolean) {
+            funnyEmptyStateSetCalls += 1
+            funnyEmptyState.value = enabled
+        }
+
+        fun emitFunnyEmptyState(value: Boolean) {
+            funnyEmptyState.value = value
         }
 
         // #458 — start screen lives on its own StartScreenSettingsViewModel; this fake only

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -2107,6 +2107,10 @@ private class FakeUserPreferencesRepository(
 
     override suspend fun setNavBarLabels(enabled: Boolean) = Unit
 
+    override fun observeFunnyEmptyState(): Flow<Boolean> = MutableStateFlow(false)
+
+    override suspend fun setFunnyEmptyState(enabled: Boolean) = Unit
+
     override fun observeStartScreen(): Flow<StartScreenPreference> =
         MutableStateFlow(StartScreenPreference())
 


### PR DESCRIPTION
Closes #662.

Un onglet Drapeaux vide affiche désormais un **vrai état vide visuel** au lieu d'un simple libellé (le retour testeur sur la v186 était « je vois pas de changement »).

## Ce que ça fait
- **Défaut (style A)** : icône fine + titre + sous-texte **par onglet** (Mes sujets / Lu / Favoris).
- **Opt-in (style C)** : le même texte sous un **smiley perso HFR `[:eric le looser]`**, derrière un nouveau réglage **« États vides humoristiques »** (Réglages › Drapeaux, défaut OFF). Le texte porte tout le sens (TalkBack identique) ; le smiley est décoratif.
- **Vue groupée filtrée** (« masquer les catégories sans non-lu » actif) : état vide **distinct et factuel** (« Aucune catégorie avec un message non lu ») au lieu du « Aucun … » trompeur — correction issue de la revue Codex.

## Implémentation
- Pref `flags_funny_empty_state` (DataStore + `UserPreferencesRepository`), exposée en `StateFlow` eager sur `FlagsViewModel`, threadée aux listes via `FlagsBodyState`.
- `:feature:flags` gagne `coil-compose` (même pattern que `:feature:editor`) ; le `.gif` s'anime via l'`AnimatedImageDecoder` app-wide.
- Icônes style A = vector drawables locaux `:core:ui` (`ic_ms_forum/flag/star`) — le projet interdit `Icons.*` Material.
- Suppression du `flatEmptyLabel` + strings `flags_list_empty*` devenus morts.

## Tests & validation
- Tests ajoutés : round-trip DataStore, toggle `SettingsViewModel`, `StateFlow` `FlagsViewModel`.
- `detektAll` + `:app:lintProdDebug` + tests unitaires + `:app:assembleProdDebug` = **verts**.
- Revue **Codex (gpt-5.5 xhigh)** = GO ; les 2 points importants traités (sémantique vue groupée filtrée ; GIF décodé app-wide confirmé).

> Action par Claude Opus 4.8 (demandée par @XaaT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)