### PR TITLE
fix(gestures): start dead-zone on the system gesture bands (#752)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/pager/PageSwipe.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/pager/PageSwipe.kt
@@ -32,6 +32,17 @@ import kotlin.math.tanh
  * The page source is the *rendered* page (what the user is looking at), which matches the value the
  * Previous/Next buttons pass to the page-change callback.
  */
+/**
+ * #752 — start (edge-gesture) dead zone: `true` when a gesture's DOWN lands inside the system's
+ * left/right gesture bands ([leftInsetPx] / [rightInsetPx], from `WindowInsets.systemGestures`).
+ * A custom horizontal swipe must not START there: on a real edge the system back gesture wins
+ * anyway, and a finger-width miss just inside the band used to fire a surprise tab/page change
+ * (beta feedback by Stylken). Distinct from the existing « swipe dead-zone » wording, which
+ * denotes the nav-transition collapse (cf. `topicPageSwipe`). Pure → unit-tested without Compose.
+ */
+fun inStartGestureDeadZone(x: Float, widthPx: Int, leftInsetPx: Int, rightInsetPx: Int): Boolean =
+    x < leftInsetPx || x > widthPx - rightInsetPx
+
 fun swipeTargetPage(currentPage: Int, totalPages: Int, forward: Boolean): Int? =
     if (forward) {
         (currentPage + 1).takeIf { it <= totalPages }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/pager/PageSwipe.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/pager/PageSwipe.kt
@@ -39,9 +39,16 @@ import kotlin.math.tanh
  * anyway, and a finger-width miss just inside the band used to fire a surprise tab/page change
  * (beta feedback by Stylken). Distinct from the existing « swipe dead-zone » wording, which
  * denotes the nav-transition collapse (cf. `topicPageSwipe`). Pure → unit-tested without Compose.
+ *
+ * Edges are clamped to `0..widthPx` (and right ≥ left) so aberrant insets — split-screen or
+ * foldable postures reporting bands wider than the window — degrade to a full dead zone at worst
+ * instead of an inverted predicate.
  */
-fun inStartGestureDeadZone(x: Float, widthPx: Int, leftInsetPx: Int, rightInsetPx: Int): Boolean =
-    x < leftInsetPx || x > widthPx - rightInsetPx
+fun inStartGestureDeadZone(x: Float, widthPx: Int, leftInsetPx: Int, rightInsetPx: Int): Boolean {
+    val leftEdge = leftInsetPx.coerceIn(0, widthPx)
+    val rightEdge = (widthPx - rightInsetPx).coerceIn(leftEdge, widthPx)
+    return x < leftEdge || x > rightEdge
+}
 
 fun swipeTargetPage(currentPage: Int, totalPages: Int, forward: Boolean): Int? =
     if (forward) {

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/pager/PageSwipeTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/pager/PageSwipeTest.kt
@@ -246,6 +246,31 @@ class PageSwipeTest {
         assertEquals(1, swipeTargetPage(currentPage = 2, totalPages = 5, forward = false))
     }
 
+    // --- #752 start (edge-gesture) dead-zone contract ---
+    // A custom horizontal swipe never STARTS inside the system's left/right gesture bands: the real
+    // edge belongs to the system back gesture, and a near-miss just inside used to fire a surprise
+    // tab/page change (Stylken). The predicate is the shared gate of both gesture sites.
+
+    @Test
+    fun `a down inside either gesture band is in the dead zone`() {
+        assertTrue(inStartGestureDeadZone(x = 10f, widthPx = 1080, leftInsetPx = 30, rightInsetPx = 30))
+        assertTrue(inStartGestureDeadZone(x = 1070f, widthPx = 1080, leftInsetPx = 30, rightInsetPx = 30))
+    }
+
+    @Test
+    fun `a down between the bands starts the gesture`() {
+        assertFalse(inStartGestureDeadZone(x = 540f, widthPx = 1080, leftInsetPx = 30, rightInsetPx = 30))
+        // Boundary: exactly ON the inset edge is outside the band (strict comparisons).
+        assertFalse(inStartGestureDeadZone(x = 30f, widthPx = 1080, leftInsetPx = 30, rightInsetPx = 30))
+        assertFalse(inStartGestureDeadZone(x = 1050f, widthPx = 1080, leftInsetPx = 30, rightInsetPx = 30))
+    }
+
+    @Test
+    fun `zero insets - three-button nav - never dead-zones`() {
+        assertFalse(inStartGestureDeadZone(x = 0f, widthPx = 1080, leftInsetPx = 0, rightInsetPx = 0))
+        assertFalse(inStartGestureDeadZone(x = 1080f, widthPx = 1080, leftInsetPx = 0, rightInsetPx = 0))
+    }
+
     private companion object {
         const val TOLERANCE = 0.001f
     }

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/pager/PageSwipeTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/pager/PageSwipeTest.kt
@@ -271,6 +271,15 @@ class PageSwipeTest {
         assertFalse(inStartGestureDeadZone(x = 1080f, widthPx = 1080, leftInsetPx = 0, rightInsetPx = 0))
     }
 
+    @Test
+    fun `aberrant insets clamp to the window instead of inverting the predicate`() {
+        // Negative insets (bogus provider) behave like zero insets.
+        assertFalse(inStartGestureDeadZone(x = 0f, widthPx = 1080, leftInsetPx = -50, rightInsetPx = -50))
+        // A band wider than the window degrades to a full dead zone, never a partial inversion.
+        assertTrue(inStartGestureDeadZone(x = 540f, widthPx = 1080, leftInsetPx = 0, rightInsetPx = 2000))
+        assertTrue(inStartGestureDeadZone(x = 540f, widthPx = 1080, leftInsetPx = 2000, rightInsetPx = 0))
+    }
+
     private companion object {
         const val TOLERANCE = 0.001f
     }

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsRoute.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.systemGestures
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
@@ -81,6 +82,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.CustomAccessibilityAction
@@ -1274,6 +1276,15 @@ private fun AuthenticatedBody(
     // tab list itself can change (the DT tab is a Settings toggle).
     val haptics = LocalHapticFeedback.current
     val dragOffset = remember { mutableFloatStateOf(0f) }
+    // #752 — system-gesture band widths, resolved here (composable) and handed to the gesture as
+    // ALWAYS-FRESH lambdas: the insets object and density are read through rememberUpdatedState so
+    // the Unit-keyed pointerInput sees rotation/split-screen changes without re-keying, and the px
+    // conversion happens per gesture inside the provider.
+    val density = LocalDensity.current
+    val layoutDirection = LocalLayoutDirection.current
+    val systemGestureInsets = rememberUpdatedState(WindowInsets.systemGestures)
+    val updatedDensity = rememberUpdatedState(density)
+    val updatedLayoutDirection = rememberUpdatedState(layoutDirection)
     val updatedTabs = rememberUpdatedState(tabs)
     val updatedSelectedIndex = rememberUpdatedState(selectedIndex)
     val updatedActions = rememberUpdatedState(actions)
@@ -1289,6 +1300,12 @@ private fun AuthenticatedBody(
                 pendingSwipeForward = forward
                 updatedTabs.value.getOrNull(index)
                     ?.let { tab -> updatedActions.value.onSelectTab(tab) }
+            },
+            leftGestureInsetPx = {
+                systemGestureInsets.value.getLeft(updatedDensity.value, updatedLayoutDirection.value)
+            },
+            rightGestureInsetPx = {
+                systemGestureInsets.value.getRight(updatedDensity.value, updatedLayoutDirection.value)
             },
         )
     }

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTabSwipe.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsTabSwipe.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.compose.ui.unit.IntOffset
 import fr.forumhfr.redface2.core.ui.pager.FLING_VELOCITY_THRESHOLD
 import fr.forumhfr.redface2.core.ui.pager.MIN_COMMIT_DISTANCE
+import fr.forumhfr.redface2.core.ui.pager.inStartGestureDeadZone
 import fr.forumhfr.redface2.core.ui.pager.swipeArmed
 import fr.forumhfr.redface2.core.ui.pager.swipeCommitDirection
 import fr.forumhfr.redface2.core.ui.pager.swipeCommitDistancePx
@@ -87,6 +88,21 @@ internal fun Modifier.flagsTabSwipe(
                     swipeCommitDistancePx(size.width.toFloat(), MIN_COMMIT_DISTANCE.toPx())
                 val flingThresholdPx = FLING_VELOCITY_THRESHOLD.toPx()
                 val down = awaitFirstDown(requireUnconsumed = false)
+                // #752 — never START the tab swipe from the system gesture bands: a real edge swipe
+                // belongs to the system back gesture, and a near-miss just inside the band used to
+                // flip the tab by surprise (Stylken). The down is NOT consumed, so the list scroll
+                // proceeds normally. Placed BEFORE releaseJob/velocity so a banded touch neither
+                // interrupts a running spring-back nor arms anything. Insets read per gesture (not
+                // captured at pointerInput(Unit) start) — same staleness rule as size.width above.
+                if (inStartGestureDeadZone(
+                        x = down.position.x,
+                        widthPx = size.width,
+                        leftInsetPx = handlers.leftGestureInsetPx(),
+                        rightInsetPx = handlers.rightGestureInsetPx(),
+                    )
+                ) {
+                    return@awaitEachGesture
+                }
                 val velocityTracker = VelocityTracker()
                 velocityTracker.addPosition(down.uptimeMillis, down.position)
                 var overSlop = 0f
@@ -159,6 +175,10 @@ internal fun Modifier.flagsTabSwipe(
 internal class FlagsTabSwipeHandlers(
     val haptics: HapticFeedback,
     val onSelectTab: (index: Int, forward: Boolean) -> Unit,
+    // #752 — system-gesture band widths in px, read once per gesture at `down` (lambdas, not
+    // captured px: the pointerInput is keyed on Unit and must survive rotation/split-screen).
+    val leftGestureInsetPx: () -> Int,
+    val rightGestureInsetPx: () -> Int,
 )
 
 /**

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -19,8 +19,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.systemGestures
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
@@ -71,6 +73,8 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -1181,6 +1185,12 @@ private fun TopicLoadedContent(
     // the gesture (whose pointerInput does not re-key on this) always sees the current state.
     val entryLifecycle = LocalLifecycleOwner.current.lifecycle
     val swipeEnabled: () -> Boolean = { entryLifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED) }
+    // #752 — system-gesture band widths for the swipe's start dead-zone, resolved here (composable)
+    // and handed as ALWAYS-FRESH lambdas (rememberUpdatedState) so the currentPage-keyed
+    // pointerInput sees rotation/split-screen changes ; px conversion happens per gesture.
+    val gestureDensity = rememberUpdatedState(LocalDensity.current)
+    val gestureLayoutDirection = rememberUpdatedState(LocalLayoutDirection.current)
+    val systemGestureInsets = rememberUpdatedState(WindowInsets.systemGestures)
     // #282 (P2-b) — if the loaded page re-keys while we stay Loaded (a force-refresh or page jump that
     // lands the same screen on a new page), drop any residual translation so the page is never left
     // frozen off-centre. Keyed on `topic.page` ONLY — never `topic.totalPages`: a page-count change
@@ -1235,6 +1245,14 @@ private fun TopicLoadedContent(
                     haptics = haptics,
                     onOpenPage = onOpenPage,
                     enabled = swipeEnabled,
+                    leftGestureInsetPx = {
+                        systemGestureInsets.value
+                            .getLeft(gestureDensity.value, gestureLayoutDirection.value)
+                    },
+                    rightGestureInsetPx = {
+                        systemGestureInsets.value
+                            .getRight(gestureDensity.value, gestureLayoutDirection.value)
+                    },
                 ),
             )
             // #382 — double-tap anywhere on the list to refresh the page (RF1 parity). Child

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.ui.pager.FLING_VELOCITY_THRESHOLD
 import fr.forumhfr.redface2.core.ui.pager.MIN_COMMIT_DISTANCE
+import fr.forumhfr.redface2.core.ui.pager.inStartGestureDeadZone
 import fr.forumhfr.redface2.core.ui.pager.swipeArmed
 import fr.forumhfr.redface2.core.ui.pager.swipeCommitDirection
 import fr.forumhfr.redface2.core.ui.pager.swipeCommitDistancePx
@@ -149,6 +150,19 @@ internal fun Modifier.topicPageSwipe(
                 // off-screen (the very freeze). See #282. (A `down` that lands while still RESUMED but
                 // whose slop is crossed mid-transition is safe: the `committed` latch blocks a 2nd fire.)
                 if (!handlers.enabled()) return@awaitEachGesture
+                // #752 — same start dead-zone as the flags tab swipe: never start the page swipe
+                // from the system gesture bands (system back owns the real edge; a near-miss just
+                // inside used to fire a surprise page change). After the committed/enabled gates —
+                // their precedence is unchanged — and before anything arms.
+                if (inStartGestureDeadZone(
+                        x = down.position.x,
+                        widthPx = size.width,
+                        leftInsetPx = handlers.leftGestureInsetPx(),
+                        rightInsetPx = handlers.rightGestureInsetPx(),
+                    )
+                ) {
+                    return@awaitEachGesture
+                }
                 val velocityTracker = VelocityTracker()
                 velocityTracker.addPosition(down.uptimeMillis, down.position)
                 var overSlop = 0f
@@ -232,6 +246,10 @@ internal class TopicSwipeHandlers(
     val haptics: HapticFeedback,
     val onOpenPage: (Int) -> Unit,
     val enabled: () -> Boolean,
+    // #752 — system-gesture band widths in px, read once per gesture at `down` (lambdas: the
+    // pointerInput is keyed on currentPage, not on insets — a captured px would go stale).
+    val leftGestureInsetPx: () -> Int,
+    val rightGestureInsetPx: () -> Int,
 )
 
 /** Spring the page back to rest (cancel / no-commit), streaming the animation into [dragOffset]. */


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Closes #752.

## Problème

Sur les appareils en navigation gestuelle, un swipe horizontal qui démarre au ras du bord d'écran est disputé entre le geste système (back) et nos pagers maison (onglets Drapeaux, pages Topic #282). Résultat : la frontière est abrupte et imprévisible — parfois back, parfois changement d'onglet/page, selon quelques pixels. Repro faite en dogfood (émulateur Pixel 8, navigation gestuelle) : un départ de swipe dans la bande système déclenche un comportement incohérent.

## Solution (arbitrage : option a)

Zone morte **au départ du geste** sur les insets `WindowInsets.systemGestures`, appliquée aux deux surfaces concernées :

- **Onglets Drapeaux** (`FlagsTabSwipe`) : garde après `awaitFirstDown`, avant toute annulation de release-job ou tracking de vélocité.
- **Pages Topic** (`TopicSwipe`, geste #282) : même garde après les gardes existantes (`committed`, `enabled`).

Le prédicat est pur et testé (`core/ui/pager/PageSwipe.kt`) :

```kotlin
fun inStartGestureDeadZone(x: Float, widthPx: Int, leftInsetPx: Int, rightInsetPx: Int): Boolean =
    x < leftInsetPx || x > widthPx - rightInsetPx
```

Points de design :

- La garde **ne consomme pas** l'event : le geste système reste pleinement fonctionnel, on renonce juste à entrer en compétition.
- Les insets sont lus au call-site via `rememberUpdatedState` et passés en **lambdas toujours fraîches** dans les handlers — les `pointerInput` sont keyés sur `Unit`/`currentPage` et ne se re-keyent pas quand les insets changent (rotation, changement de mode de navigation).
- En navigation 3 boutons, les insets `systemGestures` latéraux sont à 0 → **aucune zone morte**, comportement inchangé.

## Tests

- `PageSwipeTest` : 3 tests du prédicat (bandes gauche/droite, zone centrale + frontières strictes, insets zéro).
- Modules touchés : `:core:ui:testDebugUnitTest`, `:feature:flags:testDebugUnitTest`, `:feature:topic:testDebugUnitTest` verts + detekt vert.

## Dogfood (émulateur Pixel 8, navigation gestuelle)

- Swipe onglet mi-écran : Cyan → Lurk ✓
- Swipe démarrant à x=990 (hors bande système) : Lurk → Fav ✓
- Swipe page topic mi-écran (topic DEV page 38) : page 38 → 39 ✓ (non-régression #282)

## Checklist

- [x] Review Codex (gate gpt-5.5 xhigh — verdict dans les commentaires)
- [x] Validation canonique locale (detektAll + lintProdDebug + tests + assembleProdDebug)
