### PR TITLE
chore(release): bump versionName 0.19.2 → 0.20.0 + changelog/whatsnew (fin vague 3 Lecture)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,16 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.20.0` — `internal` (dev) — 2026-07-03
+
+**Phase « Vue Topic » (#604) — vague 3 : redesign de la lecture** (PRs #770, #771, #773, #774 — cadrage + gates Codex gpt-5.5, dogfoods émulateur par lot).
+
+### Vue Topic
+- #599 : **slots FAB figés** — ‹ › ✎ ❝N occupent des emplacements réservés (40 dp) dès le squelette ; plus aucun décalage quand une action apparaît/disparaît (retour antiseptiqueIncolore). Le slot multi-citation vit à l'extrême gauche du cluster.
+- **Header dissous** (mockup « Lecture A ») : la carte d'en-tête du sujet disparaît — le titre et « page X / Y » vivent dans la top bar ; la **pilule « page X / Y » devient cliquable** et ouvre un sélecteur de page en feuille (préc./suiv., saisie, grille) ; « Modifier le premier message » migre dans le menu « … » du premier post (gates #148/#213 inchangées) ; le sondage devient une carte autonome en tête de liste (invariants d'index préservés). L'indicateur scrollTo disparaît (la surbrillance d'arrivée suffit).
+- **Frontières de page lisibles** (retours thibw & styx42) : en fin de page intermédiaire, carte primaire « Page N terminée » + « Continuer vers la page N+1 » (tap = même navigation que le FAB ›, arrivée en haut) ; en fin de sujet, carte outline calme « Fin du sujet » — les deux états ne se confondent plus.
+- #600 : **repère « Dernier message lu » traversant** (retour Colonel MythO) — règle primaire + pilule centrée sous le dernier message lu, à l'ouverture depuis un drapeau uniquement (gate sémantique testée) ; couche distincte de la surbrillance d'arrivée (#200) et de la teinte d'ancre (#104).
+
 ## `0.19.2` — `internal` (dev) — 2026-07-03
 
 **Phase « Vue Topic » (#604) — fin de la vague 2 : #459 complet** (PR #768, gate Codex gpt-5.5).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.19.2"
+        versionName = "0.20.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,4 +1,5 @@
-Redface 2 v0.19.2 — dev.
+Redface 2 v0.20.0 — dev.
 
-- Image upload in both private-message composers (reply and new message): multi-select, one image per line.
-- Completes Topic view wave 2 (0.19.1): tappable quotes, fixed email links, editor auto-focus.
+- Redesigned Topic view (wave 3): dissolved header, tappable "page X / Y" pill (page picker), fixed floating buttons.
+- Readable page boundaries: tappable "Page N done" card; calm "End of topic".
+- Traversing "Last read message" marker when opening from a flag.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,4 +1,5 @@
-Redface 2 v0.19.2 — dev.
+Redface 2 v0.20.0 — dev.
 
-- Upload d'images dans les composeurs MP (réponse et nouveau message) : sélection multiple, une image par ligne.
-- Complète la vague 2 Vue Topic (0.19.1) : citations cliquables, liens email corrigés, éditeurs auto-focus.
+- Vue Topic redessinée (vague 3) : en-tête dissous, pilule « page X / Y » cliquable (sélecteur de page), boutons flottants figés.
+- Fin de page lisible : carte « Page N terminée » cliquable ; « Fin du sujet » calme.
+- Repère « Dernier message lu » traversant à l'ouverture d'un drapeau.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump mécanique de fin de vague 3 « redesign Lecture » (#604) : `versionName` 0.20.0 (minor — vague visuelle majeure), entrée `app/CHANGELOG.md` (PRs #770 #771 #773 #774), whatsnew fr/en (version en 1re ligne, 313/288 caractères — garde whatsnew-freshness OK). Dispatch `channel=dev --ref dev` après merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnwLr4K75nLTGGzVv97A2c