### PR TITLE
fix(flags): #603 loader pull puck rond (pas un squircle) au tirer lent — dev 0.17.30

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,23 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.17.30` — `internal` (dev) — 2026-06-29
+
+> Vue Drapeaux (#603) — **correctif du loader pull-to-refresh** : au tirer lent, la pastille du redface
+> se rend de nouveau en cercle (et non en carré à coins arrondis). versionName 0.17.29 → 0.17.30.
+
+**Drapeaux — vue (#603)**
+
+- **Pastille du loader ronde au tirer lent (#603)** : au tirer-pour-rafraîchir LENT, le fond du redface
+  s'affichait comme un carré à coins arrondis au lieu d'un cercle. Cause : le fondu d'apparition
+  (`alpha < 1`) forçait une couche offscreen RECTANGULAIRE (bornes 48 dp) qui rognait l'ombre non-clippée
+  de la pastille ; réduite à petite échelle, elle se lisait comme un squircle. Corrigé via
+  `CompositingStrategy.ModulateAlpha` (module l'alpha par opération de dessin au lieu d'un buffer
+  offscreen) — le cercle ET l'ombre douce sont préservés (un clip dur aurait coupé l'ombre). Signalé par
+  thibw au dogfood ; gaté Codex (cause + fix + diff) et vérifié émulateur (pull + refreshing).
+
+---
+
 ## `0.17.29` — `internal` (dev) — 2026-06-28
 
 > Vue Drapeaux (#603) — **quatre correctifs de finition** : le « petit saut » du contenu en fin de

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.29"
+        versionName = "0.17.30"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,9 +1,4 @@
-Redface 2 v0.17.29 — dev.
+Redface 2 v0.17.30 — dev.
 
 Flags view:
-- Fixed the small content "jump" at end-of-load (manual pull and auto-reload).
-- The list no longer flashes behind the top bar when toggling "+lus".
-- "Display settings" removed from the DT/Super tabs (it did nothing there, then opened on the next tab switch).
-
-Account avatar:
-- No more white background behind a transparent avatar; the no-op "transparent background" option was removed.
+- Pull-to-refresh loader fix: on a slow pull, the redface's container is round again (no longer a rounded square).

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,9 +1,4 @@
-Redface 2 v0.17.29 — dev.
+Redface 2 v0.17.30 — dev.
 
 Vue Drapeaux :
-- Fin du « petit saut » du contenu en fin de chargement (pull manuel et rechargement auto).
-- Plus de flash de la liste derrière la barre du haut au basculement « +lus ».
-- « Réglages d'affichage » retiré des onglets DT/Super (sans effet puis s'ouvrait au changement d'onglet).
-
-Avatar du compte :
-- Plus de fond blanc derrière un avatar transparent ; option « Fond transparent » (sans effet) retirée.
+- Correctif du loader « redface » : au tirer-pour-rafraîchir lent, sa pastille s'affiche de nouveau en cercle (et non en carré à coins arrondis).

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/loader/RedfacePuck.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/loader/RedfacePuck.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.ui.post.rememberAnimationsEnabled
@@ -58,6 +59,15 @@ fun RedfacePullPuck(
                 scaleY = puckScale
                 // Drops in from behind the bar during the pull; settled (0) once refreshing.
                 translationY = if (refreshing) 0f else -RISE.toPx() * (1f - pull)
+                // #603 (thibw dogfood) — without this, `alpha < 1f` (the pull fade-in) forces an
+                // OFFSCREEN RECTANGULAR layer at the 48 dp bounds; the Surface's unclipped elevation
+                // shadow (`clip = false`) then fills that rect and, scaled down at small `puckScale`,
+                // reads as a SQUIRCLE around the round redface (« le cercle rose tronqué dans un carré »).
+                // ModulateAlpha multiplies the alpha per draw op instead of compositing through that
+                // offscreen buffer, so the round shape + soft shadow are preserved (a hard circular clip
+                // would instead cut the shadow). The puck is opaque past pull≈0.71 (ALPHA_RAMP), so the
+                // per-op modulation only differs from group-alpha during the faint early pull.
+                compositingStrategy = CompositingStrategy.ModulateAlpha
             },
     ) {
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {


### PR DESCRIPTION
## Bug (dogfood thibw)

Au tirer-pour-rafraîchir **lent**, le container du puck redface — `Surface(shape = CircleShape, shadowElevation = 6.dp)` — se rendait comme un **carré à coins arrondis** (squircle) autour du redface, lui bien circulaire. Très visible à petit `puckScale` (début de pull).

## Cause (gatée Codex)

Le fondu d'apparition `alpha < 1f` force une **couche de compositing offscreen RECTANGULAIRE** aux bornes 48 dp. L'ombre d'élévation non-clippée de la Surface (`clip = false`) remplit ce rectangle ; réduite à petite échelle, elle se lit comme un squircle.

## Fix

`CompositingStrategy.ModulateAlpha` sur le même `graphicsLayer` que `alpha/scale/translationY` : l'alpha est modulé **par opération de dessin** au lieu de passer par un buffer offscreen → la **forme ronde ET l'ombre douce** sont préservées (un clip circulaire dur aurait, lui, coupé l'ombre — écarté par Codex).

## Vérification

- **Codex gpt-5.5 xhigh à chaque étape** : cause + recommandation du fix (il a fourni le snippet `ModulateAlpha`), puis confirmation du diff livré → **GO**.
- **Dogfood émulateur avant/après** (pull lent, captures ×4) : squircle → **cercle net** ; état `refreshing` (alpha=1) = cercle + anneau de progression + ombre intacts.
- **Validation canonique** (`assembleProdDebug + test + testDebugUnitTest + lintDebug + lintProdDebug + detektAll`) : **BUILD SUCCESSFUL**.

Réserve notée (Codex) : `ModulateAlpha` diffère du group-alpha si des pixels opaques se chevauchent sous `alpha < 1` ; ici sans effet (alpha < 1 seulement au tout début du pull, opaque dès ~0.71 ; refreshing à alpha=1). À revalider si le puck gagne plus tard des recouvrements opaques.

> Action par Claude Opus 4.8 (demandée par @XaaT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)