### PR TITLE
feat(flags): « +lus » cue as a ring around the active glyph (#661/#603)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -836,14 +836,14 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             ?: CategoryBandStyle.MINIMAL
 
     /**
-     * Reads [KEY_FLAGS_PLUS_LUS_INDICATOR_STYLE] defensively (#661): an unknown / corrupt stored value
-     * falls back to [PlusLusIndicatorStyle.Eye] instead of crashing on `PlusLusIndicatorStyle.valueOf`
-     * — same stance as [readMarkerStyle].
+     * Reads [KEY_FLAGS_PLUS_LUS_INDICATOR_STYLE] defensively (#661/#603): an unknown / corrupt stored
+     * value falls back to [PlusLusIndicatorStyle.Ring] (the default) instead of crashing on
+     * `PlusLusIndicatorStyle.valueOf` — same stance as [readMarkerStyle].
      */
     private fun readPlusLusIndicatorStyle(prefs: Preferences): PlusLusIndicatorStyle =
         prefs[KEY_FLAGS_PLUS_LUS_INDICATOR_STYLE]
             ?.let { stored -> runCatching { PlusLusIndicatorStyle.valueOf(stored) }.getOrNull() }
-            ?: PlusLusIndicatorStyle.Eye
+            ?: PlusLusIndicatorStyle.Ring
 
     /**
      * Reads [KEY_FLAGS_GLYPH_STYLE] defensively (#603/#665): an unknown / corrupt stored value falls

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -446,9 +446,9 @@ class DataStoreUserPreferencesRepositoryTest {
     }
 
     @Test
-    fun `plusLusIndicatorStyle defaults to Eye on an empty store`() = runTest(dispatcher) {
+    fun `plusLusIndicatorStyle defaults to Ring on an empty store`() = runTest(dispatcher) {
         repository.observeFlagsViewSettings(FlagType.CYAN).test {
-            assertEquals(PlusLusIndicatorStyle.Eye, awaitItem().plusLusIndicatorStyle)
+            assertEquals(PlusLusIndicatorStyle.Ring, awaitItem().plusLusIndicatorStyle)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -470,16 +470,16 @@ class DataStoreUserPreferencesRepositoryTest {
         }
 
     @Test
-    fun `corrupt flags_plus_lus_indicator_style value falls back to Eye instead of crashing`() =
+    fun `corrupt flags_plus_lus_indicator_style value falls back to Ring instead of crashing`() =
         runTest(dispatcher) {
             // An unknown value from an older build / manual edit must not crash
-            // observeFlagsViewSettings on PlusLusIndicatorStyle.valueOf — it degrades to Eye.
+            // observeFlagsViewSettings on PlusLusIndicatorStyle.valueOf — it degrades to Ring (default).
             dataStore.edit { prefs ->
                 prefs[stringPreferencesKey("flags_plus_lus_indicator_style")] = "STAR"
             }
 
             repository.observeFlagsViewSettings(FlagType.CYAN).test {
-                assertEquals(PlusLusIndicatorStyle.Eye, awaitItem().plusLusIndicatorStyle)
+                assertEquals(PlusLusIndicatorStyle.Ring, awaitItem().plusLusIndicatorStyle)
                 cancelAndIgnoreRemainingEvents()
             }
         }

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FlagsViewSettings.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/FlagsViewSettings.kt
@@ -45,10 +45,10 @@ data class FlagsViewSettings(
     // (#FFB300) reads cleanly on a light background. Default false (no border). Not subject to the
     // per-tab override (like [markerStyle]). Carried on every resolution path.
     val markerBorder: Boolean = false,
-    // #661 — GLOBAL: shape of the « +lus » cue in the top-bar tab picker (eye glyph vs. coloured ring).
-    // Default EYE. Not subject to the per-tab override (like [markerStyle]). Carried on every
-    // resolution path.
-    val plusLusIndicatorStyle: PlusLusIndicatorStyle = PlusLusIndicatorStyle.Eye,
+    // #661 — GLOBAL: shape of the « +lus » cue (ring around the active glyph vs. eye capsule by the
+    // name). Default RING (#603/A, XaTriX: the cue lives ON the flag glyph). Not subject to the per-tab
+    // override (like [markerStyle]). Carried on every resolution path.
+    val plusLusIndicatorStyle: PlusLusIndicatorStyle = PlusLusIndicatorStyle.Ring,
     // #603/#665 — GLOBAL: shape of the active-type glyph in the top-bar left container (flag icon vs.
     // pastille dot). Default Flag. Not subject to the per-tab override (like [markerStyle]). Carried on
     // every resolution path.

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/PlusLusIndicatorStyle.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/PlusLusIndicatorStyle.kt
@@ -1,14 +1,14 @@
 package fr.forumhfr.redface2.core.domain.preferences
 
 /**
- * Visual style of the « +lus » cue in the Drapeaux top-bar tab picker (#661, ADR-017). When the
- * active tab (Cyan / DT) is showing read items, the left container signals it; only the SHAPE of the
- * cue varies:
+ * Visual style of the « +lus » cue in the Drapeaux top-bar left container (#661/#603, ADR-017). When
+ * the active tab (Cyan / DT) is showing read items, the container signals it; only WHERE and the SHAPE
+ * of the cue varies:
  *
- * - [Eye] — an eye glyph in a tinted capsule next to the tab name (the **default**: the most
- *   explicit, self-describing on first use).
- * - [Ring] — the section's flag dot is drawn as a hollow coloured ring instead of a filled disc
- *   (the soberest option: no extra glyph, the « drapal » itself carries the state).
+ * - [Ring] — a coloured ring is drawn AROUND the active-type glyph in zone 1 (the **default**, #603/A
+ *   chosen by XaTriX: the cue lives on the flag/dot itself, reprise of the original « anneau » idea).
+ * - [Eye] — an eye glyph in a tinted capsule next to the type name in zone 2 (the legacy, most
+ *   explicit option).
  *
  * Pure domain enum (no Android / Compose), so it can be persisted in a preference and read by the
  * top bar without dragging UI types into the model layer. GLOBAL (one value for every tab), like

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -141,12 +141,12 @@ interface UserPreferencesRepository {
     suspend fun setFlagsMarkerBorder(enabled: Boolean)
 
     /**
-     * Persists the GLOBAL « +lus » indicator style (#661): the shape of the read-items cue in the
-     * Drapeaux top-bar tab picker — [PlusLusIndicatorStyle.Eye] (default, an eye glyph) or
-     * [PlusLusIndicatorStyle.Ring] (the flag dot drawn as a coloured ring). Like
-     * [setFlagsMarkerStyle] it is NOT subject to [observeFlagsPerTabOverride]; surfaced through
-     * [observeFlagsViewSettings] ([FlagsViewSettings.plusLusIndicatorStyle]). Defaults to
-     * [PlusLusIndicatorStyle.Eye] until the first call.
+     * Persists the GLOBAL « +lus » indicator style (#661/#603): the shape and place of the read-items
+     * cue in the Drapeaux top bar — [PlusLusIndicatorStyle.Ring] (default, a coloured ring around the
+     * active-type glyph in zone 1) or [PlusLusIndicatorStyle.Eye] (legacy, an eye capsule by the type
+     * name in zone 2). Like [setFlagsMarkerStyle] it is NOT subject to [observeFlagsPerTabOverride];
+     * surfaced through [observeFlagsViewSettings] ([FlagsViewSettings.plusLusIndicatorStyle]). Defaults
+     * to [PlusLusIndicatorStyle.Ring] until the first call.
      */
     suspend fun setFlagsPlusLusIndicatorStyle(style: PlusLusIndicatorStyle)
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -695,12 +695,12 @@ private fun FlagsViewSettingsSheet(
                 RedfaceSettingsChoiceGroup(
                     options = listOf(
                         RedfaceSettingsChoice(
-                            PlusLusIndicatorStyle.Eye,
-                            stringResource(R.string.flags_view_settings_pluslus_eye),
-                        ),
-                        RedfaceSettingsChoice(
                             PlusLusIndicatorStyle.Ring,
                             stringResource(R.string.flags_view_settings_pluslus_ring),
+                        ),
+                        RedfaceSettingsChoice(
+                            PlusLusIndicatorStyle.Eye,
+                            stringResource(R.string.flags_view_settings_pluslus_eye),
                         ),
                     ),
                     selected = settings.plusLusIndicatorStyle,

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTopBar.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTopBar.kt
@@ -73,11 +73,11 @@ data class FlagsAppBarState(
      */
     val readFilterShowsRead: Boolean?,
     /**
-     * #661 — GLOBAL shape of the « +lus » cue: [PlusLusIndicatorStyle.Eye] (default, an eye glyph
-     * capsule) or [PlusLusIndicatorStyle.Ring] (the flag dot drawn as a hollow coloured ring instead
-     * of a filled disc). Only takes visual effect when [readFilterShowsRead] is `true`.
+     * #661/#603 — GLOBAL shape of the « +lus » cue: [PlusLusIndicatorStyle.Ring] (default — a coloured
+     * ring around the zone-1 glyph) or [PlusLusIndicatorStyle.Eye] (legacy — an eye capsule by the type
+     * name in zone 2). Only takes visual effect when [readFilterShowsRead] is `true`.
      */
-    val plusLusIndicatorStyle: PlusLusIndicatorStyle = PlusLusIndicatorStyle.Eye,
+    val plusLusIndicatorStyle: PlusLusIndicatorStyle = PlusLusIndicatorStyle.Ring,
     /**
      * #603/#665 — GLOBAL shape of the active-type glyph in the flag zone: [FlagGlyphStyle.Flag]
      * (default, the section's coloured flag icon — the « drapal » reprise) or [FlagGlyphStyle.Dot]
@@ -111,6 +111,9 @@ private val RightZoneShape = RoundedCornerShape(topEnd = 22.dp, bottomEnd = 22.d
 // search never changes the bar height (no content shift underneath, XaTriX dogfood).
 private val ContainerHeight = 44.dp
 private const val INDICATOR_BG_ALPHA = 0.18f
+// #661/A — diameter of the « +lus » ring drawn around the zone-1 glyph (20.dp flag / 14.dp dot). 30.dp
+// leaves breathing room (Codex: < 30.dp reads too tight around a 20.dp icon).
+private val GLYPH_RING_SIZE = 30.dp
 
 /**
  * Drapeaux top bar (#603 / #665 / #661, ADR-017) — two rounded « containers » floating over a
@@ -203,6 +206,11 @@ private fun LeftContainer(
                     color = state.currentTabColor,
                     enabled = hasPicker,
                     glyphStyle = state.flagGlyphStyle,
+                    // #661/A — when « +lus » is active and the Ring style is selected, the cue is a ring
+                    // AROUND this glyph (reprise of the original « anneau » idea, XaTriX). The Eye style
+                    // keeps its cue in the type zone instead.
+                    plusLusActive = state.readFilterShowsRead == true,
+                    indicatorStyle = state.plusLusIndicatorStyle,
                     fullTabName = flagFullTabName(state.currentTab),
                     onOpenMenu = { expanded = true },
                 )
@@ -232,17 +240,25 @@ private fun LeftContainer(
  * Material flag icon (default, the « drapal » reprise, XaTriX), [FlagGlyphStyle.Dot] = a minimal
  * filled pastille (legacy dot). When there is no picker (anonymous) it is a static, non-interactive
  * indicator.
+ *
+ * #661/A — when [plusLusActive] and [indicatorStyle] is [PlusLusIndicatorStyle.Ring] (the default),
+ * the glyph is wrapped in a coloured ring to signal « +lus » (the chosen design: the cue lives ON the
+ * glyph, not in the type zone). Works for both the flag and the dot. The Eye style draws nothing here.
  */
 @Composable
+@Suppress("LongParameterList") // Cohesive zone-1 rendering: glyph colour/style + the +lus ring state + a11y + click.
 private fun FlagGlyphZone(
     color: Color,
     enabled: Boolean,
     glyphStyle: FlagGlyphStyle,
+    plusLusActive: Boolean,
+    indicatorStyle: PlusLusIndicatorStyle,
     fullTabName: String,
     onOpenMenu: () -> Unit,
 ) {
     val openMenuLabel = stringResource(R.string.flags_appbar_open_menu)
     val description = stringResource(R.string.flags_appbar_current_tab, fullTabName)
+    val ringed = plusLusActive && indicatorStyle == PlusLusIndicatorStyle.Ring
     Box(
         modifier = Modifier
             .fillMaxHeight()
@@ -259,20 +275,29 @@ private fun FlagGlyphZone(
             .padding(horizontal = 12.dp),
         contentAlignment = Alignment.Center,
     ) {
-        when (glyphStyle) {
-            FlagGlyphStyle.Flag -> RedfaceVectorIcon(
-                resId = CoreUiR.drawable.ic_ms_flag,
-                contentDescription = null,
-                tint = color,
-                size = 20.dp,
-            )
+        Box(
+            modifier = if (ringed) {
+                Modifier.size(GLYPH_RING_SIZE).border(width = 2.dp, color = color, shape = CircleShape)
+            } else {
+                Modifier
+            },
+            contentAlignment = Alignment.Center,
+        ) {
+            when (glyphStyle) {
+                FlagGlyphStyle.Flag -> RedfaceVectorIcon(
+                    resId = CoreUiR.drawable.ic_ms_flag,
+                    contentDescription = null,
+                    tint = color,
+                    size = 20.dp,
+                )
 
-            FlagGlyphStyle.Dot -> Box(
-                modifier = Modifier
-                    .size(14.dp)
-                    .clip(CircleShape)
-                    .background(color),
-            )
+                FlagGlyphStyle.Dot -> Box(
+                    modifier = Modifier
+                        .size(14.dp)
+                        .clip(CircleShape)
+                        .background(color),
+                )
+            }
         }
     }
 }
@@ -322,39 +347,33 @@ private fun TypePlusLusZone(
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
-        if (showsRead == true) {
-            PlusLusIndicator(color = color, style = indicatorStyle)
+        // #661/A — the Eye style keeps its cue HERE (capsule, right of the name); the Ring style draws
+        // its cue around the glyph in zone 1 instead (no double marker, Codex).
+        if (showsRead == true && indicatorStyle == PlusLusIndicatorStyle.Eye) {
+            EyeChip(color = color)
         }
     }
 }
 
 /**
- * #661 — the « +lus » active cue, in zone 2 (Codex: the indicator lives here, not on the flag glyph):
- * [PlusLusIndicatorStyle.Eye] = an eye glyph in a tinted capsule (default), [PlusLusIndicatorStyle.Ring]
- * = a small hollow coloured ring.
+ * #661 — the « +lus » eye cue for the [PlusLusIndicatorStyle.Eye] (legacy) style: an eye glyph in a
+ * tinted capsule, right of the type name. The default [PlusLusIndicatorStyle.Ring] style draws its cue
+ * around the zone-1 glyph instead (see [FlagGlyphZone]).
  */
 @Composable
-private fun PlusLusIndicator(color: Color, style: PlusLusIndicatorStyle) {
-    when (style) {
-        PlusLusIndicatorStyle.Eye -> Box(
-            modifier = Modifier
-                .clip(CircleShape)
-                .background(color.copy(alpha = INDICATOR_BG_ALPHA))
-                .padding(horizontal = 6.dp, vertical = 3.dp),
-            contentAlignment = Alignment.Center,
-        ) {
-            RedfaceVectorIcon(
-                resId = CoreUiR.drawable.ic_ms_visibility,
-                contentDescription = null,
-                tint = color,
-                size = 16.dp,
-            )
-        }
-
-        PlusLusIndicatorStyle.Ring -> Box(
-            modifier = Modifier
-                .size(14.dp)
-                .border(width = 3.dp, color = color, shape = CircleShape),
+private fun EyeChip(color: Color) {
+    Box(
+        modifier = Modifier
+            .clip(CircleShape)
+            .background(color.copy(alpha = INDICATOR_BG_ALPHA))
+            .padding(horizontal = 6.dp, vertical = 3.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        RedfaceVectorIcon(
+            resId = CoreUiR.drawable.ic_ms_visibility,
+            contentDescription = null,
+            tint = color,
+            size = 16.dp,
         )
     }
 }

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -177,7 +177,7 @@
     <!-- #661 — Style de l\'indicateur « +lus » dans le sélecteur d\'onglet de la barre du haut :
          œil (par défaut) ou drapal dessiné en anneau coloré. Réglage GLOBAL (tous onglets). -->
     <string name="flags_view_settings_pluslus_title">Indicateur « +lus »</string>
-    <string name="flags_view_settings_pluslus_description">Forme du repère affiché dans le sélecteur d\'onglet quand les sujets lus sont visibles. S\'applique à tous les onglets.</string>
+    <string name="flags_view_settings_pluslus_description">Repère affiché quand les sujets lus sont visibles : un anneau autour du drapeau, ou un œil à droite du nom. S\'applique à tous les onglets.</string>
     <string name="flags_view_settings_pluslus_eye">Œil</string>
     <string name="flags_view_settings_pluslus_ring">Anneau</string>
     <!-- #603/#665 — Forme du repère de type actif dans le container gauche de la top bar : drapeau / pastille -->


### PR DESCRIPTION
Variante **A** choisie par XaTriX dans l'[artefact comparatif](https://claude.ai/code/artifact/50abc856-81a8-4dac-908e-2d395a9586c1) (reco Codex).

Le repère « +lus » passe de la zone 2 à un **anneau coloré autour du glyphe en zone 1** (drapeau ou pastille) — reprise de l'idée « anneau » d'origine.

`PlusLusIndicatorStyle` repurposé, **défaut Eye → Ring** :
- **Anneau** (défaut) : anneau 30 dp couleur du type autour du glyphe ; rien en zone 2.
- **Œil** (legacy) : capsule œil en zone 2 ; pas d'anneau.

Pas de double repère. Marche pour Flag et Dot. Segment réordonné (Anneau d'abord), défaut + fallback corrompu + état app-bar mis à jour ; tests DataStore ajustés.

## Tests
- compile + tests (core:domain/data, feature:flags) ✅ · detektAll + lintDebug ✅
- **Émulateur** : anneau cyan quand +lus actif ; mode Œil legacy OK ; bascule round-trip OK.

> Action par Claude Opus 4.8 (demandée par @XaTriX). Gate Codex GPT-5.5 xhigh en cours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)