### PR TITLE
feat(editor,topic): quote cards opt-in — default returns to inline [quotemsg] (#805 arbitrage)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -348,6 +348,22 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         }
     }
 
+    override fun observeQuoteCardsEnabled(): Flow<Boolean> =
+        dataStore.data
+            // Default `false` (#805 arbitrage): citations land as editable [quotemsg] BBCode in
+            // the field; the compact cards of #604 lots 2-3 are the opt-in rendering.
+            .map { prefs -> prefs[KEY_QUOTE_CARDS_ENABLED] ?: false }
+            .distinctUntilChanged()
+            .catch { emit(false) }
+
+    override suspend fun setQuoteCardsEnabled(enabled: Boolean) {
+        persist {
+            dataStore.edit { prefs ->
+                prefs[KEY_QUOTE_CARDS_ENABLED] = enabled
+            }
+        }
+    }
+
     override fun observeShowDtSection(): Flow<Boolean> =
         dataStore.data
             // Default `false`: the DT tab is a placeholder until the MPStorage sync (#6) — opt-in only.
@@ -962,6 +978,9 @@ class DataStoreUserPreferencesRepository @Inject constructor(
 
         // #312 — confirmation dialog before any publish action (reply / edit / new topic / MP).
         val KEY_CONFIRM_BEFORE_POSTING = booleanPreferencesKey("confirm_before_posting")
+
+        // #805 arbitrage — quote cards in the composer (default OFF = inline [quotemsg] BBCode).
+        val KEY_QUOTE_CARDS_ENABLED = booleanPreferencesKey("quote_cards_enabled")
 
         // Opt-in « DT » placeholder tab on the Drapeaux screen (MPStorage sync lands later, #6).
         val KEY_FLAGS_SHOW_DT_SECTION = booleanPreferencesKey("flags_show_dt_section")

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -569,6 +569,11 @@ class TopicRepositoryImplTest {
 
         override suspend fun setConfirmBeforePosting(enabled: Boolean) = Unit
 
+        // #805 — quote rendering is irrelevant to TopicRepositoryImpl; stubbed at its default.
+        override fun observeQuoteCardsEnabled(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setQuoteCardsEnabled(enabled: Boolean) = Unit
+
         override fun observeShowDtSection(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setShowDtSection(enabled: Boolean) = Unit

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -236,6 +236,20 @@ interface UserPreferencesRepository {
     suspend fun setConfirmBeforePosting(enabled: Boolean)
 
     /**
+     * Quote cards in the composer (#805 arbitrage, 2026-07-05): when `true`, citations picked via
+     * « Citer » / « Citer N » are rendered as compact cards above the field (quick-reply sheet AND
+     * full-screen editor) and materialised into `[quotemsg]` BBCode only at submit. Default `false`
+     * — citations are inserted as editable `[quotemsg]` BBCode directly in the text field
+     * (interleaving-friendly, web parity). Read ONCE at surface-opening time (`first()`, not
+     * collected) by `QuickReplyViewModel` and `PostEditorViewModel` — a toggle flip never
+     * rewires a composition session in flight. Toggled in Settings (« Édition et publication »).
+     */
+    fun observeQuoteCardsEnabled(): Flow<Boolean>
+
+    /** Persists [observeQuoteCardsEnabled]. Default `false` until the first call. */
+    suspend fun setQuoteCardsEnabled(enabled: Boolean)
+
+    /**
      * Opt-in « DT » section on the Drapeaux screen: when `true`, a « DT » tab appears next
      * to the flag-type tabs. Placeholder for now — the content (the followed-discussions
      * list whose flags sync through the MPStorage document, #6) lands later. Default

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -49,6 +49,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -98,14 +99,10 @@ class PostEditorViewModel @AssistedInject constructor(
             numreponse = request.numreponse,
             page = request.page,
             subcat = request.subcat,
-            // #604 lot 3 — cards seeded from the handoff, deduplicated defensively on the
-            // numreponse (same uniqueness rule as the basket / the sheet) and gated to Reply :
-            // an Edit session has nothing to quote.
-            quotes = if (request.mode == PostEditorMode.Reply) {
-                request.initialQuotes.distinctBy { it.numreponse }
-            } else {
-                emptyList()
-            },
+            // #805 arbitrage — the handoff quotes are NOT seeded here anymore : their rendering
+            // (cards vs inline [quotemsg]) is decided per opening from the persisted preference,
+            // which is a suspend read — see [resolveQuoteRenderingThenLoad] in init.
+            quotes = emptyList(),
         ),
     )
     val state: StateFlow<PostEditorState> = _state.asStateFlow()
@@ -202,8 +199,79 @@ class PostEditorViewModel @AssistedInject constructor(
         }
         restoreDraftIfAny()
         when (request.mode) {
-            PostEditorMode.Reply -> loadReplyFormIfPossible()
+            PostEditorMode.Reply -> resolveQuoteRenderingThenLoad()
             PostEditorMode.Edit -> loadEditFormIfPossible()
+        }
+    }
+
+    /**
+     * #805 arbitrage — one preference read (`first()`, decided per opening) picks the citation
+     * rendering for this session :
+     *
+     * - **cards ON** — the #604 lot 3 behaviour, unchanged : handoff previews become
+     *   [PostEditorState.quotes] (deduplicated per numreponse, Reply-only), the open-time fetch
+     *   stays PLAIN, `[quotemsg]` is materialised fresh at submit.
+     * - **cards OFF (default)** — the pre-lot-3 flow : the open-time fetch IS the materialisation
+     *   ([ReplyQuoteMaterializer.fetchFormWithQuotes]), so [launchFormFetch] hydrates the field
+     *   with the merged `[quotemsg]` prefills through the existing anti-clobber guards, and
+     *   [restoreDraftIfAny]'s `resumeSharedDraft` append stays commutative with it (#790).
+     *   `state.quotes` stays empty → submit takes the plain path (the content is the field).
+     */
+    private fun resolveQuoteRenderingThenLoad() {
+        val initialQuotes = request.initialQuotes.distinctBy { it.numreponse }
+        if (initialQuotes.isEmpty()) {
+            loadReplyFormIfPossible()
+            return
+        }
+        viewModelScope.launch {
+            if (userPreferencesRepository.observeQuoteCardsEnabled().first()) {
+                _state.update { it.copy(quotes = initialQuotes) }
+                loadReplyFormIfPossible()
+            } else {
+                loadReplyFormWithInlineQuotes(initialQuotes)
+            }
+        }
+    }
+
+    /**
+     * #805 cards OFF — open-time fetch through the materializer (quote form + merged prefills).
+     *
+     * The prefill does NOT ride [launchFormFetch]'s hydration : that path only fills a BLANK
+     * field (anti-clobber), so a `resumeSharedDraft` restore landing first would silently drop
+     * the citation. Instead the merged `[quotemsg]` blocks are PREPENDED onto the live field
+     * content at completion — commutative with the restore's append whichever lands first
+     * (réserve Codex n°5), and typing started during the fetch survives. Options still hydrate
+     * through [withFormHydration] (with a content-blanked form, so the text path stays inert).
+     */
+    private fun loadReplyFormWithInlineQuotes(quotes: List<QuotedPostPreview>) {
+        val context = buildReplyContext() ?: run {
+            _state.update { it.copy(submitError = SubmitError.MissingSubcat) }
+            return
+        }
+        val quoteContext = context.copy(quotedNumreponse = quotes.first().numreponse, quoteRef = null)
+        _state.update { it.copy(isLoadingForm = true, submitError = null) }
+        viewModelScope.launch {
+            val outcome = runCatching {
+                quoteMaterializer.fetchFormWithQuotes(
+                    context = quoteContext,
+                    extraQuoteNumreponses = quotes.drop(1).map { it.numreponse },
+                )
+            }
+            outcome.fold(
+                onSuccess = { form ->
+                    loadedForm = form
+                    val prefills = form.initialContent.trimEnd()
+                    _state.update { current ->
+                        val existing = current.draft.text
+                        val combined = if (existing.isBlank()) prefills else prefills + "\n\n" + existing
+                        current
+                            .withFormHydration(form.copy(initialContent = ""), current.preview)
+                            .copy(draft = TextFieldValue(text = combined, selection = TextRange(combined.length)))
+                    }
+                    scheduleAutosave()
+                },
+                onFailure = { error -> handleFetchFailure(error) },
+            )
         }
     }
 
@@ -213,9 +281,10 @@ class PostEditorViewModel @AssistedInject constructor(
      *
      * #790 exception — when the route carries `resumeSharedDraft` (escalation of a quick-reply
      * sheet, which JUST wrote the row), the body is APPENDED to the field instead of banner'd :
-     * the escalation continues the same composition act. (The quote-prefill prepend this used to
-     * be commutative with is gone since #604 lot 3 — citations are cards, the plain reply form
-     * carries no prefill.)
+     * the escalation continues the same composition act. With cards OFF (#805 default) the
+     * open-time quote form DOES carry a `[quotemsg]` prefill again : this append and the form
+     * hydration prepend are commutative, guarded against double-hydration — the original #790
+     * contract, restored.
      */
     private fun restoreDraftIfAny() {
         val key = draftKey ?: return
@@ -676,10 +745,11 @@ class PostEditorViewModel @AssistedInject constructor(
             _state.update { it.copy(submitError = SubmitError.MissingSubcat) }
             return
         }
-        // #604 lot 3 (mockup P3) — the open-time fetch is always the PLAIN reply form now :
-        // citations live as cards in [PostEditorState.quotes] and their [quotemsg] blocks are
-        // materialised fresh at submit (see [onSubmitClicked]), exactly like the quick-reply
-        // sheet. This fetch only warms the hash and hydrates the per-post options.
+        // #604 lot 3 (mockup P3) — with cards ON (or no citations at all) the open-time fetch is
+        // the PLAIN reply form : citations live as cards in [PostEditorState.quotes] and their
+        // [quotemsg] blocks are materialised fresh at submit (see [onSubmitClicked]), exactly
+        // like the quick-reply sheet. This fetch only warms the hash and hydrates the per-post
+        // options. Cards OFF goes through [loadReplyFormWithInlineQuotes] instead (#805).
         launchFormFetch { replyRepository.fetchReplyForm(context) }
     }
 

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -787,7 +787,11 @@ class PostEditorViewModelTest {
         initialQuotes: List<QuotedPostPreview> = emptyList(),
         resumeSharedDraft: Boolean = false,
         diagnostics: DiagnosticsLog = DiagnosticsLog(),
-        userPreferencesRepository: UserPreferencesRepository = FakeUserPreferencesRepository(),
+        // Test default = cards ON so the #604 lot 3 card suites keep exercising their mode ;
+        // the #805 inline tests pass their own fake with `quoteCardsEnabled = false` (the
+        // PRODUCTION default is false = inline [quotemsg] in the field).
+        userPreferencesRepository: UserPreferencesRepository =
+            FakeUserPreferencesRepository(quoteCardsEnabled = true),
         authRepository: AuthRepository = FakeAuthRepository(),
     ): PostEditorViewModel =
         PostEditorViewModel(
@@ -1781,6 +1785,100 @@ class PostEditorViewModelTest {
         }
     }
 
+    // ----- #805 : cartes OFF (défaut production) — [quotemsg] hydraté à l'ouverture ----------
+
+    @Test
+    fun `cards OFF - the open fetch is the quote form and the field hydrates the merged prefills`() = runTest {
+        replyRepository.formResultsByNumrep = mapOf(
+            101 to Result.success(authenticatedForm(initialContent = "[quotemsg=101,1,9]a[/quotemsg]\n\n")),
+            202 to Result.success(authenticatedForm(initialContent = "[quotemsg=202,2,9]b[/quotemsg]\n\n")),
+        )
+        val viewModel = newReplyViewModel(
+            initialQuotes = listOf(card(101), card(202)),
+            userPreferencesRepository = FakeUserPreferencesRepository(quoteCardsEnabled = false),
+        )
+        testScheduler.advanceUntilIdle()
+
+        viewModel.state.test {
+            val settled = expectMostRecentItem()
+            assertEquals(
+                "pre-lot-3 flow restored : the field hydrates the merged [quotemsg] prefills",
+                "[quotemsg=101,1,9]a[/quotemsg]\n\n[quotemsg=202,2,9]b[/quotemsg]",
+                settled.draft.text.trimEnd(),
+            )
+            assertTrue("no card in inline mode", settled.quotes.isEmpty())
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(
+            "the open fetch replays the quote contract in citation order",
+            listOf(101, 202),
+            replyRepository.fetchedContexts.map { it.quotedNumreponse },
+        )
+    }
+
+    @Test
+    fun `cards OFF - resumeSharedDraft appends after the prefill with exactly one quote block`() = runTest {
+        // Réserve Codex n°5 — the #790 trio restored : quote-form hydration (prepend) + shared-row
+        // append must compose to ONE [quotemsg] block and a stable order, whichever lands first.
+        draftStore.preload(
+            EditorDraftKey.reply(SAMPLE_CAT, SAMPLE_TOPIC_ID),
+            EditorDraftStore.Draft(body = "texte de la sheet"),
+        )
+        replyRepository.formResultsByNumrep = mapOf(
+            101 to Result.success(authenticatedForm(initialContent = "[quotemsg=101,1,9]a[/quotemsg]\n\n")),
+        )
+        val viewModel = newReplyViewModel(
+            resumeSharedDraft = true,
+            initialQuotes = listOf(card(101)),
+            userPreferencesRepository = FakeUserPreferencesRepository(quoteCardsEnabled = false),
+        )
+        testScheduler.advanceUntilIdle()
+
+        viewModel.state.test {
+            val settled = expectMostRecentItem()
+            assertEquals(
+                "[quotemsg=101,1,9]a[/quotemsg]\n\ntexte de la sheet",
+                settled.draft.text,
+            )
+            assertNull("no banner on an escalation hand-over", settled.restorableDraft)
+            assertEquals(
+                "exactly one quote block — no double hydration",
+                1,
+                Regex("\\[quotemsg=101").findAll(settled.draft.text).count(),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `cards OFF - submit rides the plain path with the field content`() = runTest {
+        // Réserve Codex n°6 — the content already carries the [quotemsg] block ; the submit is
+        // the plain path (no re-materialisation), riding the warmed quote form.
+        replyRepository.formResultsByNumrep = mapOf(
+            101 to Result.success(authenticatedForm(initialContent = "[quotemsg=101,1,9]a[/quotemsg]\n\n")),
+        )
+        replyRepository.submitResult = ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
+        val viewModel = newReplyViewModel(
+            initialQuotes = listOf(card(101)),
+            userPreferencesRepository = FakeUserPreferencesRepository(quoteCardsEnabled = false),
+        )
+        testScheduler.advanceUntilIdle()
+        val openFetches = replyRepository.formFetches
+
+        viewModel.submit(
+            PostEditorIntent.ContentChanged(TextFieldValue("[quotemsg=101,1,9]a[/quotemsg]\n\nma réponse")),
+        )
+        viewModel.submit(PostEditorIntent.SubmitClicked)
+        testScheduler.advanceUntilIdle()
+
+        assertEquals("no re-materialisation at submit", openFetches, replyRepository.formFetches)
+        assertEquals("[quotemsg=101,1,9]a[/quotemsg]\n\nma réponse", replyRepository.lastSubmittedBbcode)
+        assertNull(
+            "plain submit context — the quote already lives in the content",
+            replyRepository.lastSubmittedContext?.quotedNumreponse,
+        )
+    }
+
     // ----- #604 lot 3 : cartes de citation dans l'éditeur ---------------------
 
     @Test
@@ -2155,8 +2253,11 @@ class PostEditorViewModelTest {
         // production defaults to REDUCED (cf. DataStoreUserPreferencesRepository), exercised by the
         // dedicated mode tests below.
         editorImageInsert: EditorImageInsert = EditorImageInsert.FULL,
+        // #805 — false mirrors the production default (inline BBCode); the card tests opt in.
+        quoteCardsEnabled: Boolean = false,
     ) : UserPreferencesRepository {
         private val confirmBeforePosting = MutableStateFlow(confirmBeforePosting)
+        private val quoteCardsEnabled = MutableStateFlow(quoteCardsEnabled)
 
         override fun observeProxyConfig(): Flow<ProxyConfig> = MutableStateFlow(ProxyConfig())
         override suspend fun saveProxyConfig(config: ProxyConfig) = Unit
@@ -2192,6 +2293,10 @@ class PostEditorViewModelTest {
         override fun observeConfirmBeforePosting(): Flow<Boolean> = confirmBeforePosting
         override suspend fun setConfirmBeforePosting(enabled: Boolean) {
             confirmBeforePosting.value = enabled
+        }
+        override fun observeQuoteCardsEnabled(): Flow<Boolean> = quoteCardsEnabled
+        override suspend fun setQuoteCardsEnabled(enabled: Boolean) {
+            quoteCardsEnabled.value = enabled
         }
 
         override fun observeShowDtSection(): Flow<Boolean> = MutableStateFlow(false)

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1524,6 +1524,9 @@ class TopicFormViewModelTest {
             confirmBeforePosting.value = enabled
         }
 
+        override fun observeQuoteCardsEnabled(): Flow<Boolean> = MutableStateFlow(false)
+        override suspend fun setQuoteCardsEnabled(enabled: Boolean) = Unit
+
         override fun observeShowDtSection(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setShowDtSection(enabled: Boolean) = Unit

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -2612,6 +2612,11 @@ class FlagsViewModelTest {
 
         override suspend fun setConfirmBeforePosting(enabled: Boolean) = Unit
 
+        // #805 — quote rendering is irrelevant to FlagsViewModel; stubbed at its default.
+        override fun observeQuoteCardsEnabled(): Flow<Boolean> = MutableStateFlow(false)
+
+        override suspend fun setQuoteCardsEnabled(enabled: Boolean) = Unit
+
         override fun observeShowDtSection(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setShowDtSection(enabled: Boolean) = Unit

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -598,6 +598,16 @@ internal fun buildSettingsCatalogue(
                     .takeIf { state.confirmBeforePostingError },
                 onCheckedChange = { onIntent(SettingsIntent.ConfirmBeforePostingChanged(it)) },
             ),
+            toggleRow(
+                id = "quote_cards_enabled",
+                title = stringResource(R.string.settings_quote_cards_title),
+                description = stringResource(R.string.settings_quote_cards_description),
+                checked = state.quoteCardsEnabled,
+                enabled = state.canToggleQuoteCardsEnabled,
+                errorRes = R.string.settings_quote_cards_persist_failed
+                    .takeIf { state.quoteCardsEnabledError },
+                onCheckedChange = { onIntent(SettingsIntent.QuoteCardsEnabledChanged(it)) },
+            ),
             futureRow(
                 id = "future_auto_signature",
                 title = stringResource(R.string.settings_future_auto_signature),

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -172,6 +172,12 @@ data class SettingsState(
     val isUpdatingConfirmBeforePosting: Boolean = false,
     val confirmBeforePostingError: Boolean = false,
     val confirmBeforePostingTouchedLocally: Boolean = false,
+    // #805 arbitrage — quote cards in the composer, opt-in. Same optimistic-flip + startup-race
+    // machinery. Default false (citations = inline [quotemsg] BBCode in the field).
+    val quoteCardsEnabled: Boolean = false,
+    val isUpdatingQuoteCardsEnabled: Boolean = false,
+    val quoteCardsEnabledError: Boolean = false,
+    val quoteCardsEnabledTouchedLocally: Boolean = false,
     // Drapeaux — opt-in « DT » placeholder tab (MPStorage sync #6 lands later). Same
     // optimistic-flip + startup-race-guard machinery. Default false (tab hidden).
     val showDtSection: Boolean = false,
@@ -315,6 +321,10 @@ data class SettingsState(
     val canToggleConfirmBeforePosting: Boolean
         get() = !isUpdatingConfirmBeforePosting
 
+    // #805 — the quote-cards toggle is gated only by its own write.
+    val canToggleQuoteCardsEnabled: Boolean
+        get() = !isUpdatingQuoteCardsEnabled
+
     // DT tab — gated only by its own write.
     val canToggleShowDtSection: Boolean
         get() = !isUpdatingShowDtSection
@@ -451,6 +461,9 @@ sealed interface SettingsIntent {
     // #312 — confirm-before-posting toggle. Optimistic-flip contract, like the flags toggles:
     // the boolean is the desired post-flip state.
     data class ConfirmBeforePostingChanged(val enabled: Boolean) : SettingsIntent
+
+    // #805 — quote-cards-in-composer toggle. Optimistic-flip contract, like the flags toggles.
+    data class QuoteCardsEnabledChanged(val enabled: Boolean) : SettingsIntent
 
     // Drapeaux — opt-in « DT » placeholder tab (MPStorage sync #6 lands later). Optimistic-flip
     // contract, like the flags toggles: the boolean is the desired post-flip state.

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -155,6 +155,11 @@ class SettingsViewModel @Inject constructor(
             apply = { state, value -> state.copy(confirmBeforePosting = value) },
         )
         hydratePreference(
+            read = { userPreferencesRepository.observeQuoteCardsEnabled().first() },
+            isLocked = { it.quoteCardsEnabledTouchedLocally || it.isUpdatingQuoteCardsEnabled },
+            apply = { state, value -> state.copy(quoteCardsEnabled = value) },
+        )
+        hydratePreference(
             read = { userPreferencesRepository.observeShowDtSection().first() },
             isLocked = { it.showDtSectionTouchedLocally || it.isUpdatingShowDtSection },
             apply = { state, value -> state.copy(showDtSection = value) },
@@ -275,6 +280,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.SyncPrivateMessagesWriteEnabledChanged ->
                 updateSyncPrivateMessagesWriteEnabled(intent.enabled)
             is SettingsIntent.ConfirmBeforePostingChanged -> updateConfirmBeforePosting(intent.enabled)
+            is SettingsIntent.QuoteCardsEnabledChanged -> updateQuoteCardsEnabled(intent.enabled)
             is SettingsIntent.FlagsAutoRefreshChanged -> updateFlagsAutoRefresh(intent.enabled)
             is SettingsIntent.DisplayDensityChanged -> updateDisplayDensity(intent.density)
             is SettingsIntent.FontScaleChanged -> updateFontScale(intent.scale)
@@ -1192,6 +1198,33 @@ class SettingsViewModel @Inject constructor(
                 }
             },
             persist = userPreferencesRepository::setConfirmBeforePosting,
+        )
+    }
+
+    private fun updateQuoteCardsEnabled(desired: Boolean) {
+        val previous = _state.value.quoteCardsEnabled
+        updateBooleanPreference(
+            desired = desired,
+            optimistic = {
+                it.copy(
+                    quoteCardsEnabled = desired,
+                    isUpdatingQuoteCardsEnabled = true,
+                    quoteCardsEnabledError = false,
+                    quoteCardsEnabledTouchedLocally = true,
+                )
+            },
+            onSettled = { state, result ->
+                if (result.isSuccess) {
+                    state.copy(quoteCardsEnabled = desired, isUpdatingQuoteCardsEnabled = false)
+                } else {
+                    state.copy(
+                        quoteCardsEnabled = previous,
+                        isUpdatingQuoteCardsEnabled = false,
+                        quoteCardsEnabledError = true,
+                    )
+                }
+            },
+            persist = userPreferencesRepository::setQuoteCardsEnabled,
         )
     }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -353,6 +353,9 @@
     <string name="settings_confirm_before_posting_title">Confirmation avant publication</string>
     <string name="settings_confirm_before_posting_description">Avant chaque réponse, sujet ou MP envoyé.</string>
     <string name="settings_confirm_before_posting_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
+    <string name="settings_quote_cards_title">Citations en cartes</string>
+    <string name="settings_quote_cards_description">Représente les citations par des cartes compactes au-dessus du champ. Désactivé : la citation est insérée en BBCode, modifiable dans le texte.</string>
+    <string name="settings_quote_cards_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
 
     <!-- #459 PR3 — entrée vers l'écran « Mes images uploadées » depuis le catalogue de réglages. -->
     <string name="settings_section_images">Images</string>

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -1363,6 +1363,30 @@ class SettingsViewModelTest {
     }
 
     @Test
+    fun `QuoteCardsEnabledChanged persists the flip`() = runTest {
+        val viewModel = newViewModel()
+        assertFalse("#805 — quote cards are OFF by default (inline BBCode)", viewModel.state.value.quoteCardsEnabled)
+
+        viewModel.submit(SettingsIntent.QuoteCardsEnabledChanged(true))
+
+        assertTrue(viewModel.state.value.quoteCardsEnabled)
+        assertFalse(viewModel.state.value.isUpdatingQuoteCardsEnabled)
+        assertEquals(1, repository.quoteCardsEnabledSetCalls)
+    }
+
+    @Test
+    fun `QuoteCardsEnabledChanged reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnQuoteCardsEnabledSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.QuoteCardsEnabledChanged(true))
+
+        assertFalse("must revert to the previous value on failure", viewModel.state.value.quoteCardsEnabled)
+        assertFalse(viewModel.state.value.isUpdatingQuoteCardsEnabled)
+        assertTrue(viewModel.state.value.quoteCardsEnabledError)
+    }
+
+    @Test
     fun `init hydrates the experimental MPStorage write opt-in from the persisted preference`() = runTest {
         repository.emitSyncPrivateMessagesWriteEnabled(true)
 
@@ -2038,6 +2062,20 @@ class SettingsViewModelTest {
             confirmBeforePostingSetCalls += 1
             check(!failOnConfirmBeforePostingSet) { "boom" }
             confirmBeforePosting.value = enabled
+        }
+
+        // #805 — quote cards in the composer. Same optimistic-flip seam as confirm-before-posting.
+        private val quoteCardsEnabled = MutableStateFlow(false)
+        var quoteCardsEnabledSetCalls: Int = 0
+            private set
+        var failOnQuoteCardsEnabledSet: Boolean = false
+
+        override fun observeQuoteCardsEnabled(): Flow<Boolean> = quoteCardsEnabled
+
+        override suspend fun setQuoteCardsEnabled(enabled: Boolean) {
+            quoteCardsEnabledSetCalls += 1
+            check(!failOnQuoteCardsEnabledSet) { "boom" }
+            quoteCardsEnabled.value = enabled
         }
 
         private val showDtSection = MutableStateFlow(false)

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySheet.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySheet.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
@@ -68,7 +69,14 @@ internal fun QuickReplySheet(
         creationCallback = { factory -> factory.create(request) },
     )
     val state by viewModel.state.collectAsStateWithLifecycle()
-    LaunchedEffect(viewModel, initialQuotes) {
+    // Keyed on the VM ALONE — one `onSheetOpened` delivery per sheet composition. Keying on
+    // `initialQuotes` too would restart the effect on any launch mutation and re-seed the field
+    // from a possibly-stale row mid-typing (#805 cadrage, réserve n°1). A deliberate re-cite is
+    // a new launch, hence a new composition, hence a fresh delivery — GUARANTEED structurally :
+    // every `quickReplyFor` setter in TopicScreen (FAB, « Citer », « Citer N ») sits behind this
+    // modal's scrim, so a new launch can only happen after a dismiss nulled the previous one
+    // (gate Codex, finding 2). Re-assigning the launch over an OPEN sheet would break delivery.
+    LaunchedEffect(viewModel) {
         // Re-seed the field from the #405 row at EACH opening — the VM outlives the sheet and
         // its cached text can be stale after a full-screen edit of the same draft (gate #788).
         viewModel.onSheetOpened(initialQuotes)
@@ -119,8 +127,9 @@ internal fun QuickReplySheet(
                 )
                 IconButton(
                     onClick = viewModel::onEscalateRequested,
-                    // Gate #788 — no escalation while a POST is in flight (submit vs navigation race).
-                    enabled = !state.isSubmitting,
+                    // Gate #788 — no escalation while a POST is in flight (submit vs navigation
+                    // race) ; #805 — nor while a [quotemsg] insert is being fetched.
+                    enabled = !state.isSubmitting && !state.isPreparingQuotes,
                     modifier = Modifier.semantics { contentDescription = fullScreenLabel },
                 ) {
                     RedfaceVectorIcon(
@@ -153,6 +162,21 @@ internal fun QuickReplySheet(
                     .fillMaxWidth()
                     .focusRequester(focusRequester),
             )
+            // #805 cards OFF — the [quotemsg] fetch runs at opening : typing stays enabled (the
+            // insert concatenates onto the live field), only send/escalate wait for it.
+            if (state.isPreparingQuotes) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.padding(end = 8.dp).size(16.dp),
+                        strokeWidth = 2.dp,
+                    )
+                    Text(
+                        text = stringResource(R.string.quick_reply_preparing_quote),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
             state.submitError?.let { error ->
                 Text(
                     text = stringResource(error.messageRes()),
@@ -201,6 +225,7 @@ internal fun QuickReplySheet(
 internal fun QuickReplySubmitError.messageRes(): Int = when (this) {
     QuickReplySubmitError.Network -> R.string.quick_reply_error_network
     QuickReplySubmitError.SessionExpired -> R.string.quick_reply_error_session_expired
+    QuickReplySubmitError.QuoteFetchFailed -> R.string.quick_reply_error_quote_fetch
     is QuickReplySubmitError.Hfr -> when (reason) {
         ReplyFailureReason.EmptyMessage -> R.string.quick_reply_error_empty
         ReplyFailureReason.InvalidHashCheck -> R.string.quick_reply_error_invalid_hash

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -49,12 +50,19 @@ data class QuickReplyUiState(
      */
     val quotes: List<QuotedPostPreview> = emptyList(),
     val isSubmitting: Boolean = false,
+    /**
+     * #805 arbitrage — cards OFF : a `[quotemsg]` materialisation is in flight for this opening.
+     * Typing stays enabled (the completion CONCATENATES onto the live field, réserve Codex) ;
+     * submit and escalation wait for the insert.
+     */
+    val isPreparingQuotes: Boolean = false,
     val submitError: QuickReplySubmitError? = null,
     /** #312 — « Confirmation avant publication » : the pending-confirmation dialog is showing. */
     val confirmVisible: Boolean = false,
 ) {
     /** With quote cards armed, an empty body is a valid submit (quotes-only reply). */
-    val canSubmit: Boolean get() = (text.text.isNotBlank() || quotes.isNotEmpty()) && !isSubmitting
+    val canSubmit: Boolean
+        get() = (text.text.isNotBlank() || quotes.isNotEmpty()) && !isSubmitting && !isPreparingQuotes
 }
 
 /** Typed submit failures, the same split as the full editor's `SubmitError`. */
@@ -62,6 +70,13 @@ sealed interface QuickReplySubmitError {
     data class Hfr(val reason: ReplyFailureReason) : QuickReplySubmitError
     data object Network : QuickReplySubmitError
     data object SessionExpired : QuickReplySubmitError
+
+    /**
+     * #805 cards OFF — the opening-time `[quotemsg]` fetch failed : the field is untouched,
+     * nothing is lost, re-tapping « Citer » retries. Session expiry still maps to
+     * [SessionExpired] (reconnect is the actionable fix).
+     */
+    data object QuoteFetchFailed : QuickReplySubmitError
 }
 
 /** One-shot events consumed by the sheet composable. */
@@ -98,7 +113,7 @@ class QuickReplyViewModel @AssistedInject constructor(
     private val replyRepository: ReplyRepository,
     private val quoteMaterializer: ReplyQuoteMaterializer,
     private val draftStore: EditorDraftStore,
-    userPreferencesRepository: UserPreferencesRepository,
+    private val userPreferencesRepository: UserPreferencesRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(QuickReplyUiState())
@@ -119,6 +134,13 @@ class QuickReplyViewModel @AssistedInject constructor(
     private var formJob: Job? = null
     private var submitJob: Job? = null
     private var autosaveJob: Job? = null
+
+    /**
+     * #805 cards OFF — the opening-time materialisation. Cancelled at each (re)opening and at
+     * dismiss : a fetch started for an abandoned composition can never inject its BBCode into
+     * the next one (réserve Codex n°2).
+     */
+    private var materializeJob: Job? = null
 
     /** #405 — the SAME key the full-screen reply editor uses for this topic. */
     private val draftKey: String = EditorDraftKey.reply(request.cat, request.topicId)
@@ -149,18 +171,83 @@ class QuickReplyViewModel @AssistedInject constructor(
      * typically escalate → edit in the full-screen editor → back → reopen. The row is the
      * source of truth ; the field is unconditionally re-seeded from it (gate Codex PR #788).
      *
-     * [initialQuotes] (#604 lot 3) — the cards this opening pre-arms, in citation order : one
+     * [initialQuotes] (#604 lot 3) — the citations this opening delivers, in citation order : one
      * preview for « Citer », the whole basket for « Citer N » under the full-screen threshold.
-     * Adds are idempotent per numreponse, appended AFTER any cards the surviving VM already
-     * holds (the composition in progress keeps its order).
+     * Delivery happens ONCE per sheet composition (the sheet keys its effect on the VM alone) ;
+     * a deliberate re-cite is a new launch, hence a new composition.
+     *
+     * Rendering is decided HERE per opening (#805 arbitrage, `observeQuoteCardsEnabled().first()`) :
+     * cards ON → idempotent card adds (unchanged #604 behaviour) ; cards OFF (default) → the
+     * `[quotemsg]` prefills are fetched now and APPENDED to the live field content at completion
+     * (never a replacement computed from the row — réserve Codex n°1).
      */
     fun onSheetOpened(initialQuotes: List<QuotedPostPreview> = emptyList()) {
-        initialQuotes.forEach(::onQuoteAdded)
+        materializeJob?.cancel()
         viewModelScope.launch {
             initJob.join()
             val body = draftStore.load(draftOwner, draftKey)?.body.orEmpty()
             _state.update {
                 it.copy(text = TextFieldValue(text = body, selection = TextRange(body.length)))
+            }
+            if (initialQuotes.isEmpty() && _state.value.quotes.isEmpty()) return@launch
+            if (userPreferencesRepository.observeQuoteCardsEnabled().first()) {
+                initialQuotes.forEach(::onQuoteAdded)
+            } else {
+                // Gate Codex (finding 1) — cards armed under a previous cards-ON session must not
+                // survive an OFF opening : rendered again, they would re-arm the cards submit
+                // path against the arbitrage. They are FOLDED into this opening's inline insert
+                // instead (nothing the user cited is dropped), deduplicated like cards were.
+                val pending = (_state.value.quotes + initialQuotes).distinctBy { it.numreponse }
+                _state.update { it.copy(quotes = emptyList()) }
+                materializeInlineQuotes(pending)
+            }
+        }
+    }
+
+    /**
+     * #805 cards OFF — fetch the `[quotemsg]` prefills (same materializer call as the cards-ON
+     * submit) and insert them into the field. The insert CONCATENATES onto the field content as
+     * it is at completion time — typing during the fetch is never lost, successive citations
+     * keep their chronological order, and the caret lands after the inserted quote (the natural
+     * « continue typing » position). The fresh quote form also warms [loadedForm] : its hash is
+     * exactly what the pre-cards flow rode at submit.
+     */
+    @Suppress("TooGenericExceptionCaught") // mapped to a typed error below; cancellation rethrown.
+    private fun materializeInlineQuotes(quotes: List<QuotedPostPreview>) {
+        materializeJob?.cancel()
+        materializeJob = viewModelScope.launch {
+            _state.update { it.copy(isPreparingQuotes = true, submitError = null) }
+            try {
+                val quoteContext = context.copy(
+                    quotedNumreponse = quotes.first().numreponse,
+                    quoteRef = null,
+                )
+                val form = quoteMaterializer.fetchFormWithQuotes(
+                    context = quoteContext,
+                    extraQuoteNumreponses = quotes.drop(1).map { it.numreponse },
+                )
+                loadedForm = form
+                val prefills = form.initialContent.trimEnd()
+                _state.update { current ->
+                    val existing = current.text.text
+                    val combined = if (existing.isBlank()) prefills else existing.trimEnd() + "\n\n" + prefills
+                    current.copy(
+                        text = TextFieldValue(text = combined, selection = TextRange(combined.length)),
+                        isPreparingQuotes = false,
+                    )
+                }
+                scheduleAutosave()
+            } catch (cancelled: CancellationException) {
+                _state.update { it.copy(isPreparingQuotes = false) }
+                throw cancelled
+            } catch (_: SessionExpiredException) {
+                _state.update {
+                    it.copy(isPreparingQuotes = false, submitError = QuickReplySubmitError.SessionExpired)
+                }
+            } catch (_: Exception) {
+                _state.update {
+                    it.copy(isPreparingQuotes = false, submitError = QuickReplySubmitError.QuoteFetchFailed)
+                }
             }
         }
     }
@@ -224,6 +311,9 @@ class QuickReplyViewModel @AssistedInject constructor(
      * editor. The effect is emitted only after the save completed — see [QuickReplyEffect.EscalateToFullEditor].
      */
     fun onEscalateRequested() {
+        // #805 cards OFF — inert while the [quotemsg] insert is in flight : escalating now would
+        // hand over a row without the citation the user just asked for.
+        if (_state.value.isPreparingQuotes) return
         autosaveJob?.cancel()
         viewModelScope.launch {
             saveDraftNow()
@@ -237,6 +327,9 @@ class QuickReplyViewModel @AssistedInject constructor(
      * scoped to the topic's nav entry).
      */
     fun onDismissed() {
+        // A pending [quotemsg] insert dies with the composition it belonged to (réserve Codex
+        // n°2) — the user abandoned it; the flush below only persists what the field showed.
+        materializeJob?.cancel()
         autosaveJob?.cancel()
         viewModelScope.launch { saveDraftNow() }
     }

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -139,4 +139,6 @@
     <string name="quick_reply_error_unknown">HFR a renvoyé une réponse inattendue. Réessayez ou actualisez l\'app.</string>
     <string name="quick_reply_error_network">Erreur réseau. Vérifiez votre connexion et réessayez.</string>
     <string name="quick_reply_error_session_expired">Votre session HFR a expiré. Reconnectez-vous.</string>
+    <string name="quick_reply_error_quote_fetch">Impossible de récupérer la citation. Réessayez depuis « Citer ».</string>
+    <string name="quick_reply_preparing_quote">Insertion de la citation…</string>
 </resources>

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModelTest.kt
@@ -10,9 +10,12 @@ import fr.forumhfr.redface2.core.model.write.ReplyForm
 import fr.forumhfr.redface2.core.model.write.ReplyFormOptions
 import fr.forumhfr.redface2.core.model.write.QuotedPostPreview
 import fr.forumhfr.redface2.core.model.write.ReplySubmitResult
+import java.io.IOException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -21,6 +24,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -322,6 +326,153 @@ class QuickReplyViewModelTest {
         assertEquals(listOf(303, 101), viewModel.state.value.quotes.map { it.numreponse })
     }
 
+    // ----- #805 : cartes OFF (défaut production) — [quotemsg] inline dans le champ ----------
+
+    @Test
+    fun `inline mode appends the quote BBCode after the row body and arms no card`() = runTest {
+        val repository = FakeQuickReplyRepository()
+        val viewModel = quickReplyViewModel(
+            replyRepository = repository,
+            draftStore = FakeQuickReplyDraftStore(initialBody = "brouillon"),
+            quoteCardsEnabled = false,
+        )
+        viewModel.onSheetOpened(listOf(preview(101, "alice")))
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertEquals("brouillon\n\n[quotemsg=101]corps[/quotemsg]", state.text.text)
+        assertTrue(state.quotes.isEmpty())
+        assertFalse(state.isPreparingQuotes)
+        // Prefetch (plain) then the quote form — whose hash the later submit rides.
+        assertEquals(listOf(null, 101), repository.fetchedQuotedNumreponses)
+    }
+
+    @Test
+    fun `inline mode merges a small basket in citation order`() = runTest {
+        val repository = FakeQuickReplyRepository()
+        val viewModel = quickReplyViewModel(replyRepository = repository, quoteCardsEnabled = false)
+        viewModel.onSheetOpened(listOf(preview(202, "bob"), preview(101, "alice")))
+        advanceUntilIdle()
+
+        assertEquals(
+            "[quotemsg=202]corps[/quotemsg]\n\n[quotemsg=101]corps[/quotemsg]",
+            viewModel.state.value.text.text,
+        )
+        assertTrue(viewModel.state.value.quotes.isEmpty())
+    }
+
+    @Test
+    fun `inline mode never loses typing made during the quote fetch`() = runTest {
+        // Réserve Codex n°1 — the completion CONCATENATES onto the live field content, never a
+        // replacement recomputed from the row : keystrokes landed mid-fetch must survive.
+        val repository = GatedQuoteFormRepository()
+        val viewModel = quickReplyViewModel(replyRepository = repository, quoteCardsEnabled = false)
+        viewModel.onSheetOpened(listOf(preview(101, "alice")))
+        advanceUntilIdle()
+        assertTrue(viewModel.state.value.isPreparingQuotes)
+
+        viewModel.onTextChanged(TextFieldValue("pendant le fetch"))
+        assertFalse(viewModel.state.value.canSubmit)
+
+        repository.quoteGate.complete(Unit)
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertEquals("pendant le fetch\n\n[quotemsg=101]corps[/quotemsg]", state.text.text)
+        assertFalse(state.isPreparingQuotes)
+        assertTrue(state.canSubmit)
+    }
+
+    @Test
+    fun `inline mode surfaces a quote-fetch failure and keeps the field intact`() = runTest {
+        val repository = GatedQuoteFormRepository(failQuoteFetch = true)
+        repository.quoteGate.complete(Unit)
+        val viewModel = quickReplyViewModel(
+            replyRepository = repository,
+            draftStore = FakeQuickReplyDraftStore(initialBody = "acquis"),
+            quoteCardsEnabled = false,
+        )
+        viewModel.onSheetOpened(listOf(preview(101, "alice")))
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertEquals("acquis", state.text.text)
+        assertEquals(QuickReplySubmitError.QuoteFetchFailed, state.submitError)
+        assertFalse(state.isPreparingQuotes)
+    }
+
+    @Test
+    fun `dismiss cancels an in-flight inline materialisation`() = runTest {
+        // Réserve Codex n°2 — a fetch started for an abandoned composition must never inject
+        // its BBCode into the next one.
+        val repository = GatedQuoteFormRepository()
+        val viewModel = quickReplyViewModel(replyRepository = repository, quoteCardsEnabled = false)
+        viewModel.onSheetOpened(listOf(preview(101, "alice")))
+        advanceUntilIdle()
+        assertTrue(viewModel.state.value.isPreparingQuotes)
+
+        viewModel.onDismissed()
+        repository.quoteGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals("", viewModel.state.value.text.text)
+        assertFalse(viewModel.state.value.isPreparingQuotes)
+    }
+
+    @Test
+    fun `escalation is inert while the quote insert is in flight`() = runTest {
+        val repository = GatedQuoteFormRepository()
+        val viewModel = quickReplyViewModel(replyRepository = repository, quoteCardsEnabled = false)
+        viewModel.onSheetOpened(listOf(preview(101, "alice")))
+        advanceUntilIdle()
+        assertTrue(viewModel.state.value.isPreparingQuotes)
+
+        var escalated = false
+        val collector = launch { viewModel.effects.first(); escalated = true }
+        viewModel.onEscalateRequested()
+        advanceUntilIdle()
+        assertFalse(escalated)
+
+        repository.quoteGate.complete(Unit)
+        advanceUntilIdle()
+        collector.cancel()
+    }
+
+    @Test
+    fun `stale cards from a previous ON session are folded into the inline insert`() = runTest {
+        // Gate Codex (finding 1) — the VM outlives the sheet : cards armed while the preference
+        // was ON must not re-render (nor re-arm the cards submit path) after a flip to OFF.
+        val repository = FakeQuickReplyRepository()
+        val viewModel = quickReplyViewModel(replyRepository = repository, quoteCardsEnabled = false)
+        viewModel.onQuoteAdded(preview(101, "alice"))
+
+        viewModel.onSheetOpened(listOf(preview(202, "bob")))
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertTrue("no card survives an OFF opening", state.quotes.isEmpty())
+        assertEquals(
+            "[quotemsg=101]corps[/quotemsg]\n\n[quotemsg=202]corps[/quotemsg]",
+            state.text.text,
+        )
+    }
+
+    @Test
+    fun `inline mode submits through the plain path with the field content`() = runTest {
+        val repository = FakeQuickReplyRepository()
+        val viewModel = quickReplyViewModel(replyRepository = repository, quoteCardsEnabled = false)
+        viewModel.onSheetOpened(listOf(preview(101, "alice")))
+        advanceUntilIdle()
+        viewModel.onTextChanged(TextFieldValue("[quotemsg=101]corps[/quotemsg]\n\nmon ajout"))
+
+        viewModel.onSubmitClicked()
+        advanceUntilIdle()
+
+        assertEquals(listOf("[quotemsg=101]corps[/quotemsg]\n\nmon ajout"), repository.submittedBodies)
+        // No card in state → plain submit path, riding the warmed quote form : no extra fetch.
+        assertEquals(listOf(null, 101), repository.fetchedQuotedNumreponses)
+    }
+
     private fun preview(numreponse: Int, author: String): QuotedPostPreview =
         QuotedPostPreview(numreponse = numreponse, author = author, excerpt = "extrait")
 
@@ -329,12 +480,18 @@ class QuickReplyViewModelTest {
         replyRepository: ReplyRepository = FakeQuickReplyRepository(),
         draftStore: EditorDraftStore = FakeQuickReplyDraftStore(),
         confirmBeforePosting: Boolean = false,
+        // Test default = cards ON so the #604 lot 2-3 card suites keep exercising their mode ;
+        // the #805 inline tests opt OUT explicitly (the PRODUCTION default is false = inline).
+        quoteCardsEnabled: Boolean = true,
     ): QuickReplyViewModel = QuickReplyViewModel(
         request = QuickReplyRequest(cat = 23, subcat = 401, topicId = 35421, page = 3),
         replyRepository = replyRepository,
         quoteMaterializer = ReplyQuoteMaterializer(replyRepository),
         draftStore = draftStore,
-        userPreferencesRepository = FakeUserPreferencesRepository(confirmBeforePosting = confirmBeforePosting),
+        userPreferencesRepository = FakeUserPreferencesRepository(
+            confirmBeforePosting = confirmBeforePosting,
+            quoteCardsEnabled = quoteCardsEnabled,
+        ),
     )
 
     private companion object {
@@ -363,6 +520,38 @@ private class FakeQuickReplyDraftStore(
     override suspend fun delete(owner: String?, key: String) {
         storedBody = null
     }
+}
+
+/**
+ * #805 — quote-form fetches block on [quoteGate] (and optionally fail once released) so the
+ * inline-mode tests can observe the in-flight state ; the plain prefetch answers immediately.
+ */
+private class GatedQuoteFormRepository(
+    private val failQuoteFetch: Boolean = false,
+) : ReplyRepository {
+    val quoteGate = CompletableDeferred<Unit>()
+
+    override suspend fun fetchReplyForm(context: ReplyContext): ReplyForm {
+        val quoted = context.quotedNumreponse
+        if (quoted != null) {
+            quoteGate.await()
+            if (failQuoteFetch) throw IOException("quote fetch down")
+        }
+        return ReplyForm(
+            hashCheck = "hash",
+            sujet = "sujet",
+            hiddenFields = emptyMap(),
+            isAnonymous = false,
+            initialContent = quoted?.let { "[quotemsg=$it]corps[/quotemsg]" }.orEmpty(),
+        )
+    }
+
+    override suspend fun submitReply(
+        context: ReplyContext,
+        form: ReplyForm,
+        bbcodeContent: String,
+        options: ReplyFormOptions,
+    ): ReplySubmitResult = ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
 }
 
 private class FakeQuickReplyRepository(

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -2121,6 +2121,8 @@ internal class FakeUserPreferencesRepository(
     private val topicPollsExpanded: Boolean = false,
     private val topicSignatures: Boolean = false,
     private val confirmBeforePosting: Boolean = false,
+    // #805 — quote rendering in the composer; false mirrors the production default (inline BBCode).
+    private val quoteCardsEnabled: Boolean = false,
 ) : UserPreferencesRepository {
     override fun observeProxyConfig(): Flow<ProxyConfig> = MutableStateFlow(ProxyConfig())
 
@@ -2178,6 +2180,10 @@ internal class FakeUserPreferencesRepository(
     override fun observeConfirmBeforePosting(): Flow<Boolean> = MutableStateFlow(confirmBeforePosting)
 
     override suspend fun setConfirmBeforePosting(enabled: Boolean) = Unit
+
+    override fun observeQuoteCardsEnabled(): Flow<Boolean> = MutableStateFlow(quoteCardsEnabled)
+
+    override suspend fun setQuoteCardsEnabled(enabled: Boolean) = Unit
 
     override fun observeShowDtSection(): Flow<Boolean> = MutableStateFlow(false)
 


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Arbitrage (#805, 05/07)

Les cartes de citation (#604 lots 2-3) deviennent une **option, désactivée par défaut**. Le défaut redevient le **BBCode `[quotemsg]` inline dans le champ** — éditable, interleaving naturel, parité web — sur la feuille de réponse rapide ET l'éditeur plein écran. Les trois manques du dogfood 0.23 (édition, interleaving, relecture) disparaissent du chemin par défaut ; les cartes restent disponibles pour qui les préfère.

## Design

- **Pref** `quoteCardsEnabled` (défaut `false`), toggle Réglages > Édition et publication, lue par `.first()` au point d'entrée de chaque surface — la décision est figée par session de composition.
- **Sheet OFF** : le principe = déplacer la matérialisation du submit vers l'ouverture. À la complétion, insertion par **concaténation sur l'état courant du champ** (jamais un remplacement recalculé depuis la row — réserve bloquante du cadrage) : la frappe pendant le fetch survit, les citations successives gardent l'ordre chronologique. Job annulé au dismiss/réouverture ; cartes résiduelles d'une session ON **repliées** dans l'insert ; escalade et submit = chemins plains existants (le BBCode vit dans la row #405, process-death gratuit).
- **Éditeur OFF** : fetch d'ouverture via `ReplyQuoteMaterializer` (chemin pré-lot-3) + **prepend explicite commutatif** avec l'append `resumeSharedDraft` (#790). L'hydratation blank-only existante aurait silencieusement perdu la citation quand le restore atterrit en premier — **attrapé par le test-trio exigé au cadrage**, corrigé avant la PR.
- **Sheet** : `LaunchedEffect(viewModel)` seul (une livraison par composition ; tous les setters de `quickReplyFor` sont derrière le scrim modal → pas de redélivrance possible, contrat documenté).
- **ON** : comportement 0.24.1 strictement inchangé ; seuil « Citer N » ≥ 3 → plein écran intact (`MultiQuoteRoutingTest`).

## Cadence Codex

- **Cadrage** (gpt-5.5/xhigh) : GO-avec-réserves — 10 points, tous intégrés (concaténation-sur-état-courant, annulation, pas de dedup par numreponse, trio #790, bool pas enum, `.first()`, test frappe-pendant-fetch, pollution de row assumée+testée).
- **Gate diff** : GO-avec-réserves — 2 à-corriger traités (cartes résiduelles ON→OFF repliées + vérification du contrat de recomposition au call-site).

## Vérification

- **Validation canonique verte** : detektAll, lintDebug + lintProdDebug, tests complets, assembleProdDebug.
- **Tests** : 8 nouveaux sheet inline (insertion, merge, frappe-pendant-fetch, échec, dismiss-cancel, escalade inerte, submit plain, cartes résiduelles) + 3 éditeur (trio #790 un-seul-bloc, hydratation mergée, submit plain sans re-matérialisation) + 2 réglages (flip + rollback) ; suites cartes existantes migrées `quoteCardsEnabled = true` (défaut de builder commenté) ; fakes ×6 étendus.
- **Dogfood émulateur** (Pixel_8, ProdDebug) : OFF — Citer → `[quotemsg]` inline éditable ; escalade → plein écran restaure BBCode+frappe sans bannière ; Citer×4 → plein écran direct, 4 blocs mergés. ON — carte ❝ auteur—extrait ✕/↑/↓ intacte, toggle persistant. Captures en session.
- Réserve produit reconduite : pas d'envoi réel sur le fil public pendant le dogfood.

Réfs : #805 (reste ouverte — pistes d'amélioration des cartes), #604. Aucun mot-clé de fermeture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)