### PR TITLE
feat(ui): render-time fast-path for the hfr-cc-image marker (#256)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/CcImageMarker.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/CcImageMarker.kt
@@ -1,0 +1,80 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import java.net.URLDecoder
+
+/**
+ * #256 — detection of the community "cc-image" marker, a query parameter (`hfr-cc-image=true`)
+ * that userscript-era HFR extensions append to emoji image URLs (e.g.
+ * `…/emojis-micro/<codepoint>.png?hfr-cc-image=true&raw=true`) to declare "this `[img]` is a
+ * one-line emoji glyph, size it like text".
+ *
+ * The check is **render-time only** and applies to the ORIGINAL URL carried by the AST (the
+ * `:core:parser` `sanitizeImageHref` preserves the query string verbatim, and any redirect target —
+ * e.g. `raw.githubusercontent.com` — is a Coil concern that never reaches this code). It never
+ * alters the AST, the link semantics, the MediaCounter symmetry or the block-promotion path: its
+ * only consumers are the inline SIZING fast-path in `imageDisplayBox` and the measurement-probe
+ * exclusion in `collectMeasurableImageUrl` (both in PostRenderer).
+ *
+ * Matching contract (pure JVM, no `android.net.Uri` — `:core:ui` unit tests run on the JVM):
+ *  - only the **query** component is inspected: the substring between the first `?` and the first
+ *    following `#` (a marker in the fragment or in the path never matches);
+ *  - the query is split into `&`-separated pairs; each pair's name and value are percent-decoded
+ *    (application/x-www-form-urlencoded, so `+` decodes to a space) and compared **exactly and
+ *    case-sensitively** to `hfr-cc-image` / `true` — no naive `contains`, no case folding;
+ *  - a pair whose name cannot be decoded (malformed percent-encoding) cannot be the marker and is
+ *    ignored; a URL with no query, or any unparseable shape, simply doesn't match.
+ *
+ * DUPLICATE RULE (decided before implementation, most conservative option): the fast-path applies
+ * only when the marker is UNAMBIGUOUS — at least one `hfr-cc-image` pair is present AND **every**
+ * occurrence decodes exactly to `true`. Any occurrence carrying anything else (`false`, an empty or
+ * missing value, an undecodable value) disqualifies the whole URL, i.e. "false wins" over "first
+ * wins". Rationale: a non-match merely falls back to the normal measured-sizing path (worst case one
+ * async probe, correct rendering), while a wrong match would pin a real photo to a 16sp square — so
+ * ambiguity must resolve to NOT fast-pathing.
+ */
+@Suppress("ReturnCount") // No-query guards + trailing verdict.
+internal fun isCcImageUrl(url: String): Boolean {
+    val queryStart = url.indexOf('?')
+    if (queryStart < 0) return false
+    val fragmentStart = url.indexOf('#')
+    // A `?` after the first `#` belongs to the fragment: the URL has no query component at all
+    // (`e.png#frag?hfr-cc-image=true` must NOT match — Codex gate catch).
+    if (fragmentStart in 0..<queryStart) return false
+    val rawQuery = url.substring(queryStart + 1, if (fragmentStart >= 0) fragmentStart else url.length)
+    if (rawQuery.isEmpty()) return false
+    val occurrences = rawQuery.split('&').mapNotNull(::ccMarkerOccurrenceOrNull)
+    // Duplicate rule: at least one marker occurrence, and every one of them exactly "true".
+    return occurrences.isNotEmpty() && occurrences.all { it.value == CC_IMAGE_MARKER_VALUE }
+}
+
+/**
+ * Parses one raw `&`-separated query pair; non-null only for decodable `hfr-cc-image` pairs.
+ * Distinguishing "not a marker pair" (null) from "a marker pair with a missing/undecodable value"
+ * ([CcMarkerOccurrence] with a null [CcMarkerOccurrence.value], which disqualifies) is the whole
+ * point of the wrapper.
+ */
+@Suppress("ReturnCount") // Ignore-this-pair guards, cheaper than nesting three levels of if/else.
+private fun ccMarkerOccurrenceOrNull(pair: String): CcMarkerOccurrence? {
+    if (pair.isEmpty()) return null
+    val separator = pair.indexOf('=')
+    val rawName = if (separator >= 0) pair.substring(0, separator) else pair
+    // An undecodable name cannot be the marker — the pair is ignored, not disqualifying.
+    val name = decodeQueryComponent(rawName) ?: return null
+    if (name != CC_IMAGE_MARKER_NAME) return null
+    // A missing or undecodable value stays null and disqualifies through the "all true" rule.
+    val value = if (separator >= 0) decodeQueryComponent(pair.substring(separator + 1)) else null
+    return CcMarkerOccurrence(value)
+}
+
+/** One `hfr-cc-image` occurrence; [value] is null when the value was missing or undecodable. */
+private data class CcMarkerOccurrence(val value: String?)
+
+/**
+ * Percent-decodes one query name/value, or null when malformed (e.g. a truncated `%z` escape).
+ * Uses the charset-NAME overload: `URLDecoder.decode(String, Charset)` needs API 33 (minSdk is 29).
+ */
+private fun decodeQueryComponent(component: String): String? =
+    runCatching { URLDecoder.decode(component, "UTF-8") }.getOrNull()
+
+private const val CC_IMAGE_MARKER_NAME = "hfr-cc-image"
+private const val CC_IMAGE_MARKER_VALUE = "true"

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -1172,6 +1172,12 @@ private fun collectMeasurableSmileyUrl(inline: PostInline, urls: MutableSet<Stri
  * (no-upscale native sizing, like #175 smileys). The `:core:ui` parser has already stripped
  * non-http(s) schemes, so every collected URL is safe to hand to Coil. Recurses into inline
  * containers (e.g. an `[img]` wrapped in a `[url=…]` link), mirroring [walkInlinesForMedia].
+ *
+ * #256 — URLs carrying the `hfr-cc-image=true` marker are EXCLUDED: their box is pinned by the
+ * [imageDisplayBox] fast-path (never read from the measurement cache), so probing them would only
+ * spend a useless network round-trip. Block promotion is unaffected: an unmeasured URL never trips
+ * [shouldPromoteImagesToBlocks], which is exactly the intended always-inline treatment for a marked
+ * emoji.
  */
 internal fun collectMeasurableImageUrls(inlines: List<PostInline>): Set<String> {
     val urls = LinkedHashSet<String>()
@@ -1185,7 +1191,8 @@ private fun collectMeasurableImageUrlsInto(inlines: List<PostInline>, urls: Muta
 
 private fun collectMeasurableImageUrl(inline: PostInline, urls: MutableSet<String>) {
     when (inline) {
-        is PostInline.InlineImage -> urls += inline.url
+        // #256 — cc-image-marked URLs are not measurable (fixed one-line box, see the KDoc above).
+        is PostInline.InlineImage -> if (!isCcImageUrl(inline.url)) urls += inline.url
         is PostInline.Strong -> collectMeasurableImageUrlsInto(inline.children, urls)
         is PostInline.Emphasis -> collectMeasurableImageUrlsInto(inline.children, urls)
         is PostInline.Underline -> collectMeasurableImageUrlsInto(inline.children, urls)
@@ -1232,12 +1239,30 @@ private fun smileyDisplayBox(
  * 16×16 emoji) is already at its final size — zero flash — and any larger image just grows from a
  * one-line slot once measured instead of shrinking from a giant one. Still relative-capped so even
  * the fallback never overflows a narrow quote. Mirrors [smileyDisplayBox].
+ *
+ * #256 — a URL carrying the `hfr-cc-image=true` marker short-circuits ALL of the above: fixed
+ * one-line square, no measurement involved (see [isCcImageUrl] and the fast-path comment below).
  */
 internal fun imageDisplayBox(
     image: PostInline.InlineImage,
     measured: Map<String, IntSize?>,
     maxWidthSp: Int,
 ): InlineMediaBox {
+    // #256 — render-time fast-path: a URL carrying the `hfr-cc-image=true` marker declares itself a
+    // community cc-image emoji (a one-line glyph). Pin its box to the one-line square immediately —
+    // the same square as the #253 cold fallback below, so a marked emoji is at its final size from
+    // the very first frame (zero flash, zero reflow) — and IGNORE any measured size on record: the
+    // marker, not the measurement, is the contract (matching + duplicate rules in [isCcImageUrl]).
+    // The companion exclusion in [collectMeasurableImageUrl] skips the async probe for these URLs
+    // entirely. Still relative-capped so even this square cannot overflow a pathologically narrow
+    // container. Everything else (AST, link semantics, MediaCounter, promotion) is untouched.
+    if (isCcImageUrl(image.url)) {
+        val fixed = capToWidth(
+            PixelSize(INLINE_IMAGE_MIN_HEIGHT_SP, INLINE_IMAGE_MIN_HEIGHT_SP),
+            maxWidthSp,
+        )
+        return InlineMediaBox(fixed.width.sp, fixed.height.sp)
+    }
     val size = measured[image.url]
     val base = if (size != null) {
         // #175 no-upscale + cap with the inline-image caps, then a min-height floor so a SUB-16 low-res

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/CcImageMarkerTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/CcImageMarkerTest.kt
@@ -1,0 +1,180 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import fr.forumhfr.redface2.core.model.PostInline
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #256 — exhaustive pinning of the `hfr-cc-image=true` marker matching ([isCcImageUrl]) and of the
+ * measurement-probe exclusion ([collectMeasurableImageUrls]). The matcher is deliberately strict:
+ * exact case-sensitive name/value after percent-decoding, query component only, and the conservative
+ * duplicate rule (any non-`true` occurrence disqualifies — see the KDoc in CcImageMarker.kt).
+ */
+class CcImageMarkerTest {
+
+    // --- nominal shapes -------------------------------------------------------------------------
+
+    @Test
+    fun `nominal cc-image URL matches`() {
+        // The real-world shape from the issue: …/emojis-micro/<codepoint>.png?hfr-cc-image=true&raw=true
+        assertTrue(isCcImageUrl("https://cdn.example.org/emojis-micro/1f600.png?hfr-cc-image=true&raw=true"))
+    }
+
+    @Test
+    fun `reordered query parameters still match`() {
+        assertTrue(isCcImageUrl("https://cdn.example.org/emojis-micro/1f600.png?raw=true&hfr-cc-image=true"))
+    }
+
+    @Test
+    fun `marker as the only parameter matches`() {
+        assertTrue(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image=true"))
+    }
+
+    @Test
+    fun `marker followed by a fragment matches (fragment excluded, query kept)`() {
+        assertTrue(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image=true#section"))
+    }
+
+    @Test
+    fun `scheme-less URL with the marker matches (parser guarantees http-s in production)`() {
+        // Sample shape used by InlineImagePromotionTest — the matcher is scheme-agnostic on purpose.
+        assertTrue(isCcImageUrl("emoji?hfr-cc-image=true"))
+    }
+
+    // --- percent-encoding -----------------------------------------------------------------------
+
+    @Test
+    fun `percent-encoded name still matches after decoding`() {
+        // %68 = 'h' → the decoded name is exactly hfr-cc-image.
+        assertTrue(isCcImageUrl("https://cdn.example.org/e.png?%68fr-cc-image=true"))
+    }
+
+    @Test
+    fun `percent-encoded value still matches after decoding`() {
+        // %74 = 't' → the decoded value is exactly true.
+        assertTrue(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image=%74rue"))
+    }
+
+    @Test
+    fun `malformed percent-encoding in the marker value disqualifies`() {
+        // The name matches but the value cannot be decoded → treated as a non-true occurrence.
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image=%zz"))
+    }
+
+    @Test
+    fun `malformed percent-encoding in an unrelated parameter is ignored`() {
+        assertTrue(isCcImageUrl("https://cdn.example.org/e.png?a=%zz&hfr-cc-image=true"))
+    }
+
+    @Test
+    fun `plus decodes to a space and disqualifies the value`() {
+        // application/x-www-form-urlencoded: "+true" decodes to " true" ≠ "true".
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image=+true"))
+    }
+
+    // --- value rule -----------------------------------------------------------------------------
+
+    @Test
+    fun `explicit false value does not match`() {
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image=false"))
+    }
+
+    @Test
+    fun `valueless or empty-valued marker does not match`() {
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image"))
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image="))
+    }
+
+    @Test
+    fun `matching is case-sensitive on both name and value`() {
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?HFR-CC-IMAGE=true"))
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image=TRUE"))
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image=True"))
+    }
+
+    // --- duplicate rule (conservative: any non-true occurrence disqualifies) ---------------------
+
+    @Test
+    fun `duplicated true markers match`() {
+        assertTrue(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image=true&hfr-cc-image=true"))
+    }
+
+    @Test
+    fun `duplicate true plus false disqualifies regardless of order`() {
+        // The decided rule: "false wins" — ambiguity resolves to NOT fast-pathing (worst case is one
+        // async probe and normal sizing; a wrong match would pin a real photo to a 16sp square).
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image=true&hfr-cc-image=false"))
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image=false&hfr-cc-image=true"))
+    }
+
+    // --- component and name strictness ----------------------------------------------------------
+
+    @Test
+    fun `marker in the fragment only does not match`() {
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png#hfr-cc-image=true"))
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?raw=true#hfr-cc-image=true"))
+    }
+
+    @Test
+    fun `question mark inside the fragment is not a query`() {
+        // The whole `#frag?hfr-cc-image=true` is a fragment: no query component exists at all.
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png#frag?hfr-cc-image=true"))
+    }
+
+    @Test
+    fun `marker in the path only does not match`() {
+        assertFalse(isCcImageUrl("https://cdn.example.org/hfr-cc-image=true/e.png?raw=true"))
+    }
+
+    @Test
+    fun `name matching is exact, not substring`() {
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?xhfr-cc-image=true"))
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image2=true"))
+    }
+
+    @Test
+    fun `no query, empty query or unparseable input does not match`() {
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png"))
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?"))
+        assertFalse(isCcImageUrl(""))
+        assertFalse(isCcImageUrl("not a url at all"))
+        assertFalse(isCcImageUrl("http://[malformed"))
+    }
+
+    // --- measurement-probe exclusion (#256 companion change) -------------------------------------
+
+    private fun img(url: String) = PostInline.InlineImage(url = url, description = null)
+
+    @Test
+    fun `cc-image URLs are excluded from the measurable set, plain URLs are kept`() {
+        val urls = collectMeasurableImageUrls(
+            listOf(
+                img("https://i.example.org/photo.jpg"),
+                img("https://cdn.example.org/e.png?hfr-cc-image=true&raw=true"),
+            ),
+        )
+        assertEquals(setOf("https://i.example.org/photo.jpg"), urls)
+    }
+
+    @Test
+    fun `exclusion also applies to nested cc-image URLs (Link Strong shape)`() {
+        // The real cc-image nesting from the issue: Link → Strong → InlineImage.
+        val nested = listOf(
+            PostInline.Link(
+                url = "https://youtu.be/x",
+                children = listOf(
+                    PostInline.Strong(
+                        children = listOf(
+                            PostInline.Text("Doublé à Most "),
+                            img("https://cdn.example.org/e.png?hfr-cc-image=true"),
+                        ),
+                    ),
+                ),
+            ),
+            img("https://i.example.org/photo.jpg"),
+        )
+        assertEquals(setOf("https://i.example.org/photo.jpg"), collectMeasurableImageUrls(nested))
+    }
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/InlineImageDisplayBoxTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/InlineImageDisplayBoxTest.kt
@@ -90,6 +90,52 @@ class InlineImageDisplayBoxTest {
         assertEquals(INLINE_IMAGE_MIN_HEIGHT_SP.toFloat(), b.placeholderHeight.value, TOLERANCE)
     }
 
+    // #256 — the hfr-cc-image marker pins the box to the one-line square at render time.
+
+    private val ccUrl = "https://cdn.example.org/emojis-micro/1f600.png?hfr-cc-image=true&raw=true"
+    private val ccImage = PostInline.InlineImage(url = ccUrl, description = null)
+
+    private fun ccBox(measured: IntSize?, maxWidthSp: Int): InlineMediaBox =
+        imageDisplayBox(ccImage, mapOf(ccUrl to measured), maxWidthSp)
+
+    @Test
+    fun `cc-image marker pins the one-line square without any measurement`() {
+        // The fast-path needs no measured size: the box is final from the very first frame.
+        val b = ccBox(measured = null, maxWidthSp = 400)
+        assertEquals(INLINE_IMAGE_MIN_HEIGHT_SP.toFloat(), b.placeholderWidth.value, TOLERANCE)
+        assertEquals(INLINE_IMAGE_MIN_HEIGHT_SP.toFloat(), b.placeholderHeight.value, TOLERANCE)
+    }
+
+    @Test
+    fun `cc-image marker ignores a measured size on record`() {
+        // Even a (stale or warmed-elsewhere) 500×500 measurement must not resize a marked emoji:
+        // the marker, not the measurement, is the contract.
+        val b = ccBox(measured = IntSize(500, 500), maxWidthSp = 400)
+        assertEquals(INLINE_IMAGE_MIN_HEIGHT_SP.toFloat(), b.placeholderWidth.value, TOLERANCE)
+        assertEquals(INLINE_IMAGE_MIN_HEIGHT_SP.toFloat(), b.placeholderHeight.value, TOLERANCE)
+    }
+
+    @Test
+    fun `cc-image square is still relative-capped in a pathologically narrow container`() {
+        // Defensive parity with the cold fallback: the fixed square obeys the same relative cap.
+        val b = ccBox(measured = null, maxWidthSp = 10)
+        assertEquals(10f, b.placeholderWidth.value, TOLERANCE)
+        assertEquals(10f, b.placeholderHeight.value, TOLERANCE)
+    }
+
+    @Test
+    fun `a false marker falls back to the normal measured path`() {
+        // hfr-cc-image=false is NOT the marker: normal intrinsic sizing applies.
+        val falseUrl = "https://cdn.example.org/pic.png?hfr-cc-image=false"
+        val b = imageDisplayBox(
+            PostInline.InlineImage(url = falseUrl, description = null),
+            mapOf(falseUrl to IntSize(80, 60)),
+            maxWidthSp = 400,
+        )
+        assertEquals(80f, b.placeholderWidth.value, TOLERANCE)
+        assertEquals(60f, b.placeholderHeight.value, TOLERANCE)
+    }
+
     private companion object {
         const val TOLERANCE = 0.5f
     }


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Closes #256.

## Quoi
Les URLs d'images portant le marqueur communautaire `hfr-cc-image=true` (emojis « cc-image » des userscripts) sont dimensionnées comme du texte (16sp) dès la première frame, sans probe réseau de mesure : court-circuit en tête d'`imageDisplayBox` + exclusion de `collectMeasurableImageUrl`. AST, liens, MediaCounter et promotion bloc intouchés — sizing inline uniquement (périmètre du cadrage Codex).

## Contrat de matching (strict, décidé avant code)
Query component uniquement (jamais fragment/path — y compris `#frag?marker`, cas attrapé par le gate), percent-decoding puis comparaison exacte case-sensitive, et règle des doublons « false wins » : fast-path ssi ≥1 occurrence ET toutes valent exactement `true` (une ambiguïté ne doit jamais épingler une vraie photo à 16sp).

## Tests
`CcImageMarkerTest` : ~22 cas JVM exhaustifs (réordonnancement, encodage nom/valeur, %zz, +true, casse, doublons, fragment/path/substring, `#frag?marker`, probe-exclusion y compris la forme imbriquée Link→Strong de l'issue).

## Validation
- Canonique complète verte en local.
- Cadrage puis gate Codex (gpt-5.5, xhigh) : 1re passe **NO-GO** sur un vrai trou (un `?` situé après le premier `#` était traité comme une query → faux positif fragment) — fix appliqué tel que prescrit + test dédié ; le reste du verdict validait « false wins », le périmètre sizing-only et la couverture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pm28ny4V5GSegmKJxTPVAM