### PR TITLE
chore: release 0.24.1

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,13 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.24.1` — `internal` (dev) — 2026-07-03
+
+**Fix express dogfood v220** (PR #810).
+
+### Vue Topic
+- #807 (nicko, Dintr-un lemn) : **capitalisation automatique en début de phrase dans la réponse rapide** — régression de surface du fix #237 (le champ de la feuille ne passait pas la consigne autoCap à l'IME).
+
 ## `0.24.0` — `internal` (dev) — 2026-07-03
 
 **Phase « Vue Topic » (#604) — vague 4 « Postage », lot 4a polish** (PR #803 — cadrage + gate Codex NO-GO→fixes→GO, dogfood émulateur).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.24.0"
+        versionName = "0.24.1"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,5 +1,3 @@
-Redface 2 v0.24.0 — dev.
+Redface 2 v0.24.1 — dev.
 
-- Quick reply: the sheet content scrolls (Send always reachable with the keyboard up).
-- Editor: leaving saves the draft first; back is inert while a post is in flight.
-- Quote cards: TalkBack announcements and focus handover after a removal.
+- Quick reply: automatic sentence capitalization (regression fixed).

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,5 +1,3 @@
-Redface 2 v0.24.0 — dev.
+Redface 2 v0.24.1 — dev.
 
-- Réponse rapide : le contenu défile (Envoyer toujours accessible clavier ouvert).
-- Éditeur : quitter enregistre le brouillon d'abord ; retour inerte pendant un envoi.
-- Cartes de citation : annonces TalkBack et focus rendu après un retrait.
+- Réponse rapide : majuscule automatique en début de phrase (régression corrigée).


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump versionName 0.24.1 + CHANGELOG + whatsnew (version en 1re ligne).

Contenu : fix #807 (capitalisation auto dans la réponse rapide, PR #810) — promis « prochain build » sur le fil DEV.

Edit mécanique (bump) — exception cadence Codex.