### PR TITLE
fix(ui): align [img] sizing with HFR web — max-width 90%, max-height 200dp parity (#610)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/CcImageMarker.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/CcImageMarker.kt
@@ -1,0 +1,80 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import java.net.URLDecoder
+
+/**
+ * #256 — detection of the community "cc-image" marker, a query parameter (`hfr-cc-image=true`)
+ * that userscript-era HFR extensions append to emoji image URLs (e.g.
+ * `…/emojis-micro/<codepoint>.png?hfr-cc-image=true&raw=true`) to declare "this `[img]` is a
+ * one-line emoji glyph, size it like text".
+ *
+ * The check is **render-time only** and applies to the ORIGINAL URL carried by the AST (the
+ * `:core:parser` `sanitizeImageHref` preserves the query string verbatim, and any redirect target —
+ * e.g. `raw.githubusercontent.com` — is a Coil concern that never reaches this code). It never
+ * alters the AST, the link semantics, the MediaCounter symmetry or the block-promotion path: its
+ * only consumers are the inline SIZING fast-path in `imageDisplayBox` and the measurement-probe
+ * exclusion in `collectMeasurableImageUrl` (both in PostRenderer).
+ *
+ * Matching contract (pure JVM, no `android.net.Uri` — `:core:ui` unit tests run on the JVM):
+ *  - only the **query** component is inspected: the substring between the first `?` and the first
+ *    following `#` (a marker in the fragment or in the path never matches);
+ *  - the query is split into `&`-separated pairs; each pair's name and value are percent-decoded
+ *    (application/x-www-form-urlencoded, so `+` decodes to a space) and compared **exactly and
+ *    case-sensitively** to `hfr-cc-image` / `true` — no naive `contains`, no case folding;
+ *  - a pair whose name cannot be decoded (malformed percent-encoding) cannot be the marker and is
+ *    ignored; a URL with no query, or any unparseable shape, simply doesn't match.
+ *
+ * DUPLICATE RULE (decided before implementation, most conservative option): the fast-path applies
+ * only when the marker is UNAMBIGUOUS — at least one `hfr-cc-image` pair is present AND **every**
+ * occurrence decodes exactly to `true`. Any occurrence carrying anything else (`false`, an empty or
+ * missing value, an undecodable value) disqualifies the whole URL, i.e. "false wins" over "first
+ * wins". Rationale: a non-match merely falls back to the normal measured-sizing path (worst case one
+ * async probe, correct rendering), while a wrong match would pin a real photo to a 16sp square — so
+ * ambiguity must resolve to NOT fast-pathing.
+ */
+@Suppress("ReturnCount") // No-query guards + trailing verdict.
+internal fun isCcImageUrl(url: String): Boolean {
+    val queryStart = url.indexOf('?')
+    if (queryStart < 0) return false
+    val fragmentStart = url.indexOf('#')
+    // A `?` after the first `#` belongs to the fragment: the URL has no query component at all
+    // (`e.png#frag?hfr-cc-image=true` must NOT match — Codex gate catch).
+    if (fragmentStart in 0..<queryStart) return false
+    val rawQuery = url.substring(queryStart + 1, if (fragmentStart >= 0) fragmentStart else url.length)
+    if (rawQuery.isEmpty()) return false
+    val occurrences = rawQuery.split('&').mapNotNull(::ccMarkerOccurrenceOrNull)
+    // Duplicate rule: at least one marker occurrence, and every one of them exactly "true".
+    return occurrences.isNotEmpty() && occurrences.all { it.value == CC_IMAGE_MARKER_VALUE }
+}
+
+/**
+ * Parses one raw `&`-separated query pair; non-null only for decodable `hfr-cc-image` pairs.
+ * Distinguishing "not a marker pair" (null) from "a marker pair with a missing/undecodable value"
+ * ([CcMarkerOccurrence] with a null [CcMarkerOccurrence.value], which disqualifies) is the whole
+ * point of the wrapper.
+ */
+@Suppress("ReturnCount") // Ignore-this-pair guards, cheaper than nesting three levels of if/else.
+private fun ccMarkerOccurrenceOrNull(pair: String): CcMarkerOccurrence? {
+    if (pair.isEmpty()) return null
+    val separator = pair.indexOf('=')
+    val rawName = if (separator >= 0) pair.substring(0, separator) else pair
+    // An undecodable name cannot be the marker — the pair is ignored, not disqualifying.
+    val name = decodeQueryComponent(rawName) ?: return null
+    if (name != CC_IMAGE_MARKER_NAME) return null
+    // A missing or undecodable value stays null and disqualifies through the "all true" rule.
+    val value = if (separator >= 0) decodeQueryComponent(pair.substring(separator + 1)) else null
+    return CcMarkerOccurrence(value)
+}
+
+/** One `hfr-cc-image` occurrence; [value] is null when the value was missing or undecodable. */
+private data class CcMarkerOccurrence(val value: String?)
+
+/**
+ * Percent-decodes one query name/value, or null when malformed (e.g. a truncated `%z` escape).
+ * Uses the charset-NAME overload: `URLDecoder.decode(String, Charset)` needs API 33 (minSdk is 29).
+ */
+private fun decodeQueryComponent(component: String): String? =
+    runCatching { URLDecoder.decode(component, "UTF-8") }.getOrNull()
+
+private const val CC_IMAGE_MARKER_NAME = "hfr-cc-image"
+private const val CC_IMAGE_MARKER_VALUE = "true"

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/ImageShimmer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/ImageShimmer.kt
@@ -6,7 +6,7 @@ import fr.forumhfr.redface2.core.ui.loading.SkeletonBox
 
 /**
  * #249 — animated shimmer painted INSIDE the already-reserved block-image box (see
- * [PostMediaDisplayPolicy.reservedBlockImageHeight]) while the bitmap loads, so the user reads
+ * [PostMediaDisplayPolicy.blockImageDisplaySize]) while the bitmap loads, so the user reads
  * "image en cours de chargement ici" without a spinner — and because the box is pre-sized to the
  * final image, the crossfade reveal causes no bump.
  *

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
@@ -22,14 +22,17 @@ import kotlin.math.roundToInt
  * small size directly, while perso smileys use the 70×50 cold-cache fallback while measurement is
  * in flight (and as the default `collectInlineMedia` resolver in tests).
  *
- * Inline `[img]` ([inlineImage]) is now sized like smileys (#224 option A): measured intrinsic native
- * size (no-upscale + absolute cap [INLINE_IMAGE_MAX_WIDTH_SP]×[INLINE_IMAGE_MAX_HEIGHT_SP]) then the
- * relative `0.9 × contentWidth` cap, via the same `IntrinsicMediaSizeCache` + `imageDisplayBox` in
- * PostRenderer. The **production cold fallback** (unmeasured `[img]`) is the one-line
- * [INLINE_IMAGE_MIN_HEIGHT_SP] square in `imageDisplayBox` (#253, no giant Fit flash). The fixed
- * 240×180 [inlineImage] bucket is now only the **default `collectInlineMedia` resolver** (legacy bucket
- * exercised by tests), not the runtime fallback. This kills both the empty frame around a small reaction
- * image and the overflow in a narrow quote.
+ * `[img]` — inline AND block — follows ONE policy since #610, the HFR-web parity rule
+ * `img { max-width: 90%; max-height: 200px }` ([imageParityDisplaySize]): measured intrinsic native
+ * size, no upscale, height capped to [IMAGE_MAX_HEIGHT_UNITS], width capped to the relative
+ * `0.9 × contentWidth`. The inline path (`imageDisplayBox` in PostRenderer, #224 option A) applies it
+ * in **sp** via the same `IntrinsicMediaSizeCache`; the block path ([blockImageDisplaySize]) applies
+ * it in **dp** — so a lone posted photo and the same photo inside prose render at the same size (the
+ * pre-#610 divergence was the issue). The **production cold fallback** (unmeasured inline `[img]`) is
+ * the one-line [INLINE_IMAGE_MIN_HEIGHT_SP] square in `imageDisplayBox` (#253, no giant Fit flash).
+ * The fixed 240×180 [inlineImage] bucket is now only the **default `collectInlineMedia` resolver**
+ * (legacy bucket exercised by tests), not the runtime fallback. This kills the empty frame around a
+ * small reaction image, the overflow in a narrow quote, and the full-width blow-up of block images.
  *
  * Why this took fixed buckets as a stopgap in #109: Compose `InlineTextContent` requires a **fixed**
  * `Placeholder` size when the `AnnotatedString` is built, so intrinsic sizing needs async-measure →
@@ -102,16 +105,17 @@ internal object PostMediaDisplayPolicy {
     )
 
     /**
-     * Block-level `[img]` rendered standalone via `PostBlock.Image`. Width matches the parent
-     * column; height is bounded so a 4000×3000 RAW screenshot doesn't blow up the post and
-     * destroy the scroll position.
-     *
-     * The min/max pair matters during the async lifecycle of `SubcomposeAsyncImage`: while
-     * loading or on error the bitmap has no intrinsic size yet, so without [blockImageMinHeight]
+     * Legacy slot for an UNMEASURED block-level `[img]` (cold cache before the measure effect lands,
+     * or a measurement failure — dead host / 404). Only that placeholder path still uses this pair:
+     * while loading or on error the bitmap has no intrinsic size yet, so without [blockImageMinHeight]
      * the container would collapse to the height of the loading label (~16dp), making the
-     * loading/error UX barely visible AND causing a layout jump when the bitmap finally
-     * resolves. The min reserves a stable visual slot; the max keeps long portrait shots in
-     * check (cf. issue #109 review by Codex on PR #126).
+     * loading/error UX barely visible AND causing a layout jump when the bitmap finally resolves.
+     * The min reserves a stable visual slot; the max keeps a load-without-measurement in check
+     * (cf. issue #109 review by Codex on PR #126).
+     *
+     * #610 — a MEASURED block image no longer touches this slot: it renders at its exact
+     * [blockImageDisplaySize] (web-parity `max-width:90% / max-height:200`, no upscale), replacing
+     * the former full-width fit clamped to this [160, 480] dp range.
      */
     val blockImageMaxHeight: Dp = 480.dp
     val blockImageMinHeight: Dp = 160.dp
@@ -122,29 +126,29 @@ internal object PostMediaDisplayPolicy {
     }
 
     /**
-     * #249 — exact RESERVED height (dp) for a block `[img]`, computed BEFORE the bitmap arrives so the
-     * loading placeholder occupies the same vertical slot the loaded image will, hence zero layout
-     * shift (anti-CLS) when it crossfades in.
+     * #249/#610 — exact display size (in **dp** units) for a MEASURED block `[img]`, computed BEFORE
+     * the bitmap arrives so the container occupies exactly the slot the loaded image will fill, hence
+     * zero layout shift (anti-CLS, #249) when it crossfades in.
      *
-     * Reuses the same measured intrinsic size the #175/#224 path already caches: at the block width
-     * [availableWidthDp] the image will render `availableWidthDp × (h/w)` tall (`ContentScale.Fit`,
-     * full width), so we reserve exactly that, clamped to the existing [blockImageMinHeight] /
-     * [blockImageMaxHeight] slot. A landscape shot narrower-than-tall and a portrait shot both land on
-     * their real height; only the rare clamp cases differ — exactly the bounds the loaded image already
-     * obeys, so no over-reserve vs the #175 sizing.
+     * #610 — the size is the unified HFR-web parity policy ([imageParityDisplaySize]): native size,
+     * no upscale, height ≤ [IMAGE_MAX_HEIGHT_UNITS] (web `max-height: 200px`), width ≤
+     * [SMILEY_RELATIVE_MAX_WIDTH_FRACTION] × [availableWidthDp] (web `max-width: 90%`). Before →
+     * after: a measured block image used to FILL the column width — upscaling any source narrower
+     * than the column — with its height `width × h/w` clamped to the [blockImageMinHeight] /
+     * [blockImageMaxHeight] (160/480 dp) slot; it now renders at its capped NATIVE size, the same
+     * numbers the inline path produces in sp, so a lone posted photo and the same photo inside prose
+     * finally match.
      *
      * [measured] is `null` for a not-yet-measured image — a cold cache before the measure effect lands,
      * or a measurement failure (dead host / 404). Both the paragraph effect (#175/#224) and, since the
      * #249 follow-up, the standalone `PostBlock.Image` effect feed the cache; callers fall back to the
-     * legacy [blockImageMinHeight] slot until (or unless) a size lands.
+     * legacy [blockImageMinHeight]-anchored slot until (or unless) a size lands.
      */
-    fun reservedBlockImageHeight(measured: PixelSize?, availableWidthDp: Float): Dp? {
+    fun blockImageDisplaySize(measured: PixelSize?, availableWidthDp: Float): PixelSize? {
         val size = measured?.takeIf { it.width > 0 && it.height > 0 }
         if (size == null || availableWidthDp <= 0f) return null
-        val rawHeight = availableWidthDp * (size.height.toFloat() / size.width.toFloat())
-        return rawHeight
-            .coerceIn(blockImageMinHeight.value, blockImageMaxHeight.value)
-            .dp
+        val maxWidthDp = (availableWidthDp * SMILEY_RELATIVE_MAX_WIDTH_FRACTION).roundToInt()
+        return imageParityDisplaySize(size, maxWidthUnits = maxWidthDp)
     }
 
     /**
@@ -248,20 +252,37 @@ internal val builtinPreseedSize = PixelSize(16, 16)
 internal val persoColdFallbackSize = PixelSize(70, 50)
 
 /**
- * #224 (option A) — absolute caps for an inline `[img]`, in **sp** (intrinsic native px treated as
- * logical/CSS px, like the smiley path). More generous than the smiley height cap: an inline reaction
- * image or embedded photo can be taller than an emotive glyph, yet stays bounded so it never dominates
- * the post (a genuinely large photo belongs in a standalone `PostBlock.Image`, [blockImageMaxHeight]).
- * The real horizontal limit is the relative `0.9 × contentWidth` applied renderer-side via [capToWidth].
+ * #610 — HFR-web parity height cap for ANY `[img]`, inline or block: the web rule is
+ * `img { max-height: 200px }`, mirrored here with the native px treated as logical units (`.sp` on the
+ * inline path so the image tracks the text size, `.dp` on the block path — documented fontScale
+ * asymmetry: inline grows with the user font, block does not, exactly like text vs images on the web).
+ * Replaces (#610, before → after) the former `INLINE_IMAGE_MAX_HEIGHT_SP` (200 sp → same 200, the
+ * inline path was already at web parity) and the MEASURED-path use of
+ * [PostMediaDisplayPolicy.blockImageMaxHeight] (480 dp → 200 dp; the block path exceeded the web cap
+ * 2.4×, the visible #610 divergence).
  */
-internal const val INLINE_IMAGE_MAX_HEIGHT_SP = 200
-internal const val INLINE_IMAGE_MAX_WIDTH_SP = 240
+internal const val IMAGE_MAX_HEIGHT_UNITS = 200
 
 /**
- * #257 — upper bound (px) for the **decode** size of an inline `[img]`. The inline AsyncImage requests
- * the inline cap converted to px (density × fontScale) clamped to this, so Coil decodes ONE stable
- * bitmap that survives the cold→measured box growth without a re-decode + pixelated upscale. 1024 covers
- * the 240×200 sp cap on any realistic density/fontScale while staying cheap to decode and cache.
+ * #610 — block-promotion width threshold. Before #610 this was `INLINE_IMAGE_MAX_WIDTH_SP` (240), the
+ * ABSOLUTE inline display width cap; the display cap is now the RELATIVE `0.9 × contentWidth` (web
+ * `max-width: 90%`, [SMILEY_RELATIVE_MAX_WIDTH_FRACTION]) applied renderer-side, so no absolute width
+ * cap exists any more (before → after: an image measured 300 px wide rendered 240 sp wide; it now
+ * renders 300 sp, or `0.9 × container` if narrower). The 240 value survives ONLY as the
+ * `shouldPromoteImagesToBlocks` "this is a real photo" width threshold: with #610 sizing identical on
+ * both paths, promotion is purely layout semantics (own centred line, block loading/error UX, #257
+ * tap-through), and the threshold keeps its pre-#610 calibration.
+ */
+internal const val IMAGE_PROMOTION_WIDTH_UNITS = 240
+
+/**
+ * #257/#610 — fixed decode size (px) for an inline `[img]`: the render request decodes at this bound
+ * (INEXACT Fit) so Coil produces ONE stable bitmap that survives the cold→measured box growth without
+ * a re-decode + pixelated upscale. Before #610 the request size derived from the absolute 240×200 sp
+ * display cap converted to px (density × fontScale) and clamped here; that width cap is now relative
+ * to the container, so the request uses this flat bound directly — it covers `0.9 × container` at any
+ * realistic phone density/fontScale, stays cheap to decode and cache, and Coil never decodes past the
+ * source, so a small image still decodes at native.
  *
  * Distinct from `INTRINSIC_PROBE_SIZE_PX` (also 1024): that one bounds the **measure** probe in
  * `IntrinsicMediaSizeMeasurer`, this one bounds the **render** decode here. Same value, different role —
@@ -309,6 +330,29 @@ internal fun intrinsicSmileyDisplaySize(
         height = (nativePx.height * scale).roundToInt().coerceAtLeast(1),
     )
 }
+
+/**
+ * #610 — the unified `[img]` display policy shared by the inline path (`imageDisplayBox` in
+ * PostRenderer, sp units) and the block path ([PostMediaDisplayPolicy.blockImageDisplaySize], dp
+ * units): HFR-web `img { max-width: 90%; max-height: 200px }` parity. No upscale, height capped to
+ * [maxHeightUnits] (default [IMAGE_MAX_HEIGHT_UNITS]), width capped to [maxWidthUnits] — the caller
+ * passes the RELATIVE cap (≈ `0.9 ×` its container width, in its own units), the only width limit
+ * since #610. A non-positive [maxWidthUnits] applies no width cap (defensive, mirrors [capToWidth]:
+ * a zero-width container must not collapse the image to a sliver).
+ *
+ * Thin wrapper over [intrinsicSmileyDisplaySize] (same math: uniform scale ≤ 1, ≥ 1 px per axis),
+ * named separately so `[img]` call sites read as the #610 contract and can evolve independently of
+ * the smiley caps.
+ */
+internal fun imageParityDisplaySize(
+    nativePx: PixelSize,
+    maxWidthUnits: Int,
+    maxHeightUnits: Int = IMAGE_MAX_HEIGHT_UNITS,
+): PixelSize = intrinsicSmileyDisplaySize(
+    nativePx = nativePx,
+    maxWidthSp = if (maxWidthUnits > 0) maxWidthUnits else Int.MAX_VALUE,
+    maxHeightSp = maxHeightUnits,
+)
 
 /**
  * #175 — scale [size] down so its width fits [maxWidthSp] (the relative cap, ≈90% of the content

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -1172,6 +1172,12 @@ private fun collectMeasurableSmileyUrl(inline: PostInline, urls: MutableSet<Stri
  * (no-upscale native sizing, like #175 smileys). The `:core:ui` parser has already stripped
  * non-http(s) schemes, so every collected URL is safe to hand to Coil. Recurses into inline
  * containers (e.g. an `[img]` wrapped in a `[url=…]` link), mirroring [walkInlinesForMedia].
+ *
+ * #256 — URLs carrying the `hfr-cc-image=true` marker are EXCLUDED: their box is pinned by the
+ * [imageDisplayBox] fast-path (never read from the measurement cache), so probing them would only
+ * spend a useless network round-trip. Block promotion is unaffected: an unmeasured URL never trips
+ * [shouldPromoteImagesToBlocks], which is exactly the intended always-inline treatment for a marked
+ * emoji.
  */
 internal fun collectMeasurableImageUrls(inlines: List<PostInline>): Set<String> {
     val urls = LinkedHashSet<String>()
@@ -1185,7 +1191,8 @@ private fun collectMeasurableImageUrlsInto(inlines: List<PostInline>, urls: Muta
 
 private fun collectMeasurableImageUrl(inline: PostInline, urls: MutableSet<String>) {
     when (inline) {
-        is PostInline.InlineImage -> urls += inline.url
+        // #256 — cc-image-marked URLs are not measurable (fixed one-line box, see the KDoc above).
+        is PostInline.InlineImage -> if (!isCcImageUrl(inline.url)) urls += inline.url
         is PostInline.Strong -> collectMeasurableImageUrlsInto(inline.children, urls)
         is PostInline.Emphasis -> collectMeasurableImageUrlsInto(inline.children, urls)
         is PostInline.Underline -> collectMeasurableImageUrlsInto(inline.children, urls)
@@ -1232,12 +1239,30 @@ private fun smileyDisplayBox(
  * 16×16 emoji) is already at its final size — zero flash — and any larger image just grows from a
  * one-line slot once measured instead of shrinking from a giant one. Still relative-capped so even
  * the fallback never overflows a narrow quote. Mirrors [smileyDisplayBox].
+ *
+ * #256 — a URL carrying the `hfr-cc-image=true` marker short-circuits ALL of the above: fixed
+ * one-line square, no measurement involved (see [isCcImageUrl] and the fast-path comment below).
  */
 internal fun imageDisplayBox(
     image: PostInline.InlineImage,
     measured: Map<String, IntSize?>,
     maxWidthSp: Int,
 ): InlineMediaBox {
+    // #256 — render-time fast-path: a URL carrying the `hfr-cc-image=true` marker declares itself a
+    // community cc-image emoji (a one-line glyph). Pin its box to the one-line square immediately —
+    // the same square as the #253 cold fallback below, so a marked emoji is at its final size from
+    // the very first frame (zero flash, zero reflow) — and IGNORE any measured size on record: the
+    // marker, not the measurement, is the contract (matching + duplicate rules in [isCcImageUrl]).
+    // The companion exclusion in [collectMeasurableImageUrl] skips the async probe for these URLs
+    // entirely. Still relative-capped so even this square cannot overflow a pathologically narrow
+    // container. Everything else (AST, link semantics, MediaCounter, promotion) is untouched.
+    if (isCcImageUrl(image.url)) {
+        val fixed = capToWidth(
+            PixelSize(INLINE_IMAGE_MIN_HEIGHT_SP, INLINE_IMAGE_MIN_HEIGHT_SP),
+            maxWidthSp,
+        )
+        return InlineMediaBox(fixed.width.sp, fixed.height.sp)
+    }
     val size = measured[image.url]
     val base = if (size != null) {
         // #175 no-upscale + cap with the inline-image caps, then a min-height floor so a SUB-16 low-res

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.InlineTextContent
@@ -332,10 +333,12 @@ private fun ParagraphBlock(inlines: List<PostInline>) {
     }
 
     // #224 (option B) — a paragraph whose only content is image(s) (a gallery, or a lone posted image
-    // the parser kept inline because of a stray sibling) is promoted to full-width centred blocks once
-    // a measurement shows at least one is larger than the inline caps (a left-aligned 240sp thumbnail).
-    // cc-image emoji / small reactions never trip the threshold, so they keep their inline size. The
-    // measure LaunchedEffect above feeds the same cache the threshold reads.
+    // the parser kept inline because of a stray sibling) is promoted to centred blocks once a
+    // measurement shows at least one is larger than the promotion thresholds. Since #610 the block
+    // SIZE equals the inline size (unified parity policy): promotion only buys the layout semantics
+    // (own centred line, block loading/error UX, #257 tap-through). cc-image emoji / small reactions
+    // never trip the threshold, so they keep their inline flow. The measure LaunchedEffect above
+    // feeds the same cache the threshold reads.
     val galleryImages = remember(inlines) { imageOnlyParagraphImages(inlines) }
     if (galleryImages != null && shouldPromoteImagesToBlocks(galleryImages, measuredSizes)) {
         Column(
@@ -683,23 +686,27 @@ private fun SpoilerBlock(
 private fun ImageBlock(block: PostBlock.Image) = BlockImage(url = block.url, description = block.description)
 
 /**
- * Full-width, centred, bounded image. The home of a standalone `PostBlock.Image`, and (since #224
- * option B) of a large image promoted out of an image-only paragraph.
+ * Centred, bounded block image on its own line. The home of a standalone `PostBlock.Image`, and
+ * (since #224 option B) of a large image promoted out of an image-only paragraph.
  *
  * When [linkUrl] is non-null the image was posted as `[url=…][img]` (the "click to enlarge" pattern):
- * the whole block is tappable and opens that URL (#257), so a linked image gets the full-width
- * treatment AND keeps its tap-through instead of being kept as a small inline thumbnail.
+ * the whole block is tappable and opens that URL (#257), so a linked image gets the block treatment
+ * AND keeps its tap-through instead of being kept as a small inline thumbnail.
  *
- * Bounded so a 4000×3000 RAW screenshot can't blow up the post and destroy the scroll position.
- * SubcomposeAsyncImage exposes loading/error slots so the user gets visual feedback when an HFR image
- * host (rehost.diberie.com, super-h.fr, …) is offline rather than a silent empty Box.
+ * #610 — a MEASURED image renders in a box of EXACTLY its web-parity display size
+ * ([PostMediaDisplayPolicy.blockImageDisplaySize]: native size, no upscale, width ≤ 90% of the
+ * column, height ≤ 200 dp), centred. Before #610 the container FILLED the column width — upscaling
+ * any narrower source — with its height clamped to the legacy [160, 480] dp slot; that slot now only
+ * hosts a not-yet-measured image (cold cache / failed measurement). Bounded either way, so a
+ * 4000×3000 RAW screenshot can't blow up the post and destroy the scroll position.
  *
- * #249 — anti-CLS: instead of reserving the legacy `minHeight` slot (which then SNAPS to the bitmap's
- * real height on arrival = a bump), reserve the EXACT final height from the measured intrinsic size
- * (`width × h/w`, same #175/#224 cache) so the shimmer placeholder occupies the loaded image's slot and
- * nothing below moves. The image then `crossfade`s in (Coil native) into the already-sized box. A
- * not-yet-measured image (standalone `PostBlock.Image`, no paragraph measure effect) keeps the legacy
- * min/max slot. Animations honour the system reduce-motion preference ([rememberAnimationsEnabled]).
+ * #249 — anti-CLS survives the #610 unification: the exact box is computed BEFORE the bitmap arrives
+ * (same measured-intrinsic cache as #175/#224), so the shimmer placeholder occupies the loaded
+ * image's slot and nothing below moves; the image then `crossfade`s in (Coil native) into the
+ * already-sized box. SubcomposeAsyncImage exposes loading/error slots so the user gets visual
+ * feedback when an HFR image host (rehost.diberie.com, super-h.fr, …) is offline rather than a
+ * silent empty Box. Animations honour the system reduce-motion preference
+ * ([rememberAnimationsEnabled]).
  */
 @Composable
 private fun BlockImage(url: String, description: String?, linkUrl: String? = null) {
@@ -714,10 +721,11 @@ private fun BlockImage(url: String, description: String?, linkUrl: String? = nul
     val sizeCache = LocalIntrinsicMediaSizeCache.current
     val measured: IntSize? = sizeCache.get(url)
     // #249 follow-up — a standalone PostBlock.Image is NOT covered by the paragraph measure effect, so
-    // without this its intrinsic size never lands in the cache: reservedBlockImageHeight stays null, the
-    // image falls into the legacy min/max slot and loses both the full-width fit and the reserved loading
-    // space (#249 anti-CLS). Measure it here through the same guarded seam the paragraph effect uses; the
-    // SnapshotStateMap write then recomposes this block onto the reserved-box path.
+    // without this its intrinsic size never lands in the cache: blockImageDisplaySize stays null, the
+    // image falls into the legacy min/max slot and loses both the exact parity box (#610) and the
+    // reserved loading space (#249 anti-CLS). Measure it here through the same guarded seam the
+    // paragraph effect uses; the SnapshotStateMap write then recomposes this block onto the exact-box
+    // path.
     val platformContext = LocalPlatformContext.current
     LaunchedEffect(url, sizeCache, platformContext) {
         measureAndCacheIntrinsicMediaSize(
@@ -728,22 +736,24 @@ private fun BlockImage(url: String, description: String?, linkUrl: String? = nul
         )
     }
 
-    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
-        val reservedHeight = PostMediaDisplayPolicy.reservedBlockImageHeight(
+    // contentAlignment centres the (usually narrower-than-column, #610) exact box on its own line —
+    // the same visual centring the pre-#610 full-width Fit letterboxing produced.
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+        val displaySize = PostMediaDisplayPolicy.blockImageDisplaySize(
             measured = measured?.let { PixelSize(it.width, it.height) },
             availableWidthDp = maxWidth.value,
         )
-        // Reserved box: an exact height when measured (anti-CLS), else the legacy min/max slot.
-        val sizeModifier = if (reservedHeight != null) {
-            Modifier.height(reservedHeight)
+        // #610/#249 — the EXACT web-parity box when measured (no upscale, ≤ 90% width, ≤ 200 dp tall;
+        // anti-CLS: it is also the reserved loading slot), else the legacy full-width min/max slot.
+        val sizeModifier = if (displaySize != null) {
+            Modifier.size(displaySize.width.dp, displaySize.height.dp)
         } else {
             Modifier
+                .fillMaxWidth()
                 .defaultMinSize(minHeight = PostMediaDisplayPolicy.blockImageMinHeight)
                 .heightIn(max = PostMediaDisplayPolicy.blockImageMaxHeight)
         }
-        val containerModifier = Modifier
-            .fillMaxWidth()
-            .then(sizeModifier)
+        val containerModifier = sizeModifier
             .clip(RoundedCornerShape(8.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerHighest)
             .then(
@@ -771,11 +781,11 @@ private fun BlockImage(url: String, description: String?, linkUrl: String? = nul
             contentScale = ContentScale.Fit,
             modifier = containerModifier,
             loading = {
-                // Measured: fill the exact reserved box. Unmeasured (max-only constraint): a STABLE
+                // Measured: fill the exact parity box (#610). Unmeasured (max-only constraint): a STABLE
                 // min-height placeholder — NOT fillMaxSize, which would balloon to the max slot and then
                 // collapse to the loaded intrinsic height (a visible shift, Codex review). The legacy
-                // min→intrinsic grow on load remains for these rare standalone images.
-                val shimmerModifier = if (reservedHeight != null) {
+                // min→intrinsic grow on load remains for these rare unmeasured images.
+                val shimmerModifier = if (displaySize != null) {
                     Modifier.fillMaxSize()
                 } else {
                     Modifier.fillMaxWidth().height(PostMediaDisplayPolicy.blockImageMinHeight)
@@ -1228,9 +1238,11 @@ private fun smileyDisplayBox(
 }
 
 /**
- * #224 (option A) — resolve an inline `[img]` placeholder box from its measured intrinsic size:
- * no-upscale + absolute cap ([INLINE_IMAGE_MAX_WIDTH_SP]×[INLINE_IMAGE_MAX_HEIGHT_SP]) via the shared
- * [intrinsicSmileyDisplaySize] policy, then the relative `0.9 × contentWidth` cap ([maxWidthSp]).
+ * #224 (option A) / #610 — resolve an inline `[img]` placeholder box from its measured intrinsic
+ * size via the unified web-parity policy [imageParityDisplaySize]: no upscale, height capped to
+ * [IMAGE_MAX_HEIGHT_UNITS] (web `max-height: 200px`), width capped to the relative
+ * `0.9 × contentWidth` ([maxWidthSp], web `max-width: 90%`) — the former absolute 240 sp width cap
+ * is gone, see [IMAGE_PROMOTION_WIDTH_UNITS].
  *
  * #253 — while the measurement is in flight (cold cache / miss) it falls back to a small square of
  * [INLINE_IMAGE_MIN_HEIGHT_SP] (≈ one text line) rather than the old 240×180 bucket. With
@@ -1265,26 +1277,26 @@ internal fun imageDisplayBox(
     }
     val size = measured[image.url]
     val base = if (size != null) {
-        // #175 no-upscale + cap with the inline-image caps, then a min-height floor so a SUB-16 low-res
-        // source can't render below ~one text line. A cc-image emoji (16×16) sits exactly at the floor
-        // → kept native (per @XaaT dogfood); only smaller sources get enlarged. NB: the floor only
-        // grows the BOX — the bitmap fills it via ContentScale.Fit.
+        // #610 web-parity sizing (no upscale, height ≤ IMAGE_MAX_HEIGHT_UNITS, width ≤ the relative
+        // maxWidthSp cap), then the #253 min-height floor so a SUB-16 low-res source can't render
+        // below ~one text line. A cc-image emoji (16×16) sits exactly at the floor → kept native (per
+        // @XaaT dogfood); only smaller sources get enlarged. NB: the floor only grows the BOX — the
+        // bitmap fills it via ContentScale.Fit.
         //
-        // Re-apply the absolute caps AFTER the floor: a very wide/short source (e.g. 250×10) capped to
-        // 240×10 then floored to height 16 would grow to ~384×16 — past both the 240sp width cap and its
-        // native width. The second cap clamps that back (the floor simply doesn't apply when it can't fit
-        // the width cap), so the no-upscale/cap contract holds for every aspect ratio (Codex review #246).
-        intrinsicSmileyDisplaySize(
+        // Re-apply the parity caps AFTER the floor: a very wide/short source (e.g. 250×10) floored to
+        // height 16 grows to ~400×16 — potentially past the relative width cap. The second pass clamps
+        // that back, so the box never exceeds the caps for any aspect ratio (Codex review #246). The
+        // floor stays the one sanctioned upscale, now bounded by the relative cap instead of the
+        // former absolute 240 sp cap (#610).
+        imageParityDisplaySize(
             upscaleToMinHeight(
-                intrinsicSmileyDisplaySize(
+                imageParityDisplaySize(
                     PixelSize(size.width, size.height),
-                    maxWidthSp = INLINE_IMAGE_MAX_WIDTH_SP,
-                    maxHeightSp = INLINE_IMAGE_MAX_HEIGHT_SP,
+                    maxWidthUnits = maxWidthSp,
                 ),
                 INLINE_IMAGE_MIN_HEIGHT_SP,
             ),
-            maxWidthSp = INLINE_IMAGE_MAX_WIDTH_SP,
-            maxHeightSp = INLINE_IMAGE_MAX_HEIGHT_SP,
+            maxWidthUnits = maxWidthSp,
         )
     } else {
         // #253 cold-fallback: a one-line square, not the 240×180 bucket (no giant Fit upscale flash).
@@ -1301,12 +1313,13 @@ internal data class PromotedImage(val image: PostInline.InlineImage, val linkUrl
  * #224 (option B) / #257 — if a paragraph's only meaningful content is image(s) (a single posted image
  * the parser kept inline because of a stray sibling, or a gallery of several), return them in order,
  * each paired with the URL of its enclosing `[url=…]` link if there is one, so they can be promoted to
- * full-width centred blocks. Blank text and line breaks are ignored.
+ * centred blocks (each on its own line — since #610 the block size equals the inline size, promotion
+ * is layout semantics only). Blank text and line breaks are ignored.
  *
  * Returns null when the paragraph has any other meaningful inline (non-blank text, a smiley): genuine
  * prose keeps its inline image treatment. A link wrapping ONLY an image is fine — #257 promotes it to a
- * block that opens the link on tap, so the "click to enlarge" tap-through is preserved AND the image
- * fills the width (before #257 a linked image was kept inline → small + the inline pixelation path).
+ * block that opens the link on tap, so the "click to enlarge" tap-through is preserved (before #257 a
+ * linked image was kept inline → the link stayed a text-span affair).
  * A link wrapping image **+** text still counts as other content → null (stays inline prose).
  */
 @Suppress("CyclomaticComplexMethod") // exhaustive when over the PostInline sealed type, like appendInline
@@ -1334,18 +1347,23 @@ internal fun imageOnlyParagraphImages(inlines: List<PostInline>): List<PromotedI
 }
 
 /**
- * #224 (option B) — promote an image-only paragraph to full-width blocks only once at least one image
- * has measured larger than the inline display caps (so inline rendering would shrink it to a small
- * left-aligned thumbnail). A cc-image emoji (16×16) or a small reaction never trips this, so they keep
- * their inline size; a real posted photo / gallery does, and gets the centred full-width treatment.
- * Returns false while every size is unknown (cold) so promotion only kicks in after measurement.
+ * #224 (option B) — promote an image-only paragraph to blocks only once at least one image has
+ * measured larger than the promotion thresholds (a real posted photo, not an emoji / small reaction:
+ * a 16×16 cc-image never trips this and keeps its inline treatment). Returns false while every size
+ * is unknown (cold) so promotion only kicks in after measurement.
+ *
+ * #610 — inline and block now SIZE identically ([imageParityDisplaySize]), so promotion is purely
+ * layout semantics: the image gets its own centred line, the block loading/error UX, and the #257
+ * link tap-through. The thresholds keep their pre-#610 calibration
+ * ([IMAGE_PROMOTION_WIDTH_UNITS] = the former absolute inline width cap, [IMAGE_MAX_HEIGHT_UNITS]
+ * = the shared parity height cap).
  */
 internal fun shouldPromoteImagesToBlocks(
     images: List<PromotedImage>,
     measured: Map<String, IntSize?>,
 ): Boolean = images.any { promoted ->
     val size = measured[promoted.image.url] ?: return@any false
-    size.width > INLINE_IMAGE_MAX_WIDTH_SP || size.height > INLINE_IMAGE_MAX_HEIGHT_SP
+    size.width > IMAGE_PROMOTION_WIDTH_UNITS || size.height > IMAGE_MAX_HEIGHT_UNITS
 }
 
 /** True when [inlines] contains at least one renderable inline media (a smiley with a URL, or an image). */
@@ -1379,24 +1397,22 @@ internal fun imageInlineContent(image: PostInline.InlineImage, box: InlineMediaB
         // tracks the sp-based placeholder under any fontScale; the no-upscale rule lives in the BOX
         // sizing (imageDisplayBox), not the content scale.
         //
-        // #257 — decode at a STABLE size (the inline display cap in px, bounded) instead of letting
-        // Coil resolve the size from the placeholder constraints. The box grows from the cold-fallback
-        // square to the measured size when the measurement lands; with constraint-driven sizing Coil
-        // re-decodes at the new size and, meanwhile, paints the previous tiny bitmap upscaled →
-        // pixelated. A fixed decode size keeps ONE sharp bitmap that Fit scales into whatever box (Coil
-        // never upscales the decode past the source, so a small image still decodes at native). The
+        // #257/#610 — decode at a STABLE size (the flat INLINE_IMAGE_DECODE_CAP_PX bound) instead of
+        // letting Coil resolve the size from the placeholder constraints. The box grows from the
+        // cold-fallback square to the measured size when the measurement lands; with constraint-driven
+        // sizing Coil re-decodes at the new size and, meanwhile, paints the previous tiny bitmap
+        // upscaled → pixelated. A fixed decode size keeps ONE sharp bitmap that Fit scales into
+        // whatever box (Coil never upscales the decode past the source, so a small image still decodes
+        // at native). Before #610 the size derived from the absolute 240×200 sp display cap in px;
+        // that width cap is now relative to the container, so the request uses the flat px bound
+        // directly (still covers 0.9 × container at any realistic phone density/fontScale). The
         // request is remembered so a measurement landing doesn't rebuild it. Smileys keep their own
         // (much smaller) path — this cap is photo-sized.
-        val density = LocalDensity.current
         val context = LocalPlatformContext.current
-        val widthPx = with(density) { INLINE_IMAGE_MAX_WIDTH_SP.sp.roundToPx() }
-            .coerceAtMost(INLINE_IMAGE_DECODE_CAP_PX)
-        val heightPx = with(density) { INLINE_IMAGE_MAX_HEIGHT_SP.sp.roundToPx() }
-            .coerceAtMost(INLINE_IMAGE_DECODE_CAP_PX)
-        val request = remember(image.url, widthPx, heightPx, context) {
+        val request = remember(image.url, context) {
             ImageRequest.Builder(context)
                 .data(image.url)
-                .size(widthPx, heightPx)
+                .size(INLINE_IMAGE_DECODE_CAP_PX, INLINE_IMAGE_DECODE_CAP_PX)
                 .scale(Scale.FIT)
                 .precision(Precision.INEXACT)
                 .build()

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/CcImageMarkerTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/CcImageMarkerTest.kt
@@ -1,0 +1,180 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import fr.forumhfr.redface2.core.model.PostInline
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #256 — exhaustive pinning of the `hfr-cc-image=true` marker matching ([isCcImageUrl]) and of the
+ * measurement-probe exclusion ([collectMeasurableImageUrls]). The matcher is deliberately strict:
+ * exact case-sensitive name/value after percent-decoding, query component only, and the conservative
+ * duplicate rule (any non-`true` occurrence disqualifies — see the KDoc in CcImageMarker.kt).
+ */
+class CcImageMarkerTest {
+
+    // --- nominal shapes -------------------------------------------------------------------------
+
+    @Test
+    fun `nominal cc-image URL matches`() {
+        // The real-world shape from the issue: …/emojis-micro/<codepoint>.png?hfr-cc-image=true&raw=true
+        assertTrue(isCcImageUrl("https://cdn.example.org/emojis-micro/1f600.png?hfr-cc-image=true&raw=true"))
+    }
+
+    @Test
+    fun `reordered query parameters still match`() {
+        assertTrue(isCcImageUrl("https://cdn.example.org/emojis-micro/1f600.png?raw=true&hfr-cc-image=true"))
+    }
+
+    @Test
+    fun `marker as the only parameter matches`() {
+        assertTrue(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image=true"))
+    }
+
+    @Test
+    fun `marker followed by a fragment matches (fragment excluded, query kept)`() {
+        assertTrue(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image=true#section"))
+    }
+
+    @Test
+    fun `scheme-less URL with the marker matches (parser guarantees http-s in production)`() {
+        // Sample shape used by InlineImagePromotionTest — the matcher is scheme-agnostic on purpose.
+        assertTrue(isCcImageUrl("emoji?hfr-cc-image=true"))
+    }
+
+    // --- percent-encoding -----------------------------------------------------------------------
+
+    @Test
+    fun `percent-encoded name still matches after decoding`() {
+        // %68 = 'h' → the decoded name is exactly hfr-cc-image.
+        assertTrue(isCcImageUrl("https://cdn.example.org/e.png?%68fr-cc-image=true"))
+    }
+
+    @Test
+    fun `percent-encoded value still matches after decoding`() {
+        // %74 = 't' → the decoded value is exactly true.
+        assertTrue(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image=%74rue"))
+    }
+
+    @Test
+    fun `malformed percent-encoding in the marker value disqualifies`() {
+        // The name matches but the value cannot be decoded → treated as a non-true occurrence.
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image=%zz"))
+    }
+
+    @Test
+    fun `malformed percent-encoding in an unrelated parameter is ignored`() {
+        assertTrue(isCcImageUrl("https://cdn.example.org/e.png?a=%zz&hfr-cc-image=true"))
+    }
+
+    @Test
+    fun `plus decodes to a space and disqualifies the value`() {
+        // application/x-www-form-urlencoded: "+true" decodes to " true" ≠ "true".
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image=+true"))
+    }
+
+    // --- value rule -----------------------------------------------------------------------------
+
+    @Test
+    fun `explicit false value does not match`() {
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image=false"))
+    }
+
+    @Test
+    fun `valueless or empty-valued marker does not match`() {
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image"))
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image="))
+    }
+
+    @Test
+    fun `matching is case-sensitive on both name and value`() {
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?HFR-CC-IMAGE=true"))
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image=TRUE"))
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image=True"))
+    }
+
+    // --- duplicate rule (conservative: any non-true occurrence disqualifies) ---------------------
+
+    @Test
+    fun `duplicated true markers match`() {
+        assertTrue(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image=true&hfr-cc-image=true"))
+    }
+
+    @Test
+    fun `duplicate true plus false disqualifies regardless of order`() {
+        // The decided rule: "false wins" — ambiguity resolves to NOT fast-pathing (worst case is one
+        // async probe and normal sizing; a wrong match would pin a real photo to a 16sp square).
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image=true&hfr-cc-image=false"))
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image=false&hfr-cc-image=true"))
+    }
+
+    // --- component and name strictness ----------------------------------------------------------
+
+    @Test
+    fun `marker in the fragment only does not match`() {
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png#hfr-cc-image=true"))
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?raw=true#hfr-cc-image=true"))
+    }
+
+    @Test
+    fun `question mark inside the fragment is not a query`() {
+        // The whole `#frag?hfr-cc-image=true` is a fragment: no query component exists at all.
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png#frag?hfr-cc-image=true"))
+    }
+
+    @Test
+    fun `marker in the path only does not match`() {
+        assertFalse(isCcImageUrl("https://cdn.example.org/hfr-cc-image=true/e.png?raw=true"))
+    }
+
+    @Test
+    fun `name matching is exact, not substring`() {
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?xhfr-cc-image=true"))
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?hfr-cc-image2=true"))
+    }
+
+    @Test
+    fun `no query, empty query or unparseable input does not match`() {
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png"))
+        assertFalse(isCcImageUrl("https://cdn.example.org/e.png?"))
+        assertFalse(isCcImageUrl(""))
+        assertFalse(isCcImageUrl("not a url at all"))
+        assertFalse(isCcImageUrl("http://[malformed"))
+    }
+
+    // --- measurement-probe exclusion (#256 companion change) -------------------------------------
+
+    private fun img(url: String) = PostInline.InlineImage(url = url, description = null)
+
+    @Test
+    fun `cc-image URLs are excluded from the measurable set, plain URLs are kept`() {
+        val urls = collectMeasurableImageUrls(
+            listOf(
+                img("https://i.example.org/photo.jpg"),
+                img("https://cdn.example.org/e.png?hfr-cc-image=true&raw=true"),
+            ),
+        )
+        assertEquals(setOf("https://i.example.org/photo.jpg"), urls)
+    }
+
+    @Test
+    fun `exclusion also applies to nested cc-image URLs (Link Strong shape)`() {
+        // The real cc-image nesting from the issue: Link → Strong → InlineImage.
+        val nested = listOf(
+            PostInline.Link(
+                url = "https://youtu.be/x",
+                children = listOf(
+                    PostInline.Strong(
+                        children = listOf(
+                            PostInline.Text("Doublé à Most "),
+                            img("https://cdn.example.org/e.png?hfr-cc-image=true"),
+                        ),
+                    ),
+                ),
+            ),
+            img("https://i.example.org/photo.jpg"),
+        )
+        assertEquals(setOf("https://i.example.org/photo.jpg"), collectMeasurableImageUrls(nested))
+    }
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/InlineImageDisplayBoxTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/InlineImageDisplayBoxTest.kt
@@ -6,10 +6,12 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
- * #224 (option A) — pure unit coverage for [imageDisplayBox], the intrinsic sizing of inline `[img]`:
- * measured native size, no-upscale + absolute cap (INLINE_IMAGE_MAX_*), then the relative `0.9× width`
- * cap. #253 — while the measurement is in flight the box falls back to a one-line square
- * (INLINE_IMAGE_MIN_HEIGHT_SP), not the 240×180 bucket, so ContentScale.Fit can't flash a tiny emoji giant.
+ * #224 (option A) / #610 — pure unit coverage for [imageDisplayBox], the intrinsic sizing of inline
+ * `[img]`: measured native size through the unified web-parity policy (no upscale, height ≤
+ * IMAGE_MAX_HEIGHT_UNITS = web `max-height:200px`, width ≤ the relative `0.9 × contentWidth` = web
+ * `max-width:90%` — the pre-#610 absolute 240 sp width cap is gone). #253 — while the measurement is
+ * in flight the box falls back to a one-line square (INLINE_IMAGE_MIN_HEIGHT_SP), not the 240×180
+ * bucket, so ContentScale.Fit can't flash a tiny emoji giant.
  */
 class InlineImageDisplayBoxTest {
 
@@ -38,29 +40,59 @@ class InlineImageDisplayBoxTest {
     }
 
     @Test
-    fun `large photo is capped to the absolute bucket preserving aspect`() {
-        // 4000×3000 (4:3) → scaled by 240/4000 → 240×180.
+    fun `large photo is capped by the parity height cap preserving aspect`() {
+        // #610 — 4000×3000 (4:3): the 200-height web cap bites first (200/3000 < 400/4000) → 267×200.
+        // Before #610 the absolute 240 sp width cap gave 240×180.
         val b = box(measured = IntSize(4000, 3000), maxWidthSp = 400)
-        assertEquals(240f, b.placeholderWidth.value, TOLERANCE)
-        assertEquals(180f, b.placeholderHeight.value, TOLERANCE)
+        assertEquals(267f, b.placeholderWidth.value, TOLERANCE)
+        assertEquals(IMAGE_MAX_HEIGHT_UNITS.toFloat(), b.placeholderHeight.value, TOLERANCE)
     }
 
     @Test
-    fun `tall image is bounded by the absolute height cap`() {
-        // 100×1000 → scaled by 200/1000 → 20×200 (INLINE_IMAGE_MAX_HEIGHT_SP).
+    fun `tall image is bounded by the parity height cap`() {
+        // 100×1000 → scaled by 200/1000 → 20×200 (IMAGE_MAX_HEIGHT_UNITS, unchanged by #610).
         val b = box(measured = IntSize(100, 1000), maxWidthSp = 400)
         assertEquals(20f, b.placeholderWidth.value, TOLERANCE)
-        assertEquals(INLINE_IMAGE_MAX_HEIGHT_SP.toFloat(), b.placeholderHeight.value, TOLERANCE)
+        assertEquals(IMAGE_MAX_HEIGHT_UNITS.toFloat(), b.placeholderHeight.value, TOLERANCE)
     }
 
     @Test
-    fun `wide short banner stays within the width cap despite the min-height floor`() {
-        // #246 (Codex) — a 250×10 banner must not be blown past the 240sp width cap by the floor:
-        // cap→floor alone would reach ~384×16, the re-applied absolute cap clamps it back to ~240×10
-        // (the floor simply doesn't apply when it can't fit the width cap). No upscale past native.
+    fun `image wider than the former absolute cap keeps its native size (#610)`() {
+        // #610 before → after: a 300×150 source rendered 240×120 (absolute cap); it now stays native
+        // because only the relative 0.9×container cap remains and 300 < 400.
+        val b = box(measured = IntSize(300, 150), maxWidthSp = 400)
+        assertEquals(300f, b.placeholderWidth.value, TOLERANCE)
+        assertEquals(150f, b.placeholderHeight.value, TOLERANCE)
+    }
+
+    @Test
+    fun `portrait photo renders at the exact web parity size`() {
+        // The #610 reference case (issue repro, 360×640 portrait): web `max-height:200px` →
+        // 112.5×200, i.e. ~113×200. Same numbers as blockImageDisplaySize (parity test in
+        // PostMediaDisplayPolicyTest).
+        val b = box(measured = IntSize(360, 640), maxWidthSp = 324)
+        assertEquals(113f, b.placeholderWidth.value, TOLERANCE)
+        assertEquals(IMAGE_MAX_HEIGHT_UNITS.toFloat(), b.placeholderHeight.value, TOLERANCE)
+    }
+
+    @Test
+    fun `wide short banner stays within the relative width cap despite the min-height floor`() {
+        // #246 (Codex) — the floor is the one sanctioned upscale and must stay bounded: a 250×10
+        // banner floored to height 16 grows to 400×16, and the re-applied parity caps clamp it back
+        // to the relative cap (300 here) → 300×12. Pre-#610 the bound was the absolute 240 sp cap.
+        val b = box(measured = IntSize(250, 10), maxWidthSp = 300)
+        assertEquals(300f, b.placeholderWidth.value, TOLERANCE)
+        assertEquals(12f, b.placeholderHeight.value, TOLERANCE)
+    }
+
+    @Test
+    fun `wide short banner in a wide container is floored to one line`() {
+        // Same source, container wide enough for the floored width: the #253 legibility floor wins
+        // (400×16 ≤ caps) — the documented deviation from the web's strict no-upscale, kept so a
+        // 10 px-tall source stays visible. On the web this renders 250×10.
         val b = box(measured = IntSize(250, 10), maxWidthSp = 400)
-        assertEquals(240f, b.placeholderWidth.value, TOLERANCE)
-        assertEquals(10f, b.placeholderHeight.value, TOLERANCE)
+        assertEquals(400f, b.placeholderWidth.value, TOLERANCE)
+        assertEquals(INLINE_IMAGE_MIN_HEIGHT_SP.toFloat(), b.placeholderHeight.value, TOLERANCE)
     }
 
     @Test

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/InlineImageDisplayBoxTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/InlineImageDisplayBoxTest.kt
@@ -90,6 +90,52 @@ class InlineImageDisplayBoxTest {
         assertEquals(INLINE_IMAGE_MIN_HEIGHT_SP.toFloat(), b.placeholderHeight.value, TOLERANCE)
     }
 
+    // #256 — the hfr-cc-image marker pins the box to the one-line square at render time.
+
+    private val ccUrl = "https://cdn.example.org/emojis-micro/1f600.png?hfr-cc-image=true&raw=true"
+    private val ccImage = PostInline.InlineImage(url = ccUrl, description = null)
+
+    private fun ccBox(measured: IntSize?, maxWidthSp: Int): InlineMediaBox =
+        imageDisplayBox(ccImage, mapOf(ccUrl to measured), maxWidthSp)
+
+    @Test
+    fun `cc-image marker pins the one-line square without any measurement`() {
+        // The fast-path needs no measured size: the box is final from the very first frame.
+        val b = ccBox(measured = null, maxWidthSp = 400)
+        assertEquals(INLINE_IMAGE_MIN_HEIGHT_SP.toFloat(), b.placeholderWidth.value, TOLERANCE)
+        assertEquals(INLINE_IMAGE_MIN_HEIGHT_SP.toFloat(), b.placeholderHeight.value, TOLERANCE)
+    }
+
+    @Test
+    fun `cc-image marker ignores a measured size on record`() {
+        // Even a (stale or warmed-elsewhere) 500×500 measurement must not resize a marked emoji:
+        // the marker, not the measurement, is the contract.
+        val b = ccBox(measured = IntSize(500, 500), maxWidthSp = 400)
+        assertEquals(INLINE_IMAGE_MIN_HEIGHT_SP.toFloat(), b.placeholderWidth.value, TOLERANCE)
+        assertEquals(INLINE_IMAGE_MIN_HEIGHT_SP.toFloat(), b.placeholderHeight.value, TOLERANCE)
+    }
+
+    @Test
+    fun `cc-image square is still relative-capped in a pathologically narrow container`() {
+        // Defensive parity with the cold fallback: the fixed square obeys the same relative cap.
+        val b = ccBox(measured = null, maxWidthSp = 10)
+        assertEquals(10f, b.placeholderWidth.value, TOLERANCE)
+        assertEquals(10f, b.placeholderHeight.value, TOLERANCE)
+    }
+
+    @Test
+    fun `a false marker falls back to the normal measured path`() {
+        // hfr-cc-image=false is NOT the marker: normal intrinsic sizing applies.
+        val falseUrl = "https://cdn.example.org/pic.png?hfr-cc-image=false"
+        val b = imageDisplayBox(
+            PostInline.InlineImage(url = falseUrl, description = null),
+            mapOf(falseUrl to IntSize(80, 60)),
+            maxWidthSp = 400,
+        )
+        assertEquals(80f, b.placeholderWidth.value, TOLERANCE)
+        assertEquals(60f, b.placeholderHeight.value, TOLERANCE)
+    }
+
     private companion object {
         const val TOLERANCE = 0.5f
     }

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicyTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicyTest.kt
@@ -38,55 +38,112 @@ class PostMediaDisplayPolicyTest {
         assertEquals(PostMediaDisplayPolicy.persoSmiley, PostMediaDisplayPolicy.smileyBox(variant))
     }
 
-    // #249 / #249 follow-up — reserved block-image height: exact aspect at full width, clamped to the
-    // [blockImageMinHeight, blockImageMaxHeight] slot, null when the size is unknown/invalid.
+    // #249 / #610 — block-image display size: the exact web-parity box (no upscale, width ≤ 90% of
+    // the column, height ≤ IMAGE_MAX_HEIGHT_UNITS), null when the size is unknown/invalid (legacy
+    // placeholder slot). Doubles as the anti-CLS reservation (#249): the box is final pre-bitmap.
+
     @Test
-    fun `reserved height is the aspect-exact height at full width when within the slot`() {
-        // 400 dp wide, 4:3 image → 300 dp, inside [160, 480].
-        val height = PostMediaDisplayPolicy.reservedBlockImageHeight(
+    fun `block display size caps a 4-3 photo to the parity height, not the full width`() {
+        // Column 400 dp → relative cap 360; 400×300 → the 200-height cap bites (0.667 < 0.9) →
+        // 267×200. Before #610: full width 400 dp × 300 dp tall.
+        val size = PostMediaDisplayPolicy.blockImageDisplaySize(
             measured = PixelSize(width = 400, height = 300),
             availableWidthDp = 400f,
         )
-        assertEquals(300.dp, height)
+        assertEquals(PixelSize(267, IMAGE_MAX_HEIGHT_UNITS), size)
     }
 
     @Test
-    fun `reserved height clamps a tall portrait to the max slot`() {
-        // 400 dp wide, very tall (1:3) → 1200 dp raw → clamped to 480 dp (letterbox is the intended cap).
-        val height = PostMediaDisplayPolicy.reservedBlockImageHeight(
-            measured = PixelSize(width = 400, height = 1200),
+    fun `block display size keeps a small image native — no full-width upscale (#610)`() {
+        // THE block-path #610 fix: 80×60 in a 400 dp column stays 80×60. Before #610 fillMaxWidth
+        // upscaled it to 400 dp wide (300 dp tall, clamped to 160 min → visual blow-up).
+        val size = PostMediaDisplayPolicy.blockImageDisplaySize(
+            measured = PixelSize(width = 80, height = 60),
             availableWidthDp = 400f,
         )
-        assertEquals(PostMediaDisplayPolicy.blockImageMaxHeight, height)
+        assertEquals(PixelSize(80, 60), size)
     }
 
     @Test
-    fun `reserved height clamps a very wide image to the min slot`() {
-        // 400 dp wide, very flat (10:1) → 40 dp raw → floored to 160 dp.
-        val height = PostMediaDisplayPolicy.reservedBlockImageHeight(
-            measured = PixelSize(width = 400, height = 40),
+    fun `block display size caps a tall portrait to 200 like the web`() {
+        // The issue-repro shape (360×640): web max-height:200px → ~113×200. Before #610 the block
+        // path rendered it full-width and 480 dp tall (blockImageMaxHeight letterbox).
+        val size = PostMediaDisplayPolicy.blockImageDisplaySize(
+            measured = PixelSize(width = 360, height = 640),
             availableWidthDp = 400f,
         )
-        assertEquals(PostMediaDisplayPolicy.blockImageMinHeight, height)
+        assertEquals(PixelSize(113, IMAGE_MAX_HEIGHT_UNITS), size)
     }
 
     @Test
-    fun `reserved height is null when the size is unknown or invalid`() {
-        assertEquals(null, PostMediaDisplayPolicy.reservedBlockImageHeight(measured = null, availableWidthDp = 400f))
+    fun `block display size caps a very wide image to 90 percent of the column`() {
+        // 2000×500 in a 400 dp column → width cap 360 bites (0.18 < 0.4) → 360×90. No 160 dp floor
+        // any more: the min-height slot is placeholder-only since #610.
+        val size = PostMediaDisplayPolicy.blockImageDisplaySize(
+            measured = PixelSize(width = 2000, height = 500),
+            availableWidthDp = 400f,
+        )
+        assertEquals(PixelSize(360, 90), size)
+    }
+
+    @Test
+    fun `block display size is null when the size is unknown or invalid`() {
+        assertEquals(null, PostMediaDisplayPolicy.blockImageDisplaySize(measured = null, availableWidthDp = 400f))
         assertEquals(
             null,
-            PostMediaDisplayPolicy.reservedBlockImageHeight(
+            PostMediaDisplayPolicy.blockImageDisplaySize(
                 measured = PixelSize(width = 0, height = 300),
                 availableWidthDp = 400f,
             ),
         )
         assertEquals(
             null,
-            PostMediaDisplayPolicy.reservedBlockImageHeight(
+            PostMediaDisplayPolicy.blockImageDisplaySize(
                 measured = PixelSize(width = 400, height = 300),
                 availableWidthDp = 0f,
             ),
         )
+    }
+
+    // #610 — the unified parity policy itself, and the inline/block parity it guarantees.
+
+    @Test
+    fun `imageParityDisplaySize never upscales and caps to the web rule`() {
+        // native smaller than caps → untouched.
+        assertEquals(PixelSize(80, 60), imageParityDisplaySize(PixelSize(80, 60), maxWidthUnits = 360))
+        // height cap (web max-height:200px).
+        assertEquals(
+            PixelSize(113, IMAGE_MAX_HEIGHT_UNITS),
+            imageParityDisplaySize(PixelSize(360, 640), maxWidthUnits = 360),
+        )
+        // width cap (the caller's 0.9 × container).
+        assertEquals(PixelSize(360, 90), imageParityDisplaySize(PixelSize(2000, 500), maxWidthUnits = 360))
+        // non-positive width cap = no width cap (defensive, mirrors capToWidth): only the height
+        // cap applies → 2000×500 scaled by 200/500 → 800×200.
+        assertEquals(
+            PixelSize(800, IMAGE_MAX_HEIGHT_UNITS),
+            imageParityDisplaySize(PixelSize(2000, 500), maxWidthUnits = 0),
+        )
+    }
+
+    @Test
+    fun `inline and block paths produce the same parity numbers (#610)`() {
+        // The whole point of #610: for any measured native size, the inline box (sp) and the block
+        // box (dp) carry the SAME numbers — units differ, values match. The inline path adds a
+        // one-line legibility floor (#253) that is a no-op for these ≥16-tall parity results.
+        val columnWidthDp = 400f
+        val relativeCapUnits = 360 // 0.9 × column, what the renderer passes on both paths
+        listOf(
+            PixelSize(360, 640),
+            PixelSize(4000, 3000),
+            PixelSize(80, 60),
+            PixelSize(2000, 500),
+            PixelSize(300, 150),
+        ).forEach { native ->
+            val inline = imageParityDisplaySize(native, maxWidthUnits = relativeCapUnits)
+            val block = PostMediaDisplayPolicy.blockImageDisplaySize(native, columnWidthDp)
+            assertEquals("parity broken for $native", inline, block)
+        }
     }
 
     @Test
@@ -137,15 +194,16 @@ class PostMediaDisplayPolicyTest {
 
     @Test
     fun `block image min height is 160dp`() {
-        // Reserves a stable visual slot during SubcomposeAsyncImage loading/error to avoid a
-        // layout jump when the bitmap finally resolves (cf. PR #126 Codex review).
+        // #610 — UNMEASURED placeholder slot only: reserves a stable visual slot during
+        // SubcomposeAsyncImage loading/error so the UX stays visible and the layout jump is bounded
+        // (cf. PR #126 Codex review). A measured image uses its exact blockImageDisplaySize box.
         assertEquals(160.dp, PostMediaDisplayPolicy.blockImageMinHeight)
     }
 
     @Test
     fun `block image max height is 480dp`() {
-        // Soft cap so a 4000x3000 RAW screenshot can't blow up the post and break scrolling.
-        // Bumping this would also regress the cache estimates discussed in the policy KDoc.
+        // #610 — UNMEASURED slot cap only (load-without-measurement can't blow up the post). The
+        // measured path caps at IMAGE_MAX_HEIGHT_UNITS (200) via blockImageDisplaySize.
         assertEquals(480.dp, PostMediaDisplayPolicy.blockImageMaxHeight)
     }
 

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererImageParityRoborazziTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererImageParityRoborazziTest.kt
@@ -1,0 +1,161 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import coil3.ColorImage
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.test.FakeImageLoaderEngine
+import com.github.takahirom.roborazzi.captureRoboImage
+import fr.forumhfr.redface2.core.model.PostBlock
+import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.model.PostInline
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * #610 — diagnostic-only Roborazzi captures of the unified inline/block `[img]` parity
+ * (HFR-web `img { max-width: 90%; max-height: 200px }`, no upscale).
+ *
+ * Visual proof of the three #610 properties:
+ *  - **inline/block parity**: the same 360×640 portrait renders at the SAME size (~113×200) inside
+ *    prose (inline path, sp) and as a standalone `PostBlock.Image` (block path, dp) — pre-#610 the
+ *    block was full-width and 480 dp tall while the inline was 113×200;
+ *  - **no block upscale**: a small 80×60 image posted alone stays 80×60 centred — pre-#610
+ *    `fillMaxWidth` blew it up to the column width;
+ *  - **height cap**: a large 4:3 photo caps at 200 (267×200), not the legacy 480 dp letterbox.
+ *
+ * Images are fed by a [FakeImageLoaderEngine] returning distinct-coloured [ColorImage]s at native px,
+ * and the intrinsic cache is pre-seeded so the first composition is already at the final size (no
+ * async-measure timing dependency). Light theme so the coloured boxes read clearly.
+ *
+ * Not a CI golden gate (the Roborazzi Gradle plugin is not applied — AGP 9, cf. takahirom/roborazzi#781).
+ * Run on demand; PNGs land under `core/ui/build/outputs/roborazzi/` (gitignored) :
+ *
+ *     ./scripts/docker-dev.sh ./gradlew :core:ui:testDebugUnitTest \
+ *         --tests '*PostRendererImageParityRoborazziTest*' --console=plain --no-daemon
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@OptIn(ExperimentalTestApi::class)
+class PostRendererImageParityRoborazziTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val portraitUrl = "https://i.example.org/portrait360x640.jpg"
+    private val smallUrl = "https://i.example.org/reaction80x60.png"
+    private val photoUrl = "https://i.example.org/photo4000x3000.jpg"
+
+    @OptIn(coil3.annotation.DelicateCoilApi::class)
+    @Before
+    fun installFakeImageLoader() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val engine = FakeImageLoaderEngine.Builder()
+            .intercept(portraitUrl, ColorImage(Color(0xFF1565C0).toArgb(), width = 360, height = 640))
+            .intercept(smallUrl, ColorImage(Color(0xFF2E7D32).toArgb(), width = 80, height = 60))
+            .intercept(photoUrl, ColorImage(Color(0xFFC62828).toArgb(), width = 4000, height = 3000))
+            .build()
+        SingletonImageLoader.setUnsafe(ImageLoader.Builder(context).components { add(engine) }.build())
+    }
+
+    /** Pre-seed the cache with the same native sizes the fake engine serves → synchronous render. */
+    private fun seededCache(): IntrinsicMediaSizeCache = DefaultIntrinsicMediaSizeCache().apply {
+        putSuccess(portraitUrl, IntSize(360, 640))
+        putSuccess(smallUrl, IntSize(80, 60))
+        putSuccess(photoUrl, IntSize(4000, 3000))
+    }
+
+    @Test
+    fun portraitInlineInProse() {
+        // The #610/#813-repro paragraph shape: text + [img] + text → INLINE path. Expected ~113×200.
+        capture("img_610_inline_in_prose", widthDp = 360) {
+            PostRenderer(content = inlineInProseContent())
+        }
+    }
+
+    @Test
+    fun portraitStandaloneBlock() {
+        // Same portrait as a standalone PostBlock.Image → BLOCK path. Expected the SAME ~113×200,
+        // centred — compare with img_610_inline_in_prose (pre-#610: full width, 480 dp tall).
+        capture("img_610_standalone_block", widthDp = 360) {
+            PostRenderer(content = standaloneBlockContent(portraitUrl))
+        }
+    }
+
+    @Test
+    fun smallImageBlockKeepsNativeSize() {
+        // 80×60 posted alone: stays 80×60 centred (pre-#610: fillMaxWidth upscale to 360 dp wide).
+        capture("img_610_small_block_native", widthDp = 360) {
+            PostRenderer(content = standaloneBlockContent(smallUrl))
+        }
+    }
+
+    @Test
+    fun largePhotoBlockCapsAt200() {
+        // 4000×3000 → 267×200 (height cap), not the legacy full-width 480 dp letterbox.
+        capture("img_610_large_block_cap200", widthDp = 360) {
+            PostRenderer(content = standaloneBlockContent(photoUrl))
+        }
+    }
+
+    private fun inlineInProseContent() = PostContent(
+        blocks = listOf(
+            PostBlock.Paragraph(
+                inlines = listOf(
+                    PostInline.Text("Texte avant la photo "),
+                    PostInline.InlineImage(url = portraitUrl, description = "portrait"),
+                    PostInline.Text(" puis texte après : la photo est capée à 200 de haut (parité web)."),
+                ),
+            ),
+        ),
+    )
+
+    private fun standaloneBlockContent(url: String) = PostContent(
+        blocks = listOf(PostBlock.Image(url = url, description = "photo")),
+    )
+
+    private fun capture(name: String, widthDp: Int, content: @Composable () -> Unit) {
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalIntrinsicMediaSizeCache provides seededCache()) {
+                RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                    Surface(color = MaterialTheme.colorScheme.surface) {
+                        Box(
+                            modifier = Modifier
+                                .width(widthDp.dp)
+                                .background(MaterialTheme.colorScheme.surface)
+                                .padding(16.dp),
+                        ) {
+                            content()
+                        }
+                    }
+                }
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage(
+            filePath = "build/outputs/roborazzi/$name.png",
+        )
+    }
+}

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -495,12 +495,13 @@ fun TopicScreen(
 /**
  * #197 — keep [target] anchored at the top of the viewport while upstream block images settle.
  *
- * `PostBlock.Image` renders a `SubcomposeAsyncImage` that starts at `blockImageMinHeight` (160.dp)
- * while loading/erroring and grows to its decoded height (up to `blockImageMaxHeight`, 480.dp) once
- * Coil resolves the bitmap. Any block image in a post *above* the deep-link target shifts the
- * cumulative scroll offset by up to +320.dp *after* the initial one-shot `scrollToItem`, leaving the
- * target scrolled off-screen. A warm image cache decodes synchronously before the first measure,
- * which is why #197 only reproduces on a cold cache.
+ * An UNMEASURED `PostBlock.Image` (cold intrinsic cache) renders a `SubcomposeAsyncImage` that
+ * starts at `blockImageMinHeight` (160.dp) while loading/erroring and settles to its exact
+ * web-parity box (`blockImageDisplaySize`, ≤ 200.dp tall since #610) once the intrinsic size lands.
+ * Any block image in a post *above* the deep-link target shifts the cumulative scroll offset (in
+ * either direction) *after* the initial one-shot `scrollToItem`, leaving the target scrolled
+ * off-screen. A warm cache sizes the box exactly before the first measure (#249), which is why #197
+ * only reproduces on a cold cache.
  *
  * Each frame we re-pin the target to the top (when it has drifted) and stop once the minimum
  * settle window has elapsed *and* its position has held still for [REANCHOR_STABLE_FRAMES]


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Closes #610.

> **Empilée sur #835** (elle contient son commit jusqu'au merge de #835 ; le diff net redeviendra #610 seul ensuite). Merger #835 d'abord.

## Quoi
Politique de dimensionnement unifiée `imageParityDisplaySize()` alignée sur le web HFR (`max-width: 90%`, `max-height: 200px`) pour les images inline (sp) ET bloc (dp) :
- le bloc mesuré perd `fillMaxWidth` (qui **upscalait**) et le clamp [160dp, 480dp] au profit d'une box exacte centrée, no-upscale, ≤0.9×colonne, ≤200dp ;
- le cap absolu inline 240sp disparaît du sizing (il ne survit que comme seuil de promotion, valeur inchangée) ;
- décode inline #257 : plafond 1024×1024 plat (hausse mémoire marginale documentée).
Anti-CLS #249, carré froid #253 et invariant #175 (aucun rebuild d'AnnotatedString) préservés.

## Tests
`PostMediaDisplayPolicyTest` + `InlineImageDisplayBoxTest` étendus ; `PostRendererImageParityRoborazziTest` nouveau (diagnostic on-demand, pas de golden CI — harnais existant).

## Validation
- Canonique complète verte en local (pile #256+#610).
- Gate Codex (gpt-5.5, xhigh) : #610 jugé « cohérent : no-upscale bloc, centrage, taille exacte mesurée, parité inline/bloc, fallback #253 et décode #257 assumés » ; la suppression du cap 240sp est actée comme conséquence volontaire (une inline de 300px n'est plus réduite artificiellement).
- Changement visuel global : captures avant/après au dogfood de la release 0.26.0 (post repro de #813 : bloc 360×640 passe de 480dp à ~113×200dp centré, parité web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pm28ny4V5GSegmKJxTPVAM