### PR TITLE
feat(flags): #603 redface pull-to-refresh loader (rolling redface puck)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,22 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.27` — `internal` (dev) — 2026-06-28
+
+> Vue Drapeaux (#603) — **le loader « redface »**. L'amorce de rafraîchissement (tirer vers le bas)
+> n'est plus l'indicateur Material standard : c'est une petite tête « redface » qui émerge sous la barre
+> et **roule sur elle-même** au fil du tirage. versionName 0.17.26 → 0.17.27.
+
+**Drapeaux — vue (#603)**
+
+- **Loader « redface » à l'amorce du pull** : en tirant vers le bas pour rafraîchir, une tête ronde
+  souriante (dessinée, pas le GIF HFR) apparaît dans une pastille sous la barre et tourne sur elle-même
+  selon la distance de tirage. « Amorce seule » : dès que le rafraîchissement démarre, elle disparaît et
+  la fine barre du haut reste le seul repère de chargement (pas de double indicateur). La rotation
+  respecte le réglage système « réduire les animations ». S'applique aux deux listes (drapeaux + DT).
+
+---
+
 ## `0.17.26` — `internal` (dev) — 2026-06-28
 
 > Vue Drapeaux (#603) — **la loupe de recherche revient sur l'onglet DT**. La barre du haut harmonisée

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.26"
+        versionName = "0.17.27"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,4 +1,4 @@
-Redface 2 v0.17.26 — dev.
+Redface 2 v0.17.27 — dev.
 
 Flags view:
-- The search loupe is back on the DT tab: it filters your multi-recipient conversations by subject, just like the flag tabs. The Super tab (no list) keeps no loupe.
+- New "redface" loader: pull to refresh and a little grinning face appears under the bar and rolls on itself. It vanishes once the refresh starts (the thin top bar takes over). Honours the system "remove animations" setting.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,4 +1,4 @@
-Redface 2 v0.17.26 — dev.
+Redface 2 v0.17.27 — dev.
 
 Vue Drapeaux :
-- La loupe de recherche revient sur l'onglet DT : elle filtre les discussions à interlocuteurs multiples par sujet, comme sur les onglets de drapeaux. L'onglet Super (sans liste) reste sans loupe.
+- Nouveau loader « redface » : en tirant pour rafraîchir, une petite tête souriante apparaît sous la barre et roule sur elle-même. Elle disparaît dès le rafraîchissement (la fine barre du haut prend le relais). Respecte « réduire les animations ».

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/loader/RedfaceFace.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/loader/RedfaceFace.kt
@@ -1,0 +1,70 @@
+package fr.forumhfr.redface2.core.ui.loader
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
+
+/**
+ * #7 — the « redface » loader face, an ORIGINAL little round grinning face drawn entirely in Compose
+ * (NOT the proprietary HFR `redface.gif` — that is a third-party sprite and this app is GPL-3.0-only;
+ * an original drawing is licence-clean, crisp at any size and theme-tintable, XaTriX's choice). It is
+ * the visual that emerges + rolls in the pull-to-refresh puck ([RedfacePuck]).
+ *
+ * [rotationDegrees] tumbles the whole face (eyes + grin rotate together) so it reads as « rolling on
+ * itself » when driven by the pull distance. [tint] is the face fill — defaults to the redface coral so
+ * the loader keeps its identity on every tab/theme, but can be themed/tinted by the caller.
+ */
+@Composable
+fun RedfaceFace(
+    modifier: Modifier = Modifier,
+    tint: Color = RedfaceCoral,
+    rotationDegrees: Float = 0f,
+) {
+    Canvas(modifier = modifier.graphicsLayer { rotationZ = rotationDegrees }) {
+        val r = size.minDimension / 2f
+        val c = Offset(size.width / 2f, size.height / 2f)
+
+        // Face disc.
+        drawCircle(color = tint, radius = r, center = c)
+
+        // Eyes — two dark dots in the upper third.
+        val eyeRadius = r * 0.14f
+        val eyeOffsetX = r * 0.40f
+        val eyeOffsetY = r * 0.22f
+        drawCircle(RedfaceInk, eyeRadius, Offset(c.x - eyeOffsetX, c.y - eyeOffsetY))
+        drawCircle(RedfaceInk, eyeRadius, Offset(c.x + eyeOffsetX, c.y - eyeOffsetY))
+
+        // Grin — a lower arc (a smile) stroked across the face.
+        val grinInset = r * 0.42f
+        val grinRect = Rect(
+            offset = Offset(c.x - grinInset, c.y - grinInset * 0.55f),
+            size = Size(grinInset * 2f, grinInset * 1.7f),
+        )
+        drawArc(
+            color = RedfaceInk,
+            startAngle = GRIN_START_ANGLE,
+            sweepAngle = GRIN_SWEEP_ANGLE,
+            useCenter = false,
+            topLeft = grinRect.topLeft,
+            size = grinRect.size,
+            style = Stroke(width = r * 0.13f, cap = StrokeCap.Round),
+        )
+    }
+}
+
+// A friendly downward (smiling) arc: from ~25° clockwise through ~130°, i.e. the bottom of the face.
+private const val GRIN_START_ANGLE = 25f
+private const val GRIN_SWEEP_ANGLE = 130f
+
+/** The redface identity colour — a warm coral red, legible on the light/dark/AMOLED puck surfaces. */
+val RedfaceCoral = Color(0xFFE8584E)
+
+/** Eyes + grin ink — a deep warm brown, softer than pure black on the coral face. */
+private val RedfaceInk = Color(0xFF3A1410)

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/loader/RedfacePuck.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/loader/RedfacePuck.kt
@@ -1,0 +1,74 @@
+package fr.forumhfr.redface2.core.ui.loader
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.ui.post.rememberAnimationsEnabled
+
+/**
+ * #7 — the « redface » pull-to-refresh puck (Concept 1, XaTriX's pick): an elevated round surface that
+ * holds the [RedfaceFace], shown while the user is pulling. It EMERGES (rises + scales + fades in) and
+ * the face ROLLS on itself as a pure function of [progress] (the pull distance fraction) — no timeline,
+ * fully deterministic, so it stops the instant the user stops pulling. The face only rolls when system
+ * animations are enabled ([rememberAnimationsEnabled]); reduce-motion shows it upright.
+ *
+ * « Amorce seule » (XaTriX): this puck is the PULL cue only. The caller hides it the moment the refresh
+ * starts, leaving the thin top loading bar as the single refresh indicator (no double indicator). So the
+ * face deliberately rolls during the PULL (driven by [progress]), never in an infinite refresh spin.
+ *
+ * The container is `surfaceContainerHighest`, so the puck adapts to light/dark/AMOLED on its own.
+ */
+@Composable
+fun RedfacePullPuck(
+    progress: Float,
+    modifier: Modifier = Modifier,
+) {
+    val animationsEnabled = rememberAnimationsEnabled()
+    val pull = progress.coerceIn(0f, 1f)
+    val puckAlpha = (pull * ALPHA_RAMP).coerceIn(0f, 1f)
+    val puckScale = MIN_SCALE + (1f - MIN_SCALE) * pull
+    // Over-pull keeps rolling past the threshold (progress can exceed 1) for a livelier feel.
+    val rollDegrees = if (animationsEnabled) progress.coerceAtLeast(0f) * MAX_ROLL_DEGREES else 0f
+
+    Surface(
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        shadowElevation = PUCK_ELEVATION,
+        modifier = modifier
+            .size(PUCK_SIZE)
+            .graphicsLayer {
+                alpha = puckAlpha
+                scaleX = puckScale
+                scaleY = puckScale
+                // Descends into place: starts slightly ABOVE its slot (negative Y) and settles down to
+                // rest (0) as the pull completes — the puck drops in from behind the bar.
+                translationY = -RISE.toPx() * (1f - pull)
+            },
+    ) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            RedfaceFace(modifier = Modifier.size(FACE_SIZE), rotationDegrees = rollDegrees)
+        }
+    }
+}
+
+private val PUCK_SIZE = 40.dp
+private val FACE_SIZE = 26.dp
+private val PUCK_ELEVATION = 6.dp
+private val RISE = 16.dp
+
+// The face reaches the threshold having rolled 1.5 turns — clearly « rolling » without looking frantic.
+private const val MAX_ROLL_DEGREES = 540f
+
+// Scale at the very start of the pull (grows to 1 at the threshold).
+private const val MIN_SCALE = 0.6f
+
+// Fade-in faster than the descent so the puck is opaque before it settles.
+private const val ALPHA_RAMP = 1.4f

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -48,7 +48,6 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
-import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshState
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -113,6 +112,7 @@ import fr.forumhfr.redface2.core.ui.LocalForumRowTitleMaxLines
 import fr.forumhfr.redface2.core.ui.R as CoreUiR
 import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.formatLastReplyTimestamp
+import fr.forumhfr.redface2.core.ui.loader.RedfacePullPuck
 import fr.forumhfr.redface2.core.ui.icon.RedfaceVectorIcon
 import fr.forumhfr.redface2.core.ui.icon.categoryIcon
 import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsChoice
@@ -1260,16 +1260,16 @@ internal fun shouldShowPullAmorce(
 ): Boolean = !isRefreshing && !settling && distanceFraction > 0f
 
 /**
- * #603 (XaTriX) — « amorce seule » pull-to-refresh cue: the standard [PullToRefreshDefaults.Indicator]
+ * #603/#7 (XaTriX) — « amorce seule » pull-to-refresh cue: the « redface » loader puck ([RedfacePullPuck])
  * shown ONLY while the user is actively pulling, then NOTHING once the refresh starts so the thin top
  * [FlagsLoadingBar] is the single loading cue (no double indicator). The whole wrapper is gated, not
  * just the content, per Codex (an indicator left with empty content can keep its container visible).
  * Shared by both pull-to-refresh surfaces.
  *
  * The [settling] state keeps the indicator hidden through the post-refresh return-to-rest (see
- * [shouldShowPullAmorce]). Passing `isRefreshing = false` keeps the indicator in its determinate pull
- * state — it never reaches the persistent circular spin here (the M3-expressive `LoadingIndicator` is
- * `internal` in this BOM, so the determinate default Indicator is the amorce visual).
+ * [shouldShowPullAmorce]). The redface emerges + rolls as a pure function of `state.distanceFraction`
+ * during the PULL; it never reaches a persistent refresh spin here (amorce-only, XaTriX's pick — the
+ * M3-expressive indeterminate `LoadingIndicator` is `internal` in this BOM anyway).
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -1292,11 +1292,7 @@ private fun FlagsPullAmorce(
         }
     }
     if (shouldShowPullAmorce(isRefreshing, state.distanceFraction, settling)) {
-        PullToRefreshDefaults.Indicator(
-            state = state,
-            isRefreshing = false,
-            modifier = modifier,
-        )
+        RedfacePullPuck(progress = state.distanceFraction, modifier = modifier)
     }
 }
 


### PR DESCRIPTION
## #7 — loader « redface » à l'amorce du pull-to-refresh

Remplace l'amorce de rafraîchissement standard (Material) par le loader « redface » (Concept 1, choix XaTriX) : une petite tête ronde souriante qui **émerge sous la barre et roule sur elle-même** au fil du tirage.

### Décisions XaTriX (tranchées via question)
- **Amorce seule** : le redface est le repère du TIRAGE uniquement. Dès que le rafraîchissement démarre, il disparaît et la fine barre du haut (`FlagsLoadingBar`) reste le **seul** repère de chargement — pas de double indicateur (invariant projet conservé). La tête roule donc pendant le PULL (piloté par `distanceFraction`), jamais en spin de refresh.
- **Tête dessinée en Compose**, pas le `redface.gif` HFR (asset tiers dans un APK GPL-3.0 ; un dessin original est licence-clean, net à toute taille, theme-adaptatif).

### Implémentation
- **`core/ui/loader/RedfaceFace.kt`** : la tête dessinée au Canvas (disque corail + 2 yeux + arc sourire), tournée par un param `rotationDegrees` (graphicsLayer rotationZ → yeux + sourire tournent ensemble). Param `tint` (défaut corail).
- **`core/ui/loader/RedfacePuck.kt`** : `RedfacePullPuck(progress)` — pastille élevée `surfaceContainerHighest` (s'adapte clair/sombre/AMOLED) dont le scale, l'alpha, la descente et la rotation de la tête sont des **fonctions pures** du `progress` (distanceFraction). Rotation coupée si « réduire les animations » est actif (`rememberAnimationsEnabled`).
- **`FlagsRoute.FlagsPullAmorce`** rend `RedfacePullPuck(state.distanceFraction)` au lieu de `PullToRefreshDefaults.Indicator` ; la machine à états `shouldShowPullAmorce` + `settling` (amorce seule, anti-repop) est **inchangée**. S'applique aux deux surfaces de pull (liste drapeaux + DT). Import `PullToRefreshDefaults` retiré.

### Validation
- **CI canonique locale** : `:app:assembleProdDebug test testDebugUnitTest lintDebug :app:lintProdDebug detektAll` → **BUILD SUCCESSFUL**.
- **Émulateur authentifié** : en tirant la liste Cyan, la tête corail émerge sous la barre (offset #665) et s'incline (roule) au fil du tirage ; pastille à ombre, 2 yeux + sourire.
- **Codex GPT-5.5 (xhigh)** : **GO avec réserves**, aucun bloquant. Réserve (commentaire ambigu sur `translationY`) corrigée.

Sous-chantier de la refonte top bar #603 (le loader « redface » annoncé « à suivre »). Ne ferme aucune issue (le loader n'a pas d'issue dédiée ; #7 = archi extensions, sans rapport).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Dih2obVDx6wMdEdfCPEYc
