### PR TITLE
fix(flags): animation de swipe « slide au commit » (#660)

### DIFF
--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.feature.flags
 
 import android.annotation.SuppressLint
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -51,6 +52,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -62,6 +64,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -202,7 +205,11 @@ fun FlagsRoute(
     // Cyan's scroll index onto Favori/Rouge when switching tabs. The current tab's state drives the
     // filter-flip reset (#385) and the landing recall-to-top (#546) below, both already scoped to the
     // active tab.
-    val flagsListState = rememberFlagTabListState(selectedTab.flagType)
+    // #660 — hoisted holder (all tabs' states) so the body's Shared Axis X AnimatedContent can resolve
+    // each pane's state during a transition. The active tab's state still drives the filter-flip reset
+    // (#385) and the landing recall-to-top (#546) below, both already scoped to the current tab.
+    val flagTabListStates = rememberFlagTabListStates()
+    val flagsListState = flagTabListStates.forType(selectedTab.flagType)
     val tabUnreadFilter by viewModel.tabUnreadFilter.collectAsStateWithLifecycle()
     FilterFlipScrollResetEffect(
         tabUnreadFilter = tabUnreadFilter,
@@ -426,7 +433,7 @@ fun FlagsRoute(
                                 onOpenMultiMp = onOpenMultiMp,
                                 onRefreshDt = viewModel::refreshDt,
                             ),
-                            listState = flagsListState,
+                            listStates = flagTabListStates,
                             )
                         }
                     }
@@ -951,9 +958,9 @@ private fun AnonymousBody(onLoginRequested: () -> Unit) {
 private fun ColumnScope.AuthenticatedBody(
     state: FlagsBodyState,
     actions: AuthenticatedActions,
-    // #385 — hoisted by FlagsRoute so the filter-flip effect can reset the scroll. One state
-    // shared by the grouped and flat lists (only one is composed at a time).
-    listState: LazyListState,
+    // #660 — hoisted holder: the Shared Axis X AnimatedContent below composes two panes during a
+    // transition, so each resolves its own tab's LazyListState (never recreated, #695 preserved).
+    listStates: FlagTabListStates,
 ) {
     val selectedTab = state.selectedTab
     // #603 PR2 — the text PrimaryTabRow is gone: the app-bar flag picker (FlagsSearchAppBar) now
@@ -980,21 +987,30 @@ private fun ColumnScope.AuthenticatedBody(
     val updatedTabs = rememberUpdatedState(tabs)
     val updatedSelectedIndex = rememberUpdatedState(selectedIndex)
     val updatedActions = rememberUpdatedState(actions)
+    // #660 — the swipe's direction for the NEXT committed transition (null = a tab tap, which falls
+    // back to the tabs' order). Reset after each tab change so a later tap never inherits a stale swipe
+    // direction. Set synchronously in the gesture handler, BEFORE the ViewModel emits the new tab, so
+    // the transitionSpec below reads it on the recomposition that starts the slide.
+    var pendingSwipeForward by remember { mutableStateOf<Boolean?>(null) }
     val swipeHandlers = remember(haptics) {
         FlagsTabSwipeHandlers(
             haptics = haptics,
-            onSelectTab = { index ->
+            onSelectTab = { index, forward ->
+                pendingSwipeForward = forward
                 updatedTabs.value.getOrNull(index)
                     ?.let { tab -> updatedActions.value.onSelectTab(tab) }
             },
         )
     }
+    LaunchedEffect(selectedTab) { pendingSwipeForward = null }
     Box(
         modifier = Modifier
             .fillMaxWidth()
             // Without weight(1f) the box would not claim the remaining vertical space inside
             // the parent Column, breaking the gesture areas on short lists.
             .weight(1f)
+            // #660 — clip so the outgoing/incoming panes don't draw past the viewport mid-slide.
+            .clipToBounds()
             .flagsTabSwipe(
                 currentIndex = { updatedSelectedIndex.value },
                 tabCount = { updatedTabs.value.size },
@@ -1002,18 +1018,40 @@ private fun ColumnScope.AuthenticatedBody(
                 handlers = swipeHandlers,
             ),
     ) {
-        when (selectedTab) {
-            // Super has no backend, no fetch, no pull-to-refresh (cf. its KDoc).
-            FlagTab.Super -> SuperPlaceholderBody(funny = state.funnyEmptyState)
-            // #6 — DT is a real list now: the user's MultiMP conversations, enriched best-effort
-            // with the MPStorage reading positions.
-            FlagTab.Dt -> DtListBody(
-                state = state.dtListState,
-                isRefreshing = state.dtIsRefreshing,
-                actions = actions,
-                funny = state.funnyEmptyState,
-            )
-            else -> FlagListBody(state = state, actions = actions, listState = listState)
+        // #660 — Material « Shared Axis X » on tab commit (styx42's pick). targetState is the WHOLE
+        // FlagsBodyState and the lambda renders from its PARAMETER (`bodyState`), never the captured
+        // outer `state`: per the AnimatedContent contract (official docs: « use targetCount, not
+        // count ») each pane composes with its own state value, so the OUTGOING pane keeps its tab's
+        // data while it slides out — no flash of the incoming tab's data. contentKey = selectedTab so
+        // only a tab change slides; a data refresh within the same tab updates in place.
+        AnimatedContent(
+            targetState = state,
+            transitionSpec = {
+                val from = tabs.indexOf(initialState.selectedTab)
+                val to = tabs.indexOf(targetState.selectedTab)
+                flagsTabSlide(flagsTabSlideForward(from, to, pendingSwipeForward))
+            },
+            contentKey = { it.selectedTab },
+            label = "flagsTabSwipe",
+            modifier = Modifier.fillMaxSize(),
+        ) { bodyState ->
+            when (bodyState.selectedTab) {
+                // Super has no backend, no fetch, no pull-to-refresh (cf. its KDoc).
+                FlagTab.Super -> SuperPlaceholderBody(funny = bodyState.funnyEmptyState)
+                // #6 — DT is a real list now: the user's MultiMP conversations, enriched best-effort
+                // with the MPStorage reading positions.
+                FlagTab.Dt -> DtListBody(
+                    state = bodyState.dtListState,
+                    isRefreshing = bodyState.dtIsRefreshing,
+                    actions = actions,
+                    funny = bodyState.funnyEmptyState,
+                )
+                else -> FlagListBody(
+                    state = bodyState,
+                    actions = actions,
+                    listState = listStates.forType(bodyState.selectedTab.flagType),
+                )
+            }
         }
     }
 }
@@ -1197,20 +1235,33 @@ private fun FlagListBody(
 /**
  * #695 — one [LazyListState] per flag tab so the scroll position of Mes sujets / Lu / Favoris does not
  * bleed across tabs (a single shared state carried one tab's index onto another). The three states are
- * remembered + saveable, so each tab keeps its own position across switches and rotation; the active
- * tab's state is returned. Super has no list — it reuses the Cyan state harmlessly (never rendered).
- * Extracted from [FlagsRoute] to keep its cyclomatic complexity under the detekt threshold.
+ * remembered + saveable, so each tab keeps its own position across switches and rotation.
+ *
+ * #660 — held as a HOISTED holder rather than resolving a single active state: the body's Shared Axis X
+ * [AnimatedContent] composes BOTH the outgoing and incoming panes during a transition, so each pane must
+ * read its own tab's state. Resolving (not recreating) per pane keeps every tab's scroll position intact
+ * — recreating a [LazyListState] inside the transition would lose it and reintroduce the cross-tab bleed.
  */
-@Composable
-private fun rememberFlagTabListState(flagType: FlagType?): LazyListState {
-    val cyanListState = rememberLazyListState()
-    val redListState = rememberLazyListState()
-    val favoriteListState = rememberLazyListState()
-    return when (flagType) {
-        FlagType.RED -> redListState
-        FlagType.FAVORITE -> favoriteListState
-        FlagType.CYAN, null -> cyanListState
+@Stable
+private class FlagTabListStates(
+    val cyan: LazyListState,
+    val red: LazyListState,
+    val favorite: LazyListState,
+) {
+    // Super/DT have no real flag list — they reuse the Cyan state harmlessly (never rendered as a list).
+    fun forType(flagType: FlagType?): LazyListState = when (flagType) {
+        FlagType.RED -> red
+        FlagType.FAVORITE -> favorite
+        FlagType.CYAN, null -> cyan
     }
+}
+
+@Composable
+private fun rememberFlagTabListStates(): FlagTabListStates {
+    val cyan = rememberLazyListState()
+    val red = rememberLazyListState()
+    val favorite = rememberLazyListState()
+    return remember(cyan, red, favorite) { FlagTabListStates(cyan, red, favorite) }
 }
 
 /**

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTabSwipe.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTabSwipe.kt
@@ -1,8 +1,14 @@
 package fr.forumhfr.redface2.feature.flags
 
+import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.awaitHorizontalTouchSlopOrCancellation
@@ -15,6 +21,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.input.pointer.util.VelocityTracker
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.ui.pager.FLING_VELOCITY_THRESHOLD
 import fr.forumhfr.redface2.core.ui.pager.MIN_COMMIT_DISTANCE
@@ -34,14 +41,19 @@ import kotlinx.coroutines.launch
  * swiping the content left commits to the tab on the right, exactly like turning to the next
  * page. The tab row itself is NOT part of the gesture surface — it already has taps.
  *
- * In-place mechanics (the composition survives the tab change). On commit the offset is snapped to
- * rest and the new tab's content swaps in centred — #660: springing back from the released drag
- * offset made the incoming tab slide in from the wrong side. Only a sub-threshold drag springs back:
+ * In-place mechanics (the composition survives the tab change). On commit the new tab's content is
+ * brought in by the body's Shared Axis X [androidx.compose.animation.AnimatedContent] (see
+ * [flagsTabSlide]) — it enters from the direction of travel, the old one leaves the opposite way —
+ * while the residual drag offset always springs back to rest. #660 history: the first version sprang
+ * the offset back WITHOUT that transition, so the incoming tab rode the released offset and slid in
+ * from the wrong side; the interim fix snapped straight to rest (an abrupt « pop », styx42). With the
+ * transition owning the entry side, springing the offset back is both correct and smooth.
  *
- * - **Commit → [FlagsTabSwipeHandlers.onSelectTab]** with the target index; the caller maps it
- *   back to a `FlagTab` (the DT tab is conditional, so the index↔tab mapping lives where the tab
- *   list is built). The ViewModel's re-tap toggle (Cyan « +lus ») is unreachable by construction:
- *   [swipeTargetIndex] never returns the current index (≥2 tabs).
+ * - **Commit → [FlagsTabSwipeHandlers.onSelectTab]** with the target index AND the swipe direction;
+ *   the caller maps the index back to a `FlagTab` (the DT tab is conditional, so the index↔tab
+ *   mapping lives where the tab list is built) and feeds the direction to the transition via
+ *   [flagsTabSlideForward]. The ViewModel's re-tap toggle (Cyan « +lus ») is unreachable by
+ *   construction: [swipeTargetIndex] never returns the current index (≥2 tabs).
  * - [currentIndex] and [tabCount] are lambdas: the selected tab changes UNDER this live
  *   composition (gesture keyed on `Unit`, never re-keyed), both must be read fresh per frame.
  * - No re-entrance latch and no enabled-gate: a tab switch is local state + cached list, there
@@ -101,7 +113,6 @@ internal fun Modifier.flagsTabSwipe(
                     armed = nowArmed
                     change.consume()
                 }
-                var committed = false
                 if (completed) {
                     val velocityX = velocityTracker.calculateVelocity().x
                     val forward =
@@ -109,24 +120,17 @@ internal fun Modifier.flagsTabSwipe(
                     val target = forward?.let { swipeTargetIndex(currentIndex(), tabCount(), it) }
                     if (forward != null && target != null) {
                         handlers.haptics.performHapticFeedback(HapticFeedbackType.Confirm)
-                        handlers.onSelectTab(target)
-                        committed = true
+                        handlers.onSelectTab(target, forward)
                     }
                 }
-                if (committed) {
-                    // #660 — on commit, snap straight to rest: the new tab swaps in centred. The old
-                    // code sprang `dragOffset` back to 0 from the RELEASED offset, but that offset was
-                    // the OUTGOING tab's displacement — so the INCOMING tab rode it and slid in from
-                    // the wrong side (swipe left → next tab entered from the left). The drag-follow
-                    // already conveyed the direction; the swap itself needs no slide.
-                    dragOffset.floatValue = 0f
-                } else {
-                    // Sub-threshold drag (no commit): spring the current tab back so the damped
-                    // over-pull settles to rest.
-                    releaseJob = animationScope.launch {
-                        release.snapTo(dragOffset.floatValue)
-                        release.animateTo(0f, TAB_SPRING_BACK) { dragOffset.floatValue = value }
-                    }
+                // #660 — always settle the drag-follow back to rest with a spring, committed or not.
+                // The committed tab's entrance is owned by the Shared Axis X AnimatedContent transition
+                // (it brings the new tab in from the direction of travel), so this residual offset only
+                // damps out — it no longer dictates the entry side. A sub-threshold drag settles the
+                // same way (the damped over-pull returns to rest).
+                releaseJob = animationScope.launch {
+                    release.snapTo(dragOffset.floatValue)
+                    release.animateTo(0f, TAB_SPRING_BACK) { dragOffset.floatValue = value }
                 }
             }
         }
@@ -144,11 +148,13 @@ internal fun Modifier.flagsTabSwipe(
 /**
  * Non-per-frame inputs of [flagsTabSwipe], bundled (same shape as `ThreadSwipeHandlers`) so the
  * gesture's parameter list stays within the project's limit. [onSelectTab] receives the target
- * **tab index** in the currently displayed tab list.
+ * **tab index** in the currently displayed tab list AND the swipe direction (`forward = true` when
+ * swiping the content left, toward the next tab) — the latter drives the Shared Axis slide side via
+ * [flagsTabSlideForward], so a cyclic wrap (#663) still enters from the correct edge.
  */
 internal class FlagsTabSwipeHandlers(
     val haptics: HapticFeedback,
-    val onSelectTab: (Int) -> Unit,
+    val onSelectTab: (index: Int, forward: Boolean) -> Unit,
 )
 
 /**
@@ -178,9 +184,41 @@ private fun tabFollowOffset(
     return swipeFollowOffset(totalDx, commitDistancePx, hasTarget)
 }
 
+/**
+ * #660 — direction of the Shared Axis X tab transition (`true` = the new tab enters from the right,
+ * the « forward » side). A swipe carries an authoritative [swipeForward] (it knows the gesture
+ * direction, so the cyclic wrap last↔first lands on the correct side — the very edge case the
+ * original bug got wrong). A tab tap has no swipe direction (`swipeForward = null`); it falls back to
+ * the tabs' visual order, sliding forward when moving to a later tab.
+ */
+internal fun flagsTabSlideForward(fromIndex: Int, toIndex: Int, swipeForward: Boolean?): Boolean =
+    swipeForward ?: (toIndex >= fromIndex)
+
+/**
+ * #660 — the committed tab transition: Material « Shared Axis X » (the prototype's chosen variant,
+ * styx42). The incoming tab slides in from the [forward] side while the outgoing one slides out the
+ * opposite way, no fade (the panes never overlap), with the prototype's emphasized-decelerate easing.
+ * Pure builder so the body's `AnimatedContent` stays declarative; the parent must `clipToBounds()` so
+ * the panes don't draw past the viewport mid-slide.
+ */
+internal fun flagsTabSlide(forward: Boolean): ContentTransform {
+    val spec = tween<IntOffset>(
+        durationMillis = TAB_SLIDE_DURATION_MS,
+        easing = TAB_SLIDE_EASING,
+    )
+    val direction = if (forward) 1 else -1
+    return slideInHorizontally(spec) { fullWidth -> direction * fullWidth } togetherWith
+        slideOutHorizontally(spec) { fullWidth -> -direction * fullWidth }
+}
+
 private const val TAB_COMMIT_SHADOW_ELEVATION_DP = 8f
 
 private val TAB_SPRING_BACK = spring<Float>(
     dampingRatio = Spring.DampingRatioNoBouncy,
     stiffness = Spring.StiffnessMedium,
 )
+
+// #660 — the prototype's chosen « slide au commit » timing: emphasized-decelerate
+// cubic-bezier(.2, .8, .2, 1) over 280 ms (matches `flags-603-swipe-anim`).
+private const val TAB_SLIDE_DURATION_MS = 280
+private val TAB_SLIDE_EASING = CubicBezierEasing(0.2f, 0.8f, 0.2f, 1f)

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTabSwipeTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTabSwipeTest.kt
@@ -1,7 +1,9 @@
 package fr.forumhfr.redface2.feature.flags
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -49,5 +51,31 @@ class FlagsTabSwipeTest {
     @Test
     fun `an empty tab list has no swipe target`() {
         assertNull(swipeTargetIndex(currentIndex = 0, tabCount = 0, forward = true))
+    }
+
+    // #660 — Shared Axis X slide direction for the committed tab transition. A swipe carries an
+    // authoritative direction (handles the cyclic wrap, #663); a tap falls back to the tabs' order.
+
+    @Test
+    fun `a forward swipe slides forward even when it wraps last to first`() {
+        // Super (last) → Cyan (first) by a forward swipe: the index order alone (0 < 3) would read
+        // « backward » and bring the new tab in from the WRONG side — the original #660 bug. The
+        // gesture's own direction overrides it.
+        assertTrue(flagsTabSlideForward(fromIndex = 3, toIndex = 0, swipeForward = true))
+    }
+
+    @Test
+    fun `a backward swipe slides backward even when it wraps first to last`() {
+        assertFalse(flagsTabSlideForward(fromIndex = 0, toIndex = 3, swipeForward = false))
+    }
+
+    @Test
+    fun `a tap to a later tab slides forward`() {
+        assertTrue(flagsTabSlideForward(fromIndex = 0, toIndex = 2, swipeForward = null))
+    }
+
+    @Test
+    fun `a tap to an earlier tab slides backward`() {
+        assertFalse(flagsTabSlideForward(fromIndex = 2, toIndex = 0, swipeForward = null))
     }
 }


### PR DESCRIPTION
## #660 — animation de swipe « slide au commit » (Shared Axis X)

Closes #660.

Le swipe horizontal entre onglets Drapeaux faisait « arriver » le nouvel onglet du mauvais côté :
le fix intérimaire (`snapTo(0)`) avait remplacé le slide par un swap instantané « pop » abrupt
(rejeté par styx42). Cette PR implémente la variante validée au prototype (`flags-603-swipe-anim`) :
**Material « Shared Axis X »** — au commit, le nouvel onglet entre du côté du sens de navigation,
l'ancien sort de l'autre (easing emphasized cubic-bezier(.2,.8,.2,1), 280 ms).

### Comment
- `FlagsTabSwipe.kt` : la direction réelle du geste (`forward`) est passée à `onSelectTab(index, forward)`
  — indispensable car les onglets sont **cycliques** (#663), les indices seuls inverseraient le côté au
  wrap (Super→Cyan, Cyan→Super). Au commit l'offset de drag est toujours **settle par spring** : l'entrée
  est désormais portée par l'`AnimatedContent`, l'offset résiduel ne dicte plus le côté (c'était la cause
  du bug d'origine — spring-back sans transition).
- `flagsTabSlideForward(from, to, swipeForward)` (pure, testée) : la direction = celle du geste pour un
  swipe, sinon l'ordre des onglets pour un tap.
- `FlagsRoute.kt` : le `when(selectedTab)` du body devient un `AnimatedContent` directionnel
  (`contentKey = selectedTab` → ne slide que sur un vrai changement d'onglet, pas sur un refresh de données).
- **#695 préservé** : les `LazyListState` par onglet sont **hoistés** dans un holder (`FlagTabListStates`)
  résolu par pane — l'`AnimatedContent` compose 2 panes pendant la transition, chacune garde son scroll
  (aucun state recréé).

### Tests
4 tests purs sur `flagsTabSlideForward` (wrap forward/backward via swipe, tap forward/backward).

### Validation
`detektAll :app:lintProdDebug testDebugUnitTest :app:testProdDebugUnitTest :app:assembleProdDebug` ✅
(cf. CI). Cadrage + review Codex (gpt-5.5 xhigh) GO.

---
> PR générée par Claude Opus 4.8 (demandée par @XaaT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
