### PR TITLE
fix(flags): wire the « +lus » shortcut on the Red and Favori tabs (#751)

### DIFF
--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -218,6 +218,16 @@ fun FlagsRoute(
     val dtIsRefreshing by viewModel.dtIsRefreshing.collectAsStateWithLifecycle()
     // « +lus » suffix on the DT tab, mirroring [cyanShowsRead]: DT selected AND its unread filter off.
     val dtShowsRead by viewModel.dtShowsRead.collectAsStateWithLifecycle()
+    // #751 — Red and Favori join the « +lus » shortcut: same read-state values for the indicator,
+    // the picker's contextual entry and the tab-label suffix.
+    val redShowsRead by viewModel.redShowsReadShortcut.collectAsStateWithLifecycle()
+    val favoriteShowsRead by viewModel.favoriteShowsReadShortcut.collectAsStateWithLifecycle()
+    val readShortcuts = FlagsReadShortcuts(
+        cyan = cyanShowsRead,
+        dt = dtShowsRead,
+        red = redShowsRead,
+        favorite = favoriteShowsRead,
+    )
 
     // #6 — trigger the DT scan only when the DT tab is OPENED (a stable LaunchedEffect, not the raw
     // composition): fetchStorage scans the inbox and must stay off the per-category auto-refresh.
@@ -421,8 +431,7 @@ fun FlagsRoute(
                         tabs = flagAppBarTabs(
                             authState = authState,
                             showDtTab = showDtTab,
-                            cyanShowsRead = cyanShowsRead,
-                            dtShowsRead = dtShowsRead,
+                            readShortcuts = readShortcuts,
                         ),
                         searchEnabled = searchEnabled,
                         query = searchQuery,
@@ -432,8 +441,7 @@ fun FlagsRoute(
                         currentTab = selectedTab,
                         readFilterShowsRead = flagsReadFilterShowsRead(
                             tab = selectedTab,
-                            cyanShowsRead = cyanShowsRead,
-                            dtShowsRead = dtShowsRead,
+                            shortcuts = readShortcuts,
                         ),
                         // #661 — GLOBAL « +lus » cue shape (eye glyph vs. coloured flag ring).
                         plusLusIndicatorStyle = flagsViewSettings.plusLusIndicatorStyle,
@@ -1008,10 +1016,9 @@ private fun flagTabColor(tab: FlagTab): Color = when (tab) {
 private fun flagAppBarTabs(
     authState: AuthState?,
     showDtTab: Boolean,
-    cyanShowsRead: Boolean,
-    dtShowsRead: Boolean,
+    readShortcuts: FlagsReadShortcuts,
 ): List<FlagTabEntry> = if (authState is AuthState.Authenticated) {
-    flagTabEntries(showDtTab = showDtTab, cyanShowsRead = cyanShowsRead, dtShowsRead = dtShowsRead)
+    flagTabEntries(showDtTab = showDtTab, readShortcuts = readShortcuts)
 } else {
     emptyList()
 }
@@ -1021,8 +1028,7 @@ private fun flagAppBarTabs(
 @Composable
 private fun flagTabEntries(
     showDtTab: Boolean,
-    cyanShowsRead: Boolean,
-    dtShowsRead: Boolean,
+    readShortcuts: FlagsReadShortcuts,
 ): List<FlagTabEntry> {
     val readSuffix = stringResource(R.string.flags_tab_cyan_read_shown_suffix)
     val neutral = MaterialTheme.colorScheme.onSurfaceVariant
@@ -1030,17 +1036,30 @@ private fun flagTabEntries(
         add(
             FlagTabEntry(
                 FlagTab.Cyan,
-                stringResource(R.string.flags_tab_my_topics) + if (cyanShowsRead) readSuffix else "",
+                stringResource(R.string.flags_tab_my_topics) + if (readShortcuts.cyan) readSuffix else "",
                 FlagPalette.Cyan,
             ),
         )
-        add(FlagTabEntry(FlagTab.Red, stringResource(R.string.flags_tab_read_only), FlagPalette.Red))
-        add(FlagTabEntry(FlagTab.Favorite, stringResource(R.string.flags_tab_favorite), FlagPalette.Favorite))
+        // #751 — Red/Favori carry the same « +lus » suffix now that their filter is toggleable.
+        add(
+            FlagTabEntry(
+                FlagTab.Red,
+                stringResource(R.string.flags_tab_read_only) + if (readShortcuts.red) readSuffix else "",
+                FlagPalette.Red,
+            ),
+        )
+        add(
+            FlagTabEntry(
+                FlagTab.Favorite,
+                stringResource(R.string.flags_tab_favorite) + if (readShortcuts.favorite) readSuffix else "",
+                FlagPalette.Favorite,
+            ),
+        )
         if (showDtTab) {
             add(
                 FlagTabEntry(
                     FlagTab.Dt,
-                    stringResource(R.string.flags_tab_dt) + if (dtShowsRead) readSuffix else "",
+                    stringResource(R.string.flags_tab_dt) + if (readShortcuts.dt) readSuffix else "",
                     FlagPalette.Dt,
                 ),
             )

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTopBar.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTopBar.kt
@@ -91,18 +91,30 @@ data class FlagsAppBarState(
 )
 
 /**
- * #661 — read-filter state for the picker's contextual « +lus » entry: `null` when the active tab has
- * no such toggle (Red / Favori / Super), otherwise whether read items are currently shown (Cyan / DT).
- * Pure → unit-tested.
+ * #751 — per-tab « read items are currently shown » states, threaded as one bundle from the
+ * ViewModel's four eager shortcut StateFlows to the top bar (indicator, picker entry, label suffix).
+ */
+internal data class FlagsReadShortcuts(
+    val cyan: Boolean,
+    val dt: Boolean,
+    val red: Boolean,
+    val favorite: Boolean,
+)
+
+/**
+ * #661 → #751 — read-filter state for the picker's contextual « +lus » entry: `null` when the active
+ * tab has no such toggle (only the Super placeholder since #751 — thibw : the shortcut used to skip
+ * Red / Favori), otherwise whether read items are currently shown. Pure → unit-tested.
  */
 internal fun flagsReadFilterShowsRead(
     tab: FlagTab,
-    cyanShowsRead: Boolean,
-    dtShowsRead: Boolean,
+    shortcuts: FlagsReadShortcuts,
 ): Boolean? = when (tab) {
-    FlagTab.Cyan -> cyanShowsRead
-    FlagTab.Dt -> dtShowsRead
-    else -> null
+    FlagTab.Cyan -> shortcuts.cyan
+    FlagTab.Dt -> shortcuts.dt
+    FlagTab.Red -> shortcuts.red
+    FlagTab.Favorite -> shortcuts.favorite
+    FlagTab.Super -> null
 }
 
 private val ContainerShape = RoundedCornerShape(22.dp)

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -355,31 +355,39 @@ class FlagsViewModel @Inject constructor(
         )
 
     /**
-     * Optimistic shim for CYAN's « non-lus uniquement » value (#317), mirroring
-     * [pendingPerTabOverride]. The « +lus » re-tap is the ONLY read-then-flip site, and it is always
-     * CYAN — so the shim is deliberately CYAN-scoped (RED/FAVORITE writes never touch it, so a
-     * concurrent RED write can't clobber a CYAN flip). [setFlagsUnreadOnly] seeds it synchronously
-     * for CYAN; cleared once that write persists.
+     * Optimistic shim for the per-type « non-lus uniquement » values (#317 → #751), mirroring
+     * [pendingPerTabOverride]. The « +lus » re-tap is a read-then-flip site and — since #751 wired
+     * the shortcut on Red and Favori too — it is **type-scoped**, not CYAN-only: each type's pending
+     * flip lives under its own key, so a concurrent write on one type can never clobber another's.
+     * [setFlagsUnreadOnly] seeds the key synchronously; cleared once that write persists.
      */
-    private val pendingCyanUnreadOnly = MutableStateFlow<Boolean?>(null)
+    private val pendingUnreadOnly = MutableStateFlow<Map<FlagType, Boolean>>(emptyMap())
 
     /**
-     * CYAN's resolved « non-lus uniquement » value, optimistic shim ([pendingCyanUnreadOnly]) winning
-     * until the persisted value catches up. Tracks CYAN **regardless of the selected tab** (it is not
-     * keyed on [selectedTab]) and is eagerly seeded with CYAN's type-aware default (`true`), so the
-     * « +lus » re-tap and the Cyan tab suffix never read a value lagging a tab switch or the cold
-     * start (cf. [selectTab] / [cyanShowsReadShortcut]). The bottom-sheet switch keeps reading the
-     * selected-tab [flagsViewSettings] like every other toggle.
+     * [type]'s resolved « non-lus uniquement » value, optimistic shim ([pendingUnreadOnly]) winning
+     * until the persisted value catches up. Tracks the type **regardless of the selected tab** (it is
+     * not keyed on [selectedTab]) and is eagerly seeded with the type-aware default (CYAN `true`,
+     * others `false` — mirrors the DataStore default), so the « +lus » re-tap and the tab suffix
+     * never read a value lagging a tab switch or the cold start (cf. [selectTab] /
+     * [cyanShowsReadShortcut]). The bottom-sheet switch keeps reading the selected-tab
+     * [flagsViewSettings] like every other toggle.
      */
-    val cyanUnreadOnly: StateFlow<Boolean> = combine(
-        userPreferencesRepository.observeFlagsViewSettings(FlagType.CYAN).map { it.unreadOnly },
-        pendingCyanUnreadOnly,
-    ) { persisted, pending -> pending ?: persisted }
+    private fun unreadOnlyState(type: FlagType): StateFlow<Boolean> = combine(
+        userPreferencesRepository.observeFlagsViewSettings(type).map { it.unreadOnly },
+        pendingUnreadOnly,
+    ) { persisted, pending -> pending[type] ?: persisted }
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.Eagerly,
-            initialValue = true,
+            initialValue = type == FlagType.CYAN,
         )
+
+    val cyanUnreadOnly: StateFlow<Boolean> = unreadOnlyState(FlagType.CYAN)
+
+    // #751 — Red and Favori get the same resolved values: the « +lus » re-tap shortcut and the
+    // top-bar read-state indicator now cover every real flag type, not just Cyan.
+    val redUnreadOnly: StateFlow<Boolean> = unreadOnlyState(FlagType.RED)
+    val favoriteUnreadOnly: StateFlow<Boolean> = unreadOnlyState(FlagType.FAVORITE)
 
     /**
      * Whether the Cyan tab currently shows read participated topics (drives the discreet « +lus »
@@ -391,6 +399,33 @@ class FlagsViewModel @Inject constructor(
         selectedTab,
         cyanUnreadOnly,
     ) { tab, unreadOnly -> tab == FlagTab.Cyan && !unreadOnly }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = false,
+        )
+
+    /**
+     * #751 — same « shows read » state for the Red and Favori tabs (they default to showing read
+     * topics, so the indicator is honest from the first frame). Mirrors [cyanShowsReadShortcut];
+     * initialValue `true` matches the type-aware default (unreadOnly=false ⇒ read topics shown)
+     * pinned to the not-yet-selected state being irrelevant (the topbar only reads the selected
+     * tab's value through [flagsReadFilterShowsRead]).
+     */
+    val redShowsReadShortcut: StateFlow<Boolean> = combine(
+        selectedTab,
+        redUnreadOnly,
+    ) { tab, unreadOnly -> tab == FlagTab.Red && !unreadOnly }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = false,
+        )
+
+    val favoriteShowsReadShortcut: StateFlow<Boolean> = combine(
+        selectedTab,
+        favoriteUnreadOnly,
+    ) { tab, unreadOnly -> tab == FlagTab.Favorite && !unreadOnly }
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.Eagerly,
@@ -580,18 +615,22 @@ class FlagsViewModel @Inject constructor(
     }
 
     /**
-     * Handles a re-tap on the already-selected [tab]. Cyan and DT flip their « non-lus uniquement »
-     * filter (the « +lus » shortcut) — Cyan through the persisted [setFlagsUnreadOnly] write (reading
-     * the optimistic [cyanUnreadOnly]), DT through the in-memory [_dtUnreadOnly] (per-session, not
-     * persisted). Every other tab re-tap is a deliberate no-op (#106 tinc — keep the scroll position).
+     * Handles a re-tap on the already-selected [tab]. Every real tab flips its « non-lus uniquement »
+     * filter (the « +lus » shortcut) — Cyan/Red/Favori through the persisted [setFlagsUnreadOnly]
+     * write (reading their optimistic resolved values — #751, thibw : the shortcut used to no-op
+     * outside Cyan), DT through the in-memory [_dtUnreadOnly] (per-session, not persisted). Only the
+     * Super placeholder keeps the #106 no-op (no list, nothing to flip).
      * Never raises [_recallListToTop]: a filter flip is not a tab transition (the screen's
-     * FilterFlipScrollResetEffect handles the scroll for Cyan).
+     * FilterFlipScrollResetEffect handles the scroll — it watches the ATOMIC per-type
+     * [tabUnreadFilter], so Red/Favori flips reset the scroll exactly like Cyan's).
      */
     private fun handleReTap(tab: FlagTab) {
         when (tab) {
             FlagTab.Cyan -> setFlagsUnreadOnly(!cyanUnreadOnly.value)
+            FlagTab.Red -> setFlagsUnreadOnly(!redUnreadOnly.value)
+            FlagTab.Favorite -> setFlagsUnreadOnly(!favoriteUnreadOnly.value)
             FlagTab.Dt -> _dtUnreadOnly.value = !_dtUnreadOnly.value
-            else -> Unit // #106 — re-tapping any other tab is a no-op.
+            FlagTab.Super -> Unit // #106 — placeholder tab, nothing to flip.
         }
     }
 
@@ -658,16 +697,17 @@ class FlagsViewModel @Inject constructor(
      */
     fun setFlagsUnreadOnly(enabled: Boolean) {
         val type = _selectedTab.value.flagType ?: return
-        // CYAN is the only read-then-flip path (the « +lus » re-tap), so only CYAN needs the
-        // optimistic shim: seed it synchronously (instant, lag-free re-tap target), then persist and
-        // drop the shim only if no newer flip superseded it (compareAndSet) — same pattern as
-        // [setFlagsPerTabOverride]. RED/FAVORITE writes (bottom sheet, explicit on/off) never touch
-        // the shim, so they can't clobber a concurrent CYAN flip. Resolved settings take over once
-        // DataStore commits.
-        if (type == FlagType.CYAN) pendingCyanUnreadOnly.value = enabled
+        // Every real type is a read-then-flip path since #751 (the « +lus » re-tap on Cyan/Red/Favori),
+        // so the optimistic shim is seeded per type: synchronously (instant, lag-free re-tap target),
+        // then persist and drop the type's key only if no newer flip superseded it — same pattern as
+        // [setFlagsPerTabOverride]. Keys are type-scoped, so a concurrent write on one type can't
+        // clobber another's pending flip. Resolved settings take over once DataStore commits.
+        pendingUnreadOnly.update { it + (type to enabled) }
         viewModelScope.launch {
             userPreferencesRepository.setFlagsUnreadOnlyForType(type, enabled)
-            if (type == FlagType.CYAN) pendingCyanUnreadOnly.compareAndSet(expect = enabled, update = null)
+            pendingUnreadOnly.update { pending ->
+                if (pending[type] == enabled) pending - type else pending
+            }
         }
     }
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -407,10 +407,11 @@ class FlagsViewModel @Inject constructor(
 
     /**
      * #751 — same « shows read » state for the Red and Favori tabs (they default to showing read
-     * topics, so the indicator is honest from the first frame). Mirrors [cyanShowsReadShortcut];
-     * initialValue `true` matches the type-aware default (unreadOnly=false ⇒ read topics shown)
-     * pinned to the not-yet-selected state being irrelevant (the topbar only reads the selected
-     * tab's value through [flagsReadFilterShowsRead]).
+     * topics, so the indicator is honest as soon as the combine emits). Mirrors
+     * [cyanShowsReadShortcut]; initialValue `false` is the resting « not selected » state — both
+     * sources are eager StateFlows, so the real `tab && !unreadOnly` value lands on the first
+     * collection and the topbar only reads the SELECTED tab's value through
+     * [flagsReadFilterShowsRead] anyway.
      */
     val redShowsReadShortcut: StateFlow<Boolean> = combine(
         selectedTab,

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsReadFilterShowsReadTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsReadFilterShowsReadTest.kt
@@ -5,28 +5,46 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 
 /**
- * #661 — the picker dropdown's contextual « +lus » entry exists ONLY for the tabs that carry a read
- * filter (Cyan / DT) and its label follows their current state; the other tabs (Red / Favori / Super)
- * get no entry (null). Pure mapping → unit-tested.
+ * #661 → #751 — the picker dropdown's contextual « +lus » entry exists for every tab that carries a
+ * read filter (all real tabs since #751 — Cyan / Red / Favori / DT) and its label follows their
+ * current state; only the Super placeholder gets no entry (null). Pure mapping → unit-tested.
  */
 class FlagsReadFilterShowsReadTest {
 
+    private fun showsRead(
+        tab: FlagTab,
+        cyan: Boolean = false,
+        dt: Boolean = false,
+        red: Boolean = false,
+        favorite: Boolean = false,
+    ): Boolean? = flagsReadFilterShowsRead(
+        tab = tab,
+        shortcuts = FlagsReadShortcuts(cyan = cyan, dt = dt, red = red, favorite = favorite),
+    )
+
     @Test
     fun `cyan reflects its read-shortcut state`() {
-        assertEquals(true, flagsReadFilterShowsRead(FlagTab.Cyan, cyanShowsRead = true, dtShowsRead = false))
-        assertEquals(false, flagsReadFilterShowsRead(FlagTab.Cyan, cyanShowsRead = false, dtShowsRead = true))
+        assertEquals(true, showsRead(FlagTab.Cyan, cyan = true))
+        assertEquals(false, showsRead(FlagTab.Cyan, dt = true, red = true, favorite = true))
     }
 
     @Test
     fun `dt reflects its own read state`() {
-        assertEquals(true, flagsReadFilterShowsRead(FlagTab.Dt, cyanShowsRead = false, dtShowsRead = true))
-        assertEquals(false, flagsReadFilterShowsRead(FlagTab.Dt, cyanShowsRead = true, dtShowsRead = false))
+        assertEquals(true, showsRead(FlagTab.Dt, dt = true))
+        assertEquals(false, showsRead(FlagTab.Dt, cyan = true, red = true, favorite = true))
     }
 
     @Test
-    fun `tabs without a read filter have no entry`() {
-        assertNull(flagsReadFilterShowsRead(FlagTab.Red, cyanShowsRead = true, dtShowsRead = true))
-        assertNull(flagsReadFilterShowsRead(FlagTab.Favorite, cyanShowsRead = true, dtShowsRead = true))
-        assertNull(flagsReadFilterShowsRead(FlagTab.Super, cyanShowsRead = true, dtShowsRead = true))
+    fun `red and favorite reflect their own read state`() {
+        // #751 (thibw) — the shortcut used to skip these tabs entirely (null).
+        assertEquals(true, showsRead(FlagTab.Red, red = true))
+        assertEquals(false, showsRead(FlagTab.Red, cyan = true, dt = true, favorite = true))
+        assertEquals(true, showsRead(FlagTab.Favorite, favorite = true))
+        assertEquals(false, showsRead(FlagTab.Favorite, cyan = true, dt = true, red = true))
+    }
+
+    @Test
+    fun `the Super placeholder has no entry`() {
+        assertNull(showsRead(FlagTab.Super, cyan = true, dt = true, red = true, favorite = true))
     }
 }

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -355,6 +355,31 @@ class FlagsViewModelTest {
     }
 
     @Test
+    fun `rapid double re-tap on Favorite flips twice via the optimistic value`() = runTest {
+        // #751 gate (Codex) — same-type equivalent of the Cyan shim test below: two rapid re-taps
+        // on Favorite before either write persists must net back to the start (false → true →
+        // false), proving the second tap read the optimistic map value, not the lagging store.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val prefs = FakeUserPreferencesRepository()
+        val vm = viewModel(auth, flags, forum, prefs)
+
+        vm.selectTab(FlagTab.Favorite) // real transition
+        prefs.blockUnreadOnlySetUntil = kotlinx.coroutines.CompletableDeferred()
+
+        vm.selectTab(FlagTab.Favorite) // re-tap: false → write(true) gated, pending = true
+        vm.selectTab(FlagTab.Favorite) // re-tap: reads optimistic true → write(false) gated
+        prefs.blockUnreadOnlySetUntil!!.complete(Unit) // release both gated writes (FIFO)
+
+        assertEquals(
+            "two rapid re-taps must net back to the start, not lose the second flip",
+            false,
+            vm.flagsViewSettings.value.unreadOnly,
+        )
+    }
+
+    @Test
     fun `rapid double re-tap on Cyan flips twice via the optimistic value`() = runTest {
         // #317 review (cf. #309 shim): a re-tap reads the RESOLVED settings (an async DataStore
         // flow). Without the optimistic [pendingCyanUnreadOnly], a second rapid re-tap before the first

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -188,7 +188,10 @@ class FlagsViewModelTest {
         vm.consumeRecallListToTop()
         assertFalse(vm.recallListToTop.value)
 
-        vm.selectTab(FlagTab.Red) // re-tap the same tab: no-op, no recall (keeps scroll position)
+        // #751 — the re-tap flips Red's filter now, but it is a FILTER action, not a tab
+        // transition: it must still never raise the recall (FilterFlipScrollResetEffect owns
+        // the scroll on a flip).
+        vm.selectTab(FlagTab.Red)
         assertFalse("re-tapping the already-selected tab must not recall", vm.recallListToTop.value)
     }
 
@@ -305,6 +308,50 @@ class FlagsViewModelTest {
         vm.selectTab(FlagTab.Cyan)
         assertEquals(FlagTab.Cyan, vm.selectedTab.value)
         assertEquals(true, vm.flagsViewSettings.value.unreadOnly)
+    }
+
+    @Test
+    fun `re-tapping the already selected Favorite tab toggles its unread-only filter`() = runTest {
+        // #751 (thibw) — the « +lus » shortcut used to no-op outside Cyan/DT.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val vm = viewModel(auth, flags, forum)
+
+        vm.selectTab(FlagTab.Favorite)
+        // FAVORITE defaults to unreadOnly = false (show all); the first re-tap flips it on.
+        assertEquals(false, vm.flagsViewSettings.value.unreadOnly)
+        vm.selectTab(FlagTab.Favorite)
+        assertEquals(true, vm.flagsViewSettings.value.unreadOnly)
+        vm.selectTab(FlagTab.Favorite)
+        assertEquals(false, vm.flagsViewSettings.value.unreadOnly)
+        assertEquals(FlagTab.Favorite, vm.selectedTab.value)
+        assertTrue("re-tap must not refetch", flags.refreshCalls.isEmpty())
+    }
+
+    @Test
+    fun `flipping Favorite does not clobber Cyan's pending flip`() = runTest {
+        // #751 — the optimistic shim is a per-type map: a Favorite write gated in flight must not
+        // erase a concurrent Cyan pending value (the old CYAN-only shim guaranteed this by never
+        // touching other types; the map must keep that isolation).
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository()
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val prefs = FakeUserPreferencesRepository()
+        prefs.blockUnreadOnlySetUntil = kotlinx.coroutines.CompletableDeferred()
+        val vm = viewModel(auth, flags, forum, prefs)
+
+        vm.selectTab(FlagTab.Cyan) // re-tap: CYAN true → pending false, write gated
+        assertEquals(false, vm.cyanUnreadOnly.value)
+
+        vm.selectTab(FlagTab.Favorite) // real transition
+        vm.selectTab(FlagTab.Favorite) // re-tap: FAVORITE false → pending true, write gated
+        assertEquals(true, vm.favoriteUnreadOnly.value)
+        assertEquals("Cyan's optimistic flip must survive the Favorite write", false, vm.cyanUnreadOnly.value)
+
+        prefs.blockUnreadOnlySetUntil!!.complete(Unit)
+        assertEquals(false, vm.cyanUnreadOnly.value)
+        assertEquals(true, vm.favoriteUnreadOnly.value)
     }
 
     @Test


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Contexte

Retour bêta thibw ([#2789791](https://forum.hardware.fr/forum2.php?config=hfr.inc&cat=23&post=35421&page=36#t2789791), reconnu « petit oubli » par XaTriX) : le raccourci « +lus » (tap sur la zone type de la pilule gauche) ne bascule pas le filtre lu/non-lu sur Favoris (ni Lu). La machinerie par type existait déjà de bout en bout (filtre `filterUnreadOnly`, clés DataStore par type, `setFlagsUnreadOnly`) — seuls le dispatch re-tap (`handleReTap`, no-op #106 hors Cyan/DT) et l'indicateur (`flagsReadFilterShowsRead`, null hors Cyan/DT) excluaient Red/Favori.

**Cadrage Codex (gpt-5.5 xhigh) : « OK avec ajustements », tous appliqués** — shim en Map par type (pas de lecture directe de `flagsViewSettings.value`), no-op #106 limité au placeholder Super, `keepFullyReadSections` inchangé (CYAN-only, la sémantique #179/#309 du hide-read n'est pas touchée), wording #753 en PR séparée.

## Changements

- **Shim optimiste type-scoped** : `pendingUnreadOnly: Map<FlagType, Boolean>` — chaque type a sa clé, une écriture concurrente sur un type ne peut pas écraser le flip en attente d'un autre (la garantie CYAN-only historique, généralisée). `cyanUnreadOnly` garde sa sémantique exacte ; `redUnreadOnly`/`favoriteUnreadOnly` s'y ajoutent (même helper `unreadOnlyState`, défaut type-aware).
- **`handleReTap`** : Red et Favori basculent par le même chemin persisté que Cyan ; DT inchangé (in-memory) ; Super = seul no-op restant. Pas de recall : `FilterFlipScrollResetEffect` observe déjà le `tabUnreadFilter` ATOMIQUE par type — le reset de scroll marche pour Red/Favori **sans aucune modification**.
- **`FlagsReadShortcuts`** (bundle des 4 états) : l'indicateur œil/anneau, l'entrée contextuelle du picker et le suffixe « +lus » des labels couvrent tous les vrais onglets.

## Validation

- Compile + detektAll + `:feature:flags:testDebugUnitTest` verts ; **canonique complète en cours** (résultat avant merge).
- Tests : re-tap Favori bascule (false → true → false, défaut type-aware) ; un write Favori gated ne clobber pas le pending Cyan ; mapping pur Red/Favori/Super ; le test « re-tap ne recall pas » garde son assertion.
- Dogfood émulateur : arrivée sur Fav = œil visible (état honnête : lus affichés par défaut) → re-tap = œil disparaît (non-lus seulement) → re-tap = œil revient ; régression Cyan OK (le « +lus » ré-inclut le sujet lu [TU] Redface).

Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnwLr4K75nLTGGzVv97A2c