### PR TITLE
chore(release): bump versionName to 0.25.1 (multi-quote clear)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,13 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.25.1` — `internal` (dev) — 2026-07-05
+
+**Citation multiple : action « Tout vider »** (dernier volet de #436, PR #820).
+
+### Éditeur & réponse rapide
+- #436 : un **appui long sur le FAB « ❝N »** vide toute la sélection de citation multiple d'un coup (haptique + libellé TalkBack « Vider la sélection de citations »). Le tap court reste inchangé (ouvre l'éditeur / la feuille). Rendu en FAB « maison » (`Surface` + `combinedClickable`) pour que le geste long soit reconnu là où le compteur est visible. Clôt #436 (les volets marquage des posts et panier survivant au back étaient déjà livrés).
+
 ## `0.25.0` — `internal` (dev) — 2026-07-05
 
 **Citations : retour du BBCode inline par défaut** (arbitrage XaTriX sur #805, PR #818) + remise en phase des docs (PR #817).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.25.0"
+        versionName = "0.25.1"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,4 +1,3 @@
-Redface 2 v0.25.0 — dev.
+Redface 2 v0.25.1 — dev.
 
-- Quotes: back to inline [quotemsg] BBCode in the field by default — editable and interleavable, like the website.
-- Compact quote cards are now opt-in: Settings > Editing & publishing > "Quote cards".
+- Multi-quote: long-press the "❝N" button to clear the whole selection at once.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,4 +1,3 @@
-Redface 2 v0.25.0 — dev.
+Redface 2 v0.25.1 — dev.
 
-- Citations : retour du BBCode [quotemsg] dans le champ par défaut — modifiable et intercalable, comme sur le site.
-- Les cartes de citation compactes deviennent une option : Réglages > Édition et publication > « Citations en cartes ».
+- Citation multiple : un appui long sur le bouton « ❝N » vide toute la sélection d'un coup (« Tout vider »).


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump de release pour shipper le dernier volet de #436 (« Tout vider », PR #820) sur le canal dev.

- versionName 0.25.0 → **0.25.1** (politique de versioning A : patch, suite du chantier citations).
- CHANGELOG app : entrée 0.25.1.
- whatsnew fr-FR / en-US : version en 1re ligne (garde freshness OK, 134 / 105 car.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yTLMFqxPWTajUzsFwEwAZ