### PR TITLE
chore(release): dev 0.17.18 — Drapeaux états vides (#662) + cyan sticky (#251)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,27 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.18` — `internal` (dev) — 2026-06-27
+
+> Vue Drapeaux (#603) : les onglets vides ont enfin un vrai état visuel (icône + message par onglet,
+> avec une option « états vides humoristiques » qui affiche un smiley perso HFR, #662), et les drapeaux
+> cyan des sujets épinglés des catégories sans sous-catégorie (ex. « IA ») réapparaissent (#251).
+> versionName 0.17.17 → 0.17.18.
+
+**Drapeaux — vue (#603)**
+
+- **États vides visuels (#662)** : un onglet sans élément n'affiche plus un simple libellé mais un état
+  vide visuel — icône fine + titre + sous-texte propre à l'onglet (Mes sujets / Lu / Favoris). Une
+  nouvelle option **« États vides humoristiques »** (Réglages › Drapeaux, désactivée par défaut)
+  remplace l'icône par un smiley perso HFR. Le texte porte tout le sens, donc TalkBack lit le même état
+  dans les deux cas. La vue groupée filtrée (« masquer les catégories sans non-lu ») garde un message
+  factuel distinct.
+- **Drapeaux cyan des sujets épinglés récupérés (#251)** : les endpoints REST des drapeaux excluaient
+  les sujets épinglés (sticky) flaggés dans les catégories **sans sous-catégorie** (ex. cat « IA ») —
+  un drapeau cyan posé sur le sujet épinglé des règles restait invisible. Un supplément REST-only
+  (lecture de la première page de `topics/last`, sans repli HTML) les récupère et les fusionne dans la
+  liste. Best-effort : un échec de cette lecture ne fait pas échouer tout l'écran.
+
 ## `0.17.17` — `internal` (dev) — 2026-06-27
 
 > Vue Drapeaux (#603) : la couleur du drapeau favori passe à un jaune-ambre lisible sur clair comme sur

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.17"
+        versionName = "0.17.18"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,5 +1,5 @@
-Redface 2 v0.17.17 — dev.
+Redface 2 v0.17.18 — dev.
 
 Flags view:
-- The favorite flag colour is now an amber-yellow that stays legible on the light theme too.
-- Each tab (My topics / Read / Favorites) keeps its own scroll position instead of bleeding across tabs.
+- Empty tabs now show a real visual empty state (icon + per-tab message), with an optional "funny empty states" toggle that shows a HFR perso smiley instead.
+- Cyan flags on sticky topics of categories without a subcategory (e.g. "IA") show up again.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,5 +1,5 @@
-Redface 2 v0.17.17 — dev.
+Redface 2 v0.17.18 — dev.
 
 Vue Drapeaux :
-- La couleur du drapeau favori devient un jaune-ambre lisible aussi sur le thème clair.
-- Le défilement de chaque onglet (Mes sujets / Lu / Favoris) est indépendant : il ne saute plus d'un onglet à l'autre.
+- Les onglets vides ont un vrai état visuel (icône + message par onglet), avec une option « états vides humoristiques » qui affiche un smiley perso HFR.
+- Les drapeaux cyan des sujets épinglés des catégories sans sous-catégorie (ex. « IA ») réapparaissent.


### PR DESCRIPTION
Release-prep dev **0.17.18** (versionName 0.17.17 → 0.17.18). Groupe deux changements Drapeaux déjà mergés sur dev :
- **#662** — états vides visuels (style A par défaut + smiley opt-in style C).
- **#251** — récupération REST-only des sujets épinglés flaggés exclus par les buckets dans les catégories sans sous-catégorie.

CHANGELOG + whatsnew (fr-FR / en-US) mis à jour. versionCode alloué au dispatch par le registre de tags.

> Action par Claude Opus 4.8 (demandée par @XaaT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)