### PR TITLE
chore(release): dev 0.17.22 — top bar finitions + correctifs Drapeaux

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,35 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.22` — `internal` (dev) — 2026-06-28
+
+> Vue Drapeaux (#603) — finitions top bar + correctifs dogfood : **avatar du compte rond**, **ombre
+> moche au swipe supprimée**, **container gauche en 2 zones** (drapeau → menu, type + « +lus » → toggle
+> direct), **menu rapide restylé** (drapeaux trailing à droite, « Afficher les lus » retiré),
+> **recherche sans saut de hauteur**, **indicateur « +lus » configurable** œil/anneau (#661), et
+> **sheet d'appui-long v2** (rangée rapide ≠ liste, #676). versionName 0.17.21 → 0.17.22.
+
+**Drapeaux — vue (#603)**
+
+- **Container gauche — 2 zones (#603/#665)** : le sélecteur devient deux zones distinctes — le drapeau
+  de la section (drapal-icône coloré) ouvre le menu rapide ; le nom du type + l'indicateur « +lus »
+  bascule directement le « +lus » au tap (Cyan/DT). L'indicateur « +lus » vit dans la zone type.
+- **Menu rapide restylé (#603)** : libellé à gauche, drapeau coloré du type à droite (trailing) ;
+  l'entrée « Afficher les lus » disparaît (le toggle est désormais direct sur la zone type).
+- **Recherche — hauteur constante (#603)** : ouvrir la recherche ne décale plus le contenu (le champ
+  adopte la hauteur des containers).
+- **Avatar du compte rond** : le badge compte (PP) devient circulaire (M3) pour épouser son container ;
+  les avatars d'en-tête de posts gardent le carré arrondi.
+- **Ombre de swipe supprimée (#660)** : le cadre gris d'élévation parasite autour du panneau pendant le
+  balayage entre onglets est retiré (le geste reste signalé par le retour haptique + la transition).
+- **Indicateur « +lus » configurable (#661)** : choix œil (défaut) ou anneau coloré, dans les réglages
+  d'affichage Drapeaux.
+- **Sheet d'appui-long v2 (#676)** : la rangée rapide (Ouvrir · 1er non-lu · Super favori · Partager)
+  et la liste (Ouvrir à la dernière page · Copier le lien · Ouvrir dans le navigateur · Retirer) portent
+  désormais des actions distinctes (fini le doublon).
+
+---
+
 ## `0.17.21` — `internal` (dev) — 2026-06-28
 
 > Vue Drapeaux (#603) — **refonte de la top bar** (nouveau look : deux containers arrondis, loupe

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.21"
+        versionName = "0.17.22"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,6 +1,7 @@
-Redface 2 v0.17.21 — dev.
+Redface 2 v0.17.22 — dev.
 
 Flags view:
-- New top bar: two rounded containers, a retractable search loupe, the account avatar, and an "also-read" indicator.
-- Tab swipe now slides in from the correct side (#660).
-- Long-press sheet: the full action list is back alongside the quick-access row (#676).
+- Round account avatar; stray shadow during tab swipe removed.
+- Top bar: left container split into two zones (flag = menu, type = "+read" toggle), restyled quick menu (flags on the right), search no longer grows the bar.
+- "+read" indicator is now configurable: eye or coloured ring (#661).
+- Long-press: the quick row and the action list now carry distinct actions (#676).

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,6 +1,7 @@
-Redface 2 v0.17.21 — dev.
+Redface 2 v0.17.22 — dev.
 
 Vue Drapeaux :
-- Nouvelle barre du haut : deux containers arrondis, loupe rétractable, avatar, indicateur « +lus ».
-- Le swipe entre onglets glisse maintenant du bon côté (#660).
-- Sheet d'appui-long : liste d'actions complète + rangée d'accès rapide (#676).
+- Avatar du compte rond ; ombre parasite au swipe entre onglets supprimée.
+- Barre du haut : container gauche en 2 zones (drapeau = menu, type = bascule « +lus »), menu rapide restylé (drapeaux à droite), recherche sans saut de hauteur.
+- Indicateur « +lus » configurable : œil ou anneau (#661).
+- Appui long : rangée rapide et liste d'actions désormais distinctes (#676).


### PR DESCRIPTION
> Action par Claude Opus 4.8 (demandée par @XaaT)

Release dev **groupée** des corrections dogfood de la nuit (top bar + sheet) pour que XaTriX dogfoode tout d'un coup.

Inclus (déjà mergés sur `dev`) :
- **#661** indicateur « +lus » configurable œil/anneau (#711)
- ombre swipe supprimée + **avatar rond** + seuils swipe/geste (#712)
- **#676 v2** sheet : rangée rapide ≠ liste (#713)
- **container gauche 2 zones** + menu restylé + recherche sans saut (#715)

versionName 0.17.21 → 0.17.22. CHANGELOG + whatsnew (fr 415 / en 414 car.) à jour. Dispatch `--ref dev` après merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)