### PR TITLE
chore(release): dev 0.17.21 — refonte top bar (#603) + swipe (#660) + sheet (#676)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,26 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.21` — `internal` (dev) — 2026-06-28
+
+> Vue Drapeaux (#603) — **refonte de la top bar** (nouveau look : deux containers arrondis, loupe
+> rétractable, avatar, indicateur « +lus » en forme d'œil) + animation de **swipe entre onglets « slide
+> au commit »** (#660) + **sheet d'appui-long** avec liste d'actions complète ET rangée d'accès rapide
+> (#676). versionName 0.17.20 → 0.17.21.
+
+**Drapeaux — vue (#603)**
+
+- **Refonte de la top bar — nouveau look (#603)** : la barre plate laisse place à deux « containers »
+  arrondis flottant sur un centre transparent. À gauche, le sélecteur d'onglet (drapal de la section +
+  nom court + indicateur « +lus » en forme d'œil quand les lus sont affichés). À droite, une loupe
+  rétractable (qui s'ouvre en champ de recherche plein largeur) et l'avatar du compte. Les bascules
+  existantes (onglets, +lus, réglages d'affichage) restent dans le menu du container gauche. *(Suite à
+  venir : défilement du contenu sous la barre #665, loader « redface », option D/C de l'indicateur.)*
+- **Swipe entre onglets « slide au commit » (#660)** : le changement d'onglet par balayage glisse
+  désormais directionnellement du bon côté (Material Shared Axis X) au lieu d'apparaître brusquement.
+- **Sheet d'appui-long (#676)** : la liste verticale d'actions (libellés complets) revient et coexiste
+  avec la rangée d'accès rapide en icônes ; « Retirer » reste en dernier, toujours confirmé par dialog.
+
 ## `0.17.20` — `internal` (dev) — 2026-06-27
 
 > Vue Drapeaux (#603) — le texte explicatif du balayage de la section DT quitte la vue (où il flottait

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.20"
+        versionName = "0.17.21"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,4 +1,6 @@
-Redface 2 v0.17.20 — dev.
+Redface 2 v0.17.21 — dev.
 
 Flags view:
-- The note explaining that only the inbox's first page is scanned has moved out of the DT view into the "DT section" setting description (Settings › Flags). The view stays uncluttered.
+- New top bar: two rounded containers, a retractable search loupe, the account avatar, and an "also-read" indicator.
+- Tab swipe now slides in from the correct side (#660).
+- Long-press sheet: the full action list is back alongside the quick-access row (#676).

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,4 +1,6 @@
-Redface 2 v0.17.20 — dev.
+Redface 2 v0.17.21 — dev.
 
 Vue Drapeaux :
-- Le texte expliquant que seule la première page de la boîte est balayée a quitté la vue DT pour rejoindre la description du réglage « Section DT » (Réglages › Drapeaux). La vue reste épurée.
+- Nouvelle barre du haut : deux containers arrondis, loupe rétractable, avatar, indicateur « +lus ».
+- Le swipe entre onglets glisse maintenant du bon côté (#660).
+- Sheet d'appui-long : liste d'actions complète + rangée d'accès rapide (#676).


### PR DESCRIPTION
Release dev groupée 0.17.21 (versionName 0.17.20 → 0.17.21).

Contenu (déjà sur dev) :
- #603 refonte top bar — nouveau look
- #660 swipe « slide au commit »
- #676 sheet appui-long (liste + rangée)

CHANGELOG + whatsnew (fr/en) à jour. Dispatch release.yml --ref dev channel=dev après merge.

> PR générée par Claude Opus 4.8 (demandée par @XaaT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)