### PR TITLE
chore(release): bump versionName to 0.21.0 (Postage lot 1)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,13 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.21.0` — `internal` (dev) — 2026-07-03
+
+**Phase « Vue Topic » (#604) — vague 4 « Postage », lot 1** (PR #788 — cadrage + gate Codex gpt-5.5 NO-GO→fixes→GO, dogfood IME émulateur).
+
+### Vue Topic
+- **Réponse rapide en feuille** : le bouton ✎ ouvre une bottom sheet (champ texte, Envoyer, bouton plein écran) au lieu de l'éditeur complet. Le brouillon est partagé avec l'éditeur plein écran (#405) : l'escalade transfère le texte, la fermeture ne perd jamais la saisie (autosave), la réouverture reprend où on en était. Erreurs typées (anti-flood, sujet fermé, session) et « Confirmation avant publication » (#312) respectées. Citations, upload et smileys restent en plein écran (lots 2-4 à venir).
+
 ## `0.20.2` — `internal` (dev) — 2026-07-03
 
 **Retours bêta gestes + top bar Topic** (PRs #781, #786 — gates Codex gpt-5.5, dogfoods émulateur).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.20.2"
+        versionName = "0.21.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,4 +1,3 @@
-Redface 2 v0.20.2 — dev.
+Redface 2 v0.21.0 — dev.
 
-- Gestures: a swipe starting on the system back-gesture band no longer competes with tab or page changes.
-- Topic: tap the truncated top-bar title to reveal it in full (2 lines), tap again to fold it back.
+- Topic: quick reply sheet — the reply button opens a lightweight field (send directly or switch to full screen, shared draft, nothing is lost on close).

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,4 +1,3 @@
-Redface 2 v0.20.2 — dev.
+Redface 2 v0.21.0 — dev.
 
-- Gestes : un swipe démarré sur la bande du geste back système n'entre plus en conflit avec le changement d'onglet ou de page.
-- Sujet : tap sur le titre tronqué de la barre du haut pour l'afficher en entier (2 lignes), re-tap pour replier.
+- Sujet : réponse rapide en feuille — le bouton répondre ouvre un champ léger (envoi direct ou bascule plein écran, brouillon partagé, rien ne se perd à la fermeture).


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump de release dev : vague 4 Postage lot 1 (QuickReplySheet, PR #788) — mise en dogfood communautaire.

- `versionName` 0.20.2 → 0.21.0 (nouvelle feature visible = bump minor, même logique que 0.19/0.20 par vague)
- Entrée `app/CHANGELOG.md` + whatsnew fr/en (version en 1re ligne)

Édit mécanique (bump) — pas de gate Codex, conformément à l'exception de la cadence.