### PR TITLE
chore(release): beta 0.18.0 — clôture phase Drapeaux (#603)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,23 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.18.0` — `open` (beta) — 2026-06-29
+
+**Promotion bêta — clôture de la phase « refonte de la vue Drapeaux » (#603)** (cumul des dev 0.17.0 → 0.17.30 + audit de clôture multi-agent Claude Opus + Codex gpt-5.5).
+
+### Vue Drapeaux — refonte
+- Nouvelle top bar : conteneur gauche (drapeau du type + nom court + indicateur « +lus ») et conteneur droit (loupe rétractable + avatar rond), recherche à hauteur constante.
+- Barre translucide : la liste glisse sous la barre avec un dégradé au défilement (#665).
+- Loader « redface » au tirer-pour-rafraîchir, repositionné sur la rangée des pastilles, pastille ronde (#728).
+- Indicateur « +lus » configurable (œil / anneau coloré), option d'avatar (bordure), glyphe drapeau/pastille (#661/#717/#718).
+- Appui-long : actions rapides distinctes de la liste ; aller à une page ; poster un message (#676/#729) ; recherche sur l'onglet DT.
+- Cyan sticky récupéré (#251), états vides homogénéisés (#662), couleur favori ambre (#690), scroll indépendant par onglet (#695), swipe directionnel (#660), bandes catégorie, barre du bas compacte (#666/#671).
+
+### Corrections d'audit (clôture)
+- Les réglages d'affichage GLOBAUX (glyphe, « +lus », barre de chargement) sont conservés sur les onglets DT/Super.
+- Recherche : le retour système referme la loupe ; champ avec libellé et action clavier ; cible tactile et icône conformes.
+- Préservation du défilement par onglet ; accessibilité (TalkBack) renforcée sur la barre, le loader, les pastilles et l'avatar ; libellés au pluriel corrects.
+
 ## `0.17.30` — `internal` (dev) — 2026-06-29
 
 > Vue Drapeaux (#603) — **correctif du loader pull-to-refresh** : au tirer lent, la pastille du redface

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.17.30"
+        versionName = "0.18.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,4 +1,9 @@
-Redface 2 v0.17.30 — dev.
+Redface 2 v0.18.0 — beta.
 
-Flags view:
-- Pull-to-refresh loader fix: on a slow pull, the redface's container is round again (no longer a rounded square).
+Flags view redesign:
+- New top bar (flag + short name + "+read", retractable search, round avatar).
+- Translucent bar: the list scrolls underneath.
+- "redface" pull-to-refresh loader.
+- Configurable "+read" cue, avatar and glyph; search on the DT tab.
+- Long-press: quick actions, go to page, post a message.
+- Improved accessibility and per-tab scroll preservation.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,4 +1,9 @@
-Redface 2 v0.17.30 — dev.
+Redface 2 v0.18.0 — bêta.
 
-Vue Drapeaux :
-- Correctif du loader « redface » : au tirer-pour-rafraîchir lent, sa pastille s'affiche de nouveau en cercle (et non en carré à coins arrondis).
+Refonte de la vue Drapeaux :
+- Nouvelle barre du haut (drapeau + nom court + « +lus », loupe rétractable, avatar rond).
+- Barre translucide : la liste défile dessous.
+- Loader « redface » au tirer-pour-rafraîchir.
+- « +lus », avatar et glyphe configurables ; recherche sur l'onglet DT.
+- Appui-long : actions rapides, aller à une page, poster.
+- Accessibilité et préservation du défilement par onglet améliorées.


### PR DESCRIPTION
Bump versionName 0.17.30 → 0.18.0 + CHANGELOG + whatsnew (fr/en) pour la promotion bêta de la phase « refonte vue Drapeaux ». versionCode alloué au dispatch (registre de tags git). Edit mécanique de release (exception gate Codex). Demandée par XaTriX.