### PR TITLE
fix(navigation): titre du sujet immédiat depuis les listes (#762)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -1896,6 +1896,10 @@ private fun RedfaceNavHost(
                     // #676 v2 — [page] is chosen by the caller: row tap + sheet « Ouvrir » resume at
                     // lastReadPage, « 1er non-lu » jumps to lastReadPage+1, « dernière page » to totalPages.
                     onOpenFlag = { flag, page ->
+                        // #762 — seed the title cache from the row so the topic's top bar shows
+                        // the real title during the very first load (the cache was otherwise only
+                        // fed by onTitleLoaded AFTER a page parse, i.e. from the second page on).
+                        topicTitleNavState.onTitleLoaded(flag.cat, flag.topicId, flag.title)
                         backStack.add(
                             TopicRoute(
                                 cat = flag.cat,
@@ -2277,6 +2281,9 @@ private fun RedfaceNavHost(
                         highlightTitle = route.highlightTitle,
                     ),
                     onOpenTopic = { topic ->
+                        // #762 — same seeding as onOpenFlag: the listing row already knows the
+                        // title, show it in the top bar from the first frame of the load.
+                        topicTitleNavState.onTitleLoaded(topic.cat, topic.topicId, topic.title)
                         backStack.add(
                             TopicRoute(
                                 cat = topic.cat,


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Corrige #762 (découvert au dogfood 0.19.0) : `topicTitleCache` n'était alimenté qu'**après** le premier parse d'une page (fix build-89 pensé pour les changements de page), donc la première ouverture d'un sujet depuis la liste Drapeaux ou un listing forum affichait « Sujet » pendant tout le chargement — en contradiction avec l'annonce du changelog 0.19.0.

## Fix

Seed du cache via le callback existant `topicTitleNavState.onTitleLoaded(...)` au moment de la navigation, dans les deux call-sites qui connaissent déjà le titre :
- `onOpenFlag` (liste Drapeaux, `Flag.title`)
- `onOpenTopic` du listing forum (`TopicSummary.title`)

Aucun changement de signature, aucun nouveau state. Le vrai titre parsé remplace le hint après chargement comme avant. Hors périmètre : résultats de recherche (le callback ne transporte pas le titre, cf. #762).

## Validation

- Compile + detektAll : BUILD SUCCESSFUL ; validation canonique complète en cours (sera verte avant merge).
- Dogfood émulateur : ouverture du topic TU depuis la liste Drapeaux → la top bar affiche le vrai titre + sous-titre « Chargement… » dès la première frame du skeleton.

Refs #762.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnwLr4K75nLTGGzVv97A2c