### PR TITLE
chore: release 0.23.0

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,14 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.23.0` — `internal` (dev) — 2026-07-03
+
+**Phase « Vue Topic » (#604) — vague 4 « Postage », lot 3** (PRs #800 #801 — cadrage Codex 8 forks, gates GO-avec-réserves/GO, dogfood émulateur).
+
+### Vue Topic
+- **Citations en cartes dans l'éditeur plein écran** (mockup P3) : fini le pavé de BBCode `[quotemsg]` dans le champ — les citations s'affichent en cartes compactes au-dessus (réordonnables ↑/↓, supprimables ✕, « Tout vider » #436), le champ ne contient que votre texte, le BBCode est assemblé à l'envoi (un échec ne perd rien). La bascule réponse rapide → plein écran transporte les cartes.
+- **Le panier multi-citations (« Citer N ») choisit sa surface** : 1 ou 2 citations ouvrent la réponse rapide avec les cartes pré-armées ; 3 et plus filent directement en plein écran.
+
 ## `0.22.0` — `internal` (dev) — 2026-07-03
 
 **Phase « Vue Topic » (#604) — vague 4 « Postage », lot 2** (PRs #797 #798 — cadrage 9 forks + gates Codex gpt-5.5, dogfood émulateur).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.22.0"
+        versionName = "0.23.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,4 +1,4 @@
-Redface 2 v0.22.0 — dev.
+Redface 2 v0.23.0 — dev.
 
-- Quick reply: "Quote" now adds quote cards (reorderable, removable); send and the full-screen switch honour the order.
-- Quick reply: switching to full screen now carries the text automatically.
+- Full-screen editor: quotes are now compact cards (reorderable, removable, "Clear all") — no more BBCode wall in the field.
+- "Quote N": 1-2 quotes open the quick reply, 3+ the full-screen editor.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,4 +1,4 @@
-Redface 2 v0.22.0 — dev.
+Redface 2 v0.23.0 — dev.
 
-- Réponse rapide : « Citer » y ajoute des cartes de citation (réordonnables, supprimables) ; l'envoi et la bascule plein écran respectent l'ordre.
-- Réponse rapide : la bascule plein écran reprend le texte automatiquement.
+- Éditeur plein écran : les citations deviennent des cartes compactes (réordonnables, supprimables, « Tout vider ») — plus de pavé BBCode dans le champ.
+- « Citer N » : 1-2 citations ouvrent la réponse rapide, 3+ l'éditeur plein écran.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump versionName 0.23.0 + entrée CHANGELOG + whatsnew fr/en (version en 1re ligne).

Contenu : vague 4 « Postage » lot 3 — cartes de citation dans l'éditeur plein écran (mockup P3, PR #800) + routage au seuil du panier « Citer N » (PR #801).

Edit mécanique (bump de version) — exception cadence Codex.