### PR TITLE
feat(topic): dissolve the topic header card (#604, vague 3 lot 2)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostMenuSheet.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostMenuSheet.kt
@@ -204,12 +204,15 @@ internal fun PostMenuSheet(
 
             if (onEditFirstPost != null) {
                 Spacer(Modifier.height(8.dp))
-                // Vague 3 (#604) — topic-level edit, first post only (Phase 2D #148). The sheet
-                // closes first so the editor never opens under a still-visible menu.
+                // Vague 3 (#604) — topic-level edit, first post only (Phase 2D #148). Hide first,
+                // then dismiss AND navigate (same order as the profile hero above) — the editor
+                // must not open under a still-visible menu sheet.
                 OutlinedButton(
                     onClick = {
-                        onEditFirstPost()
-                        hideThenDismiss(coroutineScope, sheetState, onDismiss)
+                        hideThenDismiss(coroutineScope, sheetState) {
+                            onDismiss()
+                            onEditFirstPost()
+                        }
                     },
                     modifier = Modifier.fillMaxWidth(),
                 ) {

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostMenuSheet.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostMenuSheet.kt
@@ -84,6 +84,13 @@ internal fun PostMenuSheet(
      */
     onDelete: (() -> Unit)? = null,
     /**
+     * Vague 3 (#604) — « Modifier le premier message », migrated here from the dissolved header
+     * card (Phase 2D #148). Non-null ONLY on the topic's first post when the FP edit gates hold
+     * (`shouldShowEditFirstPost`: page 1, owner toolbar link, postable topic with a real
+     * sub-category — #213). Null hides the entry.
+     */
+    onEditFirstPost: (() -> Unit)? = null,
+    /**
      * #395 — opens the author's profile from the hero row (avatar + pseudo), parity with
      * the #208 tap on the post card. Null keeps the hero inert — same gate as the card
      * (`Post.profileId == null` : Publicité rows, anonymous reads). The sheet plays its
@@ -193,6 +200,21 @@ internal fun PostMenuSheet(
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(stringResource(R.string.topic_post_menu_open_in_browser))
+            }
+
+            if (onEditFirstPost != null) {
+                Spacer(Modifier.height(8.dp))
+                // Vague 3 (#604) — topic-level edit, first post only (Phase 2D #148). The sheet
+                // closes first so the editor never opens under a still-visible menu.
+                OutlinedButton(
+                    onClick = {
+                        onEditFirstPost()
+                        hideThenDismiss(coroutineScope, sheetState, onDismiss)
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(stringResource(R.string.topic_edit_first_post))
+                }
             }
 
             if (onToggleMultiQuote != null) {

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyListState
@@ -35,6 +36,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -732,6 +734,8 @@ internal fun TopicContent(
                 scrollBehavior = scrollBehavior,
                 onBack = onBack,
                 onIntent = onIntent,
+                loaded = loaded,
+                onOpenPage = onOpenPage,
             )
         },
         floatingActionButton = {
@@ -802,7 +806,6 @@ internal fun TopicContent(
                             state = state,
                             topic = mode.topic,
                             hiddenNumreponses = mode.hiddenNumreponses,
-                            onReply = onReply,
                             onQuote = onQuote,
                             onEdit = onEdit,
                             onEditFirstPost = onEditFirstPost,
@@ -860,7 +863,7 @@ private fun topicBarPageIndicator(state: TopicUiState, loaded: TopicUiState.Mode
  */
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
-@Suppress("LongParameterList") // hoisted bar : title/page/back inputs + the search intent sink.
+@Suppress("LongParameterList") // hoisted bar : title/page/back inputs + search sink + page picker.
 private fun TopicTopBar(
     state: TopicUiState,
     barTitle: String,
@@ -869,8 +872,16 @@ private fun TopicTopBar(
     scrollBehavior: androidx.compose.material3.TopAppBarScrollBehavior?,
     onBack: () -> Unit,
     onIntent: (TopicIntent) -> Unit,
+    // Vague 3 (#604) — the loaded page (null while loading / on error). Non-null makes the page
+    // indicator a tappable pill opening the page-picker sheet — the header card's page navigation
+    // (jump field + range row) now lives HERE, the reading surface's single page-change home
+    // besides the ‹/› FABs and the horizontal swipe (#282).
+    loaded: TopicUiState.Mode.Loaded? = null,
+    onOpenPage: (Int) -> Unit = {},
 ) {
     val searchLabel = stringResource(R.string.topic_search_open)
+    var pagePickerOpen by remember { mutableStateOf(false) }
+    val pagePickerLabel = stringResource(R.string.topic_page_picker_open)
     Column {
         TopAppBar(
             title = {
@@ -884,7 +895,16 @@ private fun TopicTopBar(
                     Text(
                         text = barPageIndicator,
                         style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        color = if (loaded != null) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                        modifier = if (loaded != null) {
+                            Modifier.clickable(onClickLabel = pagePickerLabel) { pagePickerOpen = true }
+                        } else {
+                            Modifier
+                        },
                     )
                 }
             },
@@ -916,6 +936,37 @@ private fun TopicTopBar(
         )
         if (state.search.isActive) {
             TopicSearchBar(search = state.search, onIntent = onIntent)
+        }
+    }
+    // Vague 3 (#604) — page-picker sheet: the dissolved header card's TopicPageNavigation
+    // (prev/next + jump field + compact range row), verbatim, in a bottom sheet anchored to the
+    // top-bar pill. The Error path keeps its own inline TopicPageNavigation — recovery navigation
+    // must not hide behind a sheet (cadrage Codex vague 3).
+    if (pagePickerOpen && loaded != null) {
+        ModalBottomSheet(onDismissRequest = { pagePickerOpen = false }) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                    .navigationBarsPadding(),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.topic_page_picker_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                TopicPageNavigation(
+                    currentPage = loaded.topic.page,
+                    availablePages = state.availablePages,
+                    canGoPrevious = state.canGoPrevious,
+                    canGoNext = state.canGoNext,
+                    onOpenPage = { target ->
+                        pagePickerOpen = false
+                        onOpenPage(target)
+                    },
+                )
+            }
         }
     }
 }
@@ -1062,7 +1113,8 @@ private fun TopicLoadedContent(
     // #509 — `numreponse` of posts whose author is blacklisted; rendered as a collapsed
     // "post masqué" placeholder instead of the full card (the post stays in the list).
     hiddenNumreponses: Set<Int> = emptySet(),
-    onReply: (subcat: Int, page: Int) -> Unit,
+    // Vague 3 (#604) — onReply dropped: the dissolved header card was its only consumer here
+    // (the bottom FAB cluster replies from TopicContent's own callback).
     onQuote: (subcat: Int, page: Int, quotedNumreponse: Int, quoteRef: Int?) -> Unit,
     onEdit: (subcat: Int, page: Int, numreponse: Int) -> Unit,
     onEditFirstPost: (subcat: Int, page: Int, numreponse: Int) -> Unit,
@@ -1199,36 +1251,23 @@ private fun TopicLoadedContent(
             },
     ) {
         item {
-            // Phase 2D #148 — the « Modifier le premier message » action is
-            // exposed only when (a) we are on page 1 (FP lives there by
-            // definition), (b) HFR rendered the FP edit link in the toolbar
-            // (`Topic.isFirstPostOwner`, parsed from the first post on the
-            // page) and (c) the topic is postable WITH a real sub-category.
-            // #213 — unlike Reply/Quote/Edit-post (gated on `canReply` alone,
-            // subcat=0 OK for a category without sub-category), FP edit also
-            // requires `subcat > 0`: the FP recategorise flow
-            // (TopicFormViewModel/TopicFormState) is NOT relaxed for subcat=0
-            // (its sub-category dropdown contract for a 0-subcat category is not
-            // captured yet), so offering it on an IA-style topic would open an
-            // editor that fails with MissingSubcat. Kept strict to avoid a
-            // button-shows-but-submit-fails regression (FP-in-0-subcat = #213 follow-up).
-            // `numreponse` of the FP comes from the first post, not `topic.post`.
-            // #220 — the gate (incl. the auth clause) is the testable `shouldShowEditFirstPost`.
-            val editFirstPostAction: (() -> Unit)? =
-                if (shouldShowEditFirstPost(topic, state.isAuthenticated)) {
-                    { onEditFirstPost(topic.subcat, topic.page, topic.posts.first().numreponse) }
-                } else {
-                    null
-                }
-            TopicHeaderCard(
-                topic = topic,
-                state = state,
-                onReply = onReply,
-                onEditFirstPost = editFirstPostAction,
-                onOpenPage = onOpenPage,
-                pollManualExpanded = pollManualExpanded,
-                onPollExpansionChanged = onPollExpansionChanged,
-            )
+            // Vague 3 (#604, mockup « Lecture A ») — the header card is DISSOLVED: title and page
+            // indicator live in the top app bar (tappable page pill → picker sheet), « Répondre »
+            // in the bottom FAB cluster (#283), « Modifier le premier message » in the first
+            // post's « … » menu (Phase 2D #148 gates unchanged), and the scrollTo indicator is
+            // gone (the amber highlight on arrival is the affordance). This LEAD slot must keep
+            // occupying index 0 unconditionally: every index-based scroll computation
+            // (ScrollToPost's `index + 1`, end-of-page `posts.size`, saved anchors #307, the
+            // re-anchor steps #412) assumes exactly one item before the posts — a poll-less topic
+            // renders it zero-size instead of dropping it.
+            topic.poll?.let { poll ->
+                TopicPollCard(
+                    poll = poll,
+                    expandedDefault = state.pollsExpandedDefault,
+                    manualExpanded = pollManualExpanded,
+                    onExpansionChanged = onPollExpansionChanged,
+                )
+            }
         }
         items(
             items = topic.posts,
@@ -1339,6 +1378,18 @@ private fun TopicLoadedContent(
         } else {
             null
         }
+        // Vague 3 (#604) — « Modifier le premier message » migrated here from the dissolved
+        // header card (Phase 2D #148, gates unchanged incl. the strict `subcat > 0` of #213 —
+        // cf. shouldShowEditFirstPost): the action acts on the topic through its FIRST post,
+        // so its natural home is that post's contextual menu.
+        val menuEditFirstPostAction: (() -> Unit)? = if (
+            isFirstPostOfTopic(topic, post) &&
+            shouldShowEditFirstPost(topic, state.isAuthenticated)
+        ) {
+            { onEditFirstPost(topic.subcat, topic.page, topic.posts.first().numreponse) }
+        } else {
+            null
+        }
         PostMenuSheet(
             post = post,
             permalink = buildPostPermalink(
@@ -1350,6 +1401,7 @@ private fun TopicLoadedContent(
             citedCount = citationCounts[post.numreponse] ?: 0,
             onDismiss = { menuPost = null },
             onDelete = menuDeleteAction,
+            onEditFirstPost = menuEditFirstPostAction,
             // #395 — same profileId gate as the post card (#208): Publicité rows and
             // anonymous reads expose no profile link, the hero stays inert.
             onOpenProfile = post.profileId?.let { profileId ->
@@ -1433,87 +1485,6 @@ private fun MorePagesFooter() {
             modifier = Modifier.weight(1f),
             color = MaterialTheme.colorScheme.outlineVariant,
         )
-    }
-}
-
-@Composable
-@Suppress("LongParameterList") // state-hoisted Composable : each param has a distinct call-site.
-private fun TopicHeaderCard(
-    topic: Topic,
-    state: TopicUiState,
-    onReply: (subcat: Int, page: Int) -> Unit,
-    onEditFirstPost: (() -> Unit)?,
-    onOpenPage: (Int) -> Unit,
-    // #465 — manual poll choice (null = follow the global default) + its toggle callback, both
-    // owned by :app so the expand/collapse choice survives the per-page TopicRoute swap.
-    pollManualExpanded: Boolean? = null,
-    onPollExpansionChanged: (Boolean) -> Unit = {},
-) {
-    Card {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Text(
-                text = topic.title,
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold,
-            )
-            Text(
-                text = stringResource(
-                    R.string.topic_caption,
-                    topic.post,
-                    topic.page,
-                    topic.totalPages,
-                ),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            state.request.scrollTo?.let { target ->
-                Text(
-                    text = stringResource(R.string.topic_scroll_to, target),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-            }
-            TopicPageNavigation(
-                currentPage = topic.page,
-                availablePages = state.availablePages,
-                canGoPrevious = state.canGoPrevious,
-                canGoNext = state.canGoNext,
-                onOpenPage = onOpenPage,
-            )
-            topic.poll?.let { poll ->
-                TopicPollCard(
-                    poll = poll,
-                    expandedDefault = state.pollsExpandedDefault,
-                    manualExpanded = pollManualExpanded,
-                    onExpansionChanged = onPollExpansionChanged,
-                )
-            }
-            Button(
-                onClick = { onReply(topic.subcat, topic.page) },
-                // #213 — enabled only when HFR rendered the `bddpost` reply form
-                // (authenticated, non-locked topic → `canReply`). #220 — also gated on the
-                // live auth state so a stale cached `canReply = true` row (the topic cache is
-                // not purged on logout) never offers Reply to a logged-out user. `subcat = 0`
-                // (cat without sub-category, e.g. IA) is a valid postable value and is forwarded.
-                enabled = shouldEnableReply(topic, state.isAuthenticated),
-            ) {
-                Text(text = stringResource(R.string.topic_reply))
-            }
-            // Phase 2D #148 — « Modifier le premier message » lives in the header
-            // card because it acts on the topic, not on a single post. We render
-            // it as an OutlinedButton to stay visually subordinate to the primary
-            // « Répondre » action above.
-            if (onEditFirstPost != null) {
-                OutlinedButton(onClick = onEditFirstPost) {
-                    Text(text = stringResource(R.string.topic_edit_first_post))
-                }
-            }
-        }
     }
 }
 

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="topic_scroll_to">Scroll ciblé demandé vers le post %1$d.</string>
-    <string name="topic_reply">Répondre depuis ce topic</string>
     <!-- #283 — bottom floating action cluster: reach reply + page change without scrolling to the header. -->
     <string name="topic_fab_reply">Répondre</string>
     <string name="topic_fab_previous_page">Page précédente</string>
@@ -41,7 +39,6 @@
     <string name="topic_search_results_end">Aucun résultat suivant</string>
     <string name="topic_error_title">Erreur de chargement</string>
     <string name="topic_error_body">Impossible d’ouvrir la page %1$d.\n\n%2$s</string>
-    <string name="topic_caption">post %1$d • page %2$d / %3$d</string>
     <string name="topic_post_index_prefix">#%1$d • </string>
     <!-- #362 — per-post contextual menu (post number, permalink copy, edit marker, citations). -->
     <!-- #436 — pastille de la bande d'identité quand le post est au panier multi-quote (#291). -->
@@ -105,4 +102,7 @@
     <string name="topic_post_delete_failed_login">Vous devez être connecté pour supprimer ce message.</string>
     <string name="topic_post_delete_failed_locked">Ce sujet est fermé : suppression impossible.</string>
     <string name="topic_post_delete_failed_generic">La suppression a échoué. Réessayez.</string>
+    <!-- Vague 3 (#604) : pilule page de la top bar + feuille de navigation. -->
+    <string name="topic_page_picker_open">Changer de page</string>
+    <string name="topic_page_picker_title">Aller à une page</string>
 </resources>


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Contexte

Vague 3 « redesign Lecture » de la phase Vue Topic (#604), lot 2 sur 4 (cadrage Codex : FABs #770 → **header** → frontières → post card). Direction produit arbitrée sur le fil DEV (mockup « Lecture A ») : la `TopicHeaderCard` dupliquait la top bar (titre + « page X / Y » depuis la vague 1) et retenait des actions qui ont de meilleures places.

## Changements

- **`TopicHeaderCard` supprimée.** La tête de liste est désormais le premier post.
- **Sondage** : item de liste autonome en tête (page 1, comme avant). Le slot de tête est émis **inconditionnellement** (sondage ou taille nulle) pour préserver l'invariant « exactement 1 lead item » dont dépend toute l'arithmétique d'index (ScrollToPost `index + 1`, ancres #307, reanchor #412) — aucun de ces chemins n'est touché.
- **« Modifier le premier message »** : migre vers le menu contextuel du premier post (`PostMenuSheet`), gates strictement inchangées (`isFirstPostOfTopic && shouldShowEditFirstPost`, y compris le `subcat > 0` strict de #213). Couverture : `TopicActionGatesTest`.
- **Navigation page** : la pilule « page X / Y » de la top bar devient primary + cliquable et ouvre une feuille (`ModalBottomSheet`) avec `TopicPageNavigation` (prev/next, saisie, grille). Le chemin **Error garde son `TopicPageNavigation` inline** (cadrage Codex : pas de feuille sur un écran d'erreur).
- **Indicateur scrollTo** supprimé (le highlight ambre #200 suffit).
- Strings : `topic_scroll_to`/`topic_reply`/`topic_caption` supprimées, `topic_page_picker_open`/`topic_page_picker_title` ajoutées.

## Validation

- Compile + detektAll + `:feature:topic:testDebugUnitTest` + assembleDevDebug verts ; **validation canonique complète en cours** (résultat posté avant merge).
- Dogfood émulateur (topic DEV) : haut de liste = premier post direct, sans carte ; pilule → feuille → saut 37 → 1 fonctionnel ; menu premier post sans entrée owner sur topic non possédé (test négatif — le positif est couvert par `TopicActionGatesTest`, gates inchangées).

Refs #604 (ne ferme rien — vérif visuelle dédiée par issue en fin de vague).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnwLr4K75nLTGGzVv97A2c