### PR TITLE
feat(editor): upload d'images dans le composeur nouveau sujet (#459 — 1/2)

### DIFF
--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -57,7 +57,7 @@ import fr.forumhfr.redface2.core.ui.editor.BbcodeToolbar
 import fr.forumhfr.redface2.core.ui.editor.EditorOptionsSheet
 
 /** Upload multi-images — cap on how many images one pick can queue, passed to the photo picker. */
-private const val MAX_IMAGES_PER_UPLOAD = 10
+internal const val MAX_IMAGES_PER_UPLOAD = 10
 
 /**
  * Multi-image upload — « n/N » counter shown under the toolbar while a batch is in flight. Extracted
@@ -65,7 +65,7 @@ private const val MAX_IMAGES_PER_UPLOAD = 10
  * image (null progress), which only flips the toolbar spinner.
  */
 @Composable
-private fun UploadProgressLabel(progress: UploadProgress?) {
+internal fun UploadProgressLabel(progress: UploadProgress?) {
     if (progress == null) return
     Text(
         text = stringResource(R.string.editor_upload_progress, progress.completed, progress.total),
@@ -534,7 +534,7 @@ private val PostEditorMode.titleResId: Int
  * rather than a plain `@StringRes Int` — the others stay argument-free.
  */
 @Composable
-private fun UploadError.bannerText(): String = when (this) {
+internal fun UploadError.bannerText(): String = when (this) {
     UploadError.TooLarge -> stringResource(R.string.editor_upload_error_too_large)
     UploadError.UnsupportedType -> stringResource(R.string.editor_upload_error_unsupported_type)
     is UploadError.Server ->

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormScreen.kt
@@ -3,6 +3,9 @@ package fr.forumhfr.redface2.feature.editor
 import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 import fr.forumhfr.redface2.core.ui.editor.SmileyPickerSheet
 import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -127,6 +130,13 @@ internal fun TopicFormContent(
 ) {
     var imageUrlDialogOpen by remember { mutableStateOf(false) }
     var optionsSheetOpen by remember { mutableStateOf(false) }
+    // #459 — modern photo picker (no runtime permission), same contract as PostEditorContent:
+    // multi-select returns a (possibly empty) List<Uri>, handed to the VM as Uri strings.
+    val pickImagesLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickMultipleVisualMedia(MAX_IMAGES_PER_UPLOAD),
+    ) { uris ->
+        if (uris.isNotEmpty()) onIntent(TopicFormIntent.ImagesPicked(uris.map { it.toString() }))
+    }
     Surface(
         modifier = modifier.fillMaxSize(),
         color = MaterialTheme.colorScheme.surface,
@@ -171,12 +181,24 @@ internal fun TopicFormContent(
                 BbcodeToolbar(
                     onAction = { onIntent(TopicFormIntent.ToolbarActionClicked(it)) },
                     onImageUrlRequested = { imageUrlDialogOpen = true },
+                    // #459 — upload wiring, same affordance as the reply editor.
+                    onImageUploadRequested = {
+                        pickImagesLauncher.launch(
+                            PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
+                        )
+                    },
+                    uploading = state.isUploading,
                 )
+                // #459 — « n/N » batch counter while a multi-image upload is in flight.
+                UploadProgressLabel(state.uploadProgress)
                 BbcodeTextField(
                     value = state.draft,
                     onValueChange = { onIntent(TopicFormIntent.ContentChanged(it)) },
                     label = stringResource(R.string.editor_field_label),
                     modifier = Modifier.fillMaxWidth(),
+                    // #459 — lock editing during a batch so the caret cannot move between two
+                    // programmatic [img] insertions (keeps them in pick order).
+                    readOnly = state.isUploading,
                 )
                 TextButton(onClick = { onIntent(TopicFormIntent.TogglePreview) }) {
                     Text(
@@ -205,16 +227,7 @@ internal fun TopicFormContent(
                         onDiscard = { onIntent(TopicFormIntent.DraftDiscardRequested) },
                     )
                 }
-                state.submitError?.let { error ->
-                    Text(
-                        text = stringResource(error.bannerResId),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.error,
-                    )
-                    TextButton(onClick = { onIntent(TopicFormIntent.ErrorDismissed) }) {
-                        Text(text = stringResource(R.string.editor_error_dismiss))
-                    }
-                }
+                TopicFormErrorBanners(state = state, onIntent = onIntent)
             }
             // Send-button accessibility — pin « Envoyer » to the bottom, above the IME, so the user
             // never has to dismiss the keyboard to submit a new topic / first-post edit (shared
@@ -256,6 +269,39 @@ internal fun TopicFormContent(
             onDismiss = { imageUrlDialogOpen = false },
             onInsert = { url -> onIntent(TopicFormIntent.ImageUrlInserted(url)) },
         )
+    }
+}
+
+/**
+ * Dismissible error banners of the topic composer: the submit failure (typed [SubmitError]) and the
+ * #459 upload failure (typed `UploadError`, same rendering as `PostEditorContent`). Extracted so
+ * [TopicFormContent] stays under detekt's cyclomatic-complexity budget (same rationale as
+ * `UploadProgressLabel`).
+ */
+@Composable
+private fun TopicFormErrorBanners(
+    state: TopicFormState,
+    onIntent: (TopicFormIntent) -> Unit,
+) {
+    state.submitError?.let { error ->
+        Text(
+            text = stringResource(error.bannerResId),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.error,
+        )
+        TextButton(onClick = { onIntent(TopicFormIntent.ErrorDismissed) }) {
+            Text(text = stringResource(R.string.editor_error_dismiss))
+        }
+    }
+    state.uploadError?.let { error ->
+        Text(
+            text = error.bannerText(),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.error,
+        )
+        TextButton(onClick = { onIntent(TopicFormIntent.UploadErrorDismissed) }) {
+            Text(text = stringResource(R.string.editor_error_dismiss))
+        }
     }
 }
 

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormState.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormState.kt
@@ -96,6 +96,16 @@ data class TopicFormState(
      */
     val restorableDraft: String? = null,
     val restorableSubject: String? = null,
+    /**
+     * #459 — `true` while an image upload (single or batch) is in flight. Drives the toolbar
+     * spinner AND locks the body field (`readOnly`) so the caret cannot move between two
+     * programmatic `[img]` insertions. Mirrors [PostEditorState.isUploading].
+     */
+    val isUploading: Boolean = false,
+    /** #459 — typed upload failure surfaced as a dismissible banner ; mirrors [PostEditorState.uploadError]. */
+    val uploadError: UploadError? = null,
+    /** #459 — « n/N » batch counter (null for a single image) ; mirrors [PostEditorState.uploadProgress]. */
+    val uploadProgress: UploadProgress? = null,
 ) {
     /**
      * Submit is allowed when the mode-specific routing context is complete,
@@ -183,6 +193,15 @@ sealed interface TopicFormIntent {
 
     /** Phase 2F-E (#189) — insert `[img]url[/img]` for a validated remote image URL. */
     data class ImageUrlInserted(val url: String) : TopicFormIntent
+
+    /**
+     * #459 — images picked by the photo picker, as Uri strings in pick order. Read + uploaded
+     * sequentially, one `[img]` inserted per success. Mirrors [PostEditorIntent.ImagesPicked].
+     */
+    data class ImagesPicked(val uris: List<String>) : TopicFormIntent
+
+    /** #459 — dismiss the upload-error banner. Mirrors [PostEditorIntent.UploadErrorDismissed]. */
+    data object UploadErrorDismissed : TopicFormIntent
 
     /** #405 — restore the editor from the cached draft (subject + body). */
     data object DraftRestoreRequested : TopicFormIntent

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModel.kt
@@ -10,6 +10,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
 import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
@@ -17,7 +18,11 @@ import fr.forumhfr.redface2.core.domain.editor.EditorDraftKey
 import fr.forumhfr.redface2.core.domain.editor.EditorDraftStore
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.smiley.SmileyRepository
+import fr.forumhfr.redface2.core.domain.upload.ImageUploadReader
+import fr.forumhfr.redface2.core.domain.upload.UploadException
+import fr.forumhfr.redface2.core.domain.upload.UploadRepository
 import fr.forumhfr.redface2.core.domain.write.TopicFormRepository
+import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import fr.forumhfr.redface2.core.model.write.EditFirstPostContext
@@ -72,6 +77,12 @@ class TopicFormViewModel @AssistedInject constructor(
     private val userPreferencesRepository: UserPreferencesRepository,
     private val draftStore: EditorDraftStore,
     private val diagnostics: DiagnosticsLog,
+    // #459 — image upload wiring, same trio as PostEditorViewModel: auth scopes the upload to the
+    // active HFR session, the reader turns a picked Uri into bytes, the repository posts to the
+    // host of the current preference.
+    private val authRepository: AuthRepository,
+    private val uploadRepository: UploadRepository,
+    private val imageUploadReader: ImageUploadReader,
 ) : ViewModel() {
 
     private val _state: MutableStateFlow<TopicFormState> = MutableStateFlow(
@@ -120,6 +131,17 @@ class TopicFormViewModel @AssistedInject constructor(
     private var autosaveJob: Job? = null
 
     /**
+     * #459 — lowercased pseudo of the authenticated session, or null when anonymous. The upload
+     * providers require an HFR session for the trace ; an anonymous pick is silently ignored
+     * (the submit-time anonymous guard already surfaces the login requirement). Mirrors
+     * `PostEditorViewModel.activeUserId`.
+     */
+    private var activeUserId: String? = null
+
+    /** #459 — in-flight image upload job ; one at a time, cancelled on [onCleared]. */
+    private var uploadJob: Job? = null
+
+    /**
      * #405 — account that owned this editor when it opened, snapshotted from [draftStore] so a
      * mid-edit account switch can't write this session's draft under another account (Codex beta
      * review). Captured in [restoreDraftIfAny]; null until then / for an anonymous session.
@@ -150,6 +172,23 @@ class TopicFormViewModel @AssistedInject constructor(
         viewModelScope.launch {
             userPreferencesRepository.observeEditorImageInsert().collect { mode ->
                 imageInsertMode = mode
+            }
+        }
+        viewModelScope.launch {
+            authRepository.observeAuthState().collect { authState ->
+                val newUserId = when (authState) {
+                    AuthState.Anonymous -> null
+                    is AuthState.Authenticated -> authState.pseudo.lowercase()
+                }
+                // #459 — account switched / logged out mid-session: cancel any in-flight upload
+                // and pending autosave so this session's image URL / draft is never attributed to
+                // the new account (same Codex-reviewed rule as PostEditorViewModel).
+                if (activeUserId != null && newUserId != activeUserId) {
+                    uploadJob?.cancel()
+                    autosaveJob?.cancel()
+                    _state.update { it.copy(isUploading = false, uploadProgress = null) }
+                }
+                activeUserId = newUserId
             }
         }
         restoreDraftIfAny()
@@ -226,6 +265,8 @@ class TopicFormViewModel @AssistedInject constructor(
             is TopicFormIntent.SmileySearchQueryChanged -> onSmileySearchQueryChanged(intent.query)
             is TopicFormIntent.SmileySelected -> onSmileySelected(intent.token)
             is TopicFormIntent.ImageUrlInserted -> onImageUrlInserted(intent.url)
+            is TopicFormIntent.ImagesPicked -> onImagesPicked(intent.uris)
+            TopicFormIntent.UploadErrorDismissed -> _state.update { it.copy(uploadError = null) }
             TopicFormIntent.DraftRestoreRequested -> onDraftRestoreRequested()
             TopicFormIntent.DraftDiscardRequested -> onDraftDiscardRequested()
         }
@@ -382,9 +423,24 @@ class TopicFormViewModel @AssistedInject constructor(
      */
     private fun onImageUrlInserted(url: String) {
         val token = imageInsertBbcodeOrNull(fullUrl = url, mode = imageInsertMode) ?: return
+        insertImageBbcodeAtCaret(token, leadingNewline = false)
+        scheduleAutosave()
+    }
+
+    /**
+     * #459 — inserts an already-built image BBCode fragment at the caret. Same cursor contract as
+     * the smiley path ([insertBbcodeToken] preserves the selection, the preview is refreshed),
+     * WITHOUT surrounding spaces (an image is self-contained). [leadingNewline] prefixes a newline
+     * when the caret is not already at a line start, so consecutive uploads land on their own lines.
+     * Mirrors `PostEditorViewModel.insertImageBbcodeAtCaret`.
+     */
+    private fun insertImageBbcodeAtCaret(bbcode: String, leadingNewline: Boolean) {
         _state.update { current ->
             val draft = current.draft
             val selection = draft.selection
+            val caret = selection.start.coerceIn(0, draft.text.length)
+            val needsNewline = leadingNewline && caret > 0 && draft.text[caret - 1] != '\n'
+            val token = if (needsNewline) "\n$bbcode" else bbcode
             val outcome = insertBbcodeToken(
                 token = token,
                 text = draft.text,
@@ -403,7 +459,85 @@ class TopicFormViewModel @AssistedInject constructor(
                 withDraft
             }
         }
-        scheduleAutosave()
+    }
+
+    /**
+     * #459 — pick→read→upload→insert for the topic composer, copied from the proven
+     * `PostEditorViewModel.onImagesPicked` contract (multi-image #490): the picked [uris] are read
+     * and uploaded sequentially (one in-flight at a time), each success inserts its `[img]` at the
+     * caret in pick order (with a leading newline from the second image on) and autosaves, and the
+     * batch stops at the first failure — the already-inserted images stay, the typed [UploadError]
+     * is surfaced. A blank list, an anonymous session (no [activeUserId]) or an upload already in
+     * flight are ignored. [TopicFormState.uploadProgress] carries « n/N » when the batch has more
+     * than one image.
+     */
+    private fun onImagesPicked(uris: List<String>) {
+        val userId = activeUserId
+        val targets = uris.filter { it.isNotBlank() }
+        // One guard (ReturnCount): nothing in flight already, an authenticated owner, a non-empty pick.
+        if (uploadJob?.isActive == true || userId == null || targets.isEmpty()) return
+        val multiple = targets.size > 1
+        _state.update {
+            it.copy(
+                isUploading = true,
+                uploadError = null,
+                uploadProgress = if (multiple) UploadProgress(completed = 0, total = targets.size) else null,
+            )
+        }
+        uploadJob = viewModelScope.launch {
+            // Snapshot the cached preference once at batch start so all N inserts use a consistent
+            // mode even if the user flips the setting mid-upload.
+            val mode = imageInsertMode
+            var completed = 0
+            for (uri in targets) {
+                val outcome = runCatching {
+                    val image = imageUploadReader.read(uri)
+                    uploadRepository.uploadWithCurrentProvider(image, userId)
+                }
+                val uploaded = outcome.getOrElse { error ->
+                    handleUploadFailure(error)
+                    return@launch
+                }
+                val bbcode = imageInsertBbcodeOrNull(
+                    fullUrl = uploaded.imageUrl,
+                    displayUrl = uploaded.resizedUrl ?: uploaded.imageUrl,
+                    mode = mode,
+                )
+                if (bbcode != null) {
+                    insertImageBbcodeAtCaret(bbcode, leadingNewline = completed > 0)
+                    // Persist after EACH insert: a later image failing must not lose the images
+                    // already inserted into the draft (Codex review #490).
+                    scheduleAutosave()
+                }
+                completed += 1
+                if (multiple) {
+                    _state.update { it.copy(uploadProgress = UploadProgress(completed, targets.size)) }
+                }
+            }
+            _state.update { it.copy(isUploading = false, uploadError = null, uploadProgress = null) }
+        }
+    }
+
+    private fun handleUploadFailure(error: Throwable) {
+        if (error is CancellationException) {
+            _state.update { it.copy(isUploading = false, uploadProgress = null) }
+            throw error
+        }
+        val mapped = when (error) {
+            is UploadException.TooLarge -> UploadError.TooLarge
+            is UploadException.UnsupportedType -> UploadError.UnsupportedType
+            is UploadException.Server -> UploadError.Server(code = error.code, providerId = error.providerId)
+            is UploadException.Malformed -> UploadError.Malformed(providerId = error.providerId)
+            is UploadException.Configuration -> UploadError.Configuration
+            is UploadException.Network -> UploadError.Network
+            else -> UploadError.Network
+        }
+        diagnostics.record(
+            DiagnosticsLog.Level.WARN,
+            LOG_TAG_VM,
+            "image upload failed: ${error::class.simpleName} → ${mapped::class.simpleName}",
+        )
+        _state.update { it.copy(isUploading = false, uploadError = mapped, uploadProgress = null) }
     }
 
     private fun onSubjectChanged(value: TextFieldValue) {
@@ -855,6 +989,16 @@ class TopicFormViewModel @AssistedInject constructor(
                 submitError
             },
         )
+    }
+
+    /**
+     * #459 — belt-and-braces upload cancellation on ViewModel death (viewModelScope is already
+     * cancelled by the lifecycle; this makes the « one upload, no leak » contract explicit).
+     * Mirrors `PostEditorViewModel.onCleared`.
+     */
+    override fun onCleared() {
+        uploadJob?.cancel()
+        super.onCleared()
     }
 
     @AssistedFactory

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -23,8 +23,16 @@ import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.MarkerStyle
 import fr.forumhfr.redface2.core.domain.preferences.PlusLusIndicatorStyle
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
+import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.smiley.SmileyRepository
+import fr.forumhfr.redface2.core.domain.upload.ImageUpload
+import fr.forumhfr.redface2.core.domain.upload.ImageUploadReader
+import fr.forumhfr.redface2.core.domain.upload.UploadException
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
+import fr.forumhfr.redface2.core.domain.upload.UploadRepository
+import fr.forumhfr.redface2.core.domain.upload.UploadedImage
+import fr.forumhfr.redface2.core.domain.upload.UploadedImageRecord
+import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import fr.forumhfr.redface2.core.domain.write.TopicFormRepository
 import fr.forumhfr.redface2.core.model.EditorSmiley
@@ -1100,11 +1108,85 @@ class TopicFormViewModelTest {
         assertTrue("a saved FP must drop its draft", draftStore.deletedKeys.contains(key))
     }
 
+    // ──────────────────────────────────────────────────────────────────────
+    // #459 — image upload wiring on the topic composer (pattern copied from PostEditorViewModel;
+    // the batch semantics themselves are pinned by PostEditorViewModelTest — here we prove the
+    // topic-form copy is actually wired: authenticated pick uploads + inserts, anonymous is inert).
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `picked images upload and insert one img per success, in pick order (#459)`() = runTest {
+        val uploads = FakeUploadRepository()
+        val reader = FakeImageUploadReader()
+        val viewModel = newTopicViewModel(
+            entrySubcat = SAMPLE_SUBCAT,
+            uploadRepository = uploads,
+            imageUploadReader = reader,
+        )
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(TopicFormIntent.ImagesPicked(listOf("content://pick/1", "content://pick/2")))
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(listOf("content://pick/1", "content://pick/2"), reader.readUris)
+        assertEquals(2, uploads.uploadCalls)
+        val state = viewModel.state.value
+        assertEquals(2, Regex("\\[img]").findAll(state.draft.text).count())
+        assertFalse(state.isUploading)
+        assertEquals(null, state.uploadError)
+        assertEquals(null, state.uploadProgress)
+    }
+
+    @Test
+    fun `an anonymous session ignores the pick entirely (#459)`() = runTest {
+        val uploads = FakeUploadRepository()
+        val viewModel = newTopicViewModel(
+            entrySubcat = SAMPLE_SUBCAT,
+            authRepository = FakeAuthRepository(AuthState.Anonymous),
+            uploadRepository = uploads,
+        )
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(TopicFormIntent.ImagesPicked(listOf("content://pick/1")))
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(0, uploads.uploadCalls)
+        assertFalse(viewModel.state.value.isUploading)
+    }
+
+    @Test
+    fun `a failed upload surfaces a typed banner and stops the batch (#459)`() = runTest {
+        val uploads = FakeUploadRepository().apply {
+            uploadException = UploadException.TooLarge(maxBytes = 1)
+        }
+        val viewModel = newTopicViewModel(
+            entrySubcat = SAMPLE_SUBCAT,
+            uploadRepository = uploads,
+        )
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(TopicFormIntent.ImagesPicked(listOf("content://pick/1", "content://pick/2")))
+        testScheduler.advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertEquals(UploadError.TooLarge, state.uploadError)
+        assertFalse(state.isUploading)
+        assertEquals(1, uploads.uploadCalls)
+        assertEquals("", state.draft.text)
+
+        viewModel.submit(TopicFormIntent.UploadErrorDismissed)
+        assertEquals(null, viewModel.state.value.uploadError)
+    }
+
+    @Suppress("LongParameterList") // test factory mirroring the ViewModel's injected dependencies.
     private fun newTopicViewModel(
         entrySubcat: Int?,
         cat: Int = SAMPLE_CAT,
         diagnostics: DiagnosticsLog = DiagnosticsLog(),
         userPreferencesRepository: UserPreferencesRepository = FakeUserPreferencesRepository(),
+        authRepository: AuthRepository = FakeAuthRepository(),
+        uploadRepository: UploadRepository = FakeUploadRepository(),
+        imageUploadReader: ImageUploadReader = FakeImageUploadReader(),
     ): TopicFormViewModel = TopicFormViewModel(
         request = TopicFormRequest(
             mode = TopicFormMode.New,
@@ -1120,6 +1202,9 @@ class TopicFormViewModelTest {
         userPreferencesRepository = userPreferencesRepository,
         draftStore = draftStore,
         diagnostics = diagnostics,
+        authRepository = authRepository,
+        uploadRepository = uploadRepository,
+        imageUploadReader = imageUploadReader,
     )
 
     private suspend fun app.cash.turbine.ReceiveTurbine<TopicFormState>.awaitHydratedState(): TopicFormState {
@@ -1151,7 +1236,58 @@ class TopicFormViewModelTest {
         userPreferencesRepository = userPreferencesRepository,
         draftStore = draftStore,
         diagnostics = diagnostics,
+        authRepository = FakeAuthRepository(),
+        uploadRepository = FakeUploadRepository(),
+        imageUploadReader = FakeImageUploadReader(),
     )
+
+    /** #459 — canned [ImageUploadReader] (1-byte PNG), records the picked uris in call order. */
+    private class FakeImageUploadReader : ImageUploadReader {
+        val readUris: MutableList<String> = mutableListOf()
+
+        override suspend fun read(uri: String): ImageUpload {
+            readUris += uri
+            return ImageUpload(bytes = byteArrayOf(0), mimeType = "image/png", displayName = null)
+        }
+    }
+
+    /** #459 — fake [UploadRepository] ; only [uploadWithCurrentProvider] matters here. */
+    private class FakeUploadRepository : UploadRepository {
+        var uploadException: Throwable? = null
+        var uploadCalls: Int = 0
+            private set
+
+        override suspend fun uploadWithCurrentProvider(image: ImageUpload, userId: String): UploadedImage {
+            uploadCalls += 1
+            uploadException?.let { throw it }
+            return UploadedImage(
+                provider = UploadProviderId.DIBERIE,
+                imageUrl = "https://rehost.diberie.com/Picture/Get/f/1",
+                thumbnailUrl = null,
+                resizedUrl = null,
+                deleteHandle = null,
+                expiresAt = null,
+            )
+        }
+
+        override fun observeUploads(userId: String): kotlinx.coroutines.flow.Flow<List<UploadedImageRecord>> =
+            kotlinx.coroutines.flow.MutableStateFlow(emptyList())
+
+        override suspend fun delete(record: UploadedImageRecord, userId: String): Boolean = false
+    }
+
+    /** #459 — fixed [AuthState] so the VM resolves (or not) an upload `userId`. */
+    private class FakeAuthRepository(
+        private val authState: AuthState = AuthState.Authenticated("alice"),
+    ) : AuthRepository {
+        override fun observeAuthState(): kotlinx.coroutines.flow.Flow<AuthState> =
+            kotlinx.coroutines.flow.MutableStateFlow(authState)
+
+        override suspend fun login(pseudo: String, password: String): Result<AuthState.Authenticated> =
+            Result.success(AuthState.Authenticated(pseudo))
+
+        override suspend fun logout() = Unit
+    }
 
     private class FakePreviewParser : BbcodePreviewParser {
         override fun parsePreview(bbcode: String): PostContent = PostContent(


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Vague 2 de la phase Vue Topic (#604) — première moitié du reste de #459 (« câbler l'upload dans les éditeurs MP et nouveau sujet »). Pattern PostEditor (multi-image #490) recopié sur `TopicFormScreen`/`TopicFormViewModel` :

- Intent `ImagesPicked` + batch séquentiel read→upload→insert : un `[img]` par succès dans l'ordre du pick (saut de ligne à partir de la 2e), autosave après CHAQUE insertion (règle Codex #490), arrêt au premier échec avec `UploadError` typé en bannière dismissible.
- Scopé auth : pick anonyme ignoré ; changement de compte en cours de batch → annulation upload + autosave (règle Codex bêta).
- Toolbar : affordance « Uploader » (`PickMultipleVisualMedia`, max 10) + compteur « n/N » ; champ `readOnly` pendant le batch (le caret ne bouge pas entre deux insertions programmatiques).
- `MAX_IMAGES_PER_UPLOAD` / `UploadProgressLabel` / `UploadError.bannerText()` passés `private` → `internal` (réutilisés dans le même module) ; bannières extraites en `TopicFormErrorBanners` (budget detekt).

**Reste pour clore #459 (PR 2/2)** : le composeur MP (`feature/messages`) — nécessite la promotion de `UploadError`/`UploadProgress`/`UploadProgressLabel` vers `:core:ui`.

## Validation

- Validation canonique complète : BUILD SUCCESSFUL.
- 3 tests VM ajoutés : pick authentifié → 2 uploads + 2 `[img]` dans l'ordre ; session anonyme → pick inerte ; échec typé → bannière `TooLarge`, batch stoppé, dismiss OK. (La sémantique fine du batch reste pinnée par `PostEditorViewModelTest`.)
- Dogfood émulateur : « Uploader » → photo picker → sélection → **upload diberie réel** → insertion `[url=…][img]…[/img][/url]` (préférence REDUCED respectée) dans le brouillon nouveau-sujet ; aucune soumission.

Refs #459.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnwLr4K75nLTGGzVv97A2c