### PR TITLE
chore: release 0.25.0

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,17 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.25.0` — `internal` (dev) — 2026-07-05
+
+**Citations : retour du BBCode inline par défaut** (arbitrage XaTriX sur #805, PR #818) + remise en phase des docs (PR #817).
+
+### Éditeur & réponse rapide
+- #805 : les **cartes de citation deviennent une option, désactivée par défaut**. Par défaut, « Citer » et « Citer N » insèrent le BBCode `[quotemsg]` directement dans le champ — modifiable, réponses intercalées possibles, parité avec le site. Les cartes compactes (#604 lots 2-3) restent disponibles via Réglages > Édition et publication > « Citations en cartes ».
+- La citation s'insère **à la fin du texte en cours, sans jamais perdre la frappe** (matérialisation à l'ouverture, annulée si la feuille est fermée) ; « Citer N » ≥ 3 ouvre toujours l'éditeur plein écran, désormais pré-rempli des blocs `[quotemsg]` fusionnés ; l'escalade feuille → plein écran et les brouillons (#405) suivent sans changement.
+
+### Docs
+- PR #817 : vitrine et specs réalignées sur le code (bêta 0.18.0, gestes Drapeaux post-#603, couverture Roborazzi réelle, ADR-001 amendé, specs v0.11.0).
+
 ## `0.24.1` — `internal` (dev) — 2026-07-03
 
 **Fix express dogfood v220** (PR #810).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.24.1"
+        versionName = "0.25.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,3 +1,4 @@
-Redface 2 v0.24.1 — dev.
+Redface 2 v0.25.0 — dev.
 
-- Quick reply: automatic sentence capitalization (regression fixed).
+- Quotes: back to inline [quotemsg] BBCode in the field by default — editable and interleavable, like the website.
+- Compact quote cards are now opt-in: Settings > Editing & publishing > "Quote cards".

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,3 +1,4 @@
-Redface 2 v0.24.1 — dev.
+Redface 2 v0.25.0 — dev.
 
-- Réponse rapide : majuscule automatique en début de phrase (régression corrigée).
+- Citations : retour du BBCode [quotemsg] dans le champ par défaut — modifiable et intercalable, comme sur le site.
+- Les cartes de citation compactes deviennent une option : Réglages > Édition et publication > « Citations en cartes ».


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump `versionName` 0.24.1 → **0.25.0** pour le ship dev de l'arbitrage citations (#805, PR #818) + reality pass docs (PR #817).

- `app/CHANGELOG.md` : entrée 0.25.0 (cartes opt-in, insertion inline, docs).
- whatsnew fr/en : version en 1re ligne, 262/228 chars (gardes `check-changelog-entry.sh` + `check-whatsnew.sh` vertes en local).

Dispatch `channel=dev --ref dev` après merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)