### PR TITLE
chore(release): bump versionName to 0.25.2 (writing surface presets + state hygiene)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,20 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.25.2` — `internal` (dev) — 2026-07-05
+
+**Presets de surface d'écriture (#806)** + lot d'hygiène d'état (audit rf2-10) + deux fixes de veille.
+
+### Éditeur & réponse rapide
+- #806 : réglage « **Surface d'écriture** » (Réglages > Édition et publication, PR #829) — « Toujours la feuille » (défaut, comportement actuel), « Feuille sauf citations » (toute citation ouvre l'éditeur plein écran — la demande du fil DEV), « Toujours plein écran ». L'escalade feuille → plein écran reste disponible partout ; réglage orthogonal à « Citations en cartes ».
+- #808 : dans la feuille de réponse rapide, le bloc de cartes de citation est plafonné (~2 cartes, scroll interne, PR #827) — le champ et « Envoyer » restent toujours visibles clavier levé.
+- #794 : la recherche du wiki smileys applique un **ET implicite** entre les termes (PR #828) — « chat noir » cherche l'intersection, plus l'union ; les opérateurs saisis (`+`/`-`) sont préservés.
+
+### Corrections d'état (audit 05/07, PR #826)
+- Réglages : les valeurs ne sont plus jamais périmées au retour sur l'écran (re-synchronisation continue, gate #788).
+- Éditeurs (sujet, MP compose/réponse) : la dernière frappe n'est plus perdue à la fermeture (flush du brouillon avant fermeture, pattern #803) ; une fermeture ne peut plus rester bloquée par un stockage défaillant.
+- Lecture : les couleurs `[color]` illisibles sont éclaircies/assombries a minima selon le thème (teinte préservée) — un `[#000080]` redevient lisible en sombre/AMOLED.
+
 ## `0.25.1` — `internal` (dev) — 2026-07-05
 
 **Citation multiple : action « Tout vider »** (dernier volet de #436, PR #820).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.25.1"
+        versionName = "0.25.2"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,3 +1,5 @@
-Redface 2 v0.25.1 — dev.
+Redface 2 v0.25.2 — dev.
 
-- Multi-quote: long-press the "❝N" button to clear the whole selection at once.
+- New "Writing surface" setting: choose what Reply and Quote open (quick-reply sheet or full-screen editor).
+- Unreadable text colors auto-corrected in dark themes.
+- Settings always fresh, last keystrokes saved on editor close, sharper smiley search.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,3 +1,5 @@
-Redface 2 v0.25.1 — dev.
+Redface 2 v0.25.2 — dev.
 
-- Citation multiple : un appui long sur le bouton « ❝N » vide toute la sélection d'un coup (« Tout vider »).
+- Nouveau réglage « Surface d'écriture » : choisissez ce qu'ouvrent Répondre et Citer (feuille rapide ou éditeur plein écran).
+- Couleurs de texte illisibles en thème sombre corrigées automatiquement.
+- Réglages toujours à jour, dernière frappe sauvée à la fermeture des éditeurs, recherche de smileys plus précise.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump de release pour shipper la vague du soir sur le canal dev : **#806 presets de surface d'écriture** (PR #829) + lot d'hygiène d'état de l'audit (PR #826) + **#808** cap des cartes dans la feuille (PR #827) + **#794** ET implicite recherche smileys (PR #828).

- versionName 0.25.1 → **0.25.2** (politique A : patch, suite du chantier).
- CHANGELOG app : entrée 0.25.2 détaillée.
- whatsnew fr-FR / en-US : version en 1re ligne (garde freshness locale OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yTLMFqxPWTajUzsFwEwAZ