### PR TITLE
chore: release 0.24.0

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,15 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.24.0` — `internal` (dev) — 2026-07-03
+
+**Phase « Vue Topic » (#604) — vague 4 « Postage », lot 4a polish** (PR #803 — cadrage + gate Codex NO-GO→fixes→GO, dogfood émulateur).
+
+### Vue Topic
+- **Réponse rapide** : le contenu de la feuille défile — plus de bouton « Envoyer » hors d'atteinte clavier ouvert sur petit écran ou en paysage.
+- **Éditeur plein écran** : quitter l'éditeur (retour système) enregistre d'abord le brouillon — les dernières frappes ne sont plus perdues si on sort dans la foulée ; le retour est inerte pendant un envoi en cours (impossible d'interrompre un POST en quittant).
+- **Accessibilité des cartes de citation** : TalkBack annonce le résultat des actions (« Citation de X retirée », « déplacée en position N ») et le focus est rendu à la carte voisine après un retrait.
+
 ## `0.23.0` — `internal` (dev) — 2026-07-03
 
 **Phase « Vue Topic » (#604) — vague 4 « Postage », lot 3** (PRs #800 #801 — cadrage Codex 8 forks, gates GO-avec-réserves/GO, dogfood émulateur).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.23.0"
+        versionName = "0.24.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,4 +1,5 @@
-Redface 2 v0.23.0 — dev.
+Redface 2 v0.24.0 — dev.
 
-- Full-screen editor: quotes are now compact cards (reorderable, removable, "Clear all") — no more BBCode wall in the field.
-- "Quote N": 1-2 quotes open the quick reply, 3+ the full-screen editor.
+- Quick reply: the sheet content scrolls (Send always reachable with the keyboard up).
+- Editor: leaving saves the draft first; back is inert while a post is in flight.
+- Quote cards: TalkBack announcements and focus handover after a removal.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,4 +1,5 @@
-Redface 2 v0.23.0 — dev.
+Redface 2 v0.24.0 — dev.
 
-- Éditeur plein écran : les citations deviennent des cartes compactes (réordonnables, supprimables, « Tout vider ») — plus de pavé BBCode dans le champ.
-- « Citer N » : 1-2 citations ouvrent la réponse rapide, 3+ l'éditeur plein écran.
+- Réponse rapide : le contenu défile (Envoyer toujours accessible clavier ouvert).
+- Éditeur : quitter enregistre le brouillon d'abord ; retour inerte pendant un envoi.
+- Cartes de citation : annonces TalkBack et focus rendu après un retrait.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump versionName 0.24.0 + CHANGELOG + whatsnew fr/en (version en 1re ligne).

Contenu : vague 4 « Postage » lot 4a — polish (scroll sheet, flush du brouillon au back, a11y cartes) (PR #803).

Edit mécanique (bump de version) — exception cadence Codex.