### PR TITLE
feat(flags): configurable « +lus » indicator — eye or coloured ring (#661)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -15,6 +15,7 @@ import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
 import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
+import fr.forumhfr.redface2.core.domain.preferences.PlusLusIndicatorStyle
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
@@ -212,6 +213,15 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         persist {
             dataStore.edit { prefs ->
                 prefs[KEY_FLAGS_MARKER_BORDER] = enabled
+            }
+        }
+    }
+
+    override suspend fun setFlagsPlusLusIndicatorStyle(style: PlusLusIndicatorStyle) {
+        // #661 — GLOBAL: a single key, no per-type variant. Persisted by name, read defensively.
+        persist {
+            dataStore.edit { prefs ->
+                prefs[KEY_FLAGS_PLUS_LUS_INDICATOR_STYLE] = style.name
             }
         }
     }
@@ -765,6 +775,8 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         val categoryBandStyle = readCategoryBandStyle(prefs)
         // #690 — GLOBAL « marker outline » toggle: resolved once, added to both return paths.
         val markerBorder = prefs[KEY_FLAGS_MARKER_BORDER] ?: false
+        // #661 — GLOBAL « +lus » indicator style: resolved once (defensively), added to both return paths.
+        val plusLusIndicatorStyle = readPlusLusIndicatorStyle(prefs)
         if (prefs[KEY_FLAGS_PER_TAB_OVERRIDE] != true) {
             return FlagsViewSettings(
                 groupByCategory = globalGroup,
@@ -774,6 +786,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
                 singleLineTitle = singleLineTitle,
                 categoryBandStyle = categoryBandStyle,
                 markerBorder = markerBorder,
+                plusLusIndicatorStyle = plusLusIndicatorStyle,
             )
         }
         return FlagsViewSettings(
@@ -784,6 +797,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             singleLineTitle = singleLineTitle,
             categoryBandStyle = categoryBandStyle,
             markerBorder = markerBorder,
+            plusLusIndicatorStyle = plusLusIndicatorStyle,
         )
     }
 
@@ -806,6 +820,16 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         prefs[KEY_FLAGS_CATEGORY_BAND_STYLE]
             ?.let { stored -> runCatching { CategoryBandStyle.valueOf(stored) }.getOrNull() }
             ?: CategoryBandStyle.MINIMAL
+
+    /**
+     * Reads [KEY_FLAGS_PLUS_LUS_INDICATOR_STYLE] defensively (#661): an unknown / corrupt stored value
+     * falls back to [PlusLusIndicatorStyle.Eye] instead of crashing on `PlusLusIndicatorStyle.valueOf`
+     * — same stance as [readMarkerStyle].
+     */
+    private fun readPlusLusIndicatorStyle(prefs: Preferences): PlusLusIndicatorStyle =
+        prefs[KEY_FLAGS_PLUS_LUS_INDICATOR_STYLE]
+            ?.let { stored -> runCatching { PlusLusIndicatorStyle.valueOf(stored) }.getOrNull() }
+            ?: PlusLusIndicatorStyle.Eye
 
     /**
      * Type-aware default for the #317 « non-lus uniquement » filter: CYAN (« Mes sujets ») shows the
@@ -840,6 +864,8 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         val KEY_FLAGS_CATEGORY_BAND_STYLE = stringPreferencesKey("flags_category_band_style")
         // #690 — GLOBAL « marker outline » toggle (thin dark border around the marker).
         val KEY_FLAGS_MARKER_BORDER = booleanPreferencesKey("flags_marker_border")
+        // #661 — GLOBAL « +lus » indicator style (PlusLusIndicatorStyle.name, defensively parsed).
+        val KEY_FLAGS_PLUS_LUS_INDICATOR_STYLE = stringPreferencesKey("flags_plus_lus_indicator_style")
         // #662 — « états vides humoristiques » opt-in (smiley empty state instead of the sober icon).
         val KEY_FLAGS_FUNNY_EMPTY_STATE = booleanPreferencesKey("flags_funny_empty_state")
         // #309 — per-tab display override. The master switch plus one nullable key per FlagType for

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -12,6 +12,7 @@ import fr.forumhfr.redface2.core.domain.preferences.AccentColor
 import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
 import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
+import fr.forumhfr.redface2.core.domain.preferences.PlusLusIndicatorStyle
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenChoice
@@ -442,6 +443,45 @@ class DataStoreUserPreferencesRepositoryTest {
             cancelAndIgnoreRemainingEvents()
         }
     }
+
+    @Test
+    fun `plusLusIndicatorStyle defaults to Eye on an empty store`() = runTest(dispatcher) {
+        repository.observeFlagsViewSettings(FlagType.CYAN).test {
+            assertEquals(PlusLusIndicatorStyle.Eye, awaitItem().plusLusIndicatorStyle)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setFlagsPlusLusIndicatorStyle persists and round-trips Ring then Eye for every tab`() =
+        runTest(dispatcher) {
+            // #661 GLOBAL: written once, observed on any tab type.
+            repository.setFlagsPlusLusIndicatorStyle(PlusLusIndicatorStyle.Ring)
+            repository.observeFlagsViewSettings(FlagType.RED).test {
+                assertEquals(PlusLusIndicatorStyle.Ring, awaitItem().plusLusIndicatorStyle)
+                cancelAndIgnoreRemainingEvents()
+            }
+            repository.setFlagsPlusLusIndicatorStyle(PlusLusIndicatorStyle.Eye)
+            repository.observeFlagsViewSettings(FlagType.FAVORITE).test {
+                assertEquals(PlusLusIndicatorStyle.Eye, awaitItem().plusLusIndicatorStyle)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `corrupt flags_plus_lus_indicator_style value falls back to Eye instead of crashing`() =
+        runTest(dispatcher) {
+            // An unknown value from an older build / manual edit must not crash
+            // observeFlagsViewSettings on PlusLusIndicatorStyle.valueOf — it degrades to Eye.
+            dataStore.edit { prefs ->
+                prefs[stringPreferencesKey("flags_plus_lus_indicator_style")] = "STAR"
+            }
+
+            repository.observeFlagsViewSettings(FlagType.CYAN).test {
+                assertEquals(PlusLusIndicatorStyle.Eye, awaitItem().plusLusIndicatorStyle)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
 
     @Test
     fun `categoryBandStyle defaults to MINIMAL on an empty store`() = runTest(dispatcher) {

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -16,6 +16,7 @@ import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
+import fr.forumhfr.redface2.core.domain.preferences.PlusLusIndicatorStyle
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
@@ -542,6 +543,7 @@ class TopicRepositoryImplTest {
         override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
         override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
         override suspend fun setFlagsMarkerBorder(enabled: Boolean) = Unit
+        override suspend fun setFlagsPlusLusIndicatorStyle(style: PlusLusIndicatorStyle) = Unit
 
         // #286 — theme prefs are irrelevant to TopicRepositoryImpl; stubbed at their defaults.
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FlagsViewSettings.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FlagsViewSettings.kt
@@ -45,4 +45,8 @@ data class FlagsViewSettings(
     // (#FFB300) reads cleanly on a light background. Default false (no border). Not subject to the
     // per-tab override (like [markerStyle]). Carried on every resolution path.
     val markerBorder: Boolean = false,
+    // #661 — GLOBAL: shape of the « +lus » cue in the top-bar tab picker (eye glyph vs. coloured ring).
+    // Default EYE. Not subject to the per-tab override (like [markerStyle]). Carried on every
+    // resolution path.
+    val plusLusIndicatorStyle: PlusLusIndicatorStyle = PlusLusIndicatorStyle.Eye,
 )

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/PlusLusIndicatorStyle.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/PlusLusIndicatorStyle.kt
@@ -1,0 +1,20 @@
+package fr.forumhfr.redface2.core.domain.preferences
+
+/**
+ * Visual style of the « +lus » cue in the Drapeaux top-bar tab picker (#661, ADR-017). When the
+ * active tab (Cyan / DT) is showing read items, the left container signals it; only the SHAPE of the
+ * cue varies:
+ *
+ * - [Eye] — an eye glyph in a tinted capsule next to the tab name (the **default**: the most
+ *   explicit, self-describing on first use).
+ * - [Ring] — the section's flag dot is drawn as a hollow coloured ring instead of a filled disc
+ *   (the soberest option: no extra glyph, the « drapal » itself carries the state).
+ *
+ * Pure domain enum (no Android / Compose), so it can be persisted in a preference and read by the
+ * top bar without dragging UI types into the model layer. GLOBAL (one value for every tab), like
+ * [MarkerStyle]; the colour is resolved at render time from the active tab's flag colour.
+ */
+enum class PlusLusIndicatorStyle {
+    Eye,
+    Ring,
+}

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -141,6 +141,16 @@ interface UserPreferencesRepository {
     suspend fun setFlagsMarkerBorder(enabled: Boolean)
 
     /**
+     * Persists the GLOBAL « +lus » indicator style (#661): the shape of the read-items cue in the
+     * Drapeaux top-bar tab picker — [PlusLusIndicatorStyle.Eye] (default, an eye glyph) or
+     * [PlusLusIndicatorStyle.Ring] (the flag dot drawn as a coloured ring). Like
+     * [setFlagsMarkerStyle] it is NOT subject to [observeFlagsPerTabOverride]; surfaced through
+     * [observeFlagsViewSettings] ([FlagsViewSettings.plusLusIndicatorStyle]). Defaults to
+     * [PlusLusIndicatorStyle.Eye] until the first call.
+     */
+    suspend fun setFlagsPlusLusIndicatorStyle(style: PlusLusIndicatorStyle)
+
+    /**
      * App theme selection (#286): [ThemeMode.SYSTEM] (default) follows the OS dark-mode setting;
      * [ThemeMode.LIGHT] / [ThemeMode.DARK] force the app theme regardless of the OS. Observed at the
      * app root ([fr.forumhfr.redface2.navigation.RedfaceApp]) to compute the effective dark theme

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -21,6 +21,7 @@ import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
+import fr.forumhfr.redface2.core.domain.preferences.PlusLusIndicatorStyle
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.ImageUpload
 import fr.forumhfr.redface2.core.domain.upload.ImageUploadReader
@@ -1967,6 +1968,7 @@ class PostEditorViewModelTest {
         override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
         override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
         override suspend fun setFlagsMarkerBorder(enabled: Boolean) = Unit
+        override suspend fun setFlagsPlusLusIndicatorStyle(style: PlusLusIndicatorStyle) = Unit
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
         override suspend fun setThemeMode(mode: ThemeMode) = Unit
         override fun observeAmoledEnabled(): Flow<Boolean> = MutableStateFlow(false)

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -19,6 +19,7 @@ import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
+import fr.forumhfr.redface2.core.domain.preferences.PlusLusIndicatorStyle
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.smiley.SmileyRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
@@ -1367,6 +1368,7 @@ class TopicFormViewModelTest {
         override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
         override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
         override suspend fun setFlagsMarkerBorder(enabled: Boolean) = Unit
+        override suspend fun setFlagsPlusLusIndicatorStyle(style: PlusLusIndicatorStyle) = Unit
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
         override suspend fun setThemeMode(mode: ThemeMode) = Unit
         override fun observeAmoledEnabled(): Flow<Boolean> = MutableStateFlow(false)

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -87,6 +87,7 @@ import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
+import fr.forumhfr.redface2.core.domain.preferences.PlusLusIndicatorStyle
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
@@ -360,6 +361,8 @@ fun FlagsRoute(
                             cyanShowsRead = cyanShowsRead,
                             dtShowsRead = dtShowsRead,
                         ),
+                        // #661 — GLOBAL « +lus » cue shape (eye glyph vs. coloured flag ring).
+                        plusLusIndicatorStyle = flagsViewSettings.plusLusIndicatorStyle,
                     ),
                     onSelectTab = viewModel::selectTab,
                     onQueryChange = { searchQuery = it },
@@ -459,6 +462,7 @@ fun FlagsRoute(
                 onMarkerBorderChange = viewModel::setFlagsMarkerBorder,
                 onSingleLineTitleChange = viewModel::setFlagsSingleLineTitle,
                 onCategoryBandStyleChange = viewModel::setFlagsCategoryBandStyle,
+                onPlusLusIndicatorStyleChange = viewModel::setFlagsPlusLusIndicatorStyle,
                 onDismiss = { showViewSettingsSheet = false },
             ),
         )
@@ -668,6 +672,35 @@ private fun FlagsViewSettingsSheet(
                 enabled = true,
                 onCheckedChange = actions.onMarkerBorderChange,
             )
+
+            // #661 — GLOBAL « +lus » indicator style selector (segmented). The shape of the read-items
+            // cue in the top-bar tab picker: an eye glyph (default) or the flag dot drawn as a ring.
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = stringResource(R.string.flags_view_settings_pluslus_title),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = stringResource(R.string.flags_view_settings_pluslus_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                RedfaceSettingsChoiceGroup(
+                    options = listOf(
+                        RedfaceSettingsChoice(
+                            PlusLusIndicatorStyle.Eye,
+                            stringResource(R.string.flags_view_settings_pluslus_eye),
+                        ),
+                        RedfaceSettingsChoice(
+                            PlusLusIndicatorStyle.Ring,
+                            stringResource(R.string.flags_view_settings_pluslus_ring),
+                        ),
+                    ),
+                    selected = settings.plusLusIndicatorStyle,
+                    onSelected = actions.onPlusLusIndicatorStyleChange,
+                )
+            }
 
             // #603 — GLOBAL « single-line topic titles » toggle (not per-tab, like the marker shape).
             ViewSettingsSwitchRow(
@@ -2297,6 +2330,7 @@ private data class FlagsViewSettingsActions(
     val onMarkerBorderChange: (Boolean) -> Unit,
     val onSingleLineTitleChange: (Boolean) -> Unit,
     val onCategoryBandStyleChange: (CategoryBandStyle) -> Unit,
+    val onPlusLusIndicatorStyleChange: (PlusLusIndicatorStyle) -> Unit,
     val onDismiss: () -> Unit,
 )
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTopBar.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTopBar.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.feature.flags
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -44,6 +45,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.domain.preferences.PlusLusIndicatorStyle
 import fr.forumhfr.redface2.core.ui.icon.RedfaceVectorIcon
 import fr.forumhfr.redface2.core.ui.R as CoreUiR
 
@@ -67,6 +69,12 @@ data class FlagsAppBarState(
      * eye indicator in the left container.
      */
     val readFilterShowsRead: Boolean?,
+    /**
+     * #661 — GLOBAL shape of the « +lus » cue: [PlusLusIndicatorStyle.Eye] (default, an eye glyph
+     * capsule) or [PlusLusIndicatorStyle.Ring] (the flag dot drawn as a hollow coloured ring instead
+     * of a filled disc). Only takes visual effect when [readFilterShowsRead] is `true`.
+     */
+    val plusLusIndicatorStyle: PlusLusIndicatorStyle = PlusLusIndicatorStyle.Eye,
 )
 
 /**
@@ -191,7 +199,11 @@ private fun LeftContainer(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                FlagDot(state.currentTabColor)
+                // #661 — in « Ring » mode, the dot itself becomes a hollow coloured ring while « +lus »
+                // is active (no extra glyph); in « Eye » mode it stays filled and the eye capsule shows.
+                val showsRead = state.readFilterShowsRead == true
+                val ringCue = showsRead && state.plusLusIndicatorStyle == PlusLusIndicatorStyle.Ring
+                FlagDot(state.currentTabColor, ring = ringCue)
                 Text(
                     text = flagShortTabName(state.currentTab),
                     style = MaterialTheme.typography.labelLarge,
@@ -199,7 +211,7 @@ private fun LeftContainer(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
-                if (state.readFilterShowsRead == true) {
+                if (showsRead && state.plusLusIndicatorStyle == PlusLusIndicatorStyle.Eye) {
                     PlusLusIndicator(state.currentTabColor)
                 }
             }
@@ -214,13 +226,22 @@ private fun LeftContainer(
     }
 }
 
+/**
+ * The section's flag « drapal ». Normally a filled disc; when [ring] is true (#661 « Ring » +lus cue)
+ * it is drawn as a hollow coloured ring, so the dot itself carries the read-items state.
+ */
 @Composable
-private fun FlagDot(color: Color) {
+private fun FlagDot(color: Color, ring: Boolean = false) {
     Box(
         modifier = Modifier
             .size(14.dp)
-            .clip(CircleShape)
-            .background(color),
+            .then(
+                if (ring) {
+                    Modifier.border(width = 3.dp, color = color, shape = CircleShape)
+                } else {
+                    Modifier.clip(CircleShape).background(color)
+                },
+            ),
     )
 }
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -13,6 +13,7 @@ import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
 import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
+import fr.forumhfr.redface2.core.domain.preferences.PlusLusIndicatorStyle
 import fr.forumhfr.redface2.core.domain.preferences.SuperFavoriteRepository
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.model.AuthState
@@ -702,6 +703,11 @@ class FlagsViewModel @Inject constructor(
     /** Bottom-sheet write for the GLOBAL « marker outline » toggle (#690) — one value for every tab. */
     fun setFlagsMarkerBorder(enabled: Boolean) {
         viewModelScope.launch { userPreferencesRepository.setFlagsMarkerBorder(enabled) }
+    }
+
+    /** Bottom-sheet write for the GLOBAL « +lus » indicator style (#661) — one value for every tab. */
+    fun setFlagsPlusLusIndicatorStyle(style: PlusLusIndicatorStyle) {
+        viewModelScope.launch { userPreferencesRepository.setFlagsPlusLusIndicatorStyle(style) }
     }
 
     fun refresh() {

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -173,6 +173,12 @@
          des favoris ressorte mieux sur fond clair. -->
     <string name="flags_view_settings_marker_border_title">Contour du marqueur</string>
     <string name="flags_view_settings_marker_border_description">Ajoute un fin liseré sombre autour de l\'indicateur de couleur, pour mieux le détacher du fond clair. S\'applique à tous les onglets.</string>
+    <!-- #661 — Style de l\'indicateur « +lus » dans le sélecteur d\'onglet de la barre du haut :
+         œil (par défaut) ou drapal dessiné en anneau coloré. Réglage GLOBAL (tous onglets). -->
+    <string name="flags_view_settings_pluslus_title">Indicateur « +lus »</string>
+    <string name="flags_view_settings_pluslus_description">Forme du repère affiché dans le sélecteur d\'onglet quand les sujets lus sont visibles. S\'applique à tous les onglets.</string>
+    <string name="flags_view_settings_pluslus_eye">Œil</string>
+    <string name="flags_view_settings_pluslus_ring">Anneau</string>
     <!-- #603 — Style de la bande de catégorie (vue groupée) : sous-titre sobre / bloc tonal /
          accent latéral / pastille en puce. Réglage GLOBAL (tous onglets), sans effet en vue à plat. -->
     <string name="flags_view_settings_band_title">Bande de catégorie</string>

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -22,6 +22,7 @@ import fr.forumhfr.redface2.core.domain.preferences.AccentColor
 import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
+import fr.forumhfr.redface2.core.domain.preferences.PlusLusIndicatorStyle
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.SuperFavoriteRepository
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
@@ -2388,6 +2389,7 @@ class FlagsViewModelTest {
         override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
         override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
         override suspend fun setFlagsMarkerBorder(enabled: Boolean) = Unit
+        override suspend fun setFlagsPlusLusIndicatorStyle(style: PlusLusIndicatorStyle) = Unit
 
         // #286 — theme prefs are irrelevant to FlagsViewModel; stubbed at their defaults.
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -12,6 +12,7 @@ import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
+import fr.forumhfr.redface2.core.domain.preferences.PlusLusIndicatorStyle
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
@@ -2073,6 +2074,7 @@ class SettingsViewModelTest {
         override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
         override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
         override suspend fun setFlagsMarkerBorder(enabled: Boolean) = Unit
+        override suspend fun setFlagsPlusLusIndicatorStyle(style: PlusLusIndicatorStyle) = Unit
 
         fun emit(value: ProxyConfig) {
             config.value = value

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -16,6 +16,7 @@ import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenPreference
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
+import fr.forumhfr.redface2.core.domain.preferences.PlusLusIndicatorStyle
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.topic.NoTopicSearchResultsException
 import fr.forumhfr.redface2.core.domain.topic.TopicRepository
@@ -2050,6 +2051,7 @@ private class FakeUserPreferencesRepository(
     override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
     override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
     override suspend fun setFlagsMarkerBorder(enabled: Boolean) = Unit
+    override suspend fun setFlagsPlusLusIndicatorStyle(style: PlusLusIndicatorStyle) = Unit
 
     override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
 


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

## Résumé
Rend l'indicateur « +lus » de la top bar Drapeaux **configurable** (réglage GLOBAL, comme `markerStyle`) :

- **Œil** (défaut, comportement actuel) : le drapal reste plein, une capsule « œil » apparaît quand les lus sont affichés (Cyan/DT).
- **Anneau** : le drapal lui-même devient un **anneau coloré creux** (pas de glyphe en plus) — le « drapal » porte l'état, pas un halo autour.

Demande XaTriX : défaut D « œil » + option C « anneau » = drapal dessiné en anneau coloré, **pas** le halo de l'artefact.

## Détail technique
- Nouvel enum `PlusLusIndicatorStyle` (`:core:domain`), transporté par `FlagsViewSettings` / `observeFlagsViewSettings` (lecture défensive `valueOf`→`Eye`, ajouté aux **deux** chemins de `resolveFlagsViewSettings`).
- Setter dans `UserPreferencesRepository` + impl DataStore (clé `flags_plus_lus_indicator_style`, persistance par `name`) + `FlagsViewModel`.
- Sélecteur segmenté dans le bottom sheet « Affichage des drapeaux ».
- Branche Œil/Anneau dans `FlagsTopBar` (`FlagDot(ring=…)` via `Modifier.border(CircleShape)`, stable Compose, pas d'`Icons.*`).
- 6 fakes explicites stubés ; 3 tests DataStore (défaut/round-trip global/corruption).

## Vérification
- Build `:app:assembleDevDebug` ✅ · tests 5 modules ✅ · `detektAll` + `lintDebug` ✅
- **Vérifié sur émulateur authentifié** : variante Œil (capsule œil cyan) et variante Anneau (anneau cyan creux à la place du dot plein, sans halo) rendues correctement.
- **Gate Codex (gpt-5.5 xhigh)** : archi complète vs le template `markerStyle`, aucun câblage manquant, rendu anneau sain. Mergeable.

closes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)