### PR TITLE
fix(flags): keep the hide-empty-categories filter off the read tab (#825)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ val detektCliTask = tasks.register<JavaExec>("detektCliCheck") {
         "--report", "html:${reportsDir.get().file("detekt.html").asFile.absolutePath}",
         "--report", "sarif:${reportsDir.get().file("detekt.sarif").asFile.absolutePath}",
         "--report", "md:${reportsDir.get().file("detekt.md").asFile.absolutePath}",
-        "--excludes", "**/build/**,**/.gradle/**,**/.gradle-user/**,**/generated/**",
+        "--excludes", "**/build/**,**/.gradle/**,**/.gradle-user/**,**/generated/**,**/.claude/**",
     )
 }
 

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagCategorySection.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagCategorySection.kt
@@ -117,11 +117,12 @@ fun groupFlagsByCategory(
  * follow-up). A section is KEPT when it has at least one unread flag; empty sections are always
  * dropped.
  *
- * [keepFullyRead] is the cyan « +lus » override: when the user explicitly opted to show
- * already-read participated topics, a section that holds only read flags is still kept (only
- * truly empty sections are dropped) — otherwise the read topics the user just asked to see would
- * be hidden by this very filter. For the RED/FAVORITE tabs (no « +lus » affordance) the caller
- * passes `false`, so fully-read categories are dropped as the preference intends.
+ * [keepFullyRead] is the « +lus » override (#317, generalised to every real type by #825): when
+ * the user explicitly opted to show already-read topics (unreadOnly off — an explicit choice on
+ * CYAN/RED/FAVORITE alike since the #751 re-tap shortcut), a section that holds only read flags
+ * is still kept (only truly empty sections are dropped) — otherwise the read topics the user
+ * just asked to see would be hidden by this very filter. Callers pass `false` only for
+ * unread-only views, where the read flags were already filtered out upstream.
  *
  * Pure, testable without Android.
  */

--- a/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
+++ b/feature/flags/src/main/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModel.kt
@@ -482,12 +482,17 @@ class FlagsViewModel @Inject constructor(
         ) { result, unreadOnly ->
             FilteredFlags(
                 result = filterUnreadOnly(result, unreadOnly),
-                // The « +lus » override: keep fully-read categories under « masquer les catégories
-                // sans non-lu » ONLY on CYAN when its unread filter is off — i.e. the user explicitly
-                // opted to see read participated topics, so this filter must not hide them right back.
-                // RED/FAVORITE default to showing read topics, but there hide-read keeps its literal
-                // meaning (drop categories without an unread flag), preserving the #179/#309 behaviour.
-                keepFullyReadSections = type == FlagType.CYAN && !unreadOnly,
+                // The « +lus » override: under « masquer les catégories sans non-lu », keep the
+                // fully-read categories whenever the tab shows read topics (unreadOnly off). Showing
+                // read topics is an explicit user choice on EVERY real type since the #751 re-tap
+                // shortcut, so this filter must not hide them right back. It used to be CYAN-only
+                // (#317), which leaked the literal filter onto the RED/FAVORITE read views and
+                // collapsed them to an empty body once every flag was read (#825).
+                // Semantics decision (#825): the option means « hide categories with no flag VISIBLE
+                // under the current filter » — no unread flag in an unread-only view, no flag at all
+                // in a « +lus » view. Inert when unreadOnly is on: [filterUnreadOnly] already removed
+                // every read flag, so a surviving non-empty section always has an unread flag.
+                keepFullyReadSections = !unreadOnly,
             )
         }
             // #225 — keep the existing list anchored during a user refresh instead of blanking
@@ -532,8 +537,8 @@ class FlagsViewModel @Inject constructor(
     /**
      * Carries the « +lus » decision ([keepFullyReadSections]) alongside the filtered [result] so it
      * travels as one unit through [keepContentDuringRefresh] and the outer `combine` (cf.
-     * [authenticatedFlagsListState]). It is the CYAN-specific override (`type == CYAN && !unreadOnly`,
-     * #317) — RED/FAVORITE always pass `false` so hide-read keeps its literal meaning there.
+     * [authenticatedFlagsListState]). It is `!unreadOnly` for every real type (#317, generalised by
+     * #825): whenever a tab shows read topics, hide-read only drops truly empty categories.
      */
     private data class FilteredFlags(
         val result: FlagsResult,
@@ -1036,9 +1041,9 @@ class FlagsViewModel @Inject constructor(
      *
      * [groupByCategory] / [hideReadCategories] are the two persisted Drapeaux layout preferences
      * (#179 follow-up): flat vs grouped layout, and whether to hide categories without an unread
-     * flag. [keepFullyReadSections] (the CYAN « +lus » override, #317) is forwarded from
-     * [FilteredFlags]: when CYAN explicitly shows read topics, its fully-read categories survive the
-     * hide filter so those topics stay reachable.
+     * flag. [keepFullyReadSections] (the « +lus » override, #317/#825) is forwarded from
+     * [FilteredFlags]: when a tab explicitly shows read topics, its fully-read categories survive
+     * the hide filter so those topics stay reachable.
      */
     private fun toFlagsListUiState(
         flagsResult: FlagsResult,

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -955,9 +955,11 @@ class FlagsViewModelTest {
     }
 
     @Test
-    fun `hide-read pref drops categories without an unread flag on RED`() = runTest {
-        // RED is not read-filtered, so both read and unread reach the grouping: hide-read must
-        // drop the all-read category (10) and the empty ones, keeping only the one with an unread.
+    fun `hide-read with unread-only on RED drops categories without an unread flag`() = runTest {
+        // Unread-only view on RED (explicit opt-in, off by default): the #317 filter removes the
+        // read flag first, so its category (10) groups empty and hide-read drops it — keeping only
+        // the one with an actionable unread. The read-showing RED default is pinned by the #825
+        // regression test below.
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository(catIds = listOf(1, 10))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
@@ -967,6 +969,7 @@ class FlagsViewModelTest {
         vm.flagsState.test {
             awaitItem() // initial null
             vm.selectTab(FlagTab.Red)
+            vm.setFlagsUnreadOnly(true)
             flags.emit(
                 FlagType.RED,
                 FlagsResult.Success(
@@ -1042,11 +1045,11 @@ class FlagsViewModelTest {
     }
 
     @Test
-    fun `hide-read with no unread flag collapses the grouped sections to empty`() = runTest {
-        // Codex review: when hide-read is on and NO category has an unread flag (all read, or CYAN
-        // all-read with +lus off), the grouped content must be Grouped(emptyList()). The screen
-        // renders a placeholder for this state so the body never blanks (anti #229 regression);
-        // this test pins the state contract the screen relies on.
+    fun `red default read-showing view keeps fully-read categories under hide-read (#825)`() = runTest {
+        // #825 regression: RED shows read topics by default (« Lu (+lus) », unreadOnly off). The
+        // CYAN-only override used to leak the literal hide-read filter onto this view — once every
+        // red flag was read, every section was dropped and the body collapsed to empty. The « +lus »
+        // override applies to every read-showing view: only truly empty categories are dropped.
         val flags = FakeFlagRepository()
         val forum = FakeForumRepository(catIds = listOf(1, 10))
         val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
@@ -1055,7 +1058,7 @@ class FlagsViewModelTest {
 
         vm.flagsState.test {
             awaitItem() // initial null
-            vm.selectTab(FlagTab.Red) // RED isn't read-filtered: the all-read flags reach grouping.
+            vm.selectTab(FlagTab.Red)
             flags.emit(
                 FlagType.RED,
                 FlagsResult.Success(
@@ -1065,9 +1068,75 @@ class FlagsViewModelTest {
                     ),
                 ),
             )
+            val success = awaitItem() as FlagsListUiState.Success
+            assertEquals(
+                "all-read categories must stay visible when RED shows read topics",
+                listOf(1, 10),
+                sections(success).map { it.catId },
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `favorite default read-showing view keeps fully-read categories under hide-read (#825)`() = runTest {
+        // #825 twin on FAVORITE: same read-showing default as RED, same override.
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1, 10))
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val prefs = FakeUserPreferencesRepository(hideReadCategories = true)
+        val vm = viewModel(auth, flags, forum, prefs)
+
+        vm.flagsState.test {
+            awaitItem() // initial null
+            vm.selectTab(FlagTab.Favorite)
+            flags.emit(
+                FlagType.FAVORITE,
+                FlagsResult.Success(
+                    listOf(
+                        stubFlag(1, FlagType.FAVORITE, hasUnread = false, cat = 1),
+                        stubFlag(2, FlagType.FAVORITE, hasUnread = false, cat = 10),
+                    ),
+                ),
+            )
+            val success = awaitItem() as FlagsListUiState.Success
+            assertEquals(
+                "all-read categories must stay visible when FAVORITE shows read topics",
+                listOf(1, 10),
+                sections(success).map { it.catId },
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `hide-read with no unread flag collapses the grouped sections to empty`() = runTest {
+        // Codex review: when hide-read is on and NO category has a VISIBLE flag (here CYAN
+        // all-read with its default unread-only filter on, so the #317 filter empties the list),
+        // the grouped content must be Grouped(emptyList()). The screen renders a placeholder for
+        // this state so the body never blanks (anti #229 regression); this test pins the state
+        // contract the screen relies on. (Moved off RED by #825: its read-showing default no
+        // longer collapses — the collapse now only happens in unread-only views.)
+        val flags = FakeFlagRepository()
+        val forum = FakeForumRepository(catIds = listOf(1, 10))
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"), flagRepository = flags)
+        val prefs = FakeUserPreferencesRepository(hideReadCategories = true)
+        val vm = viewModel(auth, flags, forum, prefs)
+
+        vm.flagsState.test {
+            awaitItem() // initial null
+            flags.emit(
+                FlagType.CYAN,
+                FlagsResult.Success(
+                    listOf(
+                        stubFlag(1, FlagType.CYAN, hasUnread = false, cat = 1),
+                        stubFlag(2, FlagType.CYAN, hasUnread = false, cat = 10),
+                    ),
+                ),
+            )
             val grouped = (awaitItem() as FlagsListUiState.Success).content as FlagsContent.Grouped
             assertTrue(
-                "every category is fully read → hide-read collapses to zero sections",
+                "no unread flag survives CYAN's unread-only filter → zero sections",
                 grouped.sections.isEmpty(),
             )
             cancelAndIgnoreRemainingEvents()


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Closes #825.

## Problème
L'option « masquer les catégories sans message non lu » s'appliquait aussi aux vues « +lus » des types RED/FAVORITE (`keepFullyReadSections = type == CYAN && !unreadOnly`) : les catégories toutes-lues disparaissaient de la vue censée les montrer, jusqu'à `Grouped(emptyList())` quand tout était lu. Le rationale historique (« pas d'affordance +lus sur ces types ») est périmé depuis #751 (re-tap flippe la vue).

## Fix
Sémantique actée dans l'arbitrage [#825 (comment)](https://github.com/ForumHFR/redface2/issues/825#issuecomment-2790449) : l'option masque les catégories sans drapeau **visible sous le filtre courant**. Concrètement : `keepFullyReadSections = !unreadOnly` — le filtre littéral ne s'applique plus qu'aux vues non-lus, où il est inerte par construction. Comportement CYAN inchangé, contrat anti-#229 (`Grouped(emptyList())`) conservé sur le seul chemin où le collapse reste légitime.

## Tests
- 2 tests de régression #825 (RED + jumeau FAVORITE) : catégorie toute-lue visible en vue +lus malgré hide-read.
- 2 tests réécrits : RED unread-only (fix inerte) + CYAN all-read (contrat anti-#229).

## Hors sujet assumé
Le commit `chore(build)` ajoute `**/.claude/**` aux excludes de `detektCliCheck` : les worktrees d'agents de fond vivent sous `.claude/worktrees/` et faisaient échouer le scan CLI du repo. Réserve mineure notée par la review Codex (« à isoler ou assumer ») — assumé ici pour débloquer la chaîne d'intégration de la nuit, sans impact runtime.

## Validation
- Canonique complète verte en local : `detektAll lintDebug :app:lintProdDebug testDebugUnitTest :app:assembleProdDebug` (BUILD SUCCESSFUL, 779 tâches).
- Gate Codex (gpt-5.5, xhigh) : **GO-avec-réserves** — fix validé sur les 4 points challengés (inertie non-lus, CYAN intact, tests pinent le contrat utilisateur, KDoc honnête) ; unique réserve = le chore build hors-sujet ci-dessus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pm28ny4V5GSegmKJxTPVAM