### PR TITLE
feat(flags): long-press sheet — distinct quick row vs menu list (#676)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -1890,22 +1890,23 @@ private fun RedfaceNavHost(
         entryProvider = entryProvider {
             entry<FlagsListRoute> {
                 FlagsRoute(
-                    onOpenFlag = { flag ->
+                    // #676 v2 — [page] is chosen by the caller: row tap + sheet « Ouvrir » resume at
+                    // lastReadPage, « 1er non-lu » jumps to lastReadPage+1, « dernière page » to totalPages.
+                    onOpenFlag = { flag, page ->
                         backStack.add(
                             TopicRoute(
                                 cat = flag.cat,
                                 post = flag.topicId,
-                                page = flag.lastReadPage,
-                                // REST `last_post_read_id` is the LAST post the user
-                                // read (not the first unread). Re-anchoring the reader
-                                // there is close enough to the legacy "where I stopped"
-                                // UX without claiming a first-unread we cannot prove
-                                // from the REST flag payload. HFR numreponse fits in
-                                // Int (largest observed ~10M), so the toInt() narrowing
-                                // is safe in practice. null = no anchor available.
+                                page = page,
+                                // REST `last_post_read_id` is the LAST post the user read. Anchoring the
+                                // reader there only makes sense when RESUMING at the last-read page; for
+                                // « 1er non-lu » / « dernière page » we want the top of that other page,
+                                // so the anchor is dropped unless page == lastReadPage. HFR numreponse
+                                // fits in Int (largest observed ~10M), so the toInt() narrowing is safe.
                                 scrollTo = flag.lastPostReadId
                                     ?.takeIf { it in 1L..Int.MAX_VALUE.toLong() }
-                                    ?.toInt(),
+                                    ?.toInt()
+                                    ?.takeIf { page == flag.lastReadPage },
                                 // #231 — a flag open means « catch up on new posts » → refresh
                                 // past the 60s snappy-cache TTL (the cached page is still shown
                                 // instantly first). Avoids landing on a stale followed topic.

--- a/core/ui/src/main/res/drawable/ic_ms_arrow_downward.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_arrow_downward.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #676 — Material Symbols Outlined (arrow_downward), grille 960 recadree via group translateY=960. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M480-200 240-440l57-57 143 143v-486h80v486l143-143 57 57-240 240Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_last_page.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_last_page.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #676 — Material Symbols Outlined (last_page), grille 960 recadree via group translateY=960. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M220-240l-57-57 184-183-184-183 57-57 240 240-240 240Zm480 0v-480h80v480h-80Z" />
+    </group>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_ms_share.xml
+++ b/core/ui/src/main/res/drawable/ic_ms_share.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <!-- #676 — Material Symbols Outlined (share), grille 960 recadree via group translateY=960. -->
+    <group android:translateY="960">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M720-80q-50 0-85-35t-35-85q0-7 1-14.5t3-13.5L322-392q-17 15-38 23.5T240-360q-50 0-85-35t-35-85q0-50 35-85t85-35q23 0 44 8.5t38 23.5l282-164q-2-6-3-13.5t-1-14.5q0-50 35-85t85-35q50 0 85 35t35 85q0 50-35 85t-85 35q-23 0-44-8.5T658-672L376-508q2 6 3 13.5t1 14.5q0 7-1 14.5t-3 13.5l282 164q17-15 38-23.5t44-8.5q50 0 85 35t35 85q0 50-35 85t-85 35Zm0-80q17 0 28.5-11.5T760-200q0-17-11.5-28.5T720-240q-17 0-28.5 11.5T680-200q0 17 11.5 28.5T720-160ZM240-440q17 0 28.5-11.5T280-480q0-17-11.5-28.5T240-520q-17 0-28.5 11.5T200-480q0 17 11.5 28.5T240-440Zm480-280q17 0 28.5-11.5T760-760q0-17-11.5-28.5T720-800q-17 0-28.5 11.5T680-760q0 17 11.5 28.5T720-720Z" />
+    </group>
+</vector>

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagActionsSheet.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagActionsSheet.kt
@@ -66,6 +66,7 @@ fun FlagActionsSheet(
     val context = LocalContext.current
     val linkCopied = stringResource(R.string.flags_sheet_link_copied)
     val browserFailed = stringResource(R.string.flags_sheet_browser_failed)
+    val shareFailed = stringResource(R.string.flags_sheet_share_failed)
 
     ModalBottomSheet(onDismissRequest = actions.onDismiss, sheetState = sheetState) {
         Column(
@@ -75,22 +76,32 @@ fun FlagActionsSheet(
                 .padding(bottom = 12.dp),
         ) {
             SheetHeader(flag = flag)
-            // #676 (retour XaTriX) — TWO surfaces over the SAME action model ([sheetActionItems]) so the
-            // row and the list can never drift: the quick-access icon ROW at the top (compact, fast) and
-            // the full-label vertical LIST at the bottom ([FlagActionsList]). The v194 version had dropped
-            // the list (the misunderstanding); both are restored. « Retirer » is last in each and still
-            // routes through the removal confirmation dialog, never a one-tap destruction.
-            val items = sheetActionItems(
-                isSuperFavorite = isSuperFavorite,
-                actions = actions,
-                onCopyLink = { copyTopicLink(context, flagTopicUrl(flag), linkCopied) },
-                onOpenBrowser = { openTopicInBrowser(context, flagTopicUrl(flag), browserFailed) },
+            // #676 v2 (mockup F2 v2) — the two surfaces carry DISTINCT, complementary actions (NOT the
+            // same set, the previous misunderstanding): the quick icon ROW = the frequent primary
+            // actions (open / first-unread / super-favorite / share), the full-label LIST = secondary,
+            // navigational and destructive ones. « Lu » and « Marquer la catégorie comme lue » from the
+            // mockup are intentionally ABSENT: HFR exposes no endpoint to mark a topic/category read
+            // without opening it (le réel prime — pas de faux bouton). « Mettre en sourdine » is a
+            // separate feature (own chantier), not bolted on here.
+            QuickActionsBar(
+                items = quickActions(
+                    flag = flag,
+                    isSuperFavorite = isSuperFavorite,
+                    actions = actions,
+                    onShare = { shareTopic(context, flagTopicUrl(flag), flag.title, shareFailed) },
+                ),
             )
-            QuickActionsBar(items = items)
             HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
             FlagMetadataBlock(flag = flag, categoryName = categoryName)
             HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-            FlagActionsList(items = items)
+            FlagActionsList(
+                items = menuActions(
+                    flag = flag,
+                    actions = actions,
+                    onCopyLink = { copyTopicLink(context, flagTopicUrl(flag), linkCopied) },
+                    onOpenBrowser = { openTopicInBrowser(context, flagTopicUrl(flag), browserFailed) },
+                ),
+            )
         }
     }
 }
@@ -125,23 +136,89 @@ private fun SheetHeader(flag: Flag) {
 }
 
 /**
- * #676 — single source of the five sheet actions (order + icon + callbacks + tint), consumed by BOTH
- * the quick-access [QuickActionsBar] (short [quickLabel]) and the full-label [FlagActionsList]
- * ([fullLabel]) so the two surfaces can never drift apart. [destructive] = « Retirer » (error tint, still
- * gated by the removal confirmation dialog).
+ * #676 v2 — one sheet action (icon + label + callback + tint). Each action now lives in EXACTLY ONE
+ * surface (quick row OR menu list), so a single [label] suffices. [enabled] greys-out + disables an
+ * action that has nothing to do (« 1er non-lu » when there is no unread); [destructive] = « Retirer »
+ * (error tint, still gated by the removal confirmation dialog).
  */
 private class SheetActionItem(
     @DrawableRes val iconRes: Int,
-    val quickLabel: String,
-    val fullLabel: String,
+    val label: String,
     val onClick: () -> Unit,
     val iconTint: Color,
+    val enabled: Boolean = true,
     val destructive: Boolean = false,
 )
 
+/** Resume page: where the user last read (never below 1). Pure → unit-tested. */
+internal fun flagLastReadPage(lastReadPage: Int): Int = lastReadPage.coerceAtLeast(1)
+
+/** Last page of the topic (never below 1). Pure → unit-tested. */
+internal fun flagLastPage(totalPages: Int): Int = totalPages.coerceAtLeast(1)
+
+/**
+ * First-unread page (#676 v2): the page right after the last-read one, clamped to `1..totalPages`. REST
+ * only gives the last-read position, so « first unread » is `lastReadPage + 1` when there is unread
+ * content; with nothing unread it collapses to the resume page (and the action is disabled anyway).
+ * Pure → unit-tested.
+ */
+internal fun flagFirstUnreadPage(lastReadPage: Int, totalPages: Int, hasUnread: Boolean): Int =
+    if (hasUnread) {
+        (lastReadPage + 1).coerceIn(1, flagLastPage(totalPages))
+    } else {
+        flagLastReadPage(lastReadPage)
+    }
+
+/**
+ * #676 v2 — the QUICK icon row: the frequent primary actions. Distinct from [menuActions]: open
+ * (resume), jump to the first unread, toggle the local super-favorite, share the topic link.
+ */
 @Composable
-private fun sheetActionItems(
+private fun quickActions(
+    flag: Flag,
     isSuperFavorite: Boolean,
+    actions: FlagSheetActions,
+    onShare: () -> Unit,
+): List<SheetActionItem> {
+    val variant = MaterialTheme.colorScheme.onSurfaceVariant
+    return listOf(
+        SheetActionItem(
+            iconRes = CoreUiR.drawable.ic_ms_forum,
+            label = stringResource(R.string.flags_sheet_quick_open),
+            onClick = { actions.onOpen(flagLastReadPage(flag.lastReadPage)) },
+            iconTint = variant,
+        ),
+        SheetActionItem(
+            iconRes = CoreUiR.drawable.ic_ms_arrow_downward,
+            label = stringResource(R.string.flags_sheet_quick_first_unread),
+            onClick = { actions.onOpen(flagFirstUnreadPage(flag.lastReadPage, flag.totalPages, flag.hasUnread)) },
+            iconTint = variant,
+            // Codex: disabled when there is nothing unread, so it never duplicates « Ouvrir ».
+            enabled = flag.hasUnread,
+        ),
+        SheetActionItem(
+            iconRes = CoreUiR.drawable.ic_ms_star,
+            label = stringResource(R.string.flags_sheet_quick_super_favorite),
+            onClick = actions.onToggleSuperFavorite,
+            // Amber icon when the local super-favorite is active.
+            iconTint = if (isSuperFavorite) FlagPalette.Favorite else variant,
+        ),
+        SheetActionItem(
+            iconRes = CoreUiR.drawable.ic_ms_share,
+            label = stringResource(R.string.flags_sheet_quick_share),
+            onClick = onShare,
+            iconTint = variant,
+        ),
+    )
+}
+
+/**
+ * #676 v2 — the full-label MENU list: secondary, navigational and destructive actions. Distinct from
+ * [quickActions]: open the last page, copy the link, open in the browser, remove the flag.
+ */
+@Composable
+private fun menuActions(
+    flag: Flag,
     actions: FlagSheetActions,
     onCopyLink: () -> Unit,
     onOpenBrowser: () -> Unit,
@@ -149,44 +226,26 @@ private fun sheetActionItems(
     val variant = MaterialTheme.colorScheme.onSurfaceVariant
     return listOf(
         SheetActionItem(
-            iconRes = CoreUiR.drawable.ic_ms_forum,
-            quickLabel = stringResource(R.string.flags_sheet_quick_open),
-            fullLabel = stringResource(R.string.flags_sheet_action_open),
-            onClick = actions.onOpen,
+            iconRes = CoreUiR.drawable.ic_ms_last_page,
+            label = stringResource(R.string.flags_sheet_action_last_page),
+            onClick = { actions.onOpen(flagLastPage(flag.totalPages)) },
             iconTint = variant,
         ),
         SheetActionItem(
-            iconRes = CoreUiR.drawable.ic_ms_star,
-            quickLabel = stringResource(R.string.flags_sheet_quick_super_favorite),
-            fullLabel = stringResource(
-                if (isSuperFavorite) {
-                    R.string.flags_sheet_action_super_favorite_remove
-                } else {
-                    R.string.flags_sheet_action_super_favorite_add
-                },
-            ),
-            onClick = actions.onToggleSuperFavorite,
-            // Amber icon mirrors the « active » cue in both surfaces.
-            iconTint = if (isSuperFavorite) FlagPalette.Favorite else variant,
-        ),
-        SheetActionItem(
             iconRes = CoreUiR.drawable.ic_ms_content_copy,
-            quickLabel = stringResource(R.string.flags_sheet_quick_copy),
-            fullLabel = stringResource(R.string.flags_sheet_action_copy),
+            label = stringResource(R.string.flags_sheet_action_copy),
             onClick = onCopyLink,
             iconTint = variant,
         ),
         SheetActionItem(
             iconRes = CoreUiR.drawable.ic_ms_open_in_new,
-            quickLabel = stringResource(R.string.flags_sheet_quick_browser),
-            fullLabel = stringResource(R.string.flags_sheet_action_browser),
+            label = stringResource(R.string.flags_sheet_action_browser),
             onClick = onOpenBrowser,
             iconTint = variant,
         ),
         SheetActionItem(
             iconRes = CoreUiR.drawable.ic_ms_delete,
-            quickLabel = stringResource(R.string.flags_sheet_quick_remove),
-            fullLabel = stringResource(R.string.flags_sheet_action_remove),
+            label = stringResource(R.string.flags_sheet_action_remove),
             onClick = actions.onRemove,
             iconTint = MaterialTheme.colorScheme.error,
             destructive = true,
@@ -195,8 +254,8 @@ private fun sheetActionItems(
 }
 
 /**
- * #676 (mockup F2) — the quick-access ROW of icon buttons at the top of the sheet (short labels). The
- * full-label [FlagActionsList] coexists at the bottom (retour XaTriX), both driven by [sheetActionItems].
+ * #676 v2 (mockup F2 v2) — the quick-access ROW of icon buttons at the top of the sheet ([quickActions]):
+ * the frequent primary actions, DISTINCT from the full-label [FlagActionsList] ([menuActions]) below.
  */
 @Composable
 private fun QuickActionsBar(items: List<SheetActionItem>) {
@@ -207,32 +266,38 @@ private fun QuickActionsBar(items: List<SheetActionItem>) {
         horizontalArrangement = Arrangement.spacedBy(2.dp),
         verticalAlignment = Alignment.Top,
     ) {
-        // Each button takes an equal share of the row (weight 1f) so the five fit edge-to-edge and never
+        // Each button takes an equal share of the row (weight 1f) so they fit edge-to-edge and never
         // clip on a narrow screen (~320dp), rather than a fixed width that could overflow.
         items.forEach { item ->
             QuickActionButton(
                 modifier = Modifier.weight(1f),
                 iconRes = item.iconRes,
-                label = item.quickLabel,
+                label = item.label,
                 onClick = item.onClick,
                 tint = item.iconTint,
+                enabled = item.enabled,
             )
         }
     }
 }
 
 @Composable
+@Suppress("LongParameterList") // small private button: icon + label + click + modifier + tint + enabled.
 private fun QuickActionButton(
     @DrawableRes iconRes: Int,
     label: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     tint: Color = MaterialTheme.colorScheme.onSurfaceVariant,
+    enabled: Boolean = true,
 ) {
+    // Disabled (#676 v2, « 1er non-lu » with nothing unread): dim the content and drop the click so the
+    // action reads as unavailable rather than a no-op.
+    val effectiveTint = if (enabled) tint else tint.copy(alpha = DISABLED_ALPHA)
     Column(
         modifier = modifier
             .clip(RoundedCornerShape(12.dp))
-            .clickable(role = Role.Button, onClick = onClick)
+            .clickable(enabled = enabled, role = Role.Button, onClick = onClick)
             .padding(horizontal = 2.dp, vertical = 8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(4.dp),
@@ -240,11 +305,11 @@ private fun QuickActionButton(
         // The icon carries no contentDescription: the visible [label] below is the button's accessible
         // name (TalkBack reads the whole clickable Column, announced as a button via role), so a separate
         // icon description would double-read.
-        RedfaceVectorIcon(resId = iconRes, contentDescription = null, tint = tint)
+        RedfaceVectorIcon(resId = iconRes, contentDescription = null, tint = effectiveTint)
         Text(
             text = label,
             style = MaterialTheme.typography.labelMedium,
-            color = tint,
+            color = effectiveTint,
             textAlign = TextAlign.Center,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,
@@ -253,10 +318,10 @@ private fun QuickActionButton(
 }
 
 /**
- * #676 (retour XaTriX) — the full-label vertical action list at the bottom of the sheet, coexisting with
- * the quick-access [QuickActionsBar] row above (the row = fast icons, the list = explicit labels). Driven
- * by the shared [sheetActionItems]; « Retirer » ([SheetActionItem.destructive]) is error-tinted and still
- * routed through the removal confirmation dialog.
+ * #676 v2 — the full-label vertical action list at the bottom of the sheet ([menuActions]): secondary,
+ * navigational and destructive actions, DISTINCT from the quick-access [QuickActionsBar] row above (the
+ * row = fast primary icons, the list = explicit secondary labels). « Retirer »
+ * ([SheetActionItem.destructive]) is error-tinted and still routed through the removal confirmation dialog.
  */
 @Composable
 private fun FlagActionsList(items: List<SheetActionItem>) {
@@ -264,7 +329,7 @@ private fun FlagActionsList(items: List<SheetActionItem>) {
         items.forEach { item ->
             FlagActionRow(
                 iconRes = item.iconRes,
-                label = item.fullLabel,
+                label = item.label,
                 onClick = item.onClick,
                 iconTint = item.iconTint,
                 labelColor = if (item.destructive) {
@@ -366,3 +431,17 @@ private fun openTopicInBrowser(context: Context, url: String, failureFeedback: S
     runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, url.toUri())) }
         .onFailure { Toast.makeText(context, failureFeedback, Toast.LENGTH_SHORT).show() }
 }
+
+/** #676 v2 — shares the topic [url] via the system share sheet; toasts [failureFeedback] if none. */
+private fun shareTopic(context: Context, url: String, title: String, failureFeedback: String) {
+    val send = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_SUBJECT, title)
+        putExtra(Intent.EXTRA_TEXT, url)
+    }
+    runCatching { context.startActivity(Intent.createChooser(send, title)) }
+        .onFailure { Toast.makeText(context, failureFeedback, Toast.LENGTH_SHORT).show() }
+}
+
+/** Dimming applied to a disabled quick action (#676 v2). */
+private const val DISABLED_ALPHA = 0.38f

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagSheetActions.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagSheetActions.kt
@@ -1,8 +1,15 @@
 package fr.forumhfr.redface2.feature.flags
 
-/** Callbacks of the long-press [FlagActionsSheet] (copy-link / open-in-browser are handled inside). */
+/**
+ * Callbacks of the long-press [FlagActionsSheet] (copy-link / open-in-browser / share are handled
+ * inside the sheet via the platform Context).
+ *
+ * #676 v2 — [onOpen] now carries the target page so the sheet can offer distinct navigation actions
+ * (resume at the last-read page, jump to the first unread page, open the last page) without leaking
+ * those UI variants into the parent: the parent only needs to know which page to navigate to.
+ */
 data class FlagSheetActions(
-    val onOpen: () -> Unit,
+    val onOpen: (page: Int) -> Unit,
     val onToggleSuperFavorite: () -> Unit,
     val onRemove: () -> Unit,
     val onDismiss: () -> Unit,

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -139,7 +139,7 @@ import kotlinx.coroutines.launch
 @Composable
 @Suppress("LongParameterList") // Screen route: 4 host nav callbacks + the quick-config trigger + the account slot.
 fun FlagsRoute(
-    onOpenFlag: (Flag) -> Unit,
+    onOpenFlag: (flag: Flag, page: Int) -> Unit,
     onLoginRequested: () -> Unit,
     onOpenCategory: (Int) -> Unit = {},
     // #6 — open a DT (MultiMP) conversation : the host pushes the existing PrivateMessageThread
@@ -427,7 +427,8 @@ fun FlagsRoute(
                                 // state just changed), cf. FlagsViewModel.onFlagOpened.
                                 onOpenFlag = { flag ->
                                     viewModel.onFlagOpened()
-                                    onOpenFlag(flag)
+                                    // Row tap resumes at the last-read page; the sheet picks other pages.
+                                    onOpenFlag(flag, flag.lastReadPage)
                                 },
                                 onRefresh = viewModel::refresh,
                                 onLoginRequested = onLoginRequested,
@@ -473,10 +474,10 @@ fun FlagsRoute(
     FlagActionsSheetHost(
         flag = sheetFlag,
         superFavoriteIds = superFavoriteIds,
-        onOpen = {
+        onOpen = { flag, page ->
             sheetFlag = null
             viewModel.onFlagOpened()
-            onOpenFlag(it)
+            onOpenFlag(flag, page)
         },
         onToggleSuperFavorite = viewModel::toggleSuperFavorite,
         onRemove = {
@@ -1855,7 +1856,7 @@ private fun ScrollableFlagsEmptyState(
 private fun FlagActionsSheetHost(
     flag: Flag?,
     superFavoriteIds: Set<Int>,
-    onOpen: (Flag) -> Unit,
+    onOpen: (flag: Flag, page: Int) -> Unit,
     onToggleSuperFavorite: (Flag) -> Unit,
     onRemove: (Flag) -> Unit,
     onDismiss: () -> Unit,
@@ -1866,7 +1867,8 @@ private fun FlagActionsSheetHost(
         categoryName = flagCategoryName(flag.cat),
         isSuperFavorite = flag.topicId in superFavoriteIds,
         actions = FlagSheetActions(
-            onOpen = { onOpen(flag) },
+            // #676 v2 — the sheet decides which page (resume / first-unread / last); the host just navigates.
+            onOpen = { page -> onOpen(flag, page) },
             onToggleSuperFavorite = { onToggleSuperFavorite(flag) },
             onRemove = { onRemove(flag) },
             onDismiss = onDismiss,

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -40,23 +40,21 @@
     <!-- #603 PR5 — bottom sheet d'appui-long sur un drapeau (métadonnées + actions + super-favori). -->
     <!-- Libellé a11y / long-press de la ligne : ouvre le sheet d'actions (remplace le « Retirer » direct). -->
     <string name="flags_row_actions_label">Actions du sujet</string>
-    <!-- #676 (mockup F2) — libellés COURTS de la rangée d'accès rapide (icône + label, en haut du sheet).
-         « Retirer » passe toujours par le dialog de confirmation de retrait. -->
+    <!-- #676 v2 (mockup F2 v2) — RANGÉE rapide (icône + label) : actions primaires fréquentes, DISTINCTES
+         de la liste verticale ci-dessous. « 1er non-lu » est grisé quand il n'y a rien de non-lu. -->
     <string name="flags_sheet_quick_open">Ouvrir</string>
+    <string name="flags_sheet_quick_first_unread">1er non-lu</string>
     <string name="flags_sheet_quick_super_favorite">Super favori</string>
-    <string name="flags_sheet_quick_copy">Copier</string>
-    <string name="flags_sheet_quick_browser">Navigateur</string>
-    <string name="flags_sheet_quick_remove">Retirer</string>
-    <!-- #676 (retour XaTriX) — libellés COMPLETS de la liste verticale d'actions (en bas du sheet ;
-         coexiste avec la rangée rapide ci-dessus). Le « super favori » bascule selon l'état. -->
-    <string name="flags_sheet_action_open">Ouvrir le sujet</string>
-    <string name="flags_sheet_action_super_favorite_add">Ajouter aux super favoris</string>
-    <string name="flags_sheet_action_super_favorite_remove">Retirer des super favoris</string>
+    <string name="flags_sheet_quick_share">Partager</string>
+    <!-- #676 v2 — LISTE verticale : actions secondaires / navigation / destructive, DISTINCTES de la
+         rangée rapide. « Retirer » passe toujours par le dialog de confirmation de retrait. -->
+    <string name="flags_sheet_action_last_page">Ouvrir à la dernière page</string>
     <string name="flags_sheet_action_copy">Copier le lien</string>
     <string name="flags_sheet_action_browser">Ouvrir dans le navigateur</string>
     <string name="flags_sheet_action_remove">Retirer le drapeau</string>
     <string name="flags_sheet_link_copied">Lien copié</string>
     <string name="flags_sheet_browser_failed">Aucune application pour ouvrir ce lien</string>
+    <string name="flags_sheet_share_failed">Aucune application pour partager ce lien</string>
     <!-- Bloc métadonnées (clés). -->
     <string name="flags_sheet_meta_category">Catégorie</string>
     <string name="flags_sheet_meta_author">Créé par</string>

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagSheetPagesTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagSheetPagesTest.kt
@@ -1,0 +1,46 @@
+package fr.forumhfr.redface2.feature.flags
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #676 v2 — pure page-target helpers of the long-press sheet's navigation actions (Ouvrir / 1er
+ * non-lu / Ouvrir à la dernière page). Covers the bounds Codex asked to lock.
+ */
+class FlagSheetPagesTest {
+
+    @Test
+    fun `last-read page is never below 1`() {
+        assertEquals(1, flagLastReadPage(0))
+        assertEquals(1, flagLastReadPage(-3))
+        assertEquals(7, flagLastReadPage(7))
+    }
+
+    @Test
+    fun `last page is never below 1`() {
+        assertEquals(1, flagLastPage(0))
+        assertEquals(35, flagLastPage(35))
+    }
+
+    @Test
+    fun `first unread is the page after the last-read one when there is unread`() {
+        assertEquals(35, flagFirstUnreadPage(lastReadPage = 34, totalPages = 35, hasUnread = true))
+    }
+
+    @Test
+    fun `first unread is clamped to the last page`() {
+        // lastReadPage == totalPages with unread: lastReadPage+1 must not exceed totalPages.
+        assertEquals(35, flagFirstUnreadPage(lastReadPage = 35, totalPages = 35, hasUnread = true))
+    }
+
+    @Test
+    fun `first unread falls back to the resume page when nothing is unread`() {
+        // The action is disabled in this case, but the computed page must still be the safe resume page.
+        assertEquals(20, flagFirstUnreadPage(lastReadPage = 20, totalPages = 35, hasUnread = false))
+    }
+
+    @Test
+    fun `first unread stays at least 1 on an empty topic`() {
+        assertEquals(1, flagFirstUnreadPage(lastReadPage = 0, totalPages = 0, hasUnread = true))
+    }
+}


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Refonte du sheet d'appui-long : les deux surfaces ne dupliquent plus les mêmes actions (le doublon jugé « débile »). D'après le mockup **F2 v2**, jeux **distincts et complémentaires** :

**Rangée rapide (primaire)** : Ouvrir (reprise page lue) · 1er non-lu (page lue + 1, **grisé si rien de non-lu**) · Super favori (toggle local) · Partager (ACTION_SEND)
**Liste (secondaire / navigation / destructif)** : Ouvrir à la dernière page · Copier le lien · Ouvrir dans le navigateur · Retirer le drapeau

### Non livré (volontaire)
« Lu » et « Marquer la catégorie comme lue » du mockup ne sont **pas** câblés : **aucun endpoint HFR** pour marquer un sujet/une catégorie lu sans l'ouvrir (le réel prime — pas de faux bouton). « Mettre en sourdine » = vraie feature, **chantier séparé**.

### Technique
- `FlagSheetActions.onOpen(page: Int)` : le sheet calcule reprise / 1er-non-lu / dernière page ; le parent ne fait que naviguer. L'ancre scroll (`lastPostReadId`) n'est posée que si on ouvre à la page lue.
- Helpers de page purs **extraits + testés** (bornage, clamp, fallback).
- Nouvelles icônes Material Symbols : share, last_page, arrow_downward.

### Vérification
- Build ✅ · `:feature:flags` tests (dont `FlagSheetPagesTest`) ✅ · `detektAll` + `lint` ✅
- **Cadré ET reviewé par Codex (gpt-5.5 xhigh)** : périmètre réaliste, logique de page + état désactivé sains.
- **Vérifié sur émulateur authentifié** : les 2 jeux distincts s'affichent, aucun doublon.

closes #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)