### PR TITLE
feat(messages): upload d'images dans les deux composeurs MP (#459 — 2/2)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/EditorUpload.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/EditorUpload.kt
@@ -1,0 +1,89 @@
+package fr.forumhfr.redface2.core.ui.editor
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
+import fr.forumhfr.redface2.core.ui.R
+
+/**
+ * #459 — shared image-upload UI vocabulary of the BBCode editors. Born in `:feature:editor`
+ * (reply editor #485, multi-image #490, topic composer PR #766) and promoted here for the MP
+ * composers (`:feature:messages`) — same promotion path as [SmileyPickerSheet] (#387) and
+ * `EditorOptionsSheet` (#388), so every editor surface shares one error taxonomy, one « n/N »
+ * progress label and one banner wording.
+ */
+
+/** Ceiling of the photo picker's multi-select (`PickMultipleVisualMedia`), all editor surfaces. */
+const val MAX_IMAGES_PER_UPLOAD = 10
+
+/**
+ * #459 PR2 — upload failure surfaced to the user, mapped from the repository's typed
+ * `UploadException`. `LoginRequired` has no equivalent here : an anonymous session never
+ * gets here — the ViewModels ignore a pick without a userId.
+ */
+sealed interface UploadError {
+    /** The picked image exceeds the host's accepted size. */
+    data object TooLarge : UploadError
+
+    /** The host rejected the MIME type. */
+    data object UnsupportedType : UploadError
+
+    /** The host answered a non-2xx HTTP status. [code] is the status, [providerId] the host (#474). */
+    data class Server(val code: Int, val providerId: UploadProviderId) : UploadError
+
+    /** The host answered 2xx but the body could not be parsed into the expected shape (#474). */
+    data class Malformed(val providerId: UploadProviderId) : UploadError
+
+    /** The upload provider is not configured (e.g. a blank Imgur Client-ID): the user must set it
+     * up in Settings, not retry — so the banner points at configuration, not connectivity (#474). */
+    data object Configuration : UploadError
+
+    /** No network / DNS / timeout — also covers an unreadable picked Uri (mapped to Network). */
+    data object Network : UploadError
+}
+
+/**
+ * Progress of a multi-image upload batch: [completed] images uploaded and inserted out of [total]
+ * picked. Surfaced as an « n/N » counter while the surface's `isUploading` flag is true.
+ */
+data class UploadProgress(val completed: Int, val total: Int)
+
+/**
+ * Multi-image upload — « n/N » counter shown under the toolbar while a batch is in flight. Emits
+ * nothing for a single image (null progress), which only flips the toolbar spinner.
+ */
+@Composable
+fun UploadProgressLabel(progress: UploadProgress?) {
+    if (progress == null) return
+    Text(
+        text = stringResource(R.string.editor_upload_progress, progress.completed, progress.total),
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+/**
+ * #474 — resolves the upload-error banner text. [UploadError.Server] / [UploadError.Malformed] carry
+ * the host (and the HTTP code for Server), so they need string args and a `@Composable` resolver
+ * rather than a plain `@StringRes Int` — the others stay argument-free.
+ */
+@Composable
+fun UploadError.bannerText(): String = when (this) {
+    UploadError.TooLarge -> stringResource(R.string.editor_upload_error_too_large)
+    UploadError.UnsupportedType -> stringResource(R.string.editor_upload_error_unsupported_type)
+    is UploadError.Server ->
+        stringResource(R.string.editor_upload_error_server, providerId.displayName(), code)
+    is UploadError.Malformed ->
+        stringResource(R.string.editor_upload_error_malformed, providerId.displayName())
+    UploadError.Configuration -> stringResource(R.string.editor_upload_error_configuration)
+    UploadError.Network -> stringResource(R.string.editor_upload_error_network)
+}
+
+/** French display name of an image host, for the upload-error banner (#474). */
+@Composable
+private fun UploadProviderId.displayName(): String = when (this) {
+    UploadProviderId.DIBERIE -> stringResource(R.string.editor_upload_provider_diberie)
+    UploadProviderId.IMGUR -> stringResource(R.string.editor_upload_provider_imgur)
+}

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -84,4 +84,15 @@
         <item quantity="one">%1$d page à lire</item>
         <item quantity="other">%1$d pages à lire</item>
     </plurals>
+
+    <!-- #459 - vocabulaire upload partage des editeurs BBCode (promu de :feature:editor). -->
+    <string name="editor_upload_error_too_large">Image trop volumineuse pour cet hébergeur. Choisissez une image plus légère.</string>
+    <string name="editor_upload_error_unsupported_type">Type d\'image non accepté par l\'hébergeur.</string>
+    <string name="editor_upload_error_server">L\'hébergeur %1$s a refusé l\'image (HTTP %2$d). Réessayez ou changez d\'hébergeur dans les réglages.</string>
+    <string name="editor_upload_error_malformed">Réponse illisible de l\'hébergeur %1$s. Réessayez ou changez d\'hébergeur dans les réglages.</string>
+    <string name="editor_upload_error_configuration">Hébergeur d\'images non configuré. Renseignez le Client-ID dans les réglages avant d\'envoyer une image.</string>
+    <string name="editor_upload_error_network">Erreur réseau pendant l\'upload. Vérifiez votre connexion et réessayez.</string>
+    <string name="editor_upload_progress">Envoi %1$d/%2$d…</string>
+    <string name="editor_upload_provider_diberie">diberie</string>
+    <string name="editor_upload_provider_imgur">imgur</string>
 </resources>

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorIntent.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorIntent.kt
@@ -1,4 +1,6 @@
 package fr.forumhfr.redface2.feature.editor
+import fr.forumhfr.redface2.core.ui.editor.UploadError
+import fr.forumhfr.redface2.core.ui.editor.UploadProgress
 
 import androidx.compose.ui.text.input.TextFieldValue
 import fr.forumhfr.redface2.core.ui.editor.BbcodeAction

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -1,4 +1,9 @@
 package fr.forumhfr.redface2.feature.editor
+import fr.forumhfr.redface2.core.ui.editor.MAX_IMAGES_PER_UPLOAD
+import fr.forumhfr.redface2.core.ui.editor.UploadError
+import fr.forumhfr.redface2.core.ui.editor.UploadProgress
+import fr.forumhfr.redface2.core.ui.editor.UploadProgressLabel
+import fr.forumhfr.redface2.core.ui.editor.bannerText
 
 import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 import fr.forumhfr.redface2.core.ui.editor.SmileyPickerSheet
@@ -56,23 +61,6 @@ import fr.forumhfr.redface2.core.ui.editor.BbcodeTextField
 import fr.forumhfr.redface2.core.ui.editor.BbcodeToolbar
 import fr.forumhfr.redface2.core.ui.editor.EditorOptionsSheet
 
-/** Upload multi-images — cap on how many images one pick can queue, passed to the photo picker. */
-internal const val MAX_IMAGES_PER_UPLOAD = 10
-
-/**
- * Multi-image upload — « n/N » counter shown under the toolbar while a batch is in flight. Extracted
- * so [PostEditorContent] stays under the cyclomatic-complexity budget. Emits nothing for a single
- * image (null progress), which only flips the toolbar spinner.
- */
-@Composable
-internal fun UploadProgressLabel(progress: UploadProgress?) {
-    if (progress == null) return
-    Text(
-        text = stringResource(R.string.editor_upload_progress, progress.completed, progress.total),
-        style = MaterialTheme.typography.labelMedium,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-    )
-}
 
 /**
  * Post-level editor screen. Phase 2C (#145) adds a Submit button that posts the
@@ -527,30 +515,6 @@ private val PostEditorMode.titleResId: Int
         PostEditorMode.Reply -> R.string.editor_post_reply_title
         PostEditorMode.Edit -> R.string.editor_post_edit_title
     }
-
-/**
- * #474 — resolves the upload-error banner text. [UploadError.Server] / [UploadError.Malformed] carry
- * the host (and the HTTP code for Server), so they need string args and a `@Composable` resolver
- * rather than a plain `@StringRes Int` — the others stay argument-free.
- */
-@Composable
-internal fun UploadError.bannerText(): String = when (this) {
-    UploadError.TooLarge -> stringResource(R.string.editor_upload_error_too_large)
-    UploadError.UnsupportedType -> stringResource(R.string.editor_upload_error_unsupported_type)
-    is UploadError.Server ->
-        stringResource(R.string.editor_upload_error_server, providerId.displayName(), code)
-    is UploadError.Malformed ->
-        stringResource(R.string.editor_upload_error_malformed, providerId.displayName())
-    UploadError.Configuration -> stringResource(R.string.editor_upload_error_configuration)
-    UploadError.Network -> stringResource(R.string.editor_upload_error_network)
-}
-
-/** French display name of an image host, for the upload-error banner (#474). */
-@Composable
-private fun UploadProviderId.displayName(): String = when (this) {
-    UploadProviderId.DIBERIE -> stringResource(R.string.editor_upload_provider_diberie)
-    UploadProviderId.IMGUR -> stringResource(R.string.editor_upload_provider_imgur)
-}
 
 private val SubmitError.bannerResId: Int
     get() = when (this) {

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
@@ -1,10 +1,11 @@
 package fr.forumhfr.redface2.feature.editor
+import fr.forumhfr.redface2.core.ui.editor.UploadError
+import fr.forumhfr.redface2.core.ui.editor.UploadProgress
 
 import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 import androidx.compose.ui.text.input.TextFieldValue
 import fr.forumhfr.redface2.core.domain.editor.BbcodeValidation
 import fr.forumhfr.redface2.core.domain.editor.validateBbcodeDraft
-import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.EditorSmiley
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
@@ -167,43 +168,9 @@ sealed interface SubmitError {
     data object MissingSubcat : SubmitError
 }
 
-/**
- * #459 PR2 / #474 — UI-facing image-upload failure. Maps the `:core:domain`
- * [fr.forumhfr.redface2.core.domain.upload.UploadException] variants onto an actionable message
- * (too large / unsupported type / host HTTP error / unreadable host response / network) instead of
- * a generic « erreur de l'hébergeur ». The HTTP [Server] case carries the status [code] and the
- * [providerId] so the banner can name the host and the exact code (#474); [Malformed] stays distinct
- * so an unreadable-but-2xx body reads differently from a flat HTTP refusal. Anonymous clients never
- * get here — the ViewModel ignores a pick without a userId.
- */
-sealed interface UploadError {
-    /** The picked image exceeds the host's accepted size. */
-    data object TooLarge : UploadError
-
-    /** The host rejected the MIME type. */
-    data object UnsupportedType : UploadError
-
-    /** The host answered a non-2xx HTTP status. [code] is the status, [providerId] the host (#474). */
-    data class Server(val code: Int, val providerId: UploadProviderId) : UploadError
-
-    /** The host answered 2xx but the body could not be parsed into the expected shape (#474). */
-    data class Malformed(val providerId: UploadProviderId) : UploadError
-
-    /** The upload provider is not configured (e.g. a blank Imgur Client-ID): the user must set it
-     * up in Settings, not retry — so the banner points at configuration, not connectivity (#474). */
-    data object Configuration : UploadError
-
-    /** No network / DNS / timeout — also covers an unreadable picked Uri (mapped to Network). */
-    data object Network : UploadError
-}
-
-/**
- * Progress of a multi-image upload batch: [completed] images uploaded and inserted out of [total]
- * picked. Surfaced as an « n/N » counter while [PostEditorState.isUploading] is true.
- */
-data class UploadProgress(val completed: Int, val total: Int)
-
-
+// #459 — UploadError / UploadProgress were born here and are now promoted to
+// `:core:ui` (core.ui.editor.EditorUpload) so the MP composers share the same
+// upload vocabulary as the topic-side editors.
 
 internal fun PostEditorState.withDraft(updated: TextFieldValue): PostEditorState =
     copy(

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -1,4 +1,6 @@
 package fr.forumhfr.redface2.feature.editor
+import fr.forumhfr.redface2.core.ui.editor.UploadError
+import fr.forumhfr.redface2.core.ui.editor.UploadProgress
 
 import fr.forumhfr.redface2.core.ui.editor.WikiSearchState
 import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormScreen.kt
@@ -1,4 +1,7 @@
 package fr.forumhfr.redface2.feature.editor
+import fr.forumhfr.redface2.core.ui.editor.MAX_IMAGES_PER_UPLOAD
+import fr.forumhfr.redface2.core.ui.editor.UploadProgressLabel
+import fr.forumhfr.redface2.core.ui.editor.bannerText
 
 import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 import fr.forumhfr.redface2.core.ui.editor.SmileyPickerSheet

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormState.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormState.kt
@@ -1,4 +1,6 @@
 package fr.forumhfr.redface2.feature.editor
+import fr.forumhfr.redface2.core.ui.editor.UploadError
+import fr.forumhfr.redface2.core.ui.editor.UploadProgress
 
 import fr.forumhfr.redface2.core.ui.editor.WikiSearchState
 import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModel.kt
@@ -1,4 +1,6 @@
 package fr.forumhfr.redface2.feature.editor
+import fr.forumhfr.redface2.core.ui.editor.UploadError
+import fr.forumhfr.redface2.core.ui.editor.UploadProgress
 
 import fr.forumhfr.redface2.core.ui.editor.WikiSearchState
 import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState

--- a/feature/editor/src/main/res/values/strings.xml
+++ b/feature/editor/src/main/res/values/strings.xml
@@ -45,15 +45,6 @@
     <string name="editor_draft_discard">Ignorer</string>
     <!-- #459 PR2 / #474 — erreurs d\'upload d\'image (mappées depuis UploadException). Server et
          Malformed nomment l\'hébergeur (et le code HTTP pour Server) au lieu d\'un message vague. -->
-    <string name="editor_upload_error_too_large">Image trop volumineuse pour cet hébergeur. Choisissez une image plus légère.</string>
-    <string name="editor_upload_error_unsupported_type">Type d\'image non accepté par l\'hébergeur.</string>
-    <string name="editor_upload_error_server">L\'hébergeur %1$s a refusé l\'image (HTTP %2$d). Réessayez ou changez d\'hébergeur dans les réglages.</string>
-    <string name="editor_upload_error_malformed">Réponse illisible de l\'hébergeur %1$s. Réessayez ou changez d\'hébergeur dans les réglages.</string>
-    <string name="editor_upload_error_configuration">Hébergeur d\'images non configuré. Renseignez le Client-ID dans les réglages avant d\'envoyer une image.</string>
-    <string name="editor_upload_error_network">Erreur réseau pendant l\'upload. Vérifiez votre connexion et réessayez.</string>
     <!-- Upload multi-images — compteur de progression « n/N » affiché pendant l\'envoi du lot. -->
-    <string name="editor_upload_progress">Envoi %1$d/%2$d…</string>
     <!-- Noms d\'hébergeurs d\'images affichés dans les messages d\'erreur (#474). -->
-    <string name="editor_upload_provider_diberie">diberie</string>
-    <string name="editor_upload_provider_imgur">imgur</string>
 </resources>

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -1,4 +1,6 @@
 package fr.forumhfr.redface2.feature.editor
+import fr.forumhfr.redface2.core.ui.editor.UploadError
+import fr.forumhfr.redface2.core.ui.editor.UploadProgress
 
 import fr.forumhfr.redface2.core.ui.editor.WikiSearchState
 import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1,4 +1,6 @@
 package fr.forumhfr.redface2.feature.editor
+import fr.forumhfr.redface2.core.ui.editor.UploadError
+import fr.forumhfr.redface2.core.ui.editor.UploadProgress
 
 import fr.forumhfr.redface2.core.ui.editor.WikiSearchState
 import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeScreen.kt
@@ -1,5 +1,8 @@
 package fr.forumhfr.redface2.feature.messages
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -29,6 +32,9 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.ui.editor.MAX_IMAGES_PER_UPLOAD
+import fr.forumhfr.redface2.core.ui.editor.UploadProgressLabel
+import fr.forumhfr.redface2.core.ui.editor.bannerText
 import fr.forumhfr.redface2.core.ui.editor.BbcodeAction
 import fr.forumhfr.redface2.core.ui.editor.BbcodePreview
 import fr.forumhfr.redface2.core.ui.editor.BbcodeTextField
@@ -82,6 +88,8 @@ fun PrivateMessageComposeScreen(
         onRetryFormLoad = viewModel::retryFormLoad,
         onDraftRestore = viewModel::onDraftRestoreRequested,
         onDraftDiscard = viewModel::onDraftDiscardRequested,
+        onImagesPicked = viewModel::onImagesPicked,
+        onUploadErrorDismissed = viewModel::onUploadErrorDismissed,
         smileyPicker = viewModel.smileyPicker,
         onSmileySelected = viewModel::onSmileySelected,
         modifier = modifier,
@@ -108,6 +116,9 @@ private fun PrivateMessageComposeContent(
     onRetryFormLoad: () -> Unit,
     onDraftRestore: () -> Unit,
     onDraftDiscard: () -> Unit,
+    // #459 — image upload wiring (photo picker launcher lives in the body composable).
+    onImagesPicked: (List<String>) -> Unit,
+    onUploadErrorDismissed: () -> Unit,
     smileyPicker: SmileyPickerController,
     onSmileySelected: (String) -> Unit,
     modifier: Modifier = Modifier,
@@ -136,6 +147,8 @@ private fun PrivateMessageComposeContent(
                         onErrorDismissed = onErrorDismissed,
                         onDraftRestore = onDraftRestore,
                         onDraftDiscard = onDraftDiscard,
+                        onImagesPicked = onImagesPicked,
+                        onUploadErrorDismissed = onUploadErrorDismissed,
                         modifier = Modifier.weight(1f),
                     )
                     MessageSubmitBar(
@@ -189,8 +202,16 @@ private fun ComposeEditorBody(
     onErrorDismissed: () -> Unit,
     onDraftRestore: () -> Unit,
     onDraftDiscard: () -> Unit,
+    onImagesPicked: (List<String>) -> Unit,
+    onUploadErrorDismissed: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // #459 — modern photo picker (no runtime permission), same contract as the topic-side editors.
+    val pickImagesLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickMultipleVisualMedia(MAX_IMAGES_PER_UPLOAD),
+    ) { uris ->
+        if (uris.isNotEmpty()) onImagesPicked(uris.map { it.toString() })
+    }
     // #275/#410 follow-up (dev v118 feedback, screen 520813) — compose is the ONE editor whose
     // fixed header (recipients + subject + toolbar, ~300dp) could squeeze the weighted draft
     // field to ~zero once the IME opened, with no outer scroll to bring it back into view: the
@@ -236,7 +257,18 @@ private fun ComposeEditorBody(
             modifier = Modifier.fillMaxWidth(),
         )
 
-        BbcodeToolbar(onAction = onToolbarAction)
+        BbcodeToolbar(
+            onAction = onToolbarAction,
+            // #459 — upload wiring, same affordance as the topic-side editors.
+            onImageUploadRequested = {
+                pickImagesLauncher.launch(
+                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
+                )
+            },
+            uploading = state.isUploading,
+        )
+        // #459 — « n/N » batch counter while a multi-image upload is in flight.
+        UploadProgressLabel(state.uploadProgress)
 
         BbcodeTextField(
             value = state.draft,
@@ -248,6 +280,8 @@ private fun ComposeEditorBody(
             modifier = Modifier
                 .fillMaxWidth()
                 .heightIn(min = COMPOSE_DRAFT_MIN_HEIGHT),
+            // #459 — lock editing during a batch (caret must not move between two insertions).
+            readOnly = state.isUploading,
         )
 
         Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
@@ -294,6 +328,18 @@ private fun ComposeEditorBody(
                 color = MaterialTheme.colorScheme.error,
             )
             TextButton(onClick = onErrorDismissed) {
+                Text(text = stringResource(R.string.messages_reply_error_dismiss))
+            }
+        }
+
+        // #459 — dismissible upload-error banner (shared :core:ui wording).
+        state.uploadError?.let { error ->
+            Text(
+                text = error.bannerText(),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error,
+            )
+            TextButton(onClick = onUploadErrorDismissed) {
                 Text(text = stringResource(R.string.messages_reply_error_dismiss))
             }
         }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeUiState.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeUiState.kt
@@ -2,6 +2,8 @@ package fr.forumhfr.redface2.feature.messages
 
 import androidx.compose.ui.text.input.TextFieldValue
 import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.ui.editor.UploadError
+import fr.forumhfr.redface2.core.ui.editor.UploadProgress
 
 /**
  * MVI state of the new-conversation composer (#301 follow-up). Mirrors
@@ -41,6 +43,15 @@ data class PrivateMessageComposeUiState(
     val restorableDraft: String? = null,
     val restorableSubject: String? = null,
     val restorableRecipients: String? = null,
+    /**
+     * #459 — `true` while an image upload (single or batch) is in flight: toolbar spinner + body
+     * field locked (`readOnly`) so the caret cannot move between two programmatic `[img]` insertions.
+     */
+    val isUploading: Boolean = false,
+    /** #459 — typed upload failure surfaced as a dismissible banner (shared `:core:ui` taxonomy). */
+    val uploadError: UploadError? = null,
+    /** #459 — « n/N » batch counter (null for a single image). */
+    val uploadProgress: UploadProgress? = null,
 ) {
     /** All three user-typed fields are required — HFR's « remplir tous les champs » rule. */
     val canSubmit: Boolean

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModel.kt
@@ -9,6 +9,16 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import fr.forumhfr.redface2.core.domain.auth.AuthRepository
+import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
+import fr.forumhfr.redface2.core.domain.upload.ImageUploadReader
+import fr.forumhfr.redface2.core.domain.upload.UploadException
+import fr.forumhfr.redface2.core.domain.upload.UploadRepository
+import fr.forumhfr.redface2.core.model.AuthState
+import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
+import fr.forumhfr.redface2.core.ui.editor.UploadError
+import fr.forumhfr.redface2.core.ui.editor.UploadProgress
+import fr.forumhfr.redface2.core.ui.editor.imageInsertBbcodeOrNull
 import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
 import fr.forumhfr.redface2.core.domain.editor.EditorDraftKey
 import fr.forumhfr.redface2.core.domain.editor.EditorDraftStore
@@ -51,12 +61,18 @@ import kotlinx.coroutines.launch
  * every field intact — the banner invites the user to check their messages list instead.
  */
 @HiltViewModel(assistedFactory = PrivateMessageComposeViewModel.Factory::class)
+@Suppress("LongParameterList") // Hilt ctor — one dependency per collaborator (#459 added the upload trio).
 class PrivateMessageComposeViewModel @AssistedInject constructor(
     @Assisted private val initialRecipient: String?,
     private val repository: PrivateMessageWriteRepository,
     private val previewParser: BbcodePreviewParser,
     private val userPreferencesRepository: UserPreferencesRepository,
     private val draftStore: EditorDraftStore,
+    // #459 — image upload wiring, same trio + diagnostics as the topic-side editors.
+    private val authRepository: AuthRepository,
+    private val uploadRepository: UploadRepository,
+    private val imageUploadReader: ImageUploadReader,
+    private val diagnostics: DiagnosticsLog,
     smileyRepository: SmileyRepository,
 ) : ViewModel() {
 
@@ -79,6 +95,23 @@ class PrivateMessageComposeViewModel @AssistedInject constructor(
     private var autosaveJob: Job? = null
 
     /**
+     * #459 — lowercased pseudo of the authenticated session, or null when anonymous. The upload
+     * providers require an HFR session for the trace ; an anonymous pick is silently ignored.
+     * Mirrors `PostEditorViewModel.activeUserId`.
+     */
+    private var activeUserId: String? = null
+
+    /** #459 — in-flight image upload job ; one at a time, cancelled on [onCleared]. */
+    private var uploadJob: Job? = null
+
+    /**
+     * #459 — mirror of the persisted [EditorImageInsert] preference, read synchronously at insert
+     * time (cf. `PostEditorViewModel.imageInsertMode`). Default mirrors the repository's REDUCED
+     * default until the first emission lands.
+     */
+    private var imageInsertMode: EditorImageInsert = EditorImageInsert.REDUCED
+
+    /**
      * #405 — account that owned this MP composer when it opened, snapshotted from [draftStore] so a
      * mid-edit account switch can't write this session's PRIVATE draft (recipients + body) under
      * another account (Codex beta review). Captured in [restoreDraftIfAny]; null until then.
@@ -92,6 +125,28 @@ class PrivateMessageComposeViewModel @AssistedInject constructor(
         viewModelScope.launch {
             userPreferencesRepository.observeConfirmBeforePosting().collect { enabled ->
                 confirmBeforePosting = enabled
+            }
+        }
+        viewModelScope.launch {
+            userPreferencesRepository.observeEditorImageInsert().collect { mode ->
+                imageInsertMode = mode
+            }
+        }
+        viewModelScope.launch {
+            authRepository.observeAuthState().collect { authState ->
+                val newUserId = when (authState) {
+                    AuthState.Anonymous -> null
+                    is AuthState.Authenticated -> authState.pseudo.lowercase()
+                }
+                // #459 — account switched / logged out mid-session: cancel any in-flight upload
+                // and pending autosave so this session's image URL / PRIVATE draft is never
+                // attributed to the new account (same Codex-reviewed rule as PostEditorViewModel).
+                if (activeUserId != null && newUserId != activeUserId) {
+                    uploadJob?.cancel()
+                    autosaveJob?.cancel()
+                    _state.update { it.copy(isUploading = false, uploadProgress = null) }
+                }
+                activeUserId = newUserId
             }
         }
         restoreDraftIfAny()
@@ -425,7 +480,130 @@ class PrivateMessageComposeViewModel @AssistedInject constructor(
     ): PrivateMessageComposeUiState = copy(
         draft = updated,
         preview = if (isPreviewVisible) previewParser.parsePreview(updated.text) else preview,
+        // #459 — a fresh text edit dismisses a stale upload banner (a successful upload INSERTS
+        // text via this path, which also clears any prior error) — parity with PostEditorState.
+        uploadError = if (updated.text != draft.text) null else uploadError,
     )
+
+
+    /**
+     * #459 — pick→read→upload→insert for this MP composer, same proven contract as
+     * `PostEditorViewModel.onImagesPicked` (multi-image #490): sequential batch, one `[img]` per
+     * success in pick order (leading newline from the 2nd on), autosave after each insertion, stop
+     * at the first failure with the typed [UploadError] surfaced. A blank list, an anonymous
+     * session or an upload already in flight are ignored.
+     */
+    fun onImagesPicked(uris: List<String>) {
+        val userId = activeUserId
+        val targets = uris.filter { it.isNotBlank() }
+        // One guard (ReturnCount): nothing in flight already, an authenticated owner, a non-empty pick.
+        if (uploadJob?.isActive == true || userId == null || targets.isEmpty()) return
+        val multiple = targets.size > 1
+        _state.update {
+            it.copy(
+                isUploading = true,
+                uploadError = null,
+                uploadProgress = if (multiple) UploadProgress(completed = 0, total = targets.size) else null,
+            )
+        }
+        uploadJob = viewModelScope.launch {
+            // Snapshot the cached preference once at batch start so all N inserts use a consistent
+            // mode even if the user flips the setting mid-upload.
+            val mode = imageInsertMode
+            var completed = 0
+            for (uri in targets) {
+                val outcome = runCatching {
+                    val image = imageUploadReader.read(uri)
+                    uploadRepository.uploadWithCurrentProvider(image, userId)
+                }
+                val uploaded = outcome.getOrElse { error ->
+                    handleUploadFailure(error)
+                    return@launch
+                }
+                val bbcode = imageInsertBbcodeOrNull(
+                    fullUrl = uploaded.imageUrl,
+                    displayUrl = uploaded.resizedUrl ?: uploaded.imageUrl,
+                    mode = mode,
+                )
+                if (bbcode != null) {
+                    insertImageBbcodeAtCaret(bbcode, leadingNewline = completed > 0)
+                    // Persist after EACH insert: a later image failing must not lose the images
+                    // already inserted into the draft (Codex review #490).
+                    scheduleAutosave()
+                }
+                completed += 1
+                if (multiple) {
+                    _state.update { it.copy(uploadProgress = UploadProgress(completed, targets.size)) }
+                }
+            }
+            _state.update { it.copy(isUploading = false, uploadError = null, uploadProgress = null) }
+        }
+    }
+
+    /** #459 — dismiss the upload-error banner. */
+    fun onUploadErrorDismissed() {
+        _state.update { it.copy(uploadError = null) }
+    }
+
+    /**
+     * #459 — inserts an already-built image BBCode fragment at the caret, WITHOUT surrounding
+     * spaces (an image is self-contained). [leadingNewline] prefixes a newline when the caret is
+     * not already at a line start, so consecutive uploads land on their own lines. Mirrors
+     * `PostEditorViewModel.insertImageBbcodeAtCaret`.
+     */
+    private fun insertImageBbcodeAtCaret(bbcode: String, leadingNewline: Boolean) {
+        _state.update { current ->
+            val draft = current.draft
+            val selection = draft.selection
+            val caret = selection.start.coerceIn(0, draft.text.length)
+            val needsNewline = leadingNewline && caret > 0 && draft.text[caret - 1] != '\n'
+            val token = if (needsNewline) "\n" + bbcode else bbcode
+            val outcome = insertBbcodeToken(
+                token = token,
+                text = draft.text,
+                selectionStart = selection.start,
+                selectionEnd = selection.end,
+                surroundWithSpaces = false,
+            )
+            current.withDraftPreview(
+                TextFieldValue(
+                    text = outcome.text,
+                    selection = TextRange(outcome.selectionStart, outcome.selectionEnd),
+                ),
+            )
+        }
+    }
+
+    private fun handleUploadFailure(error: Throwable) {
+        if (error is CancellationException) {
+            _state.update { it.copy(isUploading = false, uploadProgress = null) }
+            throw error
+        }
+        val mapped = when (error) {
+            is UploadException.TooLarge -> UploadError.TooLarge
+            is UploadException.UnsupportedType -> UploadError.UnsupportedType
+            is UploadException.Server -> UploadError.Server(code = error.code, providerId = error.providerId)
+            is UploadException.Malformed -> UploadError.Malformed(providerId = error.providerId)
+            is UploadException.Configuration -> UploadError.Configuration
+            is UploadException.Network -> UploadError.Network
+            else -> UploadError.Network
+        }
+        diagnostics.record(
+            DiagnosticsLog.Level.WARN,
+            LOG_TAG_UPLOAD,
+            "image upload failed: " + (error::class.simpleName ?: "?") + " -> " + (mapped::class.simpleName ?: "?"),
+        )
+        _state.update { it.copy(isUploading = false, uploadError = mapped, uploadProgress = null) }
+    }
+
+    /**
+     * #459 — belt-and-braces upload cancellation on ViewModel death (viewModelScope is already
+     * cancelled by the lifecycle). Mirrors `PostEditorViewModel.onCleared`.
+     */
+    override fun onCleared() {
+        uploadJob?.cancel()
+        super.onCleared()
+    }
 
     @AssistedFactory
     interface Factory {
@@ -435,6 +613,9 @@ class PrivateMessageComposeViewModel @AssistedInject constructor(
     private companion object {
         // #405 — idle window after the last edit before the draft is persisted (cf. PostEditorViewModel).
         private const val AUTOSAVE_DEBOUNCE_MS = 750L
+
+        // #459 — diagnostics tag of the upload failures (shared shape with the topic-side editors).
+        private const val LOG_TAG_UPLOAD = "MpComposeVM"
     }
 }
 

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
@@ -1,5 +1,8 @@
 package fr.forumhfr.redface2.feature.messages
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -28,6 +31,9 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.ui.editor.MAX_IMAGES_PER_UPLOAD
+import fr.forumhfr.redface2.core.ui.editor.UploadProgressLabel
+import fr.forumhfr.redface2.core.ui.editor.bannerText
 import fr.forumhfr.redface2.core.ui.editor.BbcodeAction
 import fr.forumhfr.redface2.core.ui.editor.BbcodePreview
 import fr.forumhfr.redface2.core.ui.editor.BbcodeTextField
@@ -81,6 +87,8 @@ fun PrivateMessageReplyScreen(
         onRetryFormLoad = viewModel::retryFormLoad,
         onDraftRestore = viewModel::onDraftRestoreRequested,
         onDraftDiscard = viewModel::onDraftDiscardRequested,
+        onImagesPicked = viewModel::onImagesPicked,
+        onUploadErrorDismissed = viewModel::onUploadErrorDismissed,
         onAddRecipient = viewModel::onAddRecipient,
         onRemoveRecipient = viewModel::onRemoveRecipient,
         smileyPicker = viewModel.smileyPicker,
@@ -108,6 +116,9 @@ private fun PrivateMessageReplyContent(
     onRetryFormLoad: () -> Unit,
     onDraftRestore: () -> Unit,
     onDraftDiscard: () -> Unit,
+    // #459 — image upload wiring (photo picker launcher lives in the body composable).
+    onImagesPicked: (List<String>) -> Unit,
+    onUploadErrorDismissed: () -> Unit,
     onAddRecipient: (String) -> Unit,
     onRemoveRecipient: (String) -> Unit,
     smileyPicker: SmileyPickerController,
@@ -144,6 +155,8 @@ private fun PrivateMessageReplyContent(
                         onErrorDismissed = onErrorDismissed,
                         onDraftRestore = onDraftRestore,
                         onDraftDiscard = onDraftDiscard,
+                        onImagesPicked = onImagesPicked,
+                        onUploadErrorDismissed = onUploadErrorDismissed,
                         onManageRecipients = { recipientManagerOpen = true },
                         modifier = Modifier.weight(1f),
                     )
@@ -209,9 +222,17 @@ private fun ReplyEditorBody(
     onErrorDismissed: () -> Unit,
     onDraftRestore: () -> Unit,
     onDraftDiscard: () -> Unit,
+    onImagesPicked: (List<String>) -> Unit,
+    onUploadErrorDismissed: () -> Unit,
     onManageRecipients: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // #459 — modern photo picker (no runtime permission), same contract as the topic-side editors.
+    val pickImagesLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickMultipleVisualMedia(MAX_IMAGES_PER_UPLOAD),
+    ) { uris ->
+        if (uris.isNotEmpty()) onImagesPicked(uris.map { it.toString() })
+    }
     // No outer scroll : the draft field is weighted so it stretches down to the bar (same
     // extensible-field design as the post editor) ; long content scrolls in the field's own
     // fillViewport column (#275/#410) and inside the preview pane.
@@ -233,7 +254,18 @@ private fun ReplyEditorBody(
             HorizontalDivider()
         }
 
-        BbcodeToolbar(onAction = onToolbarAction)
+        BbcodeToolbar(
+            onAction = onToolbarAction,
+            // #459 — upload wiring, same affordance as the topic-side editors.
+            onImageUploadRequested = {
+                pickImagesLauncher.launch(
+                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
+                )
+            },
+            uploading = state.isUploading,
+        )
+        // #459 — « n/N » batch counter while a multi-image upload is in flight.
+        UploadProgressLabel(state.uploadProgress)
 
         BbcodeTextField(
             value = state.draft,
@@ -244,6 +276,8 @@ private fun ReplyEditorBody(
             // #275/#410 — grow-with-content field in its own scrollable viewport so the
             // cursor stays visible under the IME (typing AND refocus after the preview).
             fillViewport = true,
+            // #459 — lock editing during a batch (caret must not move between two insertions).
+            readOnly = state.isUploading,
         )
 
         Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
@@ -283,6 +317,18 @@ private fun ReplyEditorBody(
                 color = MaterialTheme.colorScheme.error,
             )
             TextButton(onClick = onErrorDismissed) {
+                Text(text = stringResource(R.string.messages_reply_error_dismiss))
+            }
+        }
+
+        // #459 — dismissible upload-error banner (shared :core:ui wording).
+        state.uploadError?.let { error ->
+            Text(
+                text = error.bannerText(),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error,
+            )
+            TextButton(onClick = onUploadErrorDismissed) {
                 Text(text = stringResource(R.string.messages_reply_error_dismiss))
             }
         }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyUiState.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyUiState.kt
@@ -2,6 +2,8 @@ package fr.forumhfr.redface2.feature.messages
 
 import androidx.compose.ui.text.input.TextFieldValue
 import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.ui.editor.UploadError
+import fr.forumhfr.redface2.core.ui.editor.UploadProgress
 
 /**
  * MVI state of the private-message reply editor (#301). Mirrors the post editor's shape (draft +
@@ -66,6 +68,15 @@ data class PrivateMessageReplyUiState(
      * normalise whitespace / drop entries and risk losing members). Only an explicit edit arms it.
      */
     val recipientsDirty: Boolean = false,
+    /**
+     * #459 — `true` while an image upload (single or batch) is in flight: toolbar spinner + body
+     * field locked (`readOnly`) so the caret cannot move between two programmatic `[img]` insertions.
+     */
+    val isUploading: Boolean = false,
+    /** #459 — typed upload failure surfaced as a dismissible banner (shared `:core:ui` taxonomy). */
+    val uploadError: UploadError? = null,
+    /** #459 — « n/N » batch counter (null for a single image). */
+    val uploadProgress: UploadProgress? = null,
 ) {
     val canSubmit: Boolean
         get() = formAvailable && !isLoadingForm && !isSubmitting && draft.text.isNotBlank()

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
@@ -9,6 +9,16 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import fr.forumhfr.redface2.core.domain.auth.AuthRepository
+import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
+import fr.forumhfr.redface2.core.domain.upload.ImageUploadReader
+import fr.forumhfr.redface2.core.domain.upload.UploadException
+import fr.forumhfr.redface2.core.domain.upload.UploadRepository
+import fr.forumhfr.redface2.core.model.AuthState
+import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
+import fr.forumhfr.redface2.core.ui.editor.UploadError
+import fr.forumhfr.redface2.core.ui.editor.UploadProgress
+import fr.forumhfr.redface2.core.ui.editor.imageInsertBbcodeOrNull
 import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
 import fr.forumhfr.redface2.core.domain.editor.EditorDraftKey
 import fr.forumhfr.redface2.core.domain.editor.EditorDraftStore
@@ -51,12 +61,18 @@ import kotlinx.coroutines.launch
  *    mirroring the post editor.
  */
 @HiltViewModel(assistedFactory = PrivateMessageReplyViewModel.Factory::class)
+@Suppress("LongParameterList") // Hilt ctor — one dependency per collaborator (#459 added the upload trio).
 class PrivateMessageReplyViewModel @AssistedInject constructor(
     @Assisted private val request: PrivateMessageReplyRequest,
     private val repository: PrivateMessageWriteRepository,
     private val previewParser: BbcodePreviewParser,
     private val userPreferencesRepository: UserPreferencesRepository,
     private val draftStore: EditorDraftStore,
+    // #459 — image upload wiring, same trio + diagnostics as the topic-side editors.
+    private val authRepository: AuthRepository,
+    private val uploadRepository: UploadRepository,
+    private val imageUploadReader: ImageUploadReader,
+    private val diagnostics: DiagnosticsLog,
     smileyRepository: SmileyRepository,
 ) : ViewModel() {
 
@@ -82,6 +98,23 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
     private var autosaveJob: Job? = null
 
     /**
+     * #459 — lowercased pseudo of the authenticated session, or null when anonymous. The upload
+     * providers require an HFR session for the trace ; an anonymous pick is silently ignored.
+     * Mirrors `PostEditorViewModel.activeUserId`.
+     */
+    private var activeUserId: String? = null
+
+    /** #459 — in-flight image upload job ; one at a time, cancelled on [onCleared]. */
+    private var uploadJob: Job? = null
+
+    /**
+     * #459 — mirror of the persisted [EditorImageInsert] preference, read synchronously at insert
+     * time (cf. `PostEditorViewModel.imageInsertMode`). Default mirrors the repository's REDUCED
+     * default until the first emission lands.
+     */
+    private var imageInsertMode: EditorImageInsert = EditorImageInsert.REDUCED
+
+    /**
      * #405 — account that owned this MP editor when it opened, snapshotted from [draftStore] so a
      * mid-edit account switch can't write this session's PRIVATE draft under another account
      * (Codex beta review). Captured in [restoreDraftIfAny]; null until then / when anonymous.
@@ -99,6 +132,28 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
         viewModelScope.launch {
             userPreferencesRepository.observeConfirmBeforePosting().collect { enabled ->
                 confirmBeforePosting = enabled
+            }
+        }
+        viewModelScope.launch {
+            userPreferencesRepository.observeEditorImageInsert().collect { mode ->
+                imageInsertMode = mode
+            }
+        }
+        viewModelScope.launch {
+            authRepository.observeAuthState().collect { authState ->
+                val newUserId = when (authState) {
+                    AuthState.Anonymous -> null
+                    is AuthState.Authenticated -> authState.pseudo.lowercase()
+                }
+                // #459 — account switched / logged out mid-session: cancel any in-flight upload
+                // and pending autosave so this session's image URL / PRIVATE draft is never
+                // attributed to the new account (same Codex-reviewed rule as PostEditorViewModel).
+                if (activeUserId != null && newUserId != activeUserId) {
+                    uploadJob?.cancel()
+                    autosaveJob?.cancel()
+                    _state.update { it.copy(isUploading = false, uploadProgress = null) }
+                }
+                activeUserId = newUserId
             }
         }
         restoreDraftIfAny()
@@ -473,7 +528,129 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
         copy(
             draft = updated,
             preview = if (isPreviewVisible) previewParser.parsePreview(updated.text) else preview,
+            // #459 — a fresh text edit dismisses a stale upload banner — parity with PostEditorState.
+            uploadError = if (updated.text != draft.text) null else uploadError,
         )
+
+
+    /**
+     * #459 — pick→read→upload→insert for this MP composer, same proven contract as
+     * `PostEditorViewModel.onImagesPicked` (multi-image #490): sequential batch, one `[img]` per
+     * success in pick order (leading newline from the 2nd on), autosave after each insertion, stop
+     * at the first failure with the typed [UploadError] surfaced. A blank list, an anonymous
+     * session or an upload already in flight are ignored.
+     */
+    fun onImagesPicked(uris: List<String>) {
+        val userId = activeUserId
+        val targets = uris.filter { it.isNotBlank() }
+        // One guard (ReturnCount): nothing in flight already, an authenticated owner, a non-empty pick.
+        if (uploadJob?.isActive == true || userId == null || targets.isEmpty()) return
+        val multiple = targets.size > 1
+        _state.update {
+            it.copy(
+                isUploading = true,
+                uploadError = null,
+                uploadProgress = if (multiple) UploadProgress(completed = 0, total = targets.size) else null,
+            )
+        }
+        uploadJob = viewModelScope.launch {
+            // Snapshot the cached preference once at batch start so all N inserts use a consistent
+            // mode even if the user flips the setting mid-upload.
+            val mode = imageInsertMode
+            var completed = 0
+            for (uri in targets) {
+                val outcome = runCatching {
+                    val image = imageUploadReader.read(uri)
+                    uploadRepository.uploadWithCurrentProvider(image, userId)
+                }
+                val uploaded = outcome.getOrElse { error ->
+                    handleUploadFailure(error)
+                    return@launch
+                }
+                val bbcode = imageInsertBbcodeOrNull(
+                    fullUrl = uploaded.imageUrl,
+                    displayUrl = uploaded.resizedUrl ?: uploaded.imageUrl,
+                    mode = mode,
+                )
+                if (bbcode != null) {
+                    insertImageBbcodeAtCaret(bbcode, leadingNewline = completed > 0)
+                    // Persist after EACH insert: a later image failing must not lose the images
+                    // already inserted into the draft (Codex review #490).
+                    scheduleAutosave()
+                }
+                completed += 1
+                if (multiple) {
+                    _state.update { it.copy(uploadProgress = UploadProgress(completed, targets.size)) }
+                }
+            }
+            _state.update { it.copy(isUploading = false, uploadError = null, uploadProgress = null) }
+        }
+    }
+
+    /** #459 — dismiss the upload-error banner. */
+    fun onUploadErrorDismissed() {
+        _state.update { it.copy(uploadError = null) }
+    }
+
+    /**
+     * #459 — inserts an already-built image BBCode fragment at the caret, WITHOUT surrounding
+     * spaces (an image is self-contained). [leadingNewline] prefixes a newline when the caret is
+     * not already at a line start, so consecutive uploads land on their own lines. Mirrors
+     * `PostEditorViewModel.insertImageBbcodeAtCaret`.
+     */
+    private fun insertImageBbcodeAtCaret(bbcode: String, leadingNewline: Boolean) {
+        _state.update { current ->
+            val draft = current.draft
+            val selection = draft.selection
+            val caret = selection.start.coerceIn(0, draft.text.length)
+            val needsNewline = leadingNewline && caret > 0 && draft.text[caret - 1] != '\n'
+            val token = if (needsNewline) "\n" + bbcode else bbcode
+            val outcome = insertBbcodeToken(
+                token = token,
+                text = draft.text,
+                selectionStart = selection.start,
+                selectionEnd = selection.end,
+                surroundWithSpaces = false,
+            )
+            current.withDraftPreview(
+                TextFieldValue(
+                    text = outcome.text,
+                    selection = TextRange(outcome.selectionStart, outcome.selectionEnd),
+                ),
+            )
+        }
+    }
+
+    private fun handleUploadFailure(error: Throwable) {
+        if (error is CancellationException) {
+            _state.update { it.copy(isUploading = false, uploadProgress = null) }
+            throw error
+        }
+        val mapped = when (error) {
+            is UploadException.TooLarge -> UploadError.TooLarge
+            is UploadException.UnsupportedType -> UploadError.UnsupportedType
+            is UploadException.Server -> UploadError.Server(code = error.code, providerId = error.providerId)
+            is UploadException.Malformed -> UploadError.Malformed(providerId = error.providerId)
+            is UploadException.Configuration -> UploadError.Configuration
+            is UploadException.Network -> UploadError.Network
+            else -> UploadError.Network
+        }
+        diagnostics.record(
+            DiagnosticsLog.Level.WARN,
+            LOG_TAG_UPLOAD,
+            "image upload failed: " + (error::class.simpleName ?: "?") + " -> " + (mapped::class.simpleName ?: "?"),
+        )
+        _state.update { it.copy(isUploading = false, uploadError = mapped, uploadProgress = null) }
+    }
+
+    /**
+     * #459 — belt-and-braces upload cancellation on ViewModel death (viewModelScope is already
+     * cancelled by the lifecycle). Mirrors `PostEditorViewModel.onCleared`.
+     */
+    override fun onCleared() {
+        uploadJob?.cancel()
+        super.onCleared()
+    }
 
     @AssistedFactory
     interface Factory {
@@ -483,6 +660,9 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
     private companion object {
         // #405 — idle window after the last edit before the draft is persisted (cf. PostEditorViewModel).
         private const val AUTOSAVE_DEBOUNCE_MS = 750L
+
+        // #459 — diagnostics tag of the upload failures (shared shape with the topic-side editors).
+        private const val LOG_TAG_UPLOAD = "MpReplyVM"
     }
 }
 

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModelTest.kt
@@ -2,6 +2,10 @@ package fr.forumhfr.redface2.feature.messages
 
 import androidx.compose.ui.text.input.TextFieldValue
 import app.cash.turbine.test
+import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
+import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
+import fr.forumhfr.redface2.core.domain.upload.ImageUploadReader
+import fr.forumhfr.redface2.core.domain.upload.UploadRepository
 import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
 import fr.forumhfr.redface2.core.domain.editor.EditorDraftKey
 import fr.forumhfr.redface2.core.domain.editor.EditorDraftStore
@@ -50,6 +54,8 @@ class PrivateMessageComposeViewModelTest {
     private fun userPreferences(confirmBeforePosting: Boolean = false): UserPreferencesRepository =
         mockk {
             every { observeConfirmBeforePosting() } returns MutableStateFlow(confirmBeforePosting)
+            // #459 — the composer now mirrors the image-insert preference on init.
+            every { observeEditorImageInsert() } returns MutableStateFlow(EditorImageInsert.REDUCED)
         }
 
     /** Mirrors the standalone composer's parsed shape (fixture `mp_compose_form.html`). */
@@ -77,19 +83,44 @@ class PrivateMessageComposeViewModelTest {
 
     private val draftStore = FakeEditorDraftStore()
 
+    @Suppress("LongParameterList") // test factory mirroring the ViewModel's injected dependencies.
     private fun viewModel(
         repository: PrivateMessageWriteRepository,
         initialRecipient: String? = null,
         confirmBeforePosting: Boolean = false,
         smileyRepository: SmileyRepository = mockk(relaxed = true),
+        uploadRepository: UploadRepository = FakeUploadRepository(),
+        imageUploadReader: ImageUploadReader = FakeImageUploadReader(),
     ): PrivateMessageComposeViewModel = PrivateMessageComposeViewModel(
         initialRecipient = initialRecipient,
         repository = repository,
         previewParser = previewParser,
         userPreferencesRepository = userPreferences(confirmBeforePosting),
         draftStore = draftStore,
+        authRepository = FakeAuthRepository(),
+        uploadRepository = uploadRepository,
+        imageUploadReader = imageUploadReader,
+        diagnostics = DiagnosticsLog(),
         smileyRepository = smileyRepository,
     )
+
+    @Test
+    fun `picked images upload and insert one img per success (#459)`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchComposeForm(any()) } returns composeForm()
+        val uploads = FakeUploadRepository()
+        val reader = FakeImageUploadReader()
+        val vm = viewModel(repository, uploadRepository = uploads, imageUploadReader = reader)
+        advanceUntilIdle()
+
+        vm.onImagesPicked(listOf("content://pick/1", "content://pick/2"))
+        advanceUntilIdle()
+
+        assertEquals(listOf("content://pick/1", "content://pick/2"), reader.readUris)
+        assertEquals(2, uploads.uploadCalls)
+        assertEquals(2, Regex("\\[img]").findAll(vm.state.value.draft.text).count())
+        assertFalse(vm.state.value.isUploading)
+    }
 
     @Test
     fun `the wiki search carries the loaded form's userId (#440)`() = runTest {

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
@@ -2,6 +2,8 @@ package fr.forumhfr.redface2.feature.messages
 
 import androidx.compose.ui.text.input.TextFieldValue
 import app.cash.turbine.test
+import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
+import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import fr.forumhfr.redface2.core.domain.editor.BbcodePreviewParser
 import fr.forumhfr.redface2.core.domain.editor.EditorDraftKey
 import fr.forumhfr.redface2.core.domain.editor.EditorDraftStore
@@ -70,6 +72,8 @@ class PrivateMessageReplyViewModelTest {
     private fun userPreferences(confirmBeforePosting: Boolean = false): UserPreferencesRepository =
         mockk {
             every { observeConfirmBeforePosting() } returns MutableStateFlow(confirmBeforePosting)
+            // #459 — the composer now mirrors the image-insert preference on init.
+            every { observeEditorImageInsert() } returns MutableStateFlow(EditorImageInsert.REDUCED)
         }
 
     private fun form(
@@ -103,12 +107,37 @@ class PrivateMessageReplyViewModelTest {
     )
 
     @Test
+    fun `picked images upload and insert one img per success (#459)`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any(), any()) } returns form()
+        val uploads = FakeUploadRepository()
+        val reader = FakeImageUploadReader()
+
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), uploads, reader, DiagnosticsLog(),
+            smileyRepository(),
+        )
+        advanceUntilIdle()
+
+        viewModel.onImagesPicked(listOf("content://pick/1", "content://pick/2"))
+        advanceUntilIdle()
+
+        assertEquals(listOf("content://pick/1", "content://pick/2"), reader.readUris)
+        assertEquals(2, uploads.uploadCalls)
+        assertEquals(2, Regex("\\[img]").findAll(viewModel.state.value.draft.text).count())
+        assertFalse(viewModel.state.value.isUploading)
+    }
+
+    @Test
     fun `loads the form on init and hydrates signature from the hidden field`() = runTest {
         val repository = mockk<PrivateMessageWriteRepository>()
         coEvery { repository.fetchReplyForm(any(), any()) } returns form()
 
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
 
         val state = viewModel.state.value
@@ -126,7 +155,9 @@ class PrivateMessageReplyViewModelTest {
         val smileys = smileyRepository()
 
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileys,
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileys,
         )
 
         viewModel.smileyPicker.open()
@@ -144,7 +175,9 @@ class PrivateMessageReplyViewModelTest {
             ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
 
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
         viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
 
@@ -168,7 +201,9 @@ class PrivateMessageReplyViewModelTest {
             ReplySubmitResult.Failure(ReplyFailureReason.EmptyMessage)
 
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
         viewModel.onContentChanged(TextFieldValue("non-blank"))
         viewModel.onSubmit()
@@ -187,7 +222,9 @@ class PrivateMessageReplyViewModelTest {
             ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)
 
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
         viewModel.onContentChanged(TextFieldValue("hello"))
         viewModel.onSubmit()
@@ -205,7 +242,9 @@ class PrivateMessageReplyViewModelTest {
             ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)
 
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
         // First load hydrates signature ON (hidden `signature=1`); the user turns it OFF.
         viewModel.onToggleSignature(false)
@@ -229,7 +268,9 @@ class PrivateMessageReplyViewModelTest {
             ReplySubmitResult.Failure(ReplyFailureReason.Unknown)
 
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
         viewModel.onContentChanged(TextFieldValue("hello"))
         viewModel.onSubmit()
@@ -246,7 +287,9 @@ class PrivateMessageReplyViewModelTest {
         coEvery { repository.fetchReplyForm(any(), any()) } throws IOException("network down")
 
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
 
         val state = viewModel.state.value
@@ -261,7 +304,9 @@ class PrivateMessageReplyViewModelTest {
         coEvery { repository.fetchReplyForm(any(), any()) } returns form(isAnonymous = true)
 
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
 
         assertTrue(viewModel.state.value.formError)
@@ -286,7 +331,9 @@ class PrivateMessageReplyViewModelTest {
             ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
 
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
         viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
         viewModel.onSubmit()
@@ -306,6 +353,7 @@ class PrivateMessageReplyViewModelTest {
             previewParser,
             userPreferences(confirmBeforePosting = true),
             draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
             smileyRepository(),
         )
         viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
@@ -329,6 +377,7 @@ class PrivateMessageReplyViewModelTest {
             previewParser,
             userPreferences(confirmBeforePosting = true),
             draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
             smileyRepository(),
         )
         viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
@@ -359,6 +408,7 @@ class PrivateMessageReplyViewModelTest {
             previewParser,
             userPreferences(confirmBeforePosting = true),
             draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
             smileyRepository(),
         )
         viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
@@ -385,6 +435,7 @@ class PrivateMessageReplyViewModelTest {
             previewParser,
             userPreferences(confirmBeforePosting = true),
             draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
             smileyRepository(),
         )
         viewModel.onSubmit()
@@ -404,6 +455,7 @@ class PrivateMessageReplyViewModelTest {
             previewParser,
             userPreferences(confirmBeforePosting = true),
             draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
             smileyRepository(),
         )
         viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
@@ -438,6 +490,7 @@ class PrivateMessageReplyViewModelTest {
             previewParser,
             userPreferences(confirmBeforePosting = true),
             draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
             smileyRepository(),
         )
         viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
@@ -461,7 +514,9 @@ class PrivateMessageReplyViewModelTest {
         val repository = mockk<PrivateMessageWriteRepository>()
         coEvery { repository.fetchReplyForm(any(), any()) } returns form()
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
 
         viewModel.onContentChanged(TextFieldValue("private draft"))
@@ -481,7 +536,9 @@ class PrivateMessageReplyViewModelTest {
             EditorDraftStore.Draft(body = "rescued MP", isPrivate = true),
         )
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
 
         assertEquals("rescued MP", viewModel.state.value.restorableDraft)
@@ -499,7 +556,9 @@ class PrivateMessageReplyViewModelTest {
         val key = EditorDraftKey.mpReply(request.threadId)
         draftStore.preload(key, EditorDraftStore.Draft(body = "rescued MP", isPrivate = true))
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
 
         viewModel.onDraftDiscardRequested()
@@ -516,7 +575,9 @@ class PrivateMessageReplyViewModelTest {
         coEvery { repository.submitReply(any(), any(), any(), any(), any()) } returns
             ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
         viewModel.onContentChanged(TextFieldValue("Coucou en privé."))
 
@@ -536,7 +597,9 @@ class PrivateMessageReplyViewModelTest {
             ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
 
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
 
         assertFalse(viewModel.state.value.canManageRecipients)
@@ -567,7 +630,9 @@ class PrivateMessageReplyViewModelTest {
         coEvery { repository.fetchReplyForm(any(), any()) } returns ownerForm()
 
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
 
         assertTrue(viewModel.state.value.canManageRecipients)
@@ -585,7 +650,9 @@ class PrivateMessageReplyViewModelTest {
             ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
 
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
         viewModel.onContentChanged(TextFieldValue("hello"))
 
@@ -611,7 +678,9 @@ class PrivateMessageReplyViewModelTest {
         coEvery { repository.fetchReplyForm(any(), any()) } returns ownerForm(newdest = "alice, bob")
 
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
 
         viewModel.onAddRecipient("  charlie  ") // trimmed before insertion
@@ -624,7 +693,9 @@ class PrivateMessageReplyViewModelTest {
         coEvery { repository.fetchReplyForm(any(), any()) } returns ownerForm(newdest = "alice, bob")
 
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
 
         viewModel.onAddRecipient(" alice ")
@@ -637,7 +708,9 @@ class PrivateMessageReplyViewModelTest {
         coEvery { repository.fetchReplyForm(any(), any()) } returns ownerForm(newdest = "alice, bob, bob2")
 
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
 
         viewModel.onRemoveRecipient("bob")
@@ -650,7 +723,9 @@ class PrivateMessageReplyViewModelTest {
         coEvery { repository.fetchReplyForm(any(), any()) } returns ownerForm(newdest = "alice, bob")
 
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
 
         viewModel.onRemoveRecipient("alice")
@@ -668,7 +743,9 @@ class PrivateMessageReplyViewModelTest {
             ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
 
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
         viewModel.onRemoveRecipient("alice")
         viewModel.onAddRecipient("Bébé Yoda")
@@ -694,7 +771,9 @@ class PrivateMessageReplyViewModelTest {
             ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)
 
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
         viewModel.onRemoveRecipient("alice") // user edit before the failed submit
         viewModel.onContentChanged(TextFieldValue("hello"))
@@ -720,7 +799,9 @@ class PrivateMessageReplyViewModelTest {
             ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)
 
         val viewModel = PrivateMessageReplyViewModel(
-            request, repository, previewParser, userPreferences(), draftStore, smileyRepository(),
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
         )
         viewModel.onContentChanged(TextFieldValue("hello")) // no member edit
         viewModel.onSubmit()

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/UploadTestFakes.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/UploadTestFakes.kt
@@ -1,0 +1,64 @@
+package fr.forumhfr.redface2.feature.messages
+
+import fr.forumhfr.redface2.core.domain.auth.AuthRepository
+import fr.forumhfr.redface2.core.domain.upload.ImageUpload
+import fr.forumhfr.redface2.core.domain.upload.ImageUploadReader
+import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
+import fr.forumhfr.redface2.core.domain.upload.UploadRepository
+import fr.forumhfr.redface2.core.domain.upload.UploadedImage
+import fr.forumhfr.redface2.core.domain.upload.UploadedImageRecord
+import fr.forumhfr.redface2.core.model.AuthState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * #459 — shared fakes of the MP composers' upload trio, mirrored from TopicFormViewModelTest.
+ * Top-level (not nested) so both PrivateMessageComposeViewModelTest and
+ * PrivateMessageReplyViewModelTest reuse them without duplication.
+ */
+
+/** Fixed [AuthState] so the VM resolves (or not) an upload `userId`. */
+internal class FakeAuthRepository(
+    private val authState: AuthState = AuthState.Authenticated("alice"),
+) : AuthRepository {
+    override fun observeAuthState(): Flow<AuthState> = MutableStateFlow(authState)
+    override suspend fun login(pseudo: String, password: String): Result<AuthState.Authenticated> =
+        Result.success(AuthState.Authenticated(pseudo))
+
+    override suspend fun logout() = Unit
+}
+
+/** Canned [ImageUploadReader] (1-byte PNG), records the picked uris in call order. */
+internal class FakeImageUploadReader : ImageUploadReader {
+    val readUris: MutableList<String> = mutableListOf()
+
+    override suspend fun read(uri: String): ImageUpload {
+        readUris += uri
+        return ImageUpload(bytes = byteArrayOf(0), mimeType = "image/png", displayName = null)
+    }
+}
+
+/** Fake [UploadRepository] ; only [uploadWithCurrentProvider] matters to the composers. */
+internal class FakeUploadRepository : UploadRepository {
+    var uploadException: Throwable? = null
+    var uploadCalls: Int = 0
+        private set
+
+    override suspend fun uploadWithCurrentProvider(image: ImageUpload, userId: String): UploadedImage {
+        uploadCalls += 1
+        uploadException?.let { throw it }
+        return UploadedImage(
+            provider = UploadProviderId.DIBERIE,
+            imageUrl = "https://rehost.diberie.com/Picture/Get/f/1",
+            thumbnailUrl = null,
+            resizedUrl = null,
+            deleteHandle = null,
+            expiresAt = null,
+        )
+    }
+
+    override fun observeUploads(userId: String): Flow<List<UploadedImageRecord>> =
+        MutableStateFlow(emptyList())
+
+    override suspend fun delete(record: UploadedImageRecord, userId: String): Boolean = false
+}


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Seconde et dernière moitié de #459 — toutes les surfaces d'édition savent maintenant uploader des images.

## Promotion `:core:ui`

`UploadError` / `UploadProgress` / `UploadProgressLabel` / `bannerText()` / `MAX_IMAGES_PER_UPLOAD` promus de `:feature:editor` vers `core.ui.editor.EditorUpload` (+ les 8 strings) — même chemin de promotion que le SmileyPickerSheet (#387), un seul vocabulaire d'upload pour tous les éditeurs. Les surfaces `feature:editor` importent désormais le vocabulaire partagé (aucun changement de comportement, tests verts inchangés).

## Câblage MP (réponse + nouvelle conversation)

Les deux VMs reçoivent le contrat batch éprouvé de PostEditor (multi-image #490) : `onImagesPicked` séquentiel (un `[img]` par succès dans l'ordre du pick, saut de ligne dès la 2e), autosave après chaque insertion, arrêt au premier échec avec bannière typée, pick anonyme ignoré, annulation upload+autosave sur switch de compte, `onCleared` ceinture-bretelles, dismiss de la bannière sur édition du texte (parité `withDraft`). Les deux écrans : affordance Uploader (max 10), compteur n/N, champ `readOnly` pendant le batch, bannière dismissible.

## Validation

- Validation canonique complète : BUILD SUCCESSFUL.
- Tests : fakes partagés `UploadTestFakes`, un smoke test de câblage par composeur (2 uploads → 2 `[img]` dans l'ordre) ; les 30 constructions positionnelles du test reply mises à jour ; le mock `userPreferences` stubbe `observeEditorImageInsert`.
- Dogfood émulateur : composeur MP « Nouveau » → Uploader → picker → **upload diberie réel** → `[url=…][img]…[/img][/url]` inséré ; aucun envoi.

Closes-at-promotion : #459 (fermeture au prochain passage `dev → main`, ou manuelle après merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnwLr4K75nLTGGzVv97A2c