### PR TITLE
feat(flags): long-press sheet — « Aller à une page » + « Poster un message » (#15)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -1914,6 +1914,20 @@ private fun RedfaceNavHost(
                             ),
                         )
                     },
+                    // #15 — long-press sheet « Poster un message » : open the reply editor. HFR appends
+                    // the reply at the END of the topic, so open on the last page (Codex), not the
+                    // last-read page. subcat carries the flag's sub-forum for the POST target.
+                    onReplyFlag = { flag ->
+                        backStack.add(
+                            PostEditorRoute(
+                                mode = PostEditorMode.Reply,
+                                cat = flag.cat,
+                                topicId = flag.topicId,
+                                page = flag.totalPages.coerceAtLeast(1),
+                                subcat = flag.subcat,
+                            ),
+                        )
+                    },
                     onLoginRequested = {
                         backStack.add(LoginRoute)
                     },

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagActionsSheet.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagActionsSheet.kt
@@ -16,13 +16,22 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -30,6 +39,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -67,6 +78,21 @@ fun FlagActionsSheet(
     val linkCopied = stringResource(R.string.flags_sheet_link_copied)
     val browserFailed = stringResource(R.string.flags_sheet_browser_failed)
     val shareFailed = stringResource(R.string.flags_sheet_share_failed)
+    // #15 — the « Aller à une page » dialog state is hoisted here, above the sheet content (Codex), so
+    // Back closes the dialog before the sheet and the input survives recompositions.
+    var showPageDialog by remember { mutableStateOf(false) }
+
+    if (showPageDialog) {
+        PageInputDialog(
+            totalPages = flag.totalPages,
+            onConfirm = { page ->
+                showPageDialog = false
+                // onOpen closes the sheet (host clears sheetFlag) then navigates — no double-modal.
+                actions.onOpen(page)
+            },
+            onDismiss = { showPageDialog = false },
+        )
+    }
 
     ModalBottomSheet(onDismissRequest = actions.onDismiss, sheetState = sheetState) {
         Column(
@@ -98,6 +124,7 @@ fun FlagActionsSheet(
                 items = menuActions(
                     flag = flag,
                     actions = actions,
+                    onGoToPage = { showPageDialog = true },
                     onCopyLink = { copyTopicLink(context, flagTopicUrl(flag), linkCopied) },
                     onOpenBrowser = { openTopicInBrowser(context, flagTopicUrl(flag), browserFailed) },
                 ),
@@ -213,44 +240,85 @@ private fun quickActions(
 }
 
 /**
- * #676 v2 — the full-label MENU list: secondary, navigational and destructive actions. Distinct from
- * [quickActions]: open the last page, copy the link, open in the browser, remove the flag.
+ * #676 v2 / #15 — the full-label MENU list: secondary, navigational and destructive actions. Distinct
+ * from [quickActions]: open the last page, jump to a specific page (dialog), reply, copy the link, open
+ * in the browser, remove the flag. Order follows Codex: navigation → reply → utilities → destructive.
+ *
+ * [onGoToPage] opens the in-sheet page-number dialog ([PageInputDialog]); the « Aller à une page » row
+ * is omitted for single-page topics (nothing to choose). [actions.onReply] opens the reply editor.
  */
 @Composable
 private fun menuActions(
     flag: Flag,
     actions: FlagSheetActions,
+    onGoToPage: () -> Unit,
     onCopyLink: () -> Unit,
     onOpenBrowser: () -> Unit,
 ): List<SheetActionItem> {
     val variant = MaterialTheme.colorScheme.onSurfaceVariant
-    return listOf(
-        SheetActionItem(
-            iconRes = CoreUiR.drawable.ic_ms_last_page,
-            label = stringResource(R.string.flags_sheet_action_last_page),
-            onClick = { actions.onOpen(flagLastPage(flag.totalPages)) },
-            iconTint = variant,
-        ),
-        SheetActionItem(
-            iconRes = CoreUiR.drawable.ic_ms_content_copy,
-            label = stringResource(R.string.flags_sheet_action_copy),
-            onClick = onCopyLink,
-            iconTint = variant,
-        ),
-        SheetActionItem(
-            iconRes = CoreUiR.drawable.ic_ms_open_in_new,
-            label = stringResource(R.string.flags_sheet_action_browser),
-            onClick = onOpenBrowser,
-            iconTint = variant,
-        ),
-        SheetActionItem(
-            iconRes = CoreUiR.drawable.ic_ms_delete,
-            label = stringResource(R.string.flags_sheet_action_remove),
-            onClick = actions.onRemove,
-            iconTint = MaterialTheme.colorScheme.error,
-            destructive = true,
-        ),
-    )
+    return buildList {
+        add(
+            SheetActionItem(
+                iconRes = CoreUiR.drawable.ic_ms_last_page,
+                label = stringResource(R.string.flags_sheet_action_last_page),
+                onClick = { actions.onOpen(flagLastPage(flag.totalPages)) },
+                iconTint = variant,
+            ),
+        )
+        // « Aller à une page » only makes sense when there is more than one page (Codex).
+        if (flag.totalPages > 1) {
+            add(
+                SheetActionItem(
+                    iconRes = CoreUiR.drawable.ic_ms_article,
+                    label = stringResource(R.string.flags_sheet_action_goto_page),
+                    onClick = onGoToPage,
+                    iconTint = variant,
+                ),
+            )
+        }
+        add(
+            SheetActionItem(
+                iconRes = CoreUiR.drawable.ic_ms_edit_square,
+                label = stringResource(R.string.flags_sheet_action_reply),
+                onClick = actions.onReply,
+                iconTint = variant,
+            ),
+        )
+        add(
+            SheetActionItem(
+                iconRes = CoreUiR.drawable.ic_ms_content_copy,
+                label = stringResource(R.string.flags_sheet_action_copy),
+                onClick = onCopyLink,
+                iconTint = variant,
+            ),
+        )
+        add(
+            SheetActionItem(
+                iconRes = CoreUiR.drawable.ic_ms_open_in_new,
+                label = stringResource(R.string.flags_sheet_action_browser),
+                onClick = onOpenBrowser,
+                iconTint = variant,
+            ),
+        )
+        add(
+            SheetActionItem(
+                iconRes = CoreUiR.drawable.ic_ms_delete,
+                label = stringResource(R.string.flags_sheet_action_remove),
+                onClick = actions.onRemove,
+                iconTint = MaterialTheme.colorScheme.error,
+                destructive = true,
+            ),
+        )
+    }
+}
+
+/**
+ * #15 — clamps a raw page-number input to a valid topic page, or `null` when it is not a usable page.
+ * Trims, rejects non-digits / empty / out-of-range (`1..totalPages`). Pure → unit-tested.
+ */
+internal fun parseTopicPageInput(input: String, totalPages: Int): Int? {
+    val page = input.trim().toIntOrNull() ?: return null
+    return page.takeIf { it in 1..flagLastPage(totalPages) }
 }
 
 /**
@@ -417,6 +485,50 @@ private fun MetaRow(key: String, value: String) {
     }
 }
 
+/**
+ * #15 — « Aller à une page » dialog (Codex reco: AlertDialog + numeric field, no slider). Validates the
+ * input against `1..totalPages` ([parseTopicPageInput]); « Aller » is disabled while invalid and the
+ * IME action fires only on a valid value — the dialog never silently corrects an out-of-range entry.
+ */
+@Composable
+private fun PageInputDialog(
+    totalPages: Int,
+    onConfirm: (page: Int) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var input by remember { mutableStateOf("") }
+    val page = parseTopicPageInput(input, totalPages)
+    val confirm = { page?.let(onConfirm) ?: Unit }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.flags_sheet_goto_page_title)) },
+        text = {
+            OutlinedTextField(
+                value = input,
+                onValueChange = { new -> input = new.filter(Char::isDigit).take(MAX_PAGE_DIGITS) },
+                singleLine = true,
+                label = { Text(stringResource(R.string.flags_sheet_goto_page_label)) },
+                supportingText = { Text(stringResource(R.string.flags_sheet_goto_page_supporting, totalPages)) },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Go,
+                ),
+                keyboardActions = KeyboardActions(onGo = { confirm() }),
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = confirm, enabled = page != null) {
+                Text(stringResource(R.string.flags_sheet_goto_page_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.flags_sheet_goto_page_cancel))
+            }
+        },
+    )
+}
+
 /** Copies [url] to the clipboard; on pre-Android-13 (no system confirmation) shows a [feedback] toast. */
 private fun copyTopicLink(context: Context, url: String, feedback: String) {
     val clipboard = context.getSystemService(ClipboardManager::class.java) ?: return
@@ -445,3 +557,6 @@ private fun shareTopic(context: Context, url: String, title: String, failureFeed
 
 /** Dimming applied to a disabled quick action (#676 v2). */
 private const val DISABLED_ALPHA = 0.38f
+
+/** #15 — cap on the page-number field length (HFR topics stay well under 100k pages). */
+private const val MAX_PAGE_DIGITS = 6

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagActionsSheet.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagActionsSheet.kt
@@ -507,6 +507,9 @@ private fun PageInputDialog(
                 value = input,
                 onValueChange = { new -> input = new.filter(Char::isDigit).take(MAX_PAGE_DIGITS) },
                 singleLine = true,
+                // Codex polish: flag a non-empty out-of-range entry as an error (TalkBack + visual) rather
+                // than only greying « Aller ». Empty stays neutral (nothing typed yet).
+                isError = input.isNotBlank() && page == null,
                 label = { Text(stringResource(R.string.flags_sheet_goto_page_label)) },
                 supportingText = { Text(stringResource(R.string.flags_sheet_goto_page_supporting, totalPages)) },
                 keyboardOptions = KeyboardOptions(

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagSheetActions.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagSheetActions.kt
@@ -10,6 +10,9 @@ package fr.forumhfr.redface2.feature.flags
  */
 data class FlagSheetActions(
     val onOpen: (page: Int) -> Unit,
+    // #15 — open the reply editor for this topic (HFR appends at the end, so the host opens it on the
+    // last page). « Aller à une page » reuses [onOpen] with the page picked in the in-sheet dialog.
+    val onReply: () -> Unit,
     val onToggleSuperFavorite: () -> Unit,
     val onRemove: () -> Unit,
     val onDismiss: () -> Unit,

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -142,6 +142,9 @@ import kotlinx.coroutines.launch
 @Suppress("LongParameterList") // Screen route: 4 host nav callbacks + the quick-config trigger + the account slot.
 fun FlagsRoute(
     onOpenFlag: (flag: Flag, page: Int) -> Unit,
+    // #15 — open the reply editor for a topic (long-press sheet « Poster un message »). Defaulted so
+    // existing call sites / previews compile; the real host wires it to a PostEditorRoute(Reply).
+    onReplyFlag: (flag: Flag) -> Unit = {},
     onLoginRequested: () -> Unit,
     onOpenCategory: (Int) -> Unit = {},
     // #6 — open a DT (MultiMP) conversation : the host pushes the existing PrivateMessageThread
@@ -483,6 +486,10 @@ fun FlagsRoute(
             sheetFlag = null
             viewModel.onFlagOpened()
             onOpenFlag(flag, page)
+        },
+        onReply = { flag ->
+            sheetFlag = null
+            onReplyFlag(flag)
         },
         onToggleSuperFavorite = viewModel::toggleSuperFavorite,
         onRemove = {
@@ -1911,11 +1918,12 @@ private fun ScrollableFlagsEmptyState(
 // #603 PR5 — hosts the long-press actions sheet; the null-check lives here (not in FlagsRoute) to keep
 // the route's cyclomatic complexity in budget. `flag == null` ⇒ nothing composed (sheet closed).
 @Composable
-@Suppress("LongParameterList") // host: the sheet flag + super-favorite set + 4 action callbacks.
+@Suppress("LongParameterList") // host: the sheet flag + super-favorite set + 5 action callbacks.
 private fun FlagActionsSheetHost(
     flag: Flag?,
     superFavoriteIds: Set<Int>,
     onOpen: (flag: Flag, page: Int) -> Unit,
+    onReply: (Flag) -> Unit,
     onToggleSuperFavorite: (Flag) -> Unit,
     onRemove: (Flag) -> Unit,
     onDismiss: () -> Unit,
@@ -1928,6 +1936,7 @@ private fun FlagActionsSheetHost(
         actions = FlagSheetActions(
             // #676 v2 — the sheet decides which page (resume / first-unread / last); the host just navigates.
             onOpen = { page -> onOpen(flag, page) },
+            onReply = { onReply(flag) },
             onToggleSuperFavorite = { onToggleSuperFavorite(flag) },
             onRemove = { onRemove(flag) },
             onDismiss = onDismiss,

--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -52,9 +52,18 @@
     <!-- #676 v2 — LISTE verticale : actions secondaires / navigation / destructive, DISTINCTES de la
          rangée rapide. « Retirer » passe toujours par le dialog de confirmation de retrait. -->
     <string name="flags_sheet_action_last_page">Ouvrir à la dernière page</string>
+    <!-- #15 — aller à une page précise (dialog) + poster une réponse -->
+    <string name="flags_sheet_action_goto_page">Aller à une page</string>
+    <string name="flags_sheet_action_reply">Poster un message</string>
     <string name="flags_sheet_action_copy">Copier le lien</string>
     <string name="flags_sheet_action_browser">Ouvrir dans le navigateur</string>
     <string name="flags_sheet_action_remove">Retirer le drapeau</string>
+    <!-- #15 — dialog « aller à une page » -->
+    <string name="flags_sheet_goto_page_title">Aller à une page</string>
+    <string name="flags_sheet_goto_page_label">Numéro de page</string>
+    <string name="flags_sheet_goto_page_supporting">1 à %1$d</string>
+    <string name="flags_sheet_goto_page_confirm">Aller</string>
+    <string name="flags_sheet_goto_page_cancel">Annuler</string>
     <string name="flags_sheet_link_copied">Lien copié</string>
     <string name="flags_sheet_browser_failed">Aucune application pour ouvrir ce lien</string>
     <string name="flags_sheet_share_failed">Aucune application pour partager ce lien</string>

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagSheetPagesTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagSheetPagesTest.kt
@@ -43,4 +43,28 @@ class FlagSheetPagesTest {
     fun `first unread stays at least 1 on an empty topic`() {
         assertEquals(1, flagFirstUnreadPage(lastReadPage = 0, totalPages = 0, hasUnread = true))
     }
+
+    // #15 — « Aller à une page » input parsing.
+
+    @Test
+    fun `page input accepts a valid in-range page`() {
+        assertEquals(12, parseTopicPageInput("12", totalPages = 35))
+        assertEquals(1, parseTopicPageInput(" 1 ", totalPages = 35))
+        assertEquals(35, parseTopicPageInput("35", totalPages = 35))
+    }
+
+    @Test
+    fun `page input rejects out-of-range, zero, empty and non-numeric`() {
+        assertEquals(null, parseTopicPageInput("36", totalPages = 35))
+        assertEquals(null, parseTopicPageInput("0", totalPages = 35))
+        assertEquals(null, parseTopicPageInput("-2", totalPages = 35))
+        assertEquals(null, parseTopicPageInput("", totalPages = 35))
+        assertEquals(null, parseTopicPageInput("abc", totalPages = 35))
+    }
+
+    @Test
+    fun `page input treats totalPages below 1 as a single page`() {
+        assertEquals(1, parseTopicPageInput("1", totalPages = 0))
+        assertEquals(null, parseTopicPageInput("2", totalPages = 0))
+    }
 }


### PR DESCRIPTION
Deux actions ajoutées à la liste du sheet d'appui-long (UX cadrée par Codex).

- **Aller à une page** — `AlertDialog` M3 + champ numérique, validé `1..totalPages` (`parseTopicPageInput`, pur + testé) ; « Aller » désactivé tant qu'invalide, IME Go seulement si valide. Masquée pour les sujets d'une seule page. Navigue via `onOpen(page)`.
- **Poster un message** — ouvre l'éditeur de réponse (`PostEditorRoute(Reply)`) sur la **dernière page** (HFR ajoute en fin de topic), avec cat / topicId / subcat.

Ordre (Codex) : dernière page → aller à une page → poster → copier → navigateur → retirer. État dialog hoisté au-dessus du sheet (Back ferme le dialog d'abord).

## Tests
- compile (feature:flags, app) + tests (dont `parseTopicPageInput`) + detektAll + lintDebug ✅
- **Émulateur** : appui long → 2 actions ; « Aller à une page » → saisie 5 → topic « page 5 / 35 » ; « Poster » → éditeur « Répondre au sujet ».

> Action par Claude Opus 4.8 (demandée par @XaTriX). Gate Codex GPT-5.5 xhigh en cours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)