### PR TITLE
feat(topic): quote cards in the quick-reply sheet — Postage lot 2 PR B (#604)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -358,6 +358,14 @@ data class PostEditorRoute(
      * reply ; defaulted so older serialised back stacks deserialise.
      */
     val extraQuoteNumreponses: List<Int> = emptyList(),
+    /**
+     * #790 (#604 lot 2) — `true` when this editor is the ESCALATION of a quick-reply sheet: the
+     * shared #405 draft row was just written by the sheet, so the editor auto-applies it instead
+     * of surfacing the restore banner (the escalation continues the same composition act). The
+     * text itself never rides the route — only this flag does. Defaulted so older serialised
+     * back stacks deserialise.
+     */
+    val resumeSharedDraft: Boolean = false,
 ) : RedfaceNavKey
 
 @Serializable
@@ -2397,7 +2405,11 @@ private fun RedfaceNavHost(
                         topicScrollNavState.onAnchorSaved(route.cat, route.post, route.page, anchor)
                     },
                     onOpenProfile = onOpenProfile,
-                    onReply = { subcat, page ->
+                    // #604 lots 1-2 — onReply is the quick-reply sheet's ESCALATION : the sheet
+                    // just persisted the shared #405 row, so the editor auto-applies it (#790,
+                    // resumeSharedDraft) instead of surfacing the restore banner. The armed quote
+                    // cards ride the route in citation order, same shape as the multi-quote FAB.
+                    onReply = { subcat, page, quoteNumreponses ->
                         backStack.add(
                             PostEditorRoute(
                                 mode = PostEditorMode.Reply,
@@ -2405,6 +2417,10 @@ private fun RedfaceNavHost(
                                 topicId = route.post,
                                 page = page,
                                 subcat = subcat,
+                                quotedNumreponse = quoteNumreponses.firstOrNull(),
+                                quoteRef = null,
+                                extraQuoteNumreponses = quoteNumreponses.drop(1),
+                                resumeSharedDraft = true,
                             ),
                         )
                     },
@@ -2425,23 +2441,6 @@ private fun RedfaceNavHost(
                                 ),
                             )
                         }
-                    },
-                    onQuote = { subcat, page, quotedNumreponse, quoteRef ->
-                        // Phase 2C (#146) — same destination as reply ; only the
-                        // editor's request differs (quotedNumreponse pulls the HFR
-                        // quote prefill). Route is `PostEditorMode.Reply` because
-                        // quote is a flavour of reply, not a new editor mode.
-                        backStack.add(
-                            PostEditorRoute(
-                                mode = PostEditorMode.Reply,
-                                cat = route.cat,
-                                topicId = route.post,
-                                page = page,
-                                subcat = subcat,
-                                quotedNumreponse = quotedNumreponse,
-                                quoteRef = quoteRef,
-                            ),
-                        )
                     },
                     // #291 — selection of THIS topic's basket (another topic's selection must
                     // never leak into the menu checkmarks or the « Citer N » FAB).
@@ -2601,6 +2600,7 @@ private fun RedfaceNavHost(
                         quotedNumreponse = route.quotedNumreponse,
                         quoteRef = route.quoteRef,
                         extraQuoteNumreponses = route.extraQuoteNumreponses,
+                        resumeSharedDraft = route.resumeSharedDraft,
                     ),
                     onSubmitSucceeded = { targetPage, scrollTo ->
                         // Pop the editor and refresh the topic page. `targetPage` is parsed

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorRequest.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorRequest.kt
@@ -40,4 +40,11 @@ data class PostEditorRequest(
      * single quote or a plain reply.
      */
     val extraQuoteNumreponses: List<Int> = emptyList(),
+    /**
+     * #790 (#604 lot 2) — `true` when this editor is the ESCALATION of a quick-reply sheet. The
+     * ViewModel then auto-applies the shared #405 draft row instead of surfacing the restore
+     * banner, and COMBINES it with a quote prefill when both are present (prefill first, body
+     * after — commutative whatever lands first, never clobbering either).
+     */
+    val resumeSharedDraft: Boolean = false,
 )

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -217,7 +217,13 @@ class PostEditorViewModel @AssistedInject constructor(
             if (body.isNullOrBlank()) return@launch
             if (request.resumeSharedDraft) {
                 _state.update { current ->
-                    val combined = current.draft.text + body
+                    // Conditional separator (gate #798): a late restore during typing must not
+                    // glue the resumed body to the user's last word.
+                    val combined = if (current.draft.text.isBlank()) {
+                        body
+                    } else {
+                        current.draft.text.trimEnd() + "\n\n" + body
+                    }
                     current
                         .withDraft(TextFieldValue(text = combined, selection = TextRange(combined.length)))
                         .copy(draftHydratedFromForm = current.draft.text.isNotBlank())

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -203,13 +203,27 @@ class PostEditorViewModel @AssistedInject constructor(
     /**
      * #405 — surface a cached draft for [draftKey] on the banner (never auto-apply : a quote prefill
      * or an edit body would otherwise be silently clobbered). Empty drafts are ignored.
+     *
+     * #790 exception — when the route carries `resumeSharedDraft` (escalation of a quick-reply
+     * sheet, which JUST wrote the row), the body is APPENDED to the field instead of banner'd :
+     * the escalation continues the same composition act. Append (not replace) keeps this
+     * commutative with the quote-prefill prepend in [withFormHydration], whichever lands first.
      */
     private fun restoreDraftIfAny() {
         val key = draftKey ?: return
         viewModelScope.launch {
             draftOwner = draftStore.currentOwner()
             val body = draftStore.load(draftOwner, key)?.body
-            if (!body.isNullOrBlank()) {
+            if (body.isNullOrBlank()) return@launch
+            if (request.resumeSharedDraft) {
+                _state.update { current ->
+                    val combined = current.draft.text + body
+                    current
+                        .withDraft(TextFieldValue(text = combined, selection = TextRange(combined.length)))
+                        .copy(draftHydratedFromForm = current.draft.text.isNotBlank())
+                }
+                scheduleAutosave()
+            } else {
                 _state.update { it.copy(restorableDraft = body) }
             }
         }
@@ -653,6 +667,37 @@ class PostEditorViewModel @AssistedInject constructor(
             form.initialContent.isNotBlank()
 
     /**
+     * #790 resume — the shared draft body reached the field first (classic hydration is
+     * blank-field-only): PREPEND the quote prefill instead, keeping the escalated text after
+     * the [quotemsg] blocks. Guarded by draftHydratedFromForm so the InvalidHashCheck silent
+     * refetch can never prepend twice.
+     */
+    private fun PostEditorState.shouldPrependPrefillFrom(form: ReplyForm, shouldHydrate: Boolean): Boolean =
+        request.resumeSharedDraft &&
+            !draftHydratedFromForm &&
+            !shouldHydrate &&
+            form.initialContent.isNotBlank() &&
+            draft.text.isNotBlank()
+
+    private fun PostEditorState.resolveHydratedDraft(
+        form: ReplyForm,
+        shouldHydrate: Boolean,
+        shouldPrependPrefill: Boolean,
+    ): TextFieldValue = when {
+        shouldHydrate -> TextFieldValue(
+            text = form.initialContent,
+            // Place caret at the end so the user can type their content
+            // right after the prefill — matches HFR's web behavior.
+            selection = TextRange(form.initialContent.length),
+        )
+        shouldPrependPrefill -> {
+            val combined = form.initialContent.trimEnd() + "\n\n" + draft.text
+            TextFieldValue(text = combined, selection = TextRange(combined.length))
+        }
+        else -> draft
+    }
+
+    /**
      * Pure state transformer : produces the next [PostEditorState] after a form
      * fetch lands. The preview AST is supplied by the caller (pre-computed off
      * the state-flow lambda to keep the heavier `parsePreview` call off the
@@ -678,16 +723,8 @@ class PostEditorViewModel @AssistedInject constructor(
         nextPreview: PostContent,
     ): PostEditorState {
         val shouldHydrate = shouldHydrateFrom(form)
-        val nextDraft = if (shouldHydrate) {
-            TextFieldValue(
-                text = form.initialContent,
-                // Place caret at the end so the user can type their content
-                // right after the prefill — matches HFR's web behavior.
-                selection = TextRange(form.initialContent.length),
-            )
-        } else {
-            draft
-        }
+        val shouldPrependPrefill = shouldPrependPrefillFrom(form, shouldHydrate)
+        val nextDraft = resolveHydratedDraft(form, shouldHydrate, shouldPrependPrefill)
         val hydrateOptions = !optionsHydratedFromForm
         return copy(
             isLoadingForm = false,
@@ -698,7 +735,7 @@ class PostEditorViewModel @AssistedInject constructor(
             // flips to false on `current` and we keep the user-driven
             // preview ; the parsed `nextPreview` is dropped.
             preview = if (shouldHydrate && isPreviewVisible) nextPreview else preview,
-            draftHydratedFromForm = draftHydratedFromForm || shouldHydrate,
+            draftHydratedFromForm = draftHydratedFromForm || shouldHydrate || shouldPrependPrefill,
             signatureEnabled = if (hydrateOptions) form.options.signatureEnabled else signatureEnabled,
             smileyDisabled = if (hydrateOptions) form.options.smileyDisabled else smileyDisabled,
             emailNotificationEnabled = if (hydrateOptions) {

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -791,6 +791,7 @@ class PostEditorViewModelTest {
         quotedNumreponse: Int? = null,
         quoteRef: Int? = null,
         extraQuoteNumreponses: List<Int> = emptyList(),
+        resumeSharedDraft: Boolean = false,
         diagnostics: DiagnosticsLog = DiagnosticsLog(),
         userPreferencesRepository: UserPreferencesRepository = FakeUserPreferencesRepository(),
         authRepository: AuthRepository = FakeAuthRepository(),
@@ -806,6 +807,7 @@ class PostEditorViewModelTest {
                 quotedNumreponse = quotedNumreponse,
                 quoteRef = quoteRef,
                 extraQuoteNumreponses = extraQuoteNumreponses,
+                resumeSharedDraft = resumeSharedDraft,
             ),
             previewParser = previewParser,
             replyRepository = replyRepository,
@@ -1748,6 +1750,63 @@ class PostEditorViewModelTest {
         viewModel.submit(PostEditorIntent.SubmitClicked)
         testScheduler.advanceUntilIdle()
         assertTrue("a saved edit must drop its draft", draftStore.deletedKeys.contains(key))
+    }
+
+    // ----- #790 : resumeSharedDraft (escalade de la réponse rapide) ----------
+
+    @Test
+    fun `resumeSharedDraft auto-applies the shared draft without the banner`() = runTest {
+        draftStore.preload(
+            EditorDraftKey.reply(SAMPLE_CAT, SAMPLE_TOPIC_ID),
+            EditorDraftStore.Draft(body = "texte de la sheet"),
+        )
+        replyRepository.formResult = Result.success(authenticatedForm())
+        val viewModel = newReplyViewModel(resumeSharedDraft = true)
+        testScheduler.advanceUntilIdle()
+
+        viewModel.state.test {
+            val settled = expectMostRecentItem()
+            assertEquals("texte de la sheet", settled.draft.text)
+            assertNull("no banner on an escalation hand-over", settled.restorableDraft)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `resumeSharedDraft prepends the quote prefill to the resumed body`() = runTest {
+        draftStore.preload(
+            EditorDraftKey.reply(SAMPLE_CAT, SAMPLE_TOPIC_ID),
+            EditorDraftStore.Draft(body = "texte de la sheet"),
+        )
+        replyRepository.formResult =
+            Result.success(authenticatedForm(initialContent = "[quotemsg=101]cité[/quotemsg]"))
+        val viewModel = newReplyViewModel(resumeSharedDraft = true, quotedNumreponse = 101)
+        testScheduler.advanceUntilIdle()
+
+        viewModel.state.test {
+            val settled = expectMostRecentItem()
+            assertEquals(
+                "[quotemsg=101]cité[/quotemsg]\n\ntexte de la sheet",
+                settled.draft.text,
+            )
+            assertNull(settled.restorableDraft)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `resumeSharedDraft with no stored draft falls back to classic prefill hydration`() = runTest {
+        replyRepository.formResult =
+            Result.success(authenticatedForm(initialContent = "[quotemsg=101]cité[/quotemsg]"))
+        val viewModel = newReplyViewModel(resumeSharedDraft = true, quotedNumreponse = 101)
+        testScheduler.advanceUntilIdle()
+
+        viewModel.state.test {
+            val settled = expectMostRecentItem()
+            assertEquals("[quotemsg=101]cité[/quotemsg]", settled.draft.text)
+            assertNull(settled.restorableDraft)
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     private fun authenticatedForm(initialContent: String = ""): ReplyForm = ReplyForm(

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySheet.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySheet.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SheetValue
@@ -30,9 +31,11 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.model.write.QuotedPostPreview
 import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
 import fr.forumhfr.redface2.core.ui.icon.RedfaceVectorIcon
 
@@ -48,8 +51,10 @@ import fr.forumhfr.redface2.core.ui.icon.RedfaceVectorIcon
 internal fun QuickReplySheet(
     request: QuickReplyRequest,
     onDismiss: () -> Unit,
-    onEscalate: () -> Unit,
+    onEscalate: (quoteNumreponses: List<Int>) -> Unit,
     onSubmitted: (targetPage: Int?, scrollTo: Int?) -> Unit,
+    // #604 lot 2 — « Citer » opens the sheet with this card pre-armed (1-citation session).
+    initialQuote: QuotedPostPreview? = null,
 ) {
     val viewModel = hiltViewModel<QuickReplyViewModel, QuickReplyViewModel.Factory>(
         creationCallback = { factory -> factory.create(request) },
@@ -58,11 +63,11 @@ internal fun QuickReplySheet(
     LaunchedEffect(viewModel) {
         // Re-seed the field from the #405 row at EACH opening — the VM outlives the sheet and
         // its cached text can be stale after a full-screen edit of the same draft (gate #788).
-        viewModel.onSheetOpened()
+        viewModel.onSheetOpened(initialQuote)
         viewModel.effects.collect { effect ->
             when (effect) {
                 is QuickReplyEffect.SubmitSucceeded -> onSubmitted(effect.targetPage, effect.scrollTo)
-                QuickReplyEffect.EscalateToFullEditor -> onEscalate()
+                is QuickReplyEffect.EscalateToFullEditor -> onEscalate(effect.quoteNumreponses)
             }
         }
     }
@@ -110,6 +115,19 @@ internal fun QuickReplySheet(
                         resId = fr.forumhfr.redface2.core.ui.R.drawable.ic_ms_open_in_new,
                     )
                 }
+            }
+            state.quotes.forEachIndexed { index, quote ->
+                QuoteCard(
+                    quote = quote,
+                    controls = QuoteCardControls(
+                        canMoveUp = index > 0,
+                        canMoveDown = index < state.quotes.lastIndex,
+                        enabled = !state.isSubmitting,
+                        onMoveUp = { viewModel.onQuoteMoved(quote.numreponse, delta = -1) },
+                        onMoveDown = { viewModel.onQuoteMoved(quote.numreponse, delta = 1) },
+                        onRemove = { viewModel.onQuoteRemoved(quote.numreponse) },
+                    ),
+                )
             }
             OutlinedTextField(
                 value = state.text,
@@ -177,5 +195,86 @@ internal fun QuickReplySubmitError.messageRes(): Int = when (this) {
         ReplyFailureReason.TopicLocked -> R.string.quick_reply_error_topic_locked
         ReplyFailureReason.LoginRequired -> R.string.quick_reply_error_login_required
         ReplyFailureReason.Unknown -> R.string.quick_reply_error_unknown
+    }
+}
+
+/**
+ * #604 lot 2 — one quote card: « ❝ author — excerpt » on a single line, with reorder and remove
+ * affordances. Reordering is up/down buttons by design (cadrage : a11y first, drag deferred) ;
+ * first/last are disabled instead of hidden so TalkBack users hear a stable layout.
+ */
+/** Reorder/remove affordances of one card, bundled for detekt's parameter budget. */
+private data class QuoteCardControls(
+    val canMoveUp: Boolean,
+    val canMoveDown: Boolean,
+    val enabled: Boolean,
+    val onMoveUp: () -> Unit,
+    val onMoveDown: () -> Unit,
+    val onRemove: () -> Unit,
+)
+
+@Composable
+private fun QuoteCard(
+    quote: QuotedPostPreview,
+    controls: QuoteCardControls,
+) {
+    val moveUpLabel = stringResource(R.string.quick_reply_quote_move_up, quote.author)
+    val moveDownLabel = stringResource(R.string.quick_reply_quote_move_down, quote.author)
+    val removeLabel = stringResource(R.string.quick_reply_quote_remove, quote.author)
+    Surface(
+        shape = MaterialTheme.shapes.small,
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        tonalElevation = 1.dp,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = stringResource(
+                    R.string.quick_reply_quote_line,
+                    quote.author,
+                    quote.excerpt.ifBlank { stringResource(R.string.quick_reply_quote_no_text) },
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(start = 12.dp),
+            )
+            QuoteCardAction(
+                enabled = controls.enabled && controls.canMoveUp,
+                label = moveUpLabel,
+                glyph = "↑",
+                onClick = controls.onMoveUp,
+            )
+            QuoteCardAction(
+                enabled = controls.enabled && controls.canMoveDown,
+                label = moveDownLabel,
+                glyph = "↓",
+                onClick = controls.onMoveDown,
+            )
+            QuoteCardAction(
+                enabled = controls.enabled,
+                label = removeLabel,
+                glyph = "✕",
+                onClick = controls.onRemove,
+            )
+        }
+    }
+}
+
+@Composable
+private fun QuoteCardAction(
+    enabled: Boolean,
+    label: String,
+    glyph: String,
+    onClick: () -> Unit,
+) {
+    IconButton(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = Modifier.semantics { contentDescription = label },
+    ) {
+        Text(text = glyph, style = MaterialTheme.typography.titleMedium)
     }
 }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySheet.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySheet.kt
@@ -60,7 +60,7 @@ internal fun QuickReplySheet(
         creationCallback = { factory -> factory.create(request) },
     )
     val state by viewModel.state.collectAsStateWithLifecycle()
-    LaunchedEffect(viewModel) {
+    LaunchedEffect(viewModel, initialQuote?.numreponse) {
         // Re-seed the field from the #405 row at EACH opening — the VM outlives the sheet and
         // its cached text can be stale after a full-screen edit of the same draft (gate #788).
         viewModel.onSheetOpened(initialQuote)

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModel.kt
@@ -12,10 +12,12 @@ import fr.forumhfr.redface2.core.domain.auth.SessionExpiredException
 import fr.forumhfr.redface2.core.domain.editor.EditorDraftKey
 import fr.forumhfr.redface2.core.domain.editor.EditorDraftStore
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
+import fr.forumhfr.redface2.core.domain.write.ReplyQuoteMaterializer
 import fr.forumhfr.redface2.core.domain.write.ReplyRepository
 import fr.forumhfr.redface2.core.model.write.ReplyContext
 import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
 import fr.forumhfr.redface2.core.model.write.ReplyForm
+import fr.forumhfr.redface2.core.model.write.QuotedPostPreview
 import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
 import java.io.IOException
 import kotlin.coroutines.cancellation.CancellationException
@@ -41,12 +43,18 @@ data class QuickReplyRequest(
 /** UI state of the quick-reply sheet. [text] is the whole contract — no toolbar, no preview. */
 data class QuickReplyUiState(
     val text: TextFieldValue = TextFieldValue(""),
+    /**
+     * #604 lot 2 — the quote cards, in citation order (reorderable). Transient like the
+     * multi-quote basket : never persisted, the #405 row only ever carries the typed body.
+     */
+    val quotes: List<QuotedPostPreview> = emptyList(),
     val isSubmitting: Boolean = false,
     val submitError: QuickReplySubmitError? = null,
     /** #312 — « Confirmation avant publication » : the pending-confirmation dialog is showing. */
     val confirmVisible: Boolean = false,
 ) {
-    val canSubmit: Boolean get() = text.text.isNotBlank() && !isSubmitting
+    /** With quote cards armed, an empty body is a valid submit (quotes-only reply). */
+    val canSubmit: Boolean get() = (text.text.isNotBlank() || quotes.isNotEmpty()) && !isSubmitting
 }
 
 /** Typed submit failures, the same split as the full editor's `SubmitError`. */
@@ -63,11 +71,13 @@ sealed interface QuickReplyEffect {
 
     /**
      * The draft is persisted — the sheet can hand over to the full-screen editor. Emitted only
-     * AFTER the save completed: the full editor restores the SAME `EditorDraftKey.reply` row,
-     * so the ordering is the whole transfer mechanism (cadrage Codex vague 4 : never a long
-     * text in a route arg, never a memory-only holder).
+     * AFTER the save completed: the full editor restores the SAME `EditorDraftKey.reply` row
+     * (auto-applied, #790), so the ordering is the whole transfer mechanism (cadrage Codex :
+     * never a long text in a route arg, never a memory-only holder). [quoteNumreponses] rides
+     * the route as `quotedNumreponse`/`extraQuoteNumreponses` — the full editor materialises
+     * the `[quotemsg]` prefills itself, exactly like the multi-quote FAB path.
      */
-    data object EscalateToFullEditor : QuickReplyEffect
+    data class EscalateToFullEditor(val quoteNumreponses: List<Int>) : QuickReplyEffect
 }
 
 /**
@@ -86,6 +96,7 @@ sealed interface QuickReplyEffect {
 class QuickReplyViewModel @AssistedInject constructor(
     @Assisted private val request: QuickReplyRequest,
     private val replyRepository: ReplyRepository,
+    private val quoteMaterializer: ReplyQuoteMaterializer,
     private val draftStore: EditorDraftStore,
     userPreferencesRepository: UserPreferencesRepository,
 ) : ViewModel() {
@@ -138,13 +149,44 @@ class QuickReplyViewModel @AssistedInject constructor(
      * typically escalate → edit in the full-screen editor → back → reopen. The row is the
      * source of truth ; the field is unconditionally re-seeded from it (gate Codex PR #788).
      */
-    fun onSheetOpened() {
+    fun onSheetOpened(initialQuote: QuotedPostPreview? = null) {
+        if (initialQuote != null) onQuoteAdded(initialQuote)
         viewModelScope.launch {
             initJob.join()
             val body = draftStore.load(draftOwner, draftKey)?.body.orEmpty()
             _state.update {
                 it.copy(text = TextFieldValue(text = body, selection = TextRange(body.length)))
             }
+        }
+    }
+
+    /** #604 lot 2 — arm a quote card ; idempotent per numreponse (re-citing a post is a no-op). */
+    fun onQuoteAdded(preview: QuotedPostPreview) {
+        _state.update { current ->
+            if (current.quotes.any { it.numreponse == preview.numreponse }) {
+                current
+            } else {
+                current.copy(quotes = current.quotes + preview)
+            }
+        }
+    }
+
+    fun onQuoteRemoved(numreponse: Int) {
+        _state.update { current ->
+            current.copy(quotes = current.quotes.filterNot { it.numreponse == numreponse })
+        }
+    }
+
+    /** Move the card one slot up ([delta] = -1) or down (+1) ; out-of-range moves are no-ops. */
+    fun onQuoteMoved(numreponse: Int, delta: Int) {
+        _state.update { current ->
+            val index = current.quotes.indexOfFirst { it.numreponse == numreponse }
+            val target = index + delta
+            if (index < 0 || target < 0 || target > current.quotes.lastIndex) return@update current
+            val reordered = current.quotes.toMutableList().apply {
+                add(target, removeAt(index))
+            }
+            current.copy(quotes = reordered)
         }
     }
 
@@ -180,7 +222,7 @@ class QuickReplyViewModel @AssistedInject constructor(
         autosaveJob?.cancel()
         viewModelScope.launch {
             saveDraftNow()
-            _effects.send(QuickReplyEffect.EscalateToFullEditor)
+            _effects.send(QuickReplyEffect.EscalateToFullEditor(_state.value.quotes.map { it.numreponse }))
         }
     }
 
@@ -225,13 +267,36 @@ class QuickReplyViewModel @AssistedInject constructor(
         _state.update { it.copy(isSubmitting = true, submitError = null) }
         submitJob = viewModelScope.launch {
             val outcome = runCatching {
-                val form = loadedForm ?: replyRepository.fetchReplyForm(context).also { loadedForm = it }
-                replyRepository.submitReply(
-                    context = context,
-                    form = form,
-                    bbcodeContent = _state.value.text.text,
-                    options = form.options,
-                )
+                val quotes = _state.value.quotes
+                if (quotes.isEmpty()) {
+                    val form = loadedForm ?: replyRepository.fetchReplyForm(context).also { loadedForm = it }
+                    replyRepository.submitReply(
+                        context = context,
+                        form = form,
+                        bbcodeContent = _state.value.text.text,
+                        options = form.options,
+                    )
+                } else {
+                    // #604 lot 2 — materialise the [quotemsg] prefills fresh (never the cached
+                    // plain form: the quote form carries the prefills AND the hash the submit
+                    // rides). Card order = citation order ; the typed body follows the quotes.
+                    // A network failure leaves body AND cards untouched (state only mutates on
+                    // success), per the cadrage's partial-submit interdiction.
+                    val quoteContext = context.copy(
+                        quotedNumreponse = quotes.first().numreponse,
+                        quoteRef = null,
+                    )
+                    val form = quoteMaterializer.fetchFormWithQuotes(
+                        context = quoteContext,
+                        extraQuoteNumreponses = quotes.drop(1).map { it.numreponse },
+                    )
+                    replyRepository.submitReply(
+                        context = quoteContext,
+                        form = form,
+                        bbcodeContent = form.initialContent.trimEnd() + "\n\n" + _state.value.text.text,
+                        options = form.options,
+                    )
+                }
             }
             outcome.fold(
                 onSuccess = { result -> handleSubmitOutcome(result) },

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModel.kt
@@ -290,10 +290,17 @@ class QuickReplyViewModel @AssistedInject constructor(
                         context = quoteContext,
                         extraQuoteNumreponses = quotes.drop(1).map { it.numreponse },
                     )
+                    val body = _state.value.text.text
                     replyRepository.submitReply(
                         context = quoteContext,
                         form = form,
-                        bbcodeContent = form.initialContent.trimEnd() + "\n\n" + _state.value.text.text,
+                        // Quotes-only reply: no trailing blank lines after the last [quotemsg]
+                        // (gate #798 — the exact BBCode is pinned by the VM tests).
+                        bbcodeContent = if (body.isBlank()) {
+                            form.initialContent.trimEnd()
+                        } else {
+                            form.initialContent.trimEnd() + "\n\n" + body
+                        },
                         options = form.options,
                     )
                 }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -126,13 +126,14 @@ import kotlinx.coroutines.flow.first
 fun TopicScreen(
     request: TopicRequest,
     /**
-     * Open the reply editor for this topic. The lambda receives the topic's
-     * sub-category id (parsed from the loaded page) and the current page number ;
-     * cat and topicId are derived from [request]. Phase 2C-A only invokes this
-     * callback when the topic carries a valid `subcat` (otherwise the reply button
-     * stays disabled to avoid passing a sentinel value to the HFR write contract).
+     * Open the FULL-SCREEN reply editor for this topic — since #604 lot 1 this is the quick-reply
+     * sheet's ESCALATION only (the reply FAB opens the sheet). The lambda receives the topic's
+     * sub-category id, the current page, and the armed quote cards' numreponses in citation order
+     * (lot 2 — empty for a plain escalation) ; cat and topicId are derived from [request]. `:app`
+     * rides the quotes on the editor route (`quotedNumreponse`/`extraQuoteNumreponses`) with
+     * `resumeSharedDraft = true` (#790) so the editor auto-applies the sheet's #405 row.
      */
-    onReply: (subcat: Int, page: Int) -> Unit,
+    onReply: (subcat: Int, page: Int, quoteNumreponses: List<Int>) -> Unit,
     /**
      * Vague 4 (#604) lot 1 — HFR accepted a reply POSTed from the quick-reply sheet. `:app` must
      * refresh this topic route exactly like the full editor's onSubmitSucceeded (replace the route
@@ -140,18 +141,6 @@ fun TopicScreen(
      * since the sheet never entered the back stack.
      */
     onQuickReplySubmitted: (targetPage: Int?, scrollTo: Int?) -> Unit = { _, _ -> },
-    /**
-     * Open the editor in quote mode (Phase 2C, #146). Same destination as [onReply],
-     * but the editor GETs HFR's quote form and hydrates the draft with the
-     * `[quotemsg=…]` block HFR prefills. The call-site supplies
-     * `quotedNumreponse = post.numreponse` (always known) and `quoteRef = post.quoteRef`
-     * (forwarded when known, may be `null`). HFR identifies the cited post by
-     * `numrep={numreponse}` alone — `ref` is positional/optional (#227, proven live;
-     * `HfrClient.getReplyForm` omits `&ref=` when null) — so « Citer » is gated on
-     * `Topic.canReply` (cf. the per-post gate below), never on the presence of a
-     * parsed quote link. Obfuscated/cached rows with `quoteRef = null` are supported.
-     */
-    onQuote: (subcat: Int, page: Int, quotedNumreponse: Int, quoteRef: Int?) -> Unit,
     /**
      * Open the editor in edit mode (Phase 2D, #147). HFR exposes the edit link on
      * the post's left toolbar only when the post belongs to the current user and
@@ -251,12 +240,12 @@ fun TopicScreen(
     multiQuoteSelection: List<Int> = emptyList(),
     /**
      * #291 — toggles a post in the multi-quote basket. Only invoked under the same gate as
-     * [onQuote] (`shouldShowQuoteAction`): a topic the user cannot reply to has nothing to quote.
+     * « Citer » (`shouldShowQuoteAction`): a topic the user cannot reply to has nothing to quote.
      */
     onToggleMultiQuote: (preview: QuotedPostPreview) -> Unit = {},
     /**
      * #291 — opens the editor pre-filled with every selected quote (same destination as
-     * [onQuote]; `:app` rides the selection on the route and clears the basket). Receives the
+     * « Citer »; `:app` rides the selection on the route and clears the basket). Receives the
      * topic's `(subcat, page)` like [onReply].
      */
     onMultiQuote: (subcat: Int, page: Int) -> Unit = { _, _ -> },
@@ -461,7 +450,6 @@ fun TopicScreen(
         onBack = onBack,
         onReply = onReply,
         onQuickReplySubmitted = onQuickReplySubmitted,
-        onQuote = onQuote,
         onEdit = onEdit,
         onEditFirstPost = onEditFirstPost,
         onOpenPage = onOpenPage,
@@ -688,8 +676,7 @@ internal fun TopicContent(
     listState: LazyListState,
     onIntent: (TopicIntent) -> Unit,
     onBack: () -> Unit,
-    onReply: (subcat: Int, page: Int) -> Unit,
-    onQuote: (subcat: Int, page: Int, quotedNumreponse: Int, quoteRef: Int?) -> Unit,
+    onReply: (subcat: Int, page: Int, quoteNumreponses: List<Int>) -> Unit,
     onEdit: (subcat: Int, page: Int, numreponse: Int) -> Unit,
     onEditFirstPost: (subcat: Int, page: Int, numreponse: Int) -> Unit,
     onOpenPage: (Int) -> Unit,
@@ -739,10 +726,11 @@ internal fun TopicContent(
     } else {
         null
     }
-    // Vague 4 (#604) lot 1 — the reply FAB opens the quick-reply sheet instead of navigating ;
-    // the sheet escalates to the full-screen editor through the existing onReply. Local UI state
-    // (like the page picker) : non-null while the sheet is up, carrying the reply coordinates.
-    var quickReplyFor by remember { mutableStateOf<QuickReplyRequest?>(null) }
+    // Vague 4 (#604) lots 1-2 — the reply FAB and « Citer » both open the quick-reply sheet
+    // instead of navigating ; the sheet escalates to the full-screen editor through onReply.
+    // Local UI state (like the page picker) : non-null while the sheet is up, carrying the
+    // reply coordinates plus the card « Citer » pre-arms (null from the FAB).
+    var quickReplyFor by remember { mutableStateOf<QuickReplyLaunch?>(null) }
     Scaffold(
         modifier = if (scrollBehavior != null) {
             Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
@@ -770,11 +758,13 @@ internal fun TopicContent(
                 multiQuoteSelection = multiQuoteSelection,
                 onOpenPage = onOpenPage,
                 onReply = { subcat, page ->
-                    quickReplyFor = QuickReplyRequest(
-                        cat = state.request.cat,
-                        subcat = subcat,
-                        topicId = state.request.post,
-                        page = page,
+                    quickReplyFor = QuickReplyLaunch(
+                        request = QuickReplyRequest(
+                            cat = state.request.cat,
+                            subcat = subcat,
+                            topicId = state.request.post,
+                            page = page,
+                        ),
                     )
                 },
                 onMultiQuote = onMultiQuote,
@@ -837,7 +827,19 @@ internal fun TopicContent(
                             state = state,
                             topic = mode.topic,
                             hiddenNumreponses = mode.hiddenNumreponses,
-                            onQuote = onQuote,
+                            // #604 lot 2 — « Citer » opens the quick-reply sheet with the card
+                            // pre-armed (1-citation session) instead of the full-screen editor.
+                            onQuoteRequested = { preview ->
+                                quickReplyFor = QuickReplyLaunch(
+                                    request = QuickReplyRequest(
+                                        cat = state.request.cat,
+                                        subcat = mode.topic.subcat,
+                                        topicId = state.request.post,
+                                        page = mode.topic.page,
+                                    ),
+                                    initialQuote = preview,
+                                )
+                            },
                             onEdit = onEdit,
                             onEditFirstPost = onEditFirstPost,
                             onOpenPage = onOpenPage,
@@ -859,13 +861,14 @@ internal fun TopicContent(
             }
         }
     }
-    quickReplyFor?.let { replyRequest ->
+    quickReplyFor?.let { launch ->
         QuickReplySheet(
-            request = replyRequest,
+            request = launch.request,
+            initialQuote = launch.initialQuote,
             onDismiss = { quickReplyFor = null },
-            onEscalate = {
+            onEscalate = { quoteNumreponses ->
                 quickReplyFor = null
-                onReply(replyRequest.subcat, replyRequest.page)
+                onReply(launch.request.subcat, launch.request.page, quoteNumreponses)
             },
             onSubmitted = { targetPage, scrollTo ->
                 quickReplyFor = null
@@ -1196,7 +1199,7 @@ private fun TopicLoadedContent(
     hiddenNumreponses: Set<Int> = emptySet(),
     // Vague 3 (#604) — onReply dropped: the dissolved header card was its only consumer here
     // (the bottom FAB cluster replies from TopicContent's own callback).
-    onQuote: (subcat: Int, page: Int, quotedNumreponse: Int, quoteRef: Int?) -> Unit,
+    onQuoteRequested: (preview: QuotedPostPreview) -> Unit,
     onEdit: (subcat: Int, page: Int, numreponse: Int) -> Unit,
     onEditFirstPost: (subcat: Int, page: Int, numreponse: Int) -> Unit,
     onOpenPage: (Int) -> Unit,
@@ -1391,7 +1394,7 @@ private fun TopicLoadedContent(
             val quoteAction: (() -> Unit)?
             val multiQuoteToggle: (() -> Unit)?
             if (shouldShowQuoteAction(topic, state.isAuthenticated)) {
-                quoteAction = { onQuote(topic.subcat, topic.page, post.numreponse, post.quoteRef) }
+                quoteAction = { onQuoteRequested(post.toQuotedPreview()) }
                 multiQuoteToggle = { onToggleMultiQuote(post.toQuotedPreview()) }
             } else {
                 quoteAction = null
@@ -1953,7 +1956,7 @@ internal fun TopicPostCard(
     /**
      * #436 — toggles this post in/out of the multi-quote basket directly from the card footer
      * (RF1 quote+/quote- parity), without opening the « … » menu. Null under the same gate as
-     * [onQuote] (a non-postable topic has nothing to quote), so the « + » action and « Citer »
+     * « Citer » (a non-postable topic has nothing to quote), so the « + » action and « Citer »
      * appear together or not at all. The same [multiQuoteSelected] flag drives the glyph/label
      * here, the border, and the pill — one source of truth, they can never desynchronise.
      */
@@ -2699,6 +2702,13 @@ private fun ReplyFab(onClick: () -> Unit) {
 // not purged on logout, cf. CacheInvalidator), so these gates consult auth explicitly instead
 // of trusting `canReply` alone — symmetric with the « Créer topic » FAB
 // (CategoryViewModel.canCreateTopic).
+// #604 lot 2 — what opens the quick-reply sheet : the reply coordinates, plus the card a
+// « Citer » tap pre-arms (null when launched from the reply FAB).
+internal data class QuickReplyLaunch(
+    val request: QuickReplyRequest,
+    val initialQuote: QuotedPostPreview? = null,
+)
+
 // #604 lot 2 — the quote-card snapshot, built AT SELECTION TIME where the full Post is in scope
 // (cadrage Codex : the cards never re-parse a post ; the exact [quotemsg] is fetched at
 // materialisation). Uniqueness in the basket stays keyed on the numreponse.

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -139,4 +139,10 @@
     <string name="quick_reply_error_unknown">HFR a renvoyé une réponse inattendue. Réessayez ou actualisez l\'app.</string>
     <string name="quick_reply_error_network">Erreur réseau. Vérifiez votre connexion et réessayez.</string>
     <string name="quick_reply_error_session_expired">Votre session HFR a expiré. Reconnectez-vous.</string>
+    <!-- #604 lot 2 : cartes de citation de la réponse rapide. -->
+    <string name="quick_reply_quote_line">❝ %1$s — %2$s</string>
+    <string name="quick_reply_quote_no_text">(citation sans texte)</string>
+    <string name="quick_reply_quote_move_up">Monter la citation de %1$s</string>
+    <string name="quick_reply_quote_move_down">Descendre la citation de %1$s</string>
+    <string name="quick_reply_quote_remove">Retirer la citation de %1$s</string>
 </resources>

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModelTest.kt
@@ -2,11 +2,13 @@ package fr.forumhfr.redface2.feature.topic
 
 import androidx.compose.ui.text.input.TextFieldValue
 import fr.forumhfr.redface2.core.domain.editor.EditorDraftStore
+import fr.forumhfr.redface2.core.domain.write.ReplyQuoteMaterializer
 import fr.forumhfr.redface2.core.domain.write.ReplyRepository
 import fr.forumhfr.redface2.core.model.write.ReplyContext
 import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
 import fr.forumhfr.redface2.core.model.write.ReplyForm
 import fr.forumhfr.redface2.core.model.write.ReplyFormOptions
+import fr.forumhfr.redface2.core.model.write.QuotedPostPreview
 import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -154,7 +156,7 @@ class QuickReplyViewModelTest {
         val effect = viewModel.effects.first()
 
         // The effect is only emitted once the row is written — the full editor restores it.
-        assertEquals(QuickReplyEffect.EscalateToFullEditor, effect)
+        assertEquals(QuickReplyEffect.EscalateToFullEditor(emptyList()), effect)
         assertEquals("à finir en plein écran", store.storedBody)
     }
 
@@ -188,6 +190,100 @@ class QuickReplyViewModelTest {
         assertEquals(1, repository.submitCalls)
     }
 
+    @Test
+    fun `quote cards accumulate in citation order and adding twice is a no-op`() = runTest {
+        val viewModel = quickReplyViewModel()
+
+        viewModel.onQuoteAdded(preview(101, "alice"))
+        viewModel.onQuoteAdded(preview(202, "bob"))
+        viewModel.onQuoteAdded(preview(101, "alice-encore"))
+
+        assertEquals(listOf(101, 202), viewModel.state.value.quotes.map { it.numreponse })
+    }
+
+    @Test
+    fun `cards can be reordered within bounds and removed`() = runTest {
+        val viewModel = quickReplyViewModel()
+        viewModel.onQuoteAdded(preview(101, "alice"))
+        viewModel.onQuoteAdded(preview(202, "bob"))
+        viewModel.onQuoteAdded(preview(303, "carol"))
+
+        viewModel.onQuoteMoved(303, delta = -1)
+        assertEquals(listOf(101, 303, 202), viewModel.state.value.quotes.map { it.numreponse })
+
+        viewModel.onQuoteMoved(101, delta = -1) // already first — no-op
+        assertEquals(listOf(101, 303, 202), viewModel.state.value.quotes.map { it.numreponse })
+
+        viewModel.onQuoteRemoved(303)
+        assertEquals(listOf(101, 202), viewModel.state.value.quotes.map { it.numreponse })
+    }
+
+    @Test
+    fun `a submit with cards materialises the prefills before the typed body`() = runTest {
+        val repository = FakeQuickReplyRepository(
+            results = mutableListOf(ReplySubmitResult.Success(refreshUrl = null, targetPage = 9, numreponse = 77)),
+        )
+        val viewModel = quickReplyViewModel(replyRepository = repository)
+        advanceUntilIdle() // init prefetch (plain form)
+        viewModel.onQuoteAdded(preview(101, "alice"))
+        viewModel.onQuoteAdded(preview(202, "bob"))
+        viewModel.onTextChanged(TextFieldValue("mon avis"))
+
+        viewModel.onSubmitClicked()
+        advanceUntilIdle()
+
+        // Materialisation fetched the quote forms in citation order (after the init prefetch).
+        assertEquals(listOf(null, 101, 202), repository.fetchedQuotedNumreponses)
+        assertEquals(
+            "[quotemsg=101]corps[/quotemsg]\n\n[quotemsg=202]corps[/quotemsg]\n\nmon avis",
+            repository.submittedBodies.single(),
+        )
+        assertEquals(QuickReplyEffect.SubmitSucceeded(targetPage = 9, scrollTo = 77), viewModel.effects.first())
+        assertTrue(viewModel.state.value.quotes.isEmpty())
+    }
+
+    @Test
+    fun `a submit failure keeps the body and the cards`() = runTest {
+        val repository = FakeQuickReplyRepository(
+            results = mutableListOf(ReplySubmitResult.Failure(ReplyFailureReason.AntiFlood)),
+        )
+        val viewModel = quickReplyViewModel(replyRepository = repository)
+        viewModel.onQuoteAdded(preview(101, "alice"))
+        viewModel.onTextChanged(TextFieldValue("texte"))
+
+        viewModel.onSubmitClicked()
+        advanceUntilIdle()
+
+        assertEquals(listOf(101), viewModel.state.value.quotes.map { it.numreponse })
+        assertEquals("texte", viewModel.state.value.text.text)
+    }
+
+    @Test
+    fun `cards alone allow the submit`() = runTest {
+        val viewModel = quickReplyViewModel()
+        assertTrue(!viewModel.state.value.canSubmit)
+        viewModel.onQuoteAdded(preview(101, "alice"))
+        assertTrue(viewModel.state.value.canSubmit)
+    }
+
+    @Test
+    fun `escalation carries the card numreponses in citation order`() = runTest {
+        val store = FakeQuickReplyDraftStore()
+        val viewModel = quickReplyViewModel(draftStore = store)
+        viewModel.onQuoteAdded(preview(202, "bob"))
+        viewModel.onQuoteAdded(preview(101, "alice"))
+        viewModel.onTextChanged(TextFieldValue("suite en plein écran"))
+
+        viewModel.onEscalateRequested()
+        val effect = viewModel.effects.first()
+
+        assertEquals(QuickReplyEffect.EscalateToFullEditor(listOf(202, 101)), effect)
+        assertEquals("suite en plein écran", store.storedBody)
+    }
+
+    private fun preview(numreponse: Int, author: String): QuotedPostPreview =
+        QuotedPostPreview(numreponse = numreponse, author = author, excerpt = "extrait")
+
     private fun quickReplyViewModel(
         replyRepository: ReplyRepository = FakeQuickReplyRepository(),
         draftStore: EditorDraftStore = FakeQuickReplyDraftStore(),
@@ -195,6 +291,7 @@ class QuickReplyViewModelTest {
     ): QuickReplyViewModel = QuickReplyViewModel(
         request = QuickReplyRequest(cat = 23, subcat = 401, topicId = 35421, page = 3),
         replyRepository = replyRepository,
+        quoteMaterializer = ReplyQuoteMaterializer(replyRepository),
         draftStore = draftStore,
         userPreferencesRepository = FakeUserPreferencesRepository(confirmBeforePosting = confirmBeforePosting),
     )
@@ -233,10 +330,19 @@ private class FakeQuickReplyRepository(
     var fetchCalls = 0
     var submitCalls = 0
     val submittedBodies = mutableListOf<String>()
+    val fetchedQuotedNumreponses = mutableListOf<Int?>()
 
     override suspend fun fetchReplyForm(context: ReplyContext): ReplyForm {
         fetchCalls++
-        return ReplyForm(hashCheck = "hash", sujet = "sujet", hiddenFields = emptyMap(), isAnonymous = false)
+        fetchedQuotedNumreponses += context.quotedNumreponse
+        val prefill = context.quotedNumreponse?.let { "[quotemsg=$it]corps[/quotemsg]" }.orEmpty()
+        return ReplyForm(
+            hashCheck = "hash",
+            sujet = "sujet",
+            hiddenFields = emptyMap(),
+            isAnonymous = false,
+            initialContent = prefill,
+        )
     }
 
     override suspend fun submitReply(

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModelTest.kt
@@ -243,6 +243,20 @@ class QuickReplyViewModelTest {
     }
 
     @Test
+    fun `a quotes-only submit pins the exact BBCode without trailing blank lines`() = runTest {
+        val repository = FakeQuickReplyRepository(
+            results = mutableListOf(ReplySubmitResult.Success(refreshUrl = null, targetPage = null)),
+        )
+        val viewModel = quickReplyViewModel(replyRepository = repository)
+        viewModel.onQuoteAdded(preview(101, "alice"))
+
+        viewModel.onSubmitClicked()
+        advanceUntilIdle()
+
+        assertEquals("[quotemsg=101]corps[/quotemsg]", repository.submittedBodies.single())
+    }
+
+    @Test
     fun `a submit failure keeps the body and the cards`() = runTest {
         val repository = FakeQuickReplyRepository(
             results = mutableListOf(ReplySubmitResult.Failure(ReplyFailureReason.AntiFlood)),


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Vague 4 « Postage » de #604 — **lot 2, PR B de 2 : les citations-cartes dans la réponse rapide**. Closes #790.

## Contenu (conforme au cadrage Codex, forks 5b/7/8)

- **« Citer » ouvre la feuille de réponse rapide** avec la carte pré-armée (session à 1 citation, même modèle que le multi-quote — fork 8). Citer un autre post pendant une session ouverte ajoute une 2e carte (idempotent par numreponse). Le plein écran reste accessible par escalade.
- **Cartes au-dessus du champ** : « ❝ auteur — extrait » sur 1 ligne, suppression ✕ et réordonnancement **↑/↓** (boutons, a11y d'abord — fork 7, drag différé ; premier/dernier désactivés, pas masqués, layout stable pour TalkBack). Un envoi cartes-seules est valide.
- **Envoi avec cartes** : matérialisation fraîche des `[quotemsg]` via le `ReplyQuoteMaterializer` partagé (PR A) — ordre des cartes = ordre de citation, texte après les citations, submit sur le hash du quote form. Un échec réseau **conserve corps et cartes** (interdiction du submit partiel du cadrage).
- **Escalade avec cartes** (fork 5b) : les numreponses montent sur la route (`quotedNumreponse` + `extraQuoteNumreponses`) — le plein écran matérialise lui-même, comme le FAB ❝N. Le corps ne voyage jamais en route arg.
- **Fix #790** (#tagbug styx42 + Dintr-un lemn, à l'heure du dogfood 0.21.0) : l'éditeur escaladé **auto-applique** la row #405 partagée au lieu de la bannière « Restaurer » (`resumeSharedDraft` sur la route). Le corps s'**appende** au restore, le prefill se **prepend** à l'arrivée du form — **commutatif** quel que soit l'ordre d'arrivée, gardé contre le double-prepend du refetch hash. C'était l'angle mort n°5 du cadrage (« sans écraser ni dupliquer ») : sans ce mode, la bannière écrasait ou bloquait le prefill.

## Tests

- `QuickReplyViewModelTest` (16 au total) : accumulation/idempotence des cartes, réordonnancement borné, suppression, envoi matérialisé (ordre des fetches + corps soumis vérifiés), échec = corps+cartes conservés, cartes-seules soumettables, escalade avec ordre.
- `PostEditorViewModelTest` (+3) : resume sans bannière, prefill prepend sur corps restauré, fallback hydration classique sans draft.
- detektAll + lint + 3 modules de tests verts.

## Dogfood (émulateur, captures)

- « Citer » → sheet + carte « ❝ styx42 — Reprise du message précé… » (↑↓ désactivés à 1 carte, Envoyer actif).
- 2e « Citer » → 2 cartes dans l'ordre ; **↓ sur la carte 1** → ordre inversé.
- **Escalade** → plein écran : `[quotemsg=2790161]` puis `[quotemsg=2790160]` (l'ordre réordonné), suivi du texte de la sheet, **sans bannière** — #790 vérifié de visu.
- Pas d'envoi réel (pas de post de test sur le fil public) — même `submitReply` éprouvé, chemin matérialisé couvert par les tests.

## Checklist

- [x] Cadrage Codex (lot 2, forks 5-8) appliqué
- [x] Review Codex (gate gpt-5.5 xhigh — verdict dans les commentaires)
- [x] Validation canonique locale (detektAll + lintProdDebug + tests + assembleProdDebug)
