### PR TITLE
chore(release): bump versionName to 0.20.2 (#752 + #772)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,16 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.20.2` — `internal` (dev) — 2026-07-03
+
+**Retours bêta gestes + top bar Topic** (PRs #781, #786 — gates Codex gpt-5.5, dogfoods émulateur).
+
+### Gestes (Drapeaux & Vue Topic)
+- #752 : **zone morte au départ des swipes sur les bandes de gestes système** — un swipe horizontal qui démarre dans la bande latérale (navigation gestuelle) est laissé au geste back système au lieu d'entrer en compétition avec le changement d'onglet (Drapeaux) ou de page (Topic, #282) ; fini la frontière imprévisible au ras du bord. Navigation 3 boutons : comportement strictement inchangé (insets nuls). Bornes clampées contre les insets aberrants (split-screen/foldable).
+
+### Vue Topic
+- #772 (tinc) : **titre dépliable au tap** — le titre tronqué de la top bar se déplie sur 2 lignes au tap (la barre grandit d'une ligne), re-tap ou changement de page le replie ; la pilule « page X / Y » garde sa propre cible (sélecteur de page). Annonces TalkBack dédiées (afficher/réduire + état).
+
 ## `0.20.1` — `internal` (dev) — 2026-07-03
 
 **Quick wins vue Drapeaux — retours bêta 0.18.0** (PRs #776, #777 — cadrage + gate Codex gpt-5.5).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.20.1"
+        versionName = "0.20.2"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,4 +1,4 @@
-Redface 2 v0.20.1 — dev.
+Redface 2 v0.20.2 — dev.
 
-- Flags: the "+read" pill shortcut now works on every tab (Read and Favorites included).
-- Flags: the empty-state text now points at the right action to see read topics again.
+- Gestures: a swipe starting on the system back-gesture band no longer competes with tab or page changes.
+- Topic: tap the truncated top-bar title to reveal it in full (2 lines), tap again to fold it back.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,4 +1,4 @@
-Redface 2 v0.20.1 — dev.
+Redface 2 v0.20.2 — dev.
 
-- Drapeaux : le raccourci « +lus » de la pilule fonctionne sur tous les onglets (Lu et Favoris compris).
-- Drapeaux : le texte de l'état vide pointe la bonne action pour revoir les sujets lus.
+- Gestes : un swipe démarré sur la bande du geste back système n'entre plus en conflit avec le changement d'onglet ou de page.
+- Sujet : tap sur le titre tronqué de la barre du haut pour l'afficher en entier (2 lignes), re-tap pour replier.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump de release dev groupée : #752 (zone morte gestes système, PR #781) + #772 (titre dépliable, PR #786).

- `versionName` 0.20.1 → 0.20.2
- Entrée `app/CHANGELOG.md`
- whatsnew fr/en rafraîchis (version en 1re ligne, garde whatsnew-freshness)

Édit mécanique (bump) — pas de gate Codex, conformément à l'exception de la cadence.