### PR TITLE
feat(topic): quick-reply bottom sheet — Postage lot 1 (#604)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -2401,6 +2401,24 @@ private fun RedfaceNavHost(
                             ),
                         )
                     },
+                    // Vague 4 (#604) lot 1 — a reply POSTed from the quick-reply sheet: same
+                    // refresh contract as the full editor's onSubmitSucceeded below (replace the
+                    // route with targetPage/scrollTo + a bumped submitSignal, #200/#226), minus
+                    // the pop — the sheet never entered the back stack.
+                    onQuickReplySubmitted = { targetPage, scrollTo ->
+                        val topicEntry = backStack.lastOrNull() as? TopicRoute
+                        if (topicEntry != null) {
+                            backStack.removeAt(backStack.lastIndex)
+                            backStack.add(
+                                topicEntry.copy(
+                                    page = targetPage ?: topicEntry.page,
+                                    scrollTo = scrollTo,
+                                    submitSignal = System.currentTimeMillis(),
+                                    postSubmitOverflowLanding = false,
+                                ),
+                            )
+                        }
+                    },
                     onQuote = { subcat, page, quotedNumreponse, quoteRef ->
                         // Phase 2C (#146) — same destination as reply ; only the
                         // editor's request differs (quotedNumreponse pulls the HFR

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySheet.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySheet.kt
@@ -14,12 +14,15 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -53,6 +56,9 @@ internal fun QuickReplySheet(
     )
     val state by viewModel.state.collectAsStateWithLifecycle()
     LaunchedEffect(viewModel) {
+        // Re-seed the field from the #405 row at EACH opening — the VM outlives the sheet and
+        // its cached text can be stale after a full-screen edit of the same draft (gate #788).
+        viewModel.onSheetOpened()
         viewModel.effects.collect { effect ->
             when (effect) {
                 is QuickReplyEffect.SubmitSucceeded -> onSubmitted(effect.targetPage, effect.scrollTo)
@@ -62,10 +68,21 @@ internal fun QuickReplySheet(
     }
     val fullScreenLabel = stringResource(R.string.quick_reply_fullscreen)
     val focusRequester = remember { FocusRequester() }
+    // Gate #788 — the sheet must not dismiss while a POST is in flight: the effect collector
+    // lives here, so tearing the sheet down mid-submit would drop SubmitSucceeded (no topic
+    // refresh) or replay it at the next opening. `submitting` is read through
+    // rememberUpdatedState because both guards below are remembered once.
+    val submitting = rememberUpdatedState(state.isSubmitting)
+    val sheetState = rememberModalBottomSheetState(
+        confirmValueChange = { target -> target != SheetValue.Hidden || !submitting.value },
+    )
     ModalBottomSheet(
+        sheetState = sheetState,
         onDismissRequest = {
-            viewModel.onDismissed()
-            onDismiss()
+            if (!submitting.value) {
+                viewModel.onDismissed()
+                onDismiss()
+            }
         },
     ) {
         Column(
@@ -85,6 +102,8 @@ internal fun QuickReplySheet(
                 )
                 IconButton(
                     onClick = viewModel::onEscalateRequested,
+                    // Gate #788 — no escalation while a POST is in flight (submit vs navigation race).
+                    enabled = !state.isSubmitting,
                     modifier = Modifier.semantics { contentDescription = fullScreenLabel },
                 ) {
                     RedfaceVectorIcon(

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySheet.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySheet.kt
@@ -1,0 +1,162 @@
+package fr.forumhfr.redface2.feature.topic
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
+import fr.forumhfr.redface2.core.ui.icon.RedfaceVectorIcon
+
+/**
+ * Vague 4 (#604) lot 1 — the quick-reply bottom sheet: a plain text field, Send, and a
+ * full-screen escalation affordance. Deliberately NO toolbar, smileys, upload or preview
+ * (cadrage Codex: those stay full-screen until lots 2-4). Local UI affordance — not a nav
+ * route ; the ViewModel is scoped to the topic's nav entry, so the field survives an
+ * accidental dismiss, and the #405 draft row survives everything else.
+ */
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+internal fun QuickReplySheet(
+    request: QuickReplyRequest,
+    onDismiss: () -> Unit,
+    onEscalate: () -> Unit,
+    onSubmitted: (targetPage: Int?, scrollTo: Int?) -> Unit,
+) {
+    val viewModel = hiltViewModel<QuickReplyViewModel, QuickReplyViewModel.Factory>(
+        creationCallback = { factory -> factory.create(request) },
+    )
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    LaunchedEffect(viewModel) {
+        viewModel.effects.collect { effect ->
+            when (effect) {
+                is QuickReplyEffect.SubmitSucceeded -> onSubmitted(effect.targetPage, effect.scrollTo)
+                QuickReplyEffect.EscalateToFullEditor -> onEscalate()
+            }
+        }
+    }
+    val fullScreenLabel = stringResource(R.string.quick_reply_fullscreen)
+    val focusRequester = remember { FocusRequester() }
+    ModalBottomSheet(
+        onDismissRequest = {
+            viewModel.onDismissed()
+            onDismiss()
+        },
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .imePadding()
+                .navigationBarsPadding(),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = stringResource(R.string.quick_reply_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.weight(1f),
+                )
+                IconButton(
+                    onClick = viewModel::onEscalateRequested,
+                    modifier = Modifier.semantics { contentDescription = fullScreenLabel },
+                ) {
+                    RedfaceVectorIcon(
+                        resId = fr.forumhfr.redface2.core.ui.R.drawable.ic_ms_open_in_new,
+                    )
+                }
+            }
+            OutlinedTextField(
+                value = state.text,
+                onValueChange = viewModel::onTextChanged,
+                enabled = !state.isSubmitting,
+                placeholder = { Text(stringResource(R.string.quick_reply_hint)) },
+                minLines = 3,
+                maxLines = 6,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester),
+            )
+            state.submitError?.let { error ->
+                Text(
+                    text = stringResource(error.messageRes()),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (state.isSubmitting) {
+                    CircularProgressIndicator(modifier = Modifier.padding(end = 12.dp))
+                }
+                TextButton(
+                    onClick = viewModel::onSubmitClicked,
+                    enabled = state.canSubmit,
+                ) {
+                    Text(stringResource(R.string.quick_reply_send))
+                }
+            }
+        }
+    }
+    // The field grabs the focus once per sheet opening — the IME rises with the sheet.
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+    if (state.confirmVisible) {
+        AlertDialog(
+            onDismissRequest = viewModel::onSubmitConfirmDismissed,
+            title = { Text(stringResource(R.string.quick_reply_confirm_title)) },
+            confirmButton = {
+                TextButton(onClick = viewModel::onSubmitConfirmed) {
+                    Text(stringResource(R.string.quick_reply_confirm_action))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = viewModel::onSubmitConfirmDismissed) {
+                    Text(stringResource(R.string.quick_reply_confirm_cancel))
+                }
+            },
+        )
+    }
+}
+
+/** The same wording as the full editor's error banner, module-local copies (feature/topic res). */
+internal fun QuickReplySubmitError.messageRes(): Int = when (this) {
+    QuickReplySubmitError.Network -> R.string.quick_reply_error_network
+    QuickReplySubmitError.SessionExpired -> R.string.quick_reply_error_session_expired
+    is QuickReplySubmitError.Hfr -> when (reason) {
+        ReplyFailureReason.EmptyMessage -> R.string.quick_reply_error_empty
+        ReplyFailureReason.InvalidHashCheck -> R.string.quick_reply_error_invalid_hash
+        ReplyFailureReason.AntiFlood -> R.string.quick_reply_error_anti_flood
+        ReplyFailureReason.TopicLocked -> R.string.quick_reply_error_topic_locked
+        ReplyFailureReason.LoginRequired -> R.string.quick_reply_error_login_required
+        ReplyFailureReason.Unknown -> R.string.quick_reply_error_unknown
+    }
+}

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModel.kt
@@ -118,21 +118,33 @@ class QuickReplyViewModel @AssistedInject constructor(
     /** #312 — mirror of the persisted « Confirmation avant publication » preference. */
     private var confirmBeforePosting: Boolean = false
 
+    /** Owner snapshot + form warm-up ; joined by every draft read/write so they never race it. */
+    private val initJob: Job = viewModelScope.launch {
+        draftOwner = draftStore.currentOwner()
+        prefetchForm()
+    }
+
     init {
         viewModelScope.launch {
             userPreferencesRepository.observeConfirmBeforePosting().collect { enabled ->
                 confirmBeforePosting = enabled
             }
         }
+    }
+
+    /**
+     * Called at EACH sheet opening (not just the first): the VM outlives the sheet, so its
+     * in-memory text can go stale whenever another surface touched the shared #405 row —
+     * typically escalate → edit in the full-screen editor → back → reopen. The row is the
+     * source of truth ; the field is unconditionally re-seeded from it (gate Codex PR #788).
+     */
+    fun onSheetOpened() {
         viewModelScope.launch {
-            draftOwner = draftStore.currentOwner()
-            val body = draftStore.load(draftOwner, draftKey)?.body
-            if (!body.isNullOrBlank() && _state.value.text.text.isBlank()) {
-                _state.update {
-                    it.copy(text = TextFieldValue(text = body, selection = TextRange(body.length)))
-                }
+            initJob.join()
+            val body = draftStore.load(draftOwner, draftKey)?.body.orEmpty()
+            _state.update {
+                it.copy(text = TextFieldValue(text = body, selection = TextRange(body.length)))
             }
-            prefetchForm()
         }
     }
 
@@ -191,6 +203,7 @@ class QuickReplyViewModel @AssistedInject constructor(
     }
 
     private suspend fun saveDraftNow() {
+        initJob.join()
         val body = _state.value.text.text
         if (body.isBlank()) {
             draftStore.delete(draftOwner, draftKey)

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModel.kt
@@ -1,0 +1,281 @@
+package fr.forumhfr.redface2.feature.topic
+
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
+import fr.forumhfr.redface2.core.domain.editor.EditorDraftKey
+import fr.forumhfr.redface2.core.domain.editor.EditorDraftStore
+import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
+import fr.forumhfr.redface2.core.domain.write.ReplyRepository
+import fr.forumhfr.redface2.core.model.write.ReplyContext
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
+import fr.forumhfr.redface2.core.model.write.ReplyForm
+import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
+import java.io.IOException
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/** Vague 4 (#604) lot 1 — everything the quick-reply sheet needs to talk to HFR for one topic. */
+data class QuickReplyRequest(
+    val cat: Int,
+    val subcat: Int,
+    val topicId: Int,
+    val page: Int,
+)
+
+/** UI state of the quick-reply sheet. [text] is the whole contract — no toolbar, no preview. */
+data class QuickReplyUiState(
+    val text: TextFieldValue = TextFieldValue(""),
+    val isSubmitting: Boolean = false,
+    val submitError: QuickReplySubmitError? = null,
+    /** #312 — « Confirmation avant publication » : the pending-confirmation dialog is showing. */
+    val confirmVisible: Boolean = false,
+) {
+    val canSubmit: Boolean get() = text.text.isNotBlank() && !isSubmitting
+}
+
+/** Typed submit failures, the same split as the full editor's `SubmitError`. */
+sealed interface QuickReplySubmitError {
+    data class Hfr(val reason: ReplyFailureReason) : QuickReplySubmitError
+    data object Network : QuickReplySubmitError
+    data object SessionExpired : QuickReplySubmitError
+}
+
+/** One-shot events consumed by the sheet composable. */
+sealed interface QuickReplyEffect {
+    /** HFR accepted the reply — refresh the topic like the full editor does (#200). */
+    data class SubmitSucceeded(val targetPage: Int?, val scrollTo: Int?) : QuickReplyEffect
+
+    /**
+     * The draft is persisted — the sheet can hand over to the full-screen editor. Emitted only
+     * AFTER the save completed: the full editor restores the SAME `EditorDraftKey.reply` row,
+     * so the ordering is the whole transfer mechanism (cadrage Codex vague 4 : never a long
+     * text in a route arg, never a memory-only holder).
+     */
+    data object EscalateToFullEditor : QuickReplyEffect
+}
+
+/**
+ * Vague 4 (#604) lot 1 — the THIN ViewModel behind [QuickReplySheet]. Deliberately a fraction of
+ * `PostEditorViewModel` (cadrage Codex : do not reuse it — its surface co-locates smileys, image
+ * upload, previews and edit mode) : plain text in, [ReplyRepository] out, plus the #405 draft
+ * contract shared with the full editor.
+ *
+ * Draft sharing IS the sheet↔full-screen transfer: both surfaces read and write the same
+ * [EditorDraftKey.reply] row. One deliberate divergence from the full editor — the sheet
+ * AUTO-applies a cached draft into the field instead of surfacing a restore banner: the sheet is
+ * the « resume quickly » surface, and its dirty-close contract (autosave, never a silent loss)
+ * means the field content and the row are the same thing.
+ */
+@HiltViewModel(assistedFactory = QuickReplyViewModel.Factory::class)
+class QuickReplyViewModel @AssistedInject constructor(
+    @Assisted private val request: QuickReplyRequest,
+    private val replyRepository: ReplyRepository,
+    private val draftStore: EditorDraftStore,
+    userPreferencesRepository: UserPreferencesRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(QuickReplyUiState())
+    val state: StateFlow<QuickReplyUiState> = _state.asStateFlow()
+
+    private val _effects: Channel<QuickReplyEffect> = Channel(capacity = Channel.BUFFERED)
+    val effects: Flow<QuickReplyEffect> = _effects.receiveAsFlow()
+
+    private val context = ReplyContext(
+        cat = request.cat,
+        subcat = request.subcat,
+        topicId = request.topicId,
+        page = request.page,
+    )
+
+    /** Same lifecycle as the full editor : hash_check stays here, never in the Compose state. */
+    private var loadedForm: ReplyForm? = null
+    private var formJob: Job? = null
+    private var submitJob: Job? = null
+    private var autosaveJob: Job? = null
+
+    /** #405 — the SAME key the full-screen reply editor uses for this topic. */
+    private val draftKey: String = EditorDraftKey.reply(request.cat, request.topicId)
+
+    /** #405 — account snapshotted at open so a mid-edit switch can't cross-write drafts. */
+    private var draftOwner: String? = null
+
+    /** #312 — mirror of the persisted « Confirmation avant publication » preference. */
+    private var confirmBeforePosting: Boolean = false
+
+    init {
+        viewModelScope.launch {
+            userPreferencesRepository.observeConfirmBeforePosting().collect { enabled ->
+                confirmBeforePosting = enabled
+            }
+        }
+        viewModelScope.launch {
+            draftOwner = draftStore.currentOwner()
+            val body = draftStore.load(draftOwner, draftKey)?.body
+            if (!body.isNullOrBlank() && _state.value.text.text.isBlank()) {
+                _state.update {
+                    it.copy(text = TextFieldValue(text = body, selection = TextRange(body.length)))
+                }
+            }
+            prefetchForm()
+        }
+    }
+
+    fun onTextChanged(value: TextFieldValue) {
+        _state.update { it.copy(text = value, submitError = null) }
+        scheduleAutosave()
+    }
+
+    /** #312 gate first ; the actual POST happens in [submit]. */
+    fun onSubmitClicked() {
+        if (!_state.value.canSubmit) return
+        if (confirmBeforePosting) {
+            _state.update { it.copy(confirmVisible = true) }
+        } else {
+            submit()
+        }
+    }
+
+    fun onSubmitConfirmed() {
+        _state.update { it.copy(confirmVisible = false) }
+        submit()
+    }
+
+    fun onSubmitConfirmDismissed() {
+        _state.update { it.copy(confirmVisible = false) }
+    }
+
+    /**
+     * Persist the draft NOW (cancelling the pending debounce), then hand over to the full-screen
+     * editor. The effect is emitted only after the save completed — see [QuickReplyEffect.EscalateToFullEditor].
+     */
+    fun onEscalateRequested() {
+        autosaveJob?.cancel()
+        viewModelScope.launch {
+            saveDraftNow()
+            _effects.send(QuickReplyEffect.EscalateToFullEditor)
+        }
+    }
+
+    /**
+     * Dirty close — flush the pending debounce so the last keystrokes reach the row (the sheet
+     * preserves, it never asks) ; runs in [viewModelScope], which outlives the sheet (the VM is
+     * scoped to the topic's nav entry).
+     */
+    fun onDismissed() {
+        autosaveJob?.cancel()
+        viewModelScope.launch { saveDraftNow() }
+    }
+
+    private fun scheduleAutosave() {
+        autosaveJob?.cancel()
+        autosaveJob = viewModelScope.launch {
+            delay(AUTOSAVE_DEBOUNCE_MS)
+            saveDraftNow()
+        }
+    }
+
+    private suspend fun saveDraftNow() {
+        val body = _state.value.text.text
+        if (body.isBlank()) {
+            draftStore.delete(draftOwner, draftKey)
+        } else {
+            draftStore.save(draftOwner, draftKey, EditorDraftStore.Draft(body = body))
+        }
+    }
+
+    /** Warm the hash_check early so the first submit doesn't pay the GET ; errors stay silent. */
+    private fun prefetchForm() {
+        if (loadedForm != null || formJob?.isActive == true) return
+        formJob = viewModelScope.launch {
+            loadedForm = runCatching { replyRepository.fetchReplyForm(context) }.getOrNull()
+        }
+    }
+
+    private fun submit() {
+        if (submitJob?.isActive == true) return
+        _state.update { it.copy(isSubmitting = true, submitError = null) }
+        submitJob = viewModelScope.launch {
+            val outcome = runCatching {
+                val form = loadedForm ?: replyRepository.fetchReplyForm(context).also { loadedForm = it }
+                replyRepository.submitReply(
+                    context = context,
+                    form = form,
+                    bbcodeContent = _state.value.text.text,
+                    options = form.options,
+                )
+            }
+            outcome.fold(
+                onSuccess = { result -> handleSubmitOutcome(result) },
+                onFailure = ::handleSubmitFailure,
+            )
+        }
+    }
+
+    private suspend fun handleSubmitOutcome(result: ReplySubmitResult) {
+        when (result) {
+            is ReplySubmitResult.Success -> {
+                // Same contract as the full editor: the draft dies with the successful POST,
+                // awaited so a process death cannot resurrect an already-published reply.
+                autosaveJob?.cancel()
+                draftStore.delete(draftOwner, draftKey)
+                _state.update { QuickReplyUiState() }
+                _effects.send(
+                    QuickReplyEffect.SubmitSucceeded(
+                        targetPage = result.targetPage,
+                        scrollTo = result.numreponse,
+                    ),
+                )
+            }
+            is ReplySubmitResult.Failure -> {
+                // InvalidHashCheck = the cached form expired mid-edit ; silently refetch so the
+                // user's next tap works (mirrors PostEditorViewModel.handleSubmitOutcome).
+                if (result.reason == ReplyFailureReason.InvalidHashCheck) {
+                    loadedForm = null
+                    prefetchForm()
+                }
+                _state.update {
+                    it.copy(isSubmitting = false, submitError = QuickReplySubmitError.Hfr(result.reason))
+                }
+            }
+        }
+    }
+
+    private fun handleSubmitFailure(error: Throwable) {
+        if (error is CancellationException) {
+            _state.update { it.copy(isSubmitting = false) }
+            throw error
+        }
+        val mapped = when (error) {
+            is SessionExpiredException -> QuickReplySubmitError.SessionExpired
+            is IOException -> QuickReplySubmitError.Network
+            else -> QuickReplySubmitError.Hfr(ReplyFailureReason.Unknown)
+        }
+        _state.update { it.copy(isSubmitting = false, submitError = mapped) }
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(request: QuickReplyRequest): QuickReplyViewModel
+    }
+
+    private companion object {
+        /** Same debounce as the other #405 consumers. */
+        const val AUTOSAVE_DEBOUNCE_MS = 750L
+    }
+}

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -132,6 +132,13 @@ fun TopicScreen(
      */
     onReply: (subcat: Int, page: Int) -> Unit,
     /**
+     * Vague 4 (#604) lot 1 — HFR accepted a reply POSTed from the quick-reply sheet. `:app` must
+     * refresh this topic route exactly like the full editor's onSubmitSucceeded (replace the route
+     * with `targetPage`/`scrollTo` and a bumped `submitSignal`, #200) — minus the editor pop,
+     * since the sheet never entered the back stack.
+     */
+    onQuickReplySubmitted: (targetPage: Int?, scrollTo: Int?) -> Unit = { _, _ -> },
+    /**
      * Open the editor in quote mode (Phase 2C, #146). Same destination as [onReply],
      * but the editor GETs HFR's quote form and hydrates the draft with the
      * `[quotemsg=…]` block HFR prefills. The call-site supplies
@@ -451,6 +458,7 @@ fun TopicScreen(
         onIntent = viewModel::send,
         onBack = onBack,
         onReply = onReply,
+        onQuickReplySubmitted = onQuickReplySubmitted,
         onQuote = onQuote,
         onEdit = onEdit,
         onEditFirstPost = onEditFirstPost,
@@ -698,6 +706,9 @@ internal fun TopicContent(
     // the callback recording a tap on the poll card. Threaded to the header card's poll.
     pollManualExpanded: Boolean? = null,
     onPollExpansionChanged: (Boolean) -> Unit = {},
+    // Vague 4 (#604) lot 1 — HFR accepted a quick-reply POST: `:app` refreshes the topic route the
+    // same way the full editor's onSubmitSucceeded does (bumped submitSignal, #200), minus the pop.
+    onQuickReplySubmitted: (targetPage: Int?, scrollTo: Int?) -> Unit = { _, _ -> },
 ) {
     // #285 — the topic title and #284 — the page counter live in a persistent top app bar so they
     // stay visible while the user scrolls (the in-card title/caption scrolls away). While loading,
@@ -726,6 +737,10 @@ internal fun TopicContent(
     } else {
         null
     }
+    // Vague 4 (#604) lot 1 — the reply FAB opens the quick-reply sheet instead of navigating ;
+    // the sheet escalates to the full-screen editor through the existing onReply. Local UI state
+    // (like the page picker) : non-null while the sheet is up, carrying the reply coordinates.
+    var quickReplyFor by remember { mutableStateOf<QuickReplyRequest?>(null) }
     Scaffold(
         modifier = if (scrollBehavior != null) {
             Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
@@ -752,7 +767,14 @@ internal fun TopicContent(
                 bottomActionsVisible = bottomActionsVisible,
                 multiQuoteSelection = multiQuoteSelection,
                 onOpenPage = onOpenPage,
-                onReply = onReply,
+                onReply = { subcat, page ->
+                    quickReplyFor = QuickReplyRequest(
+                        cat = state.request.cat,
+                        subcat = subcat,
+                        topicId = state.request.post,
+                        page = page,
+                    )
+                },
                 onMultiQuote = onMultiQuote,
             )
         },
@@ -834,6 +856,20 @@ internal fun TopicContent(
                 }
             }
         }
+    }
+    quickReplyFor?.let { replyRequest ->
+        QuickReplySheet(
+            request = replyRequest,
+            onDismiss = { quickReplyFor = null },
+            onEscalate = {
+                quickReplyFor = null
+                onReply(replyRequest.subcat, replyRequest.page)
+            },
+            onSubmitted = { targetPage, scrollTo ->
+                quickReplyFor = null
+                onQuickReplySubmitted(targetPage, scrollTo)
+            },
+        )
     }
 }
 

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -121,4 +121,22 @@
     <string name="topic_title_collapse">Réduire le titre</string>
     <string name="topic_title_expanded">Titre développé</string>
     <string name="topic_title_collapsed">Titre réduit</string>
+    <!-- Vague 4 (#604) lot 1 : feuille de réponse rapide. Wording d'erreurs = copie locale de
+         feature/editor (les modules res ne se partagent pas ; promotion :core:ui si un 3e copieur
+         apparaît). -->
+    <string name="quick_reply_title">Réponse rapide</string>
+    <string name="quick_reply_hint">Votre message…</string>
+    <string name="quick_reply_send">Envoyer</string>
+    <string name="quick_reply_fullscreen">Ouvrir l\'éditeur plein écran</string>
+    <string name="quick_reply_confirm_title">Publier la réponse ?</string>
+    <string name="quick_reply_confirm_action">Publier</string>
+    <string name="quick_reply_confirm_cancel">Annuler</string>
+    <string name="quick_reply_error_empty">Message vide. HFR refuse les réponses sans contenu.</string>
+    <string name="quick_reply_error_invalid_hash">Session HFR expirée pendant la saisie. Réessayez ; le formulaire est rechargé en arrière-plan.</string>
+    <string name="quick_reply_error_anti_flood">Anti-flood HFR : pas plus de 3 réponses consécutives par tranche de 10 minutes. Réessayez plus tard.</string>
+    <string name="quick_reply_error_topic_locked">Ce sujet a été fermé. Impossible de poster une réponse.</string>
+    <string name="quick_reply_error_login_required">Vous devez être connecté pour répondre. Reconnectez-vous depuis l\'onglet Messages.</string>
+    <string name="quick_reply_error_unknown">HFR a renvoyé une réponse inattendue. Réessayez ou actualisez l\'app.</string>
+    <string name="quick_reply_error_network">Erreur réseau. Vérifiez votre connexion et réessayez.</string>
+    <string name="quick_reply_error_session_expired">Votre session HFR a expiré. Reconnectez-vous.</string>
 </resources>

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModelTest.kt
@@ -44,12 +44,32 @@ class QuickReplyViewModelTest {
     }
 
     @Test
-    fun `a cached draft is auto-applied into the field on open`() = runTest {
+    fun `opening the sheet seeds the field from the draft row`() = runTest {
         val store = FakeQuickReplyDraftStore(initialBody = "brouillon en cours")
-
         val viewModel = quickReplyViewModel(draftStore = store)
 
+        viewModel.onSheetOpened()
+        advanceUntilIdle()
+
         assertEquals("brouillon en cours", viewModel.state.value.text.text)
+    }
+
+    @Test
+    fun `reopening the sheet re-seeds the field after the row changed elsewhere`() = runTest {
+        // Gate #788 — the VM outlives the sheet: escalate → the full-screen editor rewrites the
+        // shared #405 row → back → reopen. The row must win over the VM's cached text.
+        val store = FakeQuickReplyDraftStore()
+        val viewModel = quickReplyViewModel(draftStore = store)
+        viewModel.onSheetOpened()
+        viewModel.onTextChanged(TextFieldValue("version sheet"))
+        viewModel.onEscalateRequested()
+        advanceUntilIdle()
+
+        store.storedBody = "version plein écran"
+        viewModel.onSheetOpened()
+        advanceUntilIdle()
+
+        assertEquals("version plein écran", viewModel.state.value.text.text)
     }
 
     @Test

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModelTest.kt
@@ -1,0 +1,232 @@
+package fr.forumhfr.redface2.feature.topic
+
+import androidx.compose.ui.text.input.TextFieldValue
+import fr.forumhfr.redface2.core.domain.editor.EditorDraftStore
+import fr.forumhfr.redface2.core.domain.write.ReplyRepository
+import fr.forumhfr.redface2.core.model.write.ReplyContext
+import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
+import fr.forumhfr.redface2.core.model.write.ReplyForm
+import fr.forumhfr.redface2.core.model.write.ReplyFormOptions
+import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Vague 4 (#604) lot 1 — the quick-reply sheet's thin ViewModel. The pinned contracts: the #405
+ * draft row is the sheet↔full-screen transfer (auto-applied on open, flushed on dismiss, written
+ * BEFORE the escalation effect), the POST path mirrors the full editor's typed outcomes, and the
+ * #312 confirmation preference gates the POST behind the dialog.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class QuickReplyViewModelTest {
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `a cached draft is auto-applied into the field on open`() = runTest {
+        val store = FakeQuickReplyDraftStore(initialBody = "brouillon en cours")
+
+        val viewModel = quickReplyViewModel(draftStore = store)
+
+        assertEquals("brouillon en cours", viewModel.state.value.text.text)
+    }
+
+    @Test
+    fun `typing autosaves the body after the debounce`() = runTest {
+        val store = FakeQuickReplyDraftStore()
+        val viewModel = quickReplyViewModel(draftStore = store)
+
+        viewModel.onTextChanged(TextFieldValue("réponse en cours de frappe"))
+        assertTrue(store.savedBodies.isEmpty())
+        advanceTimeBy(AUTOSAVE_DEBOUNCE_PLUS_MS)
+
+        assertEquals(listOf("réponse en cours de frappe"), store.savedBodies)
+    }
+
+    @Test
+    fun `a successful submit deletes the draft, resets the field and emits the refresh effect`() = runTest {
+        val store = FakeQuickReplyDraftStore()
+        val repository = FakeQuickReplyRepository(
+            results = mutableListOf(ReplySubmitResult.Success(refreshUrl = null, targetPage = 12, numreponse = 345)),
+        )
+        val viewModel = quickReplyViewModel(replyRepository = repository, draftStore = store)
+        viewModel.onTextChanged(TextFieldValue("hop"))
+
+        viewModel.onSubmitClicked()
+        advanceUntilIdle()
+
+        val effect = viewModel.effects.first()
+        assertEquals(QuickReplyEffect.SubmitSucceeded(targetPage = 12, scrollTo = 345), effect)
+        assertEquals("", viewModel.state.value.text.text)
+        assertNull(store.storedBody)
+        assertEquals(listOf("hop"), repository.submittedBodies)
+    }
+
+    @Test
+    fun `a typed HFR failure surfaces the error and keeps the draft`() = runTest {
+        val store = FakeQuickReplyDraftStore()
+        val repository = FakeQuickReplyRepository(
+            results = mutableListOf(ReplySubmitResult.Failure(ReplyFailureReason.AntiFlood)),
+        )
+        val viewModel = quickReplyViewModel(replyRepository = repository, draftStore = store)
+        viewModel.onTextChanged(TextFieldValue("flood"))
+        advanceTimeBy(AUTOSAVE_DEBOUNCE_PLUS_MS)
+
+        viewModel.onSubmitClicked()
+        advanceUntilIdle()
+
+        assertEquals(
+            QuickReplySubmitError.Hfr(ReplyFailureReason.AntiFlood),
+            viewModel.state.value.submitError,
+        )
+        assertEquals("flood", viewModel.state.value.text.text)
+        assertEquals("flood", store.storedBody)
+    }
+
+    @Test
+    fun `an expired hash_check silently refetches the form for the next attempt`() = runTest {
+        val repository = FakeQuickReplyRepository(
+            results = mutableListOf(ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)),
+        )
+        val viewModel = quickReplyViewModel(replyRepository = repository)
+        viewModel.onTextChanged(TextFieldValue("texte"))
+        advanceUntilIdle() // init prefetch = 1st fetch
+
+        viewModel.onSubmitClicked()
+        advanceUntilIdle()
+
+        assertEquals(
+            QuickReplySubmitError.Hfr(ReplyFailureReason.InvalidHashCheck),
+            viewModel.state.value.submitError,
+        )
+        // 1 prefetch at open + 1 silent refetch after the expired hash.
+        assertEquals(2, repository.fetchCalls)
+    }
+
+    @Test
+    fun `escalation persists the draft before emitting the hand-over effect`() = runTest {
+        val store = FakeQuickReplyDraftStore()
+        val viewModel = quickReplyViewModel(draftStore = store)
+        viewModel.onTextChanged(TextFieldValue("à finir en plein écran"))
+
+        viewModel.onEscalateRequested()
+        val effect = viewModel.effects.first()
+
+        // The effect is only emitted once the row is written — the full editor restores it.
+        assertEquals(QuickReplyEffect.EscalateToFullEditor, effect)
+        assertEquals("à finir en plein écran", store.storedBody)
+    }
+
+    @Test
+    fun `dismiss flushes the pending autosave debounce`() = runTest {
+        val store = FakeQuickReplyDraftStore()
+        val viewModel = quickReplyViewModel(draftStore = store)
+        viewModel.onTextChanged(TextFieldValue("frappe interrompue"))
+        assertTrue(store.savedBodies.isEmpty())
+
+        viewModel.onDismissed()
+        advanceUntilIdle()
+
+        assertEquals("frappe interrompue", store.storedBody)
+    }
+
+    @Test
+    fun `confirm-before-posting gates the POST behind the dialog`() = runTest {
+        val repository = FakeQuickReplyRepository(
+            results = mutableListOf(ReplySubmitResult.Success(refreshUrl = null, targetPage = null)),
+        )
+        val viewModel = quickReplyViewModel(replyRepository = repository, confirmBeforePosting = true)
+        viewModel.onTextChanged(TextFieldValue("sûr ?"))
+
+        viewModel.onSubmitClicked()
+        assertTrue(viewModel.state.value.confirmVisible)
+        assertEquals(0, repository.submitCalls)
+
+        viewModel.onSubmitConfirmed()
+        advanceUntilIdle()
+        assertEquals(1, repository.submitCalls)
+    }
+
+    private fun quickReplyViewModel(
+        replyRepository: ReplyRepository = FakeQuickReplyRepository(),
+        draftStore: EditorDraftStore = FakeQuickReplyDraftStore(),
+        confirmBeforePosting: Boolean = false,
+    ): QuickReplyViewModel = QuickReplyViewModel(
+        request = QuickReplyRequest(cat = 23, subcat = 401, topicId = 35421, page = 3),
+        replyRepository = replyRepository,
+        draftStore = draftStore,
+        userPreferencesRepository = FakeUserPreferencesRepository(confirmBeforePosting = confirmBeforePosting),
+    )
+
+    private companion object {
+        /** Just past QuickReplyViewModel's 750 ms debounce. */
+        const val AUTOSAVE_DEBOUNCE_PLUS_MS = 751L
+    }
+}
+
+private class FakeQuickReplyDraftStore(
+    initialBody: String? = null,
+    private val owner: String? = "xaat",
+) : EditorDraftStore {
+    var storedBody: String? = initialBody
+    val savedBodies = mutableListOf<String>()
+
+    override suspend fun currentOwner(): String? = owner
+
+    override suspend fun load(owner: String?, key: String): EditorDraftStore.Draft? =
+        storedBody?.let { EditorDraftStore.Draft(body = it) }
+
+    override suspend fun save(owner: String?, key: String, draft: EditorDraftStore.Draft) {
+        storedBody = draft.body
+        savedBodies += draft.body
+    }
+
+    override suspend fun delete(owner: String?, key: String) {
+        storedBody = null
+    }
+}
+
+private class FakeQuickReplyRepository(
+    private val results: MutableList<ReplySubmitResult> = mutableListOf(),
+) : ReplyRepository {
+    var fetchCalls = 0
+    var submitCalls = 0
+    val submittedBodies = mutableListOf<String>()
+
+    override suspend fun fetchReplyForm(context: ReplyContext): ReplyForm {
+        fetchCalls++
+        return ReplyForm(hashCheck = "hash", sujet = "sujet", hiddenFields = emptyMap(), isAnonymous = false)
+    }
+
+    override suspend fun submitReply(
+        context: ReplyContext,
+        form: ReplyForm,
+        bbcodeContent: String,
+        options: ReplyFormOptions,
+    ): ReplySubmitResult {
+        submitCalls++
+        submittedBodies += bbcodeContent
+        return results.removeFirstOrNull() ?: ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
+    }
+}

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -2114,11 +2114,13 @@ private class FakeStreamingTopicRepository(
  * DataStore default so the fake stays a thin stand-in. The relevant values are
  * constructor-injectable so tests can assert they reach state.
  */
-private class FakeUserPreferencesRepository(
+// Internal (not private) so QuickReplyViewModelTest reuses the single fake of this wide interface.
+internal class FakeUserPreferencesRepository(
     private val topicTopBarAutoHide: Boolean = false,
     private val topicPageFabs: Boolean = true,
     private val topicPollsExpanded: Boolean = false,
     private val topicSignatures: Boolean = false,
+    private val confirmBeforePosting: Boolean = false,
 ) : UserPreferencesRepository {
     override fun observeProxyConfig(): Flow<ProxyConfig> = MutableStateFlow(ProxyConfig())
 
@@ -2173,7 +2175,7 @@ private class FakeUserPreferencesRepository(
     override suspend fun setTopicTopBarAutoHide(enabled: Boolean) = Unit
 
     // #312 — confirm-before-posting is irrelevant to TopicViewModel; stubbed at its default.
-    override fun observeConfirmBeforePosting(): Flow<Boolean> = MutableStateFlow(false)
+    override fun observeConfirmBeforePosting(): Flow<Boolean> = MutableStateFlow(confirmBeforePosting)
 
     override suspend fun setConfirmBeforePosting(enabled: Boolean) = Unit
 


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Vague 4 « Postage » de #604 — **lot 1 : QuickReplySheet MVP + socle d'état**, conformément au cadrage Codex (« OK avec ajustements ») et au GO de XaTriX sur les mockups v2 (retours fil DEV : nicko « c'est magnifique », zéro critique).

## Ce que fait ce lot

Le FAB ✎ ouvre désormais une **bottom sheet de réponse rapide** (champ texte + Envoyer + affordance plein écran) au lieu de naviguer directement vers l'éditeur. Périmètre volontairement minimal : **pas** de citations, upload, smileys ni aperçu — lots 2-4.

## Socle d'état (le cœur du lot)

- **Le contrat #405 EST le transfert** : la sheet et l'éditeur plein écran partagent la même ligne `EditorDraftKey.reply(cat, topicId)`. L'escalade **persiste le draft puis seulement émet l'effet** de hand-over — le plein écran retrouve le texte par sa bannière de restauration existante. Jamais de texte long en route arg, jamais de holder mémoire seul (process death ≠ perte).
- **Dirty close sans perte silencieuse** : autosave debounced 750 ms (même valeur que les autres consommateurs #405) + flush au dismiss. La sheet **auto-applique** un brouillon existant à l'ouverture — divergence délibérée avec la bannière du plein écran, documentée dans le KDoc (la sheet est la surface « reprendre vite »).
- **QuickReplyViewModel mince** (cadrage : ne PAS réutiliser PostEditorViewModel) : `ReplyRepository` + `EditorDraftStore` + une préférence. Template `PrivateMessageReplyViewModel`. Erreurs typées identiques au plein écran (anti-flood, sujet fermé, login, hash expiré avec refetch silencieux), gate #312 « confirmation avant publication » respectée (dialogue local).
- **Refresh post-envoi** : `:app` remplace la TopicRoute avec `submitSignal` bumpé + `targetPage`/`scrollTo` — même contrat #200/#226 que le plein écran, moins le pop (la sheet n'entre jamais dans la back stack).
- **Bypass-ready** : le point d'entrée (lambda du FAB) pourra consulter une préférence « toujours plein écran » sans refactor.

## Tests

- `QuickReplyViewModelTest` (8 tests) : auto-restore à l'ouverture, autosave debounced, succès (delete + reset + effet), échec typé (draft conservé), hash expiré → refetch silencieux, **escalade = save avant effet**, flush au dismiss, gate #312.
- `FakeUserPreferencesRepository` passé `internal` (+ param confirm) pour partager l'unique fake de cette interface large entre les deux tests de VM.
- `:feature:topic:testDebugUnitTest` + `detektAll` + `:app:compileDevDebugKotlin` verts.

## Dogfood émulateur (IME dès le lot 1, exigence du cadrage)

- FAB ✎ → sheet, **clavier levé, champ focus**, « Envoyer » désactivé à vide, `imePadding` correct (rien sous le clavier).
- Saisie → tap plein écran → l'éditeur s'ouvre, **bannière « brouillon retrouvé » → Restaurer → texte intact** (transfert prouvé de bout en bout).
- Back → FAB ✎ → la sheet **retrouve le texte**.
- Non testé en réel : le POST effectif depuis la sheet (même `submitReply` éprouvé que le plein écran ; pas de post de test sur le fil DEV public).

## Checklist

- [x] Cadrage Codex (vague 4, verdict « OK avec ajustements » — appliqué)
- [x] Review Codex (gate gpt-5.5 xhigh — verdict dans les commentaires)
- [x] Validation canonique locale (detektAll + lintProdDebug + tests + assembleProdDebug)
