### PR TITLE
feat(editor,topic): polish Postage — scroll sheet, flush au back, a11y cartes — lot 4a (#604)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -2612,6 +2612,13 @@ private fun RedfaceNavHost(
                         initialQuotes = multiQuoteNavState.pendingEditorQuotes.orEmpty(),
                         resumeSharedDraft = route.resumeSharedDraft,
                     ),
+                    // #604 lot 4a — the system back reaches here only AFTER the ViewModel
+                    // flushed the draft row (CloseCommitted). Same guarded pop as onBack.
+                    onClose = {
+                        if (backStack.size > 1) {
+                            backStack.removeAt(backStack.lastIndex)
+                        }
+                    },
                     onSubmitSucceeded = { targetPage, scrollTo ->
                         // Pop the editor and refresh the topic page. `targetPage` is parsed
                         // from HFR's success URL and tells us which page to land on;

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/QuoteCards.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/QuoteCards.kt
@@ -1,17 +1,30 @@
 package fr.forumhfr.redface2.core.ui.editor
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -30,6 +43,7 @@ import fr.forumhfr.redface2.core.ui.R
 fun QuoteCard(
     quote: QuotedPostPreview,
     controls: QuoteCardControls,
+    removeFocusRequester: FocusRequester? = null,
 ) {
     val moveUpLabel = stringResource(R.string.editor_quote_move_up, quote.author)
     val moveDownLabel = stringResource(R.string.editor_quote_move_down, quote.author)
@@ -71,6 +85,7 @@ fun QuoteCard(
                 label = removeLabel,
                 glyph = "✕",
                 onClick = controls.onRemove,
+                focusRequester = removeFocusRequester,
             )
         }
     }
@@ -86,17 +101,97 @@ data class QuoteCardControls(
     val onRemove: () -> Unit,
 )
 
+/** Per-numreponse mutation callbacks of a [QuoteCardsColumn] (controls derived per index). */
+data class QuoteCardsCallbacks(
+    val onMoveUp: (numreponse: Int) -> Unit,
+    val onMoveDown: (numreponse: Int) -> Unit,
+    val onRemove: (numreponse: Int) -> Unit,
+)
+
+/**
+ * #604 lot 4a — the whole cards block, shared by the quick-reply sheet and the full-screen
+ * editor : one [QuoteCard] per entry PLUS the accessibility plumbing the per-card labels can't
+ * provide (they describe the ACTION, not its result — cadrage Codex) :
+ *
+ * - a polite live region announcing each mutation (« Citation de X retirée », « … déplacée en
+ *   position N ») through an invisible zero-sized node that OUTLIVES the cards, so the removal
+ *   of the last card is still spoken ;
+ * - focus restoration after a removal : the ✕ of the card that takes the removed slot (next,
+ *   else previous) so TalkBack/keyboard users are not silently dropped ; with no card left the
+ *   focus is released to the surface's natural order.
+ *
+ * Always compose it (it renders nothing visible when [quotes] is empty) — hiding it behind an
+ * `if` would kill the pending announcement with the last card.
+ */
+@Composable
+fun QuoteCardsColumn(
+    quotes: List<QuotedPostPreview>,
+    enabled: Boolean,
+    callbacks: QuoteCardsCallbacks,
+    modifier: Modifier = Modifier,
+) {
+    var announcement by remember { mutableStateOf("") }
+    var pendingFocusIndex by remember { mutableStateOf<Int?>(null) }
+    val removeFocusRequesters = remember(quotes.size) { List(quotes.size) { FocusRequester() } }
+    // Invisible live region : TalkBack re-announces whenever the description CHANGES.
+    Box(
+        modifier = Modifier
+            .size(1.dp)
+            .semantics {
+                liveRegion = LiveRegionMode.Polite
+                contentDescription = announcement
+            },
+    )
+    LaunchedEffect(quotes) {
+        val target = pendingFocusIndex ?: return@LaunchedEffect
+        pendingFocusIndex = null
+        removeFocusRequesters.getOrNull(target.coerceAtMost(quotes.lastIndex))
+            ?.takeIf { quotes.isNotEmpty() }
+            ?.requestFocus()
+    }
+    val movedTemplate = stringResource(R.string.editor_quote_a11y_moved)
+    val removedTemplate = stringResource(R.string.editor_quote_a11y_removed)
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp), modifier = modifier) {
+        quotes.forEachIndexed { index, quote ->
+            QuoteCard(
+                quote = quote,
+                controls = QuoteCardControls(
+                    canMoveUp = index > 0,
+                    canMoveDown = index < quotes.lastIndex,
+                    enabled = enabled,
+                    onMoveUp = {
+                        announcement = movedTemplate.format(quote.author, index)
+                        callbacks.onMoveUp(quote.numreponse)
+                    },
+                    onMoveDown = {
+                        announcement = movedTemplate.format(quote.author, index + 2)
+                        callbacks.onMoveDown(quote.numreponse)
+                    },
+                    onRemove = {
+                        announcement = removedTemplate.format(quote.author)
+                        pendingFocusIndex = index
+                        callbacks.onRemove(quote.numreponse)
+                    },
+                ),
+                removeFocusRequester = removeFocusRequesters[index],
+            )
+        }
+    }
+}
+
 @Composable
 private fun QuoteCardAction(
     enabled: Boolean,
     label: String,
     glyph: String,
     onClick: () -> Unit,
+    focusRequester: FocusRequester? = null,
 ) {
+    val base = if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier
     IconButton(
         onClick = onClick,
         enabled = enabled,
-        modifier = Modifier.semantics { contentDescription = label },
+        modifier = base.semantics { contentDescription = label },
     ) {
         Text(text = glyph, style = MaterialTheme.typography.titleMedium)
     }

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -102,4 +102,8 @@
     <string name="editor_quote_move_up">Monter la citation de %1$s</string>
     <string name="editor_quote_move_down">Descendre la citation de %1$s</string>
     <string name="editor_quote_remove">Retirer la citation de %1$s</string>
+    <!-- #604 lot 4a : annonces TalkBack des mutations de cartes (le label du bouton décrit
+         l'action, la live region décrit le résultat). -->
+    <string name="editor_quote_a11y_removed">Citation de %1$s retirée</string>
+    <string name="editor_quote_a11y_moved">Citation de %1$s déplacée en position %2$d</string>
 </resources>

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorIntent.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorIntent.kt
@@ -92,6 +92,14 @@ sealed interface PostEditorIntent {
 
     /** #436 (#604 lot 3) — « Tout vider » : drop every quote card. The typed body is untouched. */
     data object QuotesCleared : PostEditorIntent
+
+    /**
+     * #604 lot 4a — the user is leaving the editor (system back). The ViewModel flushes the
+     * pending debounced autosave FIRST, then emits [PostEditorEffect.CloseCommitted] — closing
+     * through the ViewModel is what guarantees the last < 750 ms of typing reach the #405 row
+     * (a plain pop would cancel the debounce with the ViewModel).
+     */
+    data object CloseRequested : PostEditorIntent
 }
 
 /**
@@ -113,4 +121,11 @@ sealed interface PostEditorEffect {
         val targetPage: Int?,
         val scrollTo: Int? = null,
     ) : PostEditorEffect
+
+    /**
+     * #604 lot 4a — the draft is persisted, the editor may now actually pop (twin of the
+     * quick-reply escalation contract : the save is AWAITED before the effect, so navigation
+     * can never cancel it).
+     */
+    data object CloseCommitted : PostEditorEffect
 }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -7,6 +7,7 @@ import fr.forumhfr.redface2.core.ui.editor.bannerText
 
 import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 import fr.forumhfr.redface2.core.ui.editor.SmileyPickerSheet
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -64,8 +65,8 @@ import fr.forumhfr.redface2.core.ui.editor.BbcodePreview
 import fr.forumhfr.redface2.core.ui.editor.BbcodeTextField
 import fr.forumhfr.redface2.core.ui.editor.BbcodeToolbar
 import fr.forumhfr.redface2.core.ui.editor.EditorOptionsSheet
-import fr.forumhfr.redface2.core.ui.editor.QuoteCard
-import fr.forumhfr.redface2.core.ui.editor.QuoteCardControls
+import fr.forumhfr.redface2.core.ui.editor.QuoteCardsCallbacks
+import fr.forumhfr.redface2.core.ui.editor.QuoteCardsColumn
 
 
 /**
@@ -78,6 +79,9 @@ import fr.forumhfr.redface2.core.ui.editor.QuoteCardControls
 fun PostEditorScreen(
     request: PostEditorRequest,
     onSubmitSucceeded: (targetPage: Int?, scrollTo: Int?) -> Unit,
+    // #604 lot 4a — pops this editor AFTER the ViewModel flushed the draft (CloseCommitted).
+    // Default keeps callers without the wiring on the platform back (no flush) — `:app` wires it.
+    onClose: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
     viewModel: PostEditorViewModel = hiltViewModel<PostEditorViewModel, PostEditorViewModel.Factory>(
         creationCallback = { factory -> factory.create(request) },
@@ -89,8 +93,15 @@ fun PostEditorScreen(
             when (effect) {
                 is PostEditorEffect.SubmitSucceeded ->
                     onSubmitSucceeded(effect.targetPage, effect.scrollTo)
+                PostEditorEffect.CloseCommitted -> onClose?.invoke()
             }
         }
+    }
+    // #604 lot 4a — route the system back through the ViewModel so the pending autosave debounce
+    // is flushed BEFORE the pop (trading the predictive-back preview for never losing the last
+    // < 750 ms of typing — cadrage Codex, item 2). Only armed when `:app` wired the pop.
+    if (onClose != null) {
+        BackHandler { viewModel.submit(PostEditorIntent.CloseRequested) }
     }
     PostEditorContent(
         state = state,
@@ -367,7 +378,8 @@ private fun EditorQuoteCards(
     enabled: Boolean,
     onIntent: (PostEditorIntent) -> Unit,
 ) {
-    if (quotes.isEmpty()) return
+    // No early-return on empty (#604 lot 4a) : the shared column hosts the live region that
+    // announces the LAST removal — hiding the whole block would silence it.
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         if (quotes.size > 1) {
             val clearAllLabel = stringResource(R.string.editor_quotes_clear_all_a11y)
@@ -381,26 +393,18 @@ private fun EditorQuoteCards(
                 }
             }
         }
-        Column(
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+        QuoteCardsColumn(
+            quotes = quotes,
+            enabled = enabled,
+            callbacks = QuoteCardsCallbacks(
+                onMoveUp = { numreponse -> onIntent(PostEditorIntent.QuoteMoved(numreponse, delta = -1)) },
+                onMoveDown = { numreponse -> onIntent(PostEditorIntent.QuoteMoved(numreponse, delta = 1)) },
+                onRemove = { numreponse -> onIntent(PostEditorIntent.QuoteRemoved(numreponse)) },
+            ),
             modifier = Modifier
                 .heightIn(max = MAX_VISIBLE_CARDS_HEIGHT)
                 .verticalScroll(rememberScrollState()),
-        ) {
-            quotes.forEachIndexed { index, quote ->
-                QuoteCard(
-                    quote = quote,
-                    controls = QuoteCardControls(
-                        canMoveUp = index > 0,
-                        canMoveDown = index < quotes.lastIndex,
-                        enabled = enabled,
-                        onMoveUp = { onIntent(PostEditorIntent.QuoteMoved(quote.numreponse, delta = -1)) },
-                        onMoveDown = { onIntent(PostEditorIntent.QuoteMoved(quote.numreponse, delta = 1)) },
-                        onRemove = { onIntent(PostEditorIntent.QuoteRemoved(quote.numreponse)) },
-                    ),
-                )
-            }
-        }
+        )
     }
 }
 

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -247,16 +247,36 @@ class PostEditorViewModel @AssistedInject constructor(
      * an active session, so nothing is persisted for an anonymous client.
      */
     private fun scheduleAutosave() {
-        val key = draftKey ?: return
-        val body = _state.value.draft.text
+        if (draftKey == null) return
         autosaveJob?.cancel()
         autosaveJob = viewModelScope.launch {
             delay(AUTOSAVE_DEBOUNCE_MS)
-            if (body.isBlank()) {
-                draftStore.delete(draftOwner, key)
-            } else {
-                draftStore.save(draftOwner, key, EditorDraftStore.Draft(body = body))
-            }
+            persistDraftNow()
+        }
+    }
+
+    /** Immediate write of the current body (blank = delete the row, cf. [scheduleAutosave]). */
+    private suspend fun persistDraftNow() {
+        val key = draftKey ?: return
+        val body = _state.value.draft.text
+        if (body.isBlank()) {
+            draftStore.delete(draftOwner, key)
+        } else {
+            draftStore.save(draftOwner, key, EditorDraftStore.Draft(body = body))
+        }
+    }
+
+    /**
+     * #604 lot 4a — dirty close : flush the pending debounce so the last keystrokes reach the
+     * #405 row, THEN let the UI pop (CloseCommitted). Without this, a system back < 750 ms
+     * after typing cancelled the debounce with the ViewModel and silently dropped the tail of
+     * the draft. Mirrors the quick-reply escalation (save awaited before the effect).
+     */
+    private fun onCloseRequested() {
+        autosaveJob?.cancel()
+        viewModelScope.launch {
+            persistDraftNow()
+            _effects.send(PostEditorEffect.CloseCommitted)
         }
     }
 
@@ -290,6 +310,7 @@ class PostEditorViewModel @AssistedInject constructor(
             is PostEditorIntent.QuoteRemoved -> onQuoteRemoved(intent.numreponse)
             is PostEditorIntent.QuoteMoved -> onQuoteMoved(intent.numreponse, intent.delta)
             PostEditorIntent.QuotesCleared -> _state.update { it.copy(quotes = emptyList()) }
+            PostEditorIntent.CloseRequested -> onCloseRequested()
         }
     }
 

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -266,13 +266,26 @@ class PostEditorViewModel @AssistedInject constructor(
         }
     }
 
+    /** #604 lot 4a — one-shot latch : a committed close is never re-emitted (gate #803). */
+    private var closeRequested = false
+
     /**
      * #604 lot 4a — dirty close : flush the pending debounce so the last keystrokes reach the
      * #405 row, THEN let the UI pop (CloseCommitted). Without this, a system back < 750 ms
      * after typing cancelled the debounce with the ViewModel and silently dropped the tail of
      * the draft. Mirrors the quick-reply escalation (save awaited before the effect).
+     *
+     * Two guards (gate #803, NO-GO findings) :
+     * - INERT while a POST is in flight — popping would cancel the submit with the
+     *   viewModelScope and leave the server state unknown with a repostable draft (the sheet
+     *   blocks its dismiss the same way, gate #788) ; on failure `isSubmitting` drops and the
+     *   back works again, on success SubmitSucceeded pops anyway ;
+     * - ONE-SHOT — a second back racing the first CloseCommitted must not emit a second
+     *   effect (each `onClose` pops blindly : the second pop would remove the screen BELOW).
      */
     private fun onCloseRequested() {
+        if (_state.value.isSubmitting || closeRequested) return
+        closeRequested = true
         autosaveJob?.cancel()
         viewModelScope.launch {
             persistDraftNow()

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -54,6 +54,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -1866,6 +1867,42 @@ class PostEditorViewModelTest {
             "the POST must ride the state's toggles, not the quote form's defaults",
             replyRepository.lastSubmittedOptions?.signatureEnabled == true,
         )
+    }
+
+    // ----- #604 lot 4a : dirty close (flush avant pop) -------------------------
+
+    @Test
+    fun `CloseRequested flushes the pending debounce before CloseCommitted`() = runTest {
+        replyRepository.formResult = Result.success(authenticatedForm())
+        val viewModel = newReplyViewModel()
+        testScheduler.advanceUntilIdle()
+
+        // Type, then close IMMEDIATELY — well inside the 750 ms debounce window.
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("dernier mot")))
+        viewModel.submit(PostEditorIntent.CloseRequested)
+
+        val effect = viewModel.effects.first()
+        assertEquals(PostEditorEffect.CloseCommitted, effect)
+        assertEquals(
+            "the tail of the draft must reach the row before the pop",
+            "dernier mot",
+            draftStore.saved[EditorDraftKey.reply(SAMPLE_CAT, SAMPLE_TOPIC_ID)]?.body,
+        )
+    }
+
+    @Test
+    fun `CloseRequested with a blank body deletes the row and still closes`() = runTest {
+        val key = EditorDraftKey.reply(SAMPLE_CAT, SAMPLE_TOPIC_ID)
+        draftStore.preload(key, EditorDraftStore.Draft(body = "stale"))
+        replyRepository.formResult = Result.success(authenticatedForm())
+        val viewModel = newReplyViewModel()
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(PostEditorIntent.CloseRequested)
+
+        val effect = viewModel.effects.first()
+        assertEquals(PostEditorEffect.CloseCommitted, effect)
+        assertTrue("an emptied editor must not leave a stale row", draftStore.deletedKeys.contains(key))
     }
 
     /** #604 lot 3 — quote-card snapshot, as the topic surface would build it at selection time. */

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -1905,6 +1905,50 @@ class PostEditorViewModelTest {
         assertTrue("an emptied editor must not leave a stale row", draftStore.deletedKeys.contains(key))
     }
 
+    @Test
+    fun `CloseRequested during an in-flight submit is ignored (gate #803)`() = runTest {
+        val submitGate = CompletableDeferred<Unit>()
+        replyRepository.formResult = Result.success(authenticatedForm())
+        replyRepository.submitResult = ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
+        replyRepository.submitGate = submitGate
+        val viewModel = newReplyViewModel()
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("en vol")))
+        viewModel.submit(PostEditorIntent.SubmitClicked)
+        // Back pressed while the POST is in flight — must be inert (parity with the sheet, #788).
+        viewModel.submit(PostEditorIntent.CloseRequested)
+        submitGate.complete(Unit)
+        testScheduler.advanceUntilIdle()
+
+        viewModel.effects.test {
+            assertTrue(
+                "the submit outcome must be the ONLY effect — no CloseCommitted",
+                awaitItem() is PostEditorEffect.SubmitSucceeded,
+            )
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `a second CloseRequested is a no-op (gate #803)`() = runTest {
+        replyRepository.formResult = Result.success(authenticatedForm())
+        val viewModel = newReplyViewModel()
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(PostEditorIntent.CloseRequested)
+        viewModel.submit(PostEditorIntent.CloseRequested)
+        testScheduler.advanceUntilIdle()
+
+        viewModel.effects.test {
+            assertEquals(PostEditorEffect.CloseCommitted, awaitItem())
+            // A double back must never yield a second pop (it would remove the screen BELOW).
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
     /** #604 lot 3 — quote-card snapshot, as the topic surface would build it at selection time. */
     private fun card(numreponse: Int, author: String = "auteur$numreponse"): QuotedPostPreview =
         QuotedPostPreview(numreponse = numreponse, author = author, excerpt = "extrait $numreponse")

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySheet.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySheet.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -35,8 +37,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.model.write.QuotedPostPreview
 import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
-import fr.forumhfr.redface2.core.ui.editor.QuoteCard
-import fr.forumhfr.redface2.core.ui.editor.QuoteCardControls
+import fr.forumhfr.redface2.core.ui.editor.QuoteCardsCallbacks
+import fr.forumhfr.redface2.core.ui.editor.QuoteCardsColumn
 import fr.forumhfr.redface2.core.ui.icon.RedfaceVectorIcon
 
 /**
@@ -99,7 +101,11 @@ internal fun QuickReplySheet(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 8.dp)
                 .imePadding()
-                .navigationBarsPadding(),
+                .navigationBarsPadding()
+                // #604 lot 4a — the sheet content scrolls : with the keyboard up (~40 % of the
+                // screen), two cards + the field + Envoyer can overflow a small or landscape
+                // display, leaving the send button unreachable (cadrage Codex, item 1).
+                .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -120,19 +126,17 @@ internal fun QuickReplySheet(
                     )
                 }
             }
-            state.quotes.forEachIndexed { index, quote ->
-                QuoteCard(
-                    quote = quote,
-                    controls = QuoteCardControls(
-                        canMoveUp = index > 0,
-                        canMoveDown = index < state.quotes.lastIndex,
-                        enabled = !state.isSubmitting,
-                        onMoveUp = { viewModel.onQuoteMoved(quote.numreponse, delta = -1) },
-                        onMoveDown = { viewModel.onQuoteMoved(quote.numreponse, delta = 1) },
-                        onRemove = { viewModel.onQuoteRemoved(quote.numreponse) },
-                    ),
-                )
-            }
+            // #604 lot 4a — shared column : cards + live-region announcements + post-removal
+            // focus (always composed ; renders nothing visible without cards).
+            QuoteCardsColumn(
+                quotes = state.quotes,
+                enabled = !state.isSubmitting,
+                callbacks = QuoteCardsCallbacks(
+                    onMoveUp = { numreponse -> viewModel.onQuoteMoved(numreponse, delta = -1) },
+                    onMoveDown = { numreponse -> viewModel.onQuoteMoved(numreponse, delta = 1) },
+                    onRemove = viewModel::onQuoteRemoved,
+                ),
+            )
             OutlinedTextField(
                 value = state.text,
                 onValueChange = viewModel::onTextChanged,


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Vague 4 « Postage » — lot 4a : polish (IME / dirty close / TalkBack)

Périmètre cadré par Codex (audit 03/07 : items 1-3 « à faire » + focus après retrait ; hors lot : unification des patterns de confirmation, wording).

### Ce que fait cette PR

1. **La feuille de réponse rapide scrolle son contenu** : clavier ouvert (~40 % de l'écran) avec 2 cartes + champ 3-6 lignes, « Envoyer » pouvait sortir de l'écran en paysage/petit écran.
2. **Dirty close de l'éditeur plein écran** : le back système passe désormais par le ViewModel — `CloseRequested` annule le debounce, **écrit la row #405 (awaité), puis** `CloseCommitted` déclenche le pop. Un back < 750 ms après la dernière frappe ne perd plus la fin de la saisie (comportement historique #405, pas une régression vague 4). Compromis assumé du cadrage : l'aperçu predictive-back de cet écran contre la non-perte de texte.
3. **`QuoteCardsColumn` partagé (:core:ui)** — les deux surfaces consomment le même bloc, qui ajoute ce que les labels par bouton ne disent pas (ils décrivent l'action, pas le résultat) :
   - **live region Polite** : « Citation de X retirée », « Citation de X déplacée en position N » — via un nœud invisible qui survit à la dernière carte (l'ultime retrait est annoncé) ;
   - **focus après retrait** : rendu au ✕ de la carte qui prend le slot (sinon la précédente) — TalkBack/clavier ne sont plus lâchés dans le vide.

### Validation

- Tests VM : flush avant `CloseCommitted` (frappe puis close immédiat → la row porte la fin de saisie), close sur champ vide = suppression de la row.
- Canonique complète verte ; dogfood émulateur : back = clavier → back = pop via flush → réouverture de la feuille = texte présent ; cartes et scroll inchangés visuellement.
- Annonces TalkBack : best-effort Compose (live region), non vérifiées avec un lecteur d'écran réel — à confirmer au dogfood communautaire.

Réf #604 (vague 4, lot 4a)
