### PR TITLE
chore(release): dev 0.17.24 — +lus ring, standard avatar, sheet page/reply (#603)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,28 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.24` — `internal` (dev) — 2026-06-28
+
+> Vue Drapeaux (#603) — suite de la review dogfood : **repère « +lus » = anneau autour du drapeau**
+> (variante A choisie par XaTriX, défaut ; œil en option), **avatar du compte à la taille standard**
+> (32 dp, validé Codex), et **sheet d'appui-long enrichi** (« Aller à une page » + « Poster un
+> message »). versionName 0.17.23 → 0.17.24.
+
+**Drapeaux — vue (#603)**
+
+- **Repère « +lus » sur l'icône (#661/#603)** : quand les sujets lus sont visibles, le glyphe de type
+  (drapeau ou pastille) est entouré d'un **anneau** coloré (nouveau défaut). L'**œil** à droite du nom
+  reste disponible en option dans les réglages d'affichage. Plus de double repère.
+- **Avatar du compte — taille standard (32 dp)** : l'avatar de la barre du haut passe de 40 dp (taille
+  d'avatar de *liste*) à 32 dp, la taille usuelle d'un avatar de *barre du haut* (validé Codex). Cible
+  tactile 48 dp inchangée.
+- **Sheet d'appui-long — « Aller à une page » (#15)** : nouvelle action qui ouvre un champ de saisie
+  (validé 1…N) pour ouvrir le sujet directement à une page précise. Masquée pour les sujets d'une page.
+- **Sheet d'appui-long — « Poster un message » (#15)** : nouvelle action qui ouvre directement
+  l'éditeur de réponse du sujet (sur la dernière page, là où HFR ajoute le message).
+
+---
+
 ## `0.17.23` — `internal` (dev) — 2026-06-28
 
 > Vue Drapeaux (#603) — passe de review top bar dogfood : **noms d'onglets courts** (Cyan/Lurk/Fav/DT/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.23"
+        versionName = "0.17.24"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,8 +1,6 @@
-Redface 2 v0.17.23 — dev.
+Redface 2 v0.17.24 — dev.
 
-Flags view (top bar pass):
-- Short tab names: Cyan, Lurk, Fav, DT, Super.
-- New "Active type marker" setting: flag icon or dot (#717).
-- Account avatar: container background, borderless; more options coming (#718).
-- "Display settings" is now available on every tab (incl. DT/Super).
-- Cleaner tap on the left container's two zones.
+Flags view:
+- "+read" cue: a ring around the flag (new default; eye still available).
+- Account avatar at the standard top-bar size (32 dp).
+- Long-press: "Go to a page" (number input) and "Post a message" (direct reply).

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,8 +1,6 @@
-Redface 2 v0.17.23 — dev.
+Redface 2 v0.17.24 — dev.
 
-Vue Drapeaux (passe top bar) :
-- Noms d'onglets courts : Cyan, Lurk, Fav, DT, Super.
-- Nouveau réglage « Repère du type actif » : icône drapeau ou pastille (#717).
-- Avatar du compte : fond du container, sans bordure ; options à venir (#718).
-- « Réglages d'affichage » désormais disponible sur tous les onglets (dont DT/Super).
-- Tap plus propre des deux zones du container gauche.
+Vue Drapeaux :
+- Repère « +lus » : anneau autour du drapeau (nouveau défaut ; œil en option).
+- Avatar du compte à la taille standard d'une barre du haut (32 dp).
+- Appui long : « Aller à une page » (saisie du numéro) et « Poster un message » (réponse directe).


### PR DESCRIPTION
Release dev groupant #721 + #722 + #723.

- **#721** — repère « +lus » = **anneau** autour du glyphe (variante A choisie par XaTriX, défaut ; œil en option).
- **#722** — avatar du compte à la **taille standard 32 dp** (validé Codex).
- **#723** — sheet d'appui-long : **« Aller à une page »** (saisie validée) + **« Poster un message »** (réponse directe).

versionName 0.17.23 → 0.17.24. CHANGELOG + whatsnew (fr/en) à jour, gardes vertes.

> Action par Claude Opus 4.8 (demandée par @XaTriX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)