### PR TITLE
chore(release): bump versionName to 0.22.0 (Postage lot 2)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,14 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.22.0` — `internal` (dev) — 2026-07-03
+
+**Phase « Vue Topic » (#604) — vague 4 « Postage », lot 2** (PRs #797 #798 — cadrage 9 forks + gates Codex gpt-5.5, dogfood émulateur).
+
+### Vue Topic
+- **Citations-cartes dans la réponse rapide** : « Citer » ouvre désormais la feuille de réponse rapide avec une carte compacte « ❝ auteur — extrait » (citer un autre message ajoute une carte) ; suppression et réordonnancement ↑/↓ par carte ; l'envoi matérialise les `[quotemsg]` dans l'ordre des cartes, le texte à la suite ; la bascule plein écran emporte les citations. Un échec d'envoi ne perd ni le texte ni les cartes.
+- #790 (styx42, Dintr-un lemn) : **la bascule réponse rapide → plein écran reprend le texte automatiquement** — plus d'étape « Restaurer » sur ce chemin (la bannière reste pour les brouillons de sessions antérieures).
+
 ## `0.21.0` — `internal` (dev) — 2026-07-03
 
 **Phase « Vue Topic » (#604) — vague 4 « Postage », lot 1** (PR #788 — cadrage + gate Codex gpt-5.5 NO-GO→fixes→GO, dogfood IME émulateur).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.21.0"
+        versionName = "0.22.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,3 +1,4 @@
-Redface 2 v0.21.0 — dev.
+Redface 2 v0.22.0 — dev.
 
-- Topic: quick reply sheet — the reply button opens a lightweight field (send directly or switch to full screen, shared draft, nothing is lost on close).
+- Quick reply: "Quote" now adds quote cards (reorderable, removable); send and the full-screen switch honour the order.
+- Quick reply: switching to full screen now carries the text automatically.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,3 +1,4 @@
-Redface 2 v0.21.0 — dev.
+Redface 2 v0.22.0 — dev.
 
-- Sujet : réponse rapide en feuille — le bouton répondre ouvre un champ léger (envoi direct ou bascule plein écran, brouillon partagé, rien ne se perd à la fermeture).
+- Réponse rapide : « Citer » y ajoute des cartes de citation (réordonnables, supprimables) ; l'envoi et la bascule plein écran respectent l'ordre.
+- Réponse rapide : la bascule plein écran reprend le texte automatiquement.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump de release dev : vague 4 Postage lot 2 (citations-cartes, PRs #797 #798) + fix #790.

- `versionName` 0.21.0 → 0.22.0 (nouvelle feature visible = bump minor)
- Entrée `app/CHANGELOG.md` + whatsnew fr/en (version en 1re ligne)

Édit mécanique (bump) — pas de gate Codex, conformément à l'exception de la cadence.