### PR TITLE
fix(topic): capitalisation auto dans le champ de la réponse rapide (#807)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySheet.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySheet.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
@@ -32,6 +33,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -141,6 +143,9 @@ internal fun QuickReplySheet(
                 value = state.text,
                 onValueChange = viewModel::onTextChanged,
                 enabled = !state.isSubmitting,
+                // #807 — same #237 contract as BbcodeTextField : Compose capitalises NOTHING by
+                // default, the IME needs the explicit autoCap hint (surface regression, v220).
+                keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
                 placeholder = { Text(stringResource(R.string.quick_reply_hint)) },
                 minLines = 3,
                 maxLines = 6,


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Régression de surface de #237 (signalée v220 par nicko et Dintr-un lemn sur le fil DEV) : le champ de la feuille ne passait aucun `keyboardOptions` → pas de consigne autoCap à l'IME. Une ligne, même contrat `KeyboardCapitalization.Sentences` que `BbcodeTextField`.

Pas de gate Codex : fix de parité une-ligne sur un pattern déjà validé en #237 (exception edit mécanique de la cadence, tracée ici).

NB : « closes #807 » dans le commit ne fermera pas l'issue au merge sur `dev` (branche par défaut = `main`) — fermeture manuelle avec commentaire au merge.

Réf #807 · #237