### PR TITLE
feat(topic): actionable page-boundary card + calm end-of-topic card (#604, vague 3 lot 3)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1474,7 +1474,11 @@ private fun EndOfTopicCard() {
 @Composable
 private fun PageBoundaryCard(donePage: Int, onNextPage: () -> Unit) {
     val nextPageLabel = stringResource(R.string.topic_page_boundary_next, donePage + 1)
+    // Card(onClick) over an inner Row.clickable (gate Codex) : the whole surface is declared as
+    // ONE interactive Material component, and the action's wording is already the card's visible
+    // subtitle — TalkBack reads it as content, no custom onClickLabel needed.
     Card(
+        onClick = onNextPage,
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.primaryContainer,
             contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
@@ -1484,7 +1488,6 @@ private fun PageBoundaryCard(donePage: Int, onNextPage: () -> Unit) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable(onClickLabel = nextPageLabel) { onNextPage() }
                 .padding(horizontal = 16.dp, vertical = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(12.dp),

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SmallFloatingActionButton
@@ -1349,14 +1350,20 @@ private fun TopicLoadedContent(
         // correct for a stateless sentinel.
         if (topic.page == topic.totalPages) {
             item {
-                EndOfTopicFooter()
+                EndOfTopicCard()
             }
         } else if (topic.page < topic.totalPages) {
-            // #110 (nicko) — symmetric marker on an intermediate page: « Suite à la page suivante »,
-            // purely informative (navigation lives in the page controls / swipe #282). Same no-key
-            // sentinel rationale as EndOfTopicFooter above.
+            // Vague 3 (#604) — the #110 hairline marker becomes an actionable boundary card
+            // (beta feedback by thibw & styx42 : the divider read too weak, and an intermediate
+            // page's end was indistinguishable from the topic's). Tapping opens the next page
+            // through the SAME onOpenPage as the › FAB / swipe (#282) — a strict « page + 1 »
+            // step never arms the #412 bottom landing, so the reader lands at the top of the
+            // next page, which is the natural continuation. Same no-key sentinel rationale.
             item {
-                MorePagesFooter()
+                PageBoundaryCard(
+                    donePage = topic.page,
+                    onNextPage = { onOpenPage(topic.page + 1) },
+                )
             }
         }
     }
@@ -1429,62 +1436,71 @@ private fun TopicLoadedContent(
 }
 
 /**
- * #379 — sober end-of-topic marker: a centred label between two hairlines, rendered as the
- * LAST LazyColumn item of the topic's last page only. Pure presentation — the condition
- * (`topic.page == topic.totalPages`) lives at the call site.
+ * #379 → vague 3 (#604) — calm end-of-topic endcard: an outlined card with a centred title and
+ * the #379 caption, rendered as the LAST LazyColumn item of the topic's last page only. Visually
+ * OPPOSITE to [PageBoundaryCard] (outline vs filled primaryContainer) so an intermediate page's
+ * end and the topic's end can never be confused again (beta feedback by thibw & styx42). Pure
+ * presentation — the condition (`topic.page == topic.totalPages`) lives at the call site.
  */
 @Composable
-private fun EndOfTopicFooter() {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        HorizontalDivider(
-            modifier = Modifier.weight(1f),
-            color = MaterialTheme.colorScheme.outlineVariant,
-        )
-        Text(
-            text = stringResource(R.string.topic_end_of_topic),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        HorizontalDivider(
-            modifier = Modifier.weight(1f),
-            color = MaterialTheme.colorScheme.outlineVariant,
-        )
+private fun EndOfTopicCard() {
+    OutlinedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = stringResource(R.string.topic_end_of_topic_title),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Text(
+                text = stringResource(R.string.topic_end_of_topic),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }
 
 /**
- * #110 (nicko) — symmetric « more pages below » marker, mirroring [EndOfTopicFooter] but rendered as the
- * LAST LazyColumn item of an INTERMEDIATE page (`topic.page < topic.totalPages`, condition at the call
- * site). Informative only — no tap action (navigation is the page controls / swipe #282). Same style.
+ * #110 → vague 3 (#604) — actionable page-boundary card on an INTERMEDIATE page
+ * (`topic.page < topic.totalPages`, condition at the call site): « Page N terminée » plus a
+ * « continue » affordance, the whole card tappable (mockup « Lecture A », arbitré fil DEV).
+ * [onNextPage] delegates to the caller's onOpenPage — the same in-place route replace as the
+ * › FAB and the horizontal swipe (#282), so scroll restoration semantics stay uniform.
  */
 @Composable
-private fun MorePagesFooter() {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
+private fun PageBoundaryCard(donePage: Int, onNextPage: () -> Unit) {
+    val nextPageLabel = stringResource(R.string.topic_page_boundary_next, donePage + 1)
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        ),
+        modifier = Modifier.fillMaxWidth(),
     ) {
-        HorizontalDivider(
-            modifier = Modifier.weight(1f),
-            color = MaterialTheme.colorScheme.outlineVariant,
-        )
-        Text(
-            text = stringResource(R.string.topic_more_pages),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        HorizontalDivider(
-            modifier = Modifier.weight(1f),
-            color = MaterialTheme.colorScheme.outlineVariant,
-        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClickLabel = nextPageLabel) { onNextPage() }
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.topic_page_boundary_done, donePage),
+                    style = MaterialTheme.typography.titleSmall,
+                )
+                Text(
+                    text = nextPageLabel,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+            RedfaceVectorIcon(resId = fr.forumhfr.redface2.core.ui.R.drawable.ic_chevron_right)
+        }
     }
 }
 

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -17,9 +17,14 @@
     <string name="topic_loading">Chargement…</string>
     <!-- #604 — libellé du skeleton de chargement (mockup « Chargement A »), sous le loader centré. -->
     <string name="topic_loading_body">Chargement de la page demandée</string>
-    <!-- #379 — marqueur explicite de fin de sujet, rendu après le dernier post de la DERNIÈRE page. -->
+    <!-- #379 → vague 3 (#604) — endcard calme de fin de sujet (titre + légende #379), rendue après
+         le dernier post de la DERNIÈRE page. -->
+    <string name="topic_end_of_topic_title">Fin du sujet</string>
     <string name="topic_end_of_topic">Dernier message du sujet</string>
-    <string name="topic_more_pages">Suite à la page suivante</string>
+    <!-- #110 → vague 3 (#604) — carte de frontière de page actionnable en fin de page intermédiaire
+         (mockup « Lecture A ») : titre + libellé d'action (aussi onClickLabel TalkBack). -->
+    <string name="topic_page_boundary_done">Page %1$d terminée</string>
+    <string name="topic_page_boundary_next">Continuer vers la page %1$d</string>
     <!-- #285 — top app bar : back affordance (content description) + fallback title shown while
          the topic page has not loaded yet (or errored), so the bar never reads blank. -->
     <string name="topic_back">Retour</string>


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Contexte

Vague 3 « redesign Lecture » (#604), lot 3 sur 4 (cadrage Codex : FABs #770 → header #771 → **frontières** → post card). Retours bêta thibw ([#2789890](https://forum.hardware.fr/forum2.php?config=hfr.inc&cat=23&post=35421&page=37#t2789890)) et styx42 ([#2789891](https://forum.hardware.fr/forum2.php?config=hfr.inc&cat=23&post=35421&page=37#t2789891)) : le marqueur filaire « Suite à la page suivante » (#110) est trop discret, et une fin de page intermédiaire est indistinguable d'une fin de sujet.

## Changements

- **`MorePagesFooter` → `PageBoundaryCard`** : carte remplie primaryContainer « Page N terminée » + « Continuer vers la page N+1 » + chevron, toute la carte cliquable (`onClickLabel` TalkBack). Le tap délègue au **même `onOpenPage`** que le FAB › et le swipe (#282) — un pas strict « page + 1 » n'arme jamais le bottom landing #412, l'arrivée se fait en haut de la page suivante (sémantique « ouvrir la page suivante » du cadrage).
- **`EndOfTopicFooter` → `EndOfTopicCard`** : carte outline calme, titre centré « Fin du sujet » + la légende #379. Visuellement **opposée** à la carte frontière (outline vs remplie) : les deux états ne peuvent plus être confondus.
- Rationale « sentinelle positionnelle sans clé » inchangée pour les deux items (Codex review #379).
- Strings : `topic_more_pages` supprimée ; `topic_end_of_topic_title`, `topic_page_boundary_done`, `topic_page_boundary_next` ajoutées.
- Icône : `ic_chevron_right` via `RedfaceVectorIcon` (ADR-015 — pas d'`Icons.*` Material).

## Validation

- Compile + detektAll + `:feature:topic:testDebugUnitTest` verts ; **canonique complète en cours** (résultat posté avant merge).
- Dogfood émulateur (topic DEV) : carte frontière en bas de page 38 → tap → page 39 chargée **en haut** ; endcard en bas de la page 39 (dernière) ; slots FAB immobiles.

Refs #604 (ne ferme rien — vérif visuelle par issue en fin de vague).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnwLr4K75nLTGGzVv97A2c