### PR TITLE
feat(topic): long-press the multi-quote FAB to clear the basket (#436)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -2454,6 +2454,8 @@ private fun RedfaceNavHost(
                     onToggleMultiQuote = { preview ->
                         multiQuoteNavState.onToggle(route.cat, route.post, preview)
                     },
+                    // #436 — « Tout vider » : a long press on the « Citer N » FAB empties the
+                    // whole hoisted basket (same reset path as the post-editor launch / logout).
                     onClearMultiQuote = multiQuoteNavState.onClear,
                     // #465 — the topic's saved manual poll choice (null = follow the global
                     // default), and the callback recording a tap on the poll card. Hoisted to

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -256,6 +257,8 @@ fun TopicScreen(
      * #604 lot 3 — clears the multi-quote basket after the sheet consumed it (« Citer N » below
      * the threshold) : the cards live on in the sheet's ViewModel, and backing out must not
      * re-arm a stale « Citer N » — same intent-consumed rule as the full-screen path.
+     * #436 — also « Tout vider » : a long press on the « Citer N » FAB empties the whole basket
+     * in one gesture. Owned by `:app` (the basket lives there); the screen only triggers the reset.
      */
     onClearMultiQuote: () -> Unit = {},
     /**
@@ -702,6 +705,7 @@ internal fun TopicContent(
     multiQuoteSelections: List<QuotedPostPreview> = emptyList(),
     onToggleMultiQuote: (preview: QuotedPostPreview) -> Unit = {},
     onMultiQuote: (subcat: Int, page: Int) -> Unit = { _, _ -> },
+    // #436 — empties the whole basket (« Tout vider », long-press on the « Citer N » FAB).
     onClearMultiQuote: () -> Unit = {},
     // #465 — the topic's manual poll choice (owned by :app, null = follow the global default) +
     // the callback recording a tap on the poll card. Threaded to the header card's poll.
@@ -802,6 +806,8 @@ internal fun TopicContent(
                         onClearMultiQuote()
                     }
                 },
+                // #436 — « Tout vider » : the long press on « ❝N » resets the hoisted basket.
+                onClearMultiQuote = onClearMultiQuote,
             )
         },
     ) { innerPadding ->
@@ -2569,6 +2575,8 @@ private fun TopicBottomActionsHost(
     onOpenPage: (Int) -> Unit,
     onReply: (subcat: Int, page: Int) -> Unit,
     onMultiQuote: (subcat: Int, page: Int) -> Unit,
+    // #436 — empties the whole basket (« Tout vider », long-press on the « Citer N » FAB).
+    onClearMultiQuote: () -> Unit,
 ) {
     // #411 — tuck the cluster away while reading down, reveal it on the first upward scroll.
     // AnimatedVisibility in the Scaffold's FAB slot simply collapses to nothing when hidden;
@@ -2595,6 +2603,7 @@ private fun TopicBottomActionsHost(
             onNextPage = { loaded?.let { onOpenPage((it.topic.page + 1).coerceAtMost(it.topic.totalPages)) } },
             onReply = { loaded?.let { onReply(it.topic.subcat, it.topic.page) } },
             onMultiQuote = { loaded?.let { onMultiQuote(it.topic.subcat, it.topic.page) } },
+            onClearMultiQuote = onClearMultiQuote,
         )
     }
 }
@@ -2628,6 +2637,7 @@ private fun TopicBottomActions(
     onNextPage: () -> Unit,
     onReply: () -> Unit,
     onMultiQuote: () -> Unit,
+    onClearMultiQuote: () -> Unit,
 ) {
     val previousLabel = stringResource(R.string.topic_fab_previous_page)
     val nextLabel = stringResource(R.string.topic_fab_next_page)
@@ -2642,7 +2652,7 @@ private fun TopicBottomActions(
         // explicitly armed, not page navigation (call-site zeroes the count when quoting is
         // unavailable).
         FabSlot(visible = multiQuoteCount > 0) {
-            MultiQuoteFab(count = multiQuoteCount, onClick = onMultiQuote)
+            MultiQuoteFab(count = multiQuoteCount, onClick = onMultiQuote, onClear = onClearMultiQuote)
         }
         // #383 — the preference only governs the ‹/› page FABs; « Répondre » keeps its own gate.
         if (showPageFabs) {
@@ -2685,17 +2695,43 @@ private fun FabSlot(visible: Boolean, content: @Composable () -> Unit) {
 /** #599 — M3 small-FAB container footprint, the reserved geometry of every [FabSlot]. */
 private val FAB_SLOT_SIZE = 40.dp
 
+// `internal` (#436): MultiQuoteFabClearTest mounts the FAB directly to pin the « Tout vider »
+// long-press wiring (tap → onClick, long press → onClear) without standing up the whole screen.
 @Composable
-private fun MultiQuoteFab(count: Int, onClick: () -> Unit) {
-    // #291 — same SmallFloatingActionButton footprint as PageFab/ReplyFab; the glyph is a
-    // decorative « ❝N » (no Material icons — detekt ForbiddenImport blocks
-    // androidx.compose.material.*) and the real label rides on contentDescription for TalkBack.
+internal fun MultiQuoteFab(count: Int, onClick: () -> Unit, onClear: () -> Unit) {
+    // #291 — same small-FAB footprint as PageFab/ReplyFab; the glyph is a decorative « ❝N » (no
+    // Material icons — detekt ForbiddenImport blocks androidx.compose.material.*) and the real
+    // label rides on contentDescription for TalkBack.
+    // #436 — a LONG PRESS empties the whole basket (« Tout vider »), on the FAB where the user
+    // sees the count (XaTriX arbitrage: not in the post menu nor the editor). Hand-rolled FAB
+    // (pattern FlagItem) : a NON-clickable Surface carries the combinedClickable, because a real
+    // SmallFloatingActionButton's inner clickable swallows the pointer input of any
+    // combinedClickable stacked on its modifier — neither gesture ever fires (pinned by
+    // MultiQuoteFabClearTest). combinedClickable brings the built-in long-press haptics and
+    // exposes « Tout vider » through onLongClickLabel for TalkBack. Shape/colors/elevation and
+    // the labelLarge glyph mirror the M3 small-FAB defaults of the sibling FABs.
     val label = pluralStringResource(R.plurals.topic_fab_multi_quote, count, count)
-    SmallFloatingActionButton(
-        onClick = onClick,
-        modifier = Modifier.semantics { contentDescription = label },
+    val clearLabel = stringResource(R.string.topic_fab_multi_quote_clear)
+    Surface(
+        modifier = Modifier
+            .semantics { contentDescription = label }
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = onClear,
+                onLongClickLabel = clearLabel,
+                role = Role.Button,
+            ),
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.primaryContainer,
+        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        shadowElevation = 6.dp,
     ) {
-        Text("❝$count")
+        Box(
+            modifier = Modifier.sizeIn(minWidth = FAB_SLOT_SIZE, minHeight = FAB_SLOT_SIZE),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text("❝$count", style = MaterialTheme.typography.labelLarge)
+        }
     }
 }
 

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -8,6 +8,8 @@
         <item quantity="one">Citer %1$d message sélectionné</item>
         <item quantity="other">Citer %1$d messages sélectionnés</item>
     </plurals>
+    <!-- #436 — appui long sur le FAB « Citer N » : vide tout le panier de citation multiple. -->
+    <string name="topic_fab_multi_quote_clear">Vider la sélection de citations</string>
     <!-- #291 — entrée du menu contextuel : ajoute/retire le post du panier de citation multiple. -->
     <string name="topic_post_menu_multi_quote_add">Ajouter à la citation multiple</string>
     <string name="topic_post_menu_multi_quote_remove">Retirer de la citation multiple</string>

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/MultiQuoteFabClearTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/MultiQuoteFabClearTest.kt
@@ -1,0 +1,75 @@
+package fr.forumhfr.redface2.feature.topic
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * #436 — the « Tout vider » action on the multi-quote FAB. The basket count FAB (« ❝N ») already
+ * opens the editor on tap (#291) ; this pins the new gesture split: a SHORT tap still fires
+ * [MultiQuoteFab]'s `onClick` (open the editor), while a LONG press fires `onClear` (empty the
+ * whole basket). The basket itself is hoisted to `:app`, so here we only prove the FAB routes the
+ * two gestures to the two distinct callbacks.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@OptIn(ExperimentalTestApi::class)
+class MultiQuoteFabClearTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `a short tap opens the editor and leaves the basket untouched`() {
+        var clicks = 0
+        var clears = 0
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                MultiQuoteFab(count = 3, onClick = { clicks++ }, onClear = { clears++ })
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription(FAB_LABEL)
+            .assertHasClickAction()
+            .performClick()
+
+        assertEquals(1, clicks)
+        assertEquals(0, clears)
+    }
+
+    @Test
+    fun `a long press empties the basket and does not open the editor`() {
+        var clicks = 0
+        var clears = 0
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                MultiQuoteFab(count = 3, onClick = { clicks++ }, onClear = { clears++ })
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription(FAB_LABEL)
+            .performTouchInput { longClick() }
+
+        assertEquals(1, clears)
+        assertEquals(0, clicks)
+    }
+
+    private companion object {
+        // The FAB carries the plural « Citer N … » label as contentDescription (the count rides
+        // on the decorative glyph) ; count = 3 selects the `other` form.
+        const val FAB_LABEL = "Citer 3 messages sélectionnés"
+    }
+}


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Dernier volet de #436 (multi-quote v2) : l'action **« Tout vider »**. Un appui long sur le FAB « ❝N » vide tout le panier de citation multiple d'un geste. Le tap court reste inchangé (ouvre l'éditeur/la feuille).

Les deux autres volets de l'issue sont déjà livrés : marquage visuel des posts au panier (#438/#471) et panier survivant au back (hoisting #291). Cette PR clôt donc l'issue.

## Ce que ça change

- **`MultiQuoteFab`** : ré-implémenté en « FAB maison » — une `Surface` non-clickable portant `combinedClickable(onClick, onLongClick, onLongClickLabel, role = Role.Button)`, pattern déjà utilisé par `FlagItem`. Un vrai `SmallFloatingActionButton` court-circuite le `combinedClickable` posé sur son modifier via son `clickable` interne : ni le tap ni le long-press ne se déclenchent (blocage historique documenté dans l'issue le 16/06). Parité visuelle M3 conservée (shape medium, primaryContainer/onPrimaryContainer, elevation 6dp, footprint 40dp du `FAB_SLOT_SIZE`).
- **Câblage `onClearMultiQuote`** threadé jusqu'au FAB (`RedfaceNavigation` → `TopicScreen` → `TopicContent` → `TopicBottomActionsHost` → `TopicBottomActions` → `MultiQuoteFab`) ; réutilise le `multiQuoteNavState.onClear` existant (même chemin que le reset au lancement de l'éditeur / au logout).
- Haptique long-press intégrée + `onLongClickLabel` « Vider la sélection de citations » exposé à TalkBack.

## Tests & validation

- **`MultiQuoteFabClearTest`** (Robolectric/Compose, 2 tests) : tap court → `onClick` seul ; appui long → `onClear` seul. Ils échouaient avec l'ancienne version `SmallFloatingActionButton` — ils épinglent la régression historique.
- Validation canonique verte : `detektAll`, `lintDebug`, `:app:lintProdDebug`, `test`, `testDebugUnitTest`, `:app:assembleProdDebug`.
- Gate Codex (gpt-5.5/xhigh) : GO-avec-réserves (ripple / taille de cible / focus à contrôler au dogfood — fait).
- **Dogfood émulateur** (Pixel 8, dev debug, connecté) : ❝1→❝2 (compteur), marquage des cartes, **appui long → panier entièrement vidé + FAB disparu**, tap court → feuille avec `[quotemsg]` inline. Parité visuelle du FAB avec ‹ › ✎ vérifiée.

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yTLMFqxPWTajUzsFwEwAZ
