### PR TITLE
chore(release): dev 0.17.23 — top bar review pass + glyph option (#603)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,29 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.23` — `internal` (dev) — 2026-06-28
+
+> Vue Drapeaux (#603) — passe de review top bar dogfood : **noms d'onglets courts** (Cyan/Lurk/Fav/DT/
+> Super), **option drapeau/pastille** du glyphe de type (#717), **avatar du compte** qui épouse le
+> container (fond du container, **sans bordure**), **« Réglages d'affichage » disponible sur tous les
+> onglets** (dont DT/Super), et **tap propre** des deux zones du container gauche. versionName
+> 0.17.22 → 0.17.23.
+
+**Drapeaux — vue (#603)**
+
+- **Option drapeau / pastille (#603/#665, #717)** : nouveau réglage « Repère du type actif » — le glyphe
+  du type dans la barre du haut est l'icône drapeau colorée (défaut) ou une pastille colorée.
+- **Noms d'onglets courts** : le container gauche affiche Cyan / Lurk / Fav / DT / Super.
+- **Avatar du compte** : le fond suit le container (`surfaceContainerHigh`) et la bordure est retirée —
+  le PP rond s'intègre proprement ; l'identité reste lisible via l'initiale teintée. Options bordure /
+  fond transparent à venir (#718, placeholders grisés dans le sheet).
+- **« Réglages d'affichage » sur tous les onglets** : l'entrée est désormais disponible sur DT et Super
+  (qui n'ont pas la loupe) — les réglages sont globaux et le menu n'existe que pour un compte connecté.
+- **Tap propre du container gauche** : chaque zone (drapeau / type) épouse son extrémité de pilule au
+  tap (demi-pilules), fini le rectangle arrondi flottant.
+
+---
+
 ## `0.17.22` — `internal` (dev) — 2026-06-28
 
 > Vue Drapeaux (#603) — finitions top bar + correctifs dogfood : **avatar du compte rond**, **ombre

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.22"
+        versionName = "0.17.23"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,7 +1,8 @@
-Redface 2 v0.17.22 — dev.
+Redface 2 v0.17.23 — dev.
 
-Flags view:
-- Round account avatar; stray shadow during tab swipe removed.
-- Top bar: left container split into two zones (flag = menu, type = "+read" toggle), restyled quick menu (flags on the right), search no longer grows the bar.
-- "+read" indicator is now configurable: eye or coloured ring (#661).
-- Long-press: the quick row and the action list now carry distinct actions (#676).
+Flags view (top bar pass):
+- Short tab names: Cyan, Lurk, Fav, DT, Super.
+- New "Active type marker" setting: flag icon or dot (#717).
+- Account avatar: container background, borderless; more options coming (#718).
+- "Display settings" is now available on every tab (incl. DT/Super).
+- Cleaner tap on the left container's two zones.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,7 +1,8 @@
-Redface 2 v0.17.22 — dev.
+Redface 2 v0.17.23 — dev.
 
-Vue Drapeaux :
-- Avatar du compte rond ; ombre parasite au swipe entre onglets supprimée.
-- Barre du haut : container gauche en 2 zones (drapeau = menu, type = bascule « +lus »), menu rapide restylé (drapeaux à droite), recherche sans saut de hauteur.
-- Indicateur « +lus » configurable : œil ou anneau (#661).
-- Appui long : rangée rapide et liste d'actions désormais distinctes (#676).
+Vue Drapeaux (passe top bar) :
+- Noms d'onglets courts : Cyan, Lurk, Fav, DT, Super.
+- Nouveau réglage « Repère du type actif » : icône drapeau ou pastille (#717).
+- Avatar du compte : fond du container, sans bordure ; options à venir (#718).
+- « Réglages d'affichage » désormais disponible sur tous les onglets (dont DT/Super).
+- Tap plus propre des deux zones du container gauche.


### PR DESCRIPTION
Release dev groupant #717 + #719.

- **#717** — option « Repère du type actif » : drapeau (défaut) / pastille.
- **#719** — passe de review top bar : noms courts (Cyan/Lurk/Fav/DT/Super), avatar (fond container, sans bordure), « Réglages d'affichage » sur tous les onglets, tap propre des 2 zones.

versionName 0.17.22 → 0.17.23. CHANGELOG + whatsnew (fr/en) à jour, gardes vertes.

> Action par Claude Opus 4.8 (demandée par @XaTriX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)