### PR TITLE
feat(flags): caveat de balayage DT déplacé vers le réglage « Section DT » (#662) — dev 0.17.20

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,20 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.20` — `internal` (dev) — 2026-06-27
+
+> Vue Drapeaux (#603) — le texte explicatif du balayage de la section DT quitte la vue (où il flottait
+> en bas de liste) pour rejoindre la **description du réglage « Section DT »**, au niveau de son
+> activation (#662, demande XaTriX). La vue DT reste épurée. versionName 0.17.19 → 0.17.20.
+
+**Drapeaux — vue (#603)**
+
+- **Texte explicatif DT déplacé vers les réglages (#662)** : l'avertissement « seule la première page de
+  la boîte de réception est balayée » n'apparaît plus dans la vue DT (ni en pied de liste, ni en
+  sous-texte d'état vide). Il est désormais porté par la **description du réglage « Section DT »**
+  (Réglages › Drapeaux), là où l'utilisateur active la section — l'explication est lue au bon moment et
+  la vue reste épurée.
+
 ## `0.17.19` — `internal` (dev) — 2026-06-27
 
 > Vue Drapeaux (#603) — finitions sur retour dogfood : les états vides visuels (#662) couvrent

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.19"
+        versionName = "0.17.20"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,6 +1,4 @@
-Redface 2 v0.17.19 — dev.
+Redface 2 v0.17.20 — dev.
 
 Flags view:
-- DT and Super Favorites tabs now also show a visual empty state (icon/smiley + message).
-- The "funny empty states" smiley is no longer pixelated.
-- New "Marker outline" option: a thin dark border around the color indicator, so the amber favorite stands out on a light background.
+- The note explaining that only the inbox's first page is scanned has moved out of the DT view into the "DT section" setting description (Settings › Flags). The view stays uncluttered.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,6 +1,4 @@
-Redface 2 v0.17.19 — dev.
+Redface 2 v0.17.20 — dev.
 
 Vue Drapeaux :
-- Les onglets DT et Super Favoris ont aussi un état vide visuel (icône/smiley + message).
-- Le smiley de l'option « états vides humoristiques » n'est plus pixelisé.
-- Nouvelle option « Contour du marqueur » : un fin liseré sombre autour de l'indicateur de couleur, pour mieux détacher l'ambre des favoris sur fond clair.
+- Le texte expliquant que seule la première page de la boîte est balayée a quitté la vue DT pour rejoindre la description du réglage « Section DT » (Réglages › Drapeaux). La vue reste épurée.

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -1257,10 +1257,6 @@ private const val CONTENT_TYPE_HEADER = "category_header"
 private const val CONTENT_TYPE_EMPTY = "empty_section"
 private const val CONTENT_TYPE_ROW = "flag_row"
 
-// #6 — the DT scan-note footer is a distinct, non-row item (not a clickable ForumListRow), so it
-// keeps its own recycling pool and never reuses a row slot.
-private const val CONTENT_TYPE_DT_FOOTER = "dt_scan_note"
-
 /**
  * Category-grouped flag list (#179). Renders one sticky band per [FlagCategorySection] in the
  * canonical category order the ViewModel produced, with the rows under each band. Empty sections
@@ -1974,9 +1970,9 @@ private fun DtListContent(state: DtListUiState, actions: AuthenticatedActions, f
         DtListUiState.NoUnread -> ScrollableFlagsEmptyState(
             iconRes = fr.forumhfr.redface2.core.ui.R.drawable.ic_ms_mail,
             title = stringResource(R.string.flags_dt_no_unread),
-            // #662 — restore the page-1 scan caveat the old footer (flags_dt_scan_note) carried in this
-            // state; the « +lus » discoverability stays deferred to #661.
-            subtitle = stringResource(R.string.flags_dt_no_unread_subtitle),
+            // #662 (demande XaTriX) — pas de sous-texte : le caveat de balayage vit dans la description du
+            // réglage « Section DT » (settings), plus dans la vue. La découvrabilité « +lus » reste #661.
+            subtitle = null,
             funny = funny,
         )
 
@@ -1999,16 +1995,9 @@ private fun DtListContent(state: DtListUiState, actions: AuthenticatedActions, f
                 DtRow(item = item, onOpenMultiMp = actions.onOpenMultiMp)
                 FlagItemDivider()
             }
-            // Scan-note footer (#6): the list only covers inbox PAGE 1 + what the DT sync knows;
-            // older inbox pages are deliberately not swept. A discreet, non-clickable trailing item.
-            item(key = "dt-scan-note", contentType = CONTENT_TYPE_DT_FOOTER) {
-                Text(
-                    text = stringResource(R.string.flags_dt_scan_note),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
-                )
-            }
+            // #662 (demande XaTriX) — le caveat de balayage (« seule la page 1 est listée ») a quitté la
+            // vue : il vit désormais dans la description du réglage « Section DT » (settings), au niveau de
+            // l'activation. Plus de footer scan-note ici.
         }
     }
 }

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -833,8 +833,9 @@ class FlagsViewModel @Inject constructor(
      *
      * [DtListUiState.Empty] iff the inbox PAGE 1 has no MultiMP AND MPStorage has no orphan entry.
      * Scope (#6): only inbox PAGE 1 is scanned + whatever MPStorage already knows ; a full multi-page
-     * inbox sweep stays DEFERRED, so older pages are not covered — the UI carries a scan note footer
-     * (`flags_dt_scan_note`) and the empty-state copy (`flags_dt_empty_subtitle`) assumes that semantics.
+     * inbox sweep stays DEFERRED, so older pages are not covered — the scan caveat lives in the « Section
+     * DT » settings toggle description (`settings_flags_show_dt_section_description`, #662), and the
+     * empty-state copy (`flags_dt_empty_subtitle`) assumes that semantics.
      */
     private fun loadDt(isRefresh: Boolean) {
         dtFetchStarted = true
@@ -1199,7 +1200,7 @@ sealed interface DtListUiState {
     /**
      * The DT union: inbox PAGE 1 MultiMP rows ∪ orphan MPStorage entries, deduplicated by
      * `threadId` and ordered inbox-first then `mpFlags.list` order (#6). The multi-page inbox limit
-     * remains — surfaced by the scan-note footer (`flags_dt_scan_note`).
+     * remains — surfaced in the « Section DT » settings toggle description (#662).
      */
     data class Content(val items: List<DtListItem>) : DtListUiState
 

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -75,13 +75,9 @@
     <!-- #546 — état « non-lus uniquement » actif mais aucune conversation non lue (l'union n'est pas
          vide, juste filtrée). Re-taper l'onglet DT affiche aussi les lues (« +lus »). Distinct de
          flags_dt_empty (aucune conversation du tout). #662 — wording aligné sur les autres états vides
-         (forme courte « Aucun(e)… », sans point ni instruction collée ; la découvrabilité du « +lus »
-         est traitée à part, #661). -->
+         (forme courte « Aucun(e)… », sans sous-texte : le caveat de balayage vit désormais dans la
+         description du réglage « Section DT », pas dans la vue — demande XaTriX). -->
     <string name="flags_dt_no_unread">Aucune conversation non lue</string>
-    <!-- #662 — sous-texte de l'état vide DT « aucune non-lue » : porte le caveat du balayage (la note
-         de bas de liste flags_dt_scan_note ne s'affiche que sous une liste peuplée), forme courte pour
-         tenir sous le titre. Ne traite PAS la découvrabilité « +lus » (déléguée à #661). -->
-    <string name="flags_dt_no_unread_subtitle">Les conversations plus anciennes ne sont pas balayées.</string>
     <!-- Description a11y d'une ligne DT : état lu/non-lu, annoncé par TalkBack (le point coloré
          est purement décoratif). %1$s = sujet de la conversation. -->
     <string name="flags_dt_row_unread">Non lu : %1$s</string>
@@ -93,9 +89,6 @@
     <!-- #6 — Description a11y d'une ligne DT orpheline (hors inbox) : l'état lu/non-lu est INCONNU,
          on n'annonce donc ni « Lu » ni « Non lu ». %1$s = titre placeholder de la conversation. -->
     <string name="flags_dt_row_state_unknown">État inconnu : %1$s</string>
-    <!-- #6 — Note de bas de liste DT : la liste ne couvre que la page 1 de la boîte + ce que la
-         synchro DT connaît ; les pages plus anciennes ne sont pas balayées (balayage différé). -->
-    <string name="flags_dt_scan_note">Seules les conversations de la première page de la boîte et celles connues de la synchro DT sont listées. Les pages plus anciennes ne sont pas balayées.</string>
     <!-- Échec du chargement de la liste DT (boîte de réception). La lecture MPStorage, best-effort,
          n'atteint jamais cet état (elle se dégrade en « pas de badge »). -->
     <string name="flags_dt_error">Impossible de charger les conversations. Vérifie ta connexion ou réessaie.</string>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -247,9 +247,11 @@
     <string name="settings_flags_per_tab_override_description">Chaque onglet (Mes sujets, Lu, Favoris) garde son propre affichage ; les réglages ci-dessus servent de valeurs par défaut.</string>
     <string name="settings_flags_per_tab_override_persist_failed">Impossible de mémoriser le réglage par onglet. Réessayez.</string>
 
-    <!-- Onglet « DT » opt-in dans l'écran Drapeaux (placeholder, synchro MPStorage à venir, #6). -->
+    <!-- Onglet « DT » opt-in dans l'écran Drapeaux (#6). La description porte le caveat de balayage,
+         déplacé ici depuis la vue DT (#662, demande XaTriX : le texte explicatif vit au niveau du réglage
+         d'activation, pas dans la vue). -->
     <string name="settings_flags_show_dt_section_title">Section DT</string>
-    <string name="settings_flags_show_dt_section_description">Affiche un onglet « DT » dans l\'écran Drapeaux (contenu à venir).</string>
+    <string name="settings_flags_show_dt_section_description">Affiche un onglet « DT » dans l\'écran Drapeaux : vos discussions à interlocuteurs multiples (MultiMP). Seules les conversations de la première page de la boîte de réception et celles connues de la synchro DT sont listées — les pages plus anciennes ne sont pas balayées.</string>
     <string name="settings_flags_show_dt_section_persist_failed">Impossible de mémoriser la section DT. Réessayez.</string>
 
     <!-- #378 — auto-refresh des listes de drapeaux à l'arrivée sur l'écran (ouverture de l'app,


### PR DESCRIPTION
Suite #662 (validé par XaTriX en dogfood) : **déplacer le texte explicatif de la vue DT vers le réglage où l'on active la section DT**.

## Changement

Le caveat « la liste DT ne balaie que la page 1 de la boîte » quitte la **vue** (il flottait en pied de liste + en sous-texte de l'état « aucune non-lue ») pour rejoindre la **description du toggle « Section DT »** dans Réglages › Drapeaux — l'explication est lue au moment de l'activation, et la vue reste épurée.

- `settings_flags_show_dt_section_description` porte désormais le caveat (et perd le « contenu à venir » périmé — DT est une vraie liste depuis #6).
- Vue DT : footer `flags_dt_scan_note` retiré (+ son `CONTENT_TYPE_DT_FOOTER`), sous-texte « aucune non-lue » remis à `null`. Strings orphelines `flags_dt_scan_note` / `flags_dt_no_unread_subtitle` supprimées. KDoc à jour.

## Release

Dev **0.17.20** (versionName 0.17.19 → 0.17.20), `app/CHANGELOG.md` + whatsnew (fr/en).

## Validation

`detektAll` + `:app:lintProdDebug` + `testDebugUnitTest` + `:app:testProdDebugUnitTest` + `:app:assembleProdDebug` → **BUILD SUCCESSFUL** (lint inclus → pas de string orpheline).

#662 reste **ouverte** (validée mais la phase continue).

> Action par Claude Opus 4.8 (demandée par @XaaT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
