### PR TITLE
feat(flags): top-bar glyph style option — flag icon vs pastille dot (#603/#665)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -14,6 +14,7 @@ import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
+import fr.forumhfr.redface2.core.domain.preferences.FlagGlyphStyle
 import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
 import fr.forumhfr.redface2.core.domain.preferences.PlusLusIndicatorStyle
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
@@ -222,6 +223,15 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         persist {
             dataStore.edit { prefs ->
                 prefs[KEY_FLAGS_PLUS_LUS_INDICATOR_STYLE] = style.name
+            }
+        }
+    }
+
+    override suspend fun setFlagsGlyphStyle(style: FlagGlyphStyle) {
+        // #603/#665 — GLOBAL: a single key, no per-type variant. Persisted by name, read defensively.
+        persist {
+            dataStore.edit { prefs ->
+                prefs[KEY_FLAGS_GLYPH_STYLE] = style.name
             }
         }
     }
@@ -777,6 +787,8 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         val markerBorder = prefs[KEY_FLAGS_MARKER_BORDER] ?: false
         // #661 — GLOBAL « +lus » indicator style: resolved once (defensively), added to both return paths.
         val plusLusIndicatorStyle = readPlusLusIndicatorStyle(prefs)
+        // #603/#665 — GLOBAL left-container glyph style: resolved once (defensively), both return paths.
+        val flagGlyphStyle = readFlagGlyphStyle(prefs)
         if (prefs[KEY_FLAGS_PER_TAB_OVERRIDE] != true) {
             return FlagsViewSettings(
                 groupByCategory = globalGroup,
@@ -787,6 +799,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
                 categoryBandStyle = categoryBandStyle,
                 markerBorder = markerBorder,
                 plusLusIndicatorStyle = plusLusIndicatorStyle,
+                flagGlyphStyle = flagGlyphStyle,
             )
         }
         return FlagsViewSettings(
@@ -798,6 +811,7 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             categoryBandStyle = categoryBandStyle,
             markerBorder = markerBorder,
             plusLusIndicatorStyle = plusLusIndicatorStyle,
+            flagGlyphStyle = flagGlyphStyle,
         )
     }
 
@@ -830,6 +844,16 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         prefs[KEY_FLAGS_PLUS_LUS_INDICATOR_STYLE]
             ?.let { stored -> runCatching { PlusLusIndicatorStyle.valueOf(stored) }.getOrNull() }
             ?: PlusLusIndicatorStyle.Eye
+
+    /**
+     * Reads [KEY_FLAGS_GLYPH_STYLE] defensively (#603/#665): an unknown / corrupt stored value falls
+     * back to [FlagGlyphStyle.Flag] instead of crashing on `FlagGlyphStyle.valueOf` — same stance as
+     * [readMarkerStyle].
+     */
+    private fun readFlagGlyphStyle(prefs: Preferences): FlagGlyphStyle =
+        prefs[KEY_FLAGS_GLYPH_STYLE]
+            ?.let { stored -> runCatching { FlagGlyphStyle.valueOf(stored) }.getOrNull() }
+            ?: FlagGlyphStyle.Flag
 
     /**
      * Type-aware default for the #317 « non-lus uniquement » filter: CYAN (« Mes sujets ») shows the
@@ -866,6 +890,8 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         val KEY_FLAGS_MARKER_BORDER = booleanPreferencesKey("flags_marker_border")
         // #661 — GLOBAL « +lus » indicator style (PlusLusIndicatorStyle.name, defensively parsed).
         val KEY_FLAGS_PLUS_LUS_INDICATOR_STYLE = stringPreferencesKey("flags_plus_lus_indicator_style")
+        // #603/#665 — GLOBAL left-container glyph style (FlagGlyphStyle.name, defensively parsed).
+        val KEY_FLAGS_GLYPH_STYLE = stringPreferencesKey("flags_glyph_style")
         // #662 — « états vides humoristiques » opt-in (smiley empty state instead of the sober icon).
         val KEY_FLAGS_FUNNY_EMPTY_STATE = booleanPreferencesKey("flags_funny_empty_state")
         // #309 — per-tab display override. The master switch plus one nullable key per FlagType for

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -12,6 +12,7 @@ import fr.forumhfr.redface2.core.domain.preferences.AccentColor
 import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
 import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
+import fr.forumhfr.redface2.core.domain.preferences.FlagGlyphStyle
 import fr.forumhfr.redface2.core.domain.preferences.PlusLusIndicatorStyle
 import fr.forumhfr.redface2.core.domain.preferences.ProxyConfig
 import fr.forumhfr.redface2.core.domain.preferences.StartScreenBootstrapStore
@@ -479,6 +480,45 @@ class DataStoreUserPreferencesRepositoryTest {
 
             repository.observeFlagsViewSettings(FlagType.CYAN).test {
                 assertEquals(PlusLusIndicatorStyle.Eye, awaitItem().plusLusIndicatorStyle)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `flagGlyphStyle defaults to Flag on an empty store`() = runTest(dispatcher) {
+        repository.observeFlagsViewSettings(FlagType.CYAN).test {
+            assertEquals(FlagGlyphStyle.Flag, awaitItem().flagGlyphStyle)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setFlagsGlyphStyle persists and round-trips Dot then Flag for every tab`() =
+        runTest(dispatcher) {
+            // #603/#665 GLOBAL: written once, observed on any tab type.
+            repository.setFlagsGlyphStyle(FlagGlyphStyle.Dot)
+            repository.observeFlagsViewSettings(FlagType.RED).test {
+                assertEquals(FlagGlyphStyle.Dot, awaitItem().flagGlyphStyle)
+                cancelAndIgnoreRemainingEvents()
+            }
+            repository.setFlagsGlyphStyle(FlagGlyphStyle.Flag)
+            repository.observeFlagsViewSettings(FlagType.FAVORITE).test {
+                assertEquals(FlagGlyphStyle.Flag, awaitItem().flagGlyphStyle)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `corrupt flags_glyph_style value falls back to Flag instead of crashing`() =
+        runTest(dispatcher) {
+            // An unknown value from an older build / manual edit must not crash
+            // observeFlagsViewSettings on FlagGlyphStyle.valueOf — it degrades to Flag.
+            dataStore.edit { prefs ->
+                prefs[stringPreferencesKey("flags_glyph_style")] = "SQUARE"
+            }
+
+            repository.observeFlagsViewSettings(FlagType.CYAN).test {
+                assertEquals(FlagGlyphStyle.Flag, awaitItem().flagGlyphStyle)
                 cancelAndIgnoreRemainingEvents()
             }
         }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -8,6 +8,7 @@ import fr.forumhfr.redface2.core.database.dao.TopicDao
 import fr.forumhfr.redface2.core.database.entities.FetchMode
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
+import fr.forumhfr.redface2.core.domain.preferences.FlagGlyphStyle
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.AccentColor
@@ -544,6 +545,7 @@ class TopicRepositoryImplTest {
         override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
         override suspend fun setFlagsMarkerBorder(enabled: Boolean) = Unit
         override suspend fun setFlagsPlusLusIndicatorStyle(style: PlusLusIndicatorStyle) = Unit
+        override suspend fun setFlagsGlyphStyle(style: FlagGlyphStyle) = Unit
 
         // #286 — theme prefs are irrelevant to TopicRepositoryImpl; stubbed at their defaults.
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FlagGlyphStyle.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FlagGlyphStyle.kt
@@ -1,0 +1,17 @@
+package fr.forumhfr.redface2.core.domain.preferences
+
+/**
+ * Visual style of the active-type glyph in the Drapeaux top-bar left container (#603/#665). The glyph
+ * sits in the « flag zone » (the button that opens the quick menu); only its shape varies:
+ *
+ * - [Flag] — the section's coloured flag icon (the **default**: the « drapal » reprise, XaTriX).
+ * - [Dot] — a minimal coloured pastille (the legacy dot), for users who prefer the soberest cue.
+ *
+ * Pure domain enum (no Android / Compose), so it can be persisted in a preference and read by the top
+ * bar without dragging UI types into the model layer. GLOBAL (one value for every tab), like
+ * [MarkerStyle] / [PlusLusIndicatorStyle]; the colour is resolved at render time from the active type.
+ */
+enum class FlagGlyphStyle {
+    Flag,
+    Dot,
+}

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FlagsViewSettings.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FlagsViewSettings.kt
@@ -50,7 +50,7 @@ data class FlagsViewSettings(
     // resolution path.
     val plusLusIndicatorStyle: PlusLusIndicatorStyle = PlusLusIndicatorStyle.Eye,
     // #603/#665 — GLOBAL: shape of the active-type glyph in the top-bar left container (flag icon vs.
-    // pastille dot). Default FLAG. Not subject to the per-tab override (like [markerStyle]). Carried on
+    // pastille dot). Default Flag. Not subject to the per-tab override (like [markerStyle]). Carried on
     // every resolution path.
     val flagGlyphStyle: FlagGlyphStyle = FlagGlyphStyle.Flag,
 )

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FlagsViewSettings.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FlagsViewSettings.kt
@@ -49,4 +49,8 @@ data class FlagsViewSettings(
     // Default EYE. Not subject to the per-tab override (like [markerStyle]). Carried on every
     // resolution path.
     val plusLusIndicatorStyle: PlusLusIndicatorStyle = PlusLusIndicatorStyle.Eye,
+    // #603/#665 — GLOBAL: shape of the active-type glyph in the top-bar left container (flag icon vs.
+    // pastille dot). Default FLAG. Not subject to the per-tab override (like [markerStyle]). Carried on
+    // every resolution path.
+    val flagGlyphStyle: FlagGlyphStyle = FlagGlyphStyle.Flag,
 )

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -151,6 +151,15 @@ interface UserPreferencesRepository {
     suspend fun setFlagsPlusLusIndicatorStyle(style: PlusLusIndicatorStyle)
 
     /**
+     * Persists the GLOBAL Drapeaux left-container glyph style (#603/#665): the active-type cue in the
+     * top bar is the section's flag icon ([FlagGlyphStyle.Flag], default) or a pastille dot
+     * ([FlagGlyphStyle.Dot]). Like [setFlagsMarkerStyle] it is NOT subject to
+     * [observeFlagsPerTabOverride]; surfaced through [observeFlagsViewSettings]
+     * ([FlagsViewSettings.flagGlyphStyle]). Defaults to [FlagGlyphStyle.Flag] until the first call.
+     */
+    suspend fun setFlagsGlyphStyle(style: FlagGlyphStyle)
+
+    /**
      * App theme selection (#286): [ThemeMode.SYSTEM] (default) follows the OS dark-mode setting;
      * [ThemeMode.LIGHT] / [ThemeMode.DARK] force the app theme regardless of the OS. Observed at the
      * app root ([fr.forumhfr.redface2.navigation.RedfaceApp]) to compute the effective dark theme

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -12,6 +12,7 @@ import fr.forumhfr.redface2.core.domain.editor.EditorDraftKey
 import fr.forumhfr.redface2.core.domain.editor.EditorDraftStore
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
+import fr.forumhfr.redface2.core.domain.preferences.FlagGlyphStyle
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.AccentColor
@@ -1969,6 +1970,7 @@ class PostEditorViewModelTest {
         override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
         override suspend fun setFlagsMarkerBorder(enabled: Boolean) = Unit
         override suspend fun setFlagsPlusLusIndicatorStyle(style: PlusLusIndicatorStyle) = Unit
+        override suspend fun setFlagsGlyphStyle(style: FlagGlyphStyle) = Unit
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
         override suspend fun setThemeMode(mode: ThemeMode) = Unit
         override fun observeAmoledEnabled(): Flow<Boolean> = MutableStateFlow(false)

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -11,6 +11,7 @@ import fr.forumhfr.redface2.core.domain.editor.EditorDraftKey
 import fr.forumhfr.redface2.core.domain.editor.EditorDraftStore
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
+import fr.forumhfr.redface2.core.domain.preferences.FlagGlyphStyle
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.AccentColor
@@ -1369,6 +1370,7 @@ class TopicFormViewModelTest {
         override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
         override suspend fun setFlagsMarkerBorder(enabled: Boolean) = Unit
         override suspend fun setFlagsPlusLusIndicatorStyle(style: PlusLusIndicatorStyle) = Unit
+        override suspend fun setFlagsGlyphStyle(style: FlagGlyphStyle) = Unit
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
         override suspend fun setThemeMode(mode: ThemeMode) = Unit
         override fun observeAmoledEnabled(): Flow<Boolean> = MutableStateFlow(false)

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -85,6 +85,7 @@ import coil3.compose.AsyncImage
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
+import fr.forumhfr.redface2.core.domain.preferences.FlagGlyphStyle
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
 import fr.forumhfr.redface2.core.domain.preferences.PlusLusIndicatorStyle
@@ -363,6 +364,8 @@ fun FlagsRoute(
                         ),
                         // #661 — GLOBAL « +lus » cue shape (eye glyph vs. coloured flag ring).
                         plusLusIndicatorStyle = flagsViewSettings.plusLusIndicatorStyle,
+                        // #603/#665 — GLOBAL left-container glyph shape (flag icon vs. pastille dot).
+                        flagGlyphStyle = flagsViewSettings.flagGlyphStyle,
                     ),
                     onSelectTab = viewModel::selectTab,
                     onQueryChange = { searchQuery = it },
@@ -464,6 +467,7 @@ fun FlagsRoute(
                 onSingleLineTitleChange = viewModel::setFlagsSingleLineTitle,
                 onCategoryBandStyleChange = viewModel::setFlagsCategoryBandStyle,
                 onPlusLusIndicatorStyleChange = viewModel::setFlagsPlusLusIndicatorStyle,
+                onGlyphStyleChange = viewModel::setFlagsGlyphStyle,
                 onDismiss = { showViewSettingsSheet = false },
             ),
         )
@@ -700,6 +704,36 @@ private fun FlagsViewSettingsSheet(
                     ),
                     selected = settings.plusLusIndicatorStyle,
                     onSelected = actions.onPlusLusIndicatorStyleChange,
+                )
+            }
+
+            // #603/#665 — GLOBAL left-container glyph style selector (segmented). The shape of the
+            // active-type glyph in the top-bar flag zone: the section's coloured flag icon (default) or
+            // a minimal coloured pastille dot.
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = stringResource(R.string.flags_view_settings_glyph_title),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = stringResource(R.string.flags_view_settings_glyph_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                RedfaceSettingsChoiceGroup(
+                    options = listOf(
+                        RedfaceSettingsChoice(
+                            FlagGlyphStyle.Flag,
+                            stringResource(R.string.flags_view_settings_glyph_flag),
+                        ),
+                        RedfaceSettingsChoice(
+                            FlagGlyphStyle.Dot,
+                            stringResource(R.string.flags_view_settings_glyph_dot),
+                        ),
+                    ),
+                    selected = settings.flagGlyphStyle,
+                    onSelected = actions.onGlyphStyleChange,
                 )
             }
 
@@ -2333,6 +2367,7 @@ private data class FlagsViewSettingsActions(
     val onSingleLineTitleChange: (Boolean) -> Unit,
     val onCategoryBandStyleChange: (CategoryBandStyle) -> Unit,
     val onPlusLusIndicatorStyleChange: (PlusLusIndicatorStyle) -> Unit,
+    val onGlyphStyleChange: (FlagGlyphStyle) -> Unit,
     val onDismiss: () -> Unit,
 )
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTopBar.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTopBar.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.domain.preferences.FlagGlyphStyle
 import fr.forumhfr.redface2.core.domain.preferences.PlusLusIndicatorStyle
 import fr.forumhfr.redface2.core.ui.icon.RedfaceVectorIcon
 import fr.forumhfr.redface2.core.ui.R as CoreUiR
@@ -77,6 +78,12 @@ data class FlagsAppBarState(
      * of a filled disc). Only takes visual effect when [readFilterShowsRead] is `true`.
      */
     val plusLusIndicatorStyle: PlusLusIndicatorStyle = PlusLusIndicatorStyle.Eye,
+    /**
+     * #603/#665 — GLOBAL shape of the active-type glyph in the flag zone: [FlagGlyphStyle.Flag]
+     * (default, the section's coloured flag icon — the « drapal » reprise) or [FlagGlyphStyle.Dot]
+     * (a minimal coloured pastille). The colour comes from [currentTabColor] either way.
+     */
+    val flagGlyphStyle: FlagGlyphStyle = FlagGlyphStyle.Flag,
 )
 
 /**
@@ -190,6 +197,7 @@ private fun LeftContainer(
                 FlagGlyphZone(
                     color = state.currentTabColor,
                     enabled = hasPicker,
+                    glyphStyle = state.flagGlyphStyle,
                     fullTabName = flagFullTabName(state.currentTab),
                     onOpenMenu = { expanded = true },
                 )
@@ -214,14 +222,17 @@ private fun LeftContainer(
 }
 
 /**
- * Zone 1 — the section's flag glyph; a button that opens the quick menu. The glyph is the
- * Material flag icon tinted with the active type colour (the « drapal » reprise, XaTriX). When there
- * is no picker (anonymous) it is a static, non-interactive indicator.
+ * Zone 1 — the section's flag glyph; a button that opens the quick menu. The glyph is tinted with the
+ * active type colour and its shape follows [glyphStyle] (#603/#665): [FlagGlyphStyle.Flag] = the
+ * Material flag icon (default, the « drapal » reprise, XaTriX), [FlagGlyphStyle.Dot] = a minimal
+ * filled pastille (legacy dot). When there is no picker (anonymous) it is a static, non-interactive
+ * indicator.
  */
 @Composable
 private fun FlagGlyphZone(
     color: Color,
     enabled: Boolean,
+    glyphStyle: FlagGlyphStyle,
     fullTabName: String,
     onOpenMenu: () -> Unit,
 ) {
@@ -243,12 +254,21 @@ private fun FlagGlyphZone(
             .padding(horizontal = 12.dp),
         contentAlignment = Alignment.Center,
     ) {
-        RedfaceVectorIcon(
-            resId = CoreUiR.drawable.ic_ms_flag,
-            contentDescription = null,
-            tint = color,
-            size = 20.dp,
-        )
+        when (glyphStyle) {
+            FlagGlyphStyle.Flag -> RedfaceVectorIcon(
+                resId = CoreUiR.drawable.ic_ms_flag,
+                contentDescription = null,
+                tint = color,
+                size = 20.dp,
+            )
+
+            FlagGlyphStyle.Dot -> Box(
+                modifier = Modifier
+                    .size(14.dp)
+                    .clip(CircleShape)
+                    .background(color),
+            )
+        }
     }
 }
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -11,6 +11,7 @@ import fr.forumhfr.redface2.core.domain.forum.ForumResult
 import fr.forumhfr.redface2.core.domain.messages.MessagesRepository
 import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
 import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
+import fr.forumhfr.redface2.core.domain.preferences.FlagGlyphStyle
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
 import fr.forumhfr.redface2.core.domain.preferences.PlusLusIndicatorStyle
@@ -708,6 +709,11 @@ class FlagsViewModel @Inject constructor(
     /** Bottom-sheet write for the GLOBAL « +lus » indicator style (#661) — one value for every tab. */
     fun setFlagsPlusLusIndicatorStyle(style: PlusLusIndicatorStyle) {
         viewModelScope.launch { userPreferencesRepository.setFlagsPlusLusIndicatorStyle(style) }
+    }
+
+    /** Bottom-sheet write for the GLOBAL left-container glyph style (#603/#665) — one value for every tab. */
+    fun setFlagsGlyphStyle(style: FlagGlyphStyle) {
+        viewModelScope.launch { userPreferencesRepository.setFlagsGlyphStyle(style) }
     }
 
     fun refresh() {

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -177,6 +177,11 @@
     <string name="flags_view_settings_pluslus_description">Forme du repère affiché dans le sélecteur d\'onglet quand les sujets lus sont visibles. S\'applique à tous les onglets.</string>
     <string name="flags_view_settings_pluslus_eye">Œil</string>
     <string name="flags_view_settings_pluslus_ring">Anneau</string>
+    <!-- #603/#665 — Forme du repère de type actif dans le container gauche de la top bar : drapeau / pastille -->
+    <string name="flags_view_settings_glyph_title">Repère du type actif</string>
+    <string name="flags_view_settings_glyph_description">Forme du repère du type de drapeau dans la barre du haut : l\'icône drapeau colorée ou une pastille. S\'applique à tous les onglets.</string>
+    <string name="flags_view_settings_glyph_flag">Drapeau</string>
+    <string name="flags_view_settings_glyph_dot">Pastille</string>
     <!-- #603 — Style de la bande de catégorie (vue groupée) : sous-titre sobre / bloc tonal /
          accent latéral / pastille en puce. Réglage GLOBAL (tous onglets), sans effet en vue à plat. -->
     <string name="flags_view_settings_band_title">Bande de catégorie</string>

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -16,6 +16,7 @@ import fr.forumhfr.redface2.core.domain.messages.MessagesRepository
 import fr.forumhfr.redface2.core.domain.mpstorage.MpStorageRepository
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
+import fr.forumhfr.redface2.core.domain.preferences.FlagGlyphStyle
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.AccentColor
@@ -2390,6 +2391,7 @@ class FlagsViewModelTest {
         override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
         override suspend fun setFlagsMarkerBorder(enabled: Boolean) = Unit
         override suspend fun setFlagsPlusLusIndicatorStyle(style: PlusLusIndicatorStyle) = Unit
+        override suspend fun setFlagsGlyphStyle(style: FlagGlyphStyle) = Unit
 
         // #286 — theme prefs are irrelevant to FlagsViewModel; stubbed at their defaults.
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -4,6 +4,7 @@ import fr.forumhfr.redface2.core.domain.cache.ImageCacheMaintenance
 import fr.forumhfr.redface2.core.domain.cache.TopicCacheMaintenance
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
+import fr.forumhfr.redface2.core.domain.preferences.FlagGlyphStyle
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.AccentColor
@@ -2075,6 +2076,7 @@ class SettingsViewModelTest {
         override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
         override suspend fun setFlagsMarkerBorder(enabled: Boolean) = Unit
         override suspend fun setFlagsPlusLusIndicatorStyle(style: PlusLusIndicatorStyle) = Unit
+        override suspend fun setFlagsGlyphStyle(style: FlagGlyphStyle) = Unit
 
         fun emit(value: ProxyConfig) {
             config.value = value

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -8,6 +8,7 @@ import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.domain.error.HfrServerException
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
+import fr.forumhfr.redface2.core.domain.preferences.FlagGlyphStyle
 import fr.forumhfr.redface2.core.domain.preferences.FlagsViewSettings
 import fr.forumhfr.redface2.core.domain.preferences.FontScalePreference
 import fr.forumhfr.redface2.core.domain.preferences.AccentColor
@@ -2052,6 +2053,7 @@ private class FakeUserPreferencesRepository(
     override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
     override suspend fun setFlagsMarkerBorder(enabled: Boolean) = Unit
     override suspend fun setFlagsPlusLusIndicatorStyle(style: PlusLusIndicatorStyle) = Unit
+    override suspend fun setFlagsGlyphStyle(style: FlagGlyphStyle) = Unit
 
     override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
 


### PR DESCRIPTION
## Quoi

Ajoute une préférence GLOBALE `FlagGlyphStyle{Flag,Dot}` (défaut `Flag`) qui contrôle la forme du **glyphe du type actif** dans la zone drapeau du container gauche de la top bar Drapeaux :

- **Drapeau** (défaut) — l'icône drapeau colorée du type (la reprise du « drapal », demande XaTriX) ;
- **Pastille** — un point coloré minimal (repère hérité).

La couleur vient du type actif dans les deux cas. Réglable depuis **Réglages d'affichage → « Repère du type actif »**.

## Pourquoi

Le container gauche en 2 zones (#715) avait figé le glyphe sur l'icône drapeau ; XaTriX voulait une **option** pour retrouver la pastille. Demandé en dogfood sur 0.17.22.

## Comment

Plomberie strictement calquée sur `PlusLusIndicatorStyle` (#661) : enum domaine pur → champ `FlagsViewSettings` → setter `UserPreferencesRepository` → impl DataStore (clé + lecteur défensif `valueOf→Flag` sur les 2 branches de `resolveFlagsViewSettings`) → setter ViewModel → champ `FlagsAppBarState` + branche `when` dans `FlagGlyphZone` → câblage `FlagsRoute` + segment de sheet → strings FR → 6 fakes de test.

## Tests

- `compileKotlin`/`compileDebugKotlin` (3 modules) : ✅
- Tests unitaires (core:data, feature:flags/editor/settings/topic) : ✅ — dont DataStore défaut/round-trip/corrupt pour `FlagGlyphStyle`
- `detektAll` + `lintDebug` (feature:flags, core:data) : ✅
- **Vérif visuelle émulateur authentifié** : segment présent, bascule Pastille → top bar affiche la pastille immédiatement, round-trip Pastille→Drapeau OK.

## Review

> Action par Claude Opus 4.8 (demandée par @XaTriX). Gate Codex GPT-5.5 xhigh en cours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)