### PR TITLE
fix(flags): drop swipe-pane elevation shadow + round account avatar (#603)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/account/RedfaceAccountMenu.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/account/RedfaceAccountMenu.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
@@ -39,8 +39,9 @@ import fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar
  * `authState` from an `AppAccountViewModel` and routes the callbacks to the active back stack,
  * keeping the account-menu logic out of every feature ViewModel.
  *
- * Badge shape is **square with rounded corners** (not a circle), aligned with the convention
- * picked for [fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar].
+ * Badge shape is a **circle** (#603/#665, XaTriX top-bar redesign): the account « PP » reads as a
+ * round avatar. Post-header avatars keep the HFR-web rounded square via
+ * [fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar]'s default shape.
  *
  * Anti-flicker contract: when [authState] is `null` (cookie jar still warming up from
  * DataStore) we render a neutral badge with "…" — never an "Anonymous" state — so a cold start
@@ -175,7 +176,7 @@ private fun AccountBadge(
     // (`X` / `?` / `…`) as a separate node.
     Surface(
         onClick = onClick,
-        shape = RoundedCornerShape(BADGE_CORNER_RADIUS),
+        shape = CircleShape,
         color = containerColor,
         contentColor = contentColor,
         // Subtle hairline so the badge reads as a distinct element against the app-bar surface.
@@ -210,7 +211,7 @@ private fun AvatarBadge(
     val accessibilityLabel = stringResource(R.string.account_menu_open_description)
     Surface(
         onClick = onClick,
-        shape = RoundedCornerShape(BADGE_CORNER_RADIUS),
+        shape = CircleShape,
         // Subtle hairline so the avatar reads as a distinct element against the app-bar surface.
         border = BorderStroke(BADGE_BORDER_WIDTH, MaterialTheme.colorScheme.outlineVariant),
         modifier = Modifier
@@ -222,6 +223,8 @@ private fun AvatarBadge(
             avatarUrl = avatarUrl,
             author = pseudo,
             size = BADGE_SIZE,
+            // Round « PP » to match the circular badge (the post-header default stays rounded-square).
+            shape = CircleShape,
         )
     }
 }
@@ -253,6 +256,5 @@ private fun AccountStatusHeader(authState: AuthState?) {
 // 48dp minimum without changing the painted badge — `Surface(onClick = ...)` does NOT
 // inject that minimum on its own (cf. M3 docs, Codex rereview on PR #207).
 private val BADGE_SIZE = 40.dp
-private val BADGE_CORNER_RADIUS = 8.dp
 private val BADGE_BORDER_WIDTH = 1.dp
 private val HEADER_PADDING = PaddingValues(horizontal = 16.dp, vertical = 8.dp)

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/avatar/RedfaceUserAvatar.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/avatar/RedfaceUserAvatar.kt
@@ -40,6 +40,7 @@ import coil3.request.ImageRequest
  * use this component.
  */
 @Composable
+@Suppress("LongParameterList") // Shared avatar component: each optional has a distinct call-site need.
 fun RedfaceUserAvatar(
     avatarUrl: String?,
     author: String,
@@ -50,8 +51,11 @@ fun RedfaceUserAvatar(
     // "Interlocuteurs multiples" and "Avatar de Interlocuteurs multiples" would read wrong.
     // `null` keeps the default "Avatar de <author>" derivation.
     contentDescriptionOverride: String? = null,
+    // #603/#665 — shape of the avatar. Defaults to the HFR-web rounded square used in post headers;
+    // the global account badge (top-bar « PP ») passes [androidx.compose.foundation.shape.CircleShape]
+    // so the profile picture reads as a round avatar (XaTriX, top-bar redesign vision).
+    shape: Shape = RoundedCornerShape(AVATAR_CORNER_RADIUS),
 ) {
-    val shape = RoundedCornerShape(AVATAR_CORNER_RADIUS)
     val initial = author.firstOrNull()?.uppercaseChar()?.toString().orEmpty()
     // Same localized "Avatar de <pseudo>" string for both branches so TalkBack reads the
     // same sentence whether the avatar URL was provided or not (Codex rereview on PR #207

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTabSwipe.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTabSwipe.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.ui.pager.FLING_VELOCITY_THRESHOLD
 import fr.forumhfr.redface2.core.ui.pager.MIN_COMMIT_DISTANCE
 import fr.forumhfr.redface2.core.ui.pager.swipeArmed
@@ -75,13 +74,18 @@ internal fun Modifier.flagsTabSwipe(
     // deltas must be read in the untranslated coordinate space (inside the translated layer each
     // frame's `positionChange()` would be Δfinger − Δtranslation → halved tracking).
     .pointerInput(Unit) {
-        val commitDistancePx = swipeCommitDistancePx(size.width.toFloat(), MIN_COMMIT_DISTANCE.toPx())
-        val flingThresholdPx = FLING_VELOCITY_THRESHOLD.toPx()
         val release = Animatable(0f)
         coroutineScope {
             val animationScope = this
             var releaseJob: Job? = null
             awaitEachGesture {
+                // Codex audit: recompute the thresholds PER GESTURE, not once at `pointerInput(Unit)`
+                // start — the block is keyed on Unit and never restarts, so a one-shot `size.width`
+                // read goes stale on rotation / split-screen / density change. `size` and `.toPx()`
+                // are available on this gesture scope, so each gesture sizes to the current viewport.
+                val commitDistancePx =
+                    swipeCommitDistancePx(size.width.toFloat(), MIN_COMMIT_DISTANCE.toPx())
+                val flingThresholdPx = FLING_VELOCITY_THRESHOLD.toPx()
                 val down = awaitFirstDown(requireUnconsumed = false)
                 val velocityTracker = VelocityTracker()
                 velocityTracker.addPosition(down.uptimeMillis, down.position)
@@ -135,14 +139,14 @@ internal fun Modifier.flagsTabSwipe(
             }
         }
     }
-    // Draw-only translation + armed elevation lift, same draw-phase contract as the other swipe
-    // gestures (reads `dragOffset` without recomposition).
+    // Draw-only translation (reads `dragOffset` without recomposition), same draw-phase contract as
+    // the other swipe gestures. The armed `shadowElevation` lift was REMOVED (XaTriX dogfood): the
+    // swipe surface is a full-bleed, background-less viewport — not a card — so an elevation cast no
+    // real surface, only an ugly grey frame around the viewport bounds that travelled with the pane
+    // (« surlignage extérieur mal placé »). The arm threshold is still cued by the haptic above; the
+    // translationX follow + the Shared Axis X commit transition are the visual cues.
     .graphicsLayer {
-        val offset = dragOffset.floatValue
-        translationX = offset
-        val commitDistancePx = swipeCommitDistancePx(size.width, MIN_COMMIT_DISTANCE.toPx())
-        shadowElevation =
-            if (swipeArmed(offset, commitDistancePx)) TAB_COMMIT_SHADOW_ELEVATION_DP.dp.toPx() else 0f
+        translationX = dragOffset.floatValue
     }
 
 /**
@@ -210,8 +214,6 @@ internal fun flagsTabSlide(forward: Boolean): ContentTransform {
     return slideInHorizontally(spec) { fullWidth -> direction * fullWidth } togetherWith
         slideOutHorizontally(spec) { fullWidth -> -direction * fullWidth }
 }
-
-private const val TAB_COMMIT_SHADOW_ELEVATION_DP = 8f
 
 private val TAB_SPRING_BACK = spring<Float>(
     dampingRatio = Spring.DampingRatioNoBouncy,


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Deux corrections de finition top bar (retours dogfood XaTriX) + un suivi d'audit du code swipe.

## 1. Ombre moche au swipe (« surlignage extérieur mal placé »)
`flagsTabSwipe` appliquait un `shadowElevation` (8 dp, quand armé) sur la **Box-viewport plein écran** du swipe. Ce viewport n'a pas de fond opaque → l'élévation ne soulevait aucune surface, elle peignait juste un **cadre gris** autour des bornes, qui translatait avec le pane. **Fix : suppression du `shadowElevation`** (translationX seul ; l'armement reste signalé par le haptic + la transition Shared Axis X au commit).

## 2. Avatar / « PP » du compte rond (M3 classique)
Le badge compte global était un carré arrondi 8 dp. **Fix : `CircleShape`** (branche image + branche initiale), pour un avatar rond qui épouse son container. Implémenté via un nouveau param `shape` sur `RedfaceUserAvatar` — **les avatars d'en-tête de posts gardent le carré arrondi HFR web par défaut**.

## 3. Audit swipe (demandé par XaTriX, via Codex)
- **Seuils recalculés par geste** : `commitDistancePx`/`flingThresholdPx` étaient calculés une seule fois au démarrage de `pointerInput(Unit)` (jamais relancé) → stale en rotation / split-screen / changement de densité. Désormais recalculés dans `awaitEachGesture`.
- Les autres pistes de l'audit (captures stale, reset d'offset) sont **déjà couvertes** par le `rememberUpdatedState` du call-site et le cycle de vie partagé modifier/état.

## Vérification
- Build ✅ · `:feature:flags` + `:core:ui` tests ✅ · `detektAll` + `lintDebug` ✅
- **Vérifié sur émulateur authentifié** : plus d'ombre au swipe (bord net), avatar rond.
- **Gate Codex (gpt-5.5 xhigh)** : les 2 fixes sains sans régression a11y ; findings d'audit traités.

🤖 Generated with [Claude Code](https://claude.com/claude-code)