### PR TITLE
chore(release): 0.19.2 — #459 complet (changelog + whatsnew)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,13 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.19.2` — `internal` (dev) — 2026-07-03
+
+**Phase « Vue Topic » (#604) — fin de la vague 2 : #459 complet** (PR #768, gate Codex gpt-5.5).
+
+### Éditeurs
+- #459 (2/2) : **upload d'images dans les deux composeurs MP** (réponse et nouvelle conversation) — bouton Uploader, sélection multiple (max 10), un `[img]` par image dans l'ordre, compteur n/N, erreurs typées ; le vocabulaire d'upload (erreurs, progression) est promu dans `:core:ui`, partagé par toutes les surfaces d'édition.
+
 ## `0.19.1` — `internal` (dev) — 2026-07-02
 
 **Phase « Vue Topic » (#604) — vague 2 : quick wins navigation & éditeurs** (PRs #763, #764, #765, #766 — cadrage + gates Codex gpt-5.5).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.19.1"
+        versionName = "0.19.2"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,8 +1,4 @@
-Redface 2 v0.19.1 — dev.
+Redface 2 v0.19.2 — dev.
 
-Topic view (wave 2):
-- Tap a quote to jump to the cited post.
-- Email links open at the right post.
-- Title shown instantly when opening from a list.
-- Editors: keyboard raised on entry, smiley search focused.
-- Image upload in the new-topic composer.
+- Image upload in both private-message composers (reply and new message): multi-select, one image per line.
+- Completes Topic view wave 2 (0.19.1): tappable quotes, fixed email links, editor auto-focus.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,8 +1,4 @@
-Redface 2 v0.19.1 — dev.
+Redface 2 v0.19.2 — dev.
 
-Vue Topic (vague 2) :
-- Tap sur une citation = saut vers le message cité.
-- Les liens email ouvrent au bon message.
-- Titre affiché dès l'ouverture depuis une liste.
-- Éditeurs : clavier levé d'office, recherche smileys focus.
-- Upload d'images dans « nouveau sujet ».
+- Upload d'images dans les composeurs MP (réponse et nouveau message) : sélection multiple, une image par ligne.
+- Complète la vague 2 Vue Topic (0.19.1) : citations cliquables, liens email corrigés, éditeurs auto-focus.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump mécanique : versionName 0.19.2, entrée CHANGELOG, whatsnew fr/en (version en 1re ligne, garde dev). Contenu : #459 (2/2) upload MP — fin de la vague 2. Dispatch après merge : `gh workflow run release.yml --ref dev -f channel=dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnwLr4K75nLTGGzVv97A2c