### PR TITLE
feat(write): quote-preview model + shared materializer — Postage lot 2 PR A (#604)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -97,6 +97,7 @@ import fr.forumhfr.redface2.BuildConfig
 import fr.forumhfr.redface2.R
 import fr.forumhfr.redface2.core.ui.R as CoreUiR
 import fr.forumhfr.redface2.core.model.AuthState
+import fr.forumhfr.redface2.core.model.write.QuotedPostPreview
 import fr.forumhfr.redface2.core.model.messages.PrivateMessageSummary
 import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.shouldRevealNavBar
@@ -1312,8 +1313,8 @@ fun RedfaceApp(intent: Intent?) {
                         ),
                         multiQuoteNavState = MultiQuoteNavState(
                             basket = multiQuoteBasket,
-                            onToggle = { cat, post, numreponse ->
-                                multiQuoteBasket = multiQuoteBasket.toggled(cat, post, numreponse)
+                            onToggle = { cat, post, preview ->
+                                multiQuoteBasket = multiQuoteBasket.toggled(cat, post, preview)
                             },
                             onClear = { multiQuoteBasket = null },
                         ),
@@ -1705,7 +1706,7 @@ private data class TopicScrollNavState(
  */
 private data class MultiQuoteNavState(
     val basket: MultiQuoteBasket?,
-    val onToggle: (cat: Int, post: Int, numreponse: Int) -> Unit,
+    val onToggle: (cat: Int, post: Int, preview: QuotedPostPreview) -> Unit,
     val onClear: () -> Unit,
 )
 
@@ -1782,31 +1783,37 @@ private fun ResetNavBarScrollOffTopic(topRoute: NavKey?, onReset: () -> Unit) {
 /**
  * #291 — multi-quote selection, hoisted to RedfaceApp (same survival rationale as
  * [TopicScrollNavState]: a page change replaces the TopicRoute entry, so any state owned by the
- * topic screen dies with it). [numreponses] keeps SELECTION ORDER — the quotes are concatenated
- * in the order the user tapped them, not post order.
+ * topic screen dies with it). [selections] keeps SELECTION ORDER — the quotes are concatenated
+ * in the order the user tapped them, not post order. #604 lot 2 enriched the entries from bare
+ * numreponses to [QuotedPostPreview]s (author + excerpt captured at selection time) so the quote
+ * cards never re-parse a post ; uniqueness stays keyed on the numreponse alone.
  */
 internal data class MultiQuoteBasket(
     val cat: Int,
     val post: Int,
-    val numreponses: List<Int>,
+    val selections: List<QuotedPostPreview>,
 ) {
+    val numreponses: List<Int> get() = selections.map { it.numreponse }
+
     fun matches(cat: Int, post: Int): Boolean = this.cat == cat && this.post == post
 }
 
 /**
- * Toggles [numreponse] in the basket for topic ([cat], [post]). Selecting in a DIFFERENT topic
- * replaces the basket (one quoting act at a time); removing the last entry clears it to null so
- * the « Citer N » affordance disappears instead of advertising an empty selection.
+ * Toggles [preview] in the basket for topic ([cat], [post]) — presence is keyed on the
+ * numreponse, so re-tapping a selected post removes it whatever snapshot the caller rebuilt.
+ * Selecting in a DIFFERENT topic replaces the basket (one quoting act at a time); removing the
+ * last entry clears it to null so the « Citer N » affordance disappears instead of advertising
+ * an empty selection.
  */
-internal fun MultiQuoteBasket?.toggled(cat: Int, post: Int, numreponse: Int): MultiQuoteBasket? {
+internal fun MultiQuoteBasket?.toggled(cat: Int, post: Int, preview: QuotedPostPreview): MultiQuoteBasket? {
     val current = this?.takeIf { it.matches(cat, post) }
-        ?: return MultiQuoteBasket(cat, post, listOf(numreponse))
-    val next = if (numreponse in current.numreponses) {
-        current.numreponses - numreponse
+        ?: return MultiQuoteBasket(cat, post, listOf(preview))
+    val next = if (current.selections.any { it.numreponse == preview.numreponse }) {
+        current.selections.filterNot { it.numreponse == preview.numreponse }
     } else {
-        current.numreponses + numreponse
+        current.selections + preview
     }
-    return if (next.isEmpty()) null else current.copy(numreponses = next)
+    return if (next.isEmpty()) null else current.copy(selections = next)
 }
 
 /**
@@ -2442,8 +2449,8 @@ private fun RedfaceNavHost(
                         ?.takeIf { it.matches(route.cat, route.post) }
                         ?.numreponses
                         .orEmpty(),
-                    onToggleMultiQuote = { numreponse ->
-                        multiQuoteNavState.onToggle(route.cat, route.post, numreponse)
+                    onToggleMultiQuote = { preview ->
+                        multiQuoteNavState.onToggle(route.cat, route.post, preview)
                     },
                     // #465 — the topic's saved manual poll choice (null = follow the global
                     // default), and the callback recording a tap on the poll card. Hoisted to

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/MultiQuoteBasketTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/MultiQuoteBasketTest.kt
@@ -1,0 +1,64 @@
+package fr.forumhfr.redface2.navigation
+
+import fr.forumhfr.redface2.core.model.write.QuotedPostPreview
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #291/#604 lot 2 — the hoisted multi-quote basket logic, enriched from bare numreponses to
+ * [QuotedPostPreview] entries. Pinned contracts: selection ORDER is the tap order, uniqueness and
+ * removal are keyed on the numreponse alone (whatever snapshot the caller rebuilt), selecting in
+ * another topic replaces the basket, and removing the last entry clears it to null.
+ */
+class MultiQuoteBasketTest {
+
+    @Test
+    fun `selections accumulate in tap order`() {
+        val basket = (null as MultiQuoteBasket?)
+            .toggled(CAT, POST, preview(101, "alice"))
+            .toggled(CAT, POST, preview(303, "carol"))
+            .toggled(CAT, POST, preview(202, "bob"))
+
+        assertEquals(listOf(101, 303, 202), basket?.numreponses)
+        assertEquals(listOf("alice", "carol", "bob"), basket?.selections?.map { it.author })
+    }
+
+    @Test
+    fun `re-toggling removes by numreponse whatever the snapshot carries`() {
+        val basket = (null as MultiQuoteBasket?)
+            .toggled(CAT, POST, preview(101, "alice"))
+            .toggled(CAT, POST, preview(202, "bob"))
+            // The caller rebuilt a DIFFERENT snapshot of the same post (author edited, say).
+            .toggled(CAT, POST, preview(101, "alice-edited"))
+
+        assertEquals(listOf(202), basket?.numreponses)
+    }
+
+    @Test
+    fun `removing the last entry clears the basket to null`() {
+        val basket = (null as MultiQuoteBasket?)
+            .toggled(CAT, POST, preview(101, "alice"))
+            .toggled(CAT, POST, preview(101, "alice"))
+
+        assertNull(basket)
+    }
+
+    @Test
+    fun `selecting in another topic replaces the basket`() {
+        val basket = (null as MultiQuoteBasket?)
+            .toggled(CAT, POST, preview(101, "alice"))
+            .toggled(CAT, POST + 1, preview(555, "dave"))
+
+        assertEquals(POST + 1, basket?.post)
+        assertEquals(listOf(555), basket?.numreponses)
+    }
+
+    private fun preview(numreponse: Int, author: String): QuotedPostPreview =
+        QuotedPostPreview(numreponse = numreponse, author = author, excerpt = "extrait de $author")
+
+    private companion object {
+        const val CAT = 23
+        const val POST = 35421
+    }
+}

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/write/ReplyQuoteMaterializer.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/write/ReplyQuoteMaterializer.kt
@@ -1,0 +1,60 @@
+package fr.forumhfr.redface2.core.domain.write
+
+import fr.forumhfr.redface2.core.model.write.ReplyContext
+import fr.forumhfr.redface2.core.model.write.ReplyForm
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * #291 multi-quote, promoted to a shared collaborator for the Postage wave (#604 lot 2, cadrage
+ * Codex : ONE implementation of « fetch N quote forms + concat + ride the first form's hash »,
+ * consumed by both the full-screen editor and the quick-reply sheet).
+ *
+ * The quote form fetch (#146) returns ONE `[quotemsg]` prefill per `numrep`, so additional quoted
+ * posts are fetched by replaying the same contract with `quotedNumreponse` swapped, then
+ * concatenated into the first form's [ReplyForm.initialContent] in selection order. Client-side
+ * only: HFR never sees a multi-numrep request, and the submit still rides the FIRST form's
+ * `hash_check`/hidden fields (per-session, not per-post).
+ *
+ * Sequential on purpose: N is tiny (a handful of posts), order must be deterministic, and a failed
+ * extra fails the whole fetch — silently dropping a quote the user explicitly selected would be
+ * worse than the retryable form-fetch error.
+ */
+@Singleton
+class ReplyQuoteMaterializer @Inject constructor(
+    private val replyRepository: ReplyRepository,
+) {
+
+    /**
+     * Fetch the reply form for [context], appending one `[quotemsg]` prefill per entry of
+     * [extraQuoteNumreponses] (selection order preserved). With no extras — or a non-quote
+     * context — this is a plain [ReplyRepository.fetchReplyForm].
+     */
+    suspend fun fetchFormWithQuotes(context: ReplyContext, extraQuoteNumreponses: List<Int>): ReplyForm {
+        val form = replyRepository.fetchReplyForm(context)
+        if (extraQuoteNumreponses.isEmpty() || !context.isQuote) return form
+        val prefills = buildList {
+            add(form.initialContent)
+            extraQuoteNumreponses.forEach { numreponse ->
+                // quoteRef is positional/cosmetic and belongs to the FIRST post only.
+                add(
+                    replyRepository
+                        .fetchReplyForm(context.copy(quotedNumreponse = numreponse, quoteRef = null))
+                        .initialContent,
+                )
+            }
+        }
+        val merged = prefills
+            .map { prefill ->
+                prefill.trimEnd().also { trimmed ->
+                    // Codex review — a 200-OK form whose prefill came back BLANK would silently
+                    // drop a quote the user explicitly selected (the exact failure mode the
+                    // sequential design refuses). Fail the whole fetch instead; callers keep
+                    // their retryable error path.
+                    check(trimmed.isNotBlank()) { "multi-quote prefill came back blank" }
+                }
+            }
+            .joinToString(separator = "\n\n", postfix = "\n\n")
+        return form.copy(initialContent = merged)
+    }
+}

--- a/core/domain/src/test/kotlin/fr/forumhfr/redface2/core/domain/write/ReplyQuoteMaterializerTest.kt
+++ b/core/domain/src/test/kotlin/fr/forumhfr/redface2/core/domain/write/ReplyQuoteMaterializerTest.kt
@@ -1,0 +1,118 @@
+package fr.forumhfr.redface2.core.domain.write
+
+import fr.forumhfr.redface2.core.model.write.ReplyContext
+import fr.forumhfr.redface2.core.model.write.ReplyForm
+import fr.forumhfr.redface2.core.model.write.ReplyFormOptions
+import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+/**
+ * #604 lot 2 — the shared multi-quote materialisation (promoted verbatim from
+ * PostEditorViewModel's #291 private path). Pinned contracts: selection order preserved, extras
+ * fetched with quoteRef nulled, submit rides the FIRST form (hash/hidden fields), a blank prefill
+ * fails the whole fetch, and a no-extra / non-quote context is a plain single fetch.
+ */
+class ReplyQuoteMaterializerTest {
+
+    @Test
+    fun `no extras - the first form is returned untouched`() = runBlocking {
+        val repository = RecordingReplyRepository()
+        val materializer = ReplyQuoteMaterializer(repository)
+
+        val form = materializer.fetchFormWithQuotes(quoteContext(quotedNumreponse = 101), emptyList())
+
+        assertEquals("[quotemsg=101]un[/quotemsg]", form.initialContent)
+        assertEquals(1, repository.fetchedNumreponses.size)
+    }
+
+    @Test
+    fun `extras are appended in selection order with quoteRef nulled`() = runBlocking {
+        val repository = RecordingReplyRepository()
+        val materializer = ReplyQuoteMaterializer(repository)
+
+        val form = materializer.fetchFormWithQuotes(
+            quoteContext(quotedNumreponse = 101, quoteRef = 7),
+            extraQuoteNumreponses = listOf(303, 202),
+        )
+
+        assertEquals(
+            "[quotemsg=101]un[/quotemsg]\n\n[quotemsg=303]un[/quotemsg]\n\n[quotemsg=202]un[/quotemsg]\n\n",
+            form.initialContent,
+        )
+        // First fetch keeps the caller's quoteRef ; every extra nulls it (positional, 1st post only).
+        assertEquals(listOf(101 to 7, 303 to null, 202 to null), repository.fetchedNumreponses)
+        // The merged form still rides the FIRST form's hash.
+        assertEquals("hash-101", form.hashCheck)
+    }
+
+    @Test
+    fun `a blank extra prefill fails the whole fetch`() {
+        val repository = RecordingReplyRepository(blankFor = setOf(202))
+        val materializer = ReplyQuoteMaterializer(repository)
+
+        assertThrows(IllegalStateException::class.java) {
+            runBlocking {
+                materializer.fetchFormWithQuotes(
+                    quoteContext(quotedNumreponse = 101),
+                    extraQuoteNumreponses = listOf(202),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `a non-quote context ignores extras`() = runBlocking {
+        val repository = RecordingReplyRepository()
+        val materializer = ReplyQuoteMaterializer(repository)
+
+        val form = materializer.fetchFormWithQuotes(
+            ReplyContext(cat = 23, subcat = 401, topicId = 35421, page = 3),
+            extraQuoteNumreponses = listOf(202),
+        )
+
+        assertEquals("", form.initialContent)
+        assertEquals(1, repository.fetchedNumreponses.size)
+    }
+
+    private fun quoteContext(quotedNumreponse: Int, quoteRef: Int? = null): ReplyContext = ReplyContext(
+        cat = 23,
+        subcat = 401,
+        topicId = 35421,
+        page = 3,
+        quotedNumreponse = quotedNumreponse,
+        quoteRef = quoteRef,
+    )
+}
+
+private class RecordingReplyRepository(
+    private val blankFor: Set<Int> = emptySet(),
+) : ReplyRepository {
+    val fetchedNumreponses = mutableListOf<Pair<Int?, Int?>>()
+
+    override suspend fun fetchReplyForm(context: ReplyContext): ReplyForm {
+        fetchedNumreponses += context.quotedNumreponse to context.quoteRef
+        val numreponse = context.quotedNumreponse
+        val prefill = when {
+            numreponse == null -> ""
+            numreponse in blankFor -> "   "
+            else -> "[quotemsg=$numreponse]un[/quotemsg]"
+        }
+        return ReplyForm(
+            hashCheck = "hash-${numreponse ?: 0}",
+            sujet = "sujet",
+            hiddenFields = emptyMap(),
+            isAnonymous = false,
+            initialContent = prefill,
+        )
+    }
+
+    override suspend fun submitReply(
+        context: ReplyContext,
+        form: ReplyForm,
+        bbcodeContent: String,
+        options: ReplyFormOptions,
+    ): ReplySubmitResult = ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
+}

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/PostContentExcerpt.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/PostContentExcerpt.kt
@@ -1,0 +1,65 @@
+package fr.forumhfr.redface2.core.model
+
+/**
+ * Vague 4 (#604) lot 2 — one-line plain-text excerpt of a post, for the compact quote cards
+ * (author + excerpt captured AT SELECTION TIME, cadrage Codex : the heavy parsing serves the
+ * exact materialisation, never this 1-line rendering).
+ *
+ * Conservative strip: the excerpt is the author's OWN prose — nested [PostBlock.Quote]s and
+ * [PostBlock.Spoiler]s are excluded, images are dropped, formatting is flattened to its text,
+ * smileys keep their textual code (`:jap:` / `[:name]`), whitespace is collapsed. Truncation
+ * prefers a word boundary and appends a single `…`. A post made only of excluded blocks yields
+ * `""` — the caller decides on a placeholder.
+ */
+fun postContentExcerpt(content: PostContent, maxChars: Int = DEFAULT_EXCERPT_MAX_CHARS): String {
+    val flat = buildString {
+        content.blocks.forEach { block ->
+            val text = when (block) {
+                is PostBlock.Paragraph -> flattenInlines(block.inlines)
+                is PostBlock.Fixed -> block.text
+                is PostBlock.CodeBlock -> block.text
+                // The author's own words only — quoted material and hidden spoilers stay out.
+                is PostBlock.Quote, is PostBlock.Spoiler, is PostBlock.Image -> ""
+            }
+            if (text.isNotBlank()) {
+                if (isNotEmpty()) append(' ')
+                append(text)
+            }
+        }
+    }
+    val collapsed = flat.replace(WHITESPACE_RUN, " ").trim()
+    if (collapsed.length <= maxChars) return collapsed
+    val cut = collapsed.take(maxChars)
+    val wordBoundary = cut.lastIndexOf(' ')
+    val kept = if (wordBoundary > 0) cut.take(wordBoundary) else cut
+    return kept.trimEnd() + "…"
+}
+
+private fun flattenInlines(inlines: List<PostInline>): String = buildString {
+    inlines.forEach { inline ->
+        when (inline) {
+            is PostInline.Text -> append(inline.value)
+            PostInline.LineBreak -> append(' ')
+            is PostInline.Strong -> append(flattenInlines(inline.children))
+            is PostInline.Emphasis -> append(flattenInlines(inline.children))
+            is PostInline.Underline -> append(flattenInlines(inline.children))
+            is PostInline.Strike -> append(flattenInlines(inline.children))
+            is PostInline.Color -> append(flattenInlines(inline.children))
+            is PostInline.Link -> append(flattenInlines(inline.children))
+            is PostInline.InlineImage -> Unit
+            is PostInline.Smiley -> {
+                if (isNotEmpty() && !endsWith(' ')) append(' ')
+                append(inline.kind.textualCode())
+            }
+        }
+    }
+}
+
+private fun SmileyKind.textualCode(): String = when (this) {
+    is SmileyKind.Builtin -> code
+    is SmileyKind.Perso -> "[:$name]"
+}
+
+private val WHITESPACE_RUN = Regex("\\s+")
+
+private const val DEFAULT_EXCERPT_MAX_CHARS = 80

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/PostContentExcerpt.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/PostContentExcerpt.kt
@@ -48,8 +48,11 @@ private fun flattenInlines(inlines: List<PostInline>): String = buildString {
             is PostInline.Link -> append(flattenInlines(inline.children))
             is PostInline.InlineImage -> Unit
             is PostInline.Smiley -> {
+                // Pad both sides so a smiley never glues to adjacent text (`foo :jap: bar`) —
+                // the whitespace collapse downstream absorbs any doubled space.
                 if (isNotEmpty() && !endsWith(' ')) append(' ')
                 append(inline.kind.textualCode())
+                append(' ')
             }
         }
     }

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/write/QuotedPostPreview.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/write/QuotedPostPreview.kt
@@ -1,0 +1,20 @@
+package fr.forumhfr.redface2.core.model.write
+
+/**
+ * Vague 4 (#604) lot 2 — a post retained for citation, as the QUOTE CARDS see it: identity plus a
+ * one-line plain-text excerpt, both captured AT SELECTION TIME (cadrage Codex — the UI never
+ * re-parses a post to render a card ; the exact `[quotemsg]` materialisation is a separate,
+ * server-fed step at submit/escalation time and only needs [numreponse]).
+ *
+ * Deliberately UI-agnostic (a « card » is presentation) and NOT persisted: quote selections are
+ * transient by design, like the multi-quote basket they extend — process death means re-selecting.
+ *
+ * The [excerpt] is a snapshot of the post as it was when selected ; the post may be edited on HFR
+ * before the reply is submitted. Accepted trade-off: the materialised quote is fetched fresh, the
+ * card is only a reminder of what was picked.
+ */
+data class QuotedPostPreview(
+    val numreponse: Int,
+    val author: String,
+    val excerpt: String,
+)

--- a/core/model/src/test/kotlin/fr/forumhfr/redface2/core/model/PostContentExcerptTest.kt
+++ b/core/model/src/test/kotlin/fr/forumhfr/redface2/core/model/PostContentExcerptTest.kt
@@ -1,0 +1,162 @@
+package fr.forumhfr.redface2.core.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Vague 4 (#604) lot 2 — 100% coverage of [postContentExcerpt], the pure one-line summary used by
+ * the quote cards (author + excerpt captured at selection time, cadrage Codex). The contract:
+ * conservative text strip — own prose only (nested quotes and spoilers excluded), formatting
+ * flattened, whitespace collapsed, word-boundary truncation with a single ellipsis character.
+ */
+class PostContentExcerptTest {
+
+    @Test
+    fun `plain paragraphs join with a space and collapse whitespace`() {
+        val content = PostContent(
+            blocks = listOf(
+                paragraph(PostInline.Text("Premier   paragraphe.")),
+                paragraph(PostInline.Text("Second\tparagraphe.")),
+            ),
+        )
+        assertEquals("Premier paragraphe. Second paragraphe.", postContentExcerpt(content))
+    }
+
+    @Test
+    fun `formatting inlines are flattened to their text`() {
+        val content = PostContent(
+            blocks = listOf(
+                paragraph(
+                    PostInline.Strong(listOf(PostInline.Text("gras"))),
+                    PostInline.Text(" et "),
+                    PostInline.Emphasis(listOf(PostInline.Text("italique"))),
+                    PostInline.Text(" et "),
+                    PostInline.Link(url = "https://x", children = listOf(PostInline.Text("lien"))),
+                ),
+            ),
+        )
+        assertEquals("gras et italique et lien", postContentExcerpt(content))
+    }
+
+    @Test
+    fun `line breaks read as spaces`() {
+        val content = PostContent(
+            blocks = listOf(
+                paragraph(PostInline.Text("Ah oui"), PostInline.LineBreak, PostInline.Text("Ça limite l'efficacité")),
+            ),
+        )
+        assertEquals("Ah oui Ça limite l'efficacité", postContentExcerpt(content))
+    }
+
+    @Test
+    fun `nested quotes are excluded - the excerpt is the author's own prose`() {
+        val content = PostContent(
+            blocks = listOf(
+                PostBlock.Quote(
+                    author = "bitubo",
+                    numreponse = 1,
+                    page = 1,
+                    content = PostContent(listOf(paragraph(PostInline.Text("propos cité")))),
+                ),
+                paragraph(PostInline.Text("Ma réponse à ça.")),
+            ),
+        )
+        assertEquals("Ma réponse à ça.", postContentExcerpt(content))
+    }
+
+    @Test
+    fun `spoilers are excluded`() {
+        val content = PostContent(
+            blocks = listOf(
+                PostBlock.Spoiler(
+                    label = null,
+                    content = PostContent(listOf(paragraph(PostInline.Text("la fin du film")))),
+                ),
+                paragraph(PostInline.Text("Sans divulgâcher :")),
+            ),
+        )
+        assertEquals("Sans divulgâcher :", postContentExcerpt(content))
+    }
+
+    @Test
+    fun `fixed and code blocks contribute their compacted text`() {
+        val content = PostContent(
+            blocks = listOf(
+                PostBlock.Fixed(text = "ligne\nfixe"),
+                PostBlock.CodeBlock(text = "val x = 1\nval y = 2", language = "kotlin"),
+            ),
+        )
+        assertEquals("ligne fixe val x = 1 val y = 2", postContentExcerpt(content))
+    }
+
+    @Test
+    fun `smileys render as their textual code`() {
+        val content = PostContent(
+            blocks = listOf(
+                paragraph(
+                    PostInline.Text("Bien vu"),
+                    PostInline.Smiley(kind = SmileyKind.Builtin(code = ":jap:"), imageUrl = null),
+                    PostInline.Smiley(kind = SmileyKind.Perso(name = "pierre_tramo"), imageUrl = null),
+                ),
+            ),
+        )
+        assertEquals("Bien vu :jap: [:pierre_tramo]", postContentExcerpt(content))
+    }
+
+    @Test
+    fun `images inline or block are ignored`() {
+        val content = PostContent(
+            blocks = listOf(
+                PostBlock.Image(url = "https://x/img.png", description = null),
+                paragraph(
+                    PostInline.Text("Regarde"),
+                    PostInline.InlineImage(url = "https://x/i.png", description = "desc"),
+                ),
+            ),
+        )
+        assertEquals("Regarde", postContentExcerpt(content))
+    }
+
+    @Test
+    fun `truncation cuts on a word boundary and appends one ellipsis`() {
+        val content = PostContent(
+            blocks = listOf(
+                paragraph(PostInline.Text("un deux trois quatre cinq six sept huit neuf dix")),
+            ),
+        )
+        assertEquals("un deux trois…", postContentExcerpt(content, maxChars = 15))
+    }
+
+    @Test
+    fun `truncation falls back to a hard cut when there is no space in range`() {
+        val content = PostContent(
+            blocks = listOf(paragraph(PostInline.Text("supercalifragilisticexpialidocious"))),
+        )
+        assertEquals("supercalif…", postContentExcerpt(content, maxChars = 10))
+    }
+
+    @Test
+    fun `content at exactly maxChars is not truncated`() {
+        val content = PostContent(blocks = listOf(paragraph(PostInline.Text("pile dix.."))))
+        assertEquals("pile dix..", postContentExcerpt(content, maxChars = 10))
+    }
+
+    @Test
+    fun `a post made only of images and quotes yields an empty excerpt`() {
+        val content = PostContent(
+            blocks = listOf(
+                PostBlock.Image(url = "https://x/img.png", description = "alt"),
+                PostBlock.Quote(
+                    author = null,
+                    numreponse = null,
+                    page = null,
+                    content = PostContent(listOf(paragraph(PostInline.Text("cité")))),
+                ),
+            ),
+        )
+        assertEquals("", postContentExcerpt(content))
+    }
+
+    private fun paragraph(vararg inlines: PostInline): PostBlock.Paragraph =
+        PostBlock.Paragraph(inlines = inlines.toList())
+}

--- a/core/model/src/test/kotlin/fr/forumhfr/redface2/core/model/PostContentExcerptTest.kt
+++ b/core/model/src/test/kotlin/fr/forumhfr/redface2/core/model/PostContentExcerptTest.kt
@@ -104,6 +104,20 @@ class PostContentExcerptTest {
     }
 
     @Test
+    fun `a smiley never glues to the following text`() {
+        val content = PostContent(
+            blocks = listOf(
+                paragraph(
+                    PostInline.Text("avant"),
+                    PostInline.Smiley(kind = SmileyKind.Builtin(code = ":jap:"), imageUrl = null),
+                    PostInline.Text("après"),
+                ),
+            ),
+        )
+        assertEquals("avant :jap: après", postContentExcerpt(content))
+    }
+
+    @Test
     fun `images inline or block are ignored`() {
         val content = PostContent(
             blocks = listOf(

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -24,6 +24,7 @@ import fr.forumhfr.redface2.core.domain.upload.ImageUploadReader
 import fr.forumhfr.redface2.core.domain.upload.UploadException
 import fr.forumhfr.redface2.core.domain.upload.UploadRepository
 import fr.forumhfr.redface2.core.domain.write.EditPostRepository
+import fr.forumhfr.redface2.core.domain.write.ReplyQuoteMaterializer
 import fr.forumhfr.redface2.core.domain.write.ReplyRepository
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.PostContent
@@ -85,6 +86,7 @@ class PostEditorViewModel @AssistedInject constructor(
     private val uploadRepository: UploadRepository,
     private val imageUploadReader: ImageUploadReader,
     private val authRepository: AuthRepository,
+    private val quoteMaterializer: ReplyQuoteMaterializer,
 ) : ViewModel() {
 
     private val _state: MutableStateFlow<PostEditorState> = MutableStateFlow(
@@ -591,48 +593,10 @@ class PostEditorViewModel @AssistedInject constructor(
             _state.update { it.copy(submitError = SubmitError.MissingSubcat) }
             return
         }
-        launchFormFetch { fetchReplyFormWithExtraQuotes(context) }
-    }
-
-    /**
-     * #291 multi-quote — the quote form fetch (#146) returns ONE `[quotemsg]` prefill per
-     * `numrep`, so additional quoted posts are fetched by replaying the same contract with
-     * `quotedNumreponse` swapped, then concatenated into the first form's [ReplyForm.initialContent]
-     * in selection order. Client-side only: HFR never sees a multi-numrep request, and the
-     * submit still rides the FIRST form's `hash_check`/hidden fields (per-session, not
-     * per-post — the single-quote and plain-reply paths already share them).
-     *
-     * Sequential on purpose: N is tiny (a handful of posts), order must be deterministic, and
-     * a failed extra fails the whole fetch — silently dropping a quote the user explicitly
-     * selected would be worse than the retryable form-fetch error.
-     */
-    private suspend fun fetchReplyFormWithExtraQuotes(context: ReplyContext): ReplyForm {
-        val form = replyRepository.fetchReplyForm(context)
-        val extras = request.extraQuoteNumreponses
-        if (extras.isEmpty() || !context.isQuote) return form
-        val prefills = buildList {
-            add(form.initialContent)
-            extras.forEach { numreponse ->
-                // quoteRef is positional/cosmetic and belongs to the FIRST post only.
-                add(
-                    replyRepository
-                        .fetchReplyForm(context.copy(quotedNumreponse = numreponse, quoteRef = null))
-                        .initialContent,
-                )
-            }
-        }
-        val merged = prefills
-            .map { prefill ->
-                prefill.trimEnd().also { trimmed ->
-                    // Codex review — a 200-OK form whose prefill came back BLANK would silently
-                    // drop a quote the user explicitly selected (the exact failure mode the
-                    // sequential design refuses). Fail the whole fetch instead; the mapped
-                    // SubmitError keeps the editor on its retryable error path.
-                    check(trimmed.isNotBlank()) { "multi-quote prefill came back blank" }
-                }
-            }
-            .joinToString(separator = "\n\n", postfix = "\n\n")
-        return form.copy(initialContent = merged)
+        // #291 multi-quote — promoted to the shared ReplyQuoteMaterializer (#604 lot 2), one
+        // implementation for the full editor and the quick-reply sheet. Same contract as before:
+        // extras fetched sequentially in selection order, submit rides the FIRST form's hash.
+        launchFormFetch { quoteMaterializer.fetchFormWithQuotes(context, request.extraQuoteNumreponses) }
     }
 
     private fun loadEditFormIfPossible() {

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -35,6 +35,7 @@ import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import fr.forumhfr.redface2.core.domain.upload.UploadRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadedImage
 import fr.forumhfr.redface2.core.domain.upload.UploadedImageRecord
+import fr.forumhfr.redface2.core.domain.write.ReplyQuoteMaterializer
 import fr.forumhfr.redface2.core.domain.write.ReplyRepository
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.FlagType
@@ -816,6 +817,7 @@ class PostEditorViewModelTest {
             uploadRepository = uploadRepository,
             imageUploadReader = imageUploadReader,
             authRepository = authRepository,
+            quoteMaterializer = ReplyQuoteMaterializer(replyRepository),
         )
 
     // ----- Phase 2F-B (#11) : smiley picker ----------------------------------
@@ -1433,6 +1435,7 @@ class PostEditorViewModelTest {
             uploadRepository = uploadRepository,
             imageUploadReader = imageUploadReader,
             authRepository = authRepository,
+            quoteMaterializer = ReplyQuoteMaterializer(replyRepository),
         )
 
     // ----- #312 : confirmation avant publication ------------------------------

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -95,6 +95,8 @@ import fr.forumhfr.redface2.core.domain.author.isRf2Creator
 import fr.forumhfr.redface2.core.model.Poll
 import fr.forumhfr.redface2.core.model.Post
 import fr.forumhfr.redface2.core.model.Topic
+import fr.forumhfr.redface2.core.model.postContentExcerpt
+import fr.forumhfr.redface2.core.model.write.QuotedPostPreview
 import fr.forumhfr.redface2.core.ui.RedfacePlaceholderScreen
 import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.icon.RedfaceVectorIcon
@@ -251,7 +253,7 @@ fun TopicScreen(
      * #291 — toggles a post in the multi-quote basket. Only invoked under the same gate as
      * [onQuote] (`shouldShowQuoteAction`): a topic the user cannot reply to has nothing to quote.
      */
-    onToggleMultiQuote: (numreponse: Int) -> Unit = {},
+    onToggleMultiQuote: (preview: QuotedPostPreview) -> Unit = {},
     /**
      * #291 — opens the editor pre-filled with every selected quote (same destination as
      * [onQuote]; `:app` rides the selection on the route and clears the basket). Receives the
@@ -700,7 +702,7 @@ internal fun TopicContent(
     // #291 — multi-quote selection (owned by :app) + its two actions, threaded to the post menu
     // (toggle) and the floating cluster (« Citer N »).
     multiQuoteSelection: List<Int> = emptyList(),
-    onToggleMultiQuote: (numreponse: Int) -> Unit = {},
+    onToggleMultiQuote: (preview: QuotedPostPreview) -> Unit = {},
     onMultiQuote: (subcat: Int, page: Int) -> Unit = { _, _ -> },
     // #465 — the topic's manual poll choice (owned by :app, null = follow the global default) +
     // the callback recording a tap on the poll card. Threaded to the header card's poll.
@@ -1207,7 +1209,7 @@ private fun TopicLoadedContent(
     listState: LazyListState,
     // #291 — selection state + toggle for the post menu's multi-quote entry.
     multiQuoteSelection: List<Int> = emptyList(),
-    onToggleMultiQuote: (numreponse: Int) -> Unit = {},
+    onToggleMultiQuote: (preview: QuotedPostPreview) -> Unit = {},
     // #509 — block/unblock a post's author from the post menu (blacklist).
     onSetAuthorBlocked: (author: String, blocked: Boolean) -> Unit = { _, _ -> },
     // #465 — the topic's manual poll choice (owned by :app, null = follow the global default) + the
@@ -1237,7 +1239,15 @@ private fun TopicLoadedContent(
     // the selection: the placeholder exposes no deselect affordance (decision #1), so leaving it
     // selected would silently quote a masqué post. The basket is hoisted in :app; reuse its toggle.
     LaunchedEffect(hiddenNumreponses, multiQuoteSelection) {
-        multiQuoteSelection.filter { it in hiddenNumreponses }.forEach(onToggleMultiQuote)
+        multiQuoteSelection.filter { it in hiddenNumreponses }.forEach { numreponse ->
+            // Removal is keyed on the numreponse alone (cf. toggled()) — resolve the hidden post
+            // to rebuild a preview, or fall back to a tombstone if the page no longer carries it.
+            val hidden = topic.posts.firstOrNull { it.numreponse == numreponse }
+            onToggleMultiQuote(
+                hidden?.toQuotedPreview()
+                    ?: QuotedPostPreview(numreponse = numreponse, author = "", excerpt = ""),
+            )
+        }
     }
     // #282 — shared offset between the gesture (drives translationX) and the edge glow. A plain
     // MutableFloatState: the gesture writes it synchronously per frame (no coroutine/alloc), the draw
@@ -1382,7 +1392,7 @@ private fun TopicLoadedContent(
             val multiQuoteToggle: (() -> Unit)?
             if (shouldShowQuoteAction(topic, state.isAuthenticated)) {
                 quoteAction = { onQuote(topic.subcat, topic.page, post.numreponse, post.quoteRef) }
-                multiQuoteToggle = { onToggleMultiQuote(post.numreponse) }
+                multiQuoteToggle = { onToggleMultiQuote(post.toQuotedPreview()) }
             } else {
                 quoteAction = null
                 multiQuoteToggle = null
@@ -1523,7 +1533,7 @@ private fun TopicLoadedContent(
             // replying; a locked topic or an anonymous session has nothing to quote).
             multiQuoteSelected = post.numreponse in multiQuoteSelection,
             onToggleMultiQuote = if (shouldShowQuoteAction(topic, state.isAuthenticated)) {
-                { onToggleMultiQuote(post.numreponse) }
+                { onToggleMultiQuote(post.toQuotedPreview()) }
             } else {
                 null
             },
@@ -2689,6 +2699,15 @@ private fun ReplyFab(onClick: () -> Unit) {
 // not purged on logout, cf. CacheInvalidator), so these gates consult auth explicitly instead
 // of trusting `canReply` alone — symmetric with the « Créer topic » FAB
 // (CategoryViewModel.canCreateTopic).
+// #604 lot 2 — the quote-card snapshot, built AT SELECTION TIME where the full Post is in scope
+// (cadrage Codex : the cards never re-parse a post ; the exact [quotemsg] is fetched at
+// materialisation). Uniqueness in the basket stays keyed on the numreponse.
+internal fun Post.toQuotedPreview(): QuotedPostPreview = QuotedPostPreview(
+    numreponse = numreponse,
+    author = author,
+    excerpt = postContentExcerpt(content),
+)
+
 internal fun shouldEnableReply(topic: Topic, isAuthenticated: Boolean): Boolean =
     topic.canReply && isAuthenticated
 


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Vague 4 « Postage » de #604 — **lot 2, PR A de 2 : socle des citations-cartes** (découpage arbitré par le cadrage Codex du lot 2). **Aucun changement UX** : tout est fondation pour la PR B (cartes dans la sheet, réordonnancement, envoi/escalade avec citations).

## Contenu

- **`QuotedPostPreview`** (`:core:model/write`) : identité + extrait 1 ligne d'un post retenu pour citation, capturés **à la sélection** — les cartes ne re-parseront jamais un post (la matérialisation `[quotemsg]` exacte reste un fetch serveur au moment de l'envoi). Transient par design, comme le panier qu'il enrichit.
- **`postContentExcerpt`** (`:core:model`) : strip conservateur pur — prose de l'auteur uniquement (citations imbriquées, spoilers et images exclus), mise en forme aplatie, smileys en code textuel, troncature sur frontière de mot. **12 tests** (TDD, couverture 100 % de la fonction pure — méthodologie du projet).
- **`ReplyQuoteMaterializer`** (`:core:domain/write`) : la matérialisation multi-quote #291 **promue verbatim** depuis le chemin privé de `PostEditorViewModel` — une seule implémentation de « N fetchs de quote form + concat + hash du 1er form » pour le plein écran ET la future sheet (réponse n°4 du cadrage : « pas deux implémentations »). Le plein écran l'injecte désormais ; comportement épinglé par 4 tests dédiés + les tests multi-quote existants du VM (inchangés, verts).
- **`MultiQuoteBasket`** (`:app`) : stocke `List<QuotedPostPreview>` (ordre de tap conservé, unicité et retrait par `numreponse` seul — quel que soit le snapshot reconstruit par l'appelant). `numreponses` reste une propriété dérivée : le FAB ❝N, la route éditeur et la descente de sélection sont **intouchés**. Les callbacks de toggle portent le preview, construit aux deux call-sites de TopicScreen où le `Post` complet est en scope ; le prune #509 (post masqué) résout le post pour en rebâtir un (tombstone en secours). **4 tests** de la logique du panier.

## Vérifications

- 5 modules testés verts (`:core:model`, `:core:domain`, `:feature:editor`, `:feature:topic`, `:app`) + detektAll + lintProdDebug.
- **Dogfood non-régression** (émulateur) : sélection de 2 posts (« ✓ Cité », FAB ❝2) → éditeur plein écran avec les **2 `[quotemsg]` dans l'ordre de sélection** via le nouveau materializer ; panier consommé ; aucune trace côté sheet.

## Checklist

- [x] Cadrage Codex (lot 2 — 9 forks tranchés, découpage PR A/PR B)
- [x] Review Codex (gate gpt-5.5 xhigh — verdict dans les commentaires)
- [x] Validation canonique locale (detektAll + lintProdDebug + tests + assembleProdDebug)
