### PR TITLE
fix(ui): account avatar to the standard 32dp top-bar size (#603)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/account/RedfaceAccountMenu.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/account/RedfaceAccountMenu.kt
@@ -252,9 +252,11 @@ private fun AccountStatusHeader(authState: AuthState?) {
     }
 }
 
-// 40dp visual size. The explicit `Modifier.minimumInteractiveComponentSize()` applied on
-// `AccountBadge` (before `.size(BADGE_SIZE)`) expands the touch target to the Material 3
-// 48dp minimum without changing the painted badge — `Surface(onClick = ...)` does NOT
-// inject that minimum on its own (cf. M3 docs, Codex rereview on PR #207).
-private val BADGE_SIZE = 40.dp
+// 32dp visual size — the standard top-bar account-avatar size (Gmail/Google ≈ 30dp), distinct from
+// the 40dp M3 *list* avatar; in the 44dp top-bar container it leaves breathing room rather than nearly
+// filling it (#603, XaTriX). The explicit `Modifier.minimumInteractiveComponentSize()` applied on
+// `AccountBadge` (before `.size(BADGE_SIZE)`) still expands the touch target to the Material 3 48dp
+// minimum without changing the painted badge — `Surface(onClick = ...)` does NOT inject that minimum
+// on its own (cf. M3 docs, Codex rereview on PR #207).
+private val BADGE_SIZE = 32.dp
 private val HEADER_PADDING = PaddingValues(horizontal = 16.dp, vertical = 8.dp)


### PR DESCRIPTION
L'avatar de compte de la top bar était à **40 dp** (taille d'avatar de *liste* M3), ce qui remplit presque le container de 44 dp. La norme pour un avatar de *barre du haut* est ~30–32 dp (Gmail/Google ≈ 30 dp). → **32 dp**, cible tactile 48 dp inchangée.

Vérifié émulateur (avatar équilibré avec la loupe).

> Action par Claude Opus 4.8 (demandée par @XaTriX). Changement trivial (constante de taille) — exception Codex « edit mécanique ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)