### PR TITLE
feat(flags): #603 — search loupe on the DT tab (harmonisation)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,21 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.26` — `internal` (dev) — 2026-06-28
+
+> Vue Drapeaux (#603) — **la loupe de recherche revient sur l'onglet DT**. La barre du haut harmonisée
+> avait laissé la loupe réservée aux onglets de drapeaux ; elle filtre désormais aussi la liste des
+> discussions à interlocuteurs multiples (DT). versionName 0.17.25 → 0.17.26.
+
+**Drapeaux — vue (#603)**
+
+- **Recherche sur l'onglet DT** : la loupe « rechercher dans les drapeaux » est désormais offerte sur
+  l'onglet DT (comme sur les onglets de drapeaux) et filtre les conversations par sujet. L'onglet Super
+  (sans liste) reste sans loupe. Filtre client-side (sujet, insensible à la casse) avec un état « aucun
+  résultat » dédié.
+
+---
+
 ## `0.17.25` — `internal` (dev) — 2026-06-28
 
 > Vue Drapeaux (#603/#665) — **top bar « overlay translucide »** : la barre du haut ne pousse plus la

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.25"
+        versionName = "0.17.26"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,5 +1,4 @@
-Redface 2 v0.17.25 — dev.
+Redface 2 v0.17.26 — dev.
 
 Flags view:
-- The top bar now overlays the list: on scroll, content glides UNDER the bar.
-- Translucent scrim on scroll: opaque behind the clock, transparent at the bottom so content fades in underneath. Bar stays transparent at the top of the list.
+- The search loupe is back on the DT tab: it filters your multi-recipient conversations by subject, just like the flag tabs. The Super tab (no list) keeps no loupe.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,5 +1,4 @@
-Redface 2 v0.17.25 — dev.
+Redface 2 v0.17.26 — dev.
 
 Vue Drapeaux :
-- La barre du haut survole la liste : au défilement, le contenu glisse SOUS la barre.
-- Voile translucide au scroll : opaque derrière l'horloge, transparent en bas pour laisser le contenu apparaître en fondu. Barre transparente en haut de liste.
+- La loupe de recherche revient sur l'onglet DT : elle filtre les discussions à interlocuteurs multiples par sujet, comme sur les onglets de drapeaux. L'onglet Super (sans liste) reste sans loupe.

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagSearch.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagSearch.kt
@@ -45,3 +45,21 @@ fun FlagsContent.isEmpty(): Boolean = when (this) {
     is FlagsContent.Flat -> flags.isEmpty()
     is FlagsContent.Grouped -> sections.all { it.topics.isEmpty() }
 }
+
+/**
+ * Pure client-side DT search (#603 harmonisation — the same « rechercher dans les drapeaux » loupe is
+ * now offered on the DT tab, applied to its conversation list). Keeps the [DtListItem.InboxBacked] rows
+ * whose conversation subject contains [query] (case-insensitive, trimmed). [DtListItem.StorageOnly]
+ * orphans carry no subject (only a threadId), so an active query drops them — they have nothing to match.
+ * A blank query is a no-op (returns [items] unchanged).
+ */
+fun filterDtItemsByQuery(items: List<DtListItem>, query: String): List<DtListItem> {
+    val q = query.trim()
+    if (q.isEmpty()) return items
+    return items.filter { item ->
+        when (item) {
+            is DtListItem.InboxBacked -> item.conversation.subject.contains(q, ignoreCase = true)
+            is DtListItem.StorageOnly -> false
+        }
+    }
+}

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -263,6 +263,12 @@ fun FlagsRoute(
     // #603 PR5 — the flag whose long-press actions sheet is open (null = closed).
     var sheetFlag by remember { mutableStateOf<Flag?>(null) }
     val canConfigureView = authState is AuthState.Authenticated && selectedTab.flagType != null
+    // #603 harmonisation (demande XaTriX : « top bar similaire pour tous les onglets, donc la
+    // loupe/recherche ») — the search loupe is offered on every tab that holds a searchable list: the
+    // three flag tabs AND DT (its conversation list). Super is a placeholder with no list, so it keeps
+    // no loupe (nothing to search). Decoupled from canConfigureView (which gates the flag-only display
+    // settings sheet) and extracted to flagsSearchEnabled so the && / || stay off FlagsRoute's budget.
+    val searchEnabled = flagsSearchEnabled(authState, selectedTab)
 
     // If the screen stops being configurable while the sheet is open (session expired, or the user
     // lands on the Super tab), clear the flag so the sheet can't silently reappear on the next
@@ -379,7 +385,7 @@ fun FlagsRoute(
                             cyanShowsRead = cyanShowsRead,
                             dtShowsRead = dtShowsRead,
                         ),
-                        searchEnabled = canConfigureView,
+                        searchEnabled = searchEnabled,
                         query = searchQuery,
                         searchActive = searchActive,
                         // #661 — the picker dropdown surfaces a contextual « +lus » toggle (Cyan/DT) and
@@ -1034,6 +1040,13 @@ private fun flagsLoadingBarVisible(
 private inline fun barLoadingGated(authState: AuthState?, barVisible: () -> Boolean): Boolean =
     authState is AuthState.Authenticated && barVisible()
 
+// #603 harmonisation — the search loupe is offered on tabs that hold a searchable list: the three flag
+// tabs (flagType != null) AND DT (its conversation list). Super has no list, so no loupe. Extracted so
+// the && / || stay off FlagsRoute's cyclomatic budget; internal so the gating is unit-tested directly
+// (Codex review — guard against a future gating regression).
+internal fun flagsSearchEnabled(authState: AuthState?, tab: FlagTab): Boolean =
+    authState is AuthState.Authenticated && (tab.flagType != null || tab == FlagTab.Dt)
+
 // #603 — extracted so the single-line-title branch doesn't count against FlagsRoute's cyclomatic budget.
 private fun flagTitleMaxLines(singleLineTitle: Boolean): Int = if (singleLineTitle) 1 else 2
 
@@ -1214,10 +1227,8 @@ private fun AuthenticatedBody(
                 // #6 — DT is a real list now: the user's MultiMP conversations, enriched best-effort
                 // with the MPStorage reading positions.
                 FlagTab.Dt -> DtListBody(
-                    state = bodyState.dtListState,
-                    isRefreshing = bodyState.dtIsRefreshing,
+                    state = bodyState,
                     actions = actions,
-                    funny = bodyState.funnyEmptyState,
                     // #665 — hoisted so the overlay scrim can read the DT scroll position.
                     listState = listStates.dt,
                 )
@@ -2213,12 +2224,12 @@ private fun DtTabOpenEffect(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun DtListBody(
-    state: DtListUiState,
-    isRefreshing: Boolean,
+    state: FlagsBodyState,
     actions: AuthenticatedActions,
-    funny: Boolean,
     listState: LazyListState,
 ) {
+    val dtState = state.dtListState
+    val isRefreshing = state.dtIsRefreshing
     // #546 directive XaTriX — pull-to-refresh (swipe down) on the DT list, like the flag tabs. Wraps
     // the whole body (every branch) so the gesture has a target even on the listless states (#229).
     // #603 — « amorce seule » (XaTriX): pull cue while dragging, nothing during the refresh; the top
@@ -2239,7 +2250,14 @@ private fun DtListBody(
         },
         modifier = Modifier.fillMaxSize(),
     ) {
-        DtListContent(state = state, actions = actions, funny = funny, listState = listState)
+        DtListContent(
+            state = dtState,
+            actions = actions,
+            funny = state.funnyEmptyState,
+            listState = listState,
+            // #603 harmonisation — the loupe now filters the DT conversation list too.
+            searchQuery = state.searchQuery,
+        )
     }
 }
 
@@ -2254,6 +2272,7 @@ private fun DtListContent(
     actions: AuthenticatedActions,
     funny: Boolean,
     listState: LazyListState,
+    searchQuery: String,
 ) {
     when (state) {
         DtListUiState.Loading -> Box(
@@ -2285,31 +2304,58 @@ private fun DtListContent(
 
         is DtListUiState.Error -> DtErrorBody(cause = state.cause, actions = actions)
 
-        is DtListUiState.Content -> LazyColumn(
-            // #665 — hoisted state so the overlay scrim can read the DT scroll position (forTab).
-            state = listState,
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.surface),
-            // #665 — reserve the overlaid bar height (content glides under the translucent bar).
-            contentPadding = PaddingValues(top = LocalFlagsContentTopPadding.current),
-        ) {
-            // DT now renders through the SAME row primitive + divider as the Cyan/Red/Favorite lists
-            // (no Card, no contentPadding/spacing) so the four lists stay visually identical and a
-            // row change propagates to all (arbitrage XaTriX 2026-06-19). The list is the union of
-            // inbox PAGE 1 MultiMP rows + orphan MPStorage entries (#6) — dispatched per variant.
-            items(
-                items = state.items,
-                key = { it.threadId },
-                contentType = { CONTENT_TYPE_ROW },
-            ) { item ->
-                DtRow(item = item, onOpenMultiMp = actions.onOpenMultiMp)
-                FlagItemDivider()
-            }
-            // #662 (demande XaTriX) — le caveat de balayage (« seule la page 1 est listée ») a quitté la
-            // vue : il vit désormais dans la description du réglage « Section DT » (settings), au niveau de
-            // l'activation. Plus de footer scan-note ici.
+        is DtListUiState.Content -> DtListContentRows(
+            items = state.items,
+            actions = actions,
+            listState = listState,
+            searchQuery = searchQuery,
+        )
+    }
+}
+
+/**
+ * The DT [DtListUiState.Content] rows, with the #603 client-side search applied. An active query that
+ * matches nothing shows the shared [NoFlagsSearchResults] empty state (scrollable, so the
+ * `PullToRefreshBox` keeps a target — #229). Extracted from [DtListContent] so the search branch does
+ * not push its `when` over the detekt cyclomatic-complexity budget.
+ */
+@Composable
+private fun DtListContentRows(
+    items: List<DtListItem>,
+    actions: AuthenticatedActions,
+    listState: LazyListState,
+    searchQuery: String,
+) {
+    val filtered = remember(items, searchQuery) { filterDtItemsByQuery(items, searchQuery) }
+    if (searchQuery.isNotBlank() && filtered.isEmpty()) {
+        NoFlagsSearchResults(query = searchQuery)
+        return
+    }
+    LazyColumn(
+        // #665 — hoisted state so the overlay scrim can read the DT scroll position (forTab).
+        state = listState,
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface),
+        // #665 — reserve the overlaid bar height (content glides under the translucent bar).
+        contentPadding = PaddingValues(top = LocalFlagsContentTopPadding.current),
+    ) {
+        // DT now renders through the SAME row primitive + divider as the Cyan/Red/Favorite lists
+        // (no Card, no contentPadding/spacing) so the four lists stay visually identical and a
+        // row change propagates to all (arbitrage XaTriX 2026-06-19). The list is the union of
+        // inbox PAGE 1 MultiMP rows + orphan MPStorage entries (#6) — dispatched per variant.
+        // #603 — `filtered` is the search-filtered view of the items (no-op on a blank query).
+        items(
+            items = filtered,
+            key = { it.threadId },
+            contentType = { CONTENT_TYPE_ROW },
+        ) { item ->
+            DtRow(item = item, onOpenMultiMp = actions.onOpenMultiMp)
+            FlagItemDivider()
         }
+        // #662 (demande XaTriX) — le caveat de balayage (« seule la page 1 est listée ») a quitté la
+        // vue : il vit désormais dans la description du réglage « Section DT » (settings), au niveau de
+        // l'activation. Plus de footer scan-note ici.
     }
 }
 

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagSearchTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagSearchTest.kt
@@ -2,10 +2,12 @@ package fr.forumhfr.redface2.feature.flags
 
 import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
+import fr.forumhfr.redface2.core.model.messages.PrivateMessageSummary
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.time.Instant
 
 /**
  * 100% coverage of the pure client-side Drapeaux search (#603, PR2). The flagged topics are already
@@ -144,6 +146,66 @@ class FlagSearchTest {
         assertEquals(emptyList<FlagCategorySection>(), (filtered as FlagsContent.Grouped).sections)
         assertTrue("all sections dropped → empty (the NoFlagsSearchResults path)", filtered.isEmpty())
     }
+
+    // --- filterDtItemsByQuery (#603 harmonisation — the loupe filters the DT list too) -------
+
+    @Test
+    fun `a blank DT query returns the list unchanged (orphans kept)`() {
+        val items = listOf(dtInbox(1, "RDNA4"), dtOrphan(9))
+        assertEquals(items, filterDtItemsByQuery(items, "  "))
+    }
+
+    @Test
+    fun `the DT query matches the conversation subject case-insensitively`() {
+        val items = listOf(dtInbox(1, "RDNA4 — AMD"), dtInbox(2, "Claviers mécaniques"))
+        assertEquals(
+            listOf(1),
+            filterDtItemsByQuery(items, "rdna").map { it.threadId },
+        )
+    }
+
+    @Test
+    fun `the DT query is trimmed before matching`() {
+        val items = listOf(dtInbox(1, "Claviers mécaniques"), dtInbox(2, "RDNA4"))
+        assertEquals(listOf(1), filterDtItemsByQuery(items, "  claviers  ").map { it.threadId })
+    }
+
+    @Test
+    fun `an active DT query drops storage-only orphans (no subject to match)`() {
+        val items = listOf(dtInbox(1, "RDNA4"), dtOrphan(9))
+        // The orphan has no subject; an active query keeps only the matching inbox row.
+        assertEquals(listOf(1), filterDtItemsByQuery(items, "rdna").map { it.threadId })
+    }
+
+    @Test
+    fun `a DT query matching nothing yields an empty list`() {
+        val items = listOf(dtInbox(1, "RDNA4"), dtInbox(2, "Claviers"))
+        assertEquals(emptyList<DtListItem>(), filterDtItemsByQuery(items, "zzz"))
+    }
+
+    @Test
+    fun `an active DT query over storage-only orphans only yields an empty list`() {
+        // Orphans carry no subject, so any active query empties the list (the NoFlagsSearchResults path).
+        val items = listOf(dtOrphan(7), dtOrphan(9))
+        assertEquals(emptyList<DtListItem>(), filterDtItemsByQuery(items, "anything"))
+    }
+
+    private fun dtInbox(threadId: Int, subject: String): DtListItem.InboxBacked =
+        DtListItem.InboxBacked(
+            conversation = PrivateMessageSummary(
+                threadId = threadId,
+                correspondent = "",
+                subject = subject,
+                date = Instant.parse("2026-06-28T12:00:00Z"),
+                hasUnread = true,
+                isMultiRecipient = true,
+                lastPage = 1,
+            ),
+            resumePage = null,
+        )
+
+    private fun dtOrphan(threadId: Int): DtListItem.StorageOnly =
+        DtListItem.StorageOnly(threadId = threadId, resumePage = 1, numreponse = null)
 
     private fun flag(title: String): Flag = Flag(
         cat = 1,

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsSearchEnabledTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsSearchEnabledTest.kt
@@ -1,0 +1,46 @@
+package fr.forumhfr.redface2.feature.flags
+
+import fr.forumhfr.redface2.core.model.AuthState
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Gating of the « rechercher dans les drapeaux » loupe (#603 harmonisation). The loupe is offered on
+ * every tab that holds a searchable list — the three flag tabs AND DT — but never when anonymous, and
+ * never on Super (a placeholder with no list). Pure, so a future gating change is caught here rather
+ * than only on-device. Guards the Codex review reserve (test the gating directly).
+ */
+class FlagsSearchEnabledTest {
+
+    private val authed = AuthState.Authenticated("xaat")
+
+    @Test
+    fun `the loupe is enabled on the three flag tabs when authenticated`() {
+        assertTrue(flagsSearchEnabled(authed, FlagTab.Cyan))
+        assertTrue(flagsSearchEnabled(authed, FlagTab.Red))
+        assertTrue(flagsSearchEnabled(authed, FlagTab.Favorite))
+    }
+
+    @Test
+    fun `the loupe is enabled on the DT tab when authenticated`() {
+        assertTrue(flagsSearchEnabled(authed, FlagTab.Dt))
+    }
+
+    @Test
+    fun `the loupe is disabled on the Super placeholder (no list to search)`() {
+        assertFalse(flagsSearchEnabled(authed, FlagTab.Super))
+    }
+
+    @Test
+    fun `the loupe is disabled when anonymous, even on a flag tab or DT`() {
+        assertFalse(flagsSearchEnabled(AuthState.Anonymous, FlagTab.Cyan))
+        assertFalse(flagsSearchEnabled(AuthState.Anonymous, FlagTab.Dt))
+    }
+
+    @Test
+    fun `the loupe is disabled while auth state is still unknown (null)`() {
+        assertFalse(flagsSearchEnabled(null, FlagTab.Cyan))
+        assertFalse(flagsSearchEnabled(null, FlagTab.Dt))
+    }
+}


### PR DESCRIPTION
## #603 — la loupe de recherche revient sur l'onglet DT

La barre du haut harmonisée (#603) avait laissé la loupe « rechercher dans les drapeaux » réservée aux trois onglets de drapeaux (`searchEnabled = canConfigureView = flagType != null`), donc **absente sur DT**. XaTriX (review dogfood) a demandé une top bar similaire pour tous les onglets, loupe comprise. DT a une vraie liste (les MultiMP), donc il récupère la loupe + un filtre ; Super (placeholder, pas de liste) reste sans.

### Ce que ça fait

- **`flagsSearchEnabled(authState, tab)`** (pur, `internal`) : la loupe s'affiche sur les flag tabs **et** DT, jamais en anonyme, jamais sur Super. Découplé de `canConfigureView` (qui garde le gating du sheet de réglages d'affichage, flag-only).
- **`filterDtItemsByQuery(items, query)`** (pur) : garde les `InboxBacked` dont le sujet de conversation contient la query (insensible à la casse, trim) ; les `StorageOnly` (orphelins MPStorage, sans sujet) sont droppés sur une query active ; query vide = no-op. Miroir de `filterFlagsByQuery`.
- **`DtListBody`** prend désormais tout le `FlagsBodyState` (comme `FlagListBody`) et thread la query → `DtListContentRows` (extrait) applique le filtre et montre l'état partagé `NoFlagsSearchResults` (scrollable, garde la cible pull-to-refresh #229) sur 0 résultat.

### Validation

- **CI canonique reproduite en local** : `:app:assembleProdDebug test testDebugUnitTest lintDebug :app:lintProdDebug detektAll` → **BUILD SUCCESSFUL**.
- **Émulateur authentifié** : section DT activée → l'onglet DT apparaît, la **loupe est présente sur DT** et le champ de recherche s'y déploie (le compte de test n'a aucune conversation MultiMP → filtrage live couvert par les tests unitaires).
- **Tests** : 6 pour `filterDtItemsByQuery` + 5 pour `flagsSearchEnabled` (gating Super/anonyme/null/DT/flag).
- **Codex GPT-5.5 (xhigh)** : **GO avec réserves**, aucun bloquant. Réserve principale traitée (test direct de `flagsSearchEnabled`, rendu `internal`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Dih2obVDx6wMdEdfCPEYc
