### PR TITLE
refactor(editor,ui): single smiley search path via SmileyPickerController + restore search on reopen (#441, #824)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerController.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerController.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.launch
 /**
  * #387 — self-contained state machine for the [SmileyPickerSheet], extracted from
  * `PostEditorViewModel`'s embedded logic so ANY editor host (the MP reply/compose ViewModels
- * today, the `:feature:editor` ViewModels as a follow-up migration) gets the picker without
+ * since #440, the `:feature:editor` ViewModels since #441) gets the picker without
  * re-implementing the debounce and its race guards.
  *
  * The host owns insertion : a tap on a smiley hands the BBCode token back to the host
@@ -28,9 +28,22 @@ import kotlinx.coroutines.launch
  *  - job-identity + query-equality guards drop stale responses (cancelled jobs, retyped
  *    queries) so an older network result can never overwrite a newer one.
  *
+ * #824 — restore-on-reopen contract : [dismiss] snapshots the visible search (query + wiki
+ * results) instead of dropping it, and the next [open] restores it, so an insertion (which
+ * dismisses the sheet on all surfaces) or an accidental swipe-down never costs the user a
+ * retype. `Results` are restored verbatim (no refetch) ; the transient `Loading` / `Error`
+ * branches are normalised to `Idle` at snapshot time (a restored Loading would spin forever
+ * — its job was cancelled — and a restored Error would resurface a stale failure). There is
+ * deliberately no public reset : the controller lives and dies with its host ViewModel, whose
+ * editorial context is frozen at construction, so « editor closed = search forgotten » is the
+ * ViewModel lifecycle itself.
+ *
  * [searchWiki] is a lambda (not `SmileyRepository`) so `:core:ui` gains no dependency on
  * `:core:domain` ; [userId] feeds HFR's wiki endpoint and falls back to 0 when the session
  * has not resolved an id (proven harmless — same fallback as `PostEditorViewModel`).
+ * [onSearchFailed] lets a host apply its own failure policy (the `:feature:editor` ViewModels
+ * record a diagnostics WARN — class name only, never the query nor the userId — while the MP
+ * composers keep the no-op default).
  */
 class SmileyPickerController(
     private val scope: CoroutineScope,
@@ -44,15 +57,46 @@ class SmileyPickerController(
 
     private var searchJob: Job? = null
 
+    /**
+     * #824 — snapshot of the last dismissed Open state, already normalised by [dismiss]
+     * (`wiki` is either `Results` or `Idle`, never a transient branch). Null until the
+     * first dismissal ; never cleared — the whole controller is dropped with its host
+     * ViewModel, which is the intended invalidation boundary.
+     */
+    private var lastDismissed: SmileyPickerState.Open? = null
+
     fun open() {
         _state.update { current ->
-            if (current is SmileyPickerState.Open) current else SmileyPickerState.Open()
+            if (current is SmileyPickerState.Open) {
+                // Idempotent while visible : a redundant open() must NOT clobber the live
+                // query/results with the stale dismissal snapshot below.
+                current
+            } else {
+                // #824 — restore the last dismissed search (query + results) so reopening
+                // right after an insertion / accidental swipe-down never costs a retype.
+                lastDismissed ?: SmileyPickerState.Open()
+            }
         }
     }
 
     fun dismiss() {
         searchJob?.cancel()
         searchJob = null
+        // #824 — keep the visible search for the next open(), normalising the transient
+        // branches : a restored Loading would spin forever (its job was just cancelled
+        // above) and a restored Error would resurface a stale failure, so both collapse
+        // to Idle. Results are restored verbatim — no refetch on reopen ; staleness within
+        // one editing session is acceptable (issue #824, immediate-reopen use case).
+        val current = _state.value
+        if (current is SmileyPickerState.Open) {
+            lastDismissed = current.copy(
+                wiki = when (val wiki = current.wiki) {
+                    is WikiSearchState.Results -> wiki
+                    WikiSearchState.Idle, WikiSearchState.Loading, WikiSearchState.Error ->
+                        WikiSearchState.Idle
+                },
+            )
+        }
         _state.value = SmileyPickerState.Hidden
     }
 

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerSheet.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerSheet.kt
@@ -74,12 +74,16 @@ fun SmileyPickerSheet(
         // way into the ViewModel. `rememberSaveable` so a configuration change (rotation,
         // dark mode toggle) does not reset the user back to the Standard tab while the
         // bottom-sheet is still open.
-        // #824 — start on the Wiki tab when the controller restored a search (non-empty
-        // query at first composition) so the reopened sheet lands on the results the user
-        // came back for. Evaluated once per sheet instance (each open is a fresh
-        // composition) ; deliberately NOT keyed on the query — that would reset the tab
-        // on every keystroke.
-        var tabIndex by rememberSaveable { mutableStateOf(if (state.query.isNotEmpty()) 1 else 0) }
+        var tabIndex by rememberSaveable { mutableStateOf(0) }
+        // #824 — land on the Wiki tab when a restored search materialises. An initial-value
+        // capture is NOT enough: the controller may deliver the restored Open state a frame
+        // after the sheet first composes, and the saveable registry can also replay a stale
+        // Standard selection over the computed initial (both observed at dogfood). Keying the
+        // effect on "has a query" keeps it one-shot per restore and inert during typing —
+        // the search field only exists on the Wiki tab, so forcing index 1 there is a no-op.
+        LaunchedEffect(state.query.isNotEmpty()) {
+            if (state.query.isNotEmpty()) tabIndex = 1
+        }
         Column(
             modifier = Modifier
                 .fillMaxWidth()

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerSheet.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerSheet.kt
@@ -74,7 +74,12 @@ fun SmileyPickerSheet(
         // way into the ViewModel. `rememberSaveable` so a configuration change (rotation,
         // dark mode toggle) does not reset the user back to the Standard tab while the
         // bottom-sheet is still open.
-        var tabIndex by rememberSaveable { mutableStateOf(0) }
+        // #824 — start on the Wiki tab when the controller restored a search (non-empty
+        // query at first composition) so the reopened sheet lands on the results the user
+        // came back for. Evaluated once per sheet instance (each open is a fresh
+        // composition) ; deliberately NOT keyed on the query — that would reset the tab
+        // on every keystroke.
+        var tabIndex by rememberSaveable { mutableStateOf(if (state.query.isNotEmpty()) 1 else 0) }
         Column(
             modifier = Modifier
                 .fillMaxWidth()

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerControllerTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerControllerTest.kt
@@ -3,9 +3,11 @@ package fr.forumhfr.redface2.core.ui.editor
 import fr.forumhfr.redface2.core.model.EditorSmiley
 import fr.forumhfr.redface2.core.model.EditorSmileySource
 import java.io.IOException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -13,7 +15,9 @@ import org.junit.Test
 
 /**
  * #387 — the picker state machine extracted from PostEditorViewModel : debounce, the ≤ 2-chars
- * idle gate, stale-result guards, the userId 0 fallback. Pure JVM (virtual time).
+ * idle gate, stale-result guards, the userId 0 fallback. #824 adds the restore-on-reopen
+ * contract (dismiss snapshots the search, open restores it, transient branches normalise to
+ * Idle). Pure JVM (virtual time).
  *
  * The controller takes the TestScope itself (NOT backgroundScope) : with coroutines 1.11
  * the test scheduler does not advance backgroundScope children from advanceUntilIdle in
@@ -153,5 +157,113 @@ class SmileyPickerControllerTest {
         advanceUntilIdle()
 
         assertEquals(0, seenUserId)
+    }
+
+    // ----- #824 : restore the search on reopen ------------------------------------
+
+    @Test
+    fun `dismiss then open restores the query and its Results without refetching`() = runTest {
+        var calls = 0
+        val controller = SmileyPickerController(this, { _, _ -> calls++; listOf(smiley) })
+
+        controller.open()
+        controller.onQueryChanged("jap")
+        advanceUntilIdle()
+        assertEquals(1, calls)
+
+        controller.dismiss() // insertion and swipe-down both land here
+        controller.open()
+
+        assertEquals(
+            "the dismissed search must come back verbatim — no refetch",
+            SmileyPickerState.Open(query = "jap", wiki = WikiSearchState.Results(listOf(smiley))),
+            controller.state.value,
+        )
+        advanceUntilIdle()
+        assertEquals("restoring Results must not arm a new search", 1, calls)
+    }
+
+    @Test
+    fun `a dismiss during Loading reopens on Idle — no phantom spinner`() = runTest {
+        val gate = CompletableDeferred<List<EditorSmiley>>()
+        val controller = SmileyPickerController(this, { _, _ -> gate.await() })
+
+        controller.open()
+        controller.onQueryChanged("jap")
+        // Cross the debounce so the state flips to Loading, with the fetch still hanging.
+        advanceTimeBy(SmileyPickerController.SEARCH_DEBOUNCE_MS)
+        runCurrent()
+        assertEquals(
+            WikiSearchState.Loading,
+            (controller.state.value as SmileyPickerState.Open).wiki,
+        )
+
+        controller.dismiss() // cancels the hanging job
+        controller.open()
+
+        // A restored Loading would spin forever (its job is dead) : it must normalise to Idle.
+        assertEquals(
+            SmileyPickerState.Open(query = "jap", wiki = WikiSearchState.Idle),
+            controller.state.value,
+        )
+    }
+
+    @Test
+    fun `a dismiss on Error reopens on Idle — no stale failure banner`() = runTest {
+        val controller = SmileyPickerController(this, { _, _ -> throw IOException("offline") })
+
+        controller.open()
+        controller.onQueryChanged("jap")
+        advanceUntilIdle()
+        assertEquals(
+            WikiSearchState.Error,
+            (controller.state.value as SmileyPickerState.Open).wiki,
+        )
+
+        controller.dismiss()
+        controller.open()
+
+        assertEquals(
+            SmileyPickerState.Open(query = "jap", wiki = WikiSearchState.Idle),
+            controller.state.value,
+        )
+    }
+
+    @Test
+    fun `a restored short query stays Idle and never searches`() = runTest {
+        var calls = 0
+        val controller = SmileyPickerController(this, { _, _ -> calls++; emptyList() })
+
+        controller.open()
+        controller.onQueryChanged("ja") // below MIN_WIKI_QUERY_LENGTH → Idle, no search
+        controller.dismiss()
+        controller.open()
+        advanceUntilIdle()
+
+        assertEquals(
+            SmileyPickerState.Open(query = "ja", wiki = WikiSearchState.Idle),
+            controller.state.value,
+        )
+        assertEquals(0, calls)
+    }
+
+    @Test
+    fun `open while already Open never clobbers the live search with the snapshot`() = runTest {
+        val controller = SmileyPickerController(this, { _, _ -> listOf(smiley) })
+
+        controller.open()
+        controller.onQueryChanged("jap")
+        advanceUntilIdle()
+        controller.dismiss() // snapshot = ("jap", Results)
+
+        controller.open() // restores the snapshot…
+        controller.onQueryChanged("sm") // …then the user starts a different search
+        controller.open() // a redundant open (e.g. re-tapped trigger) must be a no-op
+
+        assertEquals(
+            "the idempotent open must keep the live query, not resurrect the snapshot",
+            "sm",
+            (controller.state.value as SmileyPickerState.Open).query,
+        )
     }
 }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorIntent.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorIntent.kt
@@ -38,22 +38,12 @@ sealed interface PostEditorIntent {
     /** Toggle « Activer la notification par email du sujet » (HFR `emaill=1`). */
     data class ToggleEmailNotification(val enabled: Boolean) : PostEditorIntent
 
-    /** Phase 2F-B (#11) — opens the smiley picker bottom-sheet on the Standard tab. */
-    data object SmileyPickerOpened : PostEditorIntent
-
-    /** Phase 2F-B (#11) — dismisses the smiley picker (sheet swipe-down or back press). */
-    data object SmileyPickerDismissed : PostEditorIntent
-
-    /**
-     * Phase 2F-B (#11) — the user typed in the wiki search field. The ViewModel debounces
-     * and gates on `query.length > 2` before hitting the network, matching HFR's web
-     * composer behaviour (`find_smilies_timer` 300 ms debounce).
-     */
-    data class SmileySearchQueryChanged(val query: String) : PostEditorIntent
-
     /**
      * Phase 2F-B (#11) — the user tapped a smiley in the picker. The ViewModel inserts the
      * token at the current caret position via the formatter helper and closes the sheet.
+     * #441 — open / dismiss / query-change are no longer intents : the sheet talks directly
+     * to the shared `SmileyPickerController` exposed as `PostEditorViewModel.smileyPicker` ;
+     * only the insertion stays MVI because it mutates the draft.
      */
     data class SmileySelected(val token: String) : PostEditorIntent
 

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -5,6 +5,7 @@ import fr.forumhfr.redface2.core.ui.editor.UploadProgress
 import fr.forumhfr.redface2.core.ui.editor.UploadProgressLabel
 import fr.forumhfr.redface2.core.ui.editor.bannerText
 
+import fr.forumhfr.redface2.core.ui.editor.SmileyPickerController
 import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 import fr.forumhfr.redface2.core.ui.editor.SmileyPickerSheet
 import androidx.activity.compose.BackHandler
@@ -106,6 +107,9 @@ fun PostEditorScreen(
     PostEditorContent(
         state = state,
         onIntent = remember(viewModel) { { intent: PostEditorIntent -> viewModel.submit(intent) } },
+        // #441 — the picker is driven by the shared controller (same wiring as the MP
+        // composers, cf. PrivateMessageReplyScreen) ; only SmileySelected stays an intent.
+        smileyPicker = viewModel.smileyPicker,
         modifier = modifier,
     )
 }
@@ -114,6 +118,7 @@ fun PostEditorScreen(
 private fun PostEditorContent(
     state: PostEditorState,
     onIntent: (PostEditorIntent) -> Unit,
+    smileyPicker: SmileyPickerController,
     modifier: Modifier = Modifier,
 ) {
     var imageUrlDialogOpen by remember { mutableStateOf(false) }
@@ -285,22 +290,23 @@ private fun PostEditorContent(
                         onConfirmSubmit = { onIntent(PostEditorIntent.SubmitConfirmed) },
                         onDisarmConfirm = { onIntent(PostEditorIntent.SubmitConfirmationDismissed) },
                         onOpenOptions = { optionsSheetOpen = true },
-                        onOpenSmileys = { onIntent(PostEditorIntent.SmileyPickerOpened) },
+                        onOpenSmileys = smileyPicker::open,
                     ),
                 )
             }
         }
         // Phase 2F-B (#11) — bottom-sheet smiley picker. Rendered as a sibling of the
         // Column so the sheet can scrim the editor without being constrained by the
-        // verticalScroll above. Visibility is owned by the ViewModel via
-        // `SmileyPickerState` ; dismissal goes through the dedicated intent so the
-        // ViewModel can cancel any in-flight wiki search at the same time.
-        val picker = state.smileyPicker
-        if (picker is SmileyPickerState.Open) {
+        // verticalScroll above. #441 — visibility is owned by the shared
+        // SmileyPickerController ; dismissal goes through the controller (which cancels
+        // any in-flight wiki search and snapshots the search for the #824 restore), while
+        // the insertion stays an MVI intent (draft mutation).
+        val pickerState by smileyPicker.state.collectAsStateWithLifecycle()
+        (pickerState as? SmileyPickerState.Open)?.let { picker ->
             SmileyPickerSheet(
                 state = picker,
-                onDismiss = { onIntent(PostEditorIntent.SmileyPickerDismissed) },
-                onQueryChange = { query -> onIntent(PostEditorIntent.SmileySearchQueryChanged(query)) },
+                onDismiss = smileyPicker::dismiss,
+                onQueryChange = smileyPicker::onQueryChanged,
                 onSmileyClicked = { token -> onIntent(PostEditorIntent.SmileySelected(token)) },
             )
         }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorState.kt
@@ -2,11 +2,9 @@ package fr.forumhfr.redface2.feature.editor
 import fr.forumhfr.redface2.core.ui.editor.UploadError
 import fr.forumhfr.redface2.core.ui.editor.UploadProgress
 
-import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 import androidx.compose.ui.text.input.TextFieldValue
 import fr.forumhfr.redface2.core.domain.editor.BbcodeValidation
 import fr.forumhfr.redface2.core.domain.editor.validateBbcodeDraft
-import fr.forumhfr.redface2.core.model.EditorSmiley
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.write.QuotedPostPreview
 import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
@@ -74,16 +72,12 @@ data class PostEditorState(
      * submit attempt.
      */
     val optionsHydratedFromForm: Boolean = false,
-    /**
-     * Phase 2F-B (#11 partial) — smiley picker visibility + wiki search state. Hidden by
-     * default. Opening the picker is an Intent ; closing it is also an Intent, so the
-     * bottom-sheet dismiss path stays MVI-correct.
-     */
-    val smileyPicker: SmileyPickerState = SmileyPickerState.Hidden,
+    // #441 — the smiley picker state no longer lives here : visibility + wiki search moved
+    // to the shared `SmileyPickerController` exposed as `PostEditorViewModel.smileyPicker`.
     /**
      * HFR user id parsed from the form HTML (cf. `ReplyForm.userId`). Used by the wiki
-     * smiley search call. `null` when the form is anonymous or unparseable — the
-     * repository falls back to `user_id=0`.
+     * smiley search call (read by the `SmileyPickerController` lambda). `null` when the
+     * form is anonymous or unparseable — the controller falls back to `user_id=0`.
      */
     val userId: Int? = null,
     /**

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -2,8 +2,7 @@ package fr.forumhfr.redface2.feature.editor
 import fr.forumhfr.redface2.core.ui.editor.UploadError
 import fr.forumhfr.redface2.core.ui.editor.UploadProgress
 
-import fr.forumhfr.redface2.core.ui.editor.WikiSearchState
-import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
+import fr.forumhfr.redface2.core.ui.editor.SmileyPickerController
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
@@ -117,8 +116,6 @@ class PostEditorViewModel @AssistedInject constructor(
      */
     private var loadedForm: ReplyForm? = null
     private var submitJob: Job? = null
-    /** In-flight wiki smiley search ; cancelled on next query change / picker close. */
-    private var smileySearchJob: Job? = null
 
     /**
      * #405 — stable, content-free draft key for this editor session, or null when the routing args
@@ -390,9 +387,6 @@ class PostEditorViewModel @AssistedInject constructor(
                 _state.update { it.copy(smileyDisabled = intent.disabled) }
             is PostEditorIntent.ToggleEmailNotification ->
                 _state.update { it.copy(emailNotificationEnabled = intent.enabled) }
-            PostEditorIntent.SmileyPickerOpened -> onSmileyPickerOpened()
-            PostEditorIntent.SmileyPickerDismissed -> onSmileyPickerDismissed()
-            is PostEditorIntent.SmileySearchQueryChanged -> onSmileySearchQueryChanged(intent.query)
             is PostEditorIntent.SmileySelected -> onSmileySelected(intent.token)
             is PostEditorIntent.ImageUrlInserted -> onImageUrlInserted(intent.url)
             is PostEditorIntent.ImagePicked -> onImagePicked(intent.uri)
@@ -448,91 +442,38 @@ class PostEditorViewModel @AssistedInject constructor(
         viewModelScope.launch { draftStore.delete(draftOwner, key) }
     }
 
-    private fun onSmileyPickerOpened() {
-        _state.update { current ->
-            if (current.smileyPicker is SmileyPickerState.Open) current
-            else current.copy(smileyPicker = SmileyPickerState.Open())
-        }
-    }
-
-    private fun onSmileyPickerDismissed() {
-        smileySearchJob?.cancel()
-        smileySearchJob = null
-        _state.update { it.copy(smileyPicker = SmileyPickerState.Hidden) }
-    }
-
-    private fun onSmileySearchQueryChanged(query: String) {
-        _state.update { current ->
-            val open = current.smileyPicker as? SmileyPickerState.Open ?: return@update current
-            current.copy(smileyPicker = open.copy(query = query))
-        }
-        // Cancel in-flight searches so an older response can't overwrite a newer query.
-        smileySearchJob?.cancel()
-        if (query.length <= 2) {
-            // Mirrors the HFR web composer's `query.length > 2` gate. Below threshold we
-            // reset the wiki branch to Idle so the picker can render the Standard tab.
-            _state.update { current ->
-                val open = current.smileyPicker as? SmileyPickerState.Open ?: return@update current
-                current.copy(smileyPicker = open.copy(wiki = WikiSearchState.Idle))
-            }
-            return
-        }
-        smileySearchJob = viewModelScope.launch {
-            // 300 ms matches the JS `find_smilies_timer` debounce embedded in HFR's
-            // /compressed/message.js — keeping it identical avoids surprising spikes if
-            // the user types fast. We deliberately flip to `Loading` AFTER the debounce
-            // so a user typing « jap » in one burst never sees a Loading flash before
-            // the actual network call (the previous job is cancelled before its delay
-            // resolves, so the state stays on the previous wiki snapshot until the
-            // last keystroke survives the 300 ms idle window).
-            delay(SMILEY_SEARCH_DEBOUNCE_MS)
-            // Identity guard against the « same query typed twice in a 300 ms window »
-            // race : if the user types « jap » → backspaces → re-types « jap » before
-            // the first delay resolves, both jobs would pass the `open.query == query`
-            // check (the query string is identical) and launch two parallel requests.
-            // We compare the current job identity to the ViewModel's `smileySearchJob`
-            // — the second `launchSmileySearch` call replaced the reference, so the
-            // first job's `coroutineContext.job` is not the active one anymore. Abort.
-            if (coroutineContext[Job] !== smileySearchJob) return@launch
-            _state.update { current ->
-                val open = current.smileyPicker as? SmileyPickerState.Open ?: return@update current
-                if (open.query != query) return@update current
-                current.copy(smileyPicker = open.copy(wiki = WikiSearchState.Loading))
-            }
-            val effectiveUserId = _state.value.userId ?: 0
-            val outcome = runCatching { smileyRepository.searchWiki(effectiveUserId, query) }
-            outcome.fold(
-                onSuccess = { items ->
-                    _state.update { current ->
-                        val open = current.smileyPicker as? SmileyPickerState.Open
-                            ?: return@update current
-                        // Drop the result if the user closed the picker or typed a different
-                        // query while we were waiting on the network.
-                        if (open.query != query) return@update current
-                        current.copy(smileyPicker = open.copy(wiki = WikiSearchState.Results(items)))
-                    }
-                },
-                onFailure = { error ->
-                    if (error is CancellationException) throw error
-                    diagnostics.record(
-                        DiagnosticsLog.Level.WARN,
-                        LOG_TAG_VM,
-                        "wiki smiley search failed: ${error::class.simpleName}",
-                    )
-                    _state.update { current ->
-                        val open = current.smileyPicker as? SmileyPickerState.Open
-                            ?: return@update current
-                        if (open.query != query) return@update current
-                        current.copy(smileyPicker = open.copy(wiki = WikiSearchState.Error))
-                    }
-                },
+    /**
+     * #441 — smiley picker (Standard + Wiki search), delegated to the shared
+     * [SmileyPickerController] exactly like the MP composers (#387/#440) : the controller owns
+     * open/dismiss/query, the 300 ms debounce and its race guards, and the #824
+     * restore-search-on-reopen contract. This ViewModel keeps only the insertion
+     * ([onSmileySelected] — a draft mutation, so it stays an MVI intent). Mixed wiring is
+     * deliberate : the sheet talks to the controller directly for open/dismiss/query and goes
+     * through [PostEditorIntent.SmileySelected] for insertion — do not re-route one into the
+     * other for « consistency ».
+     *
+     * Lifecycle (réserve Codex #441) : this ViewModel's editorial context is frozen at
+     * construction (`@Assisted request` ; one `PostEditorRoute` nav entry = one ViewModel,
+     * cf. `RedfaceNavigation`), so the controller can never be re-armed for another post —
+     * no targeted reset is needed beyond the ViewModel's own death.
+     *
+     * Failure logging stays a policy of THIS feature (the MP composers keep the controller's
+     * no-op default) : class name only — never the query nor the userId (anti-leak test).
+     */
+    val smileyPicker = SmileyPickerController(
+        scope = viewModelScope,
+        searchWiki = smileyRepository::searchWiki,
+        userId = { _state.value.userId },
+        onSearchFailed = { error ->
+            diagnostics.record(
+                DiagnosticsLog.Level.WARN,
+                LOG_TAG_VM,
+                "wiki smiley search failed: ${error::class.simpleName}",
             )
-        }
-    }
+        },
+    )
 
     private fun onSmileySelected(token: String) {
-        smileySearchJob?.cancel()
-        smileySearchJob = null
         // Reuse the formatter helper so the surrounding-spaces convention from HFR's web
         // composer is honoured uniformly (cf. `BbcodeFormatter.insertBbcodeToken`).
         _state.update { current ->
@@ -549,16 +490,17 @@ class PostEditorViewModel @AssistedInject constructor(
                 selection = TextRange(outcome.selectionStart, outcome.selectionEnd),
             )
             val withDraft = current.withDraft(updatedDraft)
-            val withPreview = if (withDraft.isPreviewVisible) {
+            if (withDraft.isPreviewVisible) {
                 withDraft.copy(preview = previewParser.parsePreview(withDraft.draft.text))
             } else {
                 withDraft
             }
-            // Close the picker on successful insertion ; the user can re-open it for another
-            // smiley if they want to chain. This matches HFR web behaviour and keeps the
-            // sheet from squatting the screen between two distant insertions.
-            withPreview.copy(smileyPicker = SmileyPickerState.Hidden)
         }
+        // Close the picker on successful insertion ; the user can re-open it for another
+        // smiley if they want to chain — #824 restores the search they just used. This
+        // matches HFR web behaviour and keeps the sheet from squatting the screen between
+        // two distant insertions.
+        smileyPicker.dismiss()
         scheduleAutosave()
     }
 
@@ -1147,11 +1089,6 @@ class PostEditorViewModel @AssistedInject constructor(
         // Distinct from the repository's "ReplyRepository" tag so the diagnostics
         // panel makes it obvious which layer recorded an entry.
         private const val LOG_TAG_VM = "PostEditorVM"
-
-        // HFR's web composer waits 300 ms after the last keystroke before calling
-        // `find_smilies`, cf. `/compressed/message.js`. Mirror it so the wiki endpoint
-        // sees roughly the same query rate as the web client.
-        private const val SMILEY_SEARCH_DEBOUNCE_MS = 300L
 
         // #405 — idle window after the last edit before the draft is persisted. Long enough to
         // coalesce a burst of keystrokes into a single Room write, short enough that an accidental

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormScreen.kt
@@ -119,21 +119,25 @@ fun TopicFormScreen(
         BackHandler { viewModel.submit(TopicFormIntent.CloseRequested) }
     }
 
+    // #441 — the picker is driven by the shared controller (same wiring as the MP composers
+    // and PostEditorScreen) ; only SmileySelected stays an intent (draft mutation).
+    val smileyPicker = viewModel.smileyPicker
     TopicFormContent(
         state = state,
         onIntent = viewModel::submit,
+        onOpenSmileys = smileyPicker::open,
         modifier = modifier,
     )
 
     // Sheet hoisted as a sibling of the scrollable content : if it lived inside
     // the `Column.verticalScroll`, the bottom sheet would get squashed by the
     // scroll container's measurement. Same rationale as `PostEditorScreen`.
-    val pickerState = state.smileyPicker
-    if (pickerState is SmileyPickerState.Open) {
+    val pickerState by smileyPicker.state.collectAsStateWithLifecycle()
+    (pickerState as? SmileyPickerState.Open)?.let { picker ->
         SmileyPickerSheet(
-            state = pickerState,
-            onDismiss = { viewModel.submit(TopicFormIntent.SmileyPickerDismissed) },
-            onQueryChange = { viewModel.submit(TopicFormIntent.SmileySearchQueryChanged(it)) },
+            state = picker,
+            onDismiss = smileyPicker::dismiss,
+            onQueryChange = smileyPicker::onQueryChanged,
             onSmileyClicked = { viewModel.submit(TopicFormIntent.SmileySelected(it)) },
         )
     }
@@ -143,6 +147,9 @@ fun TopicFormScreen(
 internal fun TopicFormContent(
     state: TopicFormState,
     onIntent: (TopicFormIntent) -> Unit,
+    // #441 — opens the shared smiley picker controller (the sheet host lives in
+    // TopicFormScreen, next to the controller's state collection).
+    onOpenSmileys: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var imageUrlDialogOpen by remember { mutableStateOf(false) }
@@ -261,7 +268,7 @@ internal fun TopicFormContent(
                     onConfirmSubmit = { onIntent(TopicFormIntent.SubmitConfirmed) },
                     onDisarmConfirm = { onIntent(TopicFormIntent.SubmitConfirmationDismissed) },
                     onOpenOptions = { optionsSheetOpen = true },
-                    onOpenSmileys = { onIntent(TopicFormIntent.SmileyPickerOpened) },
+                    onOpenSmileys = onOpenSmileys,
                 ),
             )
         }

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormState.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormState.kt
@@ -2,8 +2,6 @@ package fr.forumhfr.redface2.feature.editor
 import fr.forumhfr.redface2.core.ui.editor.UploadError
 import fr.forumhfr.redface2.core.ui.editor.UploadProgress
 
-import fr.forumhfr.redface2.core.ui.editor.WikiSearchState
-import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 import androidx.compose.ui.text.input.TextFieldValue
 import fr.forumhfr.redface2.core.domain.editor.BbcodeValidation
 import fr.forumhfr.redface2.core.domain.editor.validateBbcodeDraft
@@ -70,18 +68,14 @@ data class TopicFormState(
      * POST anyway and #154 explicitly forbids exposing the legacy anonymous flow.
      */
     val isAnonymous: Boolean = false,
-    /**
-     * Phase 2F-C (#11 partial) — smiley picker visibility + wiki search state, mirrored
-     * from [PostEditorState.smileyPicker]. Reusing the same sealed types
-     * ([SmileyPickerState] / [WikiSearchState]) defined in `PostEditorState.kt` keeps the
-     * two surfaces consistent and avoids forking a parallel sheet UI.
-     */
-    val smileyPicker: SmileyPickerState = SmileyPickerState.Hidden,
+    // #441 — the smiley picker state no longer lives here : visibility + wiki search moved
+    // to the shared `SmileyPickerController` exposed as `TopicFormViewModel.smileyPicker`.
     /**
      * HFR user id parsed from the form HTML (cf. [TopicForm.userId]). Used by the wiki
-     * smiley search call. `null` when the form is anonymous or unparseable — the
-     * repository falls back to `user_id=0`. Same anti-clobber rule as the other hydrated
-     * fields : a silent `InvalidHashCheck` refetch must never erase a previously known id.
+     * smiley search call (read by the `SmileyPickerController` lambda). `null` when the
+     * form is anonymous or unparseable — the controller falls back to `user_id=0`. Same
+     * anti-clobber rule as the other hydrated fields : a silent `InvalidHashCheck` refetch
+     * must never erase a previously known id.
      */
     val userId: Int? = null,
     /**
@@ -188,9 +182,12 @@ sealed interface TopicFormIntent {
     data class ToggleSignature(val enabled: Boolean) : TopicFormIntent
     data class ToggleSmileyDisabled(val disabled: Boolean) : TopicFormIntent
     data class ToggleEmailNotification(val enabled: Boolean) : TopicFormIntent
-    data object SmileyPickerOpened : TopicFormIntent
-    data object SmileyPickerDismissed : TopicFormIntent
-    data class SmileySearchQueryChanged(val query: String) : TopicFormIntent
+    /**
+     * The user tapped a smiley in the picker : insert the token at the caret. #441 — open /
+     * dismiss / query-change are no longer intents (the sheet talks directly to the shared
+     * `SmileyPickerController` exposed as `TopicFormViewModel.smileyPicker`) ; only the
+     * insertion stays MVI because it mutates the draft.
+     */
     data class SmileySelected(val token: String) : TopicFormIntent
 
     /** Phase 2F-E (#189) — insert `[img]url[/img]` for a validated remote image URL. */

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModel.kt
@@ -2,8 +2,7 @@ package fr.forumhfr.redface2.feature.editor
 import fr.forumhfr.redface2.core.ui.editor.UploadError
 import fr.forumhfr.redface2.core.ui.editor.UploadProgress
 
-import fr.forumhfr.redface2.core.ui.editor.WikiSearchState
-import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
+import fr.forumhfr.redface2.core.ui.editor.SmileyPickerController
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
@@ -112,8 +111,6 @@ class TopicFormViewModel @AssistedInject constructor(
 
     private var loadedForm: TopicForm? = null
     private var submitJob: Job? = null
-    /** In-flight wiki smiley search ; cancelled on next query change / picker close / selection. */
-    private var smileySearchJob: Job? = null
 
     /**
      * #405 — stable, content-free draft key. New uses the category key ; EditFirstPost needs the
@@ -290,7 +287,7 @@ class TopicFormViewModel @AssistedInject constructor(
         }
     }
 
-    @Suppress("CyclomaticComplexMethod") // MVI when-dispatch over 16 intent variants ; flat by design.
+    @Suppress("CyclomaticComplexMethod") // MVI when-dispatch over the TopicFormIntent variants ; flat by design.
     fun submit(intent: TopicFormIntent) {
         when (intent) {
             is TopicFormIntent.SubjectChanged -> onSubjectChanged(intent.value)
@@ -310,9 +307,6 @@ class TopicFormViewModel @AssistedInject constructor(
                 _state.update { it.copy(smileyDisabled = intent.disabled) }
             is TopicFormIntent.ToggleEmailNotification ->
                 _state.update { it.copy(emailNotificationEnabled = intent.enabled) }
-            TopicFormIntent.SmileyPickerOpened -> onSmileyPickerOpened()
-            TopicFormIntent.SmileyPickerDismissed -> onSmileyPickerDismissed()
-            is TopicFormIntent.SmileySearchQueryChanged -> onSmileySearchQueryChanged(intent.query)
             is TopicFormIntent.SmileySelected -> onSmileySelected(intent.token)
             is TopicFormIntent.ImageUrlInserted -> onImageUrlInserted(intent.url)
             is TopicFormIntent.ImagesPicked -> onImagesPicked(intent.uris)
@@ -363,85 +357,36 @@ class TopicFormViewModel @AssistedInject constructor(
         draftKey?.let { key -> draftStore.delete(draftOwner, key) }
     }
 
-    private fun onSmileyPickerOpened() {
-        _state.update { current ->
-            if (current.smileyPicker is SmileyPickerState.Open) current
-            else current.copy(smileyPicker = SmileyPickerState.Open())
-        }
-    }
-
-    private fun onSmileyPickerDismissed() {
-        smileySearchJob?.cancel()
-        smileySearchJob = null
-        _state.update { it.copy(smileyPicker = SmileyPickerState.Hidden) }
-    }
-
-    private fun onSmileySearchQueryChanged(query: String) {
-        _state.update { current ->
-            val open = current.smileyPicker as? SmileyPickerState.Open ?: return@update current
-            current.copy(smileyPicker = open.copy(query = query))
-        }
-        // Cancel in-flight searches so an older response can't overwrite a newer query.
-        smileySearchJob?.cancel()
-        if (query.length <= 2) {
-            // Mirrors the HFR web composer's `query.length > 2` gate. Below threshold we
-            // reset the wiki branch to Idle so the picker can render the Standard tab.
-            _state.update { current ->
-                val open = current.smileyPicker as? SmileyPickerState.Open ?: return@update current
-                current.copy(smileyPicker = open.copy(wiki = WikiSearchState.Idle))
-            }
-            return
-        }
-        smileySearchJob = viewModelScope.launch {
-            // 300 ms matches the JS `find_smilies_timer` debounce embedded in HFR's
-            // /compressed/message.js, identical to `PostEditorViewModel`. Flip to
-            // `Loading` AFTER the debounce so a fast burst of keystrokes does not
-            // flash the spinner before the actual network call.
-            delay(SMILEY_SEARCH_DEBOUNCE_MS)
-            // Identity guard against the « same query typed twice in a 300 ms window »
-            // race : if a second `onSmileySearchQueryChanged` arrived with the same
-            // query while the first was still in its debounce, the older job's
-            // `coroutineContext[Job]` is no longer the active `smileySearchJob`.
-            if (coroutineContext[Job] !== smileySearchJob) return@launch
-            _state.update { current ->
-                val open = current.smileyPicker as? SmileyPickerState.Open ?: return@update current
-                if (open.query != query) return@update current
-                current.copy(smileyPicker = open.copy(wiki = WikiSearchState.Loading))
-            }
-            val effectiveUserId = _state.value.userId ?: 0
-            val outcome = runCatching { smileyRepository.searchWiki(effectiveUserId, query) }
-            outcome.fold(
-                onSuccess = { items ->
-                    _state.update { current ->
-                        val open = current.smileyPicker as? SmileyPickerState.Open
-                            ?: return@update current
-                        // Drop the result if the user closed the picker or typed a different
-                        // query while we were waiting on the network.
-                        if (open.query != query) return@update current
-                        current.copy(smileyPicker = open.copy(wiki = WikiSearchState.Results(items)))
-                    }
-                },
-                onFailure = { error ->
-                    if (error is CancellationException) throw error
-                    diagnostics.record(
-                        DiagnosticsLog.Level.WARN,
-                        LOG_TAG_VM,
-                        "wiki smiley search failed: ${error::class.simpleName}",
-                    )
-                    _state.update { current ->
-                        val open = current.smileyPicker as? SmileyPickerState.Open
-                            ?: return@update current
-                        if (open.query != query) return@update current
-                        current.copy(smileyPicker = open.copy(wiki = WikiSearchState.Error))
-                    }
-                },
+    /**
+     * #441 — smiley picker (Standard + Wiki search), delegated to the shared
+     * [SmileyPickerController] exactly like the MP composers (#387/#440) and
+     * `PostEditorViewModel` : the controller owns open/dismiss/query, the 300 ms debounce
+     * and its race guards, and the #824 restore-search-on-reopen contract. This ViewModel
+     * keeps only the insertion ([onSmileySelected] — a draft mutation, so it stays an MVI
+     * intent) ; the mixed wiring is deliberate, do not re-route it for « consistency ».
+     *
+     * Lifecycle (réserve Codex #441) : the editorial context is frozen at construction
+     * (`@Assisted request` ; one `TopicFormRoute` nav entry = one ViewModel), so the
+     * controller can never be re-armed for another topic/form — no targeted reset needed
+     * beyond the ViewModel's own death.
+     *
+     * Failure logging stays a policy of THIS feature (the MP composers keep the controller's
+     * no-op default) : class name only — never the query nor the userId (anti-leak test).
+     */
+    val smileyPicker = SmileyPickerController(
+        scope = viewModelScope,
+        searchWiki = smileyRepository::searchWiki,
+        userId = { _state.value.userId },
+        onSearchFailed = { error ->
+            diagnostics.record(
+                DiagnosticsLog.Level.WARN,
+                LOG_TAG_VM,
+                "wiki smiley search failed: ${error::class.simpleName}",
             )
-        }
-    }
+        },
+    )
 
     private fun onSmileySelected(token: String) {
-        smileySearchJob?.cancel()
-        smileySearchJob = null
         _state.update { current ->
             val draft = current.draft
             val selection = draft.selection
@@ -456,13 +401,15 @@ class TopicFormViewModel @AssistedInject constructor(
                 selection = TextRange(outcome.selectionStart, outcome.selectionEnd),
             )
             val withDraft = current.withDraft(updatedDraft)
-            val withPreview = if (withDraft.isPreviewVisible) {
+            if (withDraft.isPreviewVisible) {
                 withDraft.copy(preview = previewParser.parsePreview(withDraft.draft.text))
             } else {
                 withDraft
             }
-            withPreview.copy(smileyPicker = SmileyPickerState.Hidden)
         }
+        // Close the picker on successful insertion (#824 restores the search on the next
+        // open) — same contract as PostEditorViewModel.onSmileySelected.
+        smileyPicker.dismiss()
         scheduleAutosave()
     }
 
@@ -1059,11 +1006,6 @@ class TopicFormViewModel @AssistedInject constructor(
 
     private companion object {
         private const val LOG_TAG_VM = "TopicFormVM"
-
-        // HFR's web composer waits 300 ms after the last keystroke before calling
-        // `find_smilies`, cf. `/compressed/message.js`. Mirror it so the wiki endpoint
-        // sees roughly the same query rate as the web client.
-        private const val SMILEY_SEARCH_DEBOUNCE_MS = 300L
 
         // #405 — idle window after the last edit before the draft is persisted (cf. PostEditorViewModel).
         private const val AUTOSAVE_DEBOUNCE_MS = 750L

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -2,7 +2,6 @@ package fr.forumhfr.redface2.feature.editor
 import fr.forumhfr.redface2.core.ui.editor.UploadError
 import fr.forumhfr.redface2.core.ui.editor.UploadProgress
 
-import fr.forumhfr.redface2.core.ui.editor.WikiSearchState
 import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
@@ -70,7 +69,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import fr.forumhfr.redface2.core.model.EditorSmiley
-import fr.forumhfr.redface2.core.model.EditorSmileySource
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @Suppress("LargeClass") // One class per ViewModel keeps every code path co-located with its
@@ -819,114 +817,46 @@ class PostEditorViewModelTest {
             quoteMaterializer = ReplyQuoteMaterializer(replyRepository),
         )
 
-    // ----- Phase 2F-B (#11) : smiley picker ----------------------------------
+    // ----- Phase 2F-B (#11) / #441 : smiley picker ----------------------------------
+    // The picker machinery (open/dismiss, ≤ 2-chars gate, debounce, stale-result guards,
+    // #824 restore-on-reopen) lives in the shared SmileyPickerController and is covered by
+    // SmileyPickerControllerTest — no duplicate coverage here. These tests only exercise
+    // what stays a ViewModel concern : the insertion intent, the userId plumbed from the
+    // parsed form, and the diagnostics policy on search failure.
 
     @Test
-    fun `SmileyPickerOpened transitions the state to Open`() = runTest {
+    fun `the wiki search carries the form's parsed userId (#441)`() = runTest {
+        replyRepository.formResult = Result.success(authenticatedForm().copy(userId = 54_596))
         val viewModel = newReplyViewModel()
-        viewModel.state.test {
-            skipItems(1) // initial idle state
-            viewModel.submit(PostEditorIntent.SmileyPickerOpened)
-            val opened = expectMostRecentItem()
-            val picker = opened.smileyPicker
-            assert(picker is SmileyPickerState.Open) {
-                "expected Open, got $picker"
-            }
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
+        testScheduler.advanceUntilIdle() // form fetch → userId hydrated into state
 
-    @Test
-    fun `SmileyPickerDismissed sets the state back to Hidden`() = runTest {
-        val viewModel = newReplyViewModel()
-        viewModel.submit(PostEditorIntent.SmileyPickerOpened)
-        viewModel.submit(PostEditorIntent.SmileyPickerDismissed)
-        viewModel.state.test {
-            val state = expectMostRecentItem()
-            assert(state.smileyPicker == SmileyPickerState.Hidden) {
-                "expected Hidden after dismiss, got ${state.smileyPicker}"
-            }
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `short queries stay below the 2-char threshold and do not hit the repository`() = runTest {
-        val viewModel = newReplyViewModel()
-        viewModel.submit(PostEditorIntent.SmileyPickerOpened)
-        viewModel.submit(PostEditorIntent.SmileySearchQueryChanged("ja"))
-        // The 2-char query is below threshold, so no debounce kicks in either ; assert by
-        // call-count rather than racing the dispatcher.
-        assertEquals(0, smileyRepository.callCount)
-        viewModel.state.test {
-            val state = expectMostRecentItem()
-            val picker = state.smileyPicker as SmileyPickerState.Open
-            assertEquals(WikiSearchState.Idle, picker.wiki)
-            assertEquals("ja", picker.query)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `queries above the threshold hit the repository after the debounce`() = runTest {
-        val viewModel = newReplyViewModel()
-        viewModel.submit(PostEditorIntent.SmileyPickerOpened)
-        viewModel.submit(PostEditorIntent.SmileySearchQueryChanged("jap"))
-        // Advance through the 300 ms debounce.
+        viewModel.smileyPicker.open()
+        viewModel.smileyPicker.onQueryChanged("jap")
         testScheduler.advanceTimeBy(400L)
         testScheduler.runCurrent()
+
         assertEquals(1, smileyRepository.callCount)
         assertEquals("jap", smileyRepository.lastQuery)
+        assertEquals(54_596, smileyRepository.lastUserId)
     }
 
     @Test
-    fun `successful wiki search lands as Results in the picker`() = runTest {
-        val viewModel = newReplyViewModel()
-        viewModel.submit(PostEditorIntent.SmileyPickerOpened)
-        viewModel.submit(PostEditorIntent.SmileySearchQueryChanged("jap"))
+    fun `the wiki search falls back to user id 0 while the form exposed no userId`() = runTest {
+        val viewModel = newReplyViewModel() // fake form carries no userId → state.userId null
+        viewModel.smileyPicker.open()
+        viewModel.smileyPicker.onQueryChanged("jap")
         testScheduler.advanceTimeBy(400L)
         testScheduler.runCurrent()
-        smileyRepository.completeNext(
-            listOf(
-                EditorSmiley(
-                    token = "[:haha jap]",
-                    imageUrl = "https://forum-images.hardware.fr/images/perso/haha%20jap.gif",
-                    source = EditorSmileySource.WIKI,
-                ),
-            ),
-        )
-        viewModel.state.test {
-            val state = expectMostRecentItem()
-            val picker = state.smileyPicker as SmileyPickerState.Open
-            val wiki = picker.wiki as WikiSearchState.Results
-            assertEquals(1, wiki.items.size)
-            assertEquals("[:haha jap]", wiki.items[0].token)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
 
-    @Test
-    fun `failed wiki search lands as Error and keeps the picker open`() = runTest {
-        val viewModel = newReplyViewModel()
-        viewModel.submit(PostEditorIntent.SmileyPickerOpened)
-        viewModel.submit(PostEditorIntent.SmileySearchQueryChanged("jap"))
-        testScheduler.advanceTimeBy(400L)
-        testScheduler.runCurrent()
-        smileyRepository.failNext(java.io.IOException("offline"))
-        viewModel.state.test {
-            val state = expectMostRecentItem()
-            val picker = state.smileyPicker as SmileyPickerState.Open
-            assertEquals(WikiSearchState.Error, picker.wiki)
-            cancelAndIgnoreRemainingEvents()
-        }
+        assertEquals(0, smileyRepository.lastUserId)
     }
 
     @Test
     fun `failed wiki search does not leak user id or query through diagnostics`() = runTest {
         val diagnostics = DiagnosticsLog()
         val viewModel = newReplyViewModel(diagnostics = diagnostics)
-        viewModel.submit(PostEditorIntent.SmileyPickerOpened)
-        viewModel.submit(PostEditorIntent.SmileySearchQueryChanged("secret"))
+        viewModel.smileyPicker.open()
+        viewModel.smileyPicker.onQueryChanged("secret")
         testScheduler.advanceTimeBy(400L)
         testScheduler.runCurrent()
 
@@ -945,40 +875,19 @@ class PostEditorViewModelTest {
     @Test
     fun `SmileySelected inserts the token at the caret and closes the picker`() = runTest {
         val viewModel = newReplyViewModel()
-        viewModel.submit(PostEditorIntent.ContentChanged(
-            androidx.compose.ui.text.input.TextFieldValue("hello", androidx.compose.ui.text.TextRange(5)),
-        ))
-        viewModel.submit(PostEditorIntent.SmileyPickerOpened)
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("hello", TextRange(5))))
+        viewModel.smileyPicker.open()
         viewModel.submit(PostEditorIntent.SmileySelected(":jap:"))
         viewModel.state.test {
             val state = expectMostRecentItem()
             // Surrounding spaces convention from `putSmiley` is honoured.
             assertEquals("hello :jap: ", state.draft.text)
             assertEquals(12, state.draft.selection.start)
-            // Picker auto-closes so the user can keep typing.
-            assertEquals(SmileyPickerState.Hidden, state.smileyPicker)
             cancelAndIgnoreRemainingEvents()
         }
-    }
-
-    @Test
-    fun `SmileySelected cancels the in-flight wiki search`() = runTest {
-        val viewModel = newReplyViewModel()
-        viewModel.submit(PostEditorIntent.SmileyPickerOpened)
-        viewModel.submit(PostEditorIntent.SmileySearchQueryChanged("jap"))
-        testScheduler.advanceTimeBy(400L)
-        testScheduler.runCurrent()
-        assertEquals(1, smileyRepository.callCount)
-
-        viewModel.submit(PostEditorIntent.SmileySelected(":jap:"))
-        testScheduler.runCurrent()
-
-        assertEquals(1, smileyRepository.cancellationCount)
-        viewModel.state.test {
-            val state = expectMostRecentItem()
-            assertEquals(SmileyPickerState.Hidden, state.smileyPicker)
-            cancelAndIgnoreRemainingEvents()
-        }
+        // Picker auto-closes (through the controller) so the user can keep typing ;
+        // #824 makes the same controller restore the search on the next open.
+        assertEquals(SmileyPickerState.Hidden, viewModel.smileyPicker.state.value)
     }
 
     @Test

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -2,7 +2,6 @@ package fr.forumhfr.redface2.feature.editor
 import fr.forumhfr.redface2.core.ui.editor.UploadError
 import fr.forumhfr.redface2.core.ui.editor.UploadProgress
 
-import fr.forumhfr.redface2.core.ui.editor.WikiSearchState
 import fr.forumhfr.redface2.core.ui.editor.SmileyPickerState
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
@@ -39,7 +38,6 @@ import fr.forumhfr.redface2.core.model.editor.EditorImageInsert
 import fr.forumhfr.redface2.core.model.editor.WritingSurfacePreset
 import fr.forumhfr.redface2.core.domain.write.TopicFormRepository
 import fr.forumhfr.redface2.core.model.EditorSmiley
-import fr.forumhfr.redface2.core.model.EditorSmileySource
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.PostBlock
 import fr.forumhfr.redface2.core.model.PostContent
@@ -520,72 +518,29 @@ class TopicFormViewModelTest {
         assertEquals(0, topicFormRepository.newTopicSubmitCalls)
     }
 
-    // ----- Phase 2F-C (#11) : smiley picker ----------------------------------
+    // ----- Phase 2F-C (#11) / #441 : smiley picker ----------------------------------
+    // The picker machinery (open/dismiss, ≤ 2-chars gate, debounce, stale-result guards,
+    // #824 restore-on-reopen) lives in the shared SmileyPickerController and is covered by
+    // SmileyPickerControllerTest — no duplicate coverage here. These tests only exercise
+    // what stays a ViewModel concern : the insertion intent, the userId plumbed from the
+    // parsed form, and the diagnostics policy on search failure.
 
     @Test
-    fun `SmileyPickerOpened transitions the picker to Open`() = runTest {
-        val viewModel = newViewModel()
-        viewModel.submit(TopicFormIntent.SmileyPickerOpened)
-        viewModel.state.test {
-            val state = expectMostRecentItem()
-            val picker = state.smileyPicker
-            assertTrue("expected Open, got $picker", picker is SmileyPickerState.Open)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `SmileyPickerDismissed closes the sheet and cancels the in-flight search`() = runTest {
-        val viewModel = newViewModel()
-        viewModel.submit(TopicFormIntent.SmileyPickerOpened)
-        viewModel.submit(TopicFormIntent.SmileySearchQueryChanged("jap"))
-        testScheduler.advanceTimeBy(400L)
-        testScheduler.runCurrent()
-        assertEquals(1, smileyRepository.callCount)
-
-        viewModel.submit(TopicFormIntent.SmileyPickerDismissed)
-        testScheduler.runCurrent()
-
-        assertEquals(1, smileyRepository.cancellationCount)
-        viewModel.state.test {
-            val state = expectMostRecentItem()
-            assertEquals(SmileyPickerState.Hidden, state.smileyPicker)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `short queries stay below the 2-char threshold and do not hit the repository`() = runTest {
-        val viewModel = newViewModel()
-        viewModel.submit(TopicFormIntent.SmileyPickerOpened)
-        viewModel.submit(TopicFormIntent.SmileySearchQueryChanged("ja"))
-        // Below threshold : the gate is synchronous, no debounce kicks in.
-        assertEquals(0, smileyRepository.callCount)
-        viewModel.state.test {
-            val state = expectMostRecentItem()
-            val picker = state.smileyPicker as SmileyPickerState.Open
-            assertEquals(WikiSearchState.Idle, picker.wiki)
-            assertEquals("ja", picker.query)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `queries above the threshold hit the repository with the hydrated userId after debounce`() = runTest {
+    fun `the wiki search carries the hydrated userId (#441)`() = runTest {
         val viewModel = newViewModel()
         // Wait for the form to be hydrated so userId lands in state.
         viewModel.state.test {
             awaitHydratedState()
             cancelAndIgnoreRemainingEvents()
         }
-        viewModel.submit(TopicFormIntent.SmileyPickerOpened)
-        viewModel.submit(TopicFormIntent.SmileySearchQueryChanged("jap"))
+        viewModel.smileyPicker.open()
+        viewModel.smileyPicker.onQueryChanged("jap")
         testScheduler.advanceTimeBy(400L)
         testScheduler.runCurrent()
         assertEquals(1, smileyRepository.callCount)
         assertEquals("jap", smileyRepository.lastQuery)
-        // The form's parsed userId is plumbed through to the search call — the
-        // repository falls back to 0 only when `state.userId` is `null`.
+        // The form's parsed userId is plumbed through the controller's userId lambda —
+        // the controller falls back to 0 only when `state.userId` is `null`.
         assertEquals(SAMPLE_USER_ID, smileyRepository.lastUserId)
     }
 
@@ -597,35 +552,19 @@ class TopicFormViewModelTest {
             awaitHydratedState()
             cancelAndIgnoreRemainingEvents()
         }
-        viewModel.submit(TopicFormIntent.SmileyPickerOpened)
-        viewModel.submit(TopicFormIntent.SmileySearchQueryChanged("jap"))
+        viewModel.smileyPicker.open()
+        viewModel.smileyPicker.onQueryChanged("jap")
         testScheduler.advanceTimeBy(400L)
         testScheduler.runCurrent()
         assertEquals(0, smileyRepository.lastUserId)
     }
 
     @Test
-    fun `failed wiki search lands as Error and keeps the picker open`() = runTest {
-        val viewModel = newViewModel()
-        viewModel.submit(TopicFormIntent.SmileyPickerOpened)
-        viewModel.submit(TopicFormIntent.SmileySearchQueryChanged("jap"))
-        testScheduler.advanceTimeBy(400L)
-        testScheduler.runCurrent()
-        smileyRepository.failNext(java.io.IOException("offline"))
-        viewModel.state.test {
-            val state = expectMostRecentItem()
-            val picker = state.smileyPicker as SmileyPickerState.Open
-            assertEquals(WikiSearchState.Error, picker.wiki)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
     fun `failed wiki search does not leak user id or query through diagnostics`() = runTest {
         val diagnostics = DiagnosticsLog()
         val viewModel = newViewModel(diagnostics = diagnostics)
-        viewModel.submit(TopicFormIntent.SmileyPickerOpened)
-        viewModel.submit(TopicFormIntent.SmileySearchQueryChanged("secret"))
+        viewModel.smileyPicker.open()
+        viewModel.smileyPicker.onQueryChanged("secret")
         testScheduler.advanceTimeBy(400L)
         testScheduler.runCurrent()
 
@@ -648,94 +587,30 @@ class TopicFormViewModelTest {
             awaitHydratedState()
             cancelAndIgnoreRemainingEvents()
         }
-        // Move caret to start of draft, open preview, then pick a smiley.
+        // Move caret to end of draft, open preview, then pick a smiley.
         viewModel.submit(
             TopicFormIntent.ContentChanged(TextFieldValue("hello", TextRange(5))),
         )
         viewModel.submit(TopicFormIntent.TogglePreview)
-        viewModel.submit(TopicFormIntent.SmileyPickerOpened)
+        viewModel.smileyPicker.open()
         viewModel.submit(TopicFormIntent.SmileySelected(":jap:"))
         viewModel.state.test {
             val state = expectMostRecentItem()
             // Surrounding-spaces convention from `insertBbcodeToken` is honoured.
             assertEquals("hello :jap: ", state.draft.text)
             assertEquals(12, state.draft.selection.start)
-            assertEquals(SmileyPickerState.Hidden, state.smileyPicker)
             // Preview was visible : the new draft text must be re-parsed.
             val firstBlock = state.preview.blocks.first() as PostBlock.Paragraph
             val firstInline = firstBlock.inlines.first() as PostInline.Text
             assertEquals("hello :jap: ", firstInline.value)
             cancelAndIgnoreRemainingEvents()
         }
+        // Picker auto-closes (through the controller) ; #824 restores the search on reopen.
+        assertEquals(SmileyPickerState.Hidden, viewModel.smileyPicker.state.value)
     }
 
     @Test
-    fun `two successive queries do not allow the first response to clobber the second`() = runTest {
-        val viewModel = newViewModel()
-        viewModel.submit(TopicFormIntent.SmileyPickerOpened)
-        viewModel.submit(TopicFormIntent.SmileySearchQueryChanged("jap"))
-        testScheduler.advanceTimeBy(400L)
-        testScheduler.runCurrent()
-        // Second keystroke arrives BEFORE the first response lands.
-        viewModel.submit(TopicFormIntent.SmileySearchQueryChanged("jap "))
-        testScheduler.advanceTimeBy(400L)
-        testScheduler.runCurrent()
-        // The repo recorded the second call ; the first was cancelled.
-        assertEquals(2, smileyRepository.callCount)
-        assertEquals(1, smileyRepository.cancellationCount)
-        assertEquals("jap ", smileyRepository.lastQuery)
-
-        // The latest response (for "jap ") lands ; the earlier "jap" job was cancelled
-        // so its result cannot overwrite the current state.
-        smileyRepository.completeNext(
-            listOf(
-                EditorSmiley(
-                    token = "[:haha jap]",
-                    imageUrl = "https://forum-images.hardware.fr/images/perso/haha%20jap.gif",
-                    source = EditorSmileySource.WIKI,
-                ),
-            ),
-        )
-        viewModel.state.test {
-            val state = expectMostRecentItem()
-            val picker = state.smileyPicker as SmileyPickerState.Open
-            val wiki = picker.wiki as WikiSearchState.Results
-            assertEquals(1, wiki.items.size)
-            assertEquals("[:haha jap]", wiki.items[0].token)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `same query typed twice within debounce window fires only one request`() = runTest {
-        // Covers the identity guard `coroutineContext[Job] !== smileySearchJob` : when the
-        // SAME query is sent twice before the first 300 ms debounce resolves, the second
-        // QueryChanged cancels the first job ; the second job survives the debounce and
-        // is the only one to land a request.
-        val viewModel = newViewModel()
-        viewModel.submit(TopicFormIntent.SmileyPickerOpened)
-        viewModel.submit(TopicFormIntent.SmileySearchQueryChanged("jap"))
-        // Inside the debounce window — no fire yet.
-        testScheduler.advanceTimeBy(100L)
-        testScheduler.runCurrent()
-        assertEquals(0, smileyRepository.callCount)
-
-        viewModel.submit(TopicFormIntent.SmileySearchQueryChanged("jap"))
-        testScheduler.advanceTimeBy(400L)
-        testScheduler.runCurrent()
-
-        // Exactly one network call : the first job was cancelled at ~100 ms by the second
-        // QueryChanged, and the second job's identity guard saw itself as the live one.
-        assertEquals(1, smileyRepository.callCount)
-        assertEquals("jap", smileyRepository.lastQuery)
-        // The first job never reached `searchWiki` (it was cancelled during its delay), so
-        // no `cancellationCount` increment is expected here — the cancellation tally only
-        // tracks cancellations that happen inside `searchWiki.await()`.
-        assertEquals(0, smileyRepository.cancellationCount)
-    }
-
-    @Test
-    fun `New mode also opens the smiley picker and uses the hydrated userId`() = runTest {
+    fun `New mode also searches the wiki with the hydrated userId`() = runTest {
         val viewModel = newTopicViewModel(entrySubcat = SAMPLE_SUBCAT)
         viewModel.state.test {
             // Wait for the form fetch to land.
@@ -743,8 +618,8 @@ class TopicFormViewModelTest {
             assertEquals(SAMPLE_USER_ID, hydrated.userId)
             cancelAndIgnoreRemainingEvents()
         }
-        viewModel.submit(TopicFormIntent.SmileyPickerOpened)
-        viewModel.submit(TopicFormIntent.SmileySearchQueryChanged("jap"))
+        viewModel.smileyPicker.open()
+        viewModel.smileyPicker.onQueryChanged("jap")
         testScheduler.advanceTimeBy(400L)
         testScheduler.runCurrent()
         assertEquals(SAMPLE_USER_ID, smileyRepository.lastUserId)


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Closes #441. Closes #824.

## #441 — un seul chemin de recherche smiley
Les copies embarquées de la machine de recherche (job/debounce/stale/cancel) dans `PostEditorViewModel` et `TopicFormViewModel` sont supprimées ; tout passe par `SmileyPickerController` (core/ui), comme les MP. Diagnostics par hook `onSearchFailed` injecté (WARN, classe d'erreur seulement — pas de query ni d'userId). −509 lignes, +327.

## #824 — la recherche survit à la fermeture du picker
`dismiss()` snapshotte l'état Open (Results verbatim ; Loading/Error normalisés → Idle), `open()` restaure sans refetch et reste idempotent. Pas de `reset()` public : VM cleared = reset naturel (contexte éditorial figé par `@Assisted request` + Navigation 3 : une route = un entry = un ViewModelStore — réserve n°4 du cadrage levée et documentée). La sheet rouvre sur l'onglet Wiki quand une recherche est restaurée. Bénéfice automatique pour les MP.

## Tests
`SmileyPickerControllerTest` 8→13 (contrat #824 : restore sans refetch, Loading/Error→Idle, idempotence) ; tests VM resserrés sur leur contrat (insertion/preview/autosave/fermeture, userId + fallback 0, anti-fuite diagnostics).

## Validation
- Canonique complète verte en local (detektAll, lintDebug, :app:lintProdDebug, testDebugUnitTest, :app:assembleProdDebug).
- Cadrage puis gate Codex (gpt-5.5, xhigh) : **GO-avec-réserves** — réserve unique sur l'onglet initial au reopen (rememberSaveable), vérifiée au dogfood émulateur (voir commentaire de PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pm28ny4V5GSegmKJxTPVAM