### PR TITLE
feat(topic): panier multi-quote → réponse rapide sous 3 citations — Postage lot 3 PR C (#604)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -2443,15 +2443,18 @@ private fun RedfaceNavHost(
                             )
                         }
                     },
-                    // #291 — selection of THIS topic's basket (another topic's selection must
-                    // never leak into the menu checkmarks or the « Citer N » FAB).
-                    multiQuoteSelection = multiQuoteNavState.basket
+                    // #291 / #604 lot 3 — selection of THIS topic's basket as full previews
+                    // (another topic's selection must never leak into the menu checkmarks or
+                    // the « Citer N » FAB) ; under the full-screen threshold the screen pre-arms
+                    // the sheet's cards from them and consumes the basket via onClearMultiQuote.
+                    multiQuoteSelections = multiQuoteNavState.basket
                         ?.takeIf { it.matches(route.cat, route.post) }
-                        ?.numreponses
+                        ?.selections
                         .orEmpty(),
                     onToggleMultiQuote = { preview ->
                         multiQuoteNavState.onToggle(route.cat, route.post, preview)
                     },
+                    onClearMultiQuote = multiQuoteNavState.onClear,
                     // #465 — the topic's saved manual poll choice (null = follow the global
                     // default), and the callback recording a tap on the poll card. Hoisted to
                     // :app so it survives the per-page TopicRoute swap, keyed by (cat, post).

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySheet.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySheet.kt
@@ -56,17 +56,18 @@ internal fun QuickReplySheet(
     // surface can snapshot. Riding the callback (→ the :app handoff), never the route.
     onEscalate: (quotes: List<QuotedPostPreview>) -> Unit,
     onSubmitted: (targetPage: Int?, scrollTo: Int?) -> Unit,
-    // #604 lot 2 — « Citer » opens the sheet with this card pre-armed (1-citation session).
-    initialQuote: QuotedPostPreview? = null,
+    // #604 lots 2-3 — the cards this opening pre-arms : one for « Citer », the whole basket
+    // for « Citer N » under the full-screen threshold (empty from the reply FAB).
+    initialQuotes: List<QuotedPostPreview> = emptyList(),
 ) {
     val viewModel = hiltViewModel<QuickReplyViewModel, QuickReplyViewModel.Factory>(
         creationCallback = { factory -> factory.create(request) },
     )
     val state by viewModel.state.collectAsStateWithLifecycle()
-    LaunchedEffect(viewModel, initialQuote?.numreponse) {
+    LaunchedEffect(viewModel, initialQuotes) {
         // Re-seed the field from the #405 row at EACH opening — the VM outlives the sheet and
         // its cached text can be stale after a full-screen edit of the same draft (gate #788).
-        viewModel.onSheetOpened(initialQuote)
+        viewModel.onSheetOpened(initialQuotes)
         viewModel.effects.collect { effect ->
             when (effect) {
                 is QuickReplyEffect.SubmitSucceeded -> onSubmitted(effect.targetPage, effect.scrollTo)

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModel.kt
@@ -148,9 +148,14 @@ class QuickReplyViewModel @AssistedInject constructor(
      * in-memory text can go stale whenever another surface touched the shared #405 row —
      * typically escalate → edit in the full-screen editor → back → reopen. The row is the
      * source of truth ; the field is unconditionally re-seeded from it (gate Codex PR #788).
+     *
+     * [initialQuotes] (#604 lot 3) — the cards this opening pre-arms, in citation order : one
+     * preview for « Citer », the whole basket for « Citer N » under the full-screen threshold.
+     * Adds are idempotent per numreponse, appended AFTER any cards the surviving VM already
+     * holds (the composition in progress keeps its order).
      */
-    fun onSheetOpened(initialQuote: QuotedPostPreview? = null) {
-        if (initialQuote != null) onQuoteAdded(initialQuote)
+    fun onSheetOpened(initialQuotes: List<QuotedPostPreview> = emptyList()) {
+        initialQuotes.forEach(::onQuoteAdded)
         viewModelScope.launch {
             initJob.join()
             val body = draftStore.load(draftOwner, draftKey)?.body.orEmpty()

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -234,22 +234,30 @@ fun TopicScreen(
      */
     onScrollAnchorSaved: (TopicScrollAnchor) -> Unit = {},
     /**
-     * #291 — numreponses currently selected for multi-quote in THIS topic, in selection order.
-     * Owned by `:app` (the basket must survive the per-page entry swap, like the title cache);
-     * the screen only renders the count and the per-post toggle state.
+     * #291 / #604 lot 3 — the multi-quote selection of THIS topic as FULL previews, in selection
+     * order. Owned by `:app` (the basket must survive the per-page entry swap, like the title
+     * cache); the screen renders the count and the per-post toggle state, and under the
+     * full-screen threshold pre-arms the quick-reply sheet's cards from them.
      */
-    multiQuoteSelection: List<Int> = emptyList(),
+    multiQuoteSelections: List<QuotedPostPreview> = emptyList(),
     /**
      * #291 — toggles a post in the multi-quote basket. Only invoked under the same gate as
      * « Citer » (`shouldShowQuoteAction`): a topic the user cannot reply to has nothing to quote.
      */
     onToggleMultiQuote: (preview: QuotedPostPreview) -> Unit = {},
     /**
-     * #291 — opens the editor pre-filled with every selected quote (same destination as
-     * « Citer »; `:app` rides the selection on the route and clears the basket). Receives the
-     * topic's `(subcat, page)` like [onReply].
+     * #291 / #604 lot 3 — « Citer N » AT OR ABOVE the full-screen threshold : opens the editor
+     * with the basket's cards (`:app` hands the previews over in memory and clears the basket).
+     * Below the threshold the screen opens the quick-reply sheet itself and consumes the basket
+     * through [onClearMultiQuote] instead. Receives the topic's `(subcat, page)` like [onReply].
      */
     onMultiQuote: (subcat: Int, page: Int) -> Unit = { _, _ -> },
+    /**
+     * #604 lot 3 — clears the multi-quote basket after the sheet consumed it (« Citer N » below
+     * the threshold) : the cards live on in the sheet's ViewModel, and backing out must not
+     * re-arm a stale « Citer N » — same intent-consumed rule as the full-screen path.
+     */
+    onClearMultiQuote: () -> Unit = {},
     /**
      * #465 — the user's MANUAL poll-expansion choice for THIS topic, owned by `:app` so it survives
      * the per-page TopicRoute swap (like the multi-quote basket / scroll anchors). `null` means « no
@@ -457,9 +465,10 @@ fun TopicScreen(
         onGoToPost = onGoToPost,
         onOpenProfile = onOpenProfile,
         onDeleteRequest = { numreponse -> deleteCandidate = numreponse },
-        multiQuoteSelection = multiQuoteSelection,
+        multiQuoteSelections = multiQuoteSelections,
         onToggleMultiQuote = onToggleMultiQuote,
         onMultiQuote = onMultiQuote,
+        onClearMultiQuote = onClearMultiQuote,
         pollManualExpanded = pollManualExpanded,
         onPollExpansionChanged = onPollExpansionChanged,
     )
@@ -687,11 +696,13 @@ internal fun TopicContent(
     // #292 — a per-post « Supprimer » tap; the screen owns the confirmation dialog, so this only
     // requests it (carrying the post's numreponse). Never invoked for the first post (excluded).
     onDeleteRequest: (numreponse: Int) -> Unit = {},
-    // #291 — multi-quote selection (owned by :app) + its two actions, threaded to the post menu
-    // (toggle) and the floating cluster (« Citer N »).
-    multiQuoteSelection: List<Int> = emptyList(),
+    // #291 / #604 lot 3 — multi-quote selection (owned by :app, full previews) + its actions :
+    // toggle on the post menu, « Citer N » on the floating cluster (threshold-routed below),
+    // and the basket clear once the sheet consumed the cards.
+    multiQuoteSelections: List<QuotedPostPreview> = emptyList(),
     onToggleMultiQuote: (preview: QuotedPostPreview) -> Unit = {},
     onMultiQuote: (subcat: Int, page: Int) -> Unit = { _, _ -> },
+    onClearMultiQuote: () -> Unit = {},
     // #465 — the topic's manual poll choice (owned by :app, null = follow the global default) +
     // the callback recording a tap on the poll card. Threaded to the header card's poll.
     pollManualExpanded: Boolean? = null,
@@ -732,6 +743,8 @@ internal fun TopicContent(
     // Local UI state (like the page picker) : non-null while the sheet is up, carrying the
     // reply coordinates plus the card « Citer » pre-arms (null from the FAB).
     var quickReplyFor by remember { mutableStateOf<QuickReplyLaunch?>(null) }
+    // #291 — the per-post toggle checkmarks and the « ❝N » count only need the numreponses.
+    val multiQuoteNumreponses = multiQuoteSelections.map { it.numreponse }
     Scaffold(
         modifier = if (scrollBehavior != null) {
             Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
@@ -756,7 +769,7 @@ internal fun TopicContent(
                 state = state,
                 loaded = loaded,
                 bottomActionsVisible = bottomActionsVisible,
-                multiQuoteSelection = multiQuoteSelection,
+                multiQuoteSelection = multiQuoteNumreponses,
                 onOpenPage = onOpenPage,
                 onReply = { subcat, page ->
                     quickReplyFor = QuickReplyLaunch(
@@ -768,7 +781,27 @@ internal fun TopicContent(
                         ),
                     )
                 },
-                onMultiQuote = onMultiQuote,
+                // #604 lot 3 — threshold routing (mockup P3, « le cas qui force le plein
+                // écran ») : a small selection opens the quick-reply sheet with the cards
+                // pre-armed and consumes the basket HERE (the cards live on in the sheet's
+                // ViewModel) ; from MULTI_QUOTE_FULL_EDITOR_THRESHOLD up, the full-screen
+                // editor path (`:app`, in-memory handoff + basket clear) takes over.
+                onMultiQuote = { subcat, page ->
+                    if (multiQuoteOpensFullEditor(multiQuoteSelections.size)) {
+                        onMultiQuote(subcat, page)
+                    } else {
+                        quickReplyFor = QuickReplyLaunch(
+                            request = QuickReplyRequest(
+                                cat = state.request.cat,
+                                subcat = subcat,
+                                topicId = state.request.post,
+                                page = page,
+                            ),
+                            initialQuotes = multiQuoteSelections,
+                        )
+                        onClearMultiQuote()
+                    }
+                },
             )
         },
     ) { innerPadding ->
@@ -838,7 +871,7 @@ internal fun TopicContent(
                                         topicId = state.request.post,
                                         page = mode.topic.page,
                                     ),
-                                    initialQuote = preview,
+                                    initialQuotes = listOf(preview),
                                 )
                             },
                             onEdit = onEdit,
@@ -849,7 +882,7 @@ internal fun TopicContent(
                             onDeleteRequest = onDeleteRequest,
                             onDoubleTapRefresh = { onIntent(TopicIntent.Refresh) },
                             listState = listState,
-                            multiQuoteSelection = multiQuoteSelection,
+                            multiQuoteSelection = multiQuoteNumreponses,
                             onToggleMultiQuote = onToggleMultiQuote,
                             onSetAuthorBlocked = { author, blocked ->
                                 onIntent(TopicIntent.SetAuthorBlocked(author, blocked))
@@ -865,7 +898,7 @@ internal fun TopicContent(
     quickReplyFor?.let { launch ->
         QuickReplySheet(
             request = launch.request,
-            initialQuote = launch.initialQuote,
+            initialQuotes = launch.initialQuotes,
             onDismiss = { quickReplyFor = null },
             onEscalate = { quotes ->
                 quickReplyFor = null
@@ -2703,12 +2736,25 @@ private fun ReplyFab(onClick: () -> Unit) {
 // not purged on logout, cf. CacheInvalidator), so these gates consult auth explicitly instead
 // of trusting `canReply` alone — symmetric with the « Créer topic » FAB
 // (CategoryViewModel.canCreateTopic).
-// #604 lot 2 — what opens the quick-reply sheet : the reply coordinates, plus the card a
-// « Citer » tap pre-arms (null when launched from the reply FAB).
+// #604 lots 2-3 — what opens the quick-reply sheet : the reply coordinates, plus the cards this
+// opening pre-arms (one for « Citer », the whole basket for « Citer N » under the full-screen
+// threshold, empty from the reply FAB).
 internal data class QuickReplyLaunch(
     val request: QuickReplyRequest,
-    val initialQuote: QuotedPostPreview? = null,
+    val initialQuotes: List<QuotedPostPreview> = emptyList(),
 )
+
+/**
+ * #604 lot 3 — « Citer N » routing (mockup P3 : « le cas qui force le plein écran ») : up to
+ * [MULTI_QUOTE_FULL_EDITOR_THRESHOLD] - 1 cards the quick-reply sheet stays comfortable with the
+ * keyboard open ; from the threshold up the selection goes straight to the full-screen editor.
+ * Pure so the boundary is unit-testable.
+ */
+internal fun multiQuoteOpensFullEditor(selectionCount: Int): Boolean =
+    selectionCount >= MULTI_QUOTE_FULL_EDITOR_THRESHOLD
+
+/** #604 lot 3 — cadrage Codex : « 3 citations = plein écran » (constante nommée, pas un réglage). */
+internal const val MULTI_QUOTE_FULL_EDITOR_THRESHOLD = 3
 
 // #604 lot 2 — the quote-card snapshot, built AT SELECTION TIME where the full Post is in scope
 // (cadrage Codex : the cards never re-parse a post ; the exact [quotemsg] is fetched at

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/MultiQuoteRoutingTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/MultiQuoteRoutingTest.kt
@@ -1,0 +1,25 @@
+package fr.forumhfr.redface2.feature.topic
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #604 lot 3 — the « Citer N » threshold boundary (mockup P3 : « le cas qui force le plein
+ * écran », cadrage Codex : 3 citations = plein écran, constante nommée). Pins the boundary so
+ * a future tweak is a deliberate constant change, not an off-by-one.
+ */
+class MultiQuoteRoutingTest {
+
+    @Test
+    fun `one or two cards stay in the quick-reply sheet`() {
+        assertFalse(multiQuoteOpensFullEditor(1))
+        assertFalse(multiQuoteOpensFullEditor(2))
+    }
+
+    @Test
+    fun `three cards and up force the full-screen editor`() {
+        assertTrue(multiQuoteOpensFullEditor(MULTI_QUOTE_FULL_EDITOR_THRESHOLD))
+        assertTrue(multiQuoteOpensFullEditor(4))
+    }
+}

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/MultiQuoteRoutingTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/MultiQuoteRoutingTest.kt
@@ -13,6 +13,8 @@ class MultiQuoteRoutingTest {
 
     @Test
     fun `one or two cards stay in the quick-reply sheet`() {
+        // 0 is unreachable from the « Citer N » FAB (it only renders armed) — documented inert.
+        assertFalse(multiQuoteOpensFullEditor(0))
         assertFalse(multiQuoteOpensFullEditor(1))
         assertFalse(multiQuoteOpensFullEditor(2))
     }

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModelTest.kt
@@ -300,6 +300,28 @@ class QuickReplyViewModelTest {
         assertEquals("suite en plein écran", store.storedBody)
     }
 
+    // ----- #604 lot 3 : pré-armement multi-cartes (panier → sheet) -----------
+
+    @Test
+    fun `onSheetOpened pre-arms several cards in citation order`() = runTest {
+        val viewModel = quickReplyViewModel()
+        viewModel.onSheetOpened(listOf(preview(202, "bob"), preview(101, "alice")))
+        advanceUntilIdle()
+
+        assertEquals(listOf(202, 101), viewModel.state.value.quotes.map { it.numreponse })
+    }
+
+    @Test
+    fun `onSheetOpened appends idempotently after the cards the VM already holds`() = runTest {
+        val viewModel = quickReplyViewModel()
+        viewModel.onQuoteAdded(preview(303, "carol"))
+        // Re-opening with an overlap (303) must neither duplicate nor reorder the existing card.
+        viewModel.onSheetOpened(listOf(preview(101, "alice"), preview(303, "carol")))
+        advanceUntilIdle()
+
+        assertEquals(listOf(303, 101), viewModel.state.value.quotes.map { it.numreponse })
+    }
+
     private fun preview(numreponse: Int, author: String): QuotedPostPreview =
         QuotedPostPreview(numreponse = numreponse, author = author, excerpt = "extrait")
 


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Vague 4 « Postage » — lot 3 PR C : le panier multi-quote ouvre la réponse rapide sous 3 citations

Dernière brique du lot 3, sur le socle de la PR D (#800). Le seuil vient du cadrage Codex : **1-2 citations = feuille de réponse rapide** (cartes pré-armées, confortable clavier ouvert), **3 et plus = éditeur plein écran direct** (mockup P3, « le cas qui force le plein écran »).

### Ce que fait cette PR

- **« Citer N » route au seuil** : sous `MULTI_QUOTE_FULL_EDITOR_THRESHOLD` (= 3, constante nommée, frontière épinglée par test), la feuille s'ouvre avec les cartes du panier pré-armées ; le panier est consommé à l'ouverture (les cartes vivent ensuite dans le ViewModel de la feuille — même règle « intent consommé » que le chemin plein écran).
- **`onSheetOpened` passe au multi** : `initialQuotes` en ordre de citation, adds idempotents APRÈS les cartes que le VM survivant tient déjà (la composition en cours garde son ordre).
- **TopicScreen reçoit les previews complets** (`multiQuoteSelections`) + `onClearMultiQuote` ; les numreponses des coches et du compteur ❝N sont dérivés.

### Validation

- Cadrage Codex : forks 2 (seuil 3) et 3 (panier consommé à l'ouverture) du cadrage lot 3.
- Tests : pré-armement multi en ordre + idempotence après cartes existantes ; frontière du seuil (1-2 sheet, 3+ plein écran).
- Canonique complète verte ; dogfood émulateur : « Citer 2 » → feuille avec les 2 cartes (panier consommé au retour) ; « Citer 3 » → plein écran direct, 3 cartes + « Tout vider ».

Le lot 3 est complet avec cette PR — reste le lot 4a (polish IME/TalkBack/erreurs) puis 4b optionnel.

Réf #604 (vague 4, lot 3) · mockup P3
