### PR TITLE
feat(editor): cartes de citation dans l'éditeur plein écran — Postage lot 3 PR D (#604)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -338,32 +338,17 @@ data class PostEditorRoute(
      */
     val subcat: Int? = null,
     /**
-     * `numreponse` of the post being quoted (Phase 2C, #146). `null` for a
-     * simple reply ; non-null when the user tapped « Citer » on a specific post.
-     * Routed verbatim into `PostEditorRequest.quotedNumreponse`.
-     */
-    val quotedNumreponse: Int? = null,
-    /**
-     * `ref` parameter extracted from HFR's quote link on the source post when HFR
-     * exposed it in clear HTML. Opaque positional id ; forwarded as-is to
-     * `HfrClient.getReplyForm`. `null` for a simple reply or for an obfuscated /
-     * absent quote link ; quote still works from `quotedNumreponse` alone.
-     */
-    val quoteRef: Int? = null,
-    /**
-     * #291 multi-quote — `numreponse`s of the ADDITIONAL posts to quote after
-     * [quotedNumreponse], in selection order. The editor replays the #146 quote
-     * form fetch once per entry and concatenates the `[quotemsg]` prefills —
-     * client-side only, no new HFR contract. Empty for single quote / plain
-     * reply ; defaulted so older serialised back stacks deserialise.
-     */
-    val extraQuoteNumreponses: List<Int> = emptyList(),
-    /**
      * #790 (#604 lot 2) — `true` when this editor is the ESCALATION of a quick-reply sheet: the
      * shared #405 draft row was just written by the sheet, so the editor auto-applies it instead
      * of surfacing the restore banner (the escalation continues the same composition act). The
      * text itself never rides the route — only this flag does. Defaulted so older serialised
      * back stacks deserialise.
+     *
+     * #604 lot 3 — the quote args (`quotedNumreponse`/`quoteRef`/`extraQuoteNumreponses`) left
+     * this route : citations are CARDS handed over in memory (cf. `MultiQuoteNavState.
+     * pendingEditorQuotes`), transient by decision. Removing serialised fields is
+     * restore-safe — the decoder reads the class descriptor's elements and simply never
+     * touches extra keys an older back stack may have stored.
      */
     val resumeSharedDraft: Boolean = false,
 ) : RedfaceNavKey
@@ -1102,6 +1087,12 @@ fun RedfaceApp(intent: Intent?) {
         // time (selecting in another topic resets it — quoting is a single-topic act). Plain
         // remember: losing it on process death just means re-selecting, like the markers above.
         var multiQuoteBasket by remember { mutableStateOf<MultiQuoteBasket?>(null) }
+        // #604 lot 3 — quote cards handed to the NEXT full-screen editor (mockup P3) : set right
+        // before pushing a PostEditorRoute (« Citer N » or a sheet escalation), consumed ONCE by
+        // the editor entry (read into the request, then cleared) so a later editor can never
+        // resurrect a stale citation set. In-memory on purpose — the cards are transient by
+        // decision (lot 2) : a process death keeps the #405 draft text but drops the cards.
+        var pendingEditorQuotes by remember { mutableStateOf<List<QuotedPostPreview>?>(null) }
         // #465 — per-topic MANUAL poll-expansion choice, keyed by (cat, post) (one poll per topic),
         // twin of topicTitleCache / topicScrollAnchorCache: a page change replaces the TopicRoute
         // (new nav entry → new ViewModel), so a `rememberSaveable` toggle inside the poll card was
@@ -1125,6 +1116,7 @@ fun RedfaceApp(intent: Intent?) {
                     // #291 — a write intention armed under another session must not survive the
                     // transition (Codex review: stale « Citer N » after logout/login).
                     multiQuoteBasket = null
+                    pendingEditorQuotes = null
                     resetStack(messagesBackStack, MessagesRoute, MessagesRoute)
                 }
                 is AuthState.Authenticated -> {
@@ -1137,6 +1129,7 @@ fun RedfaceApp(intent: Intent?) {
                     lastReconciledGeneration = 0
                     privateMessageSentSignal = null
                     multiQuoteBasket = null
+                    pendingEditorQuotes = null
                     resetStack(messagesBackStack, MessagesRoute, MessagesRoute)
                 }
             }
@@ -1325,6 +1318,8 @@ fun RedfaceApp(intent: Intent?) {
                                 multiQuoteBasket = multiQuoteBasket.toggled(cat, post, preview)
                             },
                             onClear = { multiQuoteBasket = null },
+                            pendingEditorQuotes = pendingEditorQuotes,
+                            onEditorQuotesHandoff = { pendingEditorQuotes = it },
                         ),
                         topicPollNavState = TopicPollNavState(
                             expansions = topicPollExpansionCache,
@@ -1711,11 +1706,18 @@ private data class TopicScrollNavState(
 /**
  * #291 — multi-quote nav bundle threaded into [RedfaceNavHost], same shape as the other
  * hoisted-state bundles ([TopicScrollNavState], `TopicTitleNavState`).
+ *
+ * #604 lot 3 — also carries the editor quote HANDOFF : [pendingEditorQuotes] is set (via
+ * [onEditorQuotesHandoff]) right before a PostEditorRoute is pushed with citations (« Citer N »
+ * or a sheet escalation), read once by the editor entry into `PostEditorRequest.initialQuotes`,
+ * then cleared (null). Never serialised into the route — the cards are transient by decision.
  */
 private data class MultiQuoteNavState(
     val basket: MultiQuoteBasket?,
     val onToggle: (cat: Int, post: Int, preview: QuotedPostPreview) -> Unit,
     val onClear: () -> Unit,
+    val pendingEditorQuotes: List<QuotedPostPreview>? = null,
+    val onEditorQuotesHandoff: (List<QuotedPostPreview>?) -> Unit = {},
 )
 
 /**
@@ -2405,11 +2407,13 @@ private fun RedfaceNavHost(
                         topicScrollNavState.onAnchorSaved(route.cat, route.post, route.page, anchor)
                     },
                     onOpenProfile = onOpenProfile,
-                    // #604 lots 1-2 — onReply is the quick-reply sheet's ESCALATION : the sheet
+                    // #604 lots 1-3 — onReply is the quick-reply sheet's ESCALATION : the sheet
                     // just persisted the shared #405 row, so the editor auto-applies it (#790,
                     // resumeSharedDraft) instead of surfacing the restore banner. The armed quote
-                    // cards ride the route in citation order, same shape as the multi-quote FAB.
-                    onReply = { subcat, page, quoteNumreponses ->
+                    // cards travel as FULL previews through the in-memory handoff (lot 3, mockup
+                    // P3) — the editor renders the same cards and materialises at submit.
+                    onReply = { subcat, page, quotes ->
+                        multiQuoteNavState.onEditorQuotesHandoff(quotes.takeIf { it.isNotEmpty() })
                         backStack.add(
                             PostEditorRoute(
                                 mode = PostEditorMode.Reply,
@@ -2417,9 +2421,6 @@ private fun RedfaceNavHost(
                                 topicId = route.post,
                                 page = page,
                                 subcat = subcat,
-                                quotedNumreponse = quoteNumreponses.firstOrNull(),
-                                quoteRef = null,
-                                extraQuoteNumreponses = quoteNumreponses.drop(1),
                                 resumeSharedDraft = true,
                             ),
                         )
@@ -2461,15 +2462,18 @@ private fun RedfaceNavHost(
                         topicPollNavState.onExpansionChanged(route.cat, route.post, expanded)
                     },
                     onMultiQuote = { subcat, page ->
-                        // #291 — quote flavour of reply with the EXTRA numreponses riding the
-                        // route; the editor replays the #146 fetch per entry. The basket is
-                        // cleared on launch: the selection's intent is consumed, and backing
-                        // out of the editor should not re-arm a stale « Citer N ».
+                        // #291 / #604 lot 3 — quote flavour of reply : the basket's previews are
+                        // handed to the editor (cards, mockup P3) through the in-memory handoff.
+                        // The basket is cleared on launch: the selection's intent is consumed,
+                        // and backing out of the editor should not re-arm a stale « Citer N ».
+                        // resumeSharedDraft (Codex fork 4) : quoting is a continuation of this
+                        // topic's composition — any sheet-drafted text is picked up bannerless.
                         val selection = multiQuoteNavState.basket
                             ?.takeIf { it.matches(route.cat, route.post) }
-                            ?.numreponses
+                            ?.selections
                             .orEmpty()
                         if (selection.isNotEmpty()) {
+                            multiQuoteNavState.onEditorQuotesHandoff(selection)
                             backStack.add(
                                 PostEditorRoute(
                                     mode = PostEditorMode.Reply,
@@ -2477,9 +2481,7 @@ private fun RedfaceNavHost(
                                     topicId = route.post,
                                     page = page,
                                     subcat = subcat,
-                                    quotedNumreponse = selection.first(),
-                                    quoteRef = null,
-                                    extraQuoteNumreponses = selection.drop(1),
+                                    resumeSharedDraft = true,
                                 ),
                             )
                             multiQuoteNavState.onClear()
@@ -2589,6 +2591,13 @@ private fun RedfaceNavHost(
                 )
             }
             entry<PostEditorRoute> { route ->
+                // #604 lot 3 — consume the quote handoff ONCE : the previews reach the ViewModel
+                // through the assisted request (used only at first creation — a recomposition or
+                // configuration change reuses the existing VM, so the cleared handoff is moot),
+                // and the LaunchedEffect clears the slot so a LATER editor can never resurrect a
+                // stale citation set. Process death drops the handoff with the process : the
+                // restored editor keeps the #405 text, not the cards (transient by decision).
+                LaunchedEffect(Unit) { multiQuoteNavState.onEditorQuotesHandoff(null) }
                 PostEditorScreen(
                     request = PostEditorRequest(
                         mode = route.mode,
@@ -2597,9 +2606,7 @@ private fun RedfaceNavHost(
                         numreponse = route.numreponse,
                         page = route.page,
                         subcat = route.subcat,
-                        quotedNumreponse = route.quotedNumreponse,
-                        quoteRef = route.quoteRef,
-                        extraQuoteNumreponses = route.extraQuoteNumreponses,
+                        initialQuotes = multiQuoteNavState.pendingEditorQuotes.orEmpty(),
                         resumeSharedDraft = route.resumeSharedDraft,
                     ),
                     onSubmitSucceeded = { targetPage, scrollTo ->

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/QuoteCards.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/QuoteCards.kt
@@ -1,0 +1,103 @@
+package fr.forumhfr.redface2.core.ui.editor
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.model.write.QuotedPostPreview
+import fr.forumhfr.redface2.core.ui.R
+
+/**
+ * #604 lots 2-3 — one quote card: « ❝ author — excerpt » on a single line, with reorder and
+ * remove affordances. Born in the quick-reply sheet (lot 2), promoted to `:core:ui` when the
+ * full-screen editor adopted the same cards (lot 3, mockup P3) — one rendering for the one
+ * mental model « citations = cartes, champ = texte ». Reordering is up/down buttons by design
+ * (cadrage : a11y first, drag deferred) ; first/last are disabled instead of hidden so TalkBack
+ * users hear a stable layout.
+ */
+@Composable
+fun QuoteCard(
+    quote: QuotedPostPreview,
+    controls: QuoteCardControls,
+) {
+    val moveUpLabel = stringResource(R.string.editor_quote_move_up, quote.author)
+    val moveDownLabel = stringResource(R.string.editor_quote_move_down, quote.author)
+    val removeLabel = stringResource(R.string.editor_quote_remove, quote.author)
+    Surface(
+        shape = MaterialTheme.shapes.small,
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        tonalElevation = 1.dp,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = stringResource(
+                    R.string.editor_quote_line,
+                    quote.author,
+                    quote.excerpt.ifBlank { stringResource(R.string.editor_quote_no_text) },
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(start = 12.dp),
+            )
+            QuoteCardAction(
+                enabled = controls.enabled && controls.canMoveUp,
+                label = moveUpLabel,
+                glyph = "↑",
+                onClick = controls.onMoveUp,
+            )
+            QuoteCardAction(
+                enabled = controls.enabled && controls.canMoveDown,
+                label = moveDownLabel,
+                glyph = "↓",
+                onClick = controls.onMoveDown,
+            )
+            QuoteCardAction(
+                enabled = controls.enabled,
+                label = removeLabel,
+                glyph = "✕",
+                onClick = controls.onRemove,
+            )
+        }
+    }
+}
+
+/** Reorder/remove affordances of one card, bundled for detekt's parameter budget. */
+data class QuoteCardControls(
+    val canMoveUp: Boolean,
+    val canMoveDown: Boolean,
+    val enabled: Boolean,
+    val onMoveUp: () -> Unit,
+    val onMoveDown: () -> Unit,
+    val onRemove: () -> Unit,
+)
+
+@Composable
+private fun QuoteCardAction(
+    enabled: Boolean,
+    label: String,
+    glyph: String,
+    onClick: () -> Unit,
+) {
+    IconButton(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = Modifier.semantics { contentDescription = label },
+    ) {
+        Text(text = glyph, style = MaterialTheme.typography.titleMedium)
+    }
+}

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -95,4 +95,11 @@
     <string name="editor_upload_progress">Envoi %1$d/%2$d…</string>
     <string name="editor_upload_provider_diberie">diberie</string>
     <string name="editor_upload_provider_imgur">imgur</string>
+
+    <!-- #604 lot 3 - cartes de citation partagees sheet + editeur plein ecran (promu de :feature:topic). -->
+    <string name="editor_quote_line">❝ %1$s — %2$s</string>
+    <string name="editor_quote_no_text">(citation sans texte)</string>
+    <string name="editor_quote_move_up">Monter la citation de %1$s</string>
+    <string name="editor_quote_move_down">Descendre la citation de %1$s</string>
+    <string name="editor_quote_remove">Retirer la citation de %1$s</string>
 </resources>

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorIntent.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorIntent.kt
@@ -83,6 +83,15 @@ sealed interface PostEditorIntent {
 
     /** #405 — user tapped « Ignorer » on the draft banner: delete the cached draft and clear the banner. */
     data object DraftDiscardRequested : PostEditorIntent
+
+    /** #604 lot 3 — remove one quote card (✕). Identified by numreponse, like the sheet. */
+    data class QuoteRemoved(val numreponse: Int) : PostEditorIntent
+
+    /** #604 lot 3 — move a quote card one slot up ([delta] = -1) or down (+1) ; out-of-range = no-op. */
+    data class QuoteMoved(val numreponse: Int, val delta: Int) : PostEditorIntent
+
+    /** #436 (#604 lot 3) — « Tout vider » : drop every quote card. The typed body is untouched. */
+    data object QuotesCleared : PostEditorIntent
 }
 
 /**

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorRequest.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorRequest.kt
@@ -1,5 +1,7 @@
 package fr.forumhfr.redface2.feature.editor
 
+import fr.forumhfr.redface2.core.model.write.QuotedPostPreview
+
 /**
  * Plain request payload assisted-injected into [PostEditorViewModel]. Mirrors the
  * `PostEditorRoute` NavKey from `:app/navigation` without leaking Navigation 3
@@ -20,31 +22,19 @@ data class PostEditorRequest(
     val page: Int?,
     val subcat: Int?,
     /**
-     * `numreponse` of the post the user is quoting (Phase 2C, #146). `null` for a
-     * simple reply. When non-null, the ViewModel builds a quote `ReplyContext`
-     * and HFR returns a prefilled `[quotemsg=…]` block via `ReplyForm.initialContent`.
+     * #604 lot 3 (mockup P3) — the quote CARDS this editor opens with, in citation order :
+     * « Citer N » selections or a quick-reply escalation's armed cards. Consumed once into
+     * [PostEditorViewModel]'s `quotes` state ; the `[quotemsg]` blocks are materialised at
+     * SUBMIT (never prefetched into the field — citations are cards, the field is the user's
+     * text). Handed over in memory by `:app` (never serialised into the route) : the cards are
+     * deliberately transient, a process death keeps the text (#405 row) but drops the cards.
      */
-    val quotedNumreponse: Int? = null,
-    /**
-     * `ref` parameter HFR included in the quote link of the source post when it was
-     * parseable. Opaque positional id, parsed from `Post.quoteRef`. Forwarded
-     * unchanged ; never synthesised. `null` when the source post had an obfuscated
-     * or absent quote link — HFR still quotes from [quotedNumreponse] alone.
-     */
-    val quoteRef: Int? = null,
-    /**
-     * #291 multi-quote — `numreponse`s of the ADDITIONAL posts to quote after
-     * [quotedNumreponse], in selection order. The ViewModel replays the quote form
-     * fetch once per entry (same #146 contract, `quotedNumreponse` swapped) and
-     * concatenates the `[quotemsg]` prefills into the initial draft. Empty for a
-     * single quote or a plain reply.
-     */
-    val extraQuoteNumreponses: List<Int> = emptyList(),
+    val initialQuotes: List<QuotedPostPreview> = emptyList(),
     /**
      * #790 (#604 lot 2) — `true` when this editor is the ESCALATION of a quick-reply sheet. The
      * ViewModel then auto-applies the shared #405 draft row instead of surfacing the restore
-     * banner, and COMBINES it with a quote prefill when both are present (prefill first, body
-     * after — commutative whatever lands first, never clobbering either).
+     * banner (appending to anything already typed — the escalation continues the same
+     * composition act).
      */
     val resumeSharedDraft: Boolean = false,
 )

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
@@ -47,10 +48,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
+import fr.forumhfr.redface2.core.model.write.QuotedPostPreview
 import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
 import fr.forumhfr.redface2.core.ui.editor.ArmedSubmitActions
 import fr.forumhfr.redface2.core.ui.editor.ArmedSubmitButton
@@ -60,6 +64,8 @@ import fr.forumhfr.redface2.core.ui.editor.BbcodePreview
 import fr.forumhfr.redface2.core.ui.editor.BbcodeTextField
 import fr.forumhfr.redface2.core.ui.editor.BbcodeToolbar
 import fr.forumhfr.redface2.core.ui.editor.EditorOptionsSheet
+import fr.forumhfr.redface2.core.ui.editor.QuoteCard
+import fr.forumhfr.redface2.core.ui.editor.QuoteCardControls
 
 
 /**
@@ -154,6 +160,17 @@ private fun PostEditorContent(
                 // Multi-image upload — « n/N » progress under the toolbar while a batch (> 1 image)
                 // is in flight. A single upload keeps uploadProgress null (toolbar spinner only).
                 UploadProgressLabel(state.uploadProgress)
+
+                // #604 lot 3 (mockup P3) — the armed citations as cards ABOVE the field, the same
+                // rendering as the quick-reply sheet : the field only ever holds the user's text,
+                // the [quotemsg] blocks are materialised at submit. Scrolls internally past a few
+                // cards so a heavy multiquote can never crush the weighted field below. (Renders
+                // nothing without cards — the empty-check lives inside, detekt complexity budget.)
+                EditorQuoteCards(
+                    quotes = state.quotes,
+                    enabled = !state.isSubmitting,
+                    onIntent = onIntent,
+                )
 
                 BbcodeTextField(
                     value = state.draft,
@@ -337,6 +354,58 @@ internal fun DraftRestoreBanner(
         }
     }
 }
+
+/**
+ * #604 lot 3 (mockup P3) — the quote cards block of the full-screen editor : the shared
+ * [QuoteCard] rendering plus « Tout vider » (#436, shown from two cards up — for one card the
+ * per-card ✕ is the same act). The cards column scrolls internally above [MAX_VISIBLE_CARDS_HEIGHT]
+ * so a heavy multiquote (the case that FORCES the full screen) never crushes the draft field.
+ */
+@Composable
+private fun EditorQuoteCards(
+    quotes: List<QuotedPostPreview>,
+    enabled: Boolean,
+    onIntent: (PostEditorIntent) -> Unit,
+) {
+    if (quotes.isEmpty()) return
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        if (quotes.size > 1) {
+            val clearAllLabel = stringResource(R.string.editor_quotes_clear_all_a11y)
+            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) {
+                TextButton(
+                    onClick = { onIntent(PostEditorIntent.QuotesCleared) },
+                    enabled = enabled,
+                    modifier = Modifier.semantics { contentDescription = clearAllLabel },
+                ) {
+                    Text(text = stringResource(R.string.editor_quotes_clear_all))
+                }
+            }
+        }
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier
+                .heightIn(max = MAX_VISIBLE_CARDS_HEIGHT)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            quotes.forEachIndexed { index, quote ->
+                QuoteCard(
+                    quote = quote,
+                    controls = QuoteCardControls(
+                        canMoveUp = index > 0,
+                        canMoveDown = index < quotes.lastIndex,
+                        enabled = enabled,
+                        onMoveUp = { onIntent(PostEditorIntent.QuoteMoved(quote.numreponse, delta = -1)) },
+                        onMoveDown = { onIntent(PostEditorIntent.QuoteMoved(quote.numreponse, delta = 1)) },
+                        onRemove = { onIntent(PostEditorIntent.QuoteRemoved(quote.numreponse)) },
+                    ),
+                )
+            }
+        }
+    }
+}
+
+// #604 lot 3 — ~4 one-line cards ; past that the cards column scrolls internally.
+private val MAX_VISIBLE_CARDS_HEIGHT = 192.dp
 
 /**
  * Display state of [EditorSubmitBar]. [confirmArmed] is the « confirmation avant

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
@@ -8,6 +8,7 @@ import fr.forumhfr.redface2.core.domain.editor.BbcodeValidation
 import fr.forumhfr.redface2.core.domain.editor.validateBbcodeDraft
 import fr.forumhfr.redface2.core.model.EditorSmiley
 import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.model.write.QuotedPostPreview
 import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
 
 /**
@@ -27,17 +28,13 @@ data class PostEditorState(
     /** Sub-category id required by HFR's write contract. Null when unknown — reply disabled. */
     val subcat: Int?,
     /**
-     * `numreponse` of the post being quoted (Phase 2C, #146). When non-null the
-     * editor opened in quote mode : HFR prefills `[quotemsg=…]` and we hydrate
-     * the draft with it on form load. Same surface as a simple reply otherwise.
+     * #604 lot 3 (mockup P3) — the armed quote CARDS, in citation order. Seeded from
+     * [PostEditorRequest.initialQuotes], reorderable / removable / clearable from the UI
+     * (#436 « Tout vider »). The field never contains their BBCode : the `[quotemsg]`
+     * blocks are materialised fresh at submit, exactly like the quick-reply sheet
+     * (one implementation, `ReplyQuoteMaterializer`). Always empty in [PostEditorMode.Edit].
      */
-    val quotedNumreponse: Int? = null,
-    /**
-     * `ref` parameter HFR included in the quote link when parseable — opaque,
-     * forwarded as-is. May be null on a quote: HFR still quotes from
-     * [quotedNumreponse] alone when the toolbar link was obfuscated.
-     */
-    val quoteRef: Int? = null,
+    val quotes: List<QuotedPostPreview> = emptyList(),
     val draft: TextFieldValue = TextFieldValue(),
     val preview: PostContent = PostContent(blocks = emptyList()),
     val isPreviewVisible: Boolean = false,
@@ -138,7 +135,10 @@ data class PostEditorState(
             // `Topic.subcat` / `Topic.canReply`.
             (subcat != null && subcat >= 0) &&
             topicId != null &&
-            draft.text.isNotBlank() &&
+            // #604 lot 3 — a quotes-only reply is sendable (same rule as the quick-reply
+            // sheet : the materialised [quotemsg] blocks ARE the content). Edit keeps
+            // requiring a non-blank body — its cards list is always empty.
+            (draft.text.isNotBlank() || (mode == PostEditorMode.Reply && quotes.isNotEmpty())) &&
             !isSubmitting &&
             !isLoadingForm &&
             !isUploading

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -30,6 +30,7 @@ import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import fr.forumhfr.redface2.core.model.write.EditPostContext
+import fr.forumhfr.redface2.core.model.write.QuotedPostPreview
 import fr.forumhfr.redface2.core.model.write.ReplyContext
 import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
 import fr.forumhfr.redface2.core.model.write.ReplyForm
@@ -97,8 +98,14 @@ class PostEditorViewModel @AssistedInject constructor(
             numreponse = request.numreponse,
             page = request.page,
             subcat = request.subcat,
-            quotedNumreponse = request.quotedNumreponse,
-            quoteRef = request.quoteRef,
+            // #604 lot 3 — cards seeded from the handoff, deduplicated defensively on the
+            // numreponse (same uniqueness rule as the basket / the sheet) and gated to Reply :
+            // an Edit session has nothing to quote.
+            quotes = if (request.mode == PostEditorMode.Reply) {
+                request.initialQuotes.distinctBy { it.numreponse }
+            } else {
+                emptyList()
+            },
         ),
     )
     val state: StateFlow<PostEditorState> = _state.asStateFlow()
@@ -206,8 +213,9 @@ class PostEditorViewModel @AssistedInject constructor(
      *
      * #790 exception — when the route carries `resumeSharedDraft` (escalation of a quick-reply
      * sheet, which JUST wrote the row), the body is APPENDED to the field instead of banner'd :
-     * the escalation continues the same composition act. Append (not replace) keeps this
-     * commutative with the quote-prefill prepend in [withFormHydration], whichever lands first.
+     * the escalation continues the same composition act. (The quote-prefill prepend this used to
+     * be commutative with is gone since #604 lot 3 — citations are cards, the plain reply form
+     * carries no prefill.)
      */
     private fun restoreDraftIfAny() {
         val key = draftKey ?: return
@@ -224,9 +232,7 @@ class PostEditorViewModel @AssistedInject constructor(
                     } else {
                         current.draft.text.trimEnd() + "\n\n" + body
                     }
-                    current
-                        .withDraft(TextFieldValue(text = combined, selection = TextRange(combined.length)))
-                        .copy(draftHydratedFromForm = current.draft.text.isNotBlank())
+                    current.withDraft(TextFieldValue(text = combined, selection = TextRange(combined.length)))
                 }
                 scheduleAutosave()
             } else {
@@ -281,6 +287,29 @@ class PostEditorViewModel @AssistedInject constructor(
             PostEditorIntent.UploadErrorDismissed -> _state.update { it.copy(uploadError = null) }
             PostEditorIntent.DraftRestoreRequested -> onDraftRestoreRequested()
             PostEditorIntent.DraftDiscardRequested -> onDraftDiscardRequested()
+            is PostEditorIntent.QuoteRemoved -> onQuoteRemoved(intent.numreponse)
+            is PostEditorIntent.QuoteMoved -> onQuoteMoved(intent.numreponse, intent.delta)
+            PostEditorIntent.QuotesCleared -> _state.update { it.copy(quotes = emptyList()) }
+        }
+    }
+
+    /** #604 lot 3 — same card semantics as the quick-reply sheet (remove by numreponse). */
+    private fun onQuoteRemoved(numreponse: Int) {
+        _state.update { current ->
+            current.copy(quotes = current.quotes.filterNot { it.numreponse == numreponse })
+        }
+    }
+
+    /** #604 lot 3 — move the card one slot up ([delta] = -1) or down (+1) ; out-of-range = no-op. */
+    private fun onQuoteMoved(numreponse: Int, delta: Int) {
+        _state.update { current ->
+            val index = current.quotes.indexOfFirst { it.numreponse == numreponse }
+            val target = index + delta
+            if (index < 0 || target < 0 || target > current.quotes.lastIndex) return@update current
+            val reordered = current.quotes.toMutableList().apply {
+                add(target, removeAt(index))
+            }
+            current.copy(quotes = reordered)
         }
     }
 
@@ -613,10 +642,11 @@ class PostEditorViewModel @AssistedInject constructor(
             _state.update { it.copy(submitError = SubmitError.MissingSubcat) }
             return
         }
-        // #291 multi-quote — promoted to the shared ReplyQuoteMaterializer (#604 lot 2), one
-        // implementation for the full editor and the quick-reply sheet. Same contract as before:
-        // extras fetched sequentially in selection order, submit rides the FIRST form's hash.
-        launchFormFetch { quoteMaterializer.fetchFormWithQuotes(context, request.extraQuoteNumreponses) }
+        // #604 lot 3 (mockup P3) — the open-time fetch is always the PLAIN reply form now :
+        // citations live as cards in [PostEditorState.quotes] and their [quotemsg] blocks are
+        // materialised fresh at submit (see [onSubmitClicked]), exactly like the quick-reply
+        // sheet. This fetch only warms the hash and hydrates the per-post options.
+        launchFormFetch { replyRepository.fetchReplyForm(context) }
     }
 
     private fun loadEditFormIfPossible() {
@@ -672,35 +702,18 @@ class PostEditorViewModel @AssistedInject constructor(
             draft.text.isBlank() &&
             form.initialContent.isNotBlank()
 
-    /**
-     * #790 resume — the shared draft body reached the field first (classic hydration is
-     * blank-field-only): PREPEND the quote prefill instead, keeping the escalated text after
-     * the [quotemsg] blocks. Guarded by draftHydratedFromForm so the InvalidHashCheck silent
-     * refetch can never prepend twice.
-     */
-    private fun PostEditorState.shouldPrependPrefillFrom(form: ReplyForm, shouldHydrate: Boolean): Boolean =
-        request.resumeSharedDraft &&
-            !draftHydratedFromForm &&
-            !shouldHydrate &&
-            form.initialContent.isNotBlank() &&
-            draft.text.isNotBlank()
-
     private fun PostEditorState.resolveHydratedDraft(
         form: ReplyForm,
         shouldHydrate: Boolean,
-        shouldPrependPrefill: Boolean,
-    ): TextFieldValue = when {
-        shouldHydrate -> TextFieldValue(
+    ): TextFieldValue = if (shouldHydrate) {
+        TextFieldValue(
             text = form.initialContent,
             // Place caret at the end so the user can type their content
             // right after the prefill — matches HFR's web behavior.
             selection = TextRange(form.initialContent.length),
         )
-        shouldPrependPrefill -> {
-            val combined = form.initialContent.trimEnd() + "\n\n" + draft.text
-            TextFieldValue(text = combined, selection = TextRange(combined.length))
-        }
-        else -> draft
+    } else {
+        draft
     }
 
     /**
@@ -729,8 +742,7 @@ class PostEditorViewModel @AssistedInject constructor(
         nextPreview: PostContent,
     ): PostEditorState {
         val shouldHydrate = shouldHydrateFrom(form)
-        val shouldPrependPrefill = shouldPrependPrefillFrom(form, shouldHydrate)
-        val nextDraft = resolveHydratedDraft(form, shouldHydrate, shouldPrependPrefill)
+        val nextDraft = resolveHydratedDraft(form, shouldHydrate)
         val hydrateOptions = !optionsHydratedFromForm
         return copy(
             isLoadingForm = false,
@@ -741,7 +753,7 @@ class PostEditorViewModel @AssistedInject constructor(
             // flips to false on `current` and we keep the user-driven
             // preview ; the parsed `nextPreview` is dropped.
             preview = if (shouldHydrate && isPreviewVisible) nextPreview else preview,
-            draftHydratedFromForm = draftHydratedFromForm || shouldHydrate || shouldPrependPrefill,
+            draftHydratedFromForm = draftHydratedFromForm || shouldHydrate,
             signatureEnabled = if (hydrateOptions) form.options.signatureEnabled else signatureEnabled,
             smileyDisabled = if (hydrateOptions) form.options.smileyDisabled else smileyDisabled,
             emailNotificationEnabled = if (hydrateOptions) {
@@ -834,12 +846,7 @@ class PostEditorViewModel @AssistedInject constructor(
                 when (snapshot.mode) {
                     PostEditorMode.Reply -> {
                         val context = buildReplyContext() ?: error("canSubmit lied about reply context")
-                        replyRepository.submitReply(
-                            context = context,
-                            form = form,
-                            bbcodeContent = snapshot.draft.text,
-                            options = options,
-                        )
+                        submitReply(context, form, snapshot, options)
                     }
                     PostEditorMode.Edit -> {
                         val context = buildEditPostContext() ?: error("canSubmit lied about edit context")
@@ -857,6 +864,51 @@ class PostEditorViewModel @AssistedInject constructor(
                 onFailure = ::handleSubmitFailure,
             )
         }
+    }
+
+    /**
+     * #604 lot 3 (mockup P3) — the Reply POST, quotes-aware. Without cards the cached plain form
+     * is submitted as before. With cards the [quotemsg] blocks are materialised FRESH here (never
+     * the cached plain form : the quote form carries the prefills AND the hash the submit rides),
+     * card order = citation order, the typed body follows the quotes ; a quotes-only reply keeps
+     * no trailing blank lines (same pinned BBCode as the quick-reply sheet). A failure anywhere
+     * leaves body AND cards untouched — the state only mutates on success. One divergence from
+     * the sheet : [options] comes from the editor's user-editable toggles, not the form defaults.
+     */
+    private suspend fun submitReply(
+        context: ReplyContext,
+        form: ReplyForm,
+        snapshot: PostEditorState,
+        options: ReplyFormOptions,
+    ): ReplySubmitResult {
+        val quotes = snapshot.quotes
+        if (quotes.isEmpty()) {
+            return replyRepository.submitReply(
+                context = context,
+                form = form,
+                bbcodeContent = snapshot.draft.text,
+                options = options,
+            )
+        }
+        val quoteContext = context.copy(
+            quotedNumreponse = quotes.first().numreponse,
+            quoteRef = null,
+        )
+        val quoteForm = quoteMaterializer.fetchFormWithQuotes(
+            context = quoteContext,
+            extraQuoteNumreponses = quotes.drop(1).map { it.numreponse },
+        )
+        val body = snapshot.draft.text
+        return replyRepository.submitReply(
+            context = quoteContext,
+            form = quoteForm,
+            bbcodeContent = if (body.isBlank()) {
+                quoteForm.initialContent.trimEnd()
+            } else {
+                quoteForm.initialContent.trimEnd() + "\n\n" + body
+            },
+            options = options,
+        )
     }
 
     private suspend fun handleSubmitOutcome(
@@ -950,17 +1002,13 @@ class PostEditorViewModel @AssistedInject constructor(
         // #213 — mirror the `ReplyContext.init` rule : reject only the SUBCAT_UNKNOWN
         // sentinel (-1). `subcat = 0` is postable (cat without sub-category, e.g. IA).
         if (subcat < 0) return null
+        // #604 lot 3 — always the PLAIN context : citations are cards, and [submitReply]
+        // derives the quote context (first card's numreponse) when materialising.
         return ReplyContext(
             cat = snapshot.cat,
             subcat = subcat,
             topicId = topicId,
             page = page,
-            // Phase 2C (#146) : both fields are null for a simple reply ; both
-            // non-null for a quote launched from `TopicScreen.onQuote`. The model
-            // tolerates a quote with a null `quoteRef` for forward compat (HFR
-            // could drop `ref` someday), but we keep them aligned in practice.
-            quotedNumreponse = snapshot.quotedNumreponse,
-            quoteRef = snapshot.quoteRef,
         )
     }
 

--- a/feature/editor/src/main/res/values/strings.xml
+++ b/feature/editor/src/main/res/values/strings.xml
@@ -4,6 +4,9 @@
     <string name="editor_topic_new_title">Nouveau sujet</string>
     <string name="editor_topic_edit_first_post_title">Modifier le premier message</string>
     <string name="editor_field_label">Contenu BBCode</string>
+    <!-- #436 (#604 lot 3) : cartes de citation dans l'éditeur plein écran. -->
+    <string name="editor_quotes_clear_all">Tout vider</string>
+    <string name="editor_quotes_clear_all_a11y">Retirer toutes les citations</string>
     <string name="editor_field_placeholder">Saisissez votre message…</string>
     <string name="editor_preview_show">Afficher l\'aperçu</string>
     <string name="editor_preview_hide">Masquer l\'aperçu</string>

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -42,6 +42,7 @@ import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.PostBlock
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.PostInline
+import fr.forumhfr.redface2.core.model.write.QuotedPostPreview
 import fr.forumhfr.redface2.core.model.write.ReplyContext
 import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
 import fr.forumhfr.redface2.core.model.write.ReplyForm
@@ -351,123 +352,124 @@ class PostEditorViewModelTest {
     }
 
     @Test
-    fun `quote VM forwards quotedNumreponse and quoteRef to ReplyRepository on form fetch`() = runTest {
-        replyRepository.formResult = Result.success(
-            authenticatedForm(initialContent = "[quotemsg=2784595,768,1214571]hi[/quotemsg]"),
-        )
-        newReplyViewModel(quotedNumreponse = 2784595, quoteRef = 0)
+    fun `quote cards leave the open-time fetch plain (#604 lot 3)`() = runTest {
+        replyRepository.formResult = Result.success(authenticatedForm())
+        val viewModel = newReplyViewModel(initialQuotes = listOf(card(2784595)))
         // Let the launched form fetch complete.
         testScheduler.advanceUntilIdle()
 
         val context = replyRepository.lastFetchedContext
         assertNotNull("fetchReplyForm must have been called", context)
         requireNotNull(context)
-        assertEquals("quoted numreponse must propagate", 2784595, context.quotedNumreponse)
-        assertEquals("quote ref must propagate", 0, context.quoteRef)
-        assertTrue("isQuote must be true", context.isQuote)
+        assertNull("open-time fetch must be the PLAIN form — cards materialise at submit", context.quotedNumreponse)
+        assertFalse("isQuote must be false at open", context.isQuote)
+        assertEquals(listOf(2784595), viewModel.state.value.quotes.map { it.numreponse })
     }
 
     @Test
-    fun `quote VM hydrates the draft from initialContent on first form load`() = runTest {
-        val prefill = "[quotemsg=2784595,768,1214571]hi[/quotemsg]"
-        replyRepository.formResult = Result.success(authenticatedForm(initialContent = prefill))
+    fun `quote cards never prefill the field — the draft stays user-owned`() = runTest {
+        replyRepository.formResult = Result.success(authenticatedForm())
 
-        val viewModel = newReplyViewModel(quotedNumreponse = 2784595, quoteRef = 0)
+        val viewModel = newReplyViewModel(initialQuotes = listOf(card(2784595)))
         viewModel.state.test {
             val settled = expectMostRecentItem()
             assertFalse("Form must be fully loaded", settled.isLoadingForm)
-            assertEquals("Draft hydrated with HFR prefill", prefill, settled.draft.text)
-            assertTrue("Caret placed at the end of the prefill", settled.draftHydratedFromForm)
-            assertEquals(prefill.length, settled.draft.selection.start)
+            assertEquals("field stays empty — citations are cards, not BBCode", "", settled.draft.text)
+            assertFalse("nothing hydrated from the plain form", settled.draftHydratedFromForm)
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `multi-quote VM concatenates the prefills in selection order (#291)`() = runTest {
-        // One #146 form fetch per quoted post — the FIRST carries the session form (hash_check),
-        // the extras only contribute their prefill. HFR prefills end with a trailing blank line;
-        // the merge must keep ONE blank line between quotes and one after the last.
+    fun `submit materialises the quote cards in card order (#291, #604 lot 3)`() = runTest {
+        // One #146 form fetch per card AT SUBMIT — the FIRST carries the session form
+        // (hash_check), the extras only contribute their prefill. HFR prefills end with a
+        // trailing blank line; the merge keeps ONE blank line between quotes, the typed body
+        // follows after a single blank line.
+        replyRepository.formResult = Result.success(authenticatedForm())
         replyRepository.formResultsByNumrep = mapOf(
             101 to Result.success(authenticatedForm(initialContent = "[quotemsg=101,1,9]a[/quotemsg]\n\n")),
             303 to Result.success(authenticatedForm(initialContent = "[quotemsg=303,3,9]c[/quotemsg]\n\n")),
             202 to Result.success(authenticatedForm(initialContent = "[quotemsg=202,2,9]b[/quotemsg]\n\n")),
         )
+        replyRepository.submitResult = ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
 
-        // Selection order 101 → 303 → 202 is deliberately NOT post order.
-        val viewModel = newReplyViewModel(
-            quotedNumreponse = 101,
-            quoteRef = 0,
-            extraQuoteNumreponses = listOf(303, 202),
-        )
+        // Card order 101 → 303 → 202 is deliberately NOT post order.
+        val viewModel = newReplyViewModel(initialQuotes = listOf(card(101), card(303), card(202)))
+        testScheduler.advanceUntilIdle()
+        assertEquals("open-time fetch is the plain form only", 1, replyRepository.formFetches)
+
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("Reply")))
+        viewModel.submit(PostEditorIntent.SubmitClicked)
         testScheduler.advanceUntilIdle()
 
-        assertEquals("one fetch per quoted post", 3, replyRepository.formFetches)
+        assertEquals("plain open fetch + one quote fetch per card", 4, replyRepository.formFetches)
         assertEquals(
-            "extras must replay the quote contract with the numreponse swapped (no stale quoteRef)",
-            listOf(101 to 0, 303 to null, 202 to null),
+            "cards replay the quote contract in CARD order (never a stale quoteRef)",
+            listOf(null to null, 101 to null, 303 to null, 202 to null),
             replyRepository.fetchedContexts.map { it.quotedNumreponse to it.quoteRef },
         )
-        viewModel.state.test {
-            val settled = expectMostRecentItem()
-            assertFalse("Form must be fully loaded", settled.isLoadingForm)
-            assertEquals(
-                "prefills concatenated in SELECTION order, single blank line between quotes",
-                "[quotemsg=101,1,9]a[/quotemsg]\n\n" +
-                    "[quotemsg=303,3,9]c[/quotemsg]\n\n" +
-                    "[quotemsg=202,2,9]b[/quotemsg]\n\n",
-                settled.draft.text,
-            )
-            cancelAndIgnoreRemainingEvents()
-        }
+        assertEquals("one POST riding the first quote form's hash", 1, replyRepository.submitCalls)
+        assertEquals(101, replyRepository.lastSubmittedContext?.quotedNumreponse)
+        assertEquals(
+            "prefills concatenated in card order, body after a single blank line",
+            "[quotemsg=101,1,9]a[/quotemsg]\n\n" +
+                "[quotemsg=303,3,9]c[/quotemsg]\n\n" +
+                "[quotemsg=202,2,9]b[/quotemsg]\n\nReply",
+            replyRepository.lastSubmittedBbcode,
+        )
     }
 
     @Test
-    fun `multi-quote VM fails the whole fetch when one extra quote fails (#291)`() = runTest {
+    fun `submit fails whole when one card's fetch fails — cards and body intact (#291)`() = runTest {
         // Silently dropping a quote the user explicitly selected would be worse than the
-        // retryable form-fetch error, so a failed extra fails the load.
+        // retryable error, so a failed card fails the whole submit — and loses NOTHING.
+        replyRepository.formResult = Result.success(authenticatedForm())
         replyRepository.formResultsByNumrep = mapOf(
             101 to Result.success(authenticatedForm(initialContent = "[quotemsg=101,1,9]a[/quotemsg]\n\n")),
             303 to Result.failure(java.io.IOException("boom")),
         )
 
-        val viewModel = newReplyViewModel(
-            quotedNumreponse = 101,
-            quoteRef = null,
-            extraQuoteNumreponses = listOf(303),
-        )
+        val viewModel = newReplyViewModel(initialQuotes = listOf(card(101), card(303)))
+        testScheduler.advanceUntilIdle()
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("Reply")))
+        viewModel.submit(PostEditorIntent.SubmitClicked)
         testScheduler.advanceUntilIdle()
 
+        assertEquals("nothing must reach HFR on a failed materialisation", 0, replyRepository.submitCalls)
         viewModel.state.test {
             val settled = expectMostRecentItem()
-            assertFalse(settled.isLoadingForm)
-            assertEquals("draft must not hydrate from a partial multi-quote", "", settled.draft.text)
+            assertFalse(settled.isSubmitting)
             assertEquals(SubmitError.Network, settled.submitError)
+            assertEquals("cards intact", listOf(101, 303), settled.quotes.map { it.numreponse })
+            assertEquals("body intact", "Reply", settled.draft.text)
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `multi-quote VM fails the whole fetch when a prefill comes back blank (#291)`() = runTest {
+    fun `submit fails whole when a card's prefill comes back blank (#291)`() = runTest {
         // A 200-OK form whose textarea prefill is EMPTY would otherwise silently drop a quote
-        // the user explicitly selected — same contract as a failed extra: fail globally.
+        // the user explicitly selected — same contract as a failed fetch: fail globally.
+        replyRepository.formResult = Result.success(authenticatedForm())
         replyRepository.formResultsByNumrep = mapOf(
             101 to Result.success(authenticatedForm(initialContent = "[quotemsg=101,1,9]a[/quotemsg]\n\n")),
             303 to Result.success(authenticatedForm(initialContent = "")),
         )
 
-        val viewModel = newReplyViewModel(
-            quotedNumreponse = 101,
-            quoteRef = null,
-            extraQuoteNumreponses = listOf(303),
-        )
+        val viewModel = newReplyViewModel(initialQuotes = listOf(card(101), card(303)))
+        testScheduler.advanceUntilIdle()
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("Reply")))
+        viewModel.submit(PostEditorIntent.SubmitClicked)
         testScheduler.advanceUntilIdle()
 
+        assertEquals("nothing must reach HFR", 0, replyRepository.submitCalls)
         viewModel.state.test {
             val settled = expectMostRecentItem()
-            assertFalse(settled.isLoadingForm)
-            assertEquals("draft must not hydrate from a partial multi-quote", "", settled.draft.text)
+            assertFalse(settled.isSubmitting)
             assertEquals(SubmitError.Hfr(ReplyFailureReason.Unknown), settled.submitError)
+            assertEquals("cards intact", listOf(101, 303), settled.quotes.map { it.numreponse })
+            assertEquals("body intact", "Reply", settled.draft.text)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -478,12 +480,10 @@ class PostEditorViewModelTest {
         // we gate the fetch with a CompletableDeferred so we can interleave them
         // exactly like the production race (network in flight, user typing).
         val formGate = CompletableDeferred<Unit>()
-        replyRepository.formResult = Result.success(
-            authenticatedForm(initialContent = "[quotemsg=2784595,768,1214571]hi[/quotemsg]"),
-        )
+        replyRepository.formResult = Result.success(authenticatedForm())
         replyRepository.formGate = formGate
 
-        val viewModel = newReplyViewModel(quotedNumreponse = 2784595, quoteRef = 0)
+        val viewModel = newReplyViewModel(initialQuotes = listOf(card(2784595)))
         // Type before the form lands.
         viewModel.submit(
             PostEditorIntent.ContentChanged(
@@ -716,35 +716,33 @@ class PostEditorViewModelTest {
     }
 
     @Test
-    fun `submit with InvalidHashCheck silently refetches without clobbering quote draft`() = runTest {
-        // `handleSubmitOutcome(InvalidHashCheck)` resets `loadedForm = null` and
-        // re-invokes `loadReplyFormIfPossible()`. The `draftHydratedFromForm`
-        // guard must prevent the refetch from overwriting whatever the user has
-        // typed since the initial hydration. We assert : (a) the second form
-        // fetch did happen, (b) the user's edited draft survives.
-        val prefill = "[quotemsg=2784595,768,1214571]hi[/quotemsg]"
-        replyRepository.formResult = Result.success(authenticatedForm(initialContent = prefill))
+    fun `submit with InvalidHashCheck silently refetches without clobbering draft or cards`() = runTest {
+        // `handleSubmitOutcome(InvalidHashCheck)` resets `loadedForm = null` and re-invokes
+        // `loadReplyFormIfPossible()` (plain form since #604 lot 3 — blank initialContent, so
+        // the refetch has nothing to clobber the field with). We assert : (a) the silent
+        // refetch did happen, (b) the user's text AND the cards survive.
+        replyRepository.formResult = Result.success(authenticatedForm())
+        replyRepository.formResultsByNumrep = mapOf(
+            2784595 to Result.success(
+                authenticatedForm(initialContent = "[quotemsg=2784595,768,1214571]hi[/quotemsg]\n\n"),
+            ),
+        )
         replyRepository.submitResult = ReplySubmitResult.Failure(ReplyFailureReason.InvalidHashCheck)
 
-        val viewModel = newReplyViewModel(quotedNumreponse = 2784595, quoteRef = 0)
+        val viewModel = newReplyViewModel(initialQuotes = listOf(card(2784595)))
         testScheduler.advanceUntilIdle()
-        assertEquals("initial form fetch", 1, replyRepository.formFetches)
+        assertEquals("initial plain form fetch", 1, replyRepository.formFetches)
 
-        // User edits the prefill (cursor at end → add a real reply after the quote).
-        val edited = "$prefill\n\nReply"
-        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue(edited)))
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("Reply")))
         viewModel.submit(PostEditorIntent.SubmitClicked)
         testScheduler.advanceUntilIdle()
 
-        assertEquals("silent refetch after InvalidHashCheck", 2, replyRepository.formFetches)
+        // Open (plain) + the card's quote-form materialisation + the silent plain refetch.
+        assertEquals("silent refetch after InvalidHashCheck", 3, replyRepository.formFetches)
         viewModel.state.test {
             val settled = expectMostRecentItem()
-            assertEquals(
-                "User edit must survive the silent refetch — draftHydratedFromForm blocks the rewrite",
-                edited,
-                settled.draft.text,
-            )
-            assertTrue("draftHydratedFromForm stays true across refetch", settled.draftHydratedFromForm)
+            assertEquals("user text must survive the silent refetch", "Reply", settled.draft.text)
+            assertEquals("cards must survive too", listOf(2784595), settled.quotes.map { it.numreponse })
             assertEquals(
                 SubmitError.Hfr(ReplyFailureReason.InvalidHashCheck),
                 settled.submitError,
@@ -754,18 +752,15 @@ class PostEditorViewModelTest {
     }
 
     @Test
-    fun `quote hydration refreshes preview when preview was already visible`() = runTest {
-        // Race : user opens quote editor, opens the preview pane WHILE the form
-        // is still loading, form arrives → both `draft` and `preview` must reflect
-        // the `[quotemsg=…]` prefill. Before round 2 the preview AST stayed empty
-        // until the next `ContentChanged` / `TogglePreview`, which felt like a bug
-        // even though the draft was fine.
+    fun `edit hydration refreshes preview when preview was already visible`() = runTest {
+        // Race : user opens the edit editor, opens the preview pane WHILE the form is still
+        // loading, form arrives → both `draft` and `preview` must reflect the existing post
+        // body. (Was a quote-prefill test before #604 lot 3 ; Edit is the only mode still
+        // hydrating the field from `initialContent`, so the guard now lives here.)
         val formGate = CompletableDeferred<Unit>()
-        val prefill = "[quotemsg=2784595,768,1214571]hi[/quotemsg]"
-        replyRepository.formResult = Result.success(authenticatedForm(initialContent = prefill))
-        replyRepository.formGate = formGate
+        editPostRepository.formGate = formGate
 
-        val viewModel = newReplyViewModel(quotedNumreponse = 2784595, quoteRef = 0)
+        val viewModel = newEditViewModel()
         // Toggle preview BEFORE the form lands.
         viewModel.submit(PostEditorIntent.TogglePreview)
         // Now release the form fetch.
@@ -774,11 +769,11 @@ class PostEditorViewModelTest {
 
         viewModel.state.test {
             val settled = expectMostRecentItem()
-            assertEquals("Draft hydrated with HFR prefill", prefill, settled.draft.text)
+            assertEquals("Draft hydrated with the existing post body", "existing post body", settled.draft.text)
             assertTrue("Preview was visible before hydration", settled.isPreviewVisible)
             assertEquals(
                 "Preview AST must reflect the hydrated draft",
-                previewParser.contentFor(prefill),
+                previewParser.contentFor("existing post body"),
                 settled.preview,
             )
             cancelAndIgnoreRemainingEvents()
@@ -788,9 +783,7 @@ class PostEditorViewModelTest {
     @Suppress("LongParameterList") // test helper: every param is an optional, defaulted scenario knob.
     private fun newReplyViewModel(
         subcat: Int? = SAMPLE_SUBCAT,
-        quotedNumreponse: Int? = null,
-        quoteRef: Int? = null,
-        extraQuoteNumreponses: List<Int> = emptyList(),
+        initialQuotes: List<QuotedPostPreview> = emptyList(),
         resumeSharedDraft: Boolean = false,
         diagnostics: DiagnosticsLog = DiagnosticsLog(),
         userPreferencesRepository: UserPreferencesRepository = FakeUserPreferencesRepository(),
@@ -804,9 +797,7 @@ class PostEditorViewModelTest {
                 numreponse = null,
                 page = SAMPLE_PAGE,
                 subcat = subcat,
-                quotedNumreponse = quotedNumreponse,
-                quoteRef = quoteRef,
-                extraQuoteNumreponses = extraQuoteNumreponses,
+                initialQuotes = initialQuotes,
                 resumeSharedDraft = resumeSharedDraft,
             ),
             previewParser = previewParser,
@@ -1773,41 +1764,113 @@ class PostEditorViewModelTest {
     }
 
     @Test
-    fun `resumeSharedDraft prepends the quote prefill to the resumed body`() = runTest {
-        draftStore.preload(
-            EditorDraftKey.reply(SAMPLE_CAT, SAMPLE_TOPIC_ID),
-            EditorDraftStore.Draft(body = "texte de la sheet"),
-        )
-        replyRepository.formResult =
-            Result.success(authenticatedForm(initialContent = "[quotemsg=101]cité[/quotemsg]"))
-        val viewModel = newReplyViewModel(resumeSharedDraft = true, quotedNumreponse = 101)
+    fun `resumeSharedDraft with no stored draft leaves the field empty — cards carry the citations`() = runTest {
+        // (Replaced the pre-lot-3 « prepend the quote prefill » contract : the plain reply form
+        // has no prefill anymore, the escalated citations arrive as cards.)
+        replyRepository.formResult = Result.success(authenticatedForm())
+        val viewModel = newReplyViewModel(resumeSharedDraft = true, initialQuotes = listOf(card(101)))
         testScheduler.advanceUntilIdle()
 
         viewModel.state.test {
             val settled = expectMostRecentItem()
-            assertEquals(
-                "[quotemsg=101]cité[/quotemsg]\n\ntexte de la sheet",
-                settled.draft.text,
-            )
+            assertEquals("", settled.draft.text)
             assertNull(settled.restorableDraft)
+            assertEquals(listOf(101), settled.quotes.map { it.numreponse })
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    // ----- #604 lot 3 : cartes de citation dans l'éditeur ---------------------
+
+    @Test
+    fun `initial quote cards are seeded in order and deduplicated`() = runTest {
+        replyRepository.formResult = Result.success(authenticatedForm())
+        val viewModel = newReplyViewModel(initialQuotes = listOf(card(202), card(101), card(202)))
+        assertEquals(listOf(202, 101), viewModel.state.value.quotes.map { it.numreponse })
     }
 
     @Test
-    fun `resumeSharedDraft with no stored draft falls back to classic prefill hydration`() = runTest {
-        replyRepository.formResult =
-            Result.success(authenticatedForm(initialContent = "[quotemsg=101]cité[/quotemsg]"))
-        val viewModel = newReplyViewModel(resumeSharedDraft = true, quotedNumreponse = 101)
+    fun `QuoteRemoved and QuotesCleared drop cards without touching the body`() = runTest {
+        replyRepository.formResult = Result.success(authenticatedForm())
+        val viewModel = newReplyViewModel(initialQuotes = listOf(card(101), card(202)))
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("body")))
+
+        viewModel.submit(PostEditorIntent.QuoteRemoved(101))
+        assertEquals(listOf(202), viewModel.state.value.quotes.map { it.numreponse })
+
+        viewModel.submit(PostEditorIntent.QuotesCleared)
+        assertEquals(emptyList<Int>(), viewModel.state.value.quotes.map { it.numreponse })
+        assertEquals("body untouched by card mutations", "body", viewModel.state.value.draft.text)
+    }
+
+    @Test
+    fun `QuoteMoved reorders within bounds and no-ops outside`() = runTest {
+        replyRepository.formResult = Result.success(authenticatedForm())
+        val viewModel = newReplyViewModel(initialQuotes = listOf(card(101), card(202), card(303)))
+
+        viewModel.submit(PostEditorIntent.QuoteMoved(303, delta = -1))
+        assertEquals(listOf(101, 303, 202), viewModel.state.value.quotes.map { it.numreponse })
+
+        viewModel.submit(PostEditorIntent.QuoteMoved(101, delta = -1))
+        assertEquals(
+            "first card cannot move up",
+            listOf(101, 303, 202),
+            viewModel.state.value.quotes.map { it.numreponse },
+        )
+
+        viewModel.submit(PostEditorIntent.QuoteMoved(999, delta = 1))
+        assertEquals(
+            "unknown card is a no-op",
+            listOf(101, 303, 202),
+            viewModel.state.value.quotes.map { it.numreponse },
+        )
+    }
+
+    @Test
+    fun `a quotes-only reply is submittable and keeps no trailing blank lines`() = runTest {
+        replyRepository.formResult = Result.success(authenticatedForm())
+        replyRepository.formResultsByNumrep = mapOf(
+            101 to Result.success(authenticatedForm(initialContent = "[quotemsg=101,1,9]a[/quotemsg]\n\n")),
+            202 to Result.success(authenticatedForm(initialContent = "[quotemsg=202,2,9]b[/quotemsg]\n\n")),
+        )
+        replyRepository.submitResult = ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
+        val viewModel = newReplyViewModel(initialQuotes = listOf(card(101), card(202)))
         testScheduler.advanceUntilIdle()
 
-        viewModel.state.test {
-            val settled = expectMostRecentItem()
-            assertEquals("[quotemsg=101]cité[/quotemsg]", settled.draft.text)
-            assertNull(settled.restorableDraft)
-            cancelAndIgnoreRemainingEvents()
-        }
+        assertTrue("cards alone must arm the submit (blank body)", viewModel.state.value.canSubmit)
+        viewModel.submit(PostEditorIntent.SubmitClicked)
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(
+            "quotes-only reply: pinned BBCode, no trailing blank lines (same contract as the sheet)",
+            "[quotemsg=101,1,9]a[/quotemsg]\n\n[quotemsg=202,2,9]b[/quotemsg]",
+            replyRepository.lastSubmittedBbcode,
+        )
     }
+
+    @Test
+    fun `submit with cards honours the editor's user-edited options`() = runTest {
+        replyRepository.formResult = Result.success(authenticatedForm())
+        replyRepository.formResultsByNumrep = mapOf(
+            101 to Result.success(authenticatedForm(initialContent = "[quotemsg=101,1,9]a[/quotemsg]\n\n")),
+        )
+        replyRepository.submitResult = ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
+        val viewModel = newReplyViewModel(initialQuotes = listOf(card(101)))
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(PostEditorIntent.ToggleSignature(true))
+        viewModel.submit(PostEditorIntent.SubmitClicked)
+        testScheduler.advanceUntilIdle()
+
+        assertTrue(
+            "the POST must ride the state's toggles, not the quote form's defaults",
+            replyRepository.lastSubmittedOptions?.signatureEnabled == true,
+        )
+    }
+
+    /** #604 lot 3 — quote-card snapshot, as the topic surface would build it at selection time. */
+    private fun card(numreponse: Int, author: String = "auteur$numreponse"): QuotedPostPreview =
+        QuotedPostPreview(numreponse = numreponse, author = author, excerpt = "extrait $numreponse")
 
     private fun authenticatedForm(initialContent: String = ""): ReplyForm = ReplyForm(
         hashCheck = "FAKE_HASH",

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySheet.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySheet.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SheetValue
@@ -31,12 +30,13 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.model.write.QuotedPostPreview
 import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
+import fr.forumhfr.redface2.core.ui.editor.QuoteCard
+import fr.forumhfr.redface2.core.ui.editor.QuoteCardControls
 import fr.forumhfr.redface2.core.ui.icon.RedfaceVectorIcon
 
 /**
@@ -51,7 +51,10 @@ import fr.forumhfr.redface2.core.ui.icon.RedfaceVectorIcon
 internal fun QuickReplySheet(
     request: QuickReplyRequest,
     onDismiss: () -> Unit,
-    onEscalate: (quoteNumreponses: List<Int>) -> Unit,
+    // #604 lot 3 — the escalation hands the armed cards over as full previews : the editor
+    // renders the same cards (mockup P3) and needs author + excerpt, which only the topic
+    // surface can snapshot. Riding the callback (→ the :app handoff), never the route.
+    onEscalate: (quotes: List<QuotedPostPreview>) -> Unit,
     onSubmitted: (targetPage: Int?, scrollTo: Int?) -> Unit,
     // #604 lot 2 — « Citer » opens the sheet with this card pre-armed (1-citation session).
     initialQuote: QuotedPostPreview? = null,
@@ -67,7 +70,7 @@ internal fun QuickReplySheet(
         viewModel.effects.collect { effect ->
             when (effect) {
                 is QuickReplyEffect.SubmitSucceeded -> onSubmitted(effect.targetPage, effect.scrollTo)
-                is QuickReplyEffect.EscalateToFullEditor -> onEscalate(effect.quoteNumreponses)
+                is QuickReplyEffect.EscalateToFullEditor -> onEscalate(effect.quotes)
             }
         }
     }
@@ -198,83 +201,5 @@ internal fun QuickReplySubmitError.messageRes(): Int = when (this) {
     }
 }
 
-/**
- * #604 lot 2 — one quote card: « ❝ author — excerpt » on a single line, with reorder and remove
- * affordances. Reordering is up/down buttons by design (cadrage : a11y first, drag deferred) ;
- * first/last are disabled instead of hidden so TalkBack users hear a stable layout.
- */
-/** Reorder/remove affordances of one card, bundled for detekt's parameter budget. */
-private data class QuoteCardControls(
-    val canMoveUp: Boolean,
-    val canMoveDown: Boolean,
-    val enabled: Boolean,
-    val onMoveUp: () -> Unit,
-    val onMoveDown: () -> Unit,
-    val onRemove: () -> Unit,
-)
-
-@Composable
-private fun QuoteCard(
-    quote: QuotedPostPreview,
-    controls: QuoteCardControls,
-) {
-    val moveUpLabel = stringResource(R.string.quick_reply_quote_move_up, quote.author)
-    val moveDownLabel = stringResource(R.string.quick_reply_quote_move_down, quote.author)
-    val removeLabel = stringResource(R.string.quick_reply_quote_remove, quote.author)
-    Surface(
-        shape = MaterialTheme.shapes.small,
-        color = MaterialTheme.colorScheme.surfaceContainerHighest,
-        tonalElevation = 1.dp,
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Text(
-                text = stringResource(
-                    R.string.quick_reply_quote_line,
-                    quote.author,
-                    quote.excerpt.ifBlank { stringResource(R.string.quick_reply_quote_no_text) },
-                ),
-                style = MaterialTheme.typography.bodySmall,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier
-                    .weight(1f)
-                    .padding(start = 12.dp),
-            )
-            QuoteCardAction(
-                enabled = controls.enabled && controls.canMoveUp,
-                label = moveUpLabel,
-                glyph = "↑",
-                onClick = controls.onMoveUp,
-            )
-            QuoteCardAction(
-                enabled = controls.enabled && controls.canMoveDown,
-                label = moveDownLabel,
-                glyph = "↓",
-                onClick = controls.onMoveDown,
-            )
-            QuoteCardAction(
-                enabled = controls.enabled,
-                label = removeLabel,
-                glyph = "✕",
-                onClick = controls.onRemove,
-            )
-        }
-    }
-}
-
-@Composable
-private fun QuoteCardAction(
-    enabled: Boolean,
-    label: String,
-    glyph: String,
-    onClick: () -> Unit,
-) {
-    IconButton(
-        onClick = onClick,
-        enabled = enabled,
-        modifier = Modifier.semantics { contentDescription = label },
-    ) {
-        Text(text = glyph, style = MaterialTheme.typography.titleMedium)
-    }
-}
+// #604 lot 3 — QuoteCard / QuoteCardControls promoted to `:core:ui` (core.ui.editor.QuoteCards):
+// the full-screen editor renders the same cards (mockup P3), one rendering for both surfaces.

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModel.kt
@@ -73,11 +73,11 @@ sealed interface QuickReplyEffect {
      * The draft is persisted — the sheet can hand over to the full-screen editor. Emitted only
      * AFTER the save completed: the full editor restores the SAME `EditorDraftKey.reply` row
      * (auto-applied, #790), so the ordering is the whole transfer mechanism (cadrage Codex :
-     * never a long text in a route arg, never a memory-only holder). [quoteNumreponses] rides
-     * the route as `quotedNumreponse`/`extraQuoteNumreponses` — the full editor materialises
-     * the `[quotemsg]` prefills itself, exactly like the multi-quote FAB path.
+     * never a long text in a route arg, never a memory-only holder). [quotes] (#604 lot 3)
+     * carries the armed cards as FULL previews through the :app handoff — the editor renders
+     * the same cards (mockup P3) and defers the `[quotemsg]` materialisation to its own submit.
      */
-    data class EscalateToFullEditor(val quoteNumreponses: List<Int>) : QuickReplyEffect
+    data class EscalateToFullEditor(val quotes: List<QuotedPostPreview>) : QuickReplyEffect
 }
 
 /**
@@ -222,7 +222,7 @@ class QuickReplyViewModel @AssistedInject constructor(
         autosaveJob?.cancel()
         viewModelScope.launch {
             saveDraftNow()
-            _effects.send(QuickReplyEffect.EscalateToFullEditor(_state.value.quotes.map { it.numreponse }))
+            _effects.send(QuickReplyEffect.EscalateToFullEditor(_state.value.quotes))
         }
     }
 

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -128,12 +128,13 @@ fun TopicScreen(
     /**
      * Open the FULL-SCREEN reply editor for this topic — since #604 lot 1 this is the quick-reply
      * sheet's ESCALATION only (the reply FAB opens the sheet). The lambda receives the topic's
-     * sub-category id, the current page, and the armed quote cards' numreponses in citation order
-     * (lot 2 — empty for a plain escalation) ; cat and topicId are derived from [request]. `:app`
-     * rides the quotes on the editor route (`quotedNumreponse`/`extraQuoteNumreponses`) with
-     * `resumeSharedDraft = true` (#790) so the editor auto-applies the sheet's #405 row.
+     * sub-category id, the current page, and the armed quote cards as FULL previews in citation
+     * order (lot 3 — empty for a plain escalation) ; cat and topicId are derived from [request].
+     * `:app` hands the previews to the editor through the in-memory handoff (never the route) with
+     * `resumeSharedDraft = true` (#790) so the editor auto-applies the sheet's #405 row and
+     * renders the same cards (mockup P3).
      */
-    onReply: (subcat: Int, page: Int, quoteNumreponses: List<Int>) -> Unit,
+    onReply: (subcat: Int, page: Int, quotes: List<QuotedPostPreview>) -> Unit,
     /**
      * Vague 4 (#604) lot 1 — HFR accepted a reply POSTed from the quick-reply sheet. `:app` must
      * refresh this topic route exactly like the full editor's onSubmitSucceeded (replace the route
@@ -676,7 +677,7 @@ internal fun TopicContent(
     listState: LazyListState,
     onIntent: (TopicIntent) -> Unit,
     onBack: () -> Unit,
-    onReply: (subcat: Int, page: Int, quoteNumreponses: List<Int>) -> Unit,
+    onReply: (subcat: Int, page: Int, quotes: List<QuotedPostPreview>) -> Unit,
     onEdit: (subcat: Int, page: Int, numreponse: Int) -> Unit,
     onEditFirstPost: (subcat: Int, page: Int, numreponse: Int) -> Unit,
     onOpenPage: (Int) -> Unit,
@@ -866,9 +867,9 @@ internal fun TopicContent(
             request = launch.request,
             initialQuote = launch.initialQuote,
             onDismiss = { quickReplyFor = null },
-            onEscalate = { quoteNumreponses ->
+            onEscalate = { quotes ->
                 quickReplyFor = null
-                onReply(launch.request.subcat, launch.request.page, quoteNumreponses)
+                onReply(launch.request.subcat, launch.request.page, quotes)
             },
             onSubmitted = { targetPage, scrollTo ->
                 quickReplyFor = null

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -139,10 +139,4 @@
     <string name="quick_reply_error_unknown">HFR a renvoyé une réponse inattendue. Réessayez ou actualisez l\'app.</string>
     <string name="quick_reply_error_network">Erreur réseau. Vérifiez votre connexion et réessayez.</string>
     <string name="quick_reply_error_session_expired">Votre session HFR a expiré. Reconnectez-vous.</string>
-    <!-- #604 lot 2 : cartes de citation de la réponse rapide. -->
-    <string name="quick_reply_quote_line">❝ %1$s — %2$s</string>
-    <string name="quick_reply_quote_no_text">(citation sans texte)</string>
-    <string name="quick_reply_quote_move_up">Monter la citation de %1$s</string>
-    <string name="quick_reply_quote_move_down">Descendre la citation de %1$s</string>
-    <string name="quick_reply_quote_remove">Retirer la citation de %1$s</string>
 </resources>

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModelTest.kt
@@ -281,7 +281,7 @@ class QuickReplyViewModelTest {
     }
 
     @Test
-    fun `escalation carries the card numreponses in citation order`() = runTest {
+    fun `escalation carries the full card previews in citation order`() = runTest {
         val store = FakeQuickReplyDraftStore()
         val viewModel = quickReplyViewModel(draftStore = store)
         viewModel.onQuoteAdded(preview(202, "bob"))
@@ -291,7 +291,12 @@ class QuickReplyViewModelTest {
         viewModel.onEscalateRequested()
         val effect = viewModel.effects.first()
 
-        assertEquals(QuickReplyEffect.EscalateToFullEditor(listOf(202, 101)), effect)
+        // #604 lot 3 — full previews (author + excerpt), not bare numreponses : the editor
+        // renders the same cards and needs the snapshot only the topic surface could take.
+        assertEquals(
+            QuickReplyEffect.EscalateToFullEditor(listOf(preview(202, "bob"), preview(101, "alice"))),
+            effect,
+        )
         assertEquals("suite en plein écran", store.storedBody)
     }
 


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Vague 4 « Postage » — lot 3 PR D : cartes de citation dans l'éditeur plein écran (mockup P3)

Cible P3 des mockups v2 : **les citations deviennent des cartes** dans l'éditeur plein écran — « 3 citations d'une ligne chacune (vs ~15 lignes de BBCode brut aujourd'hui), réordonnables, supprimables, Tout vider (#436) ». Le champ ne contient plus QUE le texte de l'utilisateur ; les `[quotemsg]` sont matérialisés à l'envoi.

### Ce que fait cette PR

- **`QuoteCard`/`QuoteCardControls` promus `:core:ui`** (`core.ui.editor.QuoteCards`) — un seul rendu pour la sheet et l'éditeur (strings promues aussi).
- **`PostEditorState.quotes`** : cartes en ordre de citation, ✕ / ↑ / ↓ / **« Tout vider »** (#436, dès 2 cartes), bloc scrollable au-delà de ~4 cartes (le champ garde sa place clavier ouvert). A11y par auteur, bornes disabled (layout stable TalkBack).
- **Matérialisation différée au submit** via le `ReplyQuoteMaterializer` partagé : ordre des cartes, hash du 1er quote form, texte à la suite ; quotes-only envoyable (même contrat épinglé que la sheet) ; **échec = texte ET cartes intacts** ; options = les toggles utilisateur de l'éditeur.
- **Fetch d'ouverture = form plain** : plus de prefill BBCode dans le champ. Le prepend `resumeSharedDraft` (#790) devient sans objet et disparaît ; le refetch `InvalidHashCheck` ne peut plus rien écraser.
- **Route allégée** : `quotedNumreponse`/`quoteRef`/`extraQuoteNumreponses` supprimés de `PostEditorRoute` — les previews (auteur + extrait, snapshotés à la sélection) voyagent par **handoff mémoire :app** (`MultiQuoteNavState.pendingEditorQuotes`, consommé une fois par l'entry). Transient assumé : un process death garde le texte (#405), pas les cartes.
- **« Citer N » et l'escalade sheet passent `resumeSharedDraft = true`** (continuation de composition, pas de bannière — cohérent #790) ; l'effet d'escalade porte les previews complets.

### Cadrage & validation

- Cadrage Codex gpt-5.5 xhigh AVANT implémentation — 8 forks tranchés (D avant C ; seuil 3 = plein écran → PR C ; panier consommé à l'ouverture ; handoff hoisté plutôt que route args ; unification totale des chemins ; refetch simplifié ; TalkBack inclus ; #480 hors lot).
- Tests : `PostEditorViewModelTest` réécrit matérialisation-au-submit (fetch plain à l'ouverture, concat en ordre de cartes épinglée, échec global sur extra KO/prefill blanc, InvalidHashCheck sans clobber) + 5 nouveaux tests cartes (seed/dédup, ✕/Tout vider, ↑↓ bornés, quotes-only épinglé, options utilisateur) ; test preview ré-ancré sur Edit (seul mode qui hydrate encore).
- Validation canonique complète verte (detektAll + lintProdDebug + tests + assembleProdDebug).
- **Dogfood émulateur** : « ❝2 » → éditeur 2 cartes champ vide ; ↓ réordonne (l'extrait exclut le contenu cité) ; « Tout vider » → Envoyer désactivé ; panier consommé au retour ; « Citer » → sheet carte pré-armée → escalade = carte + texte repris sans bannière.
- **Réserve produit reconduite** : l'envoi réel avec cartes n'est pas dogfoodé (pas de post de test sur le fil public) — couvert par les tests VM épinglés.

Prochain lot : PR C (panier ≤ 2 citations → sheet, seuil 3 = plein écran direct).

Réf #604 (vague 4, lot 3) · #436 · mockup P3
