### PR TITLE
fix: state-hygiene batch — settings staleness (#788), dirty-close flush ×3, [color] legibility

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -2106,6 +2106,9 @@ private fun RedfaceNavHost(
                         }
                         privateMessageNavState.onConversationSent()
                     },
+                    // #803 pattern (state-hygiene audit 2026-07-05) — invoked only on
+                    // CloseCommitted, after the ViewModel flushed the private draft. The screen
+                    // routes the system back AND the header arrow through the ViewModel first.
                     onBack = {
                         if (backStack.size > 1) {
                             backStack.removeAt(backStack.lastIndex)
@@ -2170,6 +2173,9 @@ private fun RedfaceNavHost(
                             )
                         }
                     },
+                    // #803 pattern (state-hygiene audit 2026-07-05) — invoked only on
+                    // CloseCommitted, after the ViewModel flushed the private draft. The screen
+                    // routes the system back AND the header arrow through the ViewModel first.
                     onBack = {
                         if (backStack.size > 1) {
                             backStack.removeAt(backStack.lastIndex)
@@ -2671,6 +2677,14 @@ private fun RedfaceNavHost(
                         page = route.page,
                         numreponse = route.numreponse,
                     ),
+                    // #803 pattern (state-hygiene audit 2026-07-05) — the system back reaches here
+                    // only AFTER the ViewModel flushed the draft row (CloseCommitted). Same guarded
+                    // pop as PostEditorRoute.onClose.
+                    onClose = {
+                        if (backStack.size > 1) {
+                            backStack.removeAt(backStack.lastIndex)
+                        }
+                    },
                     onSubmitSucceeded = { targetPage, scrollTo ->
                         // Phase 2D (#148) — pop the FP form, replace the topic route below
                         // with one that refreshes the target page and scrolls to the edited

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -39,6 +39,8 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -270,10 +272,15 @@ private fun ParagraphBlock(inlines: List<PostInline>) {
     val imageAlt = stringResource(R.string.post_inline_image_alt)
     // #553 — signatures provide LocalIgnoreInlineColors = true so author `[color]` is dropped.
     val ignoreColors = LocalIgnoreInlineColors.current
+    // State-hygiene audit 2026-07-05 — author `[color]` legibility: dark is detected from the
+    // surface luminance so it follows AMOLED and a forced ThemeMode, not just the system flag
+    // (same rule as CreatorHighlight). isDark keys the remember so a live theme switch rebuilds
+    // the spans; it never changes during media measurements, so the #175 invariance holds.
+    val isDark = MaterialTheme.colorScheme.surface.luminance() < DARK_SURFACE_LUMINANCE
     // The AnnotatedString is INVARIANT — it carries only the U+FFFC markers + IDs (via MediaCounter),
     // never a size — so it is never rebuilt when a measurement lands (#175 stability pivot).
-    val annotated = remember(inlines, linkStyles, imageAlt, ignoreColors) {
-        buildInlineText(inlines, linkStyles, imageAlt, ignoreColors)
+    val annotated = remember(inlines, linkStyles, imageAlt, ignoreColors, isDark) {
+        buildInlineText(inlines, linkStyles, imageAlt, ignoreColors, isDark)
     }
     val hasMedia = remember(inlines) { hasInlineMedia(inlines) }
 
@@ -967,60 +974,70 @@ internal fun buildInlineText(
     // web-tuned colours read as garish/illegible on the app theme). Text falls back to the caller's
     // colour. Default false: post bodies keep author colours.
     ignoreColors: Boolean = false,
+    // State-hygiene audit 2026-07-05 — when true, author `[color]` values are clamped for
+    // legibility on a dark surface via [ensureReadableColor] (and symmetrically on light).
+    // Default false: existing callers/tests keep the light-theme behaviour.
+    isDark: Boolean = false,
 ): AnnotatedString = buildAnnotatedString {
     val media = MediaCounter()
-    appendInlines(inlines, linkStyles, media, imageAlt, ignoreColors)
+    appendInlines(inlines, linkStyles, media, imageAlt, ignoreColors, isDark)
 }
 
+@Suppress("LongParameterList") // Recursive walker — every param is the same threaded context.
 private fun AnnotatedString.Builder.appendInlines(
     inlines: List<PostInline>,
     linkStyles: TextLinkStyles,
     media: MediaCounter,
     imageAlt: String,
     ignoreColors: Boolean,
+    isDark: Boolean,
 ) {
-    inlines.forEach { inline -> appendInline(inline, linkStyles, media, imageAlt, ignoreColors) }
+    inlines.forEach { inline -> appendInline(inline, linkStyles, media, imageAlt, ignoreColors, isDark) }
 }
 
-@Suppress("CyclomaticComplexMethod")
+// LongParameterList: recursive walker — every param is the same threaded context.
+@Suppress("CyclomaticComplexMethod", "LongParameterList")
 private fun AnnotatedString.Builder.appendInline(
     inline: PostInline,
     linkStyles: TextLinkStyles,
     media: MediaCounter,
     imageAlt: String,
     ignoreColors: Boolean,
+    isDark: Boolean,
 ) {
     when (inline) {
         is PostInline.Text -> append(inline.value)
         PostInline.LineBreak -> append('\n')
         is PostInline.Strong -> withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
-            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors)
+            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors, isDark)
         }
 
         is PostInline.Emphasis -> withStyle(SpanStyle(fontStyle = FontStyle.Italic)) {
-            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors)
+            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors, isDark)
         }
 
         is PostInline.Underline -> withStyle(SpanStyle(textDecoration = TextDecoration.Underline)) {
-            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors)
+            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors, isDark)
         }
 
         is PostInline.Strike -> withStyle(SpanStyle(textDecoration = TextDecoration.LineThrough)) {
-            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors)
+            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors, isDark)
         }
 
         // #553 — drop the author colour when asked (signatures): render the children plain so they
         // inherit the caller's neutral colour instead of the web-tuned, often-illegible author hue.
+        // Otherwise the colour is kept but clamped for legibility on the current theme
+        // (state-hygiene audit 2026-07-05): a web-tuned navy is unreadable on a dark surface.
         is PostInline.Color -> if (ignoreColors) {
-            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors)
+            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors, isDark)
         } else {
-            withStyle(SpanStyle(color = parseColor(inline.colorHex))) {
-                appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors)
+            withStyle(SpanStyle(color = ensureReadableColor(parseColor(inline.colorHex), isDark))) {
+                appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors, isDark)
             }
         }
 
         is PostInline.Link -> withLink(LinkAnnotation.Url(inline.url, linkStyles)) {
-            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors)
+            appendInlines(inline.children, linkStyles, media, imageAlt, ignoreColors, isDark)
         }
 
         is PostInline.InlineImage -> appendInlineContent(media.nextImage(), inline.description ?: imageAlt)
@@ -1438,6 +1455,68 @@ private fun SmileyKind.token(): String = when (this) {
     is SmileyKind.Builtin -> code
     is SmileyKind.Perso -> "[:$name]"
 }
+
+/**
+ * State-hygiene audit 2026-07-05 — clamps an author `[color]`'s relative luminance into the
+ * current theme's readable range, hue preserved. A web-tuned navy (`#000080`) is invisible on a
+ * dark/AMOLED surface; symmetrically a pale yellow washes out on light. Pure function (no
+ * Composable dependency) so it stays JVM-testable like [parseColor]:
+ *
+ * - dark theme + luminance below [MIN_DARK_LUMINANCE] → lerp towards White just enough to reach
+ *   the floor;
+ * - light theme + luminance above [MAX_LIGHT_LUMINANCE] → lerp towards Black down to the ceiling;
+ * - already-readable colours (e.g. `#CC0000`) pass through UNTOUCHED in both themes — this is a
+ *   clamp, not a remap.
+ *
+ * The minimal lerp fraction is found by binary search: Compose's [lerp] interpolates in Oklab, so
+ * luminance is not linear in the fraction (a closed form would be wrong). The invariant
+ * `reached(high)` guarantees the returned colour satisfies the threshold. The original alpha is
+ * preserved (the defensive #RRGGBBAA parse path).
+ */
+internal fun ensureReadableColor(color: Color, isDark: Boolean): Color {
+    if (color == Color.Unspecified) return color
+    val luminance = color.luminance()
+    return when {
+        isDark && luminance < MIN_DARK_LUMINANCE ->
+            clampLuminance(color, towards = Color.White) { it >= MIN_DARK_LUMINANCE }
+        !isDark && luminance > MAX_LIGHT_LUMINANCE ->
+            clampLuminance(color, towards = Color.Black) { it <= MAX_LIGHT_LUMINANCE }
+        else -> color
+    }
+}
+
+/** Smallest-fraction lerp of [color] towards [towards] whose luminance satisfies [reached]. */
+private fun clampLuminance(color: Color, towards: Color, reached: (Float) -> Boolean): Color {
+    var low = 0f
+    // `reached(1f)` always holds: a full lerp IS the target (White = 1.0, Black = 0.0).
+    var high = 1f
+    repeat(LUMINANCE_CLAMP_ITERATIONS) {
+        val mid = (low + high) / 2f
+        if (reached(lerp(color, towards, mid).luminance())) high = mid else low = mid
+    }
+    return lerp(color, towards, high).copy(alpha = color.alpha)
+}
+
+/**
+ * Dark detection threshold on the surface's relative luminance — duplicated from
+ * `CreatorHighlight.DARK_SURFACE_LUMINANCE` (private there): follows AMOLED and a forced
+ * ThemeMode, not just the system flag.
+ */
+private const val DARK_SURFACE_LUMINANCE = 0.5f
+
+/**
+ * Author-colour luminance floor on dark surfaces. Deliberately conservative (a CLAMP for the
+ * unreadable tail, not a beautifier): classic dark-but-readable hues like `#CC0000` (≈ 0.13) or
+ * pure red `#FF0000` (≈ 0.21) pass untouched, while navy `#000080` (≈ 0.016) or pure blue
+ * `#0000FF` (≈ 0.07) — invisible on near-black — get lifted to the floor.
+ */
+internal const val MIN_DARK_LUMINANCE = 0.1f
+
+/** Author-colour luminance ceiling on light surfaces (pure yellow `#FFFF00` ≈ 0.93 gets darkened). */
+internal const val MAX_LIGHT_LUMINANCE = 0.78f
+
+/** Binary-search depth for [clampLuminance] — 2^-12 fraction precision, plenty for 8-bit channels. */
+private const val LUMINANCE_CLAMP_ITERATIONS = 12
 
 internal fun parseColor(hex: String): Color {
     // Pure-Kotlin parsing keeps :core:ui testable on plain JVM (no Android runtime). The parser

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererColorTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererColorTest.kt
@@ -1,7 +1,12 @@
 package fr.forumhfr.redface2.core.ui.post
 
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import fr.forumhfr.redface2.core.model.PostInline
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class PostRendererColorTest {
@@ -36,5 +41,114 @@ class PostRendererColorTest {
         assertEquals(Color.Unspecified, parseColor("#FFF"))
         assertEquals(Color.Unspecified, parseColor("#FFFFFFFFFF"))
         assertEquals(Color.Unspecified, parseColor("garbage"))
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // ensureReadableColor — author [color] legibility clamp (state-hygiene audit 2026-07-05).
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `navy is lifted to the dark floor in dark theme`() {
+        val navy = parseColor("#000080")
+        val adjusted = ensureReadableColor(navy, isDark = true)
+
+        assertTrue("navy (#000080) must be lightened on a dark surface", adjusted.luminance() > navy.luminance())
+        assertTrue(
+            "the adjusted colour must reach the dark floor",
+            adjusted.luminance() >= MIN_DARK_LUMINANCE,
+        )
+    }
+
+    @Test
+    fun `pure yellow is darkened to the light ceiling in light theme`() {
+        val yellow = parseColor("#FFFF00")
+        val adjusted = ensureReadableColor(yellow, isDark = false)
+
+        assertTrue("yellow (#FFFF00) must be darkened on a light surface", adjusted.luminance() < yellow.luminance())
+        assertTrue(
+            "the adjusted colour must come down to the light ceiling",
+            adjusted.luminance() <= MAX_LIGHT_LUMINANCE,
+        )
+    }
+
+    @Test
+    fun `an already-readable red passes through untouched in both themes`() {
+        // #CC0000 sits between the two thresholds (luminance ≈ 0.13): a clamp, not a remap.
+        val red = parseColor("#CC0000")
+        assertEquals(red, ensureReadableColor(red, isDark = true))
+        assertEquals(red, ensureReadableColor(red, isDark = false))
+    }
+
+    @Test
+    fun `dark colours are untouched in light theme and light colours in dark theme`() {
+        // Each threshold only applies to its own theme.
+        val navy = parseColor("#000080")
+        assertEquals(navy, ensureReadableColor(navy, isDark = false))
+        val yellow = parseColor("#FFFF00")
+        assertEquals(yellow, ensureReadableColor(yellow, isDark = true))
+    }
+
+    @Test
+    fun `Unspecified passes through the clamp`() {
+        // parseColor returns Unspecified for malformed hex; SpanStyle treats it as "inherit".
+        assertEquals(Color.Unspecified, ensureReadableColor(Color.Unspecified, isDark = true))
+        assertEquals(Color.Unspecified, ensureReadableColor(Color.Unspecified, isDark = false))
+    }
+
+    @Test
+    fun `clamping preserves the hue family`() {
+        // The lerp runs in Oklab (perceptual hue), so the HSV hue can drift a little — lifted
+        // navy measures ≈ 221° vs 240° (Oklab's Abney correction for lightened deep blues) — but
+        // the colour must stay in its hue FAMILY: a flip to grey/purple/green would land far
+        // outside these bands.
+        val liftedNavy = ensureReadableColor(parseColor("#000080"), isDark = true)
+        val navyHue = hueOf(liftedNavy)
+        assertTrue("lifted navy must still read as a blue (hue was $navyHue)", navyHue in 200.0..260.0)
+
+        val loweredYellow = ensureReadableColor(parseColor("#FFFF00"), isDark = false)
+        val yellowHue = hueOf(loweredYellow)
+        assertTrue("darkened yellow must still read as a yellow (hue was $yellowHue)", yellowHue in 45.0..75.0)
+    }
+
+    @Test
+    fun `buildInlineText clamps the colour span when isDark is true`() {
+        val inlines = listOf(
+            PostInline.Color(colorHex = "#000080", children = listOf(PostInline.Text("navy text"))),
+        )
+
+        val annotated = buildInlineText(inlines, TextLinkStyles(), imageAlt = "img", isDark = true)
+
+        val span = annotated.spanStyles.single().item as SpanStyle
+        assertEquals(ensureReadableColor(parseColor("#000080"), isDark = true), span.color)
+        assertTrue("the applied span must sit at/above the dark floor", span.color.luminance() >= MIN_DARK_LUMINANCE)
+    }
+
+    @Test
+    fun `buildInlineText keeps the raw author colour when isDark is false`() {
+        val inlines = listOf(
+            PostInline.Color(colorHex = "#000080", children = listOf(PostInline.Text("navy text"))),
+        )
+
+        val annotated = buildInlineText(inlines, TextLinkStyles(), imageAlt = "img", isDark = false)
+
+        val span = annotated.spanStyles.single().item as SpanStyle
+        assertEquals("a dark hue is fine on a light surface", parseColor("#000080"), span.color)
+    }
+
+    /** Plain HSV hue in degrees — enough to pin "still a blue / still a yellow" after the clamp. */
+    private fun hueOf(color: Color): Double {
+        val r = color.red
+        val g = color.green
+        val b = color.blue
+        val max = maxOf(r, g, b)
+        val min = minOf(r, g, b)
+        val delta = max - min
+        if (delta == 0f) return 0.0
+        val h = when (max) {
+            r -> ((g - b) / delta) % 6f
+            g -> (b - r) / delta + 2f
+            else -> (r - g) / delta + 4f
+        }
+        return ((h * 60f) + 360f).toDouble() % 360.0
     }
 }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -357,7 +357,18 @@ class PostEditorViewModel @AssistedInject constructor(
         closeRequested = true
         autosaveJob?.cancel()
         viewModelScope.launch {
-            persistDraftNow()
+            // The close must NEVER stay blocked on a failing flush (Room is not contractually
+            // non-throwing — disk full, corrupted store) : the one-shot latch is already set, so
+            // a swallowed failure here only costs the last <750 ms of typing (the debounced
+            // autosave already persisted the rest) while a rethrow would leave the screen
+            // unclosable. CancellationException still propagates (scope teardown is not an error).
+            try {
+                persistDraftNow()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                // Best effort — the previous debounced write is what remains.
+            }
             _effects.send(PostEditorEffect.CloseCommitted)
         }
     }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormScreen.kt
@@ -6,6 +6,7 @@ import fr.forumhfr.redface2.core.ui.editor.bannerText
 import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 import fr.forumhfr.redface2.core.ui.editor.SmileyPickerSheet
 import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -63,12 +64,17 @@ import fr.forumhfr.redface2.core.ui.editor.EditorOptionsSheet
  * - Submit button + error banner.
  */
 @Composable
+@Suppress("LongParameterList") // One callback per navigation outcome — each wired to a distinct :app pop.
 fun TopicFormScreen(
     request: TopicFormRequest,
     onSubmitSucceeded: (targetPage: Int?, scrollTo: Int?) -> Unit,
     // #206 workaround — `subject` is the exact posted title, forwarded to the category
     // listing so it can highlight the freshly-created row (HFR never returns the new id).
     onNewTopicCreated: (cat: Int, subcat: Int, newTopicId: Int?, newNumreponse: Int?, subject: String) -> Unit,
+    // #803 pattern (state-hygiene audit 2026-07-05) — pops this form AFTER the ViewModel flushed
+    // the draft (CloseCommitted). Default keeps callers without the wiring on the platform back
+    // (no flush) — `:app` wires it. Mirrors PostEditorScreen.onClose.
+    onClose: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
     viewModel: TopicFormViewModel = hiltViewModel<TopicFormViewModel, TopicFormViewModel.Factory>(
         creationCallback = { factory -> factory.create(request) },
@@ -101,8 +107,16 @@ fun TopicFormScreen(
                         effect.subject,
                     )
                 }
+                TopicFormEffect.CloseCommitted -> onClose?.invoke()
             }
         }
+    }
+
+    // #803 pattern — route the system back through the ViewModel so the pending autosave debounce
+    // is flushed BEFORE the pop (trading the predictive-back preview for never losing the last
+    // < 750 ms of typing — same trade-off as PostEditorScreen). Only armed when `:app` wired the pop.
+    if (onClose != null) {
+        BackHandler { viewModel.submit(TopicFormIntent.CloseRequested) }
     }
 
     TopicFormContent(

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormState.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormState.kt
@@ -210,6 +210,15 @@ sealed interface TopicFormIntent {
 
     /** #405 — discard the cached draft : delete the row and clear the banner. */
     data object DraftDiscardRequested : TopicFormIntent
+
+    /**
+     * #803 pattern (state-hygiene audit 2026-07-05) — the user is leaving the form (system
+     * back). The ViewModel flushes the pending debounced autosave FIRST, then emits
+     * [TopicFormEffect.CloseCommitted] — closing through the ViewModel is what guarantees the
+     * last < 750 ms of typing reach the #405 row (a plain pop would cancel the debounce with
+     * the ViewModel). Mirrors [PostEditorIntent.CloseRequested].
+     */
+    data object CloseRequested : TopicFormIntent
 }
 
 /**
@@ -244,6 +253,13 @@ sealed interface TopicFormEffect {
         /** Exact subject the user posted ; used to highlight the new row in the listing (#206). */
         val subject: String,
     ) : TopicFormEffect
+
+    /**
+     * #803 pattern — the draft is persisted, the form may now actually pop (the save is AWAITED
+     * before the effect, so navigation can never cancel it). Mirrors
+     * `PostEditorEffect.CloseCommitted`.
+     */
+    data object CloseCommitted : TopicFormEffect
 }
 
 internal fun TopicFormState.withDraft(updated: TextFieldValue): TopicFormState =

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModel.kt
@@ -223,22 +223,59 @@ class TopicFormViewModel @AssistedInject constructor(
      * The store stamps `updatedAt` and is a no-op without an active session.
      */
     private fun scheduleAutosave() {
+        if (draftKey == null) return
+        autosaveJob?.cancel()
+        autosaveJob = viewModelScope.launch {
+            delay(AUTOSAVE_DEBOUNCE_MS)
+            persistDraftNow()
+        }
+    }
+
+    /**
+     * Immediate write of the current subject + body (both blank = delete the row, cf.
+     * [scheduleAutosave]). Reads [_state] AFTER the debounce delay — the previous shape captured
+     * a snapshot at scheduling time, which the #803 dirty-close flush would have re-persisted
+     * stale (state-hygiene audit 2026-07-05). Mirrors `PostEditorViewModel.persistDraftNow`.
+     */
+    private suspend fun persistDraftNow() {
         val key = draftKey ?: return
         val snapshot = _state.value
         val body = snapshot.draft.text
         val subject = snapshot.subject.text
+        if (body.isBlank() && subject.isBlank()) {
+            draftStore.delete(draftOwner, key)
+        } else {
+            draftStore.save(
+                draftOwner,
+                key,
+                EditorDraftStore.Draft(body = body, subject = subject.ifBlank { null }),
+            )
+        }
+    }
+
+    /** #803 pattern — one-shot latch : a committed close is never re-emitted. */
+    private var closeRequested = false
+
+    /**
+     * #803 pattern (ported from `PostEditorViewModel.onCloseRequested`, state-hygiene audit
+     * 2026-07-05) — dirty close : flush the pending debounce so the last keystrokes reach the
+     * #405 row, THEN let the UI pop (CloseCommitted). Without this, a system back < 750 ms after
+     * typing cancelled the debounce with the ViewModel and silently dropped the tail of the draft.
+     *
+     * Two guards (gate #803) :
+     * - INERT while a POST is in flight — popping would cancel the submit with the viewModelScope
+     *   and leave the server state unknown with a repostable draft ; on failure `isSubmitting`
+     *   drops and the back works again, on success SubmitSucceeded / NewTopicCreated pops anyway ;
+     * - ONE-SHOT — a second back racing the first CloseCommitted must not emit a second effect
+     *   (each `onClose` pops blindly : the second pop would remove the screen BELOW).
+     */
+    private fun onCloseRequested() {
+        if (_state.value.isSubmitting || closeRequested) return
+        closeRequested = true
         autosaveJob?.cancel()
-        autosaveJob = viewModelScope.launch {
-            delay(AUTOSAVE_DEBOUNCE_MS)
-            if (body.isBlank() && subject.isBlank()) {
-                draftStore.delete(draftOwner, key)
-            } else {
-                draftStore.save(
-                    draftOwner,
-                    key,
-                    EditorDraftStore.Draft(body = body, subject = subject.ifBlank { null }),
-                )
-            }
+        viewModelScope.launch {
+            persistDraftNow()
+            _effects.send(TopicFormEffect.CloseCommitted)
         }
     }
 
@@ -271,6 +308,7 @@ class TopicFormViewModel @AssistedInject constructor(
             TopicFormIntent.UploadErrorDismissed -> _state.update { it.copy(uploadError = null) }
             TopicFormIntent.DraftRestoreRequested -> onDraftRestoreRequested()
             TopicFormIntent.DraftDiscardRequested -> onDraftDiscardRequested()
+            TopicFormIntent.CloseRequested -> onCloseRequested()
         }
     }
 

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModel.kt
@@ -274,7 +274,18 @@ class TopicFormViewModel @AssistedInject constructor(
         closeRequested = true
         autosaveJob?.cancel()
         viewModelScope.launch {
-            persistDraftNow()
+            // The close must NEVER stay blocked on a failing flush (Room is not contractually
+            // non-throwing — disk full, corrupted store) : the one-shot latch is already set, so
+            // a swallowed failure here only costs the last <750 ms of typing (the debounced
+            // autosave already persisted the rest) while a rethrow would leave the screen
+            // unclosable. CancellationException still propagates (scope teardown is not an error).
+            try {
+                persistDraftNow()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                // Best effort — the previous debounced write is what remains.
+            }
             _effects.send(TopicFormEffect.CloseCommitted)
         }
     }

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -57,6 +57,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -1108,6 +1109,107 @@ class TopicFormViewModelTest {
         testScheduler.advanceUntilIdle()
         assertEquals(1, topicFormRepository.submitCalls)
         assertTrue("a saved FP must drop its draft", draftStore.deletedKeys.contains(key))
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // #803 pattern — dirty close (flush before pop), state-hygiene audit 2026-07-05.
+    // Same contract as PostEditorViewModelTest's « #604 lot 4a » block.
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `CloseRequested flushes the pending debounce before CloseCommitted`() = runTest {
+        val viewModel = newTopicViewModel(entrySubcat = SAMPLE_SUBCAT)
+        testScheduler.advanceUntilIdle()
+
+        // Type, then close IMMEDIATELY — well inside the 750 ms debounce window. The flush must
+        // persist the state at close time, not the snapshot the debounce captured at scheduling.
+        viewModel.submit(TopicFormIntent.SubjectChanged(TextFieldValue("Mon titre")))
+        viewModel.submit(TopicFormIntent.ContentChanged(TextFieldValue("dernier mot")))
+        viewModel.submit(TopicFormIntent.CloseRequested)
+
+        val effect = viewModel.effects.first()
+        assertEquals(TopicFormEffect.CloseCommitted, effect)
+        val key = EditorDraftKey.newTopic(SAMPLE_CAT)
+        assertEquals(
+            "the tail of the draft must reach the row before the pop",
+            "dernier mot",
+            draftStore.saved[key]?.body,
+        )
+        assertEquals("Mon titre", draftStore.saved[key]?.subject)
+    }
+
+    @Test
+    fun `CloseRequested with blank subject and body deletes the row and still closes`() = runTest {
+        val key = EditorDraftKey.newTopic(SAMPLE_CAT)
+        draftStore.preload(key, EditorDraftStore.Draft(body = "stale", subject = "stale title"))
+        val viewModel = newTopicViewModel(entrySubcat = SAMPLE_SUBCAT)
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(TopicFormIntent.CloseRequested)
+
+        val effect = viewModel.effects.first()
+        assertEquals(TopicFormEffect.CloseCommitted, effect)
+        assertTrue("an emptied form must not leave a stale row", draftStore.deletedKeys.contains(key))
+    }
+
+    @Test
+    fun `CloseRequested with a subject only saves the draft instead of deleting it`() = runTest {
+        // The delete branch requires BOTH fields blank : a titled-but-bodyless topic in progress
+        // is still worth restoring.
+        val viewModel = newTopicViewModel(entrySubcat = SAMPLE_SUBCAT)
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(TopicFormIntent.SubjectChanged(TextFieldValue("Titre seul")))
+        viewModel.submit(TopicFormIntent.CloseRequested)
+
+        val effect = viewModel.effects.first()
+        assertEquals(TopicFormEffect.CloseCommitted, effect)
+        val key = EditorDraftKey.newTopic(SAMPLE_CAT)
+        assertEquals("Titre seul", draftStore.saved[key]?.subject)
+        assertFalse(draftStore.deletedKeys.contains(key))
+    }
+
+    @Test
+    fun `CloseRequested during an in-flight submit is ignored (gate #803)`() = runTest {
+        val gate = CompletableDeferred<Unit>()
+        topicFormRepository.submitGate = gate
+        val viewModel = newTopicViewModel(entrySubcat = SAMPLE_SUBCAT)
+        testScheduler.advanceUntilIdle()
+        viewModel.submit(TopicFormIntent.SubjectChanged(TextFieldValue("Mon titre")))
+        viewModel.submit(TopicFormIntent.ContentChanged(TextFieldValue("Mon corps")))
+
+        viewModel.submit(TopicFormIntent.SubmitClicked)
+        // Back pressed while the POST is in flight — must be inert (gate #803: popping would
+        // cancel the submit with the viewModelScope and leave the server state unknown).
+        viewModel.submit(TopicFormIntent.CloseRequested)
+        gate.complete(Unit)
+        testScheduler.advanceUntilIdle()
+
+        viewModel.effects.test {
+            assertTrue(
+                "the submit outcome must be the ONLY effect — no CloseCommitted",
+                awaitItem() is TopicFormEffect.NewTopicCreated,
+            )
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `a second CloseRequested is a no-op (gate #803)`() = runTest {
+        val viewModel = newTopicViewModel(entrySubcat = SAMPLE_SUBCAT)
+        testScheduler.advanceUntilIdle()
+
+        viewModel.submit(TopicFormIntent.CloseRequested)
+        viewModel.submit(TopicFormIntent.CloseRequested)
+        testScheduler.advanceUntilIdle()
+
+        viewModel.effects.test {
+            assertEquals(TopicFormEffect.CloseCommitted, awaitItem())
+            // A double back must never yield a second pop (it would remove the screen BELOW).
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     // ──────────────────────────────────────────────────────────────────────

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeScreen.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.feature.messages
 
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -55,6 +56,9 @@ import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 @Composable
 fun PrivateMessageComposeScreen(
     onSubmitSucceeded: () -> Unit,
+    // #803 pattern — the actual pop. Invoked only on CloseCommitted (after the ViewModel flushed
+    // the draft), never directly by the chrome: both the system back and the header arrow route
+    // through PrivateMessageComposeViewModel.onCloseRequested first.
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
     initialRecipient: String? = null,
@@ -67,12 +71,19 @@ fun PrivateMessageComposeScreen(
         viewModel.effects.collect { effect ->
             when (effect) {
                 PrivateMessageComposeEffect.SubmitSucceeded -> onSubmitSucceeded()
+                // #803 pattern — the pop happens only AFTER the ViewModel flushed the draft.
+                PrivateMessageComposeEffect.CloseCommitted -> onBack()
             }
         }
     }
+    // #803 pattern (state-hygiene audit 2026-07-05) — every close path (system back below, header
+    // arrow via onCloseRequested in the content wiring) routes through the ViewModel so the
+    // pending autosave debounce is flushed BEFORE the pop (trading the predictive-back preview
+    // for never losing the last < 750 ms of typing — same trade-off as PostEditorScreen).
+    BackHandler { viewModel.onCloseRequested() }
     PrivateMessageComposeContent(
         state = state,
-        onBack = onBack,
+        onBack = viewModel::onCloseRequested,
         onRecipientsChanged = viewModel::onRecipientsChanged,
         onSubjectChanged = viewModel::onSubjectChanged,
         onContentChanged = viewModel::onContentChanged,

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModel.kt
@@ -184,27 +184,64 @@ class PrivateMessageComposeViewModel @AssistedInject constructor(
      * logout purge wipes it. Empty across all three fields → delete the row. No-op without a session.
      */
     private fun scheduleAutosave() {
+        autosaveJob?.cancel()
+        autosaveJob = viewModelScope.launch {
+            delay(AUTOSAVE_DEBOUNCE_MS)
+            persistDraftNow()
+        }
+    }
+
+    /**
+     * Immediate write of the current recipients + subject + body (all blank = delete the row, cf.
+     * [scheduleAutosave]). Reads [_state] AFTER the debounce delay — the previous shape captured a
+     * snapshot at scheduling time, which the #803 dirty-close flush would have re-persisted stale
+     * (state-hygiene audit 2026-07-05). Mirrors `PostEditorViewModel.persistDraftNow`.
+     */
+    private suspend fun persistDraftNow() {
         val snapshot = _state.value
         val body = snapshot.draft.text
         val subject = snapshot.subject
         val recipients = snapshot.recipients
+        if (body.isBlank() && subject.isBlank() && recipients.isBlank()) {
+            draftStore.delete(draftOwner, draftKey)
+        } else {
+            draftStore.save(
+                draftOwner,
+                draftKey,
+                EditorDraftStore.Draft(
+                    body = body,
+                    subject = subject.ifBlank { null },
+                    recipients = recipients.ifBlank { null },
+                    isPrivate = true,
+                ),
+            )
+        }
+    }
+
+    /** #803 pattern — one-shot latch : a committed close is never re-emitted. */
+    private var closeRequested = false
+
+    /**
+     * #803 pattern (ported from `PostEditorViewModel.onCloseRequested`, state-hygiene audit
+     * 2026-07-05) — dirty close : flush the pending debounce so the last keystrokes reach the #405
+     * row, THEN let the UI pop (CloseCommitted). Without this, closing the composer < 750 ms after
+     * typing (system back or the header's back arrow) cancelled the debounce with the ViewModel
+     * and silently dropped the tail of the PRIVATE draft.
+     *
+     * Two guards (gate #803) :
+     * - INERT while a POST is in flight — popping would cancel the submit with the viewModelScope
+     *   and leave the server state unknown ; on failure `isSubmitting` drops and the back works
+     *   again, on success SubmitSucceeded pops anyway ;
+     * - ONE-SHOT — a second close racing the first CloseCommitted must not emit a second effect
+     *   (the pop is blind : a second one would remove the screen BELOW).
+     */
+    fun onCloseRequested() {
+        if (_state.value.isSubmitting || closeRequested) return
+        closeRequested = true
         autosaveJob?.cancel()
-        autosaveJob = viewModelScope.launch {
-            delay(AUTOSAVE_DEBOUNCE_MS)
-            if (body.isBlank() && subject.isBlank() && recipients.isBlank()) {
-                draftStore.delete(draftOwner, draftKey)
-            } else {
-                draftStore.save(
-                    draftOwner,
-                    draftKey,
-                    EditorDraftStore.Draft(
-                        body = body,
-                        subject = subject.ifBlank { null },
-                        recipients = recipients.ifBlank { null },
-                        isPrivate = true,
-                    ),
-                )
-            }
+        viewModelScope.launch {
+            persistDraftNow()
+            _effects.send(PrivateMessageComposeEffect.CloseCommitted)
         }
     }
 
@@ -627,4 +664,11 @@ class PrivateMessageComposeViewModel @AssistedInject constructor(
  */
 sealed interface PrivateMessageComposeEffect {
     data object SubmitSucceeded : PrivateMessageComposeEffect
+
+    /**
+     * #803 pattern — the draft is persisted, the composer may now actually pop (the save is
+     * AWAITED before the effect, so navigation can never cancel it). Mirrors
+     * `PostEditorEffect.CloseCommitted`.
+     */
+    data object CloseCommitted : PrivateMessageComposeEffect
 }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModel.kt
@@ -240,7 +240,18 @@ class PrivateMessageComposeViewModel @AssistedInject constructor(
         closeRequested = true
         autosaveJob?.cancel()
         viewModelScope.launch {
-            persistDraftNow()
+            // The close must NEVER stay blocked on a failing flush (Room is not contractually
+            // non-throwing — disk full, corrupted store) : the one-shot latch is already set, so
+            // a swallowed failure here only costs the last <750 ms of typing (the debounced
+            // autosave already persisted the rest) while a rethrow would leave the screen
+            // unclosable. CancellationException still propagates (scope teardown is not an error).
+            try {
+                persistDraftNow()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                // Best effort — the previous debounced write is what remains.
+            }
             _effects.send(PrivateMessageComposeEffect.CloseCommitted)
         }
     }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyScreen.kt
@@ -1,5 +1,6 @@
 package fr.forumhfr.redface2.feature.messages
 
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -54,6 +55,9 @@ import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 fun PrivateMessageReplyScreen(
     request: PrivateMessageReplyRequest,
     onSubmitSucceeded: (threadId: Int, page: Int) -> Unit,
+    // #803 pattern — the actual pop. Invoked only on CloseCommitted (after the ViewModel flushed
+    // the draft), never directly by the chrome: both the system back and the header arrow route
+    // through PrivateMessageReplyViewModel.onCloseRequested first.
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -66,14 +70,21 @@ fun PrivateMessageReplyScreen(
             when (effect) {
                 is PrivateMessageReplyEffect.SubmitSucceeded ->
                     onSubmitSucceeded(effect.threadId, effect.page)
+                // #803 pattern — the pop happens only AFTER the ViewModel flushed the draft.
+                PrivateMessageReplyEffect.CloseCommitted -> onBack()
             }
         }
     }
+    // #803 pattern (state-hygiene audit 2026-07-05) — every close path (system back below, header
+    // arrow via onCloseRequested in the content wiring) routes through the ViewModel so the
+    // pending autosave debounce is flushed BEFORE the pop (trading the predictive-back preview
+    // for never losing the last < 750 ms of typing — same trade-off as PostEditorScreen).
+    BackHandler { viewModel.onCloseRequested() }
     PrivateMessageReplyContent(
         state = state,
         // #618 — auto-open the recipient-manager sheet when entered from the Participants sheet.
         autoOpenRecipientManager = request.openRecipientManager,
-        onBack = onBack,
+        onBack = viewModel::onCloseRequested,
         onContentChanged = viewModel::onContentChanged,
         onToolbarAction = viewModel::onToolbarAction,
         onTogglePreview = viewModel::onTogglePreview,

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
@@ -222,7 +222,18 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
         closeRequested = true
         autosaveJob?.cancel()
         viewModelScope.launch {
-            persistDraftNow()
+            // The close must NEVER stay blocked on a failing flush (Room is not contractually
+            // non-throwing — disk full, corrupted store) : the one-shot latch is already set, so
+            // a swallowed failure here only costs the last <750 ms of typing (the debounced
+            // autosave already persisted the rest) while a rethrow would leave the screen
+            // unclosable. CancellationException still propagates (scope teardown is not an error).
+            try {
+                persistDraftNow()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                // Best effort — the previous debounced write is what remains.
+            }
             _effects.send(PrivateMessageReplyEffect.CloseCommitted)
         }
     }

--- a/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
+++ b/feature/messages/src/main/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModel.kt
@@ -178,15 +178,52 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
      * it. Blank body → delete the row. The store is a no-op without an active session.
      */
     private fun scheduleAutosave() {
-        val body = _state.value.draft.text
         autosaveJob?.cancel()
         autosaveJob = viewModelScope.launch {
             delay(AUTOSAVE_DEBOUNCE_MS)
-            if (body.isBlank()) {
-                draftStore.delete(draftOwner, draftKey)
-            } else {
-                draftStore.save(draftOwner, draftKey, EditorDraftStore.Draft(body = body, isPrivate = true))
-            }
+            persistDraftNow()
+        }
+    }
+
+    /**
+     * Immediate write of the current body (blank = delete the row, cf. [scheduleAutosave]). Reads
+     * [_state] AFTER the debounce delay — the previous shape captured a snapshot at scheduling
+     * time, which the #803 dirty-close flush would have re-persisted stale (state-hygiene audit
+     * 2026-07-05). Mirrors `PostEditorViewModel.persistDraftNow`.
+     */
+    private suspend fun persistDraftNow() {
+        val body = _state.value.draft.text
+        if (body.isBlank()) {
+            draftStore.delete(draftOwner, draftKey)
+        } else {
+            draftStore.save(draftOwner, draftKey, EditorDraftStore.Draft(body = body, isPrivate = true))
+        }
+    }
+
+    /** #803 pattern — one-shot latch : a committed close is never re-emitted. */
+    private var closeRequested = false
+
+    /**
+     * #803 pattern (ported from `PostEditorViewModel.onCloseRequested`, state-hygiene audit
+     * 2026-07-05) — dirty close : flush the pending debounce so the last keystrokes reach the #405
+     * row, THEN let the UI pop (CloseCommitted). Without this, closing the reply editor < 750 ms
+     * after typing (system back or the header's back arrow) cancelled the debounce with the
+     * ViewModel and silently dropped the tail of the PRIVATE draft.
+     *
+     * Two guards (gate #803) :
+     * - INERT while a POST is in flight — popping would cancel the submit with the viewModelScope
+     *   and leave the server state unknown ; on failure `isSubmitting` drops and the back works
+     *   again, on success SubmitSucceeded pops anyway ;
+     * - ONE-SHOT — a second close racing the first CloseCommitted must not emit a second effect
+     *   (the pop is blind : a second one would remove the screen BELOW).
+     */
+    fun onCloseRequested() {
+        if (_state.value.isSubmitting || closeRequested) return
+        closeRequested = true
+        autosaveJob?.cancel()
+        viewModelScope.launch {
+            persistDraftNow()
+            _effects.send(PrivateMessageReplyEffect.CloseCommitted)
         }
     }
 
@@ -681,6 +718,13 @@ class PrivateMessageReplyViewModel @AssistedInject constructor(
  */
 sealed interface PrivateMessageReplyEffect {
     data class SubmitSucceeded(val threadId: Int, val page: Int) : PrivateMessageReplyEffect
+
+    /**
+     * #803 pattern — the draft is persisted, the editor may now actually pop (the save is AWAITED
+     * before the effect, so navigation can never cancel it). Mirrors
+     * `PostEditorEffect.CloseCommitted`.
+     */
+    data object CloseCommitted : PrivateMessageReplyEffect
 }
 
 /**

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageComposeViewModelTest.kt
@@ -20,9 +20,11 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -401,6 +403,94 @@ class PrivateMessageComposeViewModelTest {
         advanceUntilIdle()
 
         assertTrue(draftStore.deletedKeys.contains(EditorDraftKey.mpCompose()))
+    }
+
+    // ----- #803 pattern : dirty close (flush before pop), state-hygiene audit 2026-07-05 -----
+
+    @Test
+    fun `onCloseRequested flushes the pending debounce before CloseCommitted`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchComposeForm(any()) } returns composeForm()
+        val vm = viewModel(repository)
+
+        // Type, then close IMMEDIATELY — well inside the 750 ms debounce window. The flush must
+        // persist the state at close time, not the snapshot the debounce captured at scheduling.
+        vm.onRecipientsChanged("bozoleclown")
+        vm.onSubjectChanged("Salut")
+        vm.onContentChanged(TextFieldValue("dernier mot"))
+        vm.onCloseRequested()
+
+        val effect = vm.effects.first()
+        assertEquals(PrivateMessageComposeEffect.CloseCommitted, effect)
+        val saved = draftStore.saved[EditorDraftKey.mpCompose()]
+        assertEquals("the tail of the draft must reach the row before the pop", "dernier mot", saved?.body)
+        assertEquals("Salut", saved?.subject)
+        assertEquals("bozoleclown", saved?.recipients)
+        assertTrue("MP drafts must stay flagged private", saved?.isPrivate == true)
+    }
+
+    @Test
+    fun `onCloseRequested with every field blank deletes the row and still closes`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchComposeForm(any()) } returns composeForm()
+        val key = EditorDraftKey.mpCompose()
+        draftStore.preload(key, EditorDraftStore.Draft(body = "stale", isPrivate = true))
+        val vm = viewModel(repository)
+
+        vm.onCloseRequested()
+
+        val effect = vm.effects.first()
+        assertEquals(PrivateMessageComposeEffect.CloseCommitted, effect)
+        assertTrue("an emptied composer must not leave a stale row", draftStore.deletedKeys.contains(key))
+    }
+
+    @Test
+    fun `onCloseRequested during an in-flight submit is ignored (gate #803)`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchComposeForm(any()) } returns composeForm()
+        // Hold the POST in flight so the close lands while isSubmitting is true.
+        val gate = CompletableDeferred<Unit>()
+        coEvery { repository.submitNewMessage(any(), any(), any(), any(), any()) } coAnswers {
+            gate.await()
+            ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
+        }
+        val vm = viewModel(repository)
+        vm.onRecipientsChanged("bozoleclown")
+        vm.onSubjectChanged("Sujet")
+        vm.onContentChanged(TextFieldValue("en vol"))
+
+        vm.onSubmit()
+        // Close requested while the POST is in flight — must be inert (gate #803).
+        vm.onCloseRequested()
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        vm.effects.test {
+            assertTrue(
+                "the submit outcome must be the ONLY effect — no CloseCommitted",
+                awaitItem() is PrivateMessageComposeEffect.SubmitSucceeded,
+            )
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `a second onCloseRequested is a no-op (gate #803)`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchComposeForm(any()) } returns composeForm()
+        val vm = viewModel(repository)
+
+        vm.onCloseRequested()
+        vm.onCloseRequested()
+        advanceUntilIdle()
+
+        vm.effects.test {
+            assertEquals(PrivateMessageComposeEffect.CloseCommitted, awaitItem())
+            // A double close must never yield a second pop (it would remove the screen BELOW).
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     /** #405 — in-memory fake [EditorDraftStore], same shape as the one in `PostEditorViewModelTest`. */

--- a/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
+++ b/feature/messages/src/test/kotlin/fr/forumhfr/redface2/feature/messages/PrivateMessageReplyViewModelTest.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -585,6 +586,104 @@ class PrivateMessageReplyViewModelTest {
         advanceUntilIdle()
 
         assertTrue(draftStore.deletedKeys.contains(EditorDraftKey.mpReply(request.threadId)))
+    }
+
+    // ----- #803 pattern : dirty close (flush before pop), state-hygiene audit 2026-07-05 -----
+
+    @Test
+    fun `onCloseRequested flushes the pending debounce before CloseCommitted`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any(), any()) } returns form()
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
+        )
+
+        // Type, then close IMMEDIATELY — well inside the 750 ms debounce window. The flush must
+        // persist the state at close time, not the snapshot the debounce captured at scheduling.
+        viewModel.onContentChanged(TextFieldValue("dernier mot"))
+        viewModel.onCloseRequested()
+
+        val effect = viewModel.effects.first()
+        assertEquals(PrivateMessageReplyEffect.CloseCommitted, effect)
+        val saved = draftStore.saved[EditorDraftKey.mpReply(request.threadId)]
+        assertEquals("the tail of the draft must reach the row before the pop", "dernier mot", saved?.body)
+        assertTrue("MP drafts must stay flagged private", saved?.isPrivate == true)
+    }
+
+    @Test
+    fun `onCloseRequested with a blank body deletes the row and still closes`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any(), any()) } returns form()
+        val key = EditorDraftKey.mpReply(request.threadId)
+        draftStore.preload(key, EditorDraftStore.Draft(body = "stale", isPrivate = true))
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
+        )
+
+        viewModel.onCloseRequested()
+
+        val effect = viewModel.effects.first()
+        assertEquals(PrivateMessageReplyEffect.CloseCommitted, effect)
+        assertTrue("an emptied editor must not leave a stale row", draftStore.deletedKeys.contains(key))
+    }
+
+    @Test
+    fun `onCloseRequested during an in-flight submit is ignored (gate #803)`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any(), any()) } returns form()
+        // Hold the POST in flight so the close lands while isSubmitting is true.
+        val gate = CompletableDeferred<Unit>()
+        coEvery { repository.submitReply(any(), any(), any(), any(), any()) } coAnswers {
+            gate.await()
+            ReplySubmitResult.Success(refreshUrl = null, targetPage = null)
+        }
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
+        )
+        viewModel.onContentChanged(TextFieldValue("en vol"))
+
+        viewModel.onSubmit()
+        // Close requested while the POST is in flight — must be inert (gate #803).
+        viewModel.onCloseRequested()
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        viewModel.effects.test {
+            assertTrue(
+                "the submit outcome must be the ONLY effect — no CloseCommitted",
+                awaitItem() is PrivateMessageReplyEffect.SubmitSucceeded,
+            )
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `a second onCloseRequested is a no-op (gate #803)`() = runTest {
+        val repository = mockk<PrivateMessageWriteRepository>()
+        coEvery { repository.fetchReplyForm(any(), any()) } returns form()
+        val viewModel = PrivateMessageReplyViewModel(
+            request, repository, previewParser, userPreferences(), draftStore,
+            FakeAuthRepository(), FakeUploadRepository(), FakeImageUploadReader(), DiagnosticsLog(),
+            smileyRepository(),
+        )
+
+        viewModel.onCloseRequested()
+        viewModel.onCloseRequested()
+        advanceUntilIdle()
+
+        viewModel.effects.test {
+            assertEquals(PrivateMessageReplyEffect.CloseCommitted, awaitItem())
+            // A double close must never yield a second pop (it would remove the screen BELOW).
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     // ----- #606 : owner manages DT/MultiMP members --------------------------------

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -38,9 +38,13 @@ data class SettingsState(
     val isUpdatingIgnoreTopicCache: Boolean = false,
     val ignoreTopicCacheError: Boolean = false,
     /**
-     * Internal startup-race guard. Set to `true` the moment the user flips the toggle locally,
-     * so the (still-suspended) initial DataStore hydration coroutine in `init` cannot resume
-     * later and overwrite the optimistic flip with a stale snapshot. Never surfaced in the UI.
+     * Legacy write marker, set to `true` the moment the user flips the toggle locally. It used
+     * to gate the one-shot `init` hydration against a stale late snapshot; since the #788
+     * continuous re-sync it is NO LONGER CONSULTED (the in-flight `isUpdating*` flag is the only
+     * hydration guard) — every `*TouchedLocally` field below shares this status. The imgur
+     * Client-ID is the one exception: its latch still opts the instance out of the re-sync while
+     * the user types (persist-on-keystroke field). Never surfaced in the UI; removal deferred to
+     * keep this diff mechanical.
      */
     val ignoreTopicCacheTouchedLocally: Boolean = false,
     // #445 — debug bounds overlay toggle (dev-channel only; the channel gate is in the screen, which
@@ -50,11 +54,11 @@ data class SettingsState(
     val isUpdatingDebugBoundsOverlay: Boolean = false,
     val debugBoundsOverlayError: Boolean = false,
     val debugBoundsOverlayTouchedLocally: Boolean = false,
-    // Drapeaux view preferences (#179 follow-up). Same optimistic-flip + startup-race-guard
-    // machinery as ignoreTopicCache: the field is the displayed value, `isUpdating*` gates the
-    // switch while DataStore writes, `*Error` surfaces a persist failure, and `*TouchedLocally`
-    // forbids a late hydration from clobbering a fast user flip. Defaults match the DataStore
-    // defaults (grouped on, hide-read off).
+    // Drapeaux view preferences (#179 follow-up). Same optimistic-flip machinery as
+    // ignoreTopicCache: the field is the displayed value, `isUpdating*` gates the switch while
+    // DataStore writes, `*Error` surfaces a persist failure, and `*TouchedLocally` is a legacy
+    // write marker (no longer consulted — #788, cf. ignoreTopicCacheTouchedLocally). Defaults
+    // match the DataStore defaults (grouped on, hide-read off).
     val flagsGroupByCategory: Boolean = true,
     val isUpdatingFlagsGroupByCategory: Boolean = false,
     val flagsGroupByCategoryError: Boolean = false,
@@ -70,10 +74,10 @@ data class SettingsState(
     val isUpdatingFlagsPerTabOverride: Boolean = false,
     val flagsPerTabOverrideError: Boolean = false,
     val flagsPerTabOverrideTouchedLocally: Boolean = false,
-    // Theme preferences (#286). Same optimistic-flip + startup-race-guard machinery as the flags
-    // toggles: `themeMode`/`amoledEnabled` are the displayed values, `isUpdating*` gates the control
-    // while DataStore writes, `*Error` surfaces a persist failure, and `*TouchedLocally` forbids a
-    // late `init` hydration from clobbering a fast user change. Defaults match the DataStore defaults
+    // Theme preferences (#286). Same optimistic-flip machinery as the flags toggles:
+    // `themeMode`/`amoledEnabled` are the displayed values, `isUpdating*` gates the control
+    // while DataStore writes, `*Error` surfaces a persist failure, and `*TouchedLocally` is a
+    // legacy write marker (no longer consulted — #788). Defaults match the DataStore defaults
     // (SYSTEM, amoled off).
     val themeMode: ThemeMode = ThemeMode.SYSTEM,
     val isUpdatingThemeMode: Boolean = false,
@@ -89,10 +93,10 @@ data class SettingsState(
     val isUpdatingAccentColor: Boolean = false,
     val accentColorError: Boolean = false,
     val accentColorTouchedLocally: Boolean = false,
-    // Topic reading preferences (build 89 follow-up). Same optimistic-flip + startup-race-guard
-    // machinery: `topicTopBarAutoHide` is the displayed value, `isUpdating*` gates the switch while
-    // DataStore writes, `*Error` surfaces a persist failure, `*TouchedLocally` forbids a late `init`
-    // hydration from clobbering a fast user flip. Default false (top bar pinned).
+    // Topic reading preferences (build 89 follow-up). Same optimistic-flip machinery:
+    // `topicTopBarAutoHide` is the displayed value, `isUpdating*` gates the switch while
+    // DataStore writes, `*Error` surfaces a persist failure, `*TouchedLocally` is a legacy write
+    // marker (no longer consulted — #788). Default false (top bar pinned).
     val topicTopBarAutoHide: Boolean = false,
     val isUpdatingTopicTopBarAutoHide: Boolean = false,
     val topicTopBarAutoHideError: Boolean = false,
@@ -164,10 +168,10 @@ data class SettingsState(
     val isUpdatingImmersiveNavBarReveal: Boolean = false,
     val immersiveNavBarRevealError: Boolean = false,
     val immersiveNavBarRevealTouchedLocally: Boolean = false,
-    // Publishing preferences (#312). Same optimistic-flip + startup-race-guard machinery:
-    // `confirmBeforePosting` is the displayed value, `isUpdating*` gates the switch while DataStore
-    // writes, `*Error` surfaces a persist failure, `*TouchedLocally` forbids a late `init` hydration
-    // from clobbering a fast user flip. Default false (publishing stays one-tap).
+    // Publishing preferences (#312). Same optimistic-flip machinery: `confirmBeforePosting` is
+    // the displayed value, `isUpdating*` gates the switch while DataStore writes, `*Error`
+    // surfaces a persist failure, `*TouchedLocally` is a legacy write marker (no longer
+    // consulted — #788). Default false (publishing stays one-tap).
     val confirmBeforePosting: Boolean = false,
     val isUpdatingConfirmBeforePosting: Boolean = false,
     val confirmBeforePostingError: Boolean = false,
@@ -196,11 +200,11 @@ data class SettingsState(
     val isUpdatingFlagsAutoRefresh: Boolean = false,
     val flagsAutoRefreshError: Boolean = false,
     val flagsAutoRefreshTouchedLocally: Boolean = false,
-    // Reading display presets (#287). Same optimistic-flip + startup-race-guard machinery as the
-    // theme controls (both are enums, so the bespoke shape): the value is the displayed selection,
-    // `isUpdating*` gates the control while DataStore writes, `*Error` surfaces a persist failure,
-    // `*TouchedLocally` forbids a late `init` hydration from clobbering a fast user change. Defaults
-    // match the DataStore defaults (COMFORT density, M font scale).
+    // Reading display presets (#287). Same optimistic-flip machinery as the theme controls (both
+    // are enums, so the bespoke shape): the value is the displayed selection, `isUpdating*` gates
+    // the control while DataStore writes, `*Error` surfaces a persist failure, `*TouchedLocally`
+    // is a legacy write marker (no longer consulted — #788). Defaults match the DataStore
+    // defaults (COMFORT density, M font scale).
     val displayDensity: DisplayDensity = DisplayDensity.COMFORT,
     val isUpdatingDisplayDensity: Boolean = false,
     val displayDensityError: Boolean = false,
@@ -211,16 +215,17 @@ data class SettingsState(
     val fontScaleTouchedLocally: Boolean = false,
     // #459 — Hébergeur d'images. The provider is an enum, so it uses the bespoke optimistic-flip
     // shape (like themeMode): `uploadProvider` is the displayed selection, `isUpdating*` gates the
-    // control while DataStore writes, `*Error` surfaces a persist failure, `*TouchedLocally` forbids
-    // a late `init` hydration from clobbering a fast user change. Default DIBERIE (no Client-ID).
+    // control while DataStore writes, `*Error` surfaces a persist failure, `*TouchedLocally` is a
+    // legacy write marker (no longer consulted — #788). Default DIBERIE (no Client-ID).
     val uploadProvider: UploadProviderId = UploadProviderId.DIBERIE,
     val isUpdatingUploadProvider: Boolean = false,
     val uploadProviderError: Boolean = false,
     val uploadProviderTouchedLocally: Boolean = false,
     // #459 — imgur Client-ID text field. `imgurClientId` is the displayed/edited value, persisted on
     // each change (no save button — same as the optimistic prefs). `*Error` surfaces a persist
-    // failure; `*TouchedLocally` forbids the late hydration from overwriting in-progress typing.
-    // Default empty = imgur not configured.
+    // failure; `*TouchedLocally` is STILL consulted for this pref only (#788 exception): it opts
+    // the instance out of the continuous re-sync so an echoed emission never overwrites
+    // in-progress typing. Default empty = imgur not configured.
     val imgurClientId: String = "",
     val imgurClientIdError: Boolean = false,
     val imgurClientIdTouchedLocally: Boolean = false,

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -17,6 +17,7 @@ import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -40,186 +41,195 @@ class SettingsViewModel @Inject constructor(
     val state: StateFlow<SettingsState> = _state.asStateFlow()
 
     init {
-        // One-shot hydration of every persisted preference into `_state`. We deliberately
-        // use `.first()` (point-in-time read) rather than a long-lived collect, so toggling
-        // a preference from inside this screen does not race with itself via the observe
-        // path. Each `.copy(...)` keeps the other fields intact — never replace the whole
-        // state with a partial config, that would wipe the maintenance fields.
+        // #788 — continuous hydration: every persisted preference is COLLECTED for the VM's
+        // whole life, not read once. Each Settings destination scopes its own SettingsViewModel
+        // to its NavBackStackEntry, so a value written from a sub-page instance (or any other
+        // writer) must also land in the retained root instance — the previous one-shot
+        // `.first()` + touched-locally latch kept it stale forever. Each `.copy(...)` keeps the
+        // other fields intact — never replace the whole state with a partial config, that would
+        // wipe the maintenance fields.
         viewModelScope.launch {
+            // The proxy stays a point-in-time read: it is an explicit-save FORM (host / port /
+            // credentials typed locally), so a continuous re-sync would clobber in-progress edits.
             val config = userPreferencesRepository.observeProxyConfig().first()
             _state.update { it.copyFromProxy(config) }
         }
-        hydratePreference(
-            read = { userPreferencesRepository.observeIgnoreTopicCache().first() },
-            isLocked = { it.ignoreTopicCacheTouchedLocally || it.isUpdatingIgnoreTopicCache },
+        observePreference(
+            flow = userPreferencesRepository.observeIgnoreTopicCache(),
+            isLocked = { it.isUpdatingIgnoreTopicCache },
             apply = { state, value -> state.copy(ignoreTopicCache = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeDebugBoundsOverlay().first() },
-            isLocked = { it.debugBoundsOverlayTouchedLocally || it.isUpdatingDebugBoundsOverlay },
+        observePreference(
+            flow = userPreferencesRepository.observeDebugBoundsOverlay(),
+            isLocked = { it.isUpdatingDebugBoundsOverlay },
             apply = { state, value -> state.copy(debugBoundsOverlay = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeFlagsGroupByCategory().first() },
-            isLocked = { it.flagsGroupByCategoryTouchedLocally || it.isUpdatingFlagsGroupByCategory },
+        observePreference(
+            flow = userPreferencesRepository.observeFlagsGroupByCategory(),
+            isLocked = { it.isUpdatingFlagsGroupByCategory },
             apply = { state, value -> state.copy(flagsGroupByCategory = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeFlagsHideReadCategories().first() },
-            isLocked = { it.flagsHideReadCategoriesTouchedLocally || it.isUpdatingFlagsHideReadCategories },
+        observePreference(
+            flow = userPreferencesRepository.observeFlagsHideReadCategories(),
+            isLocked = { it.isUpdatingFlagsHideReadCategories },
             apply = { state, value -> state.copy(flagsHideReadCategories = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeFlagsPerTabOverride().first() },
-            isLocked = { it.flagsPerTabOverrideTouchedLocally || it.isUpdatingFlagsPerTabOverride },
+        observePreference(
+            flow = userPreferencesRepository.observeFlagsPerTabOverride(),
+            isLocked = { it.isUpdatingFlagsPerTabOverride },
             apply = { state, value -> state.copy(flagsPerTabOverride = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeThemeMode().first() },
-            isLocked = { it.themeModeTouchedLocally || it.isUpdatingThemeMode },
+        observePreference(
+            flow = userPreferencesRepository.observeThemeMode(),
+            isLocked = { it.isUpdatingThemeMode },
             apply = { state, value -> state.copy(themeMode = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeAmoledEnabled().first() },
-            isLocked = { it.amoledTouchedLocally || it.isUpdatingAmoled },
+        observePreference(
+            flow = userPreferencesRepository.observeAmoledEnabled(),
+            isLocked = { it.isUpdatingAmoled },
             apply = { state, value -> state.copy(amoledEnabled = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeTopicTopBarAutoHide().first() },
-            isLocked = { it.topicTopBarAutoHideTouchedLocally || it.isUpdatingTopicTopBarAutoHide },
+        observePreference(
+            flow = userPreferencesRepository.observeTopicTopBarAutoHide(),
+            isLocked = { it.isUpdatingTopicTopBarAutoHide },
             apply = { state, value -> state.copy(topicTopBarAutoHide = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeTopicPageFabs().first() },
-            isLocked = { it.topicPageFabsTouchedLocally || it.isUpdatingTopicPageFabs },
+        observePreference(
+            flow = userPreferencesRepository.observeTopicPageFabs(),
+            isLocked = { it.isUpdatingTopicPageFabs },
             apply = { state, value -> state.copy(topicPageFabs = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeMpUnreadBadge().first() },
-            isLocked = { it.mpUnreadBadgeTouchedLocally || it.isUpdatingMpUnreadBadge },
+        observePreference(
+            flow = userPreferencesRepository.observeMpUnreadBadge(),
+            isLocked = { it.isUpdatingMpUnreadBadge },
             apply = { state, value -> state.copy(mpUnreadBadge = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeTopicPollsExpanded().first() },
-            isLocked = { it.topicPollsExpandedTouchedLocally || it.isUpdatingTopicPollsExpanded },
+        observePreference(
+            flow = userPreferencesRepository.observeTopicPollsExpanded(),
+            isLocked = { it.isUpdatingTopicPollsExpanded },
             apply = { state, value -> state.copy(topicPollsExpanded = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeTopicSignatures().first() },
-            isLocked = { it.topicSignaturesTouchedLocally || it.isUpdatingTopicSignatures },
+        observePreference(
+            flow = userPreferencesRepository.observeTopicSignatures(),
+            isLocked = { it.isUpdatingTopicSignatures },
             apply = { state, value -> state.copy(topicSignatures = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeFoldLongQuotes().first() },
-            isLocked = { it.foldLongQuotesTouchedLocally || it.isUpdatingFoldLongQuotes },
+        observePreference(
+            flow = userPreferencesRepository.observeFoldLongQuotes(),
+            isLocked = { it.isUpdatingFoldLongQuotes },
             apply = { state, value -> state.copy(foldLongQuotes = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeShowScrollbar().first() },
-            isLocked = { it.showScrollbarTouchedLocally || it.isUpdatingShowScrollbar },
+        observePreference(
+            flow = userPreferencesRepository.observeShowScrollbar(),
+            isLocked = { it.isUpdatingShowScrollbar },
             apply = { state, value -> state.copy(showScrollbar = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeNavBarLabels().first() },
-            isLocked = { it.navBarLabelsTouchedLocally || it.isUpdatingNavBarLabels },
+        observePreference(
+            flow = userPreferencesRepository.observeNavBarLabels(),
+            isLocked = { it.isUpdatingNavBarLabels },
             apply = { state, value -> state.copy(navBarLabels = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeFunnyEmptyState().first() },
-            isLocked = { it.funnyEmptyStateTouchedLocally || it.isUpdatingFunnyEmptyState },
+        observePreference(
+            flow = userPreferencesRepository.observeFunnyEmptyState(),
+            isLocked = { it.isUpdatingFunnyEmptyState },
             apply = { state, value -> state.copy(funnyEmptyState = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeHideSystemNavBar().first() },
-            isLocked = { it.hideSystemNavBarTouchedLocally || it.isUpdatingHideSystemNavBar },
+        observePreference(
+            flow = userPreferencesRepository.observeHideSystemNavBar(),
+            isLocked = { it.isUpdatingHideSystemNavBar },
             apply = { state, value -> state.copy(hideSystemNavBar = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeImmersiveBackButton().first() },
-            isLocked = { it.immersiveBackButtonTouchedLocally || it.isUpdatingImmersiveBackButton },
+        observePreference(
+            flow = userPreferencesRepository.observeImmersiveBackButton(),
+            isLocked = { it.isUpdatingImmersiveBackButton },
             apply = { state, value -> state.copy(immersiveBackButton = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeImmersiveNavBarReveal().first() },
-            isLocked = { it.immersiveNavBarRevealTouchedLocally || it.isUpdatingImmersiveNavBarReveal },
+        observePreference(
+            flow = userPreferencesRepository.observeImmersiveNavBarReveal(),
+            isLocked = { it.isUpdatingImmersiveNavBarReveal },
             apply = { state, value -> state.copy(immersiveNavBarReveal = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeAccentColor().first() },
-            isLocked = { it.accentColorTouchedLocally || it.isUpdatingAccentColor },
+        observePreference(
+            flow = userPreferencesRepository.observeAccentColor(),
+            isLocked = { it.isUpdatingAccentColor },
             apply = { state, value -> state.copy(accentColor = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeConfirmBeforePosting().first() },
-            isLocked = { it.confirmBeforePostingTouchedLocally || it.isUpdatingConfirmBeforePosting },
+        observePreference(
+            flow = userPreferencesRepository.observeConfirmBeforePosting(),
+            isLocked = { it.isUpdatingConfirmBeforePosting },
             apply = { state, value -> state.copy(confirmBeforePosting = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeQuoteCardsEnabled().first() },
-            isLocked = { it.quoteCardsEnabledTouchedLocally || it.isUpdatingQuoteCardsEnabled },
+        observePreference(
+            flow = userPreferencesRepository.observeQuoteCardsEnabled(),
+            isLocked = { it.isUpdatingQuoteCardsEnabled },
             apply = { state, value -> state.copy(quoteCardsEnabled = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeShowDtSection().first() },
-            isLocked = { it.showDtSectionTouchedLocally || it.isUpdatingShowDtSection },
+        observePreference(
+            flow = userPreferencesRepository.observeShowDtSection(),
+            isLocked = { it.isUpdatingShowDtSection },
             apply = { state, value -> state.copy(showDtSection = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeSyncPrivateMessagesWriteEnabled().first() },
-            isLocked = {
-                it.syncPrivateMessagesWriteEnabledTouchedLocally || it.isUpdatingSyncPrivateMessagesWriteEnabled
-            },
+        observePreference(
+            flow = userPreferencesRepository.observeSyncPrivateMessagesWriteEnabled(),
+            isLocked = { it.isUpdatingSyncPrivateMessagesWriteEnabled },
             apply = { state, value -> state.copy(syncPrivateMessagesWriteEnabled = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeFlagsAutoRefresh().first() },
-            isLocked = { it.flagsAutoRefreshTouchedLocally || it.isUpdatingFlagsAutoRefresh },
+        observePreference(
+            flow = userPreferencesRepository.observeFlagsAutoRefresh(),
+            isLocked = { it.isUpdatingFlagsAutoRefresh },
             apply = { state, value -> state.copy(flagsAutoRefresh = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeDisplayDensity().first() },
-            isLocked = { it.displayDensityTouchedLocally || it.isUpdatingDisplayDensity },
+        observePreference(
+            flow = userPreferencesRepository.observeDisplayDensity(),
+            isLocked = { it.isUpdatingDisplayDensity },
             apply = { state, value -> state.copy(displayDensity = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeFontScale().first() },
-            isLocked = { it.fontScaleTouchedLocally || it.isUpdatingFontScale },
+        observePreference(
+            flow = userPreferencesRepository.observeFontScale(),
+            isLocked = { it.isUpdatingFontScale },
             apply = { state, value -> state.copy(fontScale = value) },
         )
-        // #459 — Hébergeur d'images : provider (enum) + imgur Client-ID (text). Same one-shot
-        // hydration + touched-locally guard as the other prefs.
-        hydratePreference(
-            read = { userPreferencesRepository.observeUploadProvider().first() },
-            isLocked = { it.uploadProviderTouchedLocally || it.isUpdatingUploadProvider },
+        // #459 — Hébergeur d'images : provider (enum) + imgur Client-ID (text).
+        observePreference(
+            flow = userPreferencesRepository.observeUploadProvider(),
+            isLocked = { it.isUpdatingUploadProvider },
             apply = { state, value -> state.copy(uploadProvider = value) },
         )
-        hydratePreference(
-            read = { userPreferencesRepository.observeImgurClientId().first() },
+        // #459 / #788 — the imgur Client-ID persists on each keystroke, so its re-sync guard is
+        // the TOUCH latch, not an in-flight flag: once the user typed in THIS instance, an echoed
+        // (or concurrent) emission must never rewrite the field mid-typing. An untouched instance
+        // still follows external writes like every other pref.
+        observePreference(
+            flow = userPreferencesRepository.observeImgurClientId(),
             isLocked = { it.imgurClientIdTouchedLocally },
             apply = { state, value -> state.copy(imgurClientId = value) },
         )
-        // #459 PR-images follow-up — editor image insert mode (enum), same hydration shape.
-        hydratePreference(
-            read = { userPreferencesRepository.observeEditorImageInsert().first() },
-            isLocked = { it.editorImageInsertTouchedLocally || it.isUpdatingEditorImageInsert },
+        // #459 PR-images follow-up — editor image insert mode (enum), same collection shape.
+        observePreference(
+            flow = userPreferencesRepository.observeEditorImageInsert(),
+            isLocked = { it.isUpdatingEditorImageInsert },
             apply = { state, value -> state.copy(editorImageInsert = value) },
         )
     }
 
     /**
-     * One-shot hydration of a persisted preference into [_state] (point-in-time `first()`,
-     * cf. the init comment). [isLocked] is the startup-race guard: if the user already
-     * flipped the toggle (or a write is in flight) while this coroutine was suspended on
-     * the read, the stale snapshot must NOT overwrite the local change.
+     * Long-lived re-sync of a persisted preference into [_state] (#788 gate rule: a ViewModel
+     * that caches persisted data re-syncs continuously, not once). The repository Flows are
+     * `distinctUntilChanged`, so this collect only wakes up on real changes. [isLocked] guards
+     * the only window where an emission must be ignored: an optimistic write in flight
+     * (`isUpdating*`) — on success DataStore re-emits the desired value (no-op convergence),
+     * on failure nothing is emitted and the local revert stands. The imgur Client-ID passes its
+     * touch latch instead (see the init call site).
      */
-    private fun <T> hydratePreference(
-        read: suspend () -> T,
+    private fun <T> observePreference(
+        flow: Flow<T>,
         isLocked: (SettingsState) -> Boolean,
         apply: (SettingsState, T) -> SettingsState,
     ) {
         viewModelScope.launch {
-            val value = read()
-            _state.update { current -> if (isLocked(current)) current else apply(current, value) }
+            flow.collect { value ->
+                _state.update { current -> if (isLocked(current)) current else apply(current, value) }
+            }
         }
     }
 
@@ -390,12 +400,12 @@ class SettingsViewModel @Inject constructor(
 
     private fun updateIgnoreTopicCache(desired: Boolean) {
         val previous = _state.value.ignoreTopicCache
-        // Optimistic flip — the UI reflects the intent immediately, the gate flag locks the
-        // switch while DataStore is writing, and `ignoreTopicCacheTouchedLocally = true`
-        // forbids the still-running startup hydration from overwriting this change with a
-        // stale snapshot later. We keep the touched flag at `true` for the rest of the VM's
-        // lifetime: even after a failure-revert the user has expressed an intent, so a late
-        // hydration value would no longer be the source of truth.
+        // Optimistic flip — the UI reflects the intent immediately and the gate flag locks the
+        // switch while DataStore is writing. `isUpdatingIgnoreTopicCache = true` is also what
+        // blanks the continuous #788 re-sync for the write's duration, so an emission of the
+        // OLD value cannot undo the flip mid-flight. `ignoreTopicCacheTouchedLocally` stays a
+        // write marker only — it is no longer consulted by the hydration guard (#788), so an
+        // external write made later (e.g. from another Settings destination's VM) re-syncs here.
         _state.update {
             it.copy(
                 ignoreTopicCache = desired,
@@ -407,10 +417,11 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             runCatching { userPreferencesRepository.setIgnoreTopicCache(desired) }
                 .onSuccess {
-                    // Re-affirm `ignoreTopicCache = desired` explicitly. Without this, a stale
-                    // hydration that resumed *between* the optimistic flip and onSuccess could
-                    // have left the field at a wrong value; reasserting here makes the final
-                    // state self-consistent regardless of interleaving.
+                    // Re-affirm `ignoreTopicCache = desired` explicitly. The #788 re-sync is
+                    // gated on `isUpdating*` while the write is in flight, but a conflated
+                    // emission of the OLD value could theoretically land right after the gate
+                    // drops; reasserting here makes the final state self-consistent regardless
+                    // of interleaving (DataStore then re-emits `desired` — a no-op).
                     _state.update {
                         it.copy(
                             ignoreTopicCache = desired,
@@ -683,9 +694,10 @@ class SettingsViewModel @Inject constructor(
     }
 
     // #459 — imgur Client-ID is a free-text preference persisted on each change (no save button).
-    // The optimistic value is shown immediately and the touched-locally guard blocks a late
-    // hydration from clobbering in-progress typing; a persist failure raises the error flag without
-    // reverting the typed text (it would be hostile to wipe what the user just typed).
+    // The optimistic value is shown immediately and the touched-locally latch permanently opts
+    // this instance out of the #788 re-sync (an echoed emission must not rewrite the field while
+    // the user is typing); a persist failure raises the error flag without reverting the typed
+    // text (it would be hostile to wipe what the user just typed).
     // Persist-on-keystroke writes are serialised : each keystroke cancels the previous in-flight write
     // so a slower/older write (or its failure) can never land after a newer one and strand a stale
     // Client-ID or a spurious error flag (review #459). CancellationException is rethrown, not treated
@@ -1230,9 +1242,10 @@ class SettingsViewModel @Inject constructor(
 
     /**
      * Shared optimistic-flip machinery for a persisted boolean preference (the Drapeaux view
-     * toggles). Flips the field immediately via [optimistic] (which also sets the `*TouchedLocally`
-     * guard so a late `init` hydration can't clobber it), persists [desired] on a background
-     * coroutine, then reconciles the final state from the persist [Result] via [onSettled] (success
+     * toggles). Flips the field immediately via [optimistic] (whose `isUpdating*` flag also gates
+     * the continuous #788 re-sync for the write's duration; the `*TouchedLocally` flag it sets is
+     * a write marker only, no longer consulted), persists [desired] on a background coroutine,
+     * then reconciles the final state from the persist [Result] via [onSettled] (success
      * re-affirms the value, failure reverts and raises the error flag — both captured in the
      * caller's closures). Mirrors the bespoke `updateIgnoreTopicCache` contract, factored because
      * the two new toggles are identical bar their state fields.

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -453,40 +453,51 @@ class SettingsViewModelTest {
         assertEquals(1, repository.ignoreTopicCacheSetCalls)
     }
 
-    @Test
-    fun `hydration race - a stale initial DataStore emission must not overwrite a local toggle change`() = runTest {
-        // Reproduce the startup race: the init coroutine subscribes to
-        // observeIgnoreTopicCache() and suspends on .first() because the override emits
-        // nothing yet. The user then flips the toggle locally (optimistic true + write
-        // succeeds). Finally, the still-suspended init resumes and tries to apply a
-        // stale `false` — the guard must skip the apply.
-        val initialHydrationFlow = MutableSharedFlow<Boolean>(replay = 0)
-        repository.ignoreTopicCacheObserveOverride = initialHydrationFlow
-        val viewModel = newViewModel()
+    // ──────────────────────────────────────────────────────────────────────
+    // #788 — continuous DataStore re-sync (state-hygiene). Every Settings destination owns its
+    // own SettingsViewModel instance, so a value written by another instance (sub-page, second
+    // pane) must land here too. The only guarded window is an optimistic write in flight.
+    // ──────────────────────────────────────────────────────────────────────
 
-        // Step 1: init is now suspended on `initialHydrationFlow.first()`.
-        // Step 2: user flips the toggle. The optimistic flip + DataStore write run
-        // synchronously under UnconfinedTestDispatcher and complete before we return here.
-        viewModel.submit(SettingsIntent.IgnoreTopicCacheChanged(true))
+    @Test
+    fun `an external DataStore write is reflected in an already-hydrated state (#788)`() = runTest {
+        val viewModel = newViewModel()
+        assertFalse(viewModel.state.value.ignoreTopicCache)
+
+        repository.emitIgnoreTopicCache(true)
+
         assertTrue(
-            "optimistic flip must reach the state synchronously",
+            "an external write must reach a live VM instance, not just the init hydration",
             viewModel.state.value.ignoreTopicCache,
         )
-        assertTrue(viewModel.state.value.ignoreTopicCacheTouchedLocally)
-        assertFalse(
-            "write must have completed under the UnconfinedTestDispatcher",
-            viewModel.state.value.isUpdatingIgnoreTopicCache,
+    }
+
+    @Test
+    fun `an emission during an in-flight write is ignored, then the state converges on success (#788)`() = runTest {
+        val externalFlow = MutableSharedFlow<Boolean>(replay = 0)
+        repository.ignoreTopicCacheObserveOverride = externalFlow
+        val gate = CompletableDeferred<Unit>()
+        repository.blockIgnoreTopicCacheSetUntil = gate
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.IgnoreTopicCacheChanged(true))
+        assertTrue(viewModel.state.value.ignoreTopicCache)
+        assertTrue("write must be held in flight by the gate", viewModel.state.value.isUpdatingIgnoreTopicCache)
+
+        // An emission of the OLD value landing while the optimistic write is in flight must not
+        // undo the flip — `isUpdating*` is the re-sync guard.
+        externalFlow.emit(false)
+        assertTrue(
+            "an emission during the in-flight write must not clobber the optimistic flip",
+            viewModel.state.value.ignoreTopicCache,
         )
 
-        // Step 3: the late hydration finally produces a stale `false`. On the buggy code
-        // this overwrites the local true; on the fixed code the guard skips the apply.
-        initialHydrationFlow.emit(false)
+        gate.complete(Unit)
+        // DataStore re-emits the committed value after the write — a no-op convergence.
+        externalFlow.emit(true)
 
         val finalState = viewModel.state.value
-        assertTrue(
-            "stale initial DataStore hydration must NOT overwrite the local toggle change",
-            finalState.ignoreTopicCache,
-        )
+        assertTrue(finalState.ignoreTopicCache)
         assertFalse(finalState.isUpdatingIgnoreTopicCache)
         assertFalse(finalState.ignoreTopicCacheError)
         assertEquals(1, repository.ignoreTopicCacheSetCalls)
@@ -494,33 +505,44 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun `hydration race - failure path keeps the toggle latched to the reverted previous value`() = runTest {
-        // Symmetric guard for the failure branch: the local flip happens first, then DataStore
-        // write fails (revert to previous=false + error flag), then a stale hydration arrives.
-        // The reverted state must survive — the hydration must NOT silently mutate it back to
-        // anything else, even if the stale value happens to match the reverted one.
-        repository.failOnIgnoreTopicCacheSet = true
-        val initialHydrationFlow = MutableSharedFlow<Boolean>(replay = 0)
-        repository.ignoreTopicCacheObserveOverride = initialHydrationFlow
+    fun `a successful toggle followed by an external write reflects the external value (#788)`() = runTest {
+        // The exact staleness scenario behind #788: this VM instance toggles ON, another
+        // Settings destination (its own VM) later writes OFF — this instance must follow the
+        // store, otherwise its next optimistic flip starts from a wrong `previous`.
         val viewModel = newViewModel()
-
         viewModel.submit(SettingsIntent.IgnoreTopicCacheChanged(true))
-        // After failure: reverted to false + error flag raised; touchedLocally remains true.
-        val midState = viewModel.state.value
-        assertFalse(midState.ignoreTopicCache)
-        assertTrue(midState.ignoreTopicCacheError)
-        assertTrue(midState.ignoreTopicCacheTouchedLocally)
+        assertTrue(viewModel.state.value.ignoreTopicCache)
 
-        // Stale hydration arrives — must be ignored because touchedLocally == true.
-        initialHydrationFlow.emit(true)
+        repository.emitIgnoreTopicCache(false)
 
-        val finalState = viewModel.state.value
         assertFalse(
-            "stale hydration must not flip the toggle back on after a failed write",
-            finalState.ignoreTopicCache,
+            "the state must follow the external write, not the last local toggle",
+            viewModel.state.value.ignoreTopicCache,
         )
-        assertTrue(finalState.ignoreTopicCacheError)
     }
+
+    @Test
+    fun `a failed write reverts and the persisted re-emission keeps the revert and the error flag (#788)`() =
+        runTest {
+            // Failure branch: the local flip fails (revert to previous=false + error flag). The
+            // store still holds `false`, so the only thing the re-sync may deliver afterwards is
+            // that same persisted value — applying it must keep the revert AND the error flag.
+            repository.failOnIgnoreTopicCacheSet = true
+            val externalFlow = MutableSharedFlow<Boolean>(replay = 0)
+            repository.ignoreTopicCacheObserveOverride = externalFlow
+            val viewModel = newViewModel()
+
+            viewModel.submit(SettingsIntent.IgnoreTopicCacheChanged(true))
+            val midState = viewModel.state.value
+            assertFalse(midState.ignoreTopicCache)
+            assertTrue(midState.ignoreTopicCacheError)
+
+            externalFlow.emit(false)
+
+            val finalState = viewModel.state.value
+            assertFalse("the reverted value must survive the persisted re-emission", finalState.ignoreTopicCache)
+            assertTrue("the error flag is not owned by the re-sync path", finalState.ignoreTopicCacheError)
+        }
 
     @Test
     fun `IgnoreTopicCacheChanged does not touch proxy or clear-cache state`() = runTest {
@@ -896,12 +918,9 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun `topicPageFabs hydration race - a stale emission must not overwrite a local flip`() = runTest {
-        // Same startup race as ignoreTopicCache: init suspends on .first() (the override
-        // emits nothing yet), the user opts out locally, then the stale `true` arrives —
-        // the TouchedLocally guard must skip the apply.
-        val initialHydrationFlow = MutableSharedFlow<Boolean>(replay = 0)
-        repository.topicPageFabsObserveOverride = initialHydrationFlow
+    fun `topicPageFabs - an external write after a settled local flip is reflected (#788)`() = runTest {
+        // #788 re-sync contract: once the local opt-out settled, a later external write (another
+        // Settings destination's VM) must be reflected, not shadowed by a touched-locally latch.
         val viewModel = newViewModel()
 
         viewModel.submit(SettingsIntent.TopicPageFabsChanged(false))
@@ -909,15 +928,14 @@ class SettingsViewModelTest {
             "optimistic flip must reach the state synchronously",
             viewModel.state.value.topicPageFabs,
         )
-        assertTrue(viewModel.state.value.topicPageFabsTouchedLocally)
+        assertEquals(1, repository.topicPageFabsSetCalls)
 
-        initialHydrationFlow.emit(true)
+        repository.emitTopicPageFabs(true)
 
-        assertFalse(
-            "stale initial DataStore hydration must NOT overwrite the local opt-out",
+        assertTrue(
+            "an external write must be reflected after the local flip settled",
             viewModel.state.value.topicPageFabs,
         )
-        assertEquals(1, repository.topicPageFabsSetCalls)
     }
 
     @Test
@@ -1427,14 +1445,10 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun `theme hydration race - a stale initial DataStore emission must not overwrite a local mode change`() =
+    fun `themeMode - an external write after a settled local change is reflected (#788)`() =
         runTest {
-            // Mirror of the ignoreTopicCache startup-race test for ThemeMode (#286, Codex nit): init
-            // subscribes to observeThemeMode() and suspends on .first() (override emits nothing yet),
-            // the user picks DARK locally (optimistic + write succeeds, touchedLocally = true), then the
-            // still-suspended init resumes with a stale SYSTEM — the guard must skip the apply.
-            val initialHydrationFlow = MutableSharedFlow<ThemeMode>(replay = 0)
-            repository.themeModeObserveOverride = initialHydrationFlow
+            // #788 re-sync contract for the enum shape: after the local DARK settled, an external
+            // LIGHT (e.g. written from the Display sub-page's own VM) must land here too.
             val viewModel = newViewModel()
 
             viewModel.submit(SettingsIntent.ThemeModeChanged(ThemeMode.DARK))
@@ -1443,76 +1457,64 @@ class SettingsViewModelTest {
                 ThemeMode.DARK,
                 viewModel.state.value.themeMode,
             )
-            assertTrue(viewModel.state.value.themeModeTouchedLocally)
             assertFalse(viewModel.state.value.isUpdatingThemeMode)
+            assertEquals(1, repository.themeModeSetCalls)
+            assertEquals(ThemeMode.DARK, repository.lastThemeModeSet)
 
-            // Late, stale hydration produces SYSTEM. On the buggy code this overwrites the local DARK;
-            // on the fixed code the touchedLocally guard skips the apply.
-            initialHydrationFlow.emit(ThemeMode.SYSTEM)
+            repository.emitThemeMode(ThemeMode.LIGHT)
 
             val finalState = viewModel.state.value
             assertEquals(
-                "stale initial DataStore hydration must NOT overwrite the local mode change",
-                ThemeMode.DARK,
+                "an external write must be reflected after the local change settled",
+                ThemeMode.LIGHT,
                 finalState.themeMode,
             )
             assertFalse(finalState.isUpdatingThemeMode)
             assertFalse(finalState.themeModeError)
-            assertEquals(1, repository.themeModeSetCalls)
-            assertEquals(ThemeMode.DARK, repository.lastThemeModeSet)
         }
 
     @Test
-    fun `displayDensity hydration race - a stale initial emission must not overwrite a local change`() =
+    fun `displayDensity - an external write after a settled local change is reflected (#788)`() =
         runTest {
-            // Same startup-race contract as ThemeMode (#287): the user picks COMPACT while init is
-            // still suspended on observeDisplayDensity().first(); the late stale COMFORT must be
-            // skipped by the touchedLocally guard.
-            val initialHydrationFlow = MutableSharedFlow<DisplayDensity>(replay = 0)
-            repository.displayDensityObserveOverride = initialHydrationFlow
             val viewModel = newViewModel()
 
             viewModel.submit(SettingsIntent.DisplayDensityChanged(DisplayDensity.COMPACT))
             assertEquals(DisplayDensity.COMPACT, viewModel.state.value.displayDensity)
-            assertTrue(viewModel.state.value.displayDensityTouchedLocally)
+            assertEquals(1, repository.displayDensitySetCalls)
+            assertEquals(DisplayDensity.COMPACT, repository.lastDisplayDensitySet)
 
-            initialHydrationFlow.emit(DisplayDensity.COMFORT)
+            repository.emitDisplayDensity(DisplayDensity.COMFORT)
 
             val finalState = viewModel.state.value
             assertEquals(
-                "stale hydration must NOT overwrite the local density change",
-                DisplayDensity.COMPACT,
+                "an external write must be reflected after the local change settled",
+                DisplayDensity.COMFORT,
                 finalState.displayDensity,
             )
             assertFalse(finalState.isUpdatingDisplayDensity)
             assertFalse(finalState.displayDensityError)
-            assertEquals(1, repository.displayDensitySetCalls)
-            assertEquals(DisplayDensity.COMPACT, repository.lastDisplayDensitySet)
         }
 
     @Test
-    fun `fontScale hydration race - a stale initial emission must not overwrite a local change`() =
+    fun `fontScale - an external write after a settled local change is reflected (#788)`() =
         runTest {
-            val initialHydrationFlow = MutableSharedFlow<FontScalePreference>(replay = 0)
-            repository.fontScaleObserveOverride = initialHydrationFlow
             val viewModel = newViewModel()
 
             viewModel.submit(SettingsIntent.FontScaleChanged(FontScalePreference.L))
             assertEquals(FontScalePreference.L, viewModel.state.value.fontScale)
-            assertTrue(viewModel.state.value.fontScaleTouchedLocally)
+            assertEquals(1, repository.fontScaleSetCalls)
+            assertEquals(FontScalePreference.L, repository.lastFontScaleSet)
 
-            initialHydrationFlow.emit(FontScalePreference.M)
+            repository.emitFontScale(FontScalePreference.M)
 
             val finalState = viewModel.state.value
             assertEquals(
-                "stale hydration must NOT overwrite the local font-scale change",
-                FontScalePreference.L,
+                "an external write must be reflected after the local change settled",
+                FontScalePreference.M,
                 finalState.fontScale,
             )
             assertFalse(finalState.isUpdatingFontScale)
             assertFalse(finalState.fontScaleError)
-            assertEquals(1, repository.fontScaleSetCalls)
-            assertEquals(FontScalePreference.L, repository.lastFontScaleSet)
         }
 
     // ──────────────────────────────────────────────────────────────────────
@@ -1620,29 +1622,55 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun `upload provider hydration race - a stale initial emission must not overwrite a local change`() =
+    fun `upload provider - an external write after a settled local change is reflected (#788)`() =
         runTest {
-            // Same startup-race contract as ThemeMode (#459): the user picks IMGUR while init is still
-            // suspended on observeUploadProvider().first(); the late stale DIBERIE must be skipped by
-            // the touchedLocally guard.
-            val initialHydrationFlow = MutableSharedFlow<UploadProviderId>(replay = 0)
-            repository.uploadProviderObserveOverride = initialHydrationFlow
             val viewModel = newViewModel()
 
             viewModel.submit(SettingsIntent.SetUploadProvider(UploadProviderId.IMGUR))
             assertEquals(UploadProviderId.IMGUR, viewModel.state.value.uploadProvider)
-            assertTrue(viewModel.state.value.uploadProviderTouchedLocally)
-
-            initialHydrationFlow.emit(UploadProviderId.DIBERIE)
-
-            val finalState = viewModel.state.value
-            assertEquals(
-                "stale hydration must NOT overwrite the local provider change",
-                UploadProviderId.IMGUR,
-                finalState.uploadProvider,
-            )
             assertEquals(1, repository.uploadProviderSetCalls)
             assertEquals(UploadProviderId.IMGUR, repository.lastUploadProviderSet)
+
+            repository.emitUploadProvider(UploadProviderId.DIBERIE)
+
+            assertEquals(
+                "an external write must be reflected after the local change settled",
+                UploadProviderId.DIBERIE,
+                viewModel.state.value.uploadProvider,
+            )
+        }
+
+    @Test
+    fun `imgur client id - an external write is reflected while the field is untouched (#788)`() = runTest {
+        val viewModel = newViewModel()
+        assertEquals("", viewModel.state.value.imgurClientId)
+
+        repository.emitImgurClientId("external-cid")
+
+        assertEquals(
+            "an untouched instance must follow external Client-ID writes",
+            "external-cid",
+            viewModel.state.value.imgurClientId,
+        )
+    }
+
+    @Test
+    fun `imgur client id - once touched locally, an external emission never rewrites the field (#788)`() =
+        runTest {
+            // The persist-on-keystroke field is the one pref that KEEPS its touch latch: an echoed
+            // (or concurrent) emission landing mid-typing must never rewrite what the user typed.
+            val viewModel = newViewModel()
+
+            viewModel.submit(SettingsIntent.SetImgurClientId("CID-42"))
+            assertEquals("CID-42", viewModel.state.value.imgurClientId)
+
+            repository.emitImgurClientId("external-cid")
+
+            assertEquals(
+                "the typing guard must shield the field from re-sync for this VM's lifetime",
+                "CID-42",
+                viewModel.state.value.imgurClientId,
+            )
         }
 
     private fun newViewModel(): SettingsViewModel =
@@ -1676,10 +1704,11 @@ class SettingsViewModelTest {
         override fun readProxyConfigForNetworkBootstrap(): ProxyConfig = config.value
 
         /**
-         * Test seam for the startup-race test: when non-null, `observeIgnoreTopicCache()` returns
-         * this overridden flow instead of the internal `MutableStateFlow`. That lets the test hold
-         * the initial `.first()` suspension, perform a local toggle while the hydration is still
-         * pending, and only then release a stale emission to verify the guard ignores it.
+         * Test seam for the #788 re-sync tests: when non-null, `observeIgnoreTopicCache()` returns
+         * this overridden flow instead of the internal `MutableStateFlow`. A `MutableSharedFlow`
+         * (no replay, no dedup) lets a test emit an arbitrary sequence — e.g. the OLD value while
+         * a gated write is in flight, or the persisted value after a failed write — which the
+         * conflating internal StateFlow could not replay.
          */
         var ignoreTopicCacheObserveOverride: Flow<Boolean>? = null
 
@@ -1752,14 +1781,7 @@ class SettingsViewModelTest {
             private set
         var failOnAmoledSet: Boolean = false
 
-        /**
-         * Test seam for the theme startup-race test (#286), mirroring [ignoreTopicCacheObserveOverride]:
-         * when non-null, `observeThemeMode()` returns this flow so the test can hold the init `.first()`
-         * suspension, perform a local mode change, then release a stale emission to prove the guard skips it.
-         */
-        var themeModeObserveOverride: Flow<ThemeMode>? = null
-
-        override fun observeThemeMode(): Flow<ThemeMode> = themeModeObserveOverride ?: themeMode
+        override fun observeThemeMode(): Flow<ThemeMode> = themeMode
 
         override suspend fun setThemeMode(mode: ThemeMode) {
             themeModeSetCalls += 1
@@ -1784,11 +1806,7 @@ class SettingsViewModelTest {
             private set
         var failOnDisplayDensitySet: Boolean = false
 
-        /** Startup-race seam, mirroring [themeModeObserveOverride] (#287). */
-        var displayDensityObserveOverride: Flow<DisplayDensity>? = null
-
-        override fun observeDisplayDensity(): Flow<DisplayDensity> =
-            displayDensityObserveOverride ?: displayDensity
+        override fun observeDisplayDensity(): Flow<DisplayDensity> = displayDensity
 
         override suspend fun setDisplayDensity(density: DisplayDensity) {
             displayDensitySetCalls += 1
@@ -1808,11 +1826,7 @@ class SettingsViewModelTest {
             private set
         var failOnFontScaleSet: Boolean = false
 
-        /** Startup-race seam, mirroring [themeModeObserveOverride] (#287). */
-        var fontScaleObserveOverride: Flow<FontScalePreference>? = null
-
-        override fun observeFontScale(): Flow<FontScalePreference> =
-            fontScaleObserveOverride ?: fontScale
+        override fun observeFontScale(): Flow<FontScalePreference> = fontScale
 
         override suspend fun setFontScale(scale: FontScalePreference) {
             fontScaleSetCalls += 1
@@ -1839,16 +1853,13 @@ class SettingsViewModelTest {
             topicTopBarAutoHide.value = enabled
         }
 
-        // #383 — topic page FABs. Same optimistic-flip seam as the topic top-bar toggle,
-        // plus the observe-override seam of ignoreTopicCache for the hydration-race test.
+        // #383 — topic page FABs. Same optimistic-flip seam as the topic top-bar toggle.
         private val topicPageFabs = MutableStateFlow(true)
         var topicPageFabsSetCalls: Int = 0
             private set
         var failOnTopicPageFabsSet: Boolean = false
-        var topicPageFabsObserveOverride: Flow<Boolean>? = null
 
-        override fun observeTopicPageFabs(): Flow<Boolean> =
-            topicPageFabsObserveOverride ?: topicPageFabs
+        override fun observeTopicPageFabs(): Flow<Boolean> = topicPageFabs
 
         override suspend fun setTopicPageFabs(enabled: Boolean) {
             topicPageFabsSetCalls += 1
@@ -1999,11 +2010,7 @@ class SettingsViewModelTest {
             private set
         var failOnUploadProviderSet: Boolean = false
 
-        /** Startup-race seam, mirroring [themeModeObserveOverride] (#459). */
-        var uploadProviderObserveOverride: Flow<UploadProviderId>? = null
-
-        override fun observeUploadProvider(): Flow<UploadProviderId> =
-            uploadProviderObserveOverride ?: uploadProvider
+        override fun observeUploadProvider(): Flow<UploadProviderId> = uploadProvider
 
         override suspend fun setUploadProvider(provider: UploadProviderId) {
             uploadProviderSetCalls += 1


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Trois bugs d'état identifiés par l'audit du 05/07 (session rf2-10), corrigés en un lot.

## a) Réglages : valeurs périmées entre instances (#788) — `e3b85c5f`

Chaque destination Réglages instancie sa propre `SettingsViewModel`, hydratée en one-shot (`.first()`) avec un latch `*TouchedLocally` à vie : un toggle fait dans une sous-page laissait la VM racine sur l'ancienne valeur, et re-toggler **inversait une valeur fausse**. Fix : hydratation par **collecte continue** des Flows DataStore (gate #788 : la VM re-synce en continu), garde réduite à la fenêtre d'écriture optimiste (`isUpdating*`). Exceptions documentées : `imgurClientId` (champ texte persist-on-keystroke, latch de frappe conservé) et proxy (formulaire à save explicite).

## b) Perte de frappe au dirty-close ×3 (pattern #803) — `19df079b`

`TopicFormViewModel`, `PrivateMessageComposeViewModel`, `PrivateMessageReplyViewModel` avaient l'autosave débounced 750 ms mais leurs fermetures annulaient le debounce avec la VM (≤750 ms de frappe perdue). Réplication du pattern PostEditor #803 : `persistDraftNow()` qui **relit l'état au flush** (l'ancien scheduleAutosave snapshotait avant le delay), latch one-shot, garde `isSubmitting`, flush awaité puis `CloseCommitted` → pop côté `:app`. BackHandler + onBack des headers MP reroutés via la VM (predictive-back perdu sur ces écrans — trade-off #803 déjà acté).

## c) `[color]` BBCode illisible en sombre — `4cb2da6d`

Le rendu appliquait le hex auteur brut (un `[#000080]` est invisible sur fond sombre). Ajout de `ensureReadableColor(color, isDark)` : **clamp minimal de luminance** (lerp vers White sous 0.10 en dark, vers Black au-dessus de 0.78 en light, teinte préservée, alpha conservé) — les couleurs déjà lisibles passent inchangées. `isDark` dérivé de `surface.luminance()` (suit AMOLED et le thème forcé), ajouté à la clé du `remember`.

## Durcissement post-gate — `b8839884`

Réserve du gate Codex : `EditorDraftStore` (Room) n'est pas contractuellement non-throwing — un flush qui throw dans le launch de fermeture aurait laissé l'écran **définitivement infermable** (latch one-shot déjà posé). Le close n'attend plus qu'un best effort : échec non-cancellation avalé et documenté, `CloseCommitted` toujours émis. Appliqué aux 3 nouvelles VMs et au handler #803 d'origine (même trou).

## Validation

- 681 tests verts sur les 4 modules touchés (+15 nouveaux : re-sync externe ×3, close ×4 par surface, couleur ×8) ; canonique complète verte (detektAll, lintDebug, :app:lintProdDebug, tests all-modules, assembleProdDebug).
- Gate Codex (gpt-5.5/xhigh) : **GO-avec-réserves** — P1 fenêtre de conflation (hypothèse écho DataStore documentée), P2 latch imgurClientId à vie (assumé), P3 flush du draft privé au back (préférable à la perte), P4 seuil 0.10 = clamp minimal, pas une promesse de contraste AA (arbitrage possible plus tard), P5 approximation surface vs surfaceContainerHighest (acceptée). La réserve dure (flush non protégé) est traitée par `b8839884`.

Réf. gate #788 / #803 (mémoire projet). Pas de mot-clé de fermeture : l'audit n'a pas d'issue dédiée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yTLMFqxPWTajUzsFwEwAZ
