### PR TITLE
chore(release): 0.19.1 — dev vague 2 (changelog + whatsnew)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,20 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.19.1` — `internal` (dev) — 2026-07-02
+
+**Phase « Vue Topic » (#604) — vague 2 : quick wins navigation & éditeurs** (PRs #763, #764, #765, #766 — cadrage + gates Codex gpt-5.5).
+
+### Vue Topic
+- #699 : l'en-tête d'une citation sourcée (« Citation de X ») devient cliquable (teinté couleur primaire) — tap = saut vers le message cité, avec scroll et surbrillance à l'arrivée, même s'il est sur une autre page. Chaînable de citation en citation.
+- #750 : un lien de notification **email** ouvre enfin le sujet au bon message — HFR met toujours `page=1` dans ces liens ; la vraie page est résolue via le redirect serveur (mécanisme #277 de la recherche) pendant que le squelette s'affiche. Échec réseau = comportement d'avant, jamais pire.
+- #762 : le titre du sujet s'affiche désormais réellement dès la première frame quand on ouvre depuis la liste Drapeaux ou un listing de forum (le cache de titres n'était alimenté qu'après un premier chargement — l'annonce 0.19.0 est maintenant vraie).
+
+### Éditeurs
+- #555 : ouvrir un éditeur (répondre, citer, **éditer un long message**) lève le clavier immédiatement, champ déjà focus — plus besoin de taper dans le champ pour commencer.
+- #250 : l'onglet Wiki du sélecteur de smileys donne le focus à la recherche dès l'ouverture — on tape directement.
+- #459 (1/2) : **upload d'images dans le composeur « nouveau sujet »** — bouton Uploader, sélection multiple (max 10), un `[img]` par image dans l'ordre, compteur n/N, erreurs typées ; même moteur que l'éditeur de réponse. (Reste : le composeur MP.)
+
 ## `0.19.0` — `internal` (dev) — 2026-07-02
 
 **Phase « Vue Topic » (#604) — vague 1 : écran de chargement** (mockup « Chargement A » arbitré sur le fil DEV, cadrage + gate Codex gpt-5.5).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.19.0"
+        versionName = "0.19.1"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,5 +1,8 @@
-Redface 2 v0.19.0 — dev.
+Redface 2 v0.19.1 — dev.
 
-Topic view (redesign begins):
-- Reworked page loading: title shown immediately, centered indicator and skeleton content preview.
-- Reliable page counter while loading (no more stale total).
+Topic view (wave 2):
+- Tap a quote to jump to the cited post.
+- Email links open at the right post.
+- Title shown instantly when opening from a list.
+- Editors: keyboard raised on entry, smiley search focused.
+- Image upload in the new-topic composer.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,5 +1,8 @@
-Redface 2 v0.19.0 — dev.
+Redface 2 v0.19.1 — dev.
 
-Vue Topic (début de la refonte) :
-- Chargement d'une page repensé : titre affiché immédiatement, indicateur centré et aperçu squelette du contenu.
-- Compteur de pages fiable pendant le chargement (plus de total erroné).
+Vue Topic (vague 2) :
+- Tap sur une citation = saut vers le message cité.
+- Les liens email ouvrent au bon message.
+- Titre affiché dès l'ouverture depuis une liste.
+- Éditeurs : clavier levé d'office, recherche smileys focus.
+- Upload d'images dans « nouveau sujet ».


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump `versionName` 0.19.0 → 0.19.1 + entrée `app/CHANGELOG.md` + whatsnew fr/en (version en 1re ligne, ≤ 500 caractères — le garde whatsnew-freshness s'applique aussi au canal dev). Contenu : vague 2 Vue Topic — #699 saut vers le message cité, #750 liens email, #762 titre immédiat, #555/#250 focus éditeurs, #459 (1/2) upload nouveau-sujet.

Dispatch après merge : `gh workflow run release.yml --ref dev -f channel=dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnwLr4K75nLTGGzVv97A2c