### PR TITLE
feat(topic): tap the top-bar title to reveal it in full (#772)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -81,6 +81,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
@@ -861,16 +862,22 @@ private fun topicBarPageIndicator(state: TopicUiState, loaded: TopicUiState.Mode
     else -> stringResource(R.string.topic_loading)
 }
 
+// #772 — extra room for the title's second line (titleMedium line height) while the title is
+// expanded; the small M3 top app bar keeps a fixed container height and would clip it otherwise.
+private val TopBarExpandedTitleExtraHeight = 24.dp
+
 /**
  * #285/#284 + Chantier C (#546) — the topic top app bar (title + page counter + back) plus the
  * intra-topic search affordance : a search icon in `actions` (only when the loaded page exposes a
  * usable, authenticated transsearch form) that opens the [TopicSearchBar] directly beneath the bar.
  * Extracted from `TopicContent` to keep that builder under detekt's cyclomatic-complexity cap.
+ * Internal (not private) so the Robolectric UI test can drive the #772 title expansion directly,
+ * same pattern as [TopicPostCard].
  */
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
 @Suppress("LongParameterList") // hoisted bar : title/page/back inputs + search sink + page picker.
-private fun TopicTopBar(
+internal fun TopicTopBar(
     state: TopicUiState,
     barTitle: String,
     barPageIndicator: String,
@@ -888,6 +895,16 @@ private fun TopicTopBar(
     val searchLabel = stringResource(R.string.topic_search_open)
     var pagePickerOpen by remember { mutableStateOf(false) }
     val pagePickerLabel = stringResource(R.string.topic_page_picker_open)
+    // #772 — tap on the title reveals it in full (2 lines max), tap again folds it back. Transient
+    // by design (arbitrage XaTriX) : plain `remember`, so a page change (route replace) or leaving
+    // the screen resets it — unlike the hoisted poll expansion (#465), which must survive swaps.
+    var titleExpanded by remember { mutableStateOf(false) }
+    val titleToggleLabel = stringResource(
+        if (titleExpanded) R.string.topic_title_collapse else R.string.topic_title_expand,
+    )
+    val titleStateLabel = stringResource(
+        if (titleExpanded) R.string.topic_title_expanded else R.string.topic_title_collapsed,
+    )
     Column {
         TopAppBar(
             title = {
@@ -895,8 +912,20 @@ private fun TopicTopBar(
                     Text(
                         text = barTitle,
                         style = MaterialTheme.typography.titleMedium,
-                        maxLines = 1,
+                        maxLines = if (titleExpanded) 2 else 1,
                         overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier
+                            .clickable(onClickLabel = titleToggleLabel) {
+                                val expanding = !titleExpanded
+                                titleExpanded = expanding
+                                if (expanding) {
+                                    // enterAlways may hold the bar partially collapsed — re-deploy
+                                    // it so the freshly granted second line shows instead of
+                                    // staying clipped behind the current height offset.
+                                    scrollBehavior?.state?.heightOffset = 0f
+                                }
+                            }
+                            .semantics { stateDescription = titleStateLabel },
                     )
                     Text(
                         text = barPageIndicator,
@@ -937,6 +966,13 @@ private fun TopicTopBar(
                         RedfaceVectorIcon(resId = fr.forumhfr.redface2.core.ui.R.drawable.ic_search)
                     }
                 }
+            },
+            // #772 — the small M3 top app bar has a FIXED container height that never grows for a
+            // 2-line title : grant the extra line height while expanded, else keep the M3 default.
+            expandedHeight = if (titleExpanded) {
+                TopAppBarDefaults.TopAppBarExpandedHeight + TopBarExpandedTitleExtraHeight
+            } else {
+                TopAppBarDefaults.TopAppBarExpandedHeight
             },
             scrollBehavior = scrollBehavior,
         )

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -896,9 +896,10 @@ internal fun TopicTopBar(
     var pagePickerOpen by remember { mutableStateOf(false) }
     val pagePickerLabel = stringResource(R.string.topic_page_picker_open)
     // #772 — tap on the title reveals it in full (2 lines max), tap again folds it back. Transient
-    // by design (arbitrage XaTriX) : plain `remember`, so a page change (route replace) or leaving
-    // the screen resets it — unlike the hoisted poll expansion (#465), which must survive swaps.
-    var titleExpanded by remember { mutableStateOf(false) }
+    // by design (arbitrage XaTriX) : a page change (route replace → fresh composition, the very
+    // loss the hoisted poll expansion #465 works around) or leaving the screen resets it. The
+    // post/page key is a safety net should a refactor ever reuse the composition across pages.
+    var titleExpanded by remember(state.request.post, state.request.page) { mutableStateOf(false) }
     val titleToggleLabel = stringResource(
         if (titleExpanded) R.string.topic_title_collapse else R.string.topic_title_expand,
     )

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -116,4 +116,9 @@
     <!-- Vague 3 (#604) : pilule page de la top bar + feuille de navigation. -->
     <string name="topic_page_picker_open">Changer de page</string>
     <string name="topic_page_picker_title">Aller à une page</string>
+    <!-- #772 : titre de la top bar dépliable au tap (1 ligne ↔ 2 lignes). -->
+    <string name="topic_title_expand">Afficher le titre complet</string>
+    <string name="topic_title_collapse">Réduire le titre</string>
+    <string name="topic_title_expanded">Titre développé</string>
+    <string name="topic_title_collapsed">Titre réduit</string>
 </resources>

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicTopBarTitleExpandTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicTopBarTitleExpandTest.kt
@@ -1,0 +1,93 @@
+package fr.forumhfr.redface2.feature.topic
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * #772 — the top-bar title is a tap toggle : collapsed (1 line, ellipsised) ↔ expanded (2 lines).
+ * The toggle is transient local state inside [TopicTopBar] ; these tests pin the a11y contract —
+ * the title is clickable and announces its state (« Titre réduit » / « Titre développé ») — which
+ * is also the only observable surface of the maxLines flip (line counts are not semantics).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@OptIn(ExperimentalTestApi::class, ExperimentalMaterial3Api::class)
+class TopicTopBarTitleExpandTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `the title starts collapsed and a tap expands it`() {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                TopicTopBar(
+                    state = sampleState(),
+                    barTitle = LONG_TITLE,
+                    barPageIndicator = "page 3 / 10",
+                    backLabel = "Retour",
+                    scrollBehavior = null,
+                    onBack = {},
+                    onIntent = {},
+                )
+            }
+        }
+
+        composeTestRule.onNode(withStateDescription(COLLAPSED_STATE)).assertHasClickAction()
+        composeTestRule.onNodeWithText(LONG_TITLE).performClick()
+        composeTestRule.onNode(withStateDescription(EXPANDED_STATE)).assertHasClickAction()
+    }
+
+    @Test
+    fun `a second tap folds the title back`() {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                TopicTopBar(
+                    state = sampleState(),
+                    barTitle = LONG_TITLE,
+                    barPageIndicator = "page 3 / 10",
+                    backLabel = "Retour",
+                    scrollBehavior = null,
+                    onBack = {},
+                    onIntent = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(LONG_TITLE).performClick()
+        composeTestRule.onNode(withStateDescription(EXPANDED_STATE)).assertHasClickAction()
+        composeTestRule.onNodeWithText(LONG_TITLE).performClick()
+        composeTestRule.onNode(withStateDescription(COLLAPSED_STATE)).assertHasClickAction()
+    }
+
+    private fun withStateDescription(value: String): SemanticsMatcher =
+        SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, value)
+
+    private fun sampleState(): TopicUiState = TopicUiState(
+        request = TopicRequest(cat = 23, post = 35421, page = 3, scrollTo = null),
+        mode = TopicUiState.Mode.Loading,
+        availablePages = emptyList(),
+    )
+
+    private companion object {
+        const val LONG_TITLE =
+            "Redface 2 — DEV (canal de développement) : un titre volontairement interminable " +
+                "qui ne tient jamais sur une seule ligne de top bar"
+        const val COLLAPSED_STATE = "Titre réduit"
+        const val EXPANDED_STATE = "Titre développé"
+    }
+}


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Closes #772.

## Problème

Le titre du sujet dans la top bar est tronqué dur à une ligne, sans aucun moyen de le lire en entier. Demandé par tinc sur le topic DEV (#tagsuggestion, post #2790181, à l'origine de l'issue).

## Solution (arbitrage : tap → expansion temporaire 2 lignes)

- Le titre devient un **toggle au tap** : replié (1 ligne, ellipsis) ↔ développé (2 lignes max, ellipsis conservé au-delà).
- La small `TopAppBar` M3 a une **hauteur de conteneur fixe** qui ne grandit pas avec le titre : l'expansion bumpe donc `expandedHeight` (+1 hauteur de ligne `titleMedium`) — API stable du BOM courant, vérifiée via context7. Sans ça, la 2e ligne et la pilule page seraient clippées.
- **Transient par design** : simple `remember` — un changement de page (route replace) ou la sortie de l'écran réinitialisent l'état replié. Contrairement à l'expansion des sondages (#465) qui est hoistée pour survivre au swap.
- Barre en `enterAlways` (réglage auto-hide) : au dépli, reset du `heightOffset` pour re-déployer une barre partiellement repliée — la 2e ligne accordée doit être visible, pas clippée derrière l'offset courant.
- **A11y** : `onClickLabel` (« Afficher le titre complet » / « Réduire le titre ») + `stateDescription` (« Titre développé » / « Titre réduit »).
- La **pilule page garde sa propre cible de tap** (sibling distinct dans le Column) — aucune collision.
- `TopicTopBar` passe de `private` à `internal` pour le test Robolectric (même pattern que `TopicPostCard`).

## Tests

- `TopicTopBarTitleExpandTest` (Robolectric/Compose UI, gabarit `TopicPostCardMultiQuoteTest`) : état initial replié + clickable, tap → développé, re-tap → replié — via le contrat sémantique (`StateDescription`), seule surface observable du flip `maxLines`.
- `:feature:topic:testDebugUnitTest` + `detektAll` verts.

## Dogfood (émulateur Pixel 8)

- Tap titre → 2 lignes complètes (« Redface 2 — DEV (canal de développement) »), pilule intacte, rien de clippé, la liste suit la nouvelle hauteur.
- Re-tap → repli 1 ligne, hauteur normale.
- Tap pilule « page 39 / 39 » → sélecteur de page (non-régression, le titre reste replié).
- Limite : le cas `enterAlways` (auto-hide activé) n'a pas été dogfoodé — couvert par le reset `heightOffset` au dépli, revu au gate.

## Checklist

- [x] Review Codex (gate gpt-5.5 xhigh — verdict dans les commentaires)
- [x] Validation canonique locale (detektAll + lintProdDebug + tests + assembleProdDebug)
