### PR TITLE
fix(editor): auto-focus éditeur + recherche wiki smileys (#555, #250)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextField.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextField.kt
@@ -25,6 +25,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.semantics
@@ -95,6 +97,10 @@ fun BbcodeTextField(
     // Multi-image upload — true makes the field non-editable while a batch is in flight so the user
     // cannot move the caret between two programmatic [img] insertions. Default false = editable.
     readOnly: Boolean = false,
+    // #555 — true requests focus (and thus the IME) once on first composition. Opening an editor
+    // pre-filled with a LONG post never focused the field by itself: the #447 caret-follow effect
+    // is gated on `isFocused`, and nothing set the focus — keyboard closed, follow inert.
+    autoFocus: Boolean = false,
 ) {
     if (fillViewport) {
         BoxWithConstraints(modifier = modifier) {
@@ -115,6 +121,7 @@ fun BbcodeTextField(
                     label = label,
                     placeholder = placeholder,
                     readOnly = readOnly,
+                    autoFocus = autoFocus,
                     modifier = Modifier
                         .fillMaxWidth()
                         .heightIn(min = viewportMinHeight),
@@ -128,6 +135,7 @@ fun BbcodeTextField(
             label = label,
             placeholder = placeholder,
             readOnly = readOnly,
+            autoFocus = autoFocus,
             modifier = modifier.fillMaxWidth(),
         )
     }
@@ -146,11 +154,21 @@ private fun BbcodeFieldImpl(
     placeholder: String?,
     modifier: Modifier,
     readOnly: Boolean = false,
+    autoFocus: Boolean = false,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
     val bringCursorIntoView = remember { BringIntoViewRequester() }
+    val focusRequester = remember { FocusRequester() }
     var textLayout by remember { mutableStateOf<TextLayoutResult?>(null) }
+
+    // #555 — programmatic focus on entry (one-shot). Without it an editor hydrated with existing
+    // content never opens the IME: the caret sits at the end of the text but the field waits for a
+    // tap, and the #447 caret-follow below stays inert (`isFocused` gate). Firing after the first
+    // composition also lets the follow effect scroll straight to that end-of-text caret.
+    LaunchedEffect(Unit) {
+        if (autoFocus) focusRequester.requestFocus()
+    }
 
     // #447 — follow the caret through the EXTERNAL scrollable while typing. Keyed on the
     // layout result (a new one lands after every text change) AND the selection (caret moves
@@ -172,7 +190,8 @@ private fun BbcodeFieldImpl(
         // `OutlinedTextFieldTopPadding`) — without it the minimized label is clipped at the top.
         modifier = modifier
             .semantics(mergeDescendants = true) {}
-            .padding(top = 8.dp),
+            .padding(top = 8.dp)
+            .focusRequester(focusRequester),
         // M3 OutlinedTextField defaults the content to LocalTextStyle coloured onSurface and
         // the caret to primary — replicated here since BasicTextField has no colour scheme.
         textStyle = LocalTextStyle.current.merge(

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerSheet.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerSheet.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -29,6 +30,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
@@ -118,13 +121,22 @@ private fun WikiTabContent(
     onQueryChange: (String) -> Unit,
     onSmileyClicked: (String) -> Unit,
 ) {
+    // #250 — reveal search on tab switch: focus + IME as soon as the Wiki tab composes, instead of
+    // waiting for an extra tap on the field. `LaunchedEffect(Unit)` fires on each ENTRY into the
+    // tab (the `when (tabIndex)` swaps this content in) and never again while the user stays on it.
+    val searchFocus = remember { FocusRequester() }
+    LaunchedEffect(Unit) {
+        searchFocus.requestFocus()
+    }
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         OutlinedTextField(
             value = state.query,
             onValueChange = onQueryChange,
             singleLine = true,
             label = { Text(stringResource(R.string.editor_smiley_search_label)) },
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(searchFocus),
         )
         when (val wiki = state.wiki) {
             WikiSearchState.Idle -> Text(

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -179,6 +179,10 @@ private fun PostEditorContent(
                     // Multi-image upload — lock editing during a batch so the user can't move the
                     // caret between two programmatic [img] insertions (keeps them in pick order).
                     readOnly = state.isUploading,
+                    // #555 — the editor opens ready to type: focus + IME on entry. Critical in edit
+                    // mode (field hydrated with a long post: nothing set the focus, keyboard closed,
+                    // #447 caret-follow inert) ; for a reply it is the expected behaviour anyway.
+                    autoFocus = true,
                 )
 
                 Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Vague 2 de la phase Vue Topic (#604) — premier lot de quick wins éditeur.

## #555 — clavier muet à l'ouverture de l'éditeur

`BbcodeTextField` gagne un paramètre opt-in `autoFocus` : un `FocusRequester.requestFocus()` one-shot à la première composition. Un éditeur hydraté avec un long post existant (mode édition) ouvre désormais l'IME immédiatement, et le caret-follow #447 (gaté sur `isFocused`) démarre tout de suite au lieu de rester inerte. `PostEditorScreen` opte in (reply + édition).

## #250 — recherche wiki smileys sans focus

L'onglet Wiki du `SmileyPickerSheet` focus son champ de recherche à l'entrée dans l'onglet (`LaunchedEffect(Unit)` sur le contenu swappé par le `when (tabIndex)`) — plus besoin d'un tap supplémentaire pour lever le clavier.

## Validation

- Validation canonique (detektAll + lintProdDebug + tests unitaires + assembleProdDebug) : **BUILD SUCCESSFUL**.
- Dogfood émulateur (Pixel 8, dev.debug) : ouverture éditeur → IME levé + champ focus sans tap (`mInputShown=true`) ; picker Smileys → onglet Wiki → saisie directe « pierre » sans toucher le champ, résultats chargés.

Refs #555, #250 (fermeture à la promotion `dev → main`, branche par défaut = `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnwLr4K75nLTGGzVv97A2c