### PR TITLE
feat(flags): top-bar review pass — short names, avatar, settings on all tabs (#603/#665)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/account/RedfaceAccountMenu.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/account/RedfaceAccountMenu.kt
@@ -1,6 +1,5 @@
 package fr.forumhfr.redface2.core.ui.account
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -151,12 +150,13 @@ private fun AccountBadge(
         AuthState.Anonymous -> "?"
         is AuthState.Authenticated -> authState.pseudo.firstOrNull()?.uppercaseChar()?.toString().orEmpty()
     }
-    val containerColor = when (authState) {
-        is AuthState.Authenticated -> MaterialTheme.colorScheme.primaryContainer
-        else -> MaterialTheme.colorScheme.surfaceContainerHighest
-    }
+    // #603 (XaTriX) — the badge background now FOLLOWS the top-bar container (surfaceContainerHigh)
+    // instead of a distinct primaryContainer tint, so the round « PP » blends into the right
+    // container (« il devrait être du fond du container »). The authenticated identity stays legible
+    // through the primary-tinted initial; anonymous / loading keep the muted variant tone.
+    val containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
     val contentColor = when (authState) {
-        is AuthState.Authenticated -> MaterialTheme.colorScheme.onPrimaryContainer
+        is AuthState.Authenticated -> MaterialTheme.colorScheme.primary
         else -> MaterialTheme.colorScheme.onSurfaceVariant
     }
     val accessibilityLabel = stringResource(R.string.account_menu_open_description)
@@ -179,8 +179,9 @@ private fun AccountBadge(
         shape = CircleShape,
         color = containerColor,
         contentColor = contentColor,
-        // Subtle hairline so the badge reads as a distinct element against the app-bar surface.
-        border = BorderStroke(BADGE_BORDER_WIDTH, MaterialTheme.colorScheme.outlineVariant),
+        // #603 (XaTriX) — borderless: the M3 round avatar reads cleanly without the hairline, and the
+        // matching container background already seats it. (A « show avatar border » toggle is a noted
+        // follow-up, cf. #718.)
         modifier = Modifier
             .minimumInteractiveComponentSize()
             .size(BADGE_SIZE)
@@ -212,8 +213,8 @@ private fun AvatarBadge(
     Surface(
         onClick = onClick,
         shape = CircleShape,
-        // Subtle hairline so the avatar reads as a distinct element against the app-bar surface.
-        border = BorderStroke(BADGE_BORDER_WIDTH, MaterialTheme.colorScheme.outlineVariant),
+        // #603 (XaTriX) — borderless round avatar (see [AccountBadge]); the photo seats on the
+        // matching container background. (« show avatar border » toggle = follow-up #718.)
         modifier = Modifier
             .minimumInteractiveComponentSize()
             .size(BADGE_SIZE)
@@ -256,5 +257,4 @@ private fun AccountStatusHeader(authState: AuthState?) {
 // 48dp minimum without changing the painted badge — `Surface(onClick = ...)` does NOT
 // inject that minimum on its own (cf. M3 docs, Codex rereview on PR #207).
 private val BADGE_SIZE = 40.dp
-private val BADGE_BORDER_WIDTH = 1.dp
 private val HEADER_PADDING = PaddingValues(horizontal = 16.dp, vertical = 8.dp)

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.IconButton
@@ -784,6 +785,30 @@ private fun FlagsViewSettingsSheet(
                     enabled = settings.groupByCategory,
                 )
             }
+
+            // #603/#718 (XaTriX) — greyed placeholders for upcoming account-avatar options. Disabled on
+            // purpose (« ajoute des options grisées ») so the planned work is visible; the real toggles
+            // land with #718. No-op callbacks — these never flip while disabled.
+            HorizontalDivider()
+            Text(
+                text = stringResource(R.string.flags_view_settings_avatar_section),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            ViewSettingsSwitchRow(
+                title = stringResource(R.string.flags_view_settings_avatar_border_title),
+                description = stringResource(R.string.flags_view_settings_avatar_border_description),
+                checked = false,
+                enabled = false,
+                onCheckedChange = {},
+            )
+            ViewSettingsSwitchRow(
+                title = stringResource(R.string.flags_view_settings_avatar_transparent_title),
+                description = stringResource(R.string.flags_view_settings_avatar_transparent_description),
+                checked = false,
+                enabled = false,
+                onCheckedChange = {},
+            )
 
             TextButton(
                 // Animate the sheet out (M3 stable pattern) before removing it from composition,

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTopBar.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTopBar.kt
@@ -102,6 +102,11 @@ internal fun flagsReadFilterShowsRead(
 }
 
 private val ContainerShape = RoundedCornerShape(22.dp)
+// #603 — split-pill clips for the left container's two tap zones so each ripple hugs the matching
+// pill end and the two meet on a clean straight seam (XaTriX: « au tap ce n'est pas propre »). A full
+// ContainerShape clip per zone made the ripple a rounded rectangle floating inside the pill.
+private val LeftZoneShape = RoundedCornerShape(topStart = 22.dp, bottomStart = 22.dp)
+private val RightZoneShape = RoundedCornerShape(topEnd = 22.dp, bottomEnd = 22.dp)
 // #603/#665 — shared height of every top-bar container AND the expanded search field, so entering
 // search never changes the bar height (no content shift underneath, XaTriX dogfood).
 private val ContainerHeight = 44.dp
@@ -242,7 +247,7 @@ private fun FlagGlyphZone(
         modifier = Modifier
             .fillMaxHeight()
             .widthIn(min = 48.dp)
-            .clip(ContainerShape)
+            .clip(LeftZoneShape)
             .then(
                 if (enabled) {
                     Modifier.clickable(role = Role.Button, onClickLabel = openMenuLabel, onClick = onOpenMenu)
@@ -297,7 +302,7 @@ private fun TypePlusLusZone(
     Row(
         modifier = Modifier
             .fillMaxHeight()
-            .clip(ContainerShape)
+            .clip(RightZoneShape)
             .then(
                 if (togglable) {
                     Modifier.clickable(role = Role.Button, onClickLabel = toggleLabel, onClick = onToggle)
@@ -383,16 +388,17 @@ private fun TabPickerDropdown(
                 },
             )
         }
-        if (state.searchEnabled) {
-            HorizontalDivider()
-            DropdownMenuItem(
-                text = { Text(stringResource(R.string.flags_appbar_menu_display_settings)) },
-                onClick = {
-                    onDismiss()
-                    onOpenViewSettings()
-                },
-            )
-        }
+        // #603 (XaTriX) — « Réglages d'affichage » disponible sur TOUS les onglets : le picker
+        // n'existe que pour un compte authentifié, et les réglages sont GLOBAUX, donc pertinents même
+        // sur DT / Super (qui n'ont pas la loupe). Décorrélé de `searchEnabled` (la recherche).
+        HorizontalDivider()
+        DropdownMenuItem(
+            text = { Text(stringResource(R.string.flags_appbar_menu_display_settings)) },
+            onClick = {
+                onDismiss()
+                onOpenViewSettings()
+            },
+        )
     }
 }
 
@@ -474,15 +480,15 @@ private fun ExpandedSearchContainer(
     }
 }
 
-/** Short tab name for the compact left container (« Mes sujets » → « Mes », « Favoris » → « Fav »). */
+/** Short tab name for the compact left container (XaTriX : Cyan / Lurk / Fav / DT / Super). */
 @Composable
 private fun flagShortTabName(tab: FlagTab): String = stringResource(
     when (tab) {
         FlagTab.Cyan -> R.string.flags_tab_my_topics_short
-        FlagTab.Red -> R.string.flags_tab_read_only
+        FlagTab.Red -> R.string.flags_tab_read_only_short
         FlagTab.Favorite -> R.string.flags_tab_favorite_short
-        FlagTab.Dt -> R.string.flags_tab_dt
-        FlagTab.Super -> R.string.flags_tab_super
+        FlagTab.Dt -> R.string.flags_tab_dt_short
+        FlagTab.Super -> R.string.flags_tab_super_short
     },
 )
 

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -4,11 +4,14 @@
     <string name="flags_login_cta">Se connecter à HFR</string>
 
     <string name="flags_tab_my_topics">Mes sujets</string>
-    <!-- #603/#665 — noms courts pour le container compact de la top bar. -->
-    <string name="flags_tab_my_topics_short">Mes</string>
+    <!-- #603/#665 — noms courts pour le container compact de la top bar (XaTriX : Cyan/Lurk/Fav/DT/Super). -->
+    <string name="flags_tab_my_topics_short">Cyan</string>
     <string name="flags_tab_read_only">Lu</string>
+    <string name="flags_tab_read_only_short">Lurk</string>
     <string name="flags_tab_favorite">Favoris</string>
     <string name="flags_tab_favorite_short">Fav</string>
+    <string name="flags_tab_dt_short">DT</string>
+    <string name="flags_tab_super_short">Super</string>
     <!-- Libellé du TYPE de drapeau RED, distinct du libellé d'onglet (« Lu », raccourci pour
          tenir sur le tab row). Utilisé hors tab row, ex. dans le dialog de confirmation de
          retrait (#99) où la place n'est pas contrainte et où « Lu » seul serait ambigu. -->
@@ -182,6 +185,12 @@
     <string name="flags_view_settings_glyph_description">Forme du repère du type de drapeau dans la barre du haut : l\'icône drapeau colorée ou une pastille. S\'applique à tous les onglets.</string>
     <string name="flags_view_settings_glyph_flag">Drapeau</string>
     <string name="flags_view_settings_glyph_dot">Pastille</string>
+    <!-- #718 — options avatar du compte (placeholders grisés, à venir) -->
+    <string name="flags_view_settings_avatar_section">Avatar du compte · à venir</string>
+    <string name="flags_view_settings_avatar_border_title">Bordure de l\'avatar</string>
+    <string name="flags_view_settings_avatar_border_description">Afficher un liseré autour de l\'avatar. Bientôt configurable (#718).</string>
+    <string name="flags_view_settings_avatar_transparent_title">Fond transparent</string>
+    <string name="flags_view_settings_avatar_transparent_description">Fond de l\'avatar transparent au lieu du fond du container. Bientôt configurable (#718).</string>
     <!-- #603 — Style de la bande de catégorie (vue groupée) : sous-titre sobre / bloc tonal /
          accent latéral / pastille en puce. Réglage GLOBAL (tous onglets), sans effet en vue à plat. -->
     <string name="flags_view_settings_band_title">Bande de catégorie</string>


### PR DESCRIPTION
Passe de retours dogfood XaTriX sur la top bar Drapeaux (0.17.22).

## Changements
- **Noms courts** : Cyan / Lurk / Fav / DT / Super.
- **Avatar du compte** : le fond suit le container (`surfaceContainerHigh`), **bordure retirée** → PP rond qui épouse le container ; identité via l'initiale teintée `primary`. Toggle bordure / fond transparent = suivi **#718** (placeholders **grisés** ajoutés dans le sheet, à la demande).
- **« Réglages d'affichage » sur tous les onglets authentifiés** (dont DT / Super, sans loupe) : découplé de `searchEnabled` (le picker n'existe que pour un compte connecté, et les réglages sont globaux).
- **Tap des 2 zones du container gauche** : demi-pilules (`LeftZoneShape`/`RightZoneShape`) → le ripple épouse le bon bout de la pilule, plus de rectangle arrondi flottant (« au tap ce n'est pas propre »).

## Tests
- compile + tests unitaires (core:ui, feature:flags) ✅
- detektAll + lintDebug ✅
- **Émulateur authentifié** : noms courts, avatar (fond container, sans bordure, centré), Réglages d'affichage présent sur Super, options grisées rendues, tous vérifiés.

## Review
> Action par Claude Opus 4.8 (demandée par @XaTriX). Gate Codex GPT-5.5 xhigh en cours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)