### PR TITLE
feat(topic): traversing last-read marker below the landing post (#604, vague 3 lot 4)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicRequest.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicRequest.kt
@@ -19,6 +19,11 @@ data class TopicRequest(
      * instantly but **always** refreshes afterwards, bypassing the 60s snappy-cache TTL
      * that would otherwise serve a followed topic stale. Ordinary in-app navigation
      * leaves it `false` to keep back-nav snappy.
+     *
+     * ⚠️ #600 (vague 3) piggybacks on this flag as the « last read » discriminator
+     * (`shouldShowLastReadMarker`): the flag tap is its ONLY producer today, and the only
+     * navigation whose [scrollTo] means « last read post ». Adding another producer of
+     * `forceRefresh=true` requires giving the marker its own dedicated field first.
      */
     val forceRefresh: Boolean = false,
     /**

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1320,7 +1320,7 @@ private fun TopicLoadedContent(
             // navigation whose scrollTo semantically IS « last read ». A quote jump / deep link
             // (forceRefresh=false) keeps the #104 band tint alone; the amber arrival flash (#200)
             // is a third, independent layer.
-            val showLastReadMarker = state.request.forceRefresh && highlight == post.numreponse
+            val showLastReadMarker = shouldShowLastReadMarker(state.request, post.numreponse)
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 if (post.numreponse in hiddenNumreponses && post.numreponse !in revealedHiddenPosts) {
                     HiddenPostCard(
@@ -2607,6 +2607,15 @@ internal fun shouldShowEditAction(topic: Topic, post: Post, isAuthenticated: Boo
 // #292 — « Supprimer » shares the « Modifier » gate: HFR exposes deletion through the same edit
 // form, so any post the user can edit, they can delete. The first-post exclusion (deleting it would
 // remove the whole topic) is applied at the call site by position, not here.
+// #600 (vague 3) — « Dernier message lu » separator gate. `forceRefresh` is #231's flag-tap
+// marker: the ONE navigation whose scrollTo is semantically « last read » (the flag handler only
+// sets scrollTo when resuming at the last-read page). Every route-replace (pagination #282,
+// citation jump #699, overflow landing #226) rebuilds the route WITHOUT forceRefresh, so the
+// marker never survives a navigation away from the landing. If forceRefresh ever grows another
+// producer, this gate needs its own dedicated route field — cf. TopicActionGatesTest.
+internal fun shouldShowLastReadMarker(request: TopicRequest, numreponse: Int): Boolean =
+    request.forceRefresh && request.scrollTo == numreponse
+
 internal fun shouldShowDeleteAction(topic: Topic, post: Post, isAuthenticated: Boolean): Boolean =
     post.isEditable && topic.canReply && isAuthenticated
 

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
@@ -1312,32 +1313,45 @@ private fun TopicLoadedContent(
             // #509 — a blacklisted author's post is replaced by a collapsed placeholder (the post is
             // kept in the list to preserve index/anchor/numreponse invariants), until the reader taps
             // « Afficher ». The placeholder exposes no quote/edit/menu action by design (decision #1).
-            if (post.numreponse in hiddenNumreponses && post.numreponse !in revealedHiddenPosts) {
-                HiddenPostCard(
-                    author = post.author,
-                    onReveal = { revealedHiddenPosts = revealedHiddenPosts + post.numreponse },
-                )
-            } else {
-                TopicPostCard(
-                    post = post,
-                    highlighted = highlight == post.numreponse,
-                    citedCount = citationCounts[post.numreponse] ?: 0,
-                    // #699 — makes sourced quote headers tappable (jump to the cited post).
-                    onGoToCitedPost = onGoToPost,
-                    // #330 — render the author signature beneath the body when the reading preference
-                    // is on (the signature is always parsed/cached on the Post; this is render-only).
-                    showSignature = state.showSignatures,
-                    onQuote = quoteAction,
-                    onEdit = editAction,
-                    onOpenProfile = profileAction,
-                    onOpenMenu = { menuPost = post },
-                    // #436 — same membership source as the menu entry (PostMenuSheet).
-                    multiQuoteSelected = post.numreponse in multiQuoteSelection,
-                    // #436 — per-post add/remove affordance (RF1 quote+/quote- parity), reachable
-                    // without opening the « … » menu. Null/non-null under the SAME gate as « Citer »
-                    // (derived together above), so the « + » and « Citer » always appear as a pair.
-                    onToggleMultiQuote = multiQuoteToggle,
-                )
+            // Vague 3 (#600) — traversing « Dernier message lu » separator BELOW the last-read post
+            // (mockup « Lecture A »). Rendered INSIDE this post's item (a Column, not an extra list
+            // item) so every index-based scroll computation stays untouched (lead item + posts.size
+            // invariants). Gated on forceRefresh: #231 sets it ONLY on a drapeau/flag tap — the one
+            // navigation whose scrollTo semantically IS « last read ». A quote jump / deep link
+            // (forceRefresh=false) keeps the #104 band tint alone; the amber arrival flash (#200)
+            // is a third, independent layer.
+            val showLastReadMarker = state.request.forceRefresh && highlight == post.numreponse
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (post.numreponse in hiddenNumreponses && post.numreponse !in revealedHiddenPosts) {
+                    HiddenPostCard(
+                        author = post.author,
+                        onReveal = { revealedHiddenPosts = revealedHiddenPosts + post.numreponse },
+                    )
+                } else {
+                    TopicPostCard(
+                        post = post,
+                        highlighted = highlight == post.numreponse,
+                        citedCount = citationCounts[post.numreponse] ?: 0,
+                        // #699 — makes sourced quote headers tappable (jump to the cited post).
+                        onGoToCitedPost = onGoToPost,
+                        // #330 — render the author signature beneath the body when the reading preference
+                        // is on (the signature is always parsed/cached on the Post; this is render-only).
+                        showSignature = state.showSignatures,
+                        onQuote = quoteAction,
+                        onEdit = editAction,
+                        onOpenProfile = profileAction,
+                        onOpenMenu = { menuPost = post },
+                        // #436 — same membership source as the menu entry (PostMenuSheet).
+                        multiQuoteSelected = post.numreponse in multiQuoteSelection,
+                        // #436 — per-post add/remove affordance (RF1 quote+/quote- parity), reachable
+                        // without opening the « … » menu. Null/non-null under the SAME gate as « Citer »
+                        // (derived together above), so the « + » and « Citer » always appear as a pair.
+                        onToggleMultiQuote = multiQuoteToggle,
+                    )
+                }
+                if (showLastReadMarker) {
+                    LastReadMarker()
+                }
             }
         }
         // #379 — explicit end-of-topic marker after the last post of the LAST page. The
@@ -1434,6 +1448,48 @@ private fun TopicLoadedContent(
         )
     }
 }
+
+/**
+ * #600 → vague 3 (#604) — traversing « Dernier message lu » separator (mockup « Lecture A ») :
+ * a full-width primary rule with a centred primary pill. Rendered below the last-read post,
+ * INSIDE that post's list item (cf. call site — the index math must not see an extra item).
+ * Beta feedback by Colonel MythO : the #104 band tint alone (one notch of tint on the identity
+ * band) was too subtle to spot when catching up from a flag.
+ */
+@Composable
+private fun LastReadMarker() {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        val ruleColor = MaterialTheme.colorScheme.primary.copy(alpha = LAST_READ_RULE_ALPHA)
+        HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            thickness = 2.dp,
+            color = ruleColor,
+        )
+        Text(
+            text = stringResource(R.string.topic_last_read_marker),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier
+                .background(
+                    color = MaterialTheme.colorScheme.primary,
+                    shape = MaterialTheme.shapes.extraLarge,
+                )
+                .padding(horizontal = 10.dp, vertical = 3.dp),
+        )
+        HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            thickness = 2.dp,
+            color = ruleColor,
+        )
+    }
+}
+
+// #600 — the mockup's rule opacity : strong enough to traverse, calmer than the full-strength pill.
+private const val LAST_READ_RULE_ALPHA = 0.55f
 
 /**
  * #379 → vague 3 (#604) — calm end-of-topic endcard: an outlined card with a centred title and

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -24,6 +24,9 @@
     <!-- #110 → vague 3 (#604) — carte de frontière de page actionnable en fin de page intermédiaire
          (mockup « Lecture A ») : titre + libellé d'action (aussi onClickLabel TalkBack). -->
     <string name="topic_page_boundary_done">Page %1$d terminée</string>
+    <!-- #600 → vague 3 (#604) — pilule du séparateur traversant « dernier lu » (mockup Lecture A),
+         affiché sous le dernier message lu à l'ouverture depuis un drapeau. -->
+    <string name="topic_last_read_marker">Dernier message lu</string>
     <string name="topic_page_boundary_next">Continuer vers la page %1$d</string>
     <!-- #285 — top app bar : back affordance (content description) + fallback title shown while
          the topic page has not loaded yet (or errored), so the bar never reads blank. -->

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicActionGatesTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicActionGatesTest.kt
@@ -11,6 +11,34 @@ import org.junit.Test
 class TopicActionGatesTest {
 
     @Test
+    fun `last-read marker requires the flag-tap route AND the matching post`() {
+        fun request(scrollTo: Int?, forceRefresh: Boolean) = TopicRequest(
+            cat = 23,
+            post = 35421,
+            page = 61,
+            scrollTo = scrollTo,
+            forceRefresh = forceRefresh,
+        )
+
+        assertTrue(
+            "#600 — flag tap resuming at the last-read post shows the marker there",
+            shouldShowLastReadMarker(request(scrollTo = 42, forceRefresh = true), numreponse = 42),
+        )
+        assertFalse(
+            "the marker belongs to the last-read post only, not its neighbours",
+            shouldShowLastReadMarker(request(scrollTo = 42, forceRefresh = true), numreponse = 43),
+        )
+        assertFalse(
+            "#699 — a citation jump carries scrollTo WITHOUT forceRefresh: no marker",
+            shouldShowLastReadMarker(request(scrollTo = 42, forceRefresh = false), numreponse = 42),
+        )
+        assertFalse(
+            "a flag opened on « 1er non-lu »/« dernière page » drops scrollTo: no marker",
+            shouldShowLastReadMarker(request(scrollTo = null, forceRefresh = true), numreponse = 42),
+        )
+    }
+
+    @Test
     fun `quote action requires a postable topic AND an authenticated session`() {
         val postWithNoParsedQuoteLink = post(quoteRef = null)
         val postable = topic(canReply = true, posts = listOf(postWithNoParsedQuoteLink))


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Contexte

Vague 3 « redesign Lecture » (#604), lot 4 (dernier). Retour bêta Colonel MythO (#600) : la teinte tertiaire de la bande d'identité (#104) seule est trop subtile — « on se pète la rétine ». Design arbitré par le mockup « Lecture A » : séparateur traversant entre le dernier message lu et la suite.

## Changements

- **`LastReadMarker`** : règle primary pleine largeur (2dp, alpha 0.55) + pilule primary centrée « Dernier message lu » — reprise fidèle du mockup.
- **Placement sans toucher l'arithmétique d'index** : rendu DANS l'item du post concerné (Column enveloppant la carte), jamais comme item LazyColumn supplémentaire — invariants lead item / `posts.size` (ScrollToPost, ancres #307, reanchor #412) intacts.
- **Gate sémantique** : `request.forceRefresh && scrollTo == post.numreponse`. #231 ne pose `forceRefresh` QUE sur un tap drapeau — la seule navigation dont le `scrollTo` est sémantiquement « dernier lu ». Un saut de citation ou un deep link ne l'affiche pas (bande #104 seule) ; le flash ambré d'arrivée (#200) reste une troisième couche indépendante.
- String `topic_last_read_marker` ajoutée.

## Validation

- Compile + detektAll + `:feature:topic:testDebugUnitTest` verts ; **canonique complète en cours** (résultat posté avant merge).
- Dogfood émulateur : tap drapeau (TU, +2) → marqueur sous le dernier post lu, empilé proprement avec la carte « Page 61 terminée » quand c'est le dernier post de la page ; saut de citation sur la même page → pas de marqueur (gate négative vérifiée).

Refs #604 (ne ferme pas #600 — vérif visuelle dédiée en fin de vague, avec captures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnwLr4K75nLTGGzVv97A2c