### PR TITLE
feat(topic): skeleton de chargement + compteur de pages honnête (#604, #622)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/loader/RedfacePuck.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/loader/RedfacePuck.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.ui.R
-import fr.forumhfr.redface2.core.ui.post.rememberAnimationsEnabled
+import fr.forumhfr.redface2.core.ui.motion.rememberAnimationsEnabled
 
 /**
  * #7/#728 — the « redface » pull-to-refresh puck: an elevated round M3-style CONTAINED loading

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/loading/SkeletonBox.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/loading/SkeletonBox.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
-import fr.forumhfr.redface2.core.ui.post.rememberAnimationsEnabled
+import fr.forumhfr.redface2.core.ui.motion.rememberAnimationsEnabled
 
 /**
  * #604 — shared skeleton/shimmer primitive: a tinted box swept by a diagonal highlight band, read as

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/loading/SkeletonBox.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/loading/SkeletonBox.kt
@@ -1,0 +1,76 @@
+package fr.forumhfr.redface2.core.ui.loading
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import fr.forumhfr.redface2.core.ui.post.rememberAnimationsEnabled
+
+/**
+ * #604 — shared skeleton/shimmer primitive: a tinted box swept by a diagonal highlight band, read as
+ * « du contenu se charge ici ». Extracted from the #249 block-image shimmer (which now delegates here)
+ * so loading skeletons (topic page, and later other views) reuse the exact same rendering.
+ *
+ * Allocation profile unchanged from #249: a single [Modifier.drawBehind] reads one animated progress
+ * float and rebuilds only a lightweight linear [Brush] per frame — no per-frame composable.
+ *
+ * Accessibility: when [animated] is false (system animator scale 0, see [rememberAnimationsEnabled],
+ * the default) the band is parked mid-box and the tint is STATIC — no infinite animation. Callers
+ * shape the box through [modifier] (size + clip); the box itself is purely decorative, so callers
+ * owning a semantic loading state should announce it on their container, not per block.
+ */
+@Composable
+fun SkeletonBox(modifier: Modifier = Modifier, animated: Boolean = rememberAnimationsEnabled()) {
+    val base = MaterialTheme.colorScheme.surfaceContainerHighest
+    val highlight = MaterialTheme.colorScheme.surfaceContainerHigh
+    val shimmerColors = remember(base, highlight) { listOf(base, highlight, base) }
+
+    val progress = if (animated) {
+        val transition = rememberInfiniteTransition(label = "skeleton_shimmer")
+        transition.animateFloat(
+            initialValue = 0f,
+            targetValue = 1f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = SHIMMER_PERIOD_MS, easing = LinearEasing),
+                repeatMode = RepeatMode.Restart,
+            ),
+            label = "skeleton_shimmer_progress",
+        ).value
+    } else {
+        // Reduce-motion: park the band mid-box so the static tint blends base↔highlight, no harsh edge.
+        STATIC_PROGRESS
+    }
+
+    Box(
+        modifier = modifier
+            .drawBehind {
+                // Travel the band from off-left to off-right so the highlight enters and exits the box
+                // cleanly each period (width × 2 of travel keeps the diagonal visible throughout).
+                val travel = size.width * 2f
+                val start = -size.width + travel * progress
+                drawRect(
+                    brush = Brush.linearGradient(
+                        colors = shimmerColors,
+                        start = Offset(start, 0f),
+                        end = Offset(start + size.width, size.height),
+                    ),
+                )
+            },
+    )
+}
+
+/** One full sweep period. ~1.1 s reads as "loading" without being distracting (dogfood-tunable). */
+private const val SHIMMER_PERIOD_MS = 1100
+
+private const val STATIC_PROGRESS = 0.5f

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/motion/Motion.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/motion/Motion.kt
@@ -1,0 +1,24 @@
+package fr.forumhfr.redface2.core.ui.motion
+
+import android.provider.Settings
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * #249 §4 — `true` unless the user disabled animations system-wide (Developer options / "Remove
+ * animations", or an accessibility profile setting `ANIMATOR_DURATION_SCALE` to 0). Reading the system
+ * setting (rather than the app's unwired `future_a11y_reduce_motion` row) honours the OS-level
+ * preference the same way Compose's own animations do. Defaults to enabled if the setting is absent.
+ *
+ * Moved from `core.ui.post` (#754 review): consumed by post shimmers, the pull loader AND the loading
+ * skeletons — a shared motion concern, not a post-rendering one.
+ */
+@Composable
+internal fun rememberAnimationsEnabled(): Boolean {
+    val resolver = LocalContext.current.contentResolver
+    return remember(resolver) {
+        val scale = Settings.Global.getFloat(resolver, Settings.Global.ANIMATOR_DURATION_SCALE, 1f)
+        scale != 0f
+    }
+}

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/ImageShimmer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/ImageShimmer.kt
@@ -1,10 +1,7 @@
 package fr.forumhfr.redface2.core.ui.post
 
-import android.provider.Settings
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import fr.forumhfr.redface2.core.ui.loading.SkeletonBox
 
 /**
@@ -22,17 +19,3 @@ internal fun ImageShimmer(animated: Boolean, modifier: Modifier = Modifier) {
     SkeletonBox(modifier = modifier, animated = animated)
 }
 
-/**
- * #249 §4 — `true` unless the user disabled animations system-wide (Developer options / "Remove
- * animations", or an accessibility profile setting `ANIMATOR_DURATION_SCALE` to 0). Reading the system
- * setting (rather than the app's unwired `future_a11y_reduce_motion` row) honours the OS-level
- * preference the same way Compose's own animations do. Defaults to enabled if the setting is absent.
- */
-@Composable
-internal fun rememberAnimationsEnabled(): Boolean {
-    val resolver = LocalContext.current.contentResolver
-    return remember(resolver) {
-        val scale = Settings.Global.getFloat(resolver, Settings.Global.ANIMATOR_DURATION_SCALE, 1f)
-        scale != 0f
-    }
-}

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/ImageShimmer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/ImageShimmer.kt
@@ -1,75 +1,25 @@
 package fr.forumhfr.redface2.core.ui.post
 
 import android.provider.Settings
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.layout.Box
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.LocalContext
+import fr.forumhfr.redface2.core.ui.loading.SkeletonBox
 
 /**
  * #249 — animated shimmer painted INSIDE the already-reserved block-image box (see
- * [PostMediaDisplayPolicy.reservedBlockImageHeight]) while the bitmap loads. A diagonal highlight band
- * sweeps left→right over a tinted base, so the user reads "image en cours de chargement ici" without a
- * spinner — and because the box is pre-sized to the final image, the crossfade reveal causes no bump.
+ * [PostMediaDisplayPolicy.reservedBlockImageHeight]) while the bitmap loads, so the user reads
+ * "image en cours de chargement ici" without a spinner — and because the box is pre-sized to the
+ * final image, the crossfade reveal causes no bump.
  *
- * Allocation profile mirrors [fr.forumhfr.redface2.core.ui.pager.PageSwipe]: a single
- * [Modifier.drawBehind] reads one animated progress float and rebuilds only a lightweight linear
- * [Brush] per frame over the box width — no per-frame composable, no full-screen overdraw.
- *
- * Accessibility (#249 §4 "réduire les animations") : when [animated] is false (system animator scale
- * 0, see [rememberAnimationsEnabled]) the band is parked at rest and the box shows a STATIC tint — no
- * infinite animation, no crossfade upstream. The reveal is then instant.
+ * Rendering is the shared [SkeletonBox] primitive (#604 extracted it from here so topic-page
+ * skeletons reuse the exact same band); this wrapper only keeps the call sites' explicit
+ * [animated] gate (#249 §4 "réduire les animations" — static tint, instant reveal upstream).
  */
 @Composable
 internal fun ImageShimmer(animated: Boolean, modifier: Modifier = Modifier) {
-    val base = MaterialTheme.colorScheme.surfaceContainerHighest
-    val highlight = MaterialTheme.colorScheme.surfaceContainerHigh
-    val shimmerColors = remember(base, highlight) { listOf(base, highlight, base) }
-
-    val progress = if (animated) {
-        val transition = rememberInfiniteTransition(label = "post_image_shimmer")
-        transition.animateFloat(
-            initialValue = 0f,
-            targetValue = 1f,
-            animationSpec = infiniteRepeatable(
-                animation = tween(durationMillis = SHIMMER_PERIOD_MS, easing = LinearEasing),
-                repeatMode = RepeatMode.Restart,
-            ),
-            label = "post_image_shimmer_progress",
-        ).value
-    } else {
-        // Reduce-motion: park the band mid-box so the static tint blends base↔highlight, no harsh edge.
-        STATIC_PROGRESS
-    }
-
-    Box(
-        modifier = modifier
-            .drawBehind {
-                // Travel the band from off-left to off-right so the highlight enters and exits the box
-                // cleanly each period (width × 2 of travel keeps the diagonal visible throughout).
-                val travel = size.width * 2f
-                val start = -size.width + travel * progress
-                drawRect(
-                    brush = Brush.linearGradient(
-                        colors = shimmerColors,
-                        start = Offset(start, 0f),
-                        end = Offset(start + size.width, size.height),
-                    ),
-                )
-            },
-    )
+    SkeletonBox(modifier = modifier, animated = animated)
 }
 
 /**
@@ -86,8 +36,3 @@ internal fun rememberAnimationsEnabled(): Boolean {
         scale != 0f
     }
 }
-
-/** One full sweep period. ~1.1 s reads as "loading" without being distracting (dogfood-tunable). */
-private const val SHIMMER_PERIOD_MS = 1100
-
-private const val STATIC_PROGRESS = 0.5f

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -78,6 +78,7 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import coil3.size.Precision
 import coil3.size.Scale
+import fr.forumhfr.redface2.core.ui.motion.rememberAnimationsEnabled
 import fr.forumhfr.redface2.core.ui.R
 import fr.forumhfr.redface2.core.ui.theme.LocalFoldLongQuotes
 import fr.forumhfr.redface2.core.ui.theme.LocalIgnoreInlineColors

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/CreatorHighlight.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/CreatorHighlight.kt
@@ -13,7 +13,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
-import fr.forumhfr.redface2.core.ui.post.rememberAnimationsEnabled
+import fr.forumhfr.redface2.core.ui.motion.rememberAnimationsEnabled
 
 /**
  * #221 — the gold "sheen" [Brush] applied to a Redface 2 creator's pseudo (see

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicLoadingSkeleton.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicLoadingSkeleton.kt
@@ -1,0 +1,99 @@
+package fr.forumhfr.redface2.feature.topic
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.ui.loading.SkeletonBox
+
+/**
+ * #604 — loading state of a topic page (mockup « Chargement · A Skeleton », arbitré sur le fil DEV) :
+ * a centered Material loader with a plain-language label, then ghost post cards shimmering below, so
+ * the screen reads as « la page arrive » instead of a bare top-left spinner. The REAL topic title is
+ * already in the persistent top bar (`TopicRequest.titleHint` contract) and the page counter shows
+ * « Chargement… » until the response is parsed (#622 — never a stale total).
+ *
+ * The skeleton blocks are decorative (no contentDescription — the visible label carries the state);
+ * shimmer motion is gated system-wide by [SkeletonBox]'s reduce-motion default. Card count is fixed:
+ * enough to fill a phone viewport without composing off-screen work.
+ */
+@Composable
+internal fun TopicLoadingSkeleton(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp, vertical = 20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        CircularProgressIndicator()
+        Text(
+            text = stringResource(R.string.topic_loading_body),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        repeat(SKELETON_CARD_COUNT) {
+            SkeletonPostCard()
+        }
+    }
+}
+
+/** One ghost post card: identity row (round avatar + author/date lines) above body lines. */
+@Composable
+private fun SkeletonPostCard() {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                SkeletonBox(modifier = Modifier.size(30.dp).clip(CircleShape))
+                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    SkeletonLine(widthFraction = 0.45f, height = 10.dp)
+                    SkeletonLine(widthFraction = 0.28f, height = 8.dp)
+                }
+            }
+            SkeletonLine(widthFraction = 1f, height = 9.dp)
+            SkeletonLine(widthFraction = 0.92f, height = 9.dp)
+            SkeletonLine(widthFraction = 0.68f, height = 9.dp)
+        }
+    }
+}
+
+@Composable
+private fun SkeletonLine(widthFraction: Float, height: androidx.compose.ui.unit.Dp) {
+    SkeletonBox(
+        modifier = Modifier
+            .fillMaxWidth(widthFraction)
+            .height(height)
+            .clip(RoundedCornerShape(4.dp)),
+    )
+}
+
+/** Fills a phone viewport below the loader without composing off-screen extra cards. */
+private const val SKELETON_CARD_COUNT = 3

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicLoadingSkeleton.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicLoadingSkeleton.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.ui.loading.SkeletonBox
 
@@ -86,7 +87,7 @@ private fun SkeletonPostCard() {
 }
 
 @Composable
-private fun SkeletonLine(widthFraction: Float, height: androidx.compose.ui.unit.Dp) {
+private fun SkeletonLine(widthFraction: Float, height: Dp) {
     SkeletonBox(
         modifier = Modifier
             .fillMaxWidth(widthFraction)

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.IconButton
@@ -680,8 +679,9 @@ internal fun TopicContent(
     onPollExpansionChanged: (Boolean) -> Unit = {},
 ) {
     // #285 — the topic title and #284 — the page counter live in a persistent top app bar so they
-    // stay visible while the user scrolls (the in-card title/caption scrolls away). When the page
-    // is still loading / errored, fall back to a generic title and the requested page.
+    // stay visible while the user scrolls (the in-card title/caption scrolls away). While loading,
+    // the title falls back to the cached hint (or a generic label) and the counter to « Chargement… »
+    // — never a page total that has not been parsed yet (#622).
     val loaded = state.mode as? TopicUiState.Mode.Loaded
     // #411 — bottom action cluster hides on scroll-down, re-appears on scroll-up (RF1 parity).
     val bottomActionsVisible = rememberBottomActionsVisible(listState)
@@ -694,10 +694,7 @@ internal fun TopicContent(
     } else {
         state.request.titleHint?.takeIf { it.isNotBlank() } ?: fallbackTitle
     }
-    val barCurrentPage = loaded?.topic?.page ?: state.request.page
-    val barTotalPages = loaded?.topic?.totalPages
-        ?: state.availablePages.lastOrNull()
-        ?: state.request.page
+    val barPageIndicator = topicBarPageIndicator(state, loaded)
     val backLabel = stringResource(R.string.topic_back)
     // Build 89 follow-up — when the user opted into auto-hide, give the top bar an `enterAlways`
     // scroll behaviour (collapses on scroll-down, snaps back on the first scroll-up). Otherwise
@@ -718,8 +715,7 @@ internal fun TopicContent(
             TopicTopBar(
                 state = state,
                 barTitle = barTitle,
-                barCurrentPage = barCurrentPage,
-                barTotalPages = barTotalPages,
+                barPageIndicator = barPageIndicator,
                 backLabel = backLabel,
                 scrollBehavior = scrollBehavior,
                 onBack = onBack,
@@ -773,18 +769,9 @@ internal fun TopicContent(
         ) {
             when (val mode = state.mode) {
                 TopicUiState.Mode.Loading -> {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(24.dp),
-                        verticalArrangement = Arrangement.spacedBy(16.dp),
-                    ) {
-                        CircularProgressIndicator()
-                        Text(
-                            text = stringResource(R.string.topic_loading),
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                    }
+                    // #604 — skeleton loading (mockup « Chargement A ») : loader centré + cartes
+                    // fantômes, à la place de l'ancien spinner nu aligné en haut à gauche.
+                    TopicLoadingSkeleton()
                 }
 
                 is TopicUiState.Mode.Error -> {
@@ -855,6 +842,31 @@ internal fun TopicContent(
 }
 
 /**
+ * #622 — subtitle of the persistent top bar. « page X / N » only once the response is PARSED: the
+ * previous fallback chain used `availablePages.lastOrNull()` during Loading, which can be stale from
+ * an earlier navigation (a wrong total displayed while the spinner runs, corrected on arrival).
+ * `availablePages` itself stays untouched — the Error path deliberately keeps the last-known page
+ * grid as context (see the ViewModel), so Error shows the requested page over that last-known total
+ * while Loading shows a plain « Chargement… ».
+ */
+@Composable
+private fun topicBarPageIndicator(state: TopicUiState, loaded: TopicUiState.Mode.Loaded?): String = when {
+    loaded != null -> stringResource(
+        R.string.topic_page_indicator,
+        loaded.topic.page,
+        loaded.topic.totalPages,
+    )
+
+    state.mode is TopicUiState.Mode.Error -> stringResource(
+        R.string.topic_page_indicator,
+        state.request.page,
+        state.availablePages.lastOrNull() ?: state.request.page,
+    )
+
+    else -> stringResource(R.string.topic_loading)
+}
+
+/**
  * #285/#284 + Chantier C (#546) — the topic top app bar (title + page counter + back) plus the
  * intra-topic search affordance : a search icon in `actions` (only when the loaded page exposes a
  * usable, authenticated transsearch form) that opens the [TopicSearchBar] directly beneath the bar.
@@ -866,8 +878,7 @@ internal fun TopicContent(
 private fun TopicTopBar(
     state: TopicUiState,
     barTitle: String,
-    barCurrentPage: Int,
-    barTotalPages: Int,
+    barPageIndicator: String,
     backLabel: String,
     scrollBehavior: androidx.compose.material3.TopAppBarScrollBehavior?,
     onBack: () -> Unit,
@@ -885,7 +896,7 @@ private fun TopicTopBar(
                         overflow = TextOverflow.Ellipsis,
                     )
                     Text(
-                        text = stringResource(R.string.topic_page_indicator, barCurrentPage, barTotalPages),
+                        text = barPageIndicator,
                         style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -17,6 +17,8 @@
     <string name="topic_post_hidden_by_author">Post de %1$s masqué</string>
     <string name="topic_post_hidden_reveal">Afficher</string>
     <string name="topic_loading">Chargement…</string>
+    <!-- #604 — libellé du skeleton de chargement (mockup « Chargement A »), sous le loader centré. -->
+    <string name="topic_loading_body">Chargement de la page demandée</string>
     <!-- #379 — marqueur explicite de fin de sujet, rendu après le dernier post de la DERNIÈRE page. -->
     <string name="topic_end_of_topic">Dernier message du sujet</string>
     <string name="topic_more_pages">Suite à la page suivante</string>


### PR DESCRIPTION
## Vague « Chargement » — phase Vue Topic (#604)

Implémente le mockup **« Chargement · A Skeleton »** arbitré sur le fil DEV (v2 des maquettes), premier chantier de la phase demandé par XaTriX (« quick win, impression de changement »).

### Changements
- **`TopicLoadingSkeleton`** (`:feature:topic`) : loader M3 centré + « Chargement de la page demandée » + 3 cartes fantômes — remplace le spinner nu aligné en haut à gauche.
- **`SkeletonBox`** (`:core:ui`, public) : primitive skeleton extraite du shimmer d'images #249 (`ImageShimmer` délègue désormais) — même rendu, fallback statique reduce-motion conservé.
- **#622** : le compteur de la top bar affiche « Chargement… » tant que la réponse n'est pas parsée, au lieu de retomber sur un total `availablePages` potentiellement périmé. `availablePages` est **intact** : le chemin Error garde volontairement la dernière grille connue (fix présentationnel, cadré Codex — un reset ViewModel aurait régressé le contexte Error intra-topic).

### Hors scope (assumé, tracé)
Slots FAB figés pendant le chargement → vague redesign Lecture (#599), pour ne pas faire deux fois le travail sur un cluster qui va être refondu.

### Validation
- [x] `detektAll` + `:app:lintProdDebug` + `testDebugUnitTest` + `:app:testProdDebugUnitTest` + `:app:assembleProdDebug` verts (gate canonique locale)
- [x] Dogfood émulateur avant/après : skeleton visible sur deep link à froid (loader centré, cartes fantômes, sous-titre « Chargement… ») ; page chargée = titre réel + « page 4 / 63 »
- [x] Cadrage Codex gpt-5.5 xhigh (GO-avec-réserves, toutes intégrées) — review du diff en cours

> Action par Claude Fable 5 (demandée par @XaTriX)
