### PR TITLE
fix(topic): cap the quick-reply quote-cards block so the field survives the IME (#808)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySheet.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySheet.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -31,6 +32,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -139,6 +141,13 @@ internal fun QuickReplySheet(
             }
             // #604 lot 4a — shared column : cards + live-region announcements + post-removal
             // focus (always composed ; renders nothing visible without cards).
+            // #808 — the cards block is CAPPED and scrolls internally so a heavy selection can
+            // never push the field and « Envoyer » under the IME fold : the field is the priority
+            // surface. Same pattern as the editor's EditorQuoteCards (192dp) and
+            // RecipientManagerSheet. Unconditional cap (no isImeVisible gate) : the field
+            // autofocuses on open so the IME is quasi-permanent here, and the cap also covers
+            // landscape ; nested same-direction scroll has a working precedent in
+            // RecipientManagerSheet.
             QuoteCardsColumn(
                 quotes = state.quotes,
                 enabled = !state.isSubmitting,
@@ -147,6 +156,10 @@ internal fun QuickReplySheet(
                     onMoveDown = { numreponse -> viewModel.onQuoteMoved(numreponse, delta = 1) },
                     onRemove = viewModel::onQuoteRemoved,
                 ),
+                modifier = Modifier
+                    .heightIn(max = QUICK_REPLY_MAX_CARDS_HEIGHT)
+                    .verticalScroll(rememberScrollState())
+                    .testTag("quick_reply_quote_cards"),
             )
             OutlinedTextField(
                 value = state.text,
@@ -238,3 +251,12 @@ internal fun QuickReplySubmitError.messageRes(): Int = when (this) {
 
 // #604 lot 3 — QuoteCard / QuoteCardControls promoted to `:core:ui` (core.ui.editor.QuoteCards):
 // the full-screen editor renders the same cards (mockup P3), one rendering for both surfaces.
+
+/**
+ * #808 — cap of the quote-cards block inside the sheet : two full one-line cards (2 x 48dp
+ * touch-target rows + 8dp spacing) plus the hint of a third, so the field and « Envoyer » always
+ * stay reachable with the IME up. The editor's sibling cap is 192dp (~4 cards) — the sheet is a
+ * tighter surface, it gets the smaller budget. `internal` : QuickReplyQuoteCardsCapTest mounts
+ * the capped block with this exact value to pin the budget.
+ */
+internal val QUICK_REPLY_MAX_CARDS_HEIGHT = 112.dp

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyQuoteCardsCapTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyQuoteCardsCapTest.kt
@@ -1,0 +1,80 @@
+package fr.forumhfr.redface2.feature.topic
+
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performScrollToNode
+import fr.forumhfr.redface2.core.model.write.QuotedPostPreview
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import fr.forumhfr.redface2.core.ui.editor.QuoteCardsCallbacks
+import fr.forumhfr.redface2.core.ui.editor.QuoteCardsColumn
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * #808 — the quote-cards block of the quick-reply sheet is CAPPED so a heavy selection can never
+ * crush the text field under the IME. This mounts the exact capped block QuickReplySheet composes
+ * (same [QUICK_REPLY_MAX_CARDS_HEIGHT] + internal scroll) with more cards than the budget holds,
+ * and pins the two halves of the contract : the block never grows past the cap, and the cards
+ * past the fold stay reachable through the block's OWN scroll.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@OptIn(ExperimentalTestApi::class)
+class QuickReplyQuoteCardsCapTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `five cards never grow the block past the cap and scroll to the last one`() {
+        val quotes = (1..5).map { n ->
+            QuotedPostPreview(numreponse = n, author = "author$n", excerpt = "excerpt $n")
+        }
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                QuoteCardsColumn(
+                    quotes = quotes,
+                    enabled = true,
+                    callbacks = QuoteCardsCallbacks(
+                        onMoveUp = {},
+                        onMoveDown = {},
+                        onRemove = {},
+                    ),
+                    modifier = Modifier
+                        .heightIn(max = QUICK_REPLY_MAX_CARDS_HEIGHT)
+                        .verticalScroll(rememberScrollState())
+                        .testTag(BLOCK_TAG),
+                )
+            }
+        }
+
+        val block = composeTestRule.onNodeWithTag(BLOCK_TAG)
+        val height = block.fetchSemanticsNode().boundsInRoot.height
+        val capPx = with(composeTestRule.density) { QUICK_REPLY_MAX_CARDS_HEIGHT.toPx() }
+        assertTrue(
+            "cards block is ${height}px, cap is ${capPx}px",
+            height <= capPx + 1f,
+        )
+
+        // The 5th card sits past the fold — the block's own scroll must reach it.
+        block.performScrollToNode(hasText("author5", substring = true))
+        composeTestRule.onNode(hasText("author5", substring = true)).assertExists()
+    }
+
+    private companion object {
+        const val BLOCK_TAG = "quick_reply_quote_cards_under_test"
+    }
+}


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

La feuille de réponse rapide composait `QuoteCardsColumn` **sans plafond** : clavier levé (~40 % de l'écran, et le champ s'autofocus à l'ouverture), une grosse sélection poussait le champ et « Envoyer » sous le pli — seul écart entre les deux surfaces, l'éditeur plein écran plafonne déjà ses cartes à 192 dp depuis le lot 3.

## Fix

Plafond de **112 dp** (~2 cartes une-ligne + l'amorce de la 3e) + scroll interne au bloc, au call-site (le composant partagé `:core:ui` est inchangé — l'éditeur applique déjà son propre cap au sien). Réplication à l'identique du pattern maison (`EditorQuoteCards`, `RecipientManagerSheet` pour le scroll imbriqué même-direction dans une bottom sheet). Cap **inconditionnel** : pas de gate `isImeVisible` (première `ExperimentalLayoutApi` du repo et intestable sous Robolectric), et le cap couvre aussi le paysage.

## Tests

`QuickReplyQuoteCardsCapTest` (Robolectric/Compose) : 5 cartes → le bloc ne dépasse jamais le cap, et la 5e carte reste atteignable par le scroll propre du bloc. `:feature:topic:testDebugUnitTest` vert. Le cas nominal (2 cartes, seuil 3+ routant vers le plein écran) est couvert par les tests de routage existants ; `state.quotes` peut dépasser 2 en cours de session, d'où le test à 5.

Pas de review Codex dédiée : réplication mécanique d'un pattern déjà gaté (lot 3 / lot 4a) — signalé conformément à la cadence.

Closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yTLMFqxPWTajUzsFwEwAZ