### PR TITLE
feat(data): implicit AND between wiki smiley search terms (#794)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/smiley/DefaultSmileyRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/smiley/DefaultSmileyRepository.kt
@@ -39,7 +39,7 @@ class DefaultSmileyRepository @Inject constructor(
         // the same network error. `CancellationException` still propagates untouched via
         // `withContext`'s structured concurrency.
         return withContext(ioDispatcher) {
-            val fragment = hfrClient.getSmileySearch(userId = userId, query = query)
+            val fragment = hfrClient.getSmileySearch(userId = userId, query = toImplicitAndQuery(query))
             val results = parser.parse(fragment)
             diagnostics.record(
                 DiagnosticsLog.Level.DEBUG,
@@ -54,3 +54,22 @@ class DefaultSmileyRepository @Inject constructor(
         private const val LOG_TAG = "SmileyRepository"
     }
 }
+
+/**
+ * #794 — implicit AND between search terms. The wiki engine treats a bare space as OR (union,
+ * server-capped at 1000 rows), `+term` as a requirement and `-term` as an exclusion — all three
+ * live-verified on `message-smi-mp-aj.php` (2026-07-05 : `chat noir`=1000, `+chat +noir`=25,
+ * `+chat -noir`=657−25). Nobody searching « chat noir » wants the union, so every UNOPERATED term
+ * gets a `+` prefix ; terms the user already prefixed with `+` or `-` keep their operator (the
+ * NOT is functional and must not be clobbered). Pure and unit-tested ; blank input is returned
+ * untouched.
+ */
+internal fun toImplicitAndQuery(raw: String): String {
+    val terms = raw.trim().split(WHITESPACE).filter { it.isNotBlank() }
+    if (terms.isEmpty()) return raw
+    return terms.joinToString(" ") { term ->
+        if (term.startsWith('+') || term.startsWith('-')) term else "+$term"
+    }
+}
+
+private val WHITESPACE = Regex("""\s+""")

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/smiley/DefaultSmileyRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/smiley/DefaultSmileyRepositoryTest.kt
@@ -1,0 +1,74 @@
+package fr.forumhfr.redface2.core.data.smiley
+
+import fr.forumhfr.redface2.core.domain.diagnostics.DiagnosticsLog
+import fr.forumhfr.redface2.core.network.HfrClient
+import fr.forumhfr.redface2.core.parser.smiley.SmileySearchParser
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #794 — the wiki search applies an implicit AND between terms. The engine's operators were
+ * live-verified (2026-07-05) : bare space = OR, `+term` = AND, `-term` = NOT — so the repository
+ * prefixes every unoperated term with `+` before the network call, and never rewrites an
+ * operator the user typed.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultSmileyRepositoryTest {
+
+    private val hfrClient = mockk<HfrClient> {
+        coEvery { getSmileySearch(userId = any(), query = any()) } returns ""
+    }
+    private val parser = mockk<SmileySearchParser> {
+        every { parse(any()) } returns emptyList()
+    }
+    private val diagnostics = mockk<DiagnosticsLog>(relaxed = true)
+
+    private fun repository() = DefaultSmileyRepository(
+        hfrClient = hfrClient,
+        parser = parser,
+        diagnostics = diagnostics,
+        ioDispatcher = UnconfinedTestDispatcher(),
+    )
+
+    @Test
+    fun `two bare terms reach the network with a plus prefix each`() = runTest {
+        repository().searchWiki(userId = 54596, query = "chat noir")
+
+        coVerify(exactly = 1) { hfrClient.getSmileySearch(54596, "+chat +noir") }
+    }
+
+    @Test
+    fun `user-typed operators are preserved, bare terms still get the AND prefix`() = runTest {
+        repository().searchWiki(userId = 54596, query = "chat -noir +blanc")
+
+        coVerify(exactly = 1) { hfrClient.getSmileySearch(54596, "+chat -noir +blanc") }
+    }
+
+    @Test
+    fun `a single term is prefixed too and extra whitespace collapses`() = runTest {
+        repository().searchWiki(userId = 54596, query = "  jap\t roi ")
+
+        coVerify(exactly = 1) { hfrClient.getSmileySearch(54596, "+jap +roi") }
+    }
+
+    // Pure-helper edge cases (no network shape to pin) :
+
+    @Test
+    fun `blank input is returned untouched`() {
+        assertEquals("   ", toImplicitAndQuery("   "))
+        assertEquals("", toImplicitAndQuery(""))
+    }
+
+    @Test
+    fun `already fully operated input is idempotent`() {
+        assertEquals("+chat -noir", toImplicitAndQuery("+chat -noir"))
+        assertEquals("+chat -noir", toImplicitAndQuery(toImplicitAndQuery("chat -noir")))
+    }
+}


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Suggestion de Dintr-un lemn (fil DEV 03/07) : personne ne veut le OR par défaut du moteur wiki en cherchant « chat noir ».

## Contrat vérifié live (commenté sur #794)

| `findsmilies` | résultats | lecture |
|---|---|---|
| `chat noir` | 1000 | OR (union cappée) |
| `+chat +noir` | 25 | AND |
| `+chat -noir` | 632 | `-` = NOT |

## Fix

Helper pur `toImplicitAndQuery` appliqué dans `DefaultSmileyRepository.searchWiki` (couvre les 4 surfaces d'un coup — éditeur, formulaire topic, MP compose/reply) : chaque terme **non opéré** reçoit un `+` ; les opérateurs saisis par l'utilisateur (`+`/`-`) sont préservés. Gate UI 3 caractères et log privacy (`queryLength` brut) inchangés.

## Tests

5 tests (`DefaultSmileyRepositoryTest`, nouveau) : la query transformée atteint le réseau (coVerify ×3 dont préservation d'opérateurs), blanc intouché, idempotence. `:core:data:testDebugUnitTest` vert.

Pas de review Codex dédiée : fonction pure + un point d'appel, contrat serveur prouvé live — signalé conformément à la cadence.

Closes #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yTLMFqxPWTajUzsFwEwAZ