### PR TITLE
feat(topic): aller au message cité + résolution de page des liens email (#699, #750)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -308,6 +308,14 @@ data class TopicRoute(
      * back stacks deserialise without the field.
      */
     val postSubmitOverflowLanding: Boolean = false,
+    /**
+     * #750 — `true` when [page] is untrusted: HFR email-notification links always say `page=1`
+     * while the real target travels as `numreponse`. Forwarded to `TopicRequest.resolveScrollToPage`
+     * so the ViewModel resolves the actual page (server-side redirect probe, #277 mechanism) before
+     * the first load. Only the email deep-link path sets it; defaulted so older serialised back
+     * stacks deserialise without the field.
+     */
+    val resolveScrollToPage: Boolean = false,
 ) : RedfaceNavKey
 
 @Serializable
@@ -2365,6 +2373,7 @@ private fun RedfaceNavHost(
                         forceRefresh = route.forceRefresh,
                         postSubmitOverflowLanding = route.postSubmitOverflowLanding,
                         titleHint = topicTitleNavState.titles[TopicTitleKey(route.cat, route.post)],
+                        resolveScrollToPage = route.resolveScrollToPage,
                     ),
                     onTitleLoaded = { title ->
                         topicTitleNavState.onTitleLoaded(route.cat, route.post, title)
@@ -2504,6 +2513,20 @@ private fun RedfaceNavHost(
                             post = route.post,
                             page = targetPage,
                             scrollTo = null,
+                        )
+                    },
+                    onGoToPost = { targetPage, numreponse ->
+                        // #699 — jump to a cited post: the same single-mutation in-place replace as
+                        // onOpenPage (#282), with the deep-link scroll anchor so the landing scrolls
+                        // to and highlights the target (#200 mechanism). Uniform whether the cited
+                        // post is on the current page or another. Not a « page - 1 » reading step —
+                        // clear any stale bottom-landing marker (same rule as onOpenPage's takeIf).
+                        topicScrollNavState.onPendingBottomLanding(null)
+                        backStack[backStack.lastIndex] = TopicRoute(
+                            cat = route.cat,
+                            post = route.post,
+                            page = targetPage,
+                            scrollTo = numreponse,
                         )
                     },
                     onBack = {
@@ -2717,10 +2740,22 @@ internal fun parseHfrDeepLink(uri: Uri): ParsedDeepLink? = when (uri.path) {
         val cat = uri.getQueryParameter("cat")?.toIntOrNull() ?: return null
         val post = uri.getQueryParameter("post")?.toIntOrNull() ?: return null
         val page = uri.getQueryParameter("page")?.toIntOrNull() ?: 1
+        // #750 — the `numreponse` QUERY param is the fallback target: HFR email-notification
+        // links carry it alongside the fragment, and some mail clients strip the fragment.
         val scrollTo = uri.fragment?.removePrefix("t")?.toIntOrNull()
+            ?: uri.getQueryParameter("numreponse")?.toIntOrNull()
         ParsedDeepLink(
             destination = TopLevelDestination.Flags,
-            route = TopicRoute(cat = cat, post = post, page = page, scrollTo = scrollTo),
+            route = TopicRoute(
+                cat = cat,
+                post = post,
+                page = page,
+                scrollTo = scrollTo,
+                // #750 — email links always serialise `page=1` whatever page the target post
+                // lives on; a page-1 link WITH an anchor is therefore untrusted and the real
+                // page is resolved before the first load. An explicit page > 1 is trusted as-is.
+                resolveScrollToPage = scrollTo != null && page == 1,
+            ),
         )
     }
 

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/HfrDeepLinkTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/HfrDeepLinkTest.kt
@@ -70,6 +70,7 @@ class HfrDeepLinkTest {
 
         val parsed = parseHfrDeepLink(uri)
 
+        // page > 1 is explicit and trusted — no resolution probe on arrival.
         val expectedRoute = TopicRoute(cat = 23, post = 35395, page = 12, scrollTo = 12_345)
         assertEquals(expectedRoute, parsed?.route)
         assertEquals(TopLevelDestination.Flags, parsed?.destination)
@@ -83,6 +84,49 @@ class HfrDeepLinkTest {
 
         assertEquals(
             TopicRoute(cat = 23, post = 35395, page = 1, scrollTo = null),
+            parsed?.route,
+        )
+    }
+
+    @Test
+    fun `forum2 php email link with page 1 and an anchor marks the page for resolution (#750)`() {
+        // Real-world email-notification shape (issue #750): page=1 is a lie, the target
+        // travels both as the `numreponse` query param and the `#t` fragment.
+        val uri = Uri.parse(
+            "https://forum.hardware.fr/forum2.php?config=hfr.inc&cat=23&subcat=550&post=35395" +
+                "&page=1&p=1&sondage=0&owntopic=0&numreponse=2789981&nojs=0#t2789981",
+        )
+
+        val parsed = parseHfrDeepLink(uri)
+
+        assertEquals(
+            TopicRoute(cat = 23, post = 35395, page = 1, scrollTo = 2_789_981, resolveScrollToPage = true),
+            parsed?.route,
+        )
+    }
+
+    @Test
+    fun `forum2 php numreponse query param is the scrollTo fallback when the fragment is stripped (#750)`() {
+        val uri = Uri.parse(
+            "https://forum.hardware.fr/forum2.php?cat=23&post=35395&page=1&numreponse=2789981",
+        )
+
+        val parsed = parseHfrDeepLink(uri)
+
+        assertEquals(
+            TopicRoute(cat = 23, post = 35395, page = 1, scrollTo = 2_789_981, resolveScrollToPage = true),
+            parsed?.route,
+        )
+    }
+
+    @Test
+    fun `forum2 php explicit page with anchor is trusted, no resolution (#750)`() {
+        val uri = Uri.parse("https://forum.hardware.fr/forum2.php?cat=23&post=35395&page=7#t999")
+
+        val parsed = parseHfrDeepLink(uri)
+
+        assertEquals(
+            TopicRoute(cat = 23, post = 35395, page = 7, scrollTo = 999, resolveScrollToPage = false),
             parsed?.route,
         )
     }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -208,6 +208,10 @@ fun PostRenderer(
     // surfaces outside scope (the editor BBCode preview and private-message thread keep their prior
     // non-selectable behaviour). Topic posts pass `selectable = true`.
     selectable: Boolean = false,
+    // #699 — invoked with the cited post's `(page, numreponse)` when the reader taps a sourced
+    // quote's header. Null (default) keeps the header inert — only the topic reading surface wires
+    // it (the editor preview, MP threads and signatures have nowhere meaningful to navigate).
+    onGoToCitedPost: ((page: Int, numreponse: Int) -> Unit)? = null,
 ) {
     if (selectable) {
         // #281 — allow selecting / copying a post's text. The SelectionContainer is wrapped at this
@@ -216,10 +220,15 @@ fun PostRenderer(
         // inside a SelectionContainer; inline media carry a U+FFFC placeholder that can pollute a
         // copied selection spanning them (known, acceptable limitation).
         SelectionContainer(modifier = modifier) {
-            PostBlocksRenderer(blocks = content.blocks, quoteDepth = 0)
+            PostBlocksRenderer(blocks = content.blocks, quoteDepth = 0, onGoToCitedPost = onGoToCitedPost)
         }
     } else {
-        PostBlocksRenderer(blocks = content.blocks, modifier = modifier, quoteDepth = 0)
+        PostBlocksRenderer(
+            blocks = content.blocks,
+            modifier = modifier,
+            quoteDepth = 0,
+            onGoToCitedPost = onGoToCitedPost,
+        )
     }
 }
 
@@ -228,6 +237,7 @@ private fun PostBlocksRenderer(
     blocks: List<PostBlock>,
     modifier: Modifier = Modifier,
     quoteDepth: Int,
+    onGoToCitedPost: ((page: Int, numreponse: Int) -> Unit)? = null,
 ) {
     Column(
         modifier = modifier.fillMaxWidth(),
@@ -236,8 +246,8 @@ private fun PostBlocksRenderer(
         blocks.forEach { block ->
             when (block) {
                 is PostBlock.Paragraph -> ParagraphBlock(block.inlines)
-                is PostBlock.Quote -> QuoteBlock(block, quoteDepth)
-                is PostBlock.Spoiler -> SpoilerBlock(block, quoteDepth)
+                is PostBlock.Quote -> QuoteBlock(block, quoteDepth, onGoToCitedPost)
+                is PostBlock.Spoiler -> SpoilerBlock(block, quoteDepth, onGoToCitedPost)
                 is PostBlock.Image -> ImageBlock(block)
                 is PostBlock.Fixed -> FixedBlock(block)
                 is PostBlock.CodeBlock -> CodeBlockBlock(block)
@@ -378,23 +388,28 @@ private fun ParagraphBlock(inlines: List<PostInline>) {
 }
 
 @Composable
-private fun QuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
+private fun QuoteBlock(
+    block: PostBlock.Quote,
+    quoteDepth: Int,
+    onGoToCitedPost: ((page: Int, numreponse: Int) -> Unit)? = null,
+) {
     if (isCollapsedQuoteDepth(quoteDepth)) {
-        CollapsedQuoteBlock(block, quoteDepth)
+        CollapsedQuoteBlock(block, quoteDepth, onGoToCitedPost)
         return
     }
     // #332 — the long-quote fold is gated on the user preference (default ON = historical fold).
     // When OFF we skip FoldableQuoteBlock entirely and fall through to the normal expanded render,
     // exactly as if the quote were not "long". The depth fold above is unaffected.
     if (LocalFoldLongQuotes.current && isLongQuote(block, quoteDepth)) {
-        FoldableQuoteBlock(block, quoteDepth)
+        FoldableQuoteBlock(block, quoteDepth, onGoToCitedPost)
         return
     }
     QuoteFrame(quoteDepth = quoteDepth, isBareQuote = isBareQuote(block)) {
-        QuoteHeader(block)
+        QuoteHeader(block, onGoToCitedPost)
         PostBlocksRenderer(
             blocks = block.content.blocks,
             quoteDepth = quoteDepth + 1,
+            onGoToCitedPost = onGoToCitedPost,
         )
     }
 }
@@ -404,16 +419,39 @@ private fun QuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
  * reads as a quotation, not a stray indented paragraph. A bare quote (no author) falls back to the
  * generic "Citation" label. Extracted so the expanded, depth-collapsed and long-fold variants share
  * one source of truth for the header text.
+ *
+ * #699 — when the quote carries its source coordinates (`page` + `numreponse`, parsed from the
+ * citation href) AND the surface wired [onGoToCitedPost], the header becomes the « go to the cited
+ * post » affordance: primary tint + tap. Quotes whose href HFR served in the dynamic `forum2.php`
+ * form (coordinates unparsed, cf. PostContentParser) keep the inert neutral header — no invented
+ * fallback target.
  */
 @Composable
-private fun QuoteHeader(block: PostBlock.Quote) {
-    Text(
-        text = block.author
-            ?.let { stringResource(R.string.post_quote_author, it) }
-            ?: stringResource(R.string.post_quote_bare),
-        style = MaterialTheme.typography.labelMedium,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-    )
+private fun QuoteHeader(
+    block: PostBlock.Quote,
+    onGoToCitedPost: ((page: Int, numreponse: Int) -> Unit)? = null,
+) {
+    val page = block.page
+    val numreponse = block.numreponse
+    val text = block.author
+        ?.let { stringResource(R.string.post_quote_author, it) }
+        ?: stringResource(R.string.post_quote_bare)
+    if (onGoToCitedPost != null && page != null && numreponse != null) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.clickable(
+                onClickLabel = stringResource(R.string.post_quote_go_to),
+            ) { onGoToCitedPost(page, numreponse) },
+        )
+    } else {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
 }
 
 /**
@@ -425,7 +463,11 @@ private fun QuoteHeader(block: PostBlock.Quote) {
  * real [quoteDepth] when expanded so a long quote that also nests deeply still hits the depth rule.
  */
 @Composable
-private fun FoldableQuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
+private fun FoldableQuoteBlock(
+    block: PostBlock.Quote,
+    quoteDepth: Int,
+    onGoToCitedPost: ((page: Int, numreponse: Int) -> Unit)? = null,
+) {
     var expanded by rememberSaveable(block) { mutableStateOf(false) }
     QuoteFrame(
         quoteDepth = quoteDepth,
@@ -436,7 +478,9 @@ private fun FoldableQuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            QuoteHeader(block)
+            // #699 — the header keeps its own go-to-cited-post tap INSIDE the frame's fold toggle:
+            // its clickable consumes the tap, the rest of the frame still folds/unfolds.
+            QuoteHeader(block, onGoToCitedPost)
             Text(
                 text = if (expanded) {
                     stringResource(R.string.post_quote_hide)
@@ -451,6 +495,7 @@ private fun FoldableQuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
             PostBlocksRenderer(
                 blocks = block.content.blocks,
                 quoteDepth = quoteDepth + 1,
+                onGoToCitedPost = onGoToCitedPost,
             )
         }
     }
@@ -527,7 +572,11 @@ private fun QuoteFrame(
 private val QUOTE_ACCENT_WIDTH: Dp = 4.dp
 
 @Composable
-private fun CollapsedQuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
+private fun CollapsedQuoteBlock(
+    block: PostBlock.Quote,
+    quoteDepth: Int,
+    onGoToCitedPost: ((page: Int, numreponse: Int) -> Unit)? = null,
+) {
     // Issue #3 mandates the masked tail beyond N=3 nested quotes stays *collapsible* — the user
     // must be able to ask for the deeper sub-tree on demand. We reset quoteDepth to 0 once
     // revealed so the user gets another N levels before the next collapse, instead of an
@@ -563,17 +612,22 @@ private fun CollapsedQuoteBlock(block: PostBlock.Quote, quoteDepth: Int) {
         }
         if (revealed) {
             // #252 — same "Citation"/"Citation de X" header rule as the expanded QuoteBlock.
-            QuoteHeader(block)
+            QuoteHeader(block, onGoToCitedPost)
             PostBlocksRenderer(
                 blocks = block.content.blocks,
                 quoteDepth = 0,
+                onGoToCitedPost = onGoToCitedPost,
             )
         }
     }
 }
 
 @Composable
-private fun SpoilerBlock(block: PostBlock.Spoiler, quoteDepth: Int) {
+private fun SpoilerBlock(
+    block: PostBlock.Spoiler,
+    quoteDepth: Int,
+    onGoToCitedPost: ((page: Int, numreponse: Int) -> Unit)? = null,
+) {
     var revealed by rememberSaveable(block) { mutableStateOf(false) }
     Card(
         colors = CardDefaults.cardColors(
@@ -611,6 +665,7 @@ private fun SpoilerBlock(block: PostBlock.Spoiler, quoteDepth: Int) {
                 PostBlocksRenderer(
                     blocks = block.content.blocks,
                     quoteDepth = quoteDepth,
+                    onGoToCitedPost = onGoToCitedPost,
                 )
             }
         }

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -2,6 +2,8 @@
 <resources>
     <string name="post_quote_author">Citation de %1$s</string>
     <string name="post_quote_bare">Citation</string>
+    <!-- #699 : libellé a11y du tap sur l'en-tête d'une citation sourcée (aller au message cité). -->
+    <string name="post_quote_go_to">Aller au message cité</string>
     <string name="post_quote_collapsed">Citation imbriquée repliée</string>
     <string name="post_quote_collapsed_revealed">Citations imbriquées</string>
     <string name="post_quote_show">Afficher</string>

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicRequest.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicRequest.kt
@@ -40,4 +40,13 @@ data class TopicRequest(
      * is the route allowed to redirect once.
      */
     val postSubmitOverflowLanding: Boolean = false,
+    /**
+     * #750 — `true` when [page] is NOT trusted to contain [scrollTo]: HFR email-notification links
+     * always serialise `page=1` while carrying the real target as `numreponse`. Before the first
+     * load the ViewModel resolves the actual page through HFR's server-side redirect (same probe
+     * as the search results, #277) and adopts it as the REAL target page — timeout / failure falls
+     * back to [page], never worse than before. `false` on every in-app navigation (quote taps and
+     * search results already carry a trusted page).
+     */
+    val resolveScrollToPage: Boolean = false,
 )

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -152,6 +152,13 @@ fun TopicScreen(
     onEditFirstPost: (subcat: Int, page: Int, numreponse: Int) -> Unit,
     onOpenPage: (Int) -> Unit,
     /**
+     * #699 — jump to the post a quote header cites: `(page, numreponse)` parsed from the citation
+     * href. `:app` wires it to the same in-place `TopicRoute` replace as [onOpenPage], but with
+     * `scrollTo = numreponse` so the landing scrolls to and highlights the cited post (the #200
+     * deep-link mechanism) — one uniform path whether the target is on this page or another.
+     */
+    onGoToPost: (page: Int, numreponse: Int) -> Unit,
+    /**
      * #285 — leave the topic and go back to the screen that opened it (topic list / flags).
      * Wired to a back-stack pop in `:app`. Surfaced as an explicit back arrow in the top app
      * bar so the user never has to rely on the system / gesture back to exit a topic.
@@ -437,6 +444,7 @@ fun TopicScreen(
         onEdit = onEdit,
         onEditFirstPost = onEditFirstPost,
         onOpenPage = onOpenPage,
+        onGoToPost = onGoToPost,
         onOpenProfile = onOpenProfile,
         onDeleteRequest = { numreponse -> deleteCandidate = numreponse },
         multiQuoteSelection = multiQuoteSelection,
@@ -664,6 +672,8 @@ internal fun TopicContent(
     onEdit: (subcat: Int, page: Int, numreponse: Int) -> Unit,
     onEditFirstPost: (subcat: Int, page: Int, numreponse: Int) -> Unit,
     onOpenPage: (Int) -> Unit,
+    // #699 — quote-header tap, threaded down to the post cards (cf. TopicScreen KDoc).
+    onGoToPost: (page: Int, numreponse: Int) -> Unit = { _, _ -> },
     onOpenProfile: (userId: Int, pseudo: String, avatarUrl: String?) -> Unit = { _, _, _ -> },
     // #292 — a per-post « Supprimer » tap; the screen owns the confirmation dialog, so this only
     // requests it (carrying the post's numreponse). Never invoked for the first post (excluded).
@@ -822,6 +832,7 @@ internal fun TopicContent(
                             onEdit = onEdit,
                             onEditFirstPost = onEditFirstPost,
                             onOpenPage = onOpenPage,
+                            onGoToPost = onGoToPost,
                             onOpenProfile = onOpenProfile,
                             onDeleteRequest = onDeleteRequest,
                             onDoubleTapRefresh = { onIntent(TopicIntent.Refresh) },
@@ -1081,6 +1092,8 @@ private fun TopicLoadedContent(
     onEdit: (subcat: Int, page: Int, numreponse: Int) -> Unit,
     onEditFirstPost: (subcat: Int, page: Int, numreponse: Int) -> Unit,
     onOpenPage: (Int) -> Unit,
+    // #699 — quote-header tap, forwarded into each TopicPostCard's PostRenderer.
+    onGoToPost: (page: Int, numreponse: Int) -> Unit = { _, _ -> },
     onOpenProfile: (userId: Int, pseudo: String, avatarUrl: String?) -> Unit = { _, _, _ -> },
     onDeleteRequest: (numreponse: Int) -> Unit = {},
     /** #382 — double-tap anywhere on the list refreshes the current page (RF1 parity). */
@@ -1294,6 +1307,8 @@ private fun TopicLoadedContent(
                     post = post,
                     highlighted = highlight == post.numreponse,
                     citedCount = citationCounts[post.numreponse] ?: 0,
+                    // #699 — makes sourced quote headers tappable (jump to the cited post).
+                    onGoToCitedPost = onGoToPost,
                     // #330 — render the author signature beneath the body when the reading preference
                     // is on (the signature is always parsed/cached on the Post; this is render-only).
                     showSignature = state.showSignatures,
@@ -1812,6 +1827,11 @@ internal fun TopicPostCard(
      * here, the border, and the pill — one source of truth, they can never desynchronise.
      */
     onToggleMultiQuote: (() -> Unit)? = null,
+    /**
+     * #699 — forwarded to [PostRenderer] so a sourced quote's header can jump to the cited post.
+     * Null keeps the headers inert (previews/tests that render a card without navigation).
+     */
+    onGoToCitedPost: ((page: Int, numreponse: Int) -> Unit)? = null,
 ) {
     // #287 — structural spacing from the active density preset (Comfort = the historical rhythm).
     val m = LocalDisplayMetrics.current
@@ -1884,7 +1904,7 @@ internal fun TopicPostCard(
                 verticalArrangement = Arrangement.spacedBy(m.postSpacing),
             ) {
                 // #281 — topic posts are selectable/copyable (opt-in; default is OFF in PostRenderer).
-                PostRenderer(content = post.content, selectable = true)
+                PostRenderer(content = post.content, selectable = true, onGoToCitedPost = onGoToCitedPost)
                 // #330 — the author signature (web parity), gated by the reading preference. Rendered
                 // with the shared PostRenderer (the signature is BBCode/HTML like the body) but in a
                 // subdued style: a divider separates it from the body and a reduced alpha makes it

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -12,6 +12,7 @@ import fr.forumhfr.redface2.core.domain.blacklist.BlacklistRepository
 import fr.forumhfr.redface2.core.domain.blacklist.canonicalizePseudo
 import fr.forumhfr.redface2.core.domain.error.classifyHfrError
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
+import fr.forumhfr.redface2.core.domain.search.SearchRepository
 import fr.forumhfr.redface2.core.domain.topic.NoTopicSearchResultsException
 import fr.forumhfr.redface2.core.domain.topic.TopicRepository
 import fr.forumhfr.redface2.core.domain.topic.TopicSearchRepository
@@ -36,6 +37,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Phase 1D-2 (#107) ViewModel for `:feature:topic`. Holds the cache-aside collection
@@ -51,13 +53,18 @@ import kotlinx.coroutines.launch
 @HiltViewModel(assistedFactory = TopicViewModel.Factory::class)
 @Suppress("LongParameterList") // ViewModel aggregates its injected repositories; one per concern.
 class TopicViewModel @AssistedInject constructor(
-    @Assisted private val request: TopicRequest,
+    // #750 — `var`, not `val`: when [TopicRequest.resolveScrollToPage] is set the real target page
+    // is only known after the resolution probe; the resolved request then REPLACES this one (and
+    // `state.request`) so every later read — loads, retry, refresh, page indicator, highlight —
+    // sees the actual page. Mutated in exactly one place ([resolveScrollToPageThenLoad]).
+    @Assisted private var request: TopicRequest,
     private val topicRepository: TopicRepository,
     private val authRepository: AuthRepository,
     private val userPreferencesRepository: UserPreferencesRepository,
     private val deletePostRepository: DeletePostRepository,
     private val blacklistRepository: BlacklistRepository,
     private val topicSearchRepository: TopicSearchRepository,
+    private val searchRepository: SearchRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(TopicUiState.initial(request))
@@ -130,6 +137,7 @@ class TopicViewModel @AssistedInject constructor(
         // contract) seeds [blockedCanonicals] before the load below computes the initial hidden set —
         // a blocked post therefore never flashes before it is hidden, even on the force-refresh path.
         observeBlockedCanonicals()
+        val untrustedPageTarget = request.resolveScrollToPage && request.scrollTo != null
         if (request.submitSignal != null) {
             // Issue #200 — the user just published a reply / quote / edit / edit-FP and the
             // navigation host signalled us to skip the cache so the freshly-published post
@@ -137,6 +145,9 @@ class TopicViewModel @AssistedInject constructor(
             // emit a stale cached page that doesn't contain the new post (it was created
             // server-side after the cache was populated).
             forceRefreshCurrentPage()
+        } else if (untrustedPageTarget) {
+            // #750 — email deep link: `page` is a lie (always 1), resolve the real one first.
+            resolveScrollToPageThenLoad()
         } else {
             loadCurrentPage()
         }
@@ -320,6 +331,39 @@ class TopicViewModel @AssistedInject constructor(
         if (firstContentInFlight) {
             Trace.endAsyncSection(FIRST_CONTENT_SECTION, firstContentCookie)
             firstContentInFlight = false
+        }
+    }
+
+    /**
+     * #750 — resolves the REAL page of [TopicRequest.scrollTo] through HFR's server-side redirect
+     * (same probe + timeout + fallback contract as the search results, #277:
+     * [SearchRepository.resolveSearchResultPage]) BEFORE the first load, while the screen shows the
+     * loading skeleton. On success the resolved request replaces [request] AND `state.request`, so
+     * the page becomes the real target everywhere (loads, retry, page indicator, highlight) — not a
+     * presentational patch. On timeout / failure the untrusted page loads as-is: the pre-#750
+     * behaviour, never worse. Runs at most once (init-only branch); a config change keeps the
+     * ViewModel, a route replace builds a fresh one without the flag.
+     */
+    private fun resolveScrollToPageThenLoad() {
+        val scrollTo = requireNotNull(request.scrollTo) { "resolveScrollToPageThenLoad requires scrollTo" }
+        _state.update { it.copy(mode = TopicUiState.Mode.Loading) }
+        viewModelScope.launch {
+            val outcome = runCatching {
+                withTimeoutOrNull(RESOLVE_TIMEOUT_MS) {
+                    searchRepository.resolveSearchResultPage(
+                        cat = request.cat,
+                        post = request.post,
+                        numreponse = scrollTo,
+                    )
+                }
+            }
+            (outcome.exceptionOrNull() as? CancellationException)?.let { throw it }
+            val resolved = outcome.getOrNull()
+            if (resolved != null && resolved != request.page) {
+                request = request.copy(page = resolved)
+                _state.update { it.copy(request = request) }
+            }
+            loadCurrentPage()
         }
     }
 
@@ -991,5 +1035,10 @@ class TopicViewModel @AssistedInject constructor(
         // under #117 follow-up) keeps matching after refactors.
         private const val FIRST_CONTENT_SECTION = "rf2.topic.first_content"
         private const val LOG_TAG = "TopicViewModel"
+
+        // #750 — cap on the page-resolution probe, same rationale and value as
+        // SearchViewModel.RESOLVE_TIMEOUT_MS (#277): degrade to the untrusted page
+        // rather than hold the first load hostage on a degraded network.
+        private const val RESOLVE_TIMEOUT_MS: Long = 3_000
     }
 }

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -20,11 +20,14 @@ import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
 import fr.forumhfr.redface2.core.domain.preferences.PlusLusIndicatorStyle
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
+import fr.forumhfr.redface2.core.domain.search.SearchRepository
 import fr.forumhfr.redface2.core.domain.topic.NoTopicSearchResultsException
 import fr.forumhfr.redface2.core.domain.topic.TopicRepository
 import fr.forumhfr.redface2.core.domain.topic.TopicSearchRepository
 import fr.forumhfr.redface2.core.model.TopicSearchForm
 import fr.forumhfr.redface2.core.model.TopicSearchRequest
+import fr.forumhfr.redface2.core.model.search.SearchRequest
+import fr.forumhfr.redface2.core.model.search.SearchResultPage
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import fr.forumhfr.redface2.core.domain.write.DeletePostRepository
@@ -1299,6 +1302,7 @@ class TopicViewModelTest {
         deletePostRepository: DeletePostRepository = FakeDeletePostRepository(),
         blacklistRepository: BlacklistRepository = FakeBlacklistRepository(),
         topicSearchRepository: TopicSearchRepository = FakeTopicSearchRepository(),
+        searchRepository: SearchRepository = FakeSearchRepository(),
     ): TopicViewModel = TopicViewModel(
         request = request,
         topicRepository = topicRepository,
@@ -1307,6 +1311,7 @@ class TopicViewModelTest {
         deletePostRepository = deletePostRepository,
         blacklistRepository = blacklistRepository,
         topicSearchRepository = topicSearchRepository,
+        searchRepository = searchRepository,
     )
 
     private fun topicRequest(
@@ -1314,6 +1319,7 @@ class TopicViewModelTest {
         scrollTo: Int? = null,
         submitSignal: Long? = null,
         postSubmitOverflowLanding: Boolean = false,
+        resolveScrollToPage: Boolean = false,
     ): TopicRequest = TopicRequest(
         cat = SAMPLE_CAT,
         post = SAMPLE_POST,
@@ -1321,7 +1327,59 @@ class TopicViewModelTest {
         scrollTo = scrollTo,
         submitSignal = submitSignal,
         postSubmitOverflowLanding = postSubmitOverflowLanding,
+        resolveScrollToPage = resolveScrollToPage,
     )
+
+    // ──────────────────────────────────────────────────────────────────────
+    // #750 — untrusted-page resolution before the first load (email deep links)
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `resolveScrollToPage resolves the real page before the first load (#750)`() = runTest {
+        val repository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(37, 39)) }))
+        val search = FakeSearchRepository(pageToResolve = 37)
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1, scrollTo = 4242, resolveScrollToPage = true),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Anonymous),
+            searchRepository = search,
+        )
+        // The probe must carry the full (cat, post, numreponse) tuple (numreponse is per-category).
+        assertEquals(listOf(Triple(SAMPLE_CAT, SAMPLE_POST, 4242)), search.resolveCalls)
+        // The load targets the RESOLVED page, never the untrusted page=1 from the email link…
+        assertEquals(37, repository.calls.single().third)
+        // …and the resolved page becomes the real request everywhere (indicator, retry, highlight).
+        assertEquals(37, viewModel.state.value.request.page)
+        assertEquals(4242, viewModel.state.value.request.scrollTo)
+    }
+
+    @Test
+    fun `resolveScrollToPage falls back to the link page when the probe fails (#750)`() = runTest {
+        val repository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 39)) }))
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1, scrollTo = 4242, resolveScrollToPage = true),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Anonymous),
+            searchRepository = FakeSearchRepository(pageToResolve = null),
+        )
+        // Failed probe (null) → pre-#750 behaviour: the link's own page loads, nothing worse.
+        assertEquals(1, repository.calls.single().third)
+        assertEquals(1, viewModel.state.value.request.page)
+    }
+
+    @Test
+    fun `resolveScrollToPage without scrollTo is a plain load, no probe (#750)`() = runTest {
+        val repository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) }))
+        val search = FakeSearchRepository(pageToResolve = 5)
+        topicViewModel(
+            request = topicRequest(page = 1, resolveScrollToPage = true),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Anonymous),
+            searchRepository = search,
+        )
+        assertEquals(emptyList<Triple<Int, Int, Int>>(), search.resolveCalls)
+        assertEquals(1, repository.calls.single().third)
+    }
 
     // ──────────────────────────────────────────────────────────────────────
     // Issue #200 — post-submit force refresh path
@@ -1848,6 +1906,25 @@ class TopicViewModelTest {
         private const val SAMPLE_POST = 84_540
         private const val SAMPLE_SUBCAT = 432
         private const val CANCEL_TIMEOUT_MS = 2_000L
+    }
+}
+
+/**
+ * #750 — canned page-resolution probe. [pageToResolve] null simulates a failed probe (network
+ * error / timeout / unparsable redirect); [resolveCalls] records the exact tuples asked for.
+ * `search` is unused by TopicViewModel and fails loudly if something starts calling it.
+ */
+private class FakeSearchRepository(
+    private val pageToResolve: Int? = null,
+) : SearchRepository {
+    val resolveCalls: MutableList<Triple<Int, Int, Int>> = mutableListOf()
+
+    override suspend fun search(request: SearchRequest): SearchResultPage =
+        throw UnsupportedOperationException("TopicViewModel never searches")
+
+    override suspend fun resolveSearchResultPage(cat: Int, post: Int, numreponse: Int): Int? {
+        resolveCalls += Triple(cat, post, numreponse)
+        return pageToResolve
     }
 }
 

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -1381,6 +1381,30 @@ class TopicViewModelTest {
         assertEquals(1, repository.calls.single().third)
     }
 
+    @Test
+    fun `resolveScrollToPage times out on a hung probe and falls back to the link page (#750)`() = runTest {
+        val repository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 39)) }))
+        val hungSearch = object : SearchRepository {
+            override suspend fun search(request: SearchRequest): SearchResultPage =
+                throw UnsupportedOperationException("TopicViewModel never searches")
+
+            override suspend fun resolveSearchResultPage(cat: Int, post: Int, numreponse: Int): Int? {
+                // Degraded network: the probe never answers. withTimeoutOrNull(3 s) must cut it
+                // (instantaneous under runTest's virtual clock) and degrade to the link page.
+                kotlinx.coroutines.awaitCancellation()
+            }
+        }
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1, scrollTo = 4242, resolveScrollToPage = true),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Anonymous),
+            searchRepository = hungSearch,
+        )
+        testScheduler.advanceUntilIdle()
+        assertEquals(1, repository.calls.single().third)
+        assertEquals(1, viewModel.state.value.request.page)
+    }
+
     // ──────────────────────────────────────────────────────────────────────
     // Issue #200 — post-submit force refresh path
     // ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Vague 2 de la phase Vue Topic (#604) — le câblage scroll-vers-post unique pour les deux entrées, cadré par Codex (gpt-5.5 xhigh, verdict « OK avec ajustements », tous intégrés).

## #699 — clic sur une citation → aller au message cité

- `PostRenderer` gagne un callback nullable `onGoToCitedPost(page, numreponse)`, threadé explicitement dans la récursion quote/spoiler (param, pas de CompositionLocal — choix confirmé au cadrage : action navigationnelle, pas préférence de rendu).
- L'en-tête d'une citation **sourcée** (page + numreponse parsés du href) devient teinté primary + cliquable (libellé a11y « Aller au message cité ») ; une citation sans coordonnées parsées (forme `forum2.php` dynamique, cf. #227) garde l'en-tête neutre inerte — aucun fallback inventé.
- Côté topic : route-replace in-place uniforme (miroir de `onOpenPage`, #282) avec `scrollTo = numreponse` → scroll + highlight à l'arrivée (mécanisme deep-link #200), que la cible soit sur la même page ou une autre.

## #750 — lien email ouvre au post 1

Les liens de notification email HFR disent toujours `page=1` et portent la vraie cible en `numreponse` (query + fragment `#t`). Même pathologie que les résultats de recherche (#277) :

- `parseHfrDeepLink` lit le param query `numreponse` en fallback du fragment (certains clients mail le strippent) et marque un lien page-1-avec-ancre comme **untrusted** (`resolveScrollToPage`).
- `TopicViewModel` résout la vraie page AVANT le premier chargement via `SearchRepository.resolveSearchResultPage` (probe redirect serveur, timeout 3 s, fallback page du lien — jamais pire qu'avant), pendant que le skeleton 0.19.0 s'affiche, puis **adopte** la page résolue comme vraie cible (`request` + `state.request`) — indicateur, retry et highlight cohérents.

## Validation

- Compile + detektAll + tests unitaires `:feature:topic` + `:app` : BUILD SUCCESSFUL ; validation canonique complète en cours (verte avant merge).
- Tests ajoutés : résolution OK / probe échouée → fallback / pas de scrollTo → pas de probe ; parsing de la forme réelle du lien email de #750.
- Dogfood émulateur : le lien email exact de #750 atterrit **page 61/63** scrollé + highlighté sur la cible (avant : page 1) ; tap « Citation de garath_ » → saut + highlight sur le post cité, chaînable (garath_ → styx42).

Refs #699, #750 (fermeture à la promotion `dev → main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnwLr4K75nLTGGzVv97A2c