### PR TITLE
fix(flags): point the empty-state text at the real « +lus » action (#753)

### DIFF
--- a/feature/flags/src/main/res/values/strings.xml
+++ b/feature/flags/src/main/res/values/strings.xml
@@ -137,7 +137,10 @@
          onglet vide (il peut rester des sujets lus, juste aucun non-lu). On garde donc un état vide
          distinct, factuel, plutôt que le « Aucun favori » trompeur. -->
     <string name="flags_no_unread_category">Aucune catégorie avec un message non lu</string>
-    <string name="flags_no_unread_category_subtitle">Désactive « Masquer les catégories sans non-lu » pour revoir les sujets lus.</string>
+    <!-- #753 (Dintr-un lemn) — l'ancien texte prescrivait « Masquer les catégories sans non-lu »,
+         qui ne réaffiche que les bandeaux de catégories vides : l'action qui réaffiche les SUJETS lus
+         est la bascule « +lus » (pilule d'onglet). Les deux actions sont nommées avec leur effet réel. -->
+    <string name="flags_no_unread_category_subtitle">Tape sur la pilule de l\'onglet pour afficher aussi les sujets lus (« +lus »), ou désactive « Masquer les catégories sans non-lu » pour voir les catégories vides.</string>
     <string name="flags_error">Impossible de récupérer les drapeaux. Vérifie ta connexion ou réessaie.</string>
     <string name="flags_session_expired">Session HFR expirée. Reconnecte-toi pour recharger tes drapeaux.</string>
     <string name="flags_retry">Réessayer</string>


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Retour bêta Dintr-un lemn ([#2790001](https://forum.hardware.fr/forum2.php?config=hfr.inc&cat=23&post=35421&page=38#t2790001), « #tagbug ») : le sous-texte de l'état vide « Désactive "Masquer les catégories sans non-lu" pour revoir les sujets lus » est **faux** — désactiver cette option ne réaffiche que les bandeaux de catégories vides ; l'action qui réaffiche les sujets lus est la bascule « +lus » (pilule d'onglet, fonctionnelle sur tous les onglets avec #751/PR #776).

Correction de wording pure (1 string + commentaire de contexte) : les deux réglages sont nommés avec leur effet réel. Condition d'affichage inchangée — vérifié : cet état vide (`hideReadActive`) n'apparaît sur Cyan que quand `unreadOnly` est actif, `keepFullyReadSections` forçant les sections quand « +lus » est actif.

Edit mécanique (string) — exception à la cadence Codex documentée dans AGENTS.md ; compile + lintProdDebug verts, canonique CI fait foi.

Closes #753

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnwLr4K75nLTGGzVv97A2c