### PR TITLE
chore(release): whatsnew 0.19.0

### DIFF
--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,9 +1,5 @@
-Redface 2 v0.18.0 — beta.
+Redface 2 v0.19.0 — dev.
 
-Flags view redesign:
-- New top bar (flag + short name + "+read", retractable search, round avatar).
-- Translucent bar: the list scrolls underneath.
-- "redface" pull-to-refresh loader.
-- Configurable "+read" cue, avatar and glyph; search on the DT tab.
-- Long-press: quick actions, go to page, post a message.
-- Improved accessibility and per-tab scroll preservation.
+Topic view (redesign begins):
+- Reworked page loading: title shown immediately, centered indicator and skeleton content preview.
+- Reliable page counter while loading (no more stale total).

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,9 +1,5 @@
-Redface 2 v0.18.0 — bêta.
+Redface 2 v0.19.0 — dev.
 
-Refonte de la vue Drapeaux :
-- Nouvelle barre du haut (drapeau + nom court + « +lus », loupe rétractable, avatar rond).
-- Barre translucide : la liste défile dessous.
-- Loader « redface » au tirer-pour-rafraîchir.
-- « +lus », avatar et glyphe configurables ; recherche sur l'onglet DT.
-- Appui-long : actions rapides, aller à une page, poster.
-- Accessibilité et préservation du défilement par onglet améliorées.
+Vue Topic (début de la refonte) :
+- Chargement d'une page repensé : titre affiché immédiatement, indicateur centré et aperçu squelette du contenu.
+- Compteur de pages fiable pendant le chargement (plus de total erroné).


### PR DESCRIPTION
Le garde de fraîcheur whatsnew s'applique aussi au canal dev (échec du run 28615692079). Mise à jour fr-FR/en-US pour 0.19.0.

> Action par Claude Fable 5 (demandée par @XaTriX)