### PR TITLE
feat(flags): états vides DT/Super + smiley dé-pixelisé (#662), option contour marqueur (#690) — dev 0.17.19

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,27 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.19` — `internal` (dev) — 2026-06-27
+
+> Vue Drapeaux (#603) — finitions sur retour dogfood : les états vides visuels (#662) couvrent
+> maintenant aussi les onglets **DT** et **Super Favoris**, le smiley de l'option humoristique n'est
+> plus pixelisé (#662), et le drapeau favori ambre (#690) gagne une **option de contour** (fin liseré
+> sombre) pour mieux ressortir sur fond clair. versionName 0.17.18 → 0.17.19.
+
+**Drapeaux — vue (#603)**
+
+- **États vides DT & Super Favoris (#662)** : les onglets DT et Super Favoris affichent désormais le
+  même état vide visuel (icône/smiley + titre + sous-texte) que les onglets de drapeaux, au lieu d'un
+  simple libellé. L'état DT « aucune non-lue » conserve le caveat de balayage (seules les conversations
+  récentes sont listées) en sous-texte.
+- **Smiley de l'option humoristique dé-pixelisé (#662)** : le smiley perso `[:eric le looser]` est une
+  petite photo (~47×50 px), pas du pixel-art — l'agrandissement « net » précédent le transformait en
+  blocs. Filtrage lissé + taille réduite : il reste propre.
+- **Option « Contour du marqueur » (#690)** : nouvelle bascule GLOBALE (réglages d'affichage des
+  Drapeaux, désactivée par défaut) qui dessine un fin liseré sombre (0,5 dp) autour de l'indicateur de
+  couleur, pour mieux détacher l'ambre des favoris sur fond clair. S'applique à toutes les formes de
+  marqueur (barre / pastille / point) et à tous les onglets.
+
 ## `0.17.18` — `internal` (dev) — 2026-06-27
 
 > Vue Drapeaux (#603) : les onglets vides ont enfin un vrai état visuel (icône + message par onglet,

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.18"
+        versionName = "0.17.19"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,5 +1,6 @@
-Redface 2 v0.17.18 — dev.
+Redface 2 v0.17.19 — dev.
 
 Flags view:
-- Empty tabs now show a real visual empty state (icon + per-tab message), with an optional "funny empty states" toggle that shows a HFR perso smiley instead.
-- Cyan flags on sticky topics of categories without a subcategory (e.g. "IA") show up again.
+- DT and Super Favorites tabs now also show a visual empty state (icon/smiley + message).
+- The "funny empty states" smiley is no longer pixelated.
+- New "Marker outline" option: a thin dark border around the color indicator, so the amber favorite stands out on a light background.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,5 +1,6 @@
-Redface 2 v0.17.18 — dev.
+Redface 2 v0.17.19 — dev.
 
 Vue Drapeaux :
-- Les onglets vides ont un vrai état visuel (icône + message par onglet), avec une option « états vides humoristiques » qui affiche un smiley perso HFR.
-- Les drapeaux cyan des sujets épinglés des catégories sans sous-catégorie (ex. « IA ») réapparaissent.
+- Les onglets DT et Super Favoris ont aussi un état vide visuel (icône/smiley + message).
+- Le smiley de l'option « états vides humoristiques » n'est plus pixelisé.
+- Nouvelle option « Contour du marqueur » : un fin liseré sombre autour de l'indicateur de couleur, pour mieux détacher l'ambre des favoris sur fond clair.

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -207,6 +207,15 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override suspend fun setFlagsMarkerBorder(enabled: Boolean) {
+        // #690 — GLOBAL toggle, a single key (mirrors the marker shape).
+        persist {
+            dataStore.edit { prefs ->
+                prefs[KEY_FLAGS_MARKER_BORDER] = enabled
+            }
+        }
+    }
+
     override fun observeThemeMode(): Flow<ThemeMode> =
         dataStore.data
             // Default SYSTEM: follow the OS dark-mode setting unless the user picked otherwise (#286).
@@ -754,6 +763,8 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         val singleLineTitle = prefs[KEY_FLAGS_SINGLE_LINE_TITLE] ?: false
         // #603 — GLOBAL category band style: resolved once (defensively), added to both return paths.
         val categoryBandStyle = readCategoryBandStyle(prefs)
+        // #690 — GLOBAL « marker outline » toggle: resolved once, added to both return paths.
+        val markerBorder = prefs[KEY_FLAGS_MARKER_BORDER] ?: false
         if (prefs[KEY_FLAGS_PER_TAB_OVERRIDE] != true) {
             return FlagsViewSettings(
                 groupByCategory = globalGroup,
@@ -762,6 +773,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
                 markerStyle = markerStyle,
                 singleLineTitle = singleLineTitle,
                 categoryBandStyle = categoryBandStyle,
+                markerBorder = markerBorder,
             )
         }
         return FlagsViewSettings(
@@ -771,6 +783,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             markerStyle = markerStyle,
             singleLineTitle = singleLineTitle,
             categoryBandStyle = categoryBandStyle,
+            markerBorder = markerBorder,
         )
     }
 
@@ -825,6 +838,8 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         val KEY_FLAGS_SINGLE_LINE_TITLE = booleanPreferencesKey("flags_single_line_title")
         // #603 — GLOBAL grouped-view category band style (CategoryBandStyle.name, defensively parsed).
         val KEY_FLAGS_CATEGORY_BAND_STYLE = stringPreferencesKey("flags_category_band_style")
+        // #690 — GLOBAL « marker outline » toggle (thin dark border around the marker).
+        val KEY_FLAGS_MARKER_BORDER = booleanPreferencesKey("flags_marker_border")
         // #662 — « états vides humoristiques » opt-in (smiley empty state instead of the sober icon).
         val KEY_FLAGS_FUNNY_EMPTY_STATE = booleanPreferencesKey("flags_funny_empty_state")
         // #309 — per-tab display override. The master switch plus one nullable key per FlagType for

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -421,6 +421,29 @@ class DataStoreUserPreferencesRepositoryTest {
     }
 
     @Test
+    fun `markerBorder defaults to false on an empty store`() = runTest(dispatcher) {
+        repository.observeFlagsViewSettings(FlagType.CYAN).test {
+            assertEquals(false, awaitItem().markerBorder)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setFlagsMarkerBorder persists and round-trips for every tab`() = runTest(dispatcher) {
+        // #690 GLOBAL: written once, observed on any tab type.
+        repository.setFlagsMarkerBorder(true)
+        repository.observeFlagsViewSettings(FlagType.RED).test {
+            assertEquals(true, awaitItem().markerBorder)
+            cancelAndIgnoreRemainingEvents()
+        }
+        repository.setFlagsMarkerBorder(false)
+        repository.observeFlagsViewSettings(FlagType.FAVORITE).test {
+            assertEquals(false, awaitItem().markerBorder)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `categoryBandStyle defaults to MINIMAL on an empty store`() = runTest(dispatcher) {
         repository.observeFlagsViewSettings(FlagType.CYAN).test {
             assertEquals(CategoryBandStyle.MINIMAL, awaitItem().categoryBandStyle)

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -541,6 +541,7 @@ class TopicRepositoryImplTest {
         override suspend fun setFlagsMarkerStyle(style: MarkerStyle) = Unit
         override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
         override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
+        override suspend fun setFlagsMarkerBorder(enabled: Boolean) = Unit
 
         // #286 — theme prefs are irrelevant to TopicRepositoryImpl; stubbed at their defaults.
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FlagsViewSettings.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FlagsViewSettings.kt
@@ -41,4 +41,8 @@ data class FlagsViewSettings(
     // shipped in 0.17.3). Not subject to the per-tab override (like [markerStyle]). Carried on every
     // resolution path.
     val categoryBandStyle: CategoryBandStyle = CategoryBandStyle.MINIMAL,
+    // #690 — GLOBAL: draw a thin (0.5 dp) dark outline around the colored marker so the amber FAVORITE
+    // (#FFB300) reads cleanly on a light background. Default false (no border). Not subject to the
+    // per-tab override (like [markerStyle]). Carried on every resolution path.
+    val markerBorder: Boolean = false,
 )

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -132,6 +132,15 @@ interface UserPreferencesRepository {
     suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle)
 
     /**
+     * Persists the GLOBAL « marker outline » toggle (#690): a thin 0.5 dp dark border around the
+     * Drapeaux marker so the amber FAVORITE colour reads cleanly on a light background. Like
+     * [setFlagsMarkerStyle] it is NOT subject to [observeFlagsPerTabOverride]; surfaced through
+     * [observeFlagsViewSettings] ([FlagsViewSettings.markerBorder]). Defaults to `false` (no border)
+     * until the first call.
+     */
+    suspend fun setFlagsMarkerBorder(enabled: Boolean)
+
+    /**
      * App theme selection (#286): [ThemeMode.SYSTEM] (default) follows the OS dark-mode setting;
      * [ThemeMode.LIGHT] / [ThemeMode.DARK] force the app theme regardless of the OS. Observed at the
      * app root ([fr.forumhfr.redface2.navigation.RedfaceApp]) to compute the effective dark theme

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagItem.kt
@@ -38,6 +38,14 @@ import fr.forumhfr.redface2.core.ui.theme.LocalDisplayMetrics
 val LocalForumRowTitleMaxLines = compositionLocalOf { 2 }
 
 /**
+ * #690 — GLOBAL « marker outline » preference, surfaced as a CompositionLocal so the leaf [FlagMarker]
+ * reads it WITHOUT threading the flag through every list composable (same pattern as
+ * [LocalForumRowTitleMaxLines]). Default `false` (no border); FlagsRoute provides `true` when the user
+ * enables the thin outline. Other [FlagMarker] consumers keep the default unless they provide their own.
+ */
+val LocalFlagMarkerBorder = compositionLocalOf { false }
+
+/**
  * Renders one row of the user's drapeaux list.
  *
  * Visual hierarchy mirrors what HFR users have spent ~20 years training their eyes on:

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagMarker.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagMarker.kt
@@ -2,6 +2,7 @@ package fr.forumhfr.redface2.core.ui
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
@@ -16,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
@@ -29,6 +31,12 @@ private const val READ_ALPHA = 0.35f
 
 /** Background alpha of the tonal PASTILLE behind the category glyph. */
 private const val PASTILLE_BG_ALPHA = 0.18f
+
+/** #690 — width of the optional dark outline drawn around the marker ([LocalFlagMarkerBorder]). */
+private val MARKER_BORDER_WIDTH = 0.5.dp
+
+/** #690 — opacity of the marker outline; dimmed by [READ_ALPHA] on read rows to match the fill. */
+private const val MARKER_BORDER_ALPHA = 0.5f
 
 /**
  * The left-hand marker of a Drapeaux row (#603, ADR-017). Encodes the flag color (cyan / red / favori,
@@ -60,6 +68,13 @@ fun FlagMarker(
     // VM mapper) so the rule can't silently diverge per layer.
     val base = FlagPalette.colorFor(effectiveFlagColor(type, isFavorite))
     val color = if (hasUnread) base else base.copy(alpha = READ_ALPHA)
+    // #690 — optional thin dark outline (GLOBAL pref read from the CompositionLocal, no threading). The
+    // border is dimmed on read rows so it tracks the desaturated fill instead of drawing a crisp ring
+    // around a faded marker.
+    val drawBorder = LocalFlagMarkerBorder.current
+    val borderColor = Color.Black.copy(
+        alpha = if (hasUnread) MARKER_BORDER_ALPHA else MARKER_BORDER_ALPHA * READ_ALPHA,
+    )
     when (style) {
         MarkerStyle.STRIPE -> Box(
             // #603 — the bar spans the row's content height (fillMaxHeight within ForumListRow's
@@ -68,27 +83,38 @@ fun FlagMarker(
                 .fillMaxHeight()
                 .width(4.dp)
                 .clip(RoundedCornerShape(2.dp))
-                .background(color),
+                .background(color)
+                .markerOutline(drawBorder, borderColor, RoundedCornerShape(2.dp)),
         )
 
         MarkerStyle.DOT -> Box(
             modifier = modifier
                 .size(12.dp)
                 .clip(CircleShape)
-                .background(color),
+                .background(color)
+                .markerOutline(drawBorder, borderColor, CircleShape),
         )
 
         MarkerStyle.PASTILLE -> Box(
             modifier = modifier
                 .size(30.dp)
                 .clip(CircleShape)
-                .background(color.copy(alpha = if (hasUnread) PASTILLE_BG_ALPHA else PASTILLE_BG_ALPHA / 2)),
+                .background(color.copy(alpha = if (hasUnread) PASTILLE_BG_ALPHA else PASTILLE_BG_ALPHA / 2))
+                .markerOutline(drawBorder, borderColor, CircleShape),
             contentAlignment = Alignment.Center,
         ) {
             RedfaceVectorIcon(resId = categoryIconRes, tint = color, size = 18.dp)
         }
     }
 }
+
+/**
+ * #690 — applies the optional [MARKER_BORDER_WIDTH] outline ([color]) clipped to [shape], or returns the
+ * receiver unchanged when [enabled] is false. Kept as a private extension so each marker shape stays a
+ * single readable modifier chain.
+ */
+private fun Modifier.markerOutline(enabled: Boolean, color: Color, shape: Shape): Modifier =
+    if (enabled) border(MARKER_BORDER_WIDTH, color, shape) else this
 
 /**
  * Trailing « pages à lire » pill of a Drapeaux row (#603) — shown only when the topic is unread and

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -1966,6 +1966,7 @@ class PostEditorViewModelTest {
         override suspend fun setFlagsMarkerStyle(style: MarkerStyle) = Unit
         override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
         override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
+        override suspend fun setFlagsMarkerBorder(enabled: Boolean) = Unit
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
         override suspend fun setThemeMode(mode: ThemeMode) = Unit
         override fun observeAmoledEnabled(): Flow<Boolean> = MutableStateFlow(false)

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1366,6 +1366,7 @@ class TopicFormViewModelTest {
         override suspend fun setFlagsMarkerStyle(style: MarkerStyle) = Unit
         override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
         override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
+        override suspend fun setFlagsMarkerBorder(enabled: Boolean) = Unit
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
         override suspend fun setThemeMode(mode: ThemeMode) = Unit
         override fun observeAmoledEnabled(): Flow<Boolean> = MutableStateFlow(false)

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -63,7 +63,6 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
@@ -94,6 +93,7 @@ import fr.forumhfr.redface2.core.ui.FlagItemDivider
 import fr.forumhfr.redface2.core.ui.FlagItemLongPress
 import fr.forumhfr.redface2.core.ui.FlagMetadata
 import fr.forumhfr.redface2.core.ui.ForumListRow
+import fr.forumhfr.redface2.core.ui.LocalFlagMarkerBorder
 import fr.forumhfr.redface2.core.ui.LocalForumRowTitleMaxLines
 import fr.forumhfr.redface2.core.ui.R as CoreUiR
 import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
@@ -389,6 +389,9 @@ fun FlagsRoute(
                             // ForumListRow reads this local, so no threading through list composables.
                             LocalForumRowTitleMaxLines provides
                                 flagTitleMaxLines(flagsViewSettings.singleLineTitle),
+                            // #690 — marker outline (GLOBAL pref); the leaf FlagMarker reads this local,
+                            // same no-threading pattern as the single-line titles above.
+                            LocalFlagMarkerBorder provides flagsViewSettings.markerBorder,
                         ) {
                             AuthenticatedBody(
                             state = FlagsBodyState(
@@ -446,6 +449,7 @@ fun FlagsRoute(
                 onHideReadCategoriesChange = viewModel::setFlagsHideReadCategories,
                 onUnreadOnlyChange = viewModel::setFlagsUnreadOnly,
                 onMarkerStyleChange = viewModel::setFlagsMarkerStyle,
+                onMarkerBorderChange = viewModel::setFlagsMarkerBorder,
                 onSingleLineTitleChange = viewModel::setFlagsSingleLineTitle,
                 onCategoryBandStyleChange = viewModel::setFlagsCategoryBandStyle,
                 onDismiss = { showViewSettingsSheet = false },
@@ -647,6 +651,16 @@ private fun FlagsViewSettingsSheet(
                     onSelected = actions.onMarkerStyleChange,
                 )
             }
+
+            // #690 — GLOBAL « marker outline » toggle (not per-tab, like the marker shape). A thin
+            // 0.5 dp dark border so the amber FAVORITE reads cleanly on a light background.
+            ViewSettingsSwitchRow(
+                title = stringResource(R.string.flags_view_settings_marker_border_title),
+                description = stringResource(R.string.flags_view_settings_marker_border_description),
+                checked = settings.markerBorder,
+                enabled = true,
+                onCheckedChange = actions.onMarkerBorderChange,
+            )
 
             // #603 — GLOBAL « single-line topic titles » toggle (not per-tab, like the marker shape).
             ViewSettingsSwitchRow(
@@ -990,13 +1004,14 @@ private fun ColumnScope.AuthenticatedBody(
     ) {
         when (selectedTab) {
             // Super has no backend, no fetch, no pull-to-refresh (cf. its KDoc).
-            FlagTab.Super -> SuperPlaceholderBody()
+            FlagTab.Super -> SuperPlaceholderBody(funny = state.funnyEmptyState)
             // #6 — DT is a real list now: the user's MultiMP conversations, enriched best-effort
             // with the MPStorage reading positions.
             FlagTab.Dt -> DtListBody(
                 state = state.dtListState,
                 isRefreshing = state.dtIsRefreshing,
                 actions = actions,
+                funny = state.funnyEmptyState,
             )
             else -> FlagListBody(state = state, actions = actions, listState = listState)
         }
@@ -1664,13 +1679,14 @@ private fun FlagsEmptyState(
         if (funny) {
             AsyncImage(
                 model = FUNNY_EMPTY_SMILEY_URL,
-                // Decorative: the title/subtitle below carry the meaning (a11y). FilterQuality.None
-                // keeps the pixel-art smiley crisp (same stance as the smiley picker, #236). The
-                // app-wide ImageLoader registers AnimatedImageDecoder, so the .gif animates.
+                // Decorative: the title/subtitle below carry the meaning (a11y). The perso smiley is a
+                // ~47×50 px PHOTO (not pixel-art), so the previous FilterQuality.None upscaled it into
+                // visible blocks (#662 feedback, rejected). Use smooth (default) filtering and a modest
+                // size so it stays clean. The app-wide ImageLoader registers AnimatedImageDecoder, so
+                // the .gif animates.
                 contentDescription = null,
-                modifier = Modifier.size(72.dp),
+                modifier = Modifier.size(48.dp),
                 contentScale = ContentScale.Fit,
-                filterQuality = FilterQuality.None,
             )
         } else {
             RedfaceVectorIcon(
@@ -1727,6 +1743,30 @@ private fun emptyStateSubtitle(tab: FlagTab): Int? = when (tab) {
 // perso filename is percent-encoded so the request URL is well-formed.
 private const val FUNNY_EMPTY_SMILEY_URL =
     "https://forum-images.hardware.fr/images/perso/eric%20le%20looser.gif"
+
+/**
+ * #662 — [FlagsEmptyState] wrapped in a scrollable, centred container for the non-lazy bodies (the DT
+ * tab states). Unlike the flag tabs (a lazy `item` using `fillParentMaxSize`), these sit directly
+ * under a `PullToRefreshBox`, so the body itself must stay vertically scrollable to anchor the pull
+ * gesture (#229) — even when the empty content is shorter than the viewport.
+ */
+@Composable
+private fun ScrollableFlagsEmptyState(
+    iconRes: Int,
+    title: String,
+    subtitle: String?,
+    funny: Boolean,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface)
+            .verticalScroll(rememberScrollState()),
+        contentAlignment = Alignment.Center,
+    ) {
+        FlagsEmptyState(iconRes = iconRes, title = title, subtitle = subtitle, funny = funny)
+    }
+}
 
 // #603 PR5 — hosts the long-press actions sheet; the null-check lives here (not in FlagsRoute) to keep
 // the route's cyclomatic complexity in budget. `flag == null` ⇒ nothing composed (sheet closed).
@@ -1812,24 +1852,16 @@ private fun RemovableFlagItem(
  * network call — just an explanatory message until the feature ships.
  */
 @Composable
-private fun SuperPlaceholderBody() {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = 24.dp, vertical = 32.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        Text(
-            text = stringResource(R.string.flags_super_placeholder_title),
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
-        Text(
-            text = stringResource(R.string.flags_super_placeholder_body),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
+private fun SuperPlaceholderBody(funny: Boolean) {
+    // #662 — same visual empty state as the flag tabs (icon/smiley + title + subtitle). No
+    // pull-to-refresh here (Super has no backend), so a plain centered, non-scrollable body is fine.
+    FlagsEmptyState(
+        iconRes = fr.forumhfr.redface2.core.ui.R.drawable.ic_ms_star,
+        title = stringResource(R.string.flags_super_placeholder_title),
+        subtitle = stringResource(R.string.flags_super_placeholder_body),
+        funny = funny,
+        modifier = Modifier.fillMaxSize(),
+    )
 }
 
 /**
@@ -1889,7 +1921,12 @@ private fun DtTabOpenEffect(
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun DtListBody(state: DtListUiState, isRefreshing: Boolean, actions: AuthenticatedActions) {
+private fun DtListBody(
+    state: DtListUiState,
+    isRefreshing: Boolean,
+    actions: AuthenticatedActions,
+    funny: Boolean,
+) {
     // #546 directive XaTriX — pull-to-refresh (swipe down) on the DT list, like the flag tabs. Wraps
     // the whole body (every branch) so the gesture has a target even on the listless states (#229).
     // #603 — « amorce seule » (XaTriX): pull cue while dragging, nothing during the refresh; the top
@@ -1904,7 +1941,7 @@ private fun DtListBody(state: DtListUiState, isRefreshing: Boolean, actions: Aut
         },
         modifier = Modifier.fillMaxSize(),
     ) {
-        DtListContent(state = state, actions = actions)
+        DtListContent(state = state, actions = actions, funny = funny)
     }
 }
 
@@ -1914,7 +1951,7 @@ private fun DtListBody(state: DtListUiState, isRefreshing: Boolean, actions: Aut
  * vertically scrollable so the surrounding `PullToRefreshBox` keeps a target (#229).
  */
 @Composable
-private fun DtListContent(state: DtListUiState, actions: AuthenticatedActions) {
+private fun DtListContent(state: DtListUiState, actions: AuthenticatedActions, funny: Boolean) {
     when (state) {
         DtListUiState.Loading -> Box(
             // #603 — central spinner retired (cf. FlagListBody); the top FlagsLoadingBar covers the DT
@@ -1924,11 +1961,24 @@ private fun DtListContent(state: DtListUiState, actions: AuthenticatedActions) {
                 .verticalScroll(rememberScrollState()),
         )
 
-        DtListUiState.Empty -> DtMessageBody(text = stringResource(R.string.flags_dt_empty))
+        // #662 — visual empty state (icon/smiley + message) for the DT tab, like the flag tabs.
+        DtListUiState.Empty -> ScrollableFlagsEmptyState(
+            iconRes = fr.forumhfr.redface2.core.ui.R.drawable.ic_ms_mail,
+            title = stringResource(R.string.flags_dt_empty_title),
+            subtitle = stringResource(R.string.flags_dt_empty_subtitle),
+            funny = funny,
+        )
 
         // #546 — the union is non-empty but « non-lus uniquement » hid every row: a dedicated message
         // (not the « aucune conversation » empty copy). Re-tapping the DT tab reveals « +lus ».
-        DtListUiState.NoUnread -> DtNoUnreadBody()
+        DtListUiState.NoUnread -> ScrollableFlagsEmptyState(
+            iconRes = fr.forumhfr.redface2.core.ui.R.drawable.ic_ms_mail,
+            title = stringResource(R.string.flags_dt_no_unread),
+            // #662 — restore the page-1 scan caveat the old footer (flags_dt_scan_note) carried in this
+            // state; the « +lus » discoverability stays deferred to #661.
+            subtitle = stringResource(R.string.flags_dt_no_unread_subtitle),
+            funny = funny,
+        )
 
         is DtListUiState.Error -> DtErrorBody(cause = state.cause, actions = actions)
 
@@ -2007,56 +2057,6 @@ internal fun dtRowWasUnread(item: DtListItem): Boolean = when (item) {
     is DtListItem.StorageOnly -> false
 }
 
-/**
- * #546 directive XaTriX — body for the « filtered to no unread » state ([DtListUiState.NoUnread]):
- * the union holds conversations but none is unread. Shows a discreet « aucune conversation non lue »
- * message and keeps the scan-note footer visible (the user can re-tap the DT tab for « +lus »).
- * Scrollable so the surrounding `PullToRefreshBox` keeps a swipe target (#229).
- */
-@Composable
-private fun DtNoUnreadBody() {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .background(MaterialTheme.colorScheme.surface)
-            .padding(horizontal = 24.dp, vertical = 24.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-        Text(
-            text = stringResource(R.string.flags_dt_no_unread),
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Text(
-            text = stringResource(R.string.flags_dt_scan_note),
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
-}
-
-/**
- * Single-line message body (DT empty state), sharing the surface background. Vertically scrollable
- * so the surrounding [PullToRefreshBox] keeps a swipe target on this listless state (#229) — a
- * non-scrollable body would give the pull-to-refresh gesture nothing to anchor on.
- */
-@Composable
-private fun DtMessageBody(text: String) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.surface)
-            .verticalScroll(rememberScrollState())
-            .padding(24.dp),
-    ) {
-        Text(
-            text = text,
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
-}
 
 /**
  * Error body for the DT list, mirroring the flag-list failure branch: a session-expired cause
@@ -2254,6 +2254,7 @@ private data class FlagsViewSettingsActions(
     val onHideReadCategoriesChange: (Boolean) -> Unit,
     val onUnreadOnlyChange: (Boolean) -> Unit,
     val onMarkerStyleChange: (MarkerStyle) -> Unit,
+    val onMarkerBorderChange: (Boolean) -> Unit,
     val onSingleLineTitleChange: (Boolean) -> Unit,
     val onCategoryBandStyleChange: (CategoryBandStyle) -> Unit,
     val onDismiss: () -> Unit,

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -699,6 +699,11 @@ class FlagsViewModel @Inject constructor(
         viewModelScope.launch { userPreferencesRepository.setFlagsCategoryBandStyle(style) }
     }
 
+    /** Bottom-sheet write for the GLOBAL « marker outline » toggle (#690) — one value for every tab. */
+    fun setFlagsMarkerBorder(enabled: Boolean) {
+        viewModelScope.launch { userPreferencesRepository.setFlagsMarkerBorder(enabled) }
+    }
+
     fun refresh() {
         // Super is a placeholder with no backing FlagType — pull-to-refresh is a no-op there.
         val type = _selectedTab.value.flagType ?: return
@@ -829,7 +834,7 @@ class FlagsViewModel @Inject constructor(
      * [DtListUiState.Empty] iff the inbox PAGE 1 has no MultiMP AND MPStorage has no orphan entry.
      * Scope (#6): only inbox PAGE 1 is scanned + whatever MPStorage already knows ; a full multi-page
      * inbox sweep stays DEFERRED, so older pages are not covered — the UI carries a scan note footer
-     * (`flags_dt_scan_note`) and the empty-state copy (`flags_dt_empty`) assumes that semantics.
+     * (`flags_dt_scan_note`) and the empty-state copy (`flags_dt_empty_subtitle`) assumes that semantics.
      */
     private fun loadDt(isRefresh: Boolean) {
         dtFetchStarted = true

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -66,17 +66,22 @@
     <!-- Badge discret de reprise de lecture, alimenté par MPStorage (mpFlags). %1$d = page de reprise.
          C'est une POSITION de lecture, PAS un état lu/non-lu (le point non-lu vient de l'inbox). -->
     <string name="flags_dt_resume_badge">reprise p.%1$d</string>
-    <!-- État vide DT. La liste = PAGE 1 de la boîte de réception (les conversations les plus
-         récentes) ∪ entrées connues de la synchro DT (MPStorage) — un balayage multi-pages est
-         différé (cf. DT_INBOX_PAGE). Le wording assume « récente » pour ne pas affirmer qu'AUCUNE
-         MultiMP n'existe ailleurs (ni en page 1, ni connue de la synchro DT). -->
-    <string name="flags_dt_empty">Aucune conversation multi-destinataires récente</string>
+    <!-- État vide DT (#662 — état vide visuel : titre + sous-texte). La liste = PAGE 1 de la boîte de
+         réception (les conversations les plus récentes) ∪ entrées connues de la synchro DT (MPStorage)
+         — un balayage multi-pages est différé (cf. DT_INBOX_PAGE). Le sous-texte assume « récente »
+         pour ne pas affirmer qu'AUCUNE MultiMP n'existe ailleurs. -->
+    <string name="flags_dt_empty_title">Aucune conversation</string>
+    <string name="flags_dt_empty_subtitle">Aucune discussion à interlocuteurs multiples récente.</string>
     <!-- #546 — état « non-lus uniquement » actif mais aucune conversation non lue (l'union n'est pas
          vide, juste filtrée). Re-taper l'onglet DT affiche aussi les lues (« +lus »). Distinct de
          flags_dt_empty (aucune conversation du tout). #662 — wording aligné sur les autres états vides
          (forme courte « Aucun(e)… », sans point ni instruction collée ; la découvrabilité du « +lus »
          est traitée à part, #661). -->
     <string name="flags_dt_no_unread">Aucune conversation non lue</string>
+    <!-- #662 — sous-texte de l'état vide DT « aucune non-lue » : porte le caveat du balayage (la note
+         de bas de liste flags_dt_scan_note ne s'affiche que sous une liste peuplée), forme courte pour
+         tenir sous le titre. Ne traite PAS la découvrabilité « +lus » (déléguée à #661). -->
+    <string name="flags_dt_no_unread_subtitle">Les conversations plus anciennes ne sont pas balayées.</string>
     <!-- Description a11y d'une ligne DT : état lu/non-lu, annoncé par TalkBack (le point coloré
          est purement décoratif). %1$s = sujet de la conversation. -->
     <string name="flags_dt_row_unread">Non lu : %1$s</string>
@@ -156,6 +161,10 @@
     <string name="flags_view_settings_marker_stripe">Barre</string>
     <string name="flags_view_settings_marker_pastille">Pastille</string>
     <string name="flags_view_settings_marker_dot">Point</string>
+    <!-- #690 — bascule GLOBALE : fin contour sombre (0,5 dp) autour du marqueur, pour que l\'ambre
+         des favoris ressorte mieux sur fond clair. -->
+    <string name="flags_view_settings_marker_border_title">Contour du marqueur</string>
+    <string name="flags_view_settings_marker_border_description">Ajoute un fin liseré sombre autour de l\'indicateur de couleur, pour mieux le détacher du fond clair. S\'applique à tous les onglets.</string>
     <!-- #603 — Style de la bande de catégorie (vue groupée) : sous-titre sobre / bloc tonal /
          accent latéral / pastille en puce. Réglage GLOBAL (tous onglets), sans effet en vue à plat. -->
     <string name="flags_view_settings_band_title">Bande de catégorie</string>

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -2387,6 +2387,7 @@ class FlagsViewModelTest {
 
         override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
         override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
+        override suspend fun setFlagsMarkerBorder(enabled: Boolean) = Unit
 
         // #286 — theme prefs are irrelevant to FlagsViewModel; stubbed at their defaults.
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -2072,6 +2072,7 @@ class SettingsViewModelTest {
         override suspend fun setFlagsMarkerStyle(style: MarkerStyle) = Unit
         override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
         override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
+        override suspend fun setFlagsMarkerBorder(enabled: Boolean) = Unit
 
         fun emit(value: ProxyConfig) {
             config.value = value

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -2049,6 +2049,7 @@ private class FakeUserPreferencesRepository(
     override suspend fun setFlagsMarkerStyle(style: MarkerStyle) = Unit
     override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
     override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
+    override suspend fun setFlagsMarkerBorder(enabled: Boolean) = Unit
 
     override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
 


### PR DESCRIPTION
Finitions vue Drapeaux (#603) sur retour dogfood de XaTriX (batch #2789xxx). Branche partie de `origin/dev` fraîche (app-v198 / 0.17.18).

## Contenu

**#662 (suite)** — les états vides visuels shippés en 0.17.18 pour les onglets de drapeaux couvrent maintenant aussi :
- **DT** et **Super Favoris** : même état visuel (icône/smiley + titre + sous-texte), via un `ScrollableFlagsEmptyState` factorisé qui garde une cible au pull-to-refresh (#229). L'état DT « aucune non-lue » conserve le caveat de balayage page 1 en sous-texte (l'ancien footer `flags_dt_scan_note` ne s'affichait qu'ici).
- **Smiley dé-pixelisé** : `[:eric le looser]` est une petite photo (~47×50 px), pas du pixel-art — `FilterQuality.None` + `size(72.dp)` l'upscalait en blocs (rejeté par XaTriX). Filtrage lissé + `size(48.dp)`.

**#690 (suite)** — la couleur favori ambre `#FFB300` (validée) est livrée avec une **option de contour** :
- Bascule GLOBALE « Contour du marqueur » (réglages d'affichage des Drapeaux, **désactivée par défaut**) : fin liseré sombre **0,5 dp** autour de l'indicateur de couleur, pour mieux le détacher sur fond clair.
- Exposée au leaf `FlagMarker` via un CompositionLocal `LocalFlagMarkerBorder` (pas de threading, même pattern que la pref « titre une ligne »). S'applique aux 3 formes (barre / pastille / point) et à tous les onglets.

> ⚠️ Le rendu exact du liseré (notamment sur la barre 4 dp) est à **eyeballer on-device** — c'est l'objet de l'option opt-in (« essaie 0.5px » demandé par XaTriX).

## Release

Dev **0.17.19** (versionName 0.17.18 → 0.17.19). `app/CHANGELOG.md` + whatsnew (fr-FR / en-US). versionCode alloué au dispatch par le registre de tags.

## Validation

- `detektAll` + `:app:lintProdDebug` + `testDebugUnitTest` + `:app:testProdDebugUnitTest` + `:app:assembleProdDebug` → **BUILD SUCCESSFUL** (tests verts, dont round-trip DataStore `markerBorder`).
- Review Codex (gpt-5.5 xhigh) : **GO avec réserves** — point bloquant unique (DT NoUnread avait perdu le footer scan-note) corrigé via sous-titre dédié.

Les issues #662 / #690 restent **ouvertes** (validation finale par XaTriX en dogfood).

> Action par Claude Opus 4.8 (demandée par @XaaT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
