### PR TITLE
feat(topic,settings): writing surface presets — sheet, sheet-except-quotes, full editor (#806)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -27,6 +27,7 @@ import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
+import fr.forumhfr.redface2.core.model.editor.WritingSurfacePreset
 import fr.forumhfr.redface2.core.model.FlagType
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -360,6 +361,22 @@ class DataStoreUserPreferencesRepository @Inject constructor(
         persist {
             dataStore.edit { prefs ->
                 prefs[KEY_QUOTE_CARDS_ENABLED] = enabled
+            }
+        }
+    }
+
+    override fun observeWritingSurfacePreset(): Flow<WritingSurfacePreset> =
+        dataStore.data
+            // Default SHEET (#806): the 0.25.1 behaviour — quick-reply sheet everywhere, with the
+            // 3+ multi-quote threshold escalating to the full-screen editor.
+            .map(::readWritingSurfacePreset)
+            .distinctUntilChanged()
+            .catch { emit(WritingSurfacePreset.SHEET) }
+
+    override suspend fun setWritingSurfacePreset(preset: WritingSurfacePreset) {
+        persist {
+            dataStore.edit { prefs ->
+                prefs[KEY_WRITING_SURFACE_PRESET] = preset.name
             }
         }
     }
@@ -760,6 +777,12 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             ?.let { stored -> runCatching { EditorImageInsert.valueOf(stored) }.getOrNull() }
             ?: EditorImageInsert.REDUCED
 
+    /** Reads [KEY_WRITING_SURFACE_PRESET] defensively; unknown / corrupt value → [WritingSurfacePreset.SHEET]. */
+    private fun readWritingSurfacePreset(prefs: Preferences): WritingSurfacePreset =
+        prefs[KEY_WRITING_SURFACE_PRESET]
+            ?.let { stored -> runCatching { WritingSurfacePreset.valueOf(stored) }.getOrNull() }
+            ?: WritingSurfacePreset.SHEET
+
     /**
      * Reads [KEY_DISPLAY_DENSITY] defensively (#287): an unknown / corrupt stored value (older
      * build, manual edit) falls back to [DisplayDensity.COMFORT] instead of crashing on
@@ -981,6 +1004,9 @@ class DataStoreUserPreferencesRepository @Inject constructor(
 
         // #805 arbitrage — quote cards in the composer (default OFF = inline [quotemsg] BBCode).
         val KEY_QUOTE_CARDS_ENABLED = booleanPreferencesKey("quote_cards_enabled")
+
+        // #806 — writing-surface preset (WritingSurfacePreset.name, defensively parsed).
+        val KEY_WRITING_SURFACE_PRESET = stringPreferencesKey("writing_surface_preset")
 
         // Opt-in « DT » placeholder tab on the Drapeaux screen (MPStorage sync lands later, #6).
         val KEY_FLAGS_SHOW_DT_SECTION = booleanPreferencesKey("flags_show_dt_section")

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -23,6 +23,7 @@ import fr.forumhfr.redface2.core.domain.preferences.ThemeBootstrapStore
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
+import fr.forumhfr.redface2.core.model.editor.WritingSurfacePreset
 import fr.forumhfr.redface2.core.model.FlagType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -1070,6 +1071,41 @@ class DataStoreUserPreferencesRepositoryTest {
         repository.setEditorImageInsert(EditorImageInsert.REDUCED)
         repository.observeEditorImageInsert().test {
             assertEquals(EditorImageInsert.REDUCED, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `observeWritingSurfacePreset defaults to SHEET on an empty store`() = runTest(dispatcher) {
+        // #806 — SHEET is the default (the 0.25.1 behaviour), never the enum's first ordinal by chance.
+        repository.observeWritingSurfacePreset().test {
+            assertEquals(WritingSurfacePreset.SHEET, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setWritingSurfacePreset persists and round-trips FULL_EDITOR then SHEET`() = runTest(dispatcher) {
+        repository.setWritingSurfacePreset(WritingSurfacePreset.FULL_EDITOR)
+        repository.observeWritingSurfacePreset().test {
+            assertEquals(WritingSurfacePreset.FULL_EDITOR, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repository.setWritingSurfacePreset(WritingSurfacePreset.SHEET)
+        repository.observeWritingSurfacePreset().test {
+            assertEquals(WritingSurfacePreset.SHEET, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `corrupt writing_surface_preset value falls back to SHEET instead of crashing`() = runTest(dispatcher) {
+        // An unknown value (older build / manual edit) must degrade to SHEET, not crash valueOf.
+        dataStore.edit { prefs -> prefs[stringPreferencesKey("writing_surface_preset")] = "HOLODECK" }
+
+        repository.observeWritingSurfacePreset().test {
+            assertEquals(WritingSurfacePreset.SHEET, awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -22,6 +22,7 @@ import fr.forumhfr.redface2.core.domain.preferences.PlusLusIndicatorStyle
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
+import fr.forumhfr.redface2.core.model.editor.WritingSurfacePreset
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.network.HfrClient
 import fr.forumhfr.redface2.core.parser.HfrParser
@@ -573,6 +574,12 @@ class TopicRepositoryImplTest {
         override fun observeQuoteCardsEnabled(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setQuoteCardsEnabled(enabled: Boolean) = Unit
+
+        // #806 — writing surface is irrelevant to TopicRepositoryImpl; stubbed at its default.
+        override fun observeWritingSurfacePreset(): Flow<WritingSurfacePreset> =
+            MutableStateFlow(WritingSurfacePreset.SHEET)
+
+        override suspend fun setWritingSurfacePreset(preset: WritingSurfacePreset) = Unit
 
         override fun observeShowDtSection(): Flow<Boolean> = MutableStateFlow(false)
 

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -3,6 +3,7 @@ package fr.forumhfr.redface2.core.domain.preferences
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
+import fr.forumhfr.redface2.core.model.editor.WritingSurfacePreset
 import kotlinx.coroutines.flow.Flow
 
 interface UserPreferencesRepository {
@@ -248,6 +249,19 @@ interface UserPreferencesRepository {
 
     /** Persists [observeQuoteCardsEnabled]. Default `false` until the first call. */
     suspend fun setQuoteCardsEnabled(enabled: Boolean)
+
+    /**
+     * #806 — which composition surface a write action in a topic opens (reply FAB, « Citer »,
+     * « Citer N »). Default [WritingSurfacePreset.SHEET] = the 0.25.1 behaviour exactly (quick-reply
+     * sheet everywhere, 3+ multi-quote escalating to the full-screen editor). The preset decides the
+     * surface only — quote RENDERING stays [observeQuoteCardsEnabled] (#805). A corrupt / unknown
+     * stored value degrades to the default. Observed by `:feature:topic` (decision at tap time, an
+     * open sheet is never migrated), chosen in Settings (« Édition et publication »).
+     */
+    fun observeWritingSurfacePreset(): Flow<WritingSurfacePreset>
+
+    /** Persists [observeWritingSurfacePreset]. Default [WritingSurfacePreset.SHEET] until the first call. */
+    suspend fun setWritingSurfacePreset(preset: WritingSurfacePreset)
 
     /**
      * Opt-in « DT » section on the Drapeaux screen: when `true`, a « DT » tab appears next

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/editor/WritingSurfacePreset.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/editor/WritingSurfacePreset.kt
@@ -1,0 +1,25 @@
+package fr.forumhfr.redface2.core.model.editor
+
+/**
+ * Which composition surface opens when the user starts writing from a topic (#806): the reply FAB,
+ * « Citer » on a single post, or « Citer N » on the multi-quote basket. The preset decides the
+ * SURFACE only — how citations render inside it (compact cards vs inline `[quotemsg]` BBCode) stays
+ * the separate quote-cards preference (#805). The decision is taken AT TAP TIME: a preset change
+ * never migrates a sheet (or editor) already open.
+ *
+ * The enum [name] is serialised verbatim into DataStore — renaming an entry needs a defensive read.
+ */
+enum class WritingSurfacePreset {
+    /**
+     * Default — the 0.25.1 behaviour, exactly: every write action opens the quick-reply sheet,
+     * except a multi-quote basket of 3+ cards which goes straight to the full-screen editor
+     * (the #604 lot 3 threshold, which guards THIS preset only).
+     */
+    SHEET,
+
+    /** The sheet for plain replies; any citation (single « Citer » or « Citer N ») opens the full-screen editor. */
+    SHEET_EXCEPT_QUOTES,
+
+    /** Every write action opens the full-screen editor; the quick-reply sheet never shows. */
+    FULL_EDITOR,
+}

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -32,6 +32,7 @@ import fr.forumhfr.redface2.core.domain.upload.ImageUploadReader
 import fr.forumhfr.redface2.core.domain.upload.UploadException
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
+import fr.forumhfr.redface2.core.model.editor.WritingSurfacePreset
 import fr.forumhfr.redface2.core.domain.upload.UploadRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadedImage
 import fr.forumhfr.redface2.core.domain.upload.UploadedImageRecord
@@ -2298,6 +2299,12 @@ class PostEditorViewModelTest {
         override suspend fun setQuoteCardsEnabled(enabled: Boolean) {
             quoteCardsEnabled.value = enabled
         }
+
+        // #806 — the writing-surface preset routes taps in :feature:topic, not here; default stub.
+        override fun observeWritingSurfacePreset(): Flow<WritingSurfacePreset> =
+            MutableStateFlow(WritingSurfacePreset.SHEET)
+
+        override suspend fun setWritingSurfacePreset(preset: WritingSurfacePreset) = Unit
 
         override fun observeShowDtSection(): Flow<Boolean> = MutableStateFlow(false)
 

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -36,6 +36,7 @@ import fr.forumhfr.redface2.core.domain.upload.UploadedImage
 import fr.forumhfr.redface2.core.domain.upload.UploadedImageRecord
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
+import fr.forumhfr.redface2.core.model.editor.WritingSurfacePreset
 import fr.forumhfr.redface2.core.domain.write.TopicFormRepository
 import fr.forumhfr.redface2.core.model.EditorSmiley
 import fr.forumhfr.redface2.core.model.EditorSmileySource
@@ -1628,6 +1629,12 @@ class TopicFormViewModelTest {
 
         override fun observeQuoteCardsEnabled(): Flow<Boolean> = MutableStateFlow(false)
         override suspend fun setQuoteCardsEnabled(enabled: Boolean) = Unit
+
+        // #806 — the writing-surface preset routes taps in :feature:topic, not here; default stub.
+        override fun observeWritingSurfacePreset(): Flow<WritingSurfacePreset> =
+            MutableStateFlow(WritingSurfacePreset.SHEET)
+
+        override suspend fun setWritingSurfacePreset(preset: WritingSurfacePreset) = Unit
 
         override fun observeShowDtSection(): Flow<Boolean> = MutableStateFlow(false)
 

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -31,6 +31,7 @@ import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
+import fr.forumhfr.redface2.core.model.editor.WritingSurfacePreset
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.Category
 import fr.forumhfr.redface2.core.model.Flag
@@ -2616,6 +2617,12 @@ class FlagsViewModelTest {
         override fun observeQuoteCardsEnabled(): Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setQuoteCardsEnabled(enabled: Boolean) = Unit
+
+        // #806 — writing surface is irrelevant to FlagsViewModel; stubbed at its default.
+        override fun observeWritingSurfacePreset(): Flow<WritingSurfacePreset> =
+            MutableStateFlow(WritingSurfacePreset.SHEET)
+
+        override suspend fun setWritingSurfacePreset(preset: WritingSurfacePreset) = Unit
 
         override fun observeShowDtSection(): Flow<Boolean> = MutableStateFlow(false)
 

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsScreen.kt
@@ -8,9 +8,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
@@ -25,9 +27,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.forumhfr.redface2.core.model.editor.WritingSurfacePreset
 import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsListItem
 import fr.forumhfr.redface2.core.ui.settings.RedfaceSettingsSearchTopBar
 import fr.forumhfr.redface2.core.ui.settings.shell.SettingsHomeScreen
@@ -598,6 +602,58 @@ internal fun buildSettingsCatalogue(
                     .takeIf { state.confirmBeforePostingError },
                 onCheckedChange = { onIntent(SettingsIntent.ConfirmBeforePostingChanged(it)) },
             ),
+            // #806 — writing-surface radio group (3 single-choice rows, one per preset). The
+            // group picks WHICH surface a write action opens ; the quote-cards toggle below picks
+            // how citations RENDER inside it — deliberately separate copy so the two don't blur.
+            radioRow(
+                id = "writing_surface_sheet",
+                title = stringResource(R.string.settings_writing_surface_sheet),
+                description = stringResource(R.string.settings_writing_surface_sheet_description),
+                keywords = listOf(
+                    stringResource(R.string.settings_writing_surface_title),
+                    "feuille",
+                    "réponse rapide",
+                    "plein écran",
+                    "éditeur",
+                ),
+                selected = state.writingSurfacePreset == WritingSurfacePreset.SHEET,
+                enabled = state.canChangeWritingSurfacePreset,
+                onSelect = { onIntent(SettingsIntent.SetWritingSurfacePreset(WritingSurfacePreset.SHEET)) },
+                groupTitle = stringResource(R.string.settings_writing_surface_title),
+            ),
+            radioRow(
+                id = "writing_surface_sheet_except_quotes",
+                title = stringResource(R.string.settings_writing_surface_sheet_except_quotes),
+                description = stringResource(R.string.settings_writing_surface_sheet_except_quotes_description),
+                keywords = listOf(
+                    stringResource(R.string.settings_writing_surface_title),
+                    "feuille",
+                    "citation",
+                    "plein écran",
+                    "éditeur",
+                ),
+                selected = state.writingSurfacePreset == WritingSurfacePreset.SHEET_EXCEPT_QUOTES,
+                enabled = state.canChangeWritingSurfacePreset,
+                onSelect = {
+                    onIntent(SettingsIntent.SetWritingSurfacePreset(WritingSurfacePreset.SHEET_EXCEPT_QUOTES))
+                },
+            ),
+            radioRow(
+                id = "writing_surface_full_editor",
+                title = stringResource(R.string.settings_writing_surface_full_editor),
+                description = stringResource(R.string.settings_writing_surface_full_editor_description),
+                keywords = listOf(
+                    stringResource(R.string.settings_writing_surface_title),
+                    "feuille",
+                    "plein écran",
+                    "éditeur",
+                ),
+                selected = state.writingSurfacePreset == WritingSurfacePreset.FULL_EDITOR,
+                enabled = state.canChangeWritingSurfacePreset,
+                onSelect = { onIntent(SettingsIntent.SetWritingSurfacePreset(WritingSurfacePreset.FULL_EDITOR)) },
+                errorRes = R.string.settings_writing_surface_persist_failed
+                    .takeIf { state.writingSurfacePresetError },
+            ),
             toggleRow(
                 id = "quote_cards_enabled",
                 title = stringResource(R.string.settings_quote_cards_title),
@@ -888,6 +944,60 @@ private fun toggleRow(
                 description = description,
                 trailingContent = {
                     Switch(checked = checked, enabled = enabled, onCheckedChange = onCheckedChange)
+                },
+            )
+            if (errorRes != null) {
+                Box(modifier = Modifier.padding(horizontal = 16.dp)) {
+                    PreferencePersistError(errorRes)
+                }
+            }
+        }
+    },
+)
+
+/**
+ * One option of a single-choice radio group (#806 writing surface) : a leading M3 [RadioButton] with
+ * the whole row selectable (`Role.RadioButton` semantics — the radio is not a separate touch target,
+ * so its own `onClick` is `null`). Each option is its own catalogue row so it stays individually
+ * searchable ; the group is the set of rows firing the same intent family. [groupTitle] renders a
+ * small header above the FIRST row of the group ; [errorRes] renders the group's shared persist
+ * error under the LAST row.
+ */
+@Suppress("LongParameterList") // row descriptor: id + texts + keywords + selection + slots + callback.
+private fun radioRow(
+    id: String,
+    title: String,
+    description: String,
+    keywords: List<String>,
+    selected: Boolean,
+    enabled: Boolean,
+    onSelect: () -> Unit,
+    groupTitle: String? = null,
+    errorRes: Int? = null,
+): SettingsCatalogueRow = SettingsCatalogueRow(
+    searchable = SettingsSearchableItem(id = id, title = title, description = description, keywords = keywords),
+    render = {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            if (groupTitle != null) {
+                Text(
+                    text = groupTitle,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 12.dp, bottom = 4.dp),
+                )
+            }
+            RedfaceSettingsListItem(
+                title = title,
+                description = description,
+                enabled = enabled,
+                modifier = Modifier.selectable(
+                    selected = selected,
+                    enabled = enabled,
+                    role = Role.RadioButton,
+                    onClick = onSelect,
+                ),
+                leadingContent = {
+                    RadioButton(selected = selected, onClick = null, enabled = enabled)
                 },
             )
             if (errorRes != null) {

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -7,6 +7,7 @@ import fr.forumhfr.redface2.core.domain.preferences.ImmersiveNavBarReveal
 import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
+import fr.forumhfr.redface2.core.model.editor.WritingSurfacePreset
 
 data class SettingsState(
     val proxyEnabled: Boolean = false,
@@ -182,6 +183,14 @@ data class SettingsState(
     val isUpdatingQuoteCardsEnabled: Boolean = false,
     val quoteCardsEnabledError: Boolean = false,
     val quoteCardsEnabledTouchedLocally: Boolean = false,
+    // #806 — which surface a write action in a topic opens (sheet / sheet-except-quotes / full
+    // editor). Enum, so the same bespoke optimistic-flip shape as [editorImageInsert]. Default
+    // SHEET (the 0.25.1 behaviour). Distinct from [quoteCardsEnabled], which governs the quote
+    // RENDERING inside whichever surface opens.
+    val writingSurfacePreset: WritingSurfacePreset = WritingSurfacePreset.SHEET,
+    val isUpdatingWritingSurfacePreset: Boolean = false,
+    val writingSurfacePresetError: Boolean = false,
+    val writingSurfacePresetTouchedLocally: Boolean = false,
     // Drapeaux — opt-in « DT » placeholder tab (MPStorage sync #6 lands later). Same
     // optimistic-flip + startup-race-guard machinery. Default false (tab hidden).
     val showDtSection: Boolean = false,
@@ -330,6 +339,10 @@ data class SettingsState(
     val canToggleQuoteCardsEnabled: Boolean
         get() = !isUpdatingQuoteCardsEnabled
 
+    // #806 — the writing-surface radio group is gated only by its own in-flight write.
+    val canChangeWritingSurfacePreset: Boolean
+        get() = !isUpdatingWritingSurfacePreset
+
     // DT tab — gated only by its own write.
     val canToggleShowDtSection: Boolean
         get() = !isUpdatingShowDtSection
@@ -469,6 +482,13 @@ sealed interface SettingsIntent {
 
     // #805 — quote-cards-in-composer toggle. Optimistic-flip contract, like the flags toggles.
     data class QuoteCardsEnabledChanged(val enabled: Boolean) : SettingsIntent
+
+    /**
+     * #806 — choose which surface a write action in a topic opens. `preset` is the desired
+     * selection (one intent per radio pick), applied optimistically with revert-on-failure,
+     * like [SetEditorImageInsert].
+     */
+    data class SetWritingSurfacePreset(val preset: WritingSurfacePreset) : SettingsIntent
 
     // Drapeaux — opt-in « DT » placeholder tab (MPStorage sync #6 lands later). Optimistic-flip
     // contract, like the flags toggles: the boolean is the desired post-flip state.

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModel.kt
@@ -14,6 +14,7 @@ import fr.forumhfr.redface2.core.domain.preferences.ThemeMode
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
+import fr.forumhfr.redface2.core.model.editor.WritingSurfacePreset
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
@@ -210,6 +211,12 @@ class SettingsViewModel @Inject constructor(
             isLocked = { it.isUpdatingEditorImageInsert },
             apply = { state, value -> state.copy(editorImageInsert = value) },
         )
+        // #806 — writing-surface preset (enum), same collection shape.
+        observePreference(
+            flow = userPreferencesRepository.observeWritingSurfacePreset(),
+            isLocked = { it.isUpdatingWritingSurfacePreset },
+            apply = { state, value -> state.copy(writingSurfacePreset = value) },
+        )
     }
 
     /**
@@ -297,6 +304,7 @@ class SettingsViewModel @Inject constructor(
             is SettingsIntent.SetUploadProvider -> updateUploadProvider(intent.provider)
             is SettingsIntent.SetImgurClientId -> updateImgurClientId(intent.text)
             is SettingsIntent.SetEditorImageInsert -> updateEditorImageInsert(intent.mode)
+            is SettingsIntent.SetWritingSurfacePreset -> updateWritingSurfacePreset(intent.preset)
         }
     }
 
@@ -687,6 +695,38 @@ class SettingsViewModel @Inject constructor(
                             editorImageInsert = previous,
                             isUpdatingEditorImageInsert = false,
                             editorImageInsertError = true,
+                        )
+                    }
+                }
+        }
+    }
+
+    // #806 — writing-surface preset is an enum, same optimistic-flip shape as editorImageInsert.
+    // The #788 continuous re-sync (observePreference in init) keeps every SettingsViewModel
+    // instance aligned; `isUpdatingWritingSurfacePreset` gates the re-sync during the write.
+    private fun updateWritingSurfacePreset(desired: WritingSurfacePreset) {
+        val previous = _state.value.writingSurfacePreset
+        _state.update {
+            it.copy(
+                writingSurfacePreset = desired,
+                isUpdatingWritingSurfacePreset = true,
+                writingSurfacePresetError = false,
+                writingSurfacePresetTouchedLocally = true,
+            )
+        }
+        viewModelScope.launch {
+            runCatching { userPreferencesRepository.setWritingSurfacePreset(desired) }
+                .onSuccess {
+                    _state.update {
+                        it.copy(writingSurfacePreset = desired, isUpdatingWritingSurfacePreset = false)
+                    }
+                }
+                .onFailure {
+                    _state.update {
+                        it.copy(
+                            writingSurfacePreset = previous,
+                            isUpdatingWritingSurfacePreset = false,
+                            writingSurfacePresetError = true,
                         )
                     }
                 }

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -353,6 +353,17 @@
     <string name="settings_confirm_before_posting_title">Confirmation avant publication</string>
     <string name="settings_confirm_before_posting_description">Avant chaque réponse, sujet ou MP envoyé.</string>
     <string name="settings_confirm_before_posting_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
+    <!-- #806 — surface d'écriture : quelle surface s'ouvre quand on répond ou cite depuis un sujet
+         (feuille de réponse rapide ou éditeur plein écran). Le réglage choisit la SURFACE seulement ;
+         le rendu des citations (cartes ou BBCode) reste le réglage « Citations en cartes » ci-dessous. -->
+    <string name="settings_writing_surface_title">Surface d\'écriture</string>
+    <string name="settings_writing_surface_sheet">Toujours la feuille</string>
+    <string name="settings_writing_surface_sheet_description">Répondre et citer ouvrent la feuille de réponse rapide ; à partir de 3 citations, l\'éditeur plein écran prend le relais.</string>
+    <string name="settings_writing_surface_sheet_except_quotes">Feuille sauf citations</string>
+    <string name="settings_writing_surface_sheet_except_quotes_description">Répondre ouvre la feuille ; toute citation ouvre l\'éditeur plein écran.</string>
+    <string name="settings_writing_surface_full_editor">Toujours plein écran</string>
+    <string name="settings_writing_surface_full_editor_description">Répondre et citer ouvrent directement l\'éditeur plein écran.</string>
+    <string name="settings_writing_surface_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
     <string name="settings_quote_cards_title">Citations en cartes</string>
     <string name="settings_quote_cards_description">Représente les citations par des cartes compactes au-dessus du champ. Désactivé : la citation est insérée en BBCode, modifiable dans le texte.</string>
     <string name="settings_quote_cards_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -18,6 +18,7 @@ import fr.forumhfr.redface2.core.domain.preferences.PlusLusIndicatorStyle
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
+import fr.forumhfr.redface2.core.model.editor.WritingSurfacePreset
 import fr.forumhfr.redface2.core.model.FlagType
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -1404,6 +1405,53 @@ class SettingsViewModelTest {
         assertTrue(viewModel.state.value.quoteCardsEnabledError)
     }
 
+    // ──────────────────────────────────────────────────────────────────────
+    // Writing surface preset (#806)
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `writingSurfacePreset re-syncs continuously from the persisted preference (#788)`() = runTest {
+        val viewModel = newViewModel()
+        assertEquals(
+            "#806 — SHEET is the default (the 0.25.1 behaviour)",
+            WritingSurfacePreset.SHEET,
+            viewModel.state.value.writingSurfacePreset,
+        )
+
+        // An external write (another SettingsViewModel instance, or any other writer) must land
+        // in THIS instance too — the #788 continuous re-sync, not a one-shot hydration.
+        repository.emitWritingSurfacePreset(WritingSurfacePreset.SHEET_EXCEPT_QUOTES)
+
+        assertEquals(WritingSurfacePreset.SHEET_EXCEPT_QUOTES, viewModel.state.value.writingSurfacePreset)
+    }
+
+    @Test
+    fun `SetWritingSurfacePreset persists the pick`() = runTest {
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.SetWritingSurfacePreset(WritingSurfacePreset.FULL_EDITOR))
+
+        assertEquals(WritingSurfacePreset.FULL_EDITOR, viewModel.state.value.writingSurfacePreset)
+        assertFalse(viewModel.state.value.isUpdatingWritingSurfacePreset)
+        assertEquals(1, repository.writingSurfacePresetSetCalls)
+    }
+
+    @Test
+    fun `SetWritingSurfacePreset reverts and raises the error flag on persist failure`() = runTest {
+        repository.failOnWritingSurfacePresetSet = true
+        val viewModel = newViewModel()
+
+        viewModel.submit(SettingsIntent.SetWritingSurfacePreset(WritingSurfacePreset.FULL_EDITOR))
+
+        assertEquals(
+            "must revert to the previous value on failure",
+            WritingSurfacePreset.SHEET,
+            viewModel.state.value.writingSurfacePreset,
+        )
+        assertFalse(viewModel.state.value.isUpdatingWritingSurfacePreset)
+        assertTrue(viewModel.state.value.writingSurfacePresetError)
+    }
+
     @Test
     fun `init hydrates the experimental MPStorage write opt-in from the persisted preference`() = runTest {
         repository.emitSyncPrivateMessagesWriteEnabled(true)
@@ -2083,6 +2131,24 @@ class SettingsViewModelTest {
             quoteCardsEnabledSetCalls += 1
             check(!failOnQuoteCardsEnabledSet) { "boom" }
             quoteCardsEnabled.value = enabled
+        }
+
+        // #806 — writing-surface preset. Same optimistic-flip seam, enum-typed.
+        private val writingSurfacePreset = MutableStateFlow(WritingSurfacePreset.SHEET)
+        var writingSurfacePresetSetCalls: Int = 0
+            private set
+        var failOnWritingSurfacePresetSet: Boolean = false
+
+        override fun observeWritingSurfacePreset(): Flow<WritingSurfacePreset> = writingSurfacePreset
+
+        override suspend fun setWritingSurfacePreset(preset: WritingSurfacePreset) {
+            writingSurfacePresetSetCalls += 1
+            check(!failOnWritingSurfacePresetSet) { "boom" }
+            writingSurfacePreset.value = preset
+        }
+
+        fun emitWritingSurfacePreset(value: WritingSurfacePreset) {
+            writingSurfacePreset.value = value
         }
 
         private val showDtSection = MutableStateFlow(false)

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -96,6 +96,7 @@ import fr.forumhfr.redface2.core.domain.author.isRf2Creator
 import fr.forumhfr.redface2.core.model.Poll
 import fr.forumhfr.redface2.core.model.Post
 import fr.forumhfr.redface2.core.model.Topic
+import fr.forumhfr.redface2.core.model.editor.WritingSurfacePreset
 import fr.forumhfr.redface2.core.model.postContentExcerpt
 import fr.forumhfr.redface2.core.model.write.QuotedPostPreview
 import fr.forumhfr.redface2.core.ui.RedfacePlaceholderScreen
@@ -683,7 +684,11 @@ private const val REANCHOR_STABLE_FRAMES = 3
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-@Suppress("LongParameterList") // state-hoisted Composable : each param has a distinct call-site.
+// LongParameterList: state-hoisted Composable, each param has a distinct call-site.
+// CyclomaticComplexMethod: the #806 tap-time surface routing adds one two-branch `when` per write
+// entry point (FAB / « Citer » / « Citer N ») — flat dispatches, the decision table itself lives
+// in the pure `writingSurfaceFor`.
+@Suppress("LongParameterList", "CyclomaticComplexMethod")
 internal fun TopicContent(
     state: TopicUiState,
     listState: LazyListState,
@@ -742,10 +747,11 @@ internal fun TopicContent(
     } else {
         null
     }
-    // Vague 4 (#604) lots 1-2 — the reply FAB and « Citer » both open the quick-reply sheet
-    // instead of navigating ; the sheet escalates to the full-screen editor through onReply.
-    // Local UI state (like the page picker) : non-null while the sheet is up, carrying the
-    // reply coordinates plus the card « Citer » pre-arms (null from the FAB).
+    // Vague 4 (#604) lots 1-2 / #806 — the reply FAB and « Citer » open the quick-reply sheet
+    // when the user's writing-surface preset routes them there (writingSurfaceFor, decided at
+    // tap time) ; the sheet escalates to the full-screen editor through onReply. Local UI state
+    // (like the page picker) : non-null while the sheet is up, carrying the reply coordinates
+    // plus the card « Citer » pre-arms (null from the FAB).
     var quickReplyFor by remember { mutableStateOf<QuickReplyLaunch?>(null) }
     // #291 — the per-post toggle checkmarks and the « ❝N » count only need the numreponses.
     val multiQuoteNumreponses = multiQuoteSelections.map { it.numreponse }
@@ -775,35 +781,50 @@ internal fun TopicContent(
                 bottomActionsVisible = bottomActionsVisible,
                 multiQuoteSelection = multiQuoteNumreponses,
                 onOpenPage = onOpenPage,
+                // #806 — the surface is decided AT TAP TIME from the preset (never re-evaluated
+                // on recomposition, never migrating an already-open sheet). No quotes here, so
+                // only the FULL_EDITOR preset skips the sheet.
                 onReply = { subcat, page ->
-                    quickReplyFor = QuickReplyLaunch(
-                        request = QuickReplyRequest(
-                            cat = state.request.cat,
-                            subcat = subcat,
-                            topicId = state.request.post,
-                            page = page,
-                        ),
-                    )
-                },
-                // #604 lot 3 — threshold routing (mockup P3, « le cas qui force le plein
-                // écran ») : a small selection opens the quick-reply sheet with the cards
-                // pre-armed and consumes the basket HERE (the cards live on in the sheet's
-                // ViewModel) ; from MULTI_QUOTE_FULL_EDITOR_THRESHOLD up, the full-screen
-                // editor path (`:app`, in-memory handoff + basket clear) takes over.
-                onMultiQuote = { subcat, page ->
-                    if (multiQuoteOpensFullEditor(multiQuoteSelections.size)) {
-                        onMultiQuote(subcat, page)
-                    } else {
-                        quickReplyFor = QuickReplyLaunch(
+                    when (writingSurfaceFor(state.writingSurfacePreset, quoteCount = 0)) {
+                        WritingSurface.SHEET -> quickReplyFor = QuickReplyLaunch(
                             request = QuickReplyRequest(
                                 cat = state.request.cat,
                                 subcat = subcat,
                                 topicId = state.request.post,
                                 page = page,
                             ),
-                            initialQuotes = multiQuoteSelections,
                         )
-                        onClearMultiQuote()
+                        // Same :app path as the sheet's escalation — in-memory quote handoff
+                        // (empty) + PostEditorRoute(resumeSharedDraft = true).
+                        WritingSurface.FULL_EDITOR -> onReply(subcat, page, emptyList())
+                    }
+                },
+                // #604 lot 3 / #806 — preset routing (mockup P3, « le cas qui force le plein
+                // écran ») : when the sheet wins, the cards are pre-armed and the basket is
+                // consumed HERE (they live on in the sheet's ViewModel) ; when the full-screen
+                // editor wins (3+ under SHEET, any citation under SHEET_EXCEPT_QUOTES, always
+                // under FULL_EDITOR), the `:app` path (in-memory handoff + basket clear) takes
+                // over. The sheet branch snapshots the selection BEFORE its local clear so the
+                // launch can never observe a half-emptied basket ; the full-editor branch
+                // delegates to the existing `:app` contract, which reads the hoisted basket and
+                // hands it over BEFORE clearing it (RedfaceNavigation, « Citer N » entry) — the
+                // local snapshot is not what that branch ships (gate Codex #806).
+                onMultiQuote = { subcat, page ->
+                    val selection = multiQuoteSelections.toList()
+                    when (writingSurfaceFor(state.writingSurfacePreset, quoteCount = selection.size)) {
+                        WritingSurface.FULL_EDITOR -> onMultiQuote(subcat, page)
+                        WritingSurface.SHEET -> {
+                            quickReplyFor = QuickReplyLaunch(
+                                request = QuickReplyRequest(
+                                    cat = state.request.cat,
+                                    subcat = subcat,
+                                    topicId = state.request.post,
+                                    page = page,
+                                ),
+                                initialQuotes = selection,
+                            )
+                            onClearMultiQuote()
+                        }
                     }
                 },
                 // #436 — « Tout vider » : the long press on « ❝N » resets the hoisted basket.
@@ -867,18 +888,24 @@ internal fun TopicContent(
                             state = state,
                             topic = mode.topic,
                             hiddenNumreponses = mode.hiddenNumreponses,
-                            // #604 lot 2 — « Citer » opens the quick-reply sheet with the card
-                            // pre-armed (1-citation session) instead of the full-screen editor.
+                            // #604 lot 2 / #806 — « Citer » opens the quick-reply sheet with the
+                            // card pre-armed (1-citation session), unless the preset routes any
+                            // citation to the full-screen editor (decision at tap time; same :app
+                            // path as the sheet's escalation, resumeSharedDraft = true).
                             onQuoteRequested = { preview ->
-                                quickReplyFor = QuickReplyLaunch(
-                                    request = QuickReplyRequest(
-                                        cat = state.request.cat,
-                                        subcat = mode.topic.subcat,
-                                        topicId = state.request.post,
-                                        page = mode.topic.page,
-                                    ),
-                                    initialQuotes = listOf(preview),
-                                )
+                                when (writingSurfaceFor(state.writingSurfacePreset, quoteCount = 1)) {
+                                    WritingSurface.SHEET -> quickReplyFor = QuickReplyLaunch(
+                                        request = QuickReplyRequest(
+                                            cat = state.request.cat,
+                                            subcat = mode.topic.subcat,
+                                            topicId = state.request.post,
+                                            page = mode.topic.page,
+                                        ),
+                                        initialQuotes = listOf(preview),
+                                    )
+                                    WritingSurface.FULL_EDITOR ->
+                                        onReply(mode.topic.subcat, mode.topic.page, listOf(preview))
+                                }
                             },
                             onEdit = onEdit,
                             onEditFirstPost = onEditFirstPost,
@@ -2772,24 +2799,43 @@ private fun ReplyFab(onClick: () -> Unit) {
 // not purged on logout, cf. CacheInvalidator), so these gates consult auth explicitly instead
 // of trusting `canReply` alone — symmetric with the « Créer topic » FAB
 // (CategoryViewModel.canCreateTopic).
-// #604 lots 2-3 — what opens the quick-reply sheet : the reply coordinates, plus the cards this
-// opening pre-arms (one for « Citer », the whole basket for « Citer N » under the full-screen
-// threshold, empty from the reply FAB).
+// #604 lots 2-3 / #806 — what opens the quick-reply sheet : the reply coordinates, plus the cards
+// this opening pre-arms (one for « Citer », the whole basket for « Citer N », empty from the reply
+// FAB) — whenever [writingSurfaceFor] routed the tap to the sheet rather than the editor.
 internal data class QuickReplyLaunch(
     val request: QuickReplyRequest,
     val initialQuotes: List<QuotedPostPreview> = emptyList(),
 )
 
-/**
- * #604 lot 3 — « Citer N » routing (mockup P3 : « le cas qui force le plein écran ») : up to
- * [MULTI_QUOTE_FULL_EDITOR_THRESHOLD] - 1 cards the quick-reply sheet stays comfortable with the
- * keyboard open ; from the threshold up the selection goes straight to the full-screen editor.
- * Pure so the boundary is unit-testable.
- */
-internal fun multiQuoteOpensFullEditor(selectionCount: Int): Boolean =
-    selectionCount >= MULTI_QUOTE_FULL_EDITOR_THRESHOLD
+/** #806 — the two composition surfaces a write tap can open. */
+internal enum class WritingSurface { SHEET, FULL_EDITOR }
 
-/** #604 lot 3 — cadrage Codex : « 3 citations = plein écran » (constante nommée, pas un réglage). */
+/**
+ * #806 — which surface a write tap opens, from the user's [preset] and the number of citations the
+ * tap carries (0 for the reply FAB, 1 for « Citer », the basket size for « Citer N »).
+ *
+ * - [WritingSurfacePreset.SHEET] (default) keeps the 0.25.1 routing exactly : the quick-reply
+ *   sheet, except a multi-quote basket of [MULTI_QUOTE_FULL_EDITOR_THRESHOLD]+ cards (mockup P3 :
+ *   « le cas qui force le plein écran », #604 lot 3) — up to that the sheet stays comfortable with
+ *   the keyboard open.
+ * - [WritingSurfacePreset.SHEET_EXCEPT_QUOTES] : any citation (1..N) opens the full-screen editor.
+ * - [WritingSurfacePreset.FULL_EDITOR] : always the full-screen editor.
+ *
+ * Pure so the routing table is unit-testable ([MultiQuoteRoutingTest]).
+ */
+internal fun writingSurfaceFor(preset: WritingSurfacePreset, quoteCount: Int): WritingSurface = when (preset) {
+    WritingSurfacePreset.FULL_EDITOR -> WritingSurface.FULL_EDITOR
+    WritingSurfacePreset.SHEET_EXCEPT_QUOTES ->
+        if (quoteCount > 0) WritingSurface.FULL_EDITOR else WritingSurface.SHEET
+    WritingSurfacePreset.SHEET ->
+        if (quoteCount >= MULTI_QUOTE_FULL_EDITOR_THRESHOLD) WritingSurface.FULL_EDITOR else WritingSurface.SHEET
+}
+
+/**
+ * #604 lot 3 — cadrage Codex : « 3 citations = plein écran », a named constant. Since #806 the
+ * user setting is the PRESET above ; this threshold remains a constant guarding the
+ * [WritingSurfacePreset.SHEET] preset only (the other presets ignore it by construction).
+ */
 internal const val MULTI_QUOTE_FULL_EDITOR_THRESHOLD = 3
 
 // #604 lot 2 — the quote-card snapshot, built AT SELECTION TIME where the full Post is in scope

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -2,6 +2,7 @@ package fr.forumhfr.redface2.feature.topic
 
 import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.model.Topic
+import fr.forumhfr.redface2.core.model.editor.WritingSurfacePreset
 
 data class TopicUiState(
     val request: TopicRequest,
@@ -52,6 +53,14 @@ data class TopicUiState(
      * preference emission; the field is always parsed/cached so toggling never refetches.
      */
     val showSignatures: Boolean = false,
+    /**
+     * #806 — mirrors `UserPreferencesRepository.observeWritingSurfacePreset()`. Feeds
+     * [writingSurfaceFor] AT TAP TIME on the three write entry points (reply FAB, « Citer »,
+     * « Citer N ») to pick the quick-reply sheet or the full-screen editor. Default
+     * [WritingSurfacePreset.SHEET] = the 0.25.1 behaviour. A preset change never migrates an
+     * already-open sheet (the decision is only ever taken on the next tap).
+     */
+    val writingSurfacePreset: WritingSurfacePreset = WritingSurfacePreset.SHEET,
     /**
      * #335 — `true` while a manual pull-to-refresh of the current page is in flight. Drives the
      * Material3 `PullToRefreshBox` spinner. Set on the `Refresh` intent, cleared in the refresh

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -189,6 +189,13 @@ class TopicViewModel @AssistedInject constructor(
                 _state.update { it.copy(showSignatures = show) }
             }
             .launchIn(viewModelScope)
+        // #806 — mirror the writing-surface preset so the screen can route each write tap
+        // (reply FAB / « Citer » / « Citer N ») to the sheet or the full-screen editor.
+        userPreferencesRepository.observeWritingSurfacePreset()
+            .onEach { preset ->
+                _state.update { it.copy(writingSurfacePreset = preset) }
+            }
+            .launchIn(viewModelScope)
     }
 
     fun send(intent: TopicIntent) {

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/MultiQuoteRoutingTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/MultiQuoteRoutingTest.kt
@@ -1,27 +1,53 @@
 package fr.forumhfr.redface2.feature.topic
 
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import fr.forumhfr.redface2.core.model.editor.WritingSurfacePreset
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
- * #604 lot 3 — the « Citer N » threshold boundary (mockup P3 : « le cas qui force le plein
- * écran », cadrage Codex : 3 citations = plein écran, constante nommée). Pins the boundary so
- * a future tweak is a deliberate constant change, not an off-by-one.
+ * #806 — the writing-surface routing table (preset × quote count → surface), decided at tap time
+ * by [writingSurfaceFor]. Pins SHEET to the exact 0.25.1 behaviour (#604 lot 3, mockup P3 : « le
+ * cas qui force le plein écran », threshold 3 as a named constant) so a future tweak is a
+ * deliberate table change, not an off-by-one.
  */
 class MultiQuoteRoutingTest {
 
-    @Test
-    fun `one or two cards stay in the quick-reply sheet`() {
-        // 0 is unreachable from the « Citer N » FAB (it only renders armed) — documented inert.
-        assertFalse(multiQuoteOpensFullEditor(0))
-        assertFalse(multiQuoteOpensFullEditor(1))
-        assertFalse(multiQuoteOpensFullEditor(2))
+    private fun assertSurface(expected: WritingSurface, preset: WritingSurfacePreset, quoteCount: Int) {
+        assertEquals(
+            "preset=$preset quoteCount=$quoteCount",
+            expected,
+            writingSurfaceFor(preset, quoteCount),
+        )
     }
 
     @Test
-    fun `three cards and up force the full-screen editor`() {
-        assertTrue(multiQuoteOpensFullEditor(MULTI_QUOTE_FULL_EDITOR_THRESHOLD))
-        assertTrue(multiQuoteOpensFullEditor(4))
+    fun `SHEET preset pins the 0_25_1 behaviour - sheet up to two cards, full editor from three`() {
+        // 0 = the reply FAB ; 1 = « Citer » ; 2 = « Citer 2 » — all stay in the quick-reply sheet.
+        assertSurface(WritingSurface.SHEET, WritingSurfacePreset.SHEET, quoteCount = 0)
+        assertSurface(WritingSurface.SHEET, WritingSurfacePreset.SHEET, quoteCount = 1)
+        assertSurface(WritingSurface.SHEET, WritingSurfacePreset.SHEET, quoteCount = 2)
+        // #604 lot 3 — from the named threshold up, the full-screen editor takes over.
+        assertSurface(
+            WritingSurface.FULL_EDITOR,
+            WritingSurfacePreset.SHEET,
+            quoteCount = MULTI_QUOTE_FULL_EDITOR_THRESHOLD,
+        )
+        assertSurface(WritingSurface.FULL_EDITOR, WritingSurfacePreset.SHEET, quoteCount = 4)
+    }
+
+    @Test
+    fun `SHEET_EXCEPT_QUOTES preset keeps the sheet for plain replies and escalates any citation`() {
+        assertSurface(WritingSurface.SHEET, WritingSurfacePreset.SHEET_EXCEPT_QUOTES, quoteCount = 0)
+        assertSurface(WritingSurface.FULL_EDITOR, WritingSurfacePreset.SHEET_EXCEPT_QUOTES, quoteCount = 1)
+        assertSurface(WritingSurface.FULL_EDITOR, WritingSurfacePreset.SHEET_EXCEPT_QUOTES, quoteCount = 2)
+        assertSurface(WritingSurface.FULL_EDITOR, WritingSurfacePreset.SHEET_EXCEPT_QUOTES, quoteCount = 3)
+    }
+
+    @Test
+    fun `FULL_EDITOR preset always opens the full-screen editor`() {
+        assertSurface(WritingSurface.FULL_EDITOR, WritingSurfacePreset.FULL_EDITOR, quoteCount = 0)
+        assertSurface(WritingSurface.FULL_EDITOR, WritingSurfacePreset.FULL_EDITOR, quoteCount = 1)
+        assertSurface(WritingSurface.FULL_EDITOR, WritingSurfacePreset.FULL_EDITOR, quoteCount = 2)
+        assertSurface(WritingSurface.FULL_EDITOR, WritingSurfacePreset.FULL_EDITOR, quoteCount = 3)
     }
 }

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -30,6 +30,7 @@ import fr.forumhfr.redface2.core.model.search.SearchRequest
 import fr.forumhfr.redface2.core.model.search.SearchResultPage
 import fr.forumhfr.redface2.core.domain.upload.UploadProviderId
 import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
+import fr.forumhfr.redface2.core.model.editor.WritingSurfacePreset
 import fr.forumhfr.redface2.core.domain.write.DeletePostRepository
 import fr.forumhfr.redface2.core.domain.write.DeletePostResult
 import fr.forumhfr.redface2.core.model.AuthState
@@ -506,6 +507,27 @@ class TopicViewModelTest {
             userPreferencesRepository = FakeUserPreferencesRepository(topicSignatures = true),
         )
         assertEquals(true, shown.state.value.showSignatures)
+    }
+
+    @Test
+    fun `state writingSurfacePreset reflects the user preference (#806)`() = runTest {
+        val fullEditor = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            userPreferencesRepository = FakeUserPreferencesRepository(
+                writingSurfacePreset = WritingSurfacePreset.FULL_EDITOR,
+            ),
+        )
+        assertEquals(WritingSurfacePreset.FULL_EDITOR, fullEditor.state.value.writingSurfacePreset)
+
+        val default = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            userPreferencesRepository = FakeUserPreferencesRepository(),
+        )
+        assertEquals(WritingSurfacePreset.SHEET, default.state.value.writingSurfacePreset)
     }
 
     @Test
@@ -2109,12 +2131,13 @@ private class FakeStreamingTopicRepository(
 
 /**
  * No-op preferences fake for the topic ViewModel tests. Only [observeTopicTopBarAutoHide]
- * (build 89 follow-up), [observeTopicPageFabs] (#383), [observeTopicPollsExpanded] (#456) and
- * [observeTopicSignatures] (#330) are read by [TopicViewModel] — everything else returns the
- * DataStore default so the fake stays a thin stand-in. The relevant values are
- * constructor-injectable so tests can assert they reach state.
+ * (build 89 follow-up), [observeTopicPageFabs] (#383), [observeTopicPollsExpanded] (#456),
+ * [observeTopicSignatures] (#330) and [observeWritingSurfacePreset] (#806) are read by
+ * [TopicViewModel] — everything else returns the DataStore default so the fake stays a thin
+ * stand-in. The relevant values are constructor-injectable so tests can assert they reach state.
  */
 // Internal (not private) so QuickReplyViewModelTest reuses the single fake of this wide interface.
+@Suppress("LongParameterList") // one constructor knob per observed pref — grows with TopicViewModel's reads.
 internal class FakeUserPreferencesRepository(
     private val topicTopBarAutoHide: Boolean = false,
     private val topicPageFabs: Boolean = true,
@@ -2123,6 +2146,8 @@ internal class FakeUserPreferencesRepository(
     private val confirmBeforePosting: Boolean = false,
     // #805 — quote rendering in the composer; false mirrors the production default (inline BBCode).
     private val quoteCardsEnabled: Boolean = false,
+    // #806 — writing-surface preset; SHEET mirrors the production default (0.25.1 behaviour).
+    private val writingSurfacePreset: WritingSurfacePreset = WritingSurfacePreset.SHEET,
 ) : UserPreferencesRepository {
     override fun observeProxyConfig(): Flow<ProxyConfig> = MutableStateFlow(ProxyConfig())
 
@@ -2184,6 +2209,11 @@ internal class FakeUserPreferencesRepository(
     override fun observeQuoteCardsEnabled(): Flow<Boolean> = MutableStateFlow(quoteCardsEnabled)
 
     override suspend fun setQuoteCardsEnabled(enabled: Boolean) = Unit
+
+    override fun observeWritingSurfacePreset(): Flow<WritingSurfacePreset> =
+        MutableStateFlow(writingSurfacePreset)
+
+    override suspend fun setWritingSurfacePreset(preset: WritingSurfacePreset) = Unit
 
     override fun observeShowDtSection(): Flow<Boolean> = MutableStateFlow(false)
 


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Arbitrage XaTriX rendu sur #806 (option A — presets, commenté sur l'issue) : un réglage à **choix unique** qui gouverne quelle surface s'ouvre pour écrire. Demande du fil DEV (Dintr-un lemn #2790292, +1 nicko).

## Les 3 presets (« Surface d'écriture », Réglages > Édition et publication)

| Preset | Répondre (✎) | Citer / Citer N |
|---|---|---|
| **Toujours la feuille** (défaut) | feuille | feuille ; 3+ citations → plein écran (seuil conservé, garde de CE preset uniquement) |
| **Feuille sauf citations** | feuille | **plein écran direct** (la demande du fil) |
| **Toujours plein écran** | plein écran | plein écran |

Le défaut reproduit le comportement 0.25.1 **exactement** — épinglé par la table de routage (`MultiQuoteRoutingTest` réécrit : preset × quoteCount → surface). L'escalade feuille → plein écran reste disponible dans tous les presets. Le réglage choisit la **surface**, pas le rendu des citations (pref « Citations en cartes » orthogonale, copy distincte).

## Implémentation

- `WritingSurfacePreset` (core/model) + pref DataStore string défensive (valeur inconnue → défaut) clonée sur le pattern enum existant ; 6 fakes étendus.
- Routage **pur** `writingSurfaceFor(preset, quoteCount)` dans TopicScreen, décision **au tap** (jamais recalculée) ; copie immuable de la sélection avant tout clear ; exactement-une-consommation du panier préservée (sheet → clear local, plein écran → contrat `:app` handoff-avant-clear existant, non centralisés — commentaire précisé sur réserve du gate).
- `resumeSharedDraft=true` aussi pour les lancements directs (arbitrage cadrage R1 : cohérence avec le multi-quote 3+, le brouillon partagé #405 réapparaît partout).
- Settings : hydratation **continue** (pattern #788 fraîchement mergé) + update optimiste/revert ; UI en **3 radio-rows** searchables (arbitrage R4).

## Validation

- Cadrage Codex AVANT impl : GO-a-r (arbitrages R1/R2/R4 + 4 cas de bord, tous appliqués). Gate Codex sur le diff : **GO-a-r** (O1-O6 validés ; réserve commentaire snapshot traitée ; dette `@Suppress` CyclomaticComplexMethod sur TopicContent notée — extraction en helpers si le fichier reprend du routage).
- Canonique complète verte (detektAll, lintDebug, :app:lintProdDebug, tests all-modules, assembleProdDebug).
- **Dogfood émulateur** : 3 radio-rows conformes ; « Feuille sauf citations » → Citer ouvre le plein écran direct avec `[quotemsg]` inline ; « Toujours plein écran » → ✎ ouvre le plein écran ; retour au défaut → ✎ rouvre la feuille (comportement actuel intact) ; persistance vérifiée.

Closes #806

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yTLMFqxPWTajUzsFwEwAZ
