### PR TITLE
fix(flags): #603 corrections d'audit avant bêta (prefs globales DT/Super, recall #695, a11y, gardes CI)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreSuperFavoriteRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreSuperFavoriteRepository.kt
@@ -4,10 +4,12 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringSetPreferencesKey
+import android.util.Log
 import fr.forumhfr.redface2.core.domain.coroutines.ApplicationScope
 import fr.forumhfr.redface2.core.domain.preferences.SuperFavoriteRepository
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
@@ -30,7 +32,15 @@ class DataStoreSuperFavoriteRepository @Inject constructor(
         dataStore.data
             .map { prefs -> prefs[KEY].orEmpty().mapNotNull(String::toIntOrNull).toSet() }
             .distinctUntilChanged()
-            .catch { emit(emptySet()) }
+            // Audit #1 — rethrow CancellationException before degrading: a bare `catch { emit(...) }`
+            // swallows ALL throwables, including the cooperative cancellation that structured
+            // concurrency relies on (mirrors DefaultFlagRepository.fetchStickyFlagSupplement). Only a
+            // genuine DataStore read error degrades to an empty set (e.g. corrupt prefs file).
+            .catch { e ->
+                if (e is CancellationException) throw e
+                Log.w(TAG, "Could not read super-favorite topic ids; degrading to empty set", e)
+                emit(emptySet())
+            }
 
     override suspend fun setSuperFavorite(topicId: Int, enabled: Boolean) {
         // Parented to the process-lifetime scope (cf. DataStoreUserPreferencesRepository.persist) so a
@@ -45,6 +55,7 @@ class DataStoreSuperFavoriteRepository @Inject constructor(
     }
 
     private companion object {
+        const val TAG = "SuperFavoriteRepo"
         val KEY = stringSetPreferencesKey("super_favorite_topic_ids")
     }
 }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -446,6 +446,30 @@ class DataStoreUserPreferencesRepositoryTest {
     }
 
     @Test
+    fun `singleLineTitle defaults to false on an empty store`() = runTest(dispatcher) {
+        // #603 GLOBAL: titles wrap to 2 lines by default; the single-line ellipsis is the opt-in.
+        repository.observeFlagsViewSettings(FlagType.CYAN).test {
+            assertEquals(false, awaitItem().singleLineTitle)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setFlagsSingleLineTitle persists and round-trips for every tab`() = runTest(dispatcher) {
+        // #603 GLOBAL: written once, observed on any tab type.
+        repository.setFlagsSingleLineTitle(true)
+        repository.observeFlagsViewSettings(FlagType.RED).test {
+            assertEquals(true, awaitItem().singleLineTitle)
+            cancelAndIgnoreRemainingEvents()
+        }
+        repository.setFlagsSingleLineTitle(false)
+        repository.observeFlagsViewSettings(FlagType.FAVORITE).test {
+            assertEquals(false, awaitItem().singleLineTitle)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `showLoadingBar defaults to true on an empty store`() = runTest(dispatcher) {
         // #728 GLOBAL: the thin top loading bar is shown by default (opt-out).
         repository.observeFlagsViewSettings(FlagType.CYAN).test {

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagMarker.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/FlagMarker.kt
@@ -18,6 +18,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
@@ -122,11 +126,16 @@ private fun Modifier.markerOutline(enabled: Boolean, color: Color, shape: Shape)
  */
 @Composable
 fun PagesToReadPill(count: Int, accent: Color, modifier: Modifier = Modifier) {
+    // Audit #3 — the "+N" glyph alone reads as « plus 3 » with no context in TalkBack. Carry a clear,
+    // localized, PLURAL-AWARE label on the container and mark the inner Text decorative so the pill
+    // announces a single meaningful sentence (« 1 page à lire » vs « N pages à lire »).
+    val pagesToReadDescription = pluralStringResource(R.plurals.flag_pages_to_read_a11y, count, count)
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(7.dp))
             .background(accent.copy(alpha = 0.20f))
-            .padding(horizontal = 7.dp, vertical = 1.dp),
+            .padding(horizontal = 7.dp, vertical = 1.dp)
+            .semantics { contentDescription = pagesToReadDescription },
         contentAlignment = Alignment.Center,
     ) {
         Text(
@@ -134,6 +143,8 @@ fun PagesToReadPill(count: Int, accent: Color, modifier: Modifier = Modifier) {
             style = MaterialTheme.typography.labelSmall,
             fontWeight = FontWeight.SemiBold,
             color = accent,
+            // Decorative — the container's contentDescription owns the announcement.
+            modifier = Modifier.clearAndSetSemantics {},
         )
     }
 }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/account/RedfaceAccountMenu.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/account/RedfaceAccountMenu.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -239,6 +240,12 @@ private fun AvatarBadge(
             size = BADGE_SIZE,
             // Round « PP » to match the circular badge (the post-header default stays rounded-square).
             shape = CircleShape,
+            // Audit #2 — make the inner avatar PURELY decorative for TalkBack. The parent Surface already
+            // owns the single action label « Ouvrir le menu compte »; `RedfaceUserAvatar` otherwise emits
+            // its own "Avatar de <pseudo>" contentDescription on the loaded-image branch, so the badge
+            // risked announcing TWO descriptions for one target. `clearAndSetSemantics {}` drops the
+            // avatar's subtree semantics so only the parent's action/label is read.
+            modifier = Modifier.clearAndSetSemantics {},
         )
     }
 }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/loader/RedfacePuck.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/loader/RedfacePuck.kt
@@ -13,7 +13,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.ui.R
 import fr.forumhfr.redface2.core.ui.post.rememberAnimationsEnabled
 
 /**
@@ -47,11 +53,26 @@ fun RedfacePullPuck(
     val rollDegrees =
         if (refreshing || !animationsEnabled) 0f else progress.coerceAtLeast(0f) * MAX_ROLL_DEGREES
 
+    // Audit #4 — announce the refresh to TalkBack. During a MANUAL refresh the thin top loading bar is
+    // suppressed, so this puck is the SOLE activity indicator (the face has no contentDescription and the
+    // ring carries no label). Only annotate while [refreshing]; staying silent during the pull gesture
+    // avoids spamming the live region for every progress frame.
+    val refreshingDescription = stringResource(R.string.loader_pull_refreshing)
+    val refreshSemantics = if (refreshing) {
+        Modifier.semantics {
+            liveRegion = LiveRegionMode.Polite
+            contentDescription = refreshingDescription
+        }
+    } else {
+        Modifier
+    }
+
     Surface(
         shape = CircleShape,
         color = MaterialTheme.colorScheme.surfaceContainerHighest,
         shadowElevation = PUCK_ELEVATION,
         modifier = modifier
+            .then(refreshSemantics)
             .size(PUCK_SIZE)
             .graphicsLayer {
                 alpha = puckAlpha

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -73,4 +73,13 @@
     <string name="editor_smiley_search_empty">Aucun smiley trouvé.</string>
     <string name="editor_smiley_search_error">Erreur réseau. Réessaie dans un instant.</string>
     <string name="editor_smiley_insert_description">Insérer %1$s</string>
+    <!-- a11y (#603 audit): the pull-to-refresh redface loader announces refresh progress to TalkBack;
+         on a manual pull the thin top bar is suppressed, so the puck is the SOLE activity indicator. -->
+    <string name="loader_pull_refreshing">Actualisation en cours</string>
+    <!-- a11y (#603 audit): the "+N" pages-to-read pill announces a full sentence instead of « plus N »;
+         the plural form fixes the « 1 pages » grammar bug for a single page. -->
+    <plurals name="flag_pages_to_read_a11y">
+        <item quantity="one">%1$d page à lire</item>
+        <item quantity="other">%1$d pages à lire</item>
+    </plurals>
 </resources>

--- a/docs/adr/017-refonte-vue-drapeaux.md
+++ b/docs/adr/017-refonte-vue-drapeaux.md
@@ -91,9 +91,15 @@ stable par catégorie** (clé = identité catégorie, pas un index fragile).
 
 ### 5. Persistance : extension de `FlagsViewSettings` + super-favori local
 
-- `FlagsViewSettings` est **étendu** (DataStore, champs versionnés, **defaults conservateurs**) avec
-  au moins : `markerStyle` (défaut **STRIPE**) et `density` (défaut **BALANCED/Standard**). Les
-  champs existants (`groupByCategory`, `hideReadCategories`, `unreadOnly`) sont conservés.
+- `FlagsViewSettings` est **étendu** (DataStore, champs versionnés, **defaults conservateurs**). Champs
+  GLOBAUX réellement livrés (#603, non soumis à l'override per-onglet) : `markerStyle` (défaut
+  **STRIPE**), `singleLineTitle`, `categoryBandStyle` (défaut **MINIMAL**), `markerBorder`,
+  `plusLusIndicatorStyle` (défaut **Ring**, cf. #661/#721), `flagGlyphStyle` (défaut **Flag**) et
+  `showLoadingBar` (défaut **on**, cf. #728). Les champs existants (`groupByCategory`,
+  `hideReadCategories`, `unreadOnly`) sont conservés.
+- **Note (audit 2026-06-29)** : la **densité** d'affichage envisagée initialement ici n'a finalement
+  **pas** été intégrée à `FlagsViewSettings` ; elle vit comme préférence **globale séparée**
+  (`DisplayDensity`) et n'est pas (encore) consommée par la vue Drapeaux.
 - **Super-favori** : nouvelle notion **purement locale** (ensemble de `topicId` persisté en
   DataStore), **distincte** de `isFavorite` (qui reflète `flag_owntopic == 3` côté serveur). Pas de
   mutation serveur. L'action vit dans le bottom sheet d'appui-long (cf. décision 6). L'onglet

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.feature.flags
 
 import android.annotation.SuppressLint
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -66,6 +67,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
@@ -124,6 +126,7 @@ import fr.forumhfr.redface2.core.ui.icon.categoryIcon
 import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsChoice
 import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsChoiceGroup
 import fr.forumhfr.redface2.core.ui.theme.FlagPalette
+import java.util.Locale
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -243,27 +246,25 @@ fun FlagsRoute(
     // each pane's state during a transition. The active tab's state still drives the filter-flip reset
     // (#385) and the landing recall-to-top (#546) below, both already scoped to the current tab.
     val flagTabListStates = rememberFlagTabListStates()
-    val flagsListState = flagTabListStates.forType(selectedTab.flagType)
+    // #603 audit fix — key the scroll effects on the SELECTED TAB's own list (forTab), NOT
+    // forType(flagType): DT and Super both have flagType == null, so forType(null)==cyan made the
+    // recall/filter-reset fire on the hidden CYAN list (eroding the per-tab scroll of #695) and
+    // never reach the real DT list. forTab returns null for Super (no list) → effects skipped.
+    val flagsListState: LazyListState? = flagTabListStates.forTab(selectedTab)
     // #665 — the overlay bar gains an opaque→transparent scrim only when content is actually scrolled
     // under it. The active tab's list drives it; Super (no list) and empty/loading states report
     // canScrollBackward = false, so the bar stays non-elevated without a special case (isTabScrolled).
     val barElevated = flagTabListStates.isTabScrolled(selectedTab)
     val tabUnreadFilter by viewModel.tabUnreadFilter.collectAsStateWithLifecycle()
-    FilterFlipScrollResetEffect(
-        tabUnreadFilter = tabUnreadFilter,
-        listState = flagsListState,
-    )
-
-    // #546 — recall the list to the top after a LANDING auto-refresh (app open / tab switch /
-    // resume): the refresh prepends freshly-surfaced flags and a held scroll position would leave
-    // them off-screen (« faut scroller vers le haut », tinc/Lt Ripley). Driven by a one-shot
-    // ViewModel signal (consumed once handled) rather than a replayable counter, so a rotation /
-    // route recreation does not replay a stale scroll. Return-from-topic refreshes never raise it.
     val recallListToTop by viewModel.recallListToTop.collectAsStateWithLifecycle()
-    RecallListToTopEffect(
-        recall = recallListToTop,
+    // #603 audit fix — wires the filter-flip reset (#385) + landing recall-to-top (#546) to the
+    // SELECTED TAB's own list. Extracted to a helper so its null-guard / branches stay off
+    // FlagsRoute's cyclomatic budget (detekt limit 15).
+    FlagScrollEffects(
         listState = flagsListState,
-        onConsumed = viewModel::consumeRecallListToTop,
+        tabUnreadFilter = tabUnreadFilter,
+        recallListToTop = recallListToTop,
+        onRecallConsumed = viewModel::consumeRecallListToTop,
     )
 
     // #309 — display-settings bottom sheet. Opened from the header « Affichage » action; the trigger
@@ -345,8 +346,10 @@ fun FlagsRoute(
     // #603 PR2 — client-side search over the loaded flags + the app-bar tab picker. The query is
     // hoisted here (the app bar edits it, the body filters with it) and reset on a tab change so a
     // query never carries silently from one tab to another.
-    var searchQuery by remember { mutableStateOf("") }
-    var searchActive by remember { mutableStateOf(false) }
+    // #603 audit fix — rememberSaveable so an in-progress search (query + open field) survives a
+    // rotation / process-death restore instead of being silently dropped (the list already restores).
+    var searchQuery by rememberSaveable { mutableStateOf("") }
+    var searchActive by rememberSaveable { mutableStateOf(false) }
     // #728 — a MANUAL (gesture) pull-refresh is in flight: the rich contained redface indicator shows and
     // the thin top loading bar is suppressed (no double indicator). Armed by the body's pull gesture.
     var manualRefresh by remember { mutableStateOf(false) }
@@ -366,6 +369,18 @@ fun FlagsRoute(
             snapshotFlow { anyRefreshing(isRefreshing, dtIsRefreshing) },
         )
     }
+
+    // #603 audit fix — collapse an open search on system back (mirror of SettingsScreen) and when
+    // the screen stops being searchable on the same tab (session expiry). Extracted to a helper so
+    // its branches stay off FlagsRoute's cyclomatic budget (detekt limit 15).
+    FlagsSearchBackHandler(
+        searchActive = searchActive,
+        searchEnabled = searchEnabled,
+        onCollapseSearch = {
+            searchQuery = ""
+            searchActive = false
+        },
+    )
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -1185,6 +1200,9 @@ private fun AnonymousBody(onLoginRequested: () -> Unit) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
+            // #603 audit fix — reserve the overlay bar height like every other body, otherwise the
+            // translucent top bar (#665, always drawn) covers the top of the « Se connecter » intro.
+            .padding(top = LocalFlagsContentTopPadding.current)
             .padding(horizontal = 24.dp, vertical = 16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
@@ -1739,6 +1757,52 @@ private fun RecallListToTopEffect(recall: Boolean, listState: LazyListState, onC
     }
 }
 
+/**
+ * #603 audit fix — drives the per-tab scroll effects (filter-flip reset #385 + landing recall #546)
+ * for the SELECTED tab's own list. [listState] is null for the Super placeholder (no list): the two
+ * effects are skipped, but a raised [recallListToTop] is still consumed so the one-shot signal never
+ * stays armed and later fires on the next real-list tab. Keying these effects on the tab's own list
+ * (forTab) rather than forType(flagType) stops DT/Super (both flagType==null → cyan) from recalling
+ * the hidden Cyan list and eroding the per-tab scroll preservation (#695). Extracted from FlagsRoute
+ * so its null-guard / branches stay off the cyclomatic budget (detekt limit 15).
+ */
+@Composable
+private fun FlagScrollEffects(
+    listState: LazyListState?,
+    tabUnreadFilter: Pair<FlagTab, Boolean>,
+    recallListToTop: Boolean,
+    onRecallConsumed: () -> Unit,
+) {
+    listState?.let { state ->
+        FilterFlipScrollResetEffect(tabUnreadFilter = tabUnreadFilter, listState = state)
+        RecallListToTopEffect(recall = recallListToTop, listState = state, onConsumed = onRecallConsumed)
+    }
+    LaunchedEffect(recallListToTop, listState) {
+        if (recallListToTop && listState == null) onRecallConsumed()
+    }
+}
+
+/**
+ * #603 audit fix — collapses an open search: the system back gesture restores the normal top bar
+ * first (mirrors SettingsScreen) instead of leaving the screen, and the search is also cleared when
+ * the screen stops being searchable on the same tab (e.g. session expiry). Extracted from FlagsRoute
+ * so the back-enable predicate / branches stay off its cyclomatic budget (detekt limit 15).
+ */
+@Composable
+private fun FlagsSearchBackHandler(
+    searchActive: Boolean,
+    searchEnabled: Boolean,
+    onCollapseSearch: () -> Unit,
+) {
+    // enabled = searchActive ALONE (not && searchEnabled): if the screen stops being searchable while
+    // a search is open (session expiry), back must still collapse the loupe rather than leave the
+    // screen during the brief window before the LaunchedEffect below clears it (Codex gate review).
+    BackHandler(enabled = searchActive) { onCollapseSearch() }
+    LaunchedEffect(searchEnabled) {
+        if (!searchEnabled) onCollapseSearch()
+    }
+}
+
 // LazyColumn contentType tags (#179 compose-perf): one reuse pool per structurally distinct slot
 // kind so Compose recycles like-for-like across the header→row→header alternation of the grouped
 // list. Plain strings (the contentType is only ever compared for equality).
@@ -1919,7 +1983,9 @@ private fun CategoryBandMinimal(catId: Int, label: String, onClick: () -> Unit) 
                 modifier = Modifier.padding(end = 10.dp),
             )
             Text(
-                text = label.uppercase(),
+                // #603 audit fix — explicit Locale.ROOT: an implicit-locale uppercase() mangles
+                // category names under a Turkish locale (i → İ) and trips Android lint DefaultLocale.
+                text = label.uppercase(Locale.ROOT),
                 style = MaterialTheme.typography.labelMedium.copy(letterSpacing = 0.08.em),
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.weight(1f),
@@ -1996,7 +2062,9 @@ private fun CategoryBandAccent(catId: Int, label: String, onClick: () -> Unit) {
                     modifier = Modifier.padding(end = 10.dp),
                 )
                 Text(
-                    text = label.uppercase(),
+                    // #603 audit fix — explicit Locale.ROOT: an implicit-locale uppercase() mangles
+                    // category names under a Turkish locale (i → İ) and trips Android lint DefaultLocale.
+                    text = label.uppercase(Locale.ROOT),
                     style = MaterialTheme.typography.labelMedium.copy(letterSpacing = 0.08.em),
                     color = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.weight(1f),
@@ -2355,7 +2423,11 @@ private fun SuperPlaceholderBody(funny: Boolean) {
         title = stringResource(R.string.flags_super_placeholder_title),
         subtitle = stringResource(R.string.flags_super_placeholder_body),
         funny = funny,
-        modifier = Modifier.fillMaxSize(),
+        // #603 audit fix — reserve the overlay bar height (consistent with every other body) so the
+        // centered placeholder is centered in the VISIBLE area, not behind the translucent top bar.
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(top = LocalFlagsContentTopPadding.current),
     )
 }
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTopBar.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTopBar.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -42,7 +43,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
@@ -334,12 +337,19 @@ private fun TypePlusLusZone(
             .clip(RightZoneShape)
             .then(
                 if (togglable) {
-                    Modifier.clickable(role = Role.Button, onClickLabel = toggleLabel, onClick = onToggle)
-                } else {
+                    // Togglable (Cyan/DT): a real « +lus » toggle — keep the descriptive
+                    // contentDescription + click label so the action and its state are announced.
                     Modifier
+                        .clickable(role = Role.Button, onClickLabel = toggleLabel, onClick = onToggle)
+                        .semantics { contentDescription = description }
+                } else {
+                    // #603 audit fix — non-togglable (Lu/Favori/Super): plain text, no action.
+                    // FlagGlyphZone (zone 1) already announces « Onglet actuel : X »; tagging this
+                    // zone with the SAME label made TalkBack read the tab name twice. Make it
+                    // decorative so the left container announces the current tab exactly once.
+                    Modifier.clearAndSetSemantics {}
                 },
             )
-            .semantics { contentDescription = description }
             .padding(start = 4.dp, end = 14.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp),
@@ -485,7 +495,13 @@ private fun ExpandedSearchContainer(
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             val focusRequester = remember { FocusRequester() }
+            val focusManager = LocalFocusManager.current
             LaunchedEffect(Unit) { focusRequester.requestFocus() }
+            // #603 audit fix — give the field an accessible name (TalkBack had none), a real visible
+            // placeholder (the flags_search_placeholder string existed but was never wired into the
+            // BasicTextField), and a keyboard « Search » action handler (imeAction was set but did
+            // nothing — the IME Search key was inert).
+            val searchHint = stringResource(R.string.flags_search_placeholder)
             BasicTextField(
                 value = query,
                 onValueChange = onQueryChange,
@@ -493,17 +509,34 @@ private fun ExpandedSearchContainer(
                 textStyle = LocalTextStyle.current.copy(color = MaterialTheme.colorScheme.onSurface),
                 cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                keyboardActions = KeyboardActions(onSearch = { focusManager.clearFocus() }),
                 modifier = Modifier
                     .weight(1f)
-                    .focusRequester(focusRequester),
+                    .focusRequester(focusRequester)
+                    .semantics { contentDescription = searchHint },
+                decorationBox = { innerTextField ->
+                    if (query.isEmpty()) {
+                        Text(
+                            text = searchHint,
+                            style = LocalTextStyle.current,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                        )
+                    }
+                    innerTextField()
+                },
             )
             IconButton(
+                // #603 audit fix — default 48dp touch target (was forced to 24dp, below the a11y
+                // minimum) and a real vector icon instead of a « ✕ » text glyph (project convention).
                 onClick = onClose,
-                modifier = Modifier
-                    .size(24.dp)
-                    .semantics { contentDescription = clearLabel },
+                modifier = Modifier.semantics { contentDescription = clearLabel },
             ) {
-                Text(text = "✕", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Icon(
+                    painter = painterResource(CoreUiR.drawable.ic_close),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
         }
     }

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -281,16 +281,31 @@ class FlagsViewModel @Inject constructor(
     /**
      * Display-settings bottom sheet state (#309). Tracks the RESOLVED view settings for the
      * currently selected tab so the sheet's two switches reflect what the list is actually using
-     * (global, or this tab's override). The [FlagTab.Super] placeholder has no real [FlagType], so
-     * it falls back to the global pair — the trigger is hidden there anyway (no list to configure).
+     * (global, or this tab's override). The DT and [FlagTab.Super] placeholders have no real
+     * [FlagType], so they resolve the GLOBAL appearance fields (via the CYAN path) plus the global
+     * group/hide pair — the per-list sheet trigger is hidden there anyway (no list to configure).
      */
     val flagsViewSettings: StateFlow<FlagsViewSettings> = selectedTab
         .flatMapLatest { tab ->
             when (val type = tab.flagType) {
+                // #603 audit fix — DT/Super (no real FlagType) must KEEP the 7 GLOBAL appearance
+                // fields (markerStyle, flagGlyphStyle, plusLusIndicatorStyle, showLoadingBar,
+                // markerBorder, singleLineTitle, categoryBandStyle). Resolving via CYAN carries them
+                // verbatim (they are type-agnostic on every resolution path); the per-type triplet
+                // is then overwritten with the GLOBAL group/hide and an inert unreadOnly. Without
+                // this, a user who turned the loading bar OFF (#728) or picked glyph=Dot / +lus=Eye
+                // saw the bar reappear and the glyph/indicator reset to defaults on DT/Super.
                 null -> combine(
+                    userPreferencesRepository.observeFlagsViewSettings(FlagType.CYAN),
                     userPreferencesRepository.observeFlagsGroupByCategory(),
                     userPreferencesRepository.observeFlagsHideReadCategories(),
-                ) { group, hide -> FlagsViewSettings(group, hide) }
+                ) { resolved, group, hide ->
+                    resolved.copy(
+                        groupByCategory = group,
+                        hideReadCategories = hide,
+                        unreadOnly = false,
+                    )
+                }.distinctUntilChanged()
                 else -> userPreferencesRepository.observeFlagsViewSettings(type)
             }
         }
@@ -606,14 +621,21 @@ class FlagsViewModel @Inject constructor(
         val flag = confirming.flag
         _removeFlagState.value = RemoveFlagState.Removing(flag)
         viewModelScope.launch {
-            val result = flagRepository.removeFlag(flag)
-            _removeFlagState.value = RemoveFlagState.Idle
-            _removeFlagEvent.update {
-                if (result.isSuccess) {
-                    RemoveFlagEvent.Success(flag.title)
-                } else {
-                    RemoveFlagEvent.Failure(flag.title)
+            try {
+                val result = flagRepository.removeFlag(flag)
+                _removeFlagEvent.update {
+                    if (result.isSuccess) {
+                        RemoveFlagEvent.Success(flag.title)
+                    } else {
+                        RemoveFlagEvent.Failure(flag.title)
+                    }
                 }
+            } finally {
+                // #603 audit fix (fork #5) — always release the Removing lock, even if removeFlag
+                // throws an error not wrapped in its Result (or the coroutine is cancelled).
+                // Otherwise the state stays Removing forever and the anti-double-tap guard in
+                // [requestRemoveFlag] permanently blocks any further removal until the VM is recreated.
+                _removeFlagState.value = RemoveFlagState.Idle
             }
         }
     }

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -1114,6 +1114,56 @@ class FlagsViewModelTest {
     }
 
     @Test
+    fun `DT and Super keep the GLOBAL appearance prefs instead of resetting to the defaults (#603 audit)`() =
+        runTest {
+            // #603 audit regression — DT and Super carry no real FlagType, so the OLD resolution built a
+            // bare FlagsViewSettings(group, hide) and let every GLOBAL appearance field fall back to its
+            // data-class default. A user who picked glyph = Dot (#603/#665) and turned the loading bar OFF
+            // (#728) then saw the flag glyph and the bar reappear the moment they landed on DT/Super. The
+            // fix resolves the appearance fields via observeFlagsViewSettings(CYAN) and only overwrites the
+            // group/hide pair + an inert unreadOnly. This pins that the 7 globals (here: flagGlyphStyle +
+            // showLoadingBar) survive, while group/hide mirror the globals and unreadOnly is false.
+            val flags = FakeFlagRepository()
+            val forum = FakeForumRepository(catIds = listOf(1))
+            val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+            // Non-default globals: glyph = Dot, loading bar OFF, flat (group off), hide-read ON.
+            val prefs = FakeUserPreferencesRepository(
+                groupByCategory = false,
+                hideReadCategories = true,
+                flagGlyphStyle = FlagGlyphStyle.Dot,
+                showLoadingBar = false,
+            )
+            val vm = viewModel(auth, flags, forum, prefs)
+
+            // Read the RESOLVED current value after the scheduler settles rather than awaiting
+            // separate Turbine emissions: DT and Super (both flagType == null) resolve to an
+            // IDENTICAL FlagsViewSettings, which the StateFlow conflates — so a per-tab awaitItem for
+            // Super would never arrive. The .value read is deterministic and conflation-proof.
+            advanceUntilIdle()
+            val cyan = vm.flagsViewSettings.value
+            assertEquals(FlagGlyphStyle.Dot, cyan.flagGlyphStyle)
+            assertEquals(false, cyan.showLoadingBar)
+
+            vm.selectTab(FlagTab.Dt)
+            advanceUntilIdle()
+            val dt = vm.flagsViewSettings.value
+            assertEquals("DT must keep glyph = Dot, not reset to Flag", FlagGlyphStyle.Dot, dt.flagGlyphStyle)
+            assertEquals("DT must keep the loading bar OFF, not reappear", false, dt.showLoadingBar)
+            assertFalse("DT mirrors the global flat layout", dt.groupByCategory)
+            assertTrue("DT mirrors the global hide-read", dt.hideReadCategories)
+            assertFalse("DT carries an inert unreadOnly (no list to filter)", dt.unreadOnly)
+
+            vm.selectTab(FlagTab.Super)
+            advanceUntilIdle()
+            val sup = vm.flagsViewSettings.value
+            assertEquals("Super must keep glyph = Dot", FlagGlyphStyle.Dot, sup.flagGlyphStyle)
+            assertEquals("Super must keep the loading bar OFF", false, sup.showLoadingBar)
+            assertFalse("Super mirrors the global flat layout", sup.groupByCategory)
+            assertTrue("Super mirrors the global hide-read", sup.hideReadCategories)
+            assertFalse("Super carries an inert unreadOnly", sup.unreadOnly)
+        }
+
+    @Test
     fun `setFlagsHideReadCategories writes the global scope when the override is off`() = runTest {
         // hide-read routing mirror of the group-by tests; asserted via flagsViewSettings.value since
         // the cross-tab value is identical (global), which a StateFlow would dedup out of a turbine.
@@ -2287,11 +2337,18 @@ class FlagsViewModelTest {
         hideReadCategories: Boolean = false,
         perTabOverride: Boolean = false,
         funnyEmptyState: Boolean = false,
+        // #603 audit — GLOBAL appearance fields configurable so a test can prove they survive the
+        // DT/Super resolution path (tab.flagType == null). They are surfaced verbatim by
+        // observeFlagsViewSettings on every type, mirroring the real DataStore impl.
+        flagGlyphStyle: FlagGlyphStyle = FlagGlyphStyle.Flag,
+        showLoadingBar: Boolean = true,
     ) : UserPreferencesRepository {
         private val groupBy = MutableStateFlow(groupByCategory)
         private val hideRead = MutableStateFlow(hideReadCategories)
         private val perTab = MutableStateFlow(perTabOverride)
         private val funnyEmpty = MutableStateFlow(funnyEmptyState)
+        private val glyphStyle = MutableStateFlow(flagGlyphStyle)
+        private val loadingBar = MutableStateFlow(showLoadingBar)
         private val perTypeGroup: Map<FlagType, MutableStateFlow<Boolean?>> =
             FlagType.entries.associateWith { MutableStateFlow<Boolean?>(null) }
         private val perTypeHide: Map<FlagType, MutableStateFlow<Boolean?>> =
@@ -2350,12 +2407,23 @@ class FlagsViewModelTest {
                     global to globalHide
                 }
             }
+            // #603 audit — fold in the GLOBAL appearance fields the DT/Super path must preserve.
+            val appearance = combine(markerStyle, glyphStyle, loadingBar) { marker, glyph, bar ->
+                Triple(marker, glyph, bar)
+            }
             return combine(
                 layout,
                 perTypeUnread.getValue(type),
-                markerStyle,
-            ) { (group, hide), unread, marker ->
-                FlagsViewSettings(group, hide, unread ?: defaultUnreadOnly(type), marker)
+                appearance,
+            ) { (group, hide), unread, (marker, glyph, bar) ->
+                FlagsViewSettings(
+                    groupByCategory = group,
+                    hideReadCategories = hide,
+                    unreadOnly = unread ?: defaultUnreadOnly(type),
+                    markerStyle = marker,
+                    flagGlyphStyle = glyph,
+                    showLoadingBar = bar,
+                )
             }
         }
 
@@ -2391,11 +2459,15 @@ class FlagsViewModelTest {
         override suspend fun setFlagsSingleLineTitle(enabled: Boolean) = Unit
         override suspend fun setFlagsCategoryBandStyle(style: CategoryBandStyle) = Unit
         override suspend fun setFlagsMarkerBorder(enabled: Boolean) = Unit
-        override suspend fun setFlagsShowLoadingBar(enabled: Boolean) = Unit
+        override suspend fun setFlagsShowLoadingBar(enabled: Boolean) {
+            loadingBar.value = enabled
+        }
         override fun observeAvatarAppearance(): Flow<AvatarAppearance> = MutableStateFlow(AvatarAppearance())
         override suspend fun setAvatarBorder(enabled: Boolean) = Unit
         override suspend fun setFlagsPlusLusIndicatorStyle(style: PlusLusIndicatorStyle) = Unit
-        override suspend fun setFlagsGlyphStyle(style: FlagGlyphStyle) = Unit
+        override suspend fun setFlagsGlyphStyle(style: FlagGlyphStyle) {
+            glyphStyle.value = style
+        }
 
         // #286 — theme prefs are irrelevant to FlagsViewModel; stubbed at their defaults.
         override fun observeThemeMode(): Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -585,6 +585,35 @@ class SettingsViewModelTest {
     }
 
     @Test
+    fun `NavBarLabelsChanged persists the flip and clears the updating flag`() = runTest {
+        // #666 — bottom-nav labels are shown by default; hiding them is the opt-out. Toggling
+        // persists and settles (same optimistic-flip seam as FunnyEmptyState).
+        val viewModel = newViewModel()
+        assertTrue("nav-bar labels are shown by default", viewModel.state.value.navBarLabels)
+
+        viewModel.submit(SettingsIntent.NavBarLabelsChanged(false))
+
+        assertFalse(viewModel.state.value.navBarLabels)
+        assertFalse(viewModel.state.value.isUpdatingNavBarLabels)
+        assertFalse(viewModel.state.value.navBarLabelsError)
+        assertEquals(1, repository.navBarLabelsSetCalls)
+    }
+
+    @Test
+    fun `NavBarLabelsChanged reverts and raises the error flag on persist failure`() = runTest {
+        // The optimistic flip must roll back to the previous value and surface the error flag when
+        // the DataStore write fails (mirror of the FlagsGroupByCategory failure path).
+        repository.failOnNavBarLabelsSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.NavBarLabelsChanged(false))
+
+        assertTrue("must revert to the previous value on failure", viewModel.state.value.navBarLabels)
+        assertFalse(viewModel.state.value.isUpdatingNavBarLabels)
+        assertTrue(viewModel.state.value.navBarLabelsError)
+    }
+
+    @Test
     fun `hide-read categories switch is disabled while the flat flags view is selected`() = runTest {
         val viewModel = newViewModel()
         assertTrue(viewModel.state.value.canToggleFlagsHideReadCategories)

--- a/scripts/check-changelog-entry.sh
+++ b/scripts/check-changelog-entry.sh
@@ -7,15 +7,19 @@ version="${1:?usage: check-changelog-entry.sh <versionName>}"
 changelog="app/CHANGELOG.md"
 [[ -f "$changelog" ]] || { echo "::error::$changelog introuvable"; exit 1; }
 # Match en deux temps (pas de regex sur la version → aucun souci d'échappement de métacaractères) :
-# 1) isoler les lignes de heading markdown, 2) y chercher la version en chaîne LITTÉRALE.
+# 1) isoler les lignes de heading markdown, 2) y chercher la version en token DÉLIMITÉ.
 # NB : surtout PAS de pipe « grep | grep -Fq » ici. Sous `set -o pipefail`, le `-q` sort au
 # premier match et ferme le pipe ; le grep amont reçoit alors un SIGPIPE (exit 141) que pipefail
 # propage comme échec du pipeline → faux négatif intermittent selon le timing du runner
-# (« grep: write error: Broken pipe »). On capture d'abord les headings, puis on teste en
-# substring littérale via `case`, sans pipe ni sous-processus à fermeture anticipée.
+# (« grep: write error: Broken pipe »). On capture d'abord les headings, puis on teste via `case`,
+# sans pipe ni sous-processus à fermeture anticipée.
+# DÉLIMITATION (correctif audit #603) : la version doit être bordée par un caractère NON [0-9.]
+# de part et d'autre, sinon « 0.17.3 » passerait à tort contre le heading « 0.17.30 » (fail-open).
+# Les headings ont la forme « ## `0.17.30` — … » donc la version est toujours bordée par un
+# backtick ; le motif générique [!0-9.] couvre aussi tout futur format sans dépendre du backtick.
 headings="$(grep -E '^#{1,6}[[:space:]]' "$changelog" || true)"
 case "$headings" in
-  *"$version"*)
+  *[!0-9.]"$version"[!0-9.]*)
     echo "CHANGELOG: entrée trouvée pour $version"
     ;;
   *)

--- a/scripts/check-whatsnew.sh
+++ b/scripts/check-whatsnew.sh
@@ -10,11 +10,20 @@ files=("$dir"/whatsnew-*)
 (( ${#files[@]} > 0 )) || { echo "::error::aucun fichier whatsnew dans $dir"; exit 1; }
 for file in "${files[@]}"; do
   first_line="$(head -n 1 "$file")"
-  [[ "$first_line" == *"$version"* ]] || {
-    echo "::error::$file : 1re ligne ne contient pas le versionName '$version' (freshness)"
-    exit 1
-  }
-  chars="$(LC_ALL=C.UTF-8 wc -m < "$file" | tr -d '[:space:]')"
+  # DÉLIMITATION (correctif audit #603) : la version doit être bordée par un caractère NON [0-9.]
+  # de part et d'autre, sinon « 0.17.3 » passerait à tort contre « v0.17.30 — dev. » (fail-open).
+  # La 1re ligne a la forme « Redface 2 v0.17.30 — dev. » : version toujours bordée (v… et espace).
+  case "$first_line" in
+    *[!0-9.]"$version"[!0-9.]*) : ;;
+    *)
+      echo "::error::$file : 1re ligne ne contient pas le versionName '$version' (freshness)"
+      exit 1
+      ;;
+  esac
+  # Compter les CARACTÈRES VISIBLES : `cat` via substitution retire le newline final (que Play ne
+  # compte pas) ; sans ce strip, wc -m comptait le \n terminal et ramenait la limite réelle à 499.
+  content="$(cat "$file")"
+  chars="$(printf '%s' "$content" | LC_ALL=C.UTF-8 wc -m | tr -d '[:space:]')"
   (( chars <= 500 )) || {
     echo "::error::$file : $chars caractères (> 500, limite Play Console)"
     exit 1


### PR DESCRIPTION
## Corrections d'audit de fin de phase Drapeaux (#603) — avant promotion bêta

> Demandée par XaTriX. Issue d'un audit multi-agent (Claude Opus : 3 reviewers indépendants + Codex gpt-5.5 xhigh) de la PR de phase #734 (dev→main). 13 findings confirmés corrigés ; 2 faux positifs réfutés.

### Régressions / correction
- **Prefs globales perdues sur DT/Super** (régression du toggle « barre de chargement » #728, glyph #717, +lus #661) : la branche `flagType==null` du ViewModel ignorait les 7 champs GLOBAUX de `FlagsViewSettings` → désormais résolus via le chemin CYAN.
- **Recall #695** : les effets de scroll étaient keyés sur `forType(flagType)` → DT/Super (`null→cyan`) recallaient la liste Cyan cachée et le recall DT n'atteignait jamais sa liste. Keyé sur `forTab(selectedTab)` (corrige aussi le retour fil DEV « arrive en haut puis descend brutalement »).
- **`confirmRemoveFlag`** : `try/finally` (l'état `Removing` ne se verrouille plus si l'appel lève).

### A11y / UX
- Recherche : back replie la loupe (au lieu de quitter l'écran), `rememberSaveable`, placeholder branché, action clavier Search, nom accessible, croix cible 48 dp + icône vectorielle.
- TalkBack : suppression de la double annonce d'onglet, loader pull (live region), pill « +N pages à lire » (plurals), avatar décoratif.
- `uppercase(Locale.ROOT)` (i18n) ; `AnonymousBody`/`SuperPlaceholderBody` réservent la hauteur de la barre overlay.

### Robustesse / process
- `DataStoreSuperFavoriteRepository` : rethrow `CancellationException`.
- Gardes CI `check-changelog`/`check-whatsnew` : ancrage de version (fail-open `0.17`→`0.17.30` éliminé) + comptage whatsnew correct.
- ADR-017 aligné sur le code livré.

### Tests
Non-régression prefs globales DT/Super, #666 NavBarLabels (handler + rollback), round-trip `singleLineTitle`.

### Validation
Gate local vert (detektAll + lintProdDebug + tests tous modules + testProdDebugUnitTest + assembleProdDebug) + gate Codex GO (réserves traitées).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
