### PR TITLE
chore(release): bump versionName 0.20.0 → 0.20.1 + changelog/whatsnew (quick wins Drapeaux)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,14 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.20.1` — `internal` (dev) — 2026-07-03
+
+**Quick wins vue Drapeaux — retours bêta 0.18.0** (PRs #776, #777 — cadrage + gate Codex gpt-5.5).
+
+### Drapeaux
+- #751 (thibw) : le raccourci **« +lus »** (tap sur la zone type de la pilule) fonctionne désormais sur **tous les onglets** — Lu et Favoris rejoignent Cyan et DT (même chemin persisté, même anti-double-tap ; l'indicateur œil/anneau et le suffixe du picker suivent l'état sur chaque onglet).
+- #753 (Dintr-un lemn) : le texte de l'état vide « aucune catégorie avec un message non lu » pointe la bonne action — la bascule « +lus » pour revoir les sujets lus (l'ancien texte prescrivait « Masquer les catégories sans non-lu », qui ne réaffiche que les catégories vides).
+
 ## `0.20.0` — `internal` (dev) — 2026-07-03
 
 **Phase « Vue Topic » (#604) — vague 3 : redesign de la lecture** (PRs #770, #771, #773, #774 — cadrage + gates Codex gpt-5.5, dogfoods émulateur par lot).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.20.0"
+        versionName = "0.20.1"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,5 +1,4 @@
-Redface 2 v0.20.0 — dev.
+Redface 2 v0.20.1 — dev.
 
-- Redesigned Topic view (wave 3): dissolved header, tappable "page X / Y" pill (page picker), fixed floating buttons.
-- Readable page boundaries: tappable "Page N done" card; calm "End of topic".
-- Traversing "Last read message" marker when opening from a flag.
+- Flags: the "+read" pill shortcut now works on every tab (Read and Favorites included).
+- Flags: the empty-state text now points at the right action to see read topics again.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,5 +1,4 @@
-Redface 2 v0.20.0 — dev.
+Redface 2 v0.20.1 — dev.
 
-- Vue Topic redessinée (vague 3) : en-tête dissous, pilule « page X / Y » cliquable (sélecteur de page), boutons flottants figés.
-- Fin de page lisible : carte « Page N terminée » cliquable ; « Fin du sujet » calme.
-- Repère « Dernier message lu » traversant à l'ouverture d'un drapeau.
+- Drapeaux : le raccourci « +lus » de la pilule fonctionne sur tous les onglets (Lu et Favoris compris).
+- Drapeaux : le texte de l'état vide pointe la bonne action pour revoir les sujets lus.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump mécanique : `versionName` 0.20.1, entrée `app/CHANGELOG.md` (PRs #776 #777 — #751 « +lus » tous onglets + #753 wording état vide), whatsnew fr/en (version en 1re ligne, garde whatsnew-freshness OK). Dispatch `channel=dev --ref dev` après merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnwLr4K75nLTGGzVv97A2c