### PR TITLE
feat(ui,topic): long-press context menu on post images — copy, open, save (#831)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/media/AndroidPostImageSaver.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/media/AndroidPostImageSaver.kt
@@ -102,6 +102,7 @@ internal class AndroidPostImageSaver @Inject constructor(
     }
 
     /** MediaStore write with the IS_PENDING 1 → 0 protocol and orphan-row cleanup on failure. */
+    @Suppress("ThrowsCount") // The IS_PENDING protocol's failure exits ARE the contract.
     private fun insertIntoMediaStore(bytes: ByteArray, mimeType: String, displayName: String) {
         val resolver = context.contentResolver
         val collection = MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/media/AndroidPostImageSaver.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/media/AndroidPostImageSaver.kt
@@ -1,0 +1,138 @@
+package fr.forumhfr.redface2.core.data.media
+
+import android.content.ContentValues
+import android.content.Context
+import android.provider.MediaStore
+import coil3.SingletonImageLoader
+import dagger.hilt.android.qualifiers.ApplicationContext
+import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
+import fr.forumhfr.redface2.core.domain.media.ImageSaveException
+import fr.forumhfr.redface2.core.domain.media.PostImageSaver
+import fr.forumhfr.redface2.core.domain.media.SavedPostImage
+import fr.forumhfr.redface2.core.network.qualifiers.AnonymousClient
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okio.Buffer
+import okio.BufferedSource
+import okio.buffer
+
+/**
+ * Android [PostImageSaver] (#831): writes a post image into the shared `Pictures/Redface2`
+ * collection via `MediaStore.Images` — `minSdk = 29`, so scoped storage applies and NO runtime
+ * permission is needed for app-created rows.
+ *
+ * Byte source (arbitrated contract — « octets ORIGINAUX, jamais réencoder ») :
+ *  1. the Coil singleton [coil3.ImageLoader]'s disk cache — Coil 3 stores the RAW network body
+ *     (`DiskCache.openSnapshot(url).data`, key = URL), so an animated GIF is saved animated and a
+ *     JPEG keeps its original compression. The loader is resolved lazily via
+ *     [SingletonImageLoader.get], same no-`:app`-dependency seam as `DefaultImageCacheMaintenance`;
+ *  2. fallback: a network re-fetch on the [AnonymousClient] OkHttp client (the same client the
+ *     image pipeline uses — no HFR auth cookies leaked to external image hosts).
+ *
+ * The decoded bitmap is NEVER re-encoded. Write protocol: the row is inserted `IS_PENDING = 1`
+ * (invisible to galleries), the bytes streamed, then the row flipped to `IS_PENDING = 0`; a write
+ * failure deletes the orphan row so no ghost entry survives. All I/O hops to [ioDispatcher]
+ * (project rule: data sources own their dispatcher), and a hard [MAX_SAVE_BYTES] ceiling bounds
+ * both byte sources against a pathological input, mirroring `AndroidImageUploadReader`.
+ */
+@Singleton
+internal class AndroidPostImageSaver @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    @param:AnonymousClient private val httpClient: OkHttpClient,
+) : PostImageSaver {
+
+    override suspend fun save(url: String): SavedPostImage = withContext(ioDispatcher) {
+        val bytes = readFromCoilDiskCache(url) ?: fetchFromNetwork(url)
+        val mediaType = resolveImageMediaType(bytes, url)
+        val displayName = imageDisplayName(url, mediaType)
+        insertIntoMediaStore(bytes, mediaType.mimeType, displayName)
+        SavedPostImage(displayName = displayName)
+    }
+
+    /**
+     * Original bytes from Coil's disk cache (key = the request URL, Coil 3 default). Null on a
+     * cache miss, an absent disk cache, or an unreadable snapshot (→ the network fallback takes
+     * over) ; only [ImageSaveException.TooLarge] escapes — re-fetching would hit the same ceiling.
+     */
+    private fun readFromCoilDiskCache(url: String): ByteArray? {
+        val diskCache = SingletonImageLoader.get(context).diskCache
+        val snapshot = diskCache?.openSnapshot(url)
+        if (diskCache == null || snapshot == null) return null
+        return try {
+            diskCache.fileSystem.source(snapshot.data).buffer().use { drainBounded(it) }
+        } catch (ignored: IOException) {
+            null
+        } finally {
+            snapshot.close()
+        }
+    }
+
+    /** Network re-fetch of the original bytes on the anonymous client (cache miss path). */
+    private fun fetchFromNetwork(url: String): ByteArray = try {
+        val request = Request.Builder().url(url).build()
+        httpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) throw ImageSaveException.Fetch()
+            drainBounded(response.body.source())
+        }
+    } catch (e: IOException) {
+        throw ImageSaveException.Fetch(e)
+    } catch (e: IllegalArgumentException) {
+        // Request.Builder.url refuses non-HTTP(S) URLs — the UI eligibility gate should have
+        // filtered these, but a typed failure beats a crash if one slips through.
+        throw ImageSaveException.Fetch(e)
+    }
+
+    /** Copies [source] into a byte array, throwing [ImageSaveException.TooLarge] past the ceiling. */
+    private fun drainBounded(source: BufferedSource): ByteArray {
+        val buffer = Buffer()
+        var total = 0L
+        while (true) {
+            val read = source.read(buffer, DEFAULT_BUFFER_SIZE.toLong())
+            if (read < 0L) break
+            total += read
+            if (total > MAX_SAVE_BYTES) throw ImageSaveException.TooLarge(MAX_SAVE_BYTES)
+        }
+        return buffer.readByteArray()
+    }
+
+    /** MediaStore write with the IS_PENDING 1 → 0 protocol and orphan-row cleanup on failure. */
+    private fun insertIntoMediaStore(bytes: ByteArray, mimeType: String, displayName: String) {
+        val resolver = context.contentResolver
+        val collection = MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+        val pendingValues = ContentValues().apply {
+            put(MediaStore.Images.Media.DISPLAY_NAME, displayName)
+            put(MediaStore.Images.Media.MIME_TYPE, mimeType)
+            put(MediaStore.Images.Media.RELATIVE_PATH, RELATIVE_PATH)
+            put(MediaStore.Images.Media.IS_PENDING, 1)
+        }
+        val itemUri = resolver.insert(collection, pendingValues) ?: throw ImageSaveException.Storage()
+        try {
+            val stream = resolver.openOutputStream(itemUri)
+                ?: throw IOException("ContentResolver returned no output stream for $itemUri")
+            stream.use { it.write(bytes) }
+            val publishedValues = ContentValues().apply { put(MediaStore.Images.Media.IS_PENDING, 0) }
+            resolver.update(itemUri, publishedValues, null, null)
+        } catch (e: IOException) {
+            // Never leave a ghost IS_PENDING row behind a failed write.
+            resolver.delete(itemUri, null, null)
+            throw ImageSaveException.Storage(e)
+        }
+    }
+
+    private companion object {
+        /** Gallery destination, surfaced to the user in the success feedback string. */
+        private const val RELATIVE_PATH = "Pictures/Redface2"
+
+        /**
+         * Hard anti-OOM ceiling (32 MiB) — far above any real forum image, far below the heap.
+         * Same rationale and value as `AndroidImageUploadReader.MAX_READ_BYTES`.
+         */
+        private const val MAX_SAVE_BYTES = 32L * 1024 * 1024
+    }
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/media/ImageMediaType.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/media/ImageMediaType.kt
@@ -47,11 +47,7 @@ internal fun resolveImageMediaType(bytes: ByteArray, url: String): ImageMediaTyp
 internal fun sniffImageMediaType(bytes: ByteArray): ImageMediaType? {
     if (bytes.size < 12) return null
     if (bytes[0] == 0xFF.toByte() && bytes[1] == 0xD8.toByte() && bytes[2] == 0xFF.toByte()) return JPEG
-    if (bytes[0] == 0x89.toByte() && bytes[1] == 'P'.code.toByte() &&
-        bytes[2] == 'N'.code.toByte() && bytes[3] == 'G'.code.toByte()
-    ) {
-        return PNG
-    }
+    if (bytes[0] == 0x89.toByte() && bytes.startsWithAscii(1, "PNG")) return PNG
     if (bytes.startsWithAscii(0, "GIF8")) return GIF
     if (bytes.startsWithAscii(0, "RIFF") && bytes.startsWithAscii(8, "WEBP")) return WEBP
     if (bytes.startsWithAscii(0, "BM")) return BMP

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/media/MediaModule.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/media/MediaModule.kt
@@ -1,0 +1,20 @@
+package fr.forumhfr.redface2.core.data.media
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import fr.forumhfr.redface2.core.domain.media.PostImageSaver
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal interface MediaBindingsModule {
+
+    // #831 — the image contextual menu's « Enregistrer l'image » saves through this seam ; the
+    // Android impl lives here (it needs MediaStore + the Coil disk cache) so the feature ViewModel
+    // stays platform-free — same pattern as UploadProviderBindingsModule.bindImageUploadReader.
+    @Binds
+    @Singleton
+    fun bindPostImageSaver(impl: AndroidPostImageSaver): PostImageSaver
+}

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/media/MediaModule.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/media/MediaModule.kt
@@ -9,7 +9,7 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-internal interface MediaBindingsModule {
+internal interface MediaModule {
 
     // #831 — the image contextual menu's « Enregistrer l'image » saves through this seam ; the
     // Android impl lives here (it needs MediaStore + the Coil disk cache) so the feature ViewModel

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/media/PostImageMediaType.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/media/PostImageMediaType.kt
@@ -1,0 +1,99 @@
+package fr.forumhfr.redface2.core.data.media
+
+/**
+ * #831 — a saved image's MediaStore identity: the MIME type recorded on the row and the file
+ * extension appended to the display name. Always produced as a PAIR by [resolveImageMediaType] so
+ * the two can never disagree (the arbitrated contract: « extension cohérente avec le MIME sniffé »).
+ */
+internal data class ImageMediaType(val mimeType: String, val extension: String)
+
+private val JPEG = ImageMediaType("image/jpeg", "jpg")
+private val PNG = ImageMediaType("image/png", "png")
+private val GIF = ImageMediaType("image/gif", "gif")
+private val WEBP = ImageMediaType("image/webp", "webp")
+private val BMP = ImageMediaType("image/bmp", "bmp")
+private val AVIF = ImageMediaType("image/avif", "avif")
+
+private val EXTENSION_TYPES = mapOf(
+    "jpg" to JPEG,
+    "jpeg" to JPEG,
+    "png" to PNG,
+    "gif" to GIF,
+    "webp" to WEBP,
+    "bmp" to BMP,
+    "avif" to AVIF,
+)
+
+/**
+ * #831 — resolves the [ImageMediaType] of the ORIGINAL bytes about to be saved. Priority order:
+ *
+ *  1. magic-byte sniffing ([sniffImageMediaType]) — the bytes themselves are the truth (an image
+ *     host can serve a PNG behind a `.jpg` URL);
+ *  2. the URL's file extension — covers formats the sniffer doesn't know;
+ *  3. a STABLE fallback (JPEG) so the save never fails just because the type is exotic — a wrong
+ *     label is recoverable, a refused save is not.
+ *
+ * Pure (bytes + string in, value out) so the whole decision is pinned by a JVM test.
+ */
+internal fun resolveImageMediaType(bytes: ByteArray, url: String): ImageMediaType =
+    sniffImageMediaType(bytes) ?: imageMediaTypeFromUrl(url) ?: JPEG
+
+/**
+ * Sniffs the common raster formats HFR image hosts serve, from their magic bytes:
+ * JPEG (`FF D8 FF`), PNG (`89 50 4E 47`), GIF (`GIF8`), WebP (`RIFF….WEBP`), BMP (`BM`) and
+ * AVIF (`ftypavif` at offset 4). Returns null when no signature matches (caller falls back).
+ */
+@Suppress("ReturnCount", "MagicNumber") // signature table — early returns ARE the table.
+internal fun sniffImageMediaType(bytes: ByteArray): ImageMediaType? {
+    if (bytes.size < 12) return null
+    if (bytes[0] == 0xFF.toByte() && bytes[1] == 0xD8.toByte() && bytes[2] == 0xFF.toByte()) return JPEG
+    if (bytes[0] == 0x89.toByte() && bytes[1] == 'P'.code.toByte() &&
+        bytes[2] == 'N'.code.toByte() && bytes[3] == 'G'.code.toByte()
+    ) {
+        return PNG
+    }
+    if (bytes.startsWithAscii(0, "GIF8")) return GIF
+    if (bytes.startsWithAscii(0, "RIFF") && bytes.startsWithAscii(8, "WEBP")) return WEBP
+    if (bytes.startsWithAscii(0, "BM")) return BMP
+    if (bytes.startsWithAscii(4, "ftypavif")) return AVIF
+    return null
+}
+
+private fun ByteArray.startsWithAscii(offset: Int, ascii: String): Boolean {
+    if (size < offset + ascii.length) return false
+    return ascii.indices.all { this[offset + it] == ascii[it].code.toByte() }
+}
+
+/** Media type from the URL path's extension (query/fragment stripped), null when unknown. */
+internal fun imageMediaTypeFromUrl(url: String): ImageMediaType? {
+    val path = url.substringBefore('?').substringBefore('#')
+    val lastSegment = path.substringAfterLast('/')
+    val extension = lastSegment.substringAfterLast('.', missingDelimiterValue = "")
+    return EXTENSION_TYPES[extension.lowercase()]
+}
+
+/** Display-name base cap — generous for findability, well under MediaStore's 255-byte limit. */
+private const val MAX_BASE_NAME_LENGTH = 64
+
+/** Characters allowed verbatim in a saved file's base name; anything else becomes `_`. */
+private fun Char.isAllowedInFileName(): Boolean =
+    this in 'A'..'Z' || this in 'a'..'z' || this in '0'..'9' || this == '.' || this == '_' || this == '-'
+
+/**
+ * #831 — display name of the saved file: the URL's last path segment without its extension,
+ * sanitized to a safe charset, capped, with the [mediaType]'s extension appended (so name and
+ * MIME always agree). An unusable base (empty path, all-special characters) falls back to the
+ * stable `"image"` — MediaStore de-duplicates colliding display names on its own (` (1)` suffix).
+ */
+internal fun imageDisplayName(url: String, mediaType: ImageMediaType): String {
+    val path = url.substringBefore('?').substringBefore('#')
+    val lastSegment = path.substringAfterLast('/')
+    val rawBase = lastSegment.substringBeforeLast('.', missingDelimiterValue = lastSegment)
+    val sanitized = rawBase
+        .map { char -> if (char.isAllowedInFileName()) char else '_' }
+        .joinToString(separator = "")
+        .trim { it == '.' || it == '_' }
+        .take(MAX_BASE_NAME_LENGTH)
+    val base = sanitized.ifEmpty { "image" }
+    return "$base.${mediaType.extension}"
+}

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/media/PostImageMediaTypeTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/media/PostImageMediaTypeTest.kt
@@ -1,0 +1,104 @@
+package fr.forumhfr.redface2.core.data.media
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #831 — pins the pure identity decisions of the image saver: magic-byte sniffing beats the URL
+ * extension, the fallback is stable, and the display name's extension always agrees with the
+ * recorded MIME (« extension cohérente avec le MIME sniffé », Codex framing arbitrage #4).
+ */
+class PostImageMediaTypeTest {
+
+    // ---- magic-byte sniffing -------------------------------------------------------------
+
+    private fun bytes(vararg header: Int): ByteArray =
+        ByteArray(16) { index -> if (index < header.size) header[index].toByte() else 0 }
+
+    @Test
+    fun `sniffs the common raster signatures`() {
+        assertEquals("image/jpeg", sniffImageMediaType(bytes(0xFF, 0xD8, 0xFF, 0xE0))?.mimeType)
+        assertEquals("image/png", sniffImageMediaType(bytes(0x89, 'P'.code, 'N'.code, 'G'.code))?.mimeType)
+        assertEquals(
+            "image/gif",
+            sniffImageMediaType(bytes('G'.code, 'I'.code, 'F'.code, '8'.code, '9'.code, 'a'.code))?.mimeType,
+        )
+        assertEquals("image/bmp", sniffImageMediaType(bytes('B'.code, 'M'.code))?.mimeType)
+    }
+
+    @Test
+    fun `sniffs WebP through its RIFF container`() {
+        val webp = ByteArray(16)
+        "RIFF".forEachIndexed { i, c -> webp[i] = c.code.toByte() }
+        "WEBP".forEachIndexed { i, c -> webp[8 + i] = c.code.toByte() }
+        assertEquals("image/webp", sniffImageMediaType(webp)?.mimeType)
+    }
+
+    @Test
+    fun `sniffs AVIF through its ftyp brand at offset 4`() {
+        val avif = ByteArray(16)
+        "ftypavif".forEachIndexed { i, c -> avif[4 + i] = c.code.toByte() }
+        assertEquals("image/avif", sniffImageMediaType(avif)?.mimeType)
+    }
+
+    @Test
+    fun `unknown signatures and short payloads sniff to null`() {
+        assertNull(sniffImageMediaType(bytes('<'.code, 'h'.code, 't'.code, 'm'.code, 'l'.code)))
+        assertNull(sniffImageMediaType(ByteArray(4))) // shorter than any reliable signature window
+    }
+
+    // ---- resolution priority -------------------------------------------------------------
+
+    @Test
+    fun `sniffed bytes beat a lying URL extension`() {
+        // A PNG served behind a `.jpg` URL is saved as a PNG (the bytes are the truth).
+        val resolved = resolveImageMediaType(bytes(0x89, 'P'.code, 'N'.code, 'G'.code), "https://x.com/photo.jpg")
+        assertEquals("image/png", resolved.mimeType)
+        assertEquals("png", resolved.extension)
+    }
+
+    @Test
+    fun `URL extension is the fallback when sniffing fails`() {
+        val resolved = resolveImageMediaType(ByteArray(16), "https://x.com/anim.GIF?v=2#frag")
+        assertEquals("image/gif", resolved.mimeType)
+    }
+
+    @Test
+    fun `stable JPEG fallback when neither bytes nor URL identify the type`() {
+        val resolved = resolveImageMediaType(ByteArray(16), "https://x.com/picture")
+        assertEquals("image/jpeg", resolved.mimeType)
+        assertEquals("jpg", resolved.extension)
+    }
+
+    // ---- display name --------------------------------------------------------------------
+
+    private val png = resolveImageMediaType(bytes(0x89, 'P'.code, 'N'.code, 'G'.code), "")
+
+    @Test
+    fun `display name derives from the URL last segment with the resolved extension`() {
+        assertEquals(
+            "screenshot-2026.png",
+            imageDisplayName("https://x.com/a/b/screenshot-2026.jpg?token=abc", png),
+        )
+    }
+
+    @Test
+    fun `special characters are sanitized and the base is capped`() {
+        // '%', ' ', '(', ')', '!' all collapse to '_' ; the trailing runs of '_' are trimmed.
+        assertEquals(
+            "mon_20image__1.png",
+            imageDisplayName("https://x.com/mon%20image (1)!.png", png),
+        )
+
+        val longBase = "a".repeat(200)
+        val capped = imageDisplayName("https://x.com/$longBase.png", png)
+        assertEquals("a".repeat(64) + ".png", capped)
+    }
+
+    @Test
+    fun `unusable bases fall back to the stable default`() {
+        assertEquals("image.png", imageDisplayName("https://x.com/", png))
+        assertEquals("image.png", imageDisplayName("https://x.com/....", png))
+    }
+}

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/media/PostImageSaver.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/media/PostImageSaver.kt
@@ -1,0 +1,45 @@
+package fr.forumhfr.redface2.core.domain.media
+
+/**
+ * #831 — saves a post image (the « Enregistrer l'image » entry of the image contextual menu) into
+ * the device's shared image collection.
+ *
+ * The seam exists so `:feature:topic` stays platform-free and Konsist-compliant: the write needs
+ * `MediaStore` + the Coil disk cache + an OkHttp fallback, all of which live in the Android layer
+ * (`:core:data`, cf. `AndroidPostImageSaver`). The ViewModel only knows this interface and is
+ * tested with a fake — same architecture as [fr.forumhfr.redface2.core.domain.upload.ImageUploadReader].
+ */
+interface PostImageSaver {
+
+    /**
+     * Persists the image behind [url] (an http(s) post-image URL) into the shared Pictures
+     * collection, preserving the ORIGINAL bytes (an animated GIF stays animated — no re-encode of
+     * a decoded bitmap). Returns the [SavedPostImage] describing the created entry. Throws
+     * [ImageSaveException] on failure. Runs its I/O off the main thread (the implementation hops
+     * to the IO dispatcher, per the project rule that data sources own their dispatcher).
+     */
+    suspend fun save(url: String): SavedPostImage
+}
+
+/** #831 — the MediaStore entry created by [PostImageSaver.save]. */
+data class SavedPostImage(
+    /** Final display name of the saved file (sanitized URL-derived base + sniffed extension). */
+    val displayName: String,
+)
+
+/**
+ * Typed failure surface of a post-image save (#831), modelled on
+ * [fr.forumhfr.redface2.core.domain.upload.UploadException] so the UI renders an actionable
+ * message (download vs. storage vs. size) instead of a generic « save failed ».
+ */
+sealed class ImageSaveException(message: String, cause: Throwable? = null) : Exception(message, cause) {
+
+    /** The image bytes could not be obtained (disk-cache miss AND the network re-fetch failed). */
+    class Fetch(cause: Throwable? = null) : ImageSaveException("Could not fetch image bytes", cause)
+
+    /** The MediaStore insert/write failed (row insert refused, stream unwritable). */
+    class Storage(cause: Throwable? = null) : ImageSaveException("Could not write image to MediaStore", cause)
+
+    /** The image exceeds the anti-OOM ceiling ([maxBytes] is the cap that was hit). */
+    class TooLarge(val maxBytes: Long) : ImageSaveException("Image exceeds $maxBytes bytes")
+}

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostImageActions.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostImageActions.kt
@@ -1,0 +1,51 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * #831 — the post image a contextual action targets: the rendered [url], its BBCode alt text
+ * ([description]) and, for a `[url=…][img]` linked image (#257), the wrapping [linkUrl].
+ *
+ * Built at gesture time from the frozen content models (`PostInline.InlineImage`,
+ * `PostBlock.Image`, promoted gallery images) — the on-disk `PostContent` contract is never
+ * touched. A data class so gesture keys (`Modifier.pointerInput`) compare by value.
+ */
+data class PostImageTarget(
+    val url: String,
+    val description: String?,
+    val linkUrl: String?,
+)
+
+/**
+ * #831 — actions a hosting surface offers on post images. PR1 carries the single long-press
+ * entry point (the contextual menu); the PR2 viewer adds its own member when it lands.
+ */
+class PostImageActions(
+    val onLongPress: (PostImageTarget) -> Unit,
+)
+
+/**
+ * #831 — CompositionLocal wiring [PostImageActions] into the two image render paths of
+ * [PostRenderer] (inline `[img]` and block/promoted images). Same `staticCompositionLocalOf`
+ * rationale as `LocalFoldLongQuotes` (DisplayMetrics.kt): the value changes only when the hosting
+ * surface swaps its handler, so scoped reads without fine-grained tracking are the right trade.
+ *
+ * Defaults to `null` = the surface offers NO image actions: private messages, the editor BBCode
+ * preview and signatures keep their existing inert behaviour without any change on their side.
+ * Only the topic reading surface provides a non-null value (TopicScreen).
+ */
+val LocalPostImageActions = staticCompositionLocalOf<PostImageActions?> { null }
+
+/**
+ * #831 — whether a post image URL is eligible for the contextual image actions. The menu offers
+ * « open in browser » / « save » / « copy », all of which assume a fetchable http(s) resource:
+ * `data:` / `blob:` payloads, empty URLs and exotic schemes are refused up front (the long-press
+ * handler is simply not installed), instead of failing later inside an Intent or the saver.
+ *
+ * Pure so the boundary is pinned by a JVM test ([PostImageUrlEligibilityTest]) without Compose.
+ */
+fun isEligiblePostImageUrl(url: String): Boolean {
+    val trimmed = url.trim()
+    return trimmed.startsWith("http://", ignoreCase = true) ||
+        trimmed.startsWith("https://", ignoreCase = true)
+}

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostImageThumbnail.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostImageThumbnail.kt
@@ -1,0 +1,52 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+
+/**
+ * #831 — small square thumbnail of a post image, the hero of the image contextual menu
+ * (`PostImageMenuSheet`, `:feature:topic`).
+ *
+ * Lives in `:core:ui` for the same reason as [fr.forumhfr.redface2.core.ui.avatar.RedfaceUserAvatar]:
+ * Coil is already wired here (`coil-compose` is an `implementation` dependency of this module),
+ * so `:feature:topic` does not need to grow a Coil dependency for one image. The neutral
+ * `surfaceContainerHighest` square doubles as the loading and error placeholder — the sheet
+ * remains fully usable when the image host is down (the actions operate on the URL, not the
+ * bitmap). The bitmap is served from Coil's caches (same URL key as the post render), so no
+ * second network fetch in the common case.
+ */
+@Composable
+fun PostImageThumbnail(
+    url: String,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    size: Dp = DEFAULT_THUMBNAIL_SIZE,
+) {
+    Box(
+        modifier = modifier
+            .size(size)
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+    ) {
+        AsyncImage(
+            model = url,
+            contentDescription = contentDescription,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+}
+
+/** Same footprint as the post-menu hero avatar (`RedfaceUserAvatar` at 56.dp in PostMenuSheet). */
+private val DEFAULT_THUMBNAIL_SIZE = 56.dp

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -2,6 +2,8 @@ package fr.forumhfr.redface2.core.ui.post
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -42,12 +44,18 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.hapticfeedback.HapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.onLongClick
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.Placeholder
@@ -833,20 +841,54 @@ private fun BlockImage(url: String, description: String?, linkUrl: String? = nul
                 .defaultMinSize(minHeight = PostMediaDisplayPolicy.blockImageMinHeight)
                 .heightIn(max = PostMediaDisplayPolicy.blockImageMaxHeight)
         }
+        // #831 — contextual image menu on long-press. The tap contract is preserved EXACTLY (Codex
+        // framing, firm reserve): a linked image (#257) keeps its tap-through and gains the
+        // long-press through ONE combinedClickable (a tap already exists there); an unlinked block
+        // image gets a long-press-ONLY handler (no onClick — its tap stays inert as before). When
+        // the surface provides no actions (MP threads, editor preview, signatures: default null),
+        // or the URL is not actionable (data:/blob:/empty), the historical modifiers are
+        // reproduced verbatim.
+        val imageActions = LocalPostImageActions.current?.takeIf { isEligiblePostImageUrl(url) }
+        val interactionModifier = when {
+            imageActions != null && linkUrl != null ->
+                // Role.Image (not Button): the element IS an image that opens its full version on
+                // tap; the localized labels carry both actions for TalkBack. combinedClickable
+                // brings the built-in long-press haptics (#436 precedent, MultiQuoteFab).
+                Modifier.combinedClickable(
+                    role = Role.Image,
+                    onClickLabel = openLabel,
+                    onLongClickLabel = stringResource(R.string.post_image_options_action),
+                    onLongClick = {
+                        imageActions.onLongPress(
+                            PostImageTarget(url = url, description = description, linkUrl = linkUrl),
+                        )
+                    },
+                ) {
+                    runCatching { uriHandler.openUri(linkUrl) }
+                }
+
+            imageActions != null -> Modifier.postImageLongPress(
+                actions = imageActions,
+                target = PostImageTarget(url = url, description = description, linkUrl = null),
+                haptics = LocalHapticFeedback.current,
+                optionsLabel = stringResource(R.string.post_image_options_action),
+            )
+
+            linkUrl != null ->
+                // Role.Image (not Button): the element IS an image that opens its full version on
+                // tap; the localized onClickLabel carries the action for TalkBack.
+                Modifier.clickable(role = Role.Image, onClickLabel = openLabel) {
+                    runCatching { uriHandler.openUri(linkUrl) }
+                }
+
+            else -> Modifier
+        }
+        // #610 — the exact parity box centres via the BoxWithConstraints contentAlignment; no
+        // fillMaxWidth here (the pre-#610 full-width shape is gone).
         val containerModifier = sizeModifier
             .clip(RoundedCornerShape(8.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerHighest)
-            .then(
-                if (linkUrl != null) {
-                    // Role.Image (not Button): the element IS an image that opens its full version on
-                    // tap; the localized onClickLabel carries the action for TalkBack.
-                    Modifier.clickable(role = Role.Image, onClickLabel = openLabel) {
-                        runCatching { uriHandler.openUri(linkUrl) }
-                    }
-                } else {
-                    Modifier
-                },
-            )
+            .then(interactionModifier)
         val request = remember(url, animationsEnabled, platformContext) {
             ImageRequest.Builder(platformContext)
                 .data(url)
@@ -1497,14 +1539,66 @@ internal fun imageInlineContent(image: PostInline.InlineImage, box: InlineMediaB
                 .precision(Precision.INEXACT)
                 .build()
         }
+        // #831 — the hosting surface (topic reading) may provide image actions; the lambda of an
+        // InlineTextContent is @Composable, so the CompositionLocal is read HERE, without touching
+        // the invariant AnnotatedString (#175) nor the remember keys of ParagraphBlock. Codex
+        // framing (firm reserve): LONG-PRESS ONLY — no combinedClickable / no-op onClick on inline
+        // images, which would eat the tap and disturb text selection around the image. The
+        // long-press detector does claim the initial down, which is precisely what keeps the
+        // parent SelectionContainer (#281) from starting a word selection under a finger resting
+        // on the image; selection drags STARTED on the surrounding text still travel across the
+        // image unaffected, and taps outside the image keep their behaviour.
+        val imageActions = LocalPostImageActions.current
+        val longPressModifier = if (imageActions != null && isEligiblePostImageUrl(image.url)) {
+            Modifier.postImageLongPress(
+                actions = imageActions,
+                target = PostImageTarget(url = image.url, description = image.description, linkUrl = null),
+                haptics = LocalHapticFeedback.current,
+                optionsLabel = stringResource(R.string.post_image_options_action),
+            )
+        } else {
+            Modifier
+        }
         AsyncImage(
             model = request,
             contentDescription = image.description,
             contentScale = PostMediaDisplayPolicy.inlineImageContentScale,
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier.fillMaxSize().then(longPressModifier),
         )
     }
 }
+
+/**
+ * #831 — long-press-ONLY gesture + a11y surface for a post image. Deliberately NOT a
+ * `combinedClickable`: that would install an onClick and consume every tap (Codex framing, firm
+ * reserve — cf. the call-site comments for the tap contracts it would break). `detectTapGestures`
+ * with only `onLongPress` set fires the haptic + the action on a stationary long press and nothing
+ * on a tap; the `semantics` block exposes the same action to TalkBack as a custom long-click
+ * action labelled [optionsLabel] (`combinedClickable`'s `onLongClickLabel` equivalent).
+ *
+ * Non-composable on purpose (the resolved [haptics]/[optionsLabel] come in as parameters):
+ * composable `Modifier` factories are flagged by the Compose lint (`ComposableModifierFactory`).
+ */
+private fun Modifier.postImageLongPress(
+    actions: PostImageActions,
+    target: PostImageTarget,
+    haptics: HapticFeedback,
+    optionsLabel: String,
+): Modifier = this
+    .pointerInput(actions, target) {
+        detectTapGestures(
+            onLongPress = {
+                haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                actions.onLongPress(target)
+            },
+        )
+    }
+    .semantics {
+        onLongClick(label = optionsLabel) {
+            actions.onLongPress(target)
+            true
+        }
+    }
 
 internal fun smileyInlineContent(
     smiley: PostInline.Smiley,

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -3,6 +3,9 @@ package fr.forumhfr.redface2.core.ui.post
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitLongPressOrCancellation
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -1571,9 +1574,13 @@ internal fun imageInlineContent(image: PostInline.InlineImage, box: InlineMediaB
 /**
  * #831 — long-press-ONLY gesture + a11y surface for a post image. Deliberately NOT a
  * `combinedClickable`: that would install an onClick and consume every tap (Codex framing, firm
- * reserve — cf. the call-site comments for the tap contracts it would break). `detectTapGestures`
- * with only `onLongPress` set fires the haptic + the action on a stationary long press and nothing
- * on a tap; the `semantics` block exposes the same action to TalkBack as a custom long-click
+ * reserve — cf. the call-site comments for the tap contracts it would break). And deliberately NOT
+ * `detectTapGestures(onLongPress)` either: that detector still consumes the down/up of every
+ * gesture, so a tap or a text-selection drag starting on the image would die inside it (Codex
+ * gate catch). Instead the raw `awaitEachGesture` loop below observes the down WITHOUT consuming
+ * it and only consumes the event once a stationary long press has actually completed — taps,
+ * selection drags and scrolls through the image reach their own handlers untouched by
+ * construction. The `semantics` block exposes the same action to TalkBack as a custom long-click
  * action labelled [optionsLabel] (`combinedClickable`'s `onLongClickLabel` equivalent).
  *
  * Non-composable on purpose (the resolved [haptics]/[optionsLabel] come in as parameters):
@@ -1586,12 +1593,17 @@ private fun Modifier.postImageLongPress(
     optionsLabel: String,
 ): Modifier = this
     .pointerInput(actions, target) {
-        detectTapGestures(
-            onLongPress = {
+        awaitEachGesture {
+            val down = awaitFirstDown(requireUnconsumed = false)
+            // Null when the pointer lifts (tap) or moves past the touch slop (scroll/selection)
+            // before the long-press timeout — in which case NOTHING was consumed here.
+            val longPress = awaitLongPressOrCancellation(down.id)
+            if (longPress != null) {
+                longPress.consume()
                 haptics.performHapticFeedback(HapticFeedbackType.LongPress)
                 actions.onLongPress(target)
-            },
-        )
+            }
+        }
     }
     .semantics {
         onLongClick(label = optionsLabel) {

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -3,9 +3,6 @@ package fr.forumhfr.redface2.core.ui.post
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.gestures.awaitEachGesture
-import androidx.compose.foundation.gestures.awaitFirstDown
-import androidx.compose.foundation.gestures.awaitLongPressOrCancellation
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -1574,14 +1571,20 @@ internal fun imageInlineContent(image: PostInline.InlineImage, box: InlineMediaB
 /**
  * #831 — long-press-ONLY gesture + a11y surface for a post image. Deliberately NOT a
  * `combinedClickable`: that would install an onClick and consume every tap (Codex framing, firm
- * reserve — cf. the call-site comments for the tap contracts it would break). And deliberately NOT
- * `detectTapGestures(onLongPress)` either: that detector still consumes the down/up of every
- * gesture, so a tap or a text-selection drag starting on the image would die inside it (Codex
- * gate catch). Instead the raw `awaitEachGesture` loop below observes the down WITHOUT consuming
- * it and only consumes the event once a stationary long press has actually completed — taps,
- * selection drags and scrolls through the image reach their own handlers untouched by
- * construction. The `semantics` block exposes the same action to TalkBack as a custom long-click
- * action labelled [optionsLabel] (`combinedClickable`'s `onLongClickLabel` equivalent).
+ * reserve — cf. the call-site comments for the tap contracts it would break).
+ *
+ * `detectTapGestures(onLongPress)` DOES claim the gesture's down, and that claim is load-bearing:
+ * a fully non-consuming variant (`awaitEachGesture` + `awaitLongPressOrCancellation`) was tried
+ * after the Codex gate flagged the consumption, and its own tests proved it worse — with the down
+ * unclaimed, the parent SelectionContainer (#281) ALSO reacts to the long press, starting a word
+ * selection with its magnifier underneath the menu sheet (the Robolectric suite crashes in
+ * `Magnifier.dismiss`, pinning exactly that). The claim costs what a tap on an inline image was
+ * already documented to cost (a no-op — the known clear-selection loss), and does NOT break
+ * scrolling: Compose `scrollable` starts from unconsumed MOVE deltas past the touch slop and is
+ * insensitive to a consumed down. Selection drags STARTED on surrounding text never reach this
+ * node (they are captured by the text at their own down) and keep travelling across the image.
+ * The `semantics` block exposes the same action to TalkBack as a custom long-click action
+ * labelled [optionsLabel] (`combinedClickable`'s `onLongClickLabel` equivalent).
  *
  * Non-composable on purpose (the resolved [haptics]/[optionsLabel] come in as parameters):
  * composable `Modifier` factories are flagged by the Compose lint (`ComposableModifierFactory`).
@@ -1593,17 +1596,12 @@ private fun Modifier.postImageLongPress(
     optionsLabel: String,
 ): Modifier = this
     .pointerInput(actions, target) {
-        awaitEachGesture {
-            val down = awaitFirstDown(requireUnconsumed = false)
-            // Null when the pointer lifts (tap) or moves past the touch slop (scroll/selection)
-            // before the long-press timeout — in which case NOTHING was consumed here.
-            val longPress = awaitLongPressOrCancellation(down.id)
-            if (longPress != null) {
-                longPress.consume()
+        detectTapGestures(
+            onLongPress = {
                 haptics.performHapticFeedback(HapticFeedbackType.LongPress)
                 actions.onLongPress(target)
-            }
-        }
+            },
+        )
     }
     .semantics {
         onLongClick(label = optionsLabel) {

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -18,6 +18,8 @@
     <string name="post_image_error">Image indisponible</string>
     <string name="post_image_error_with_alt">Image indisponible — %1$s</string>
     <string name="post_image_open_link">Ouvrir l\'image</string>
+    <!-- #831 : libellé a11y de l'appui long sur une image de post (menu contextuel image). -->
+    <string name="post_image_options_action">Options de l\'image</string>
     <string name="bbcode_action_bold">Gras</string>
     <string name="bbcode_action_italic">Italique</string>
     <string name="bbcode_action_underline">Souligné</string>

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostImageUrlEligibilityTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostImageUrlEligibilityTest.kt
@@ -1,0 +1,46 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #831 — pins the eligibility boundary of the image contextual menu: the long-press handler is
+ * installed ONLY on fetchable http(s) post images. `data:` / `blob:` payloads, empty URLs and
+ * exotic schemes must stay inert (no menu offering « open in browser » / « save » on something
+ * that cannot be fetched), per the Codex framing (arbitrage #5).
+ */
+class PostImageUrlEligibilityTest {
+
+    @Test
+    fun `plain http and https URLs are eligible`() {
+        assertTrue(isEligiblePostImageUrl("https://rehost.diberie.com/Picture/Get/f/123.png"))
+        assertTrue(isEligiblePostImageUrl("http://forum-images.hardware.fr/images/perso/o.gif"))
+    }
+
+    @Test
+    fun `scheme matching is case-insensitive and tolerates surrounding whitespace`() {
+        assertTrue(isEligiblePostImageUrl("HTTPS://example.com/a.png"))
+        assertTrue(isEligiblePostImageUrl("  https://example.com/a.png  "))
+    }
+
+    @Test
+    fun `empty and blank URLs are refused`() {
+        assertFalse(isEligiblePostImageUrl(""))
+        assertFalse(isEligiblePostImageUrl("   "))
+    }
+
+    @Test
+    fun `data and blob payloads are refused`() {
+        assertFalse(isEligiblePostImageUrl("data:image/png;base64,iVBORw0KGgo="))
+        assertFalse(isEligiblePostImageUrl("blob:https://example.com/9115d58c"))
+    }
+
+    @Test
+    fun `non-http schemes and relative paths are refused`() {
+        assertFalse(isEligiblePostImageUrl("ftp://example.com/a.png"))
+        assertFalse(isEligiblePostImageUrl("file:///sdcard/a.png"))
+        assertFalse(isEligiblePostImageUrl("images/perso/o.gif"))
+        assertFalse(isEligiblePostImageUrl("//example.com/protocol-relative.png"))
+    }
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererImageLongPressTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererImageLongPressTest.kt
@@ -138,6 +138,49 @@ class PostRendererImageLongPressTest {
     }
 
     @Test
+    fun `long press on a promoted linked image reaches the handler with the link URL`() {
+        // The [url=…][img] shape from the field (Codex review: this non-regression was missing):
+        // an image-only paragraph whose image measures past the inline caps is promoted to a
+        // block (#224/#257) carrying its enclosing link — the ONE path that combines a tap
+        // (browser) and the #831 long-press on the same node.
+        var received: PostImageTarget? = null
+        val cache = DefaultIntrinsicMediaSizeCache()
+        cache.putSuccess(blockUrl, androidx.compose.ui.unit.IntSize(800, 600))
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                CompositionLocalProvider(
+                    LocalPostImageActions provides PostImageActions(onLongPress = { received = it }),
+                    LocalIntrinsicMediaSizeCache provides cache,
+                ) {
+                    PostRenderer(
+                        content = PostContent(
+                            blocks = listOf(
+                                PostBlock.Paragraph(
+                                    inlines = listOf(
+                                        PostInline.Link(
+                                            url = "https://example.org/full",
+                                            children = listOf(
+                                                PostInline.InlineImage(url = blockUrl, description = "promue"),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                        selectable = true,
+                    )
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("promue")
+            .performTouchInput { longClick() }
+
+        assertEquals(blockUrl, received?.url)
+        assertEquals("https://example.org/full", received?.linkUrl)
+    }
+
+    @Test
     fun `without provided actions the image stays inert (MP, preview, signatures)`() {
         composeTestRule.setContent {
             RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererImageLongPressTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererImageLongPressTest.kt
@@ -146,10 +146,12 @@ class PostRendererImageLongPressTest {
             }
         }
 
+        // The semantics assertion IS the contract: no affordance means no modifier was installed.
+        // No synthetic long press here — on a bare selectable text that lands in the base
+        // selection machinery, whose magnifier NPEs under this Robolectric harness (not a #831
+        // behaviour; identical to dev without this change).
         composeTestRule.onNodeWithContentDescription("photo")
             .assert(SemanticsMatcher.keyNotDefined(SemanticsActions.OnLongClick))
-            // A long press must not crash either — it simply lands in the selection machinery.
-            .performTouchInput { longClick() }
     }
 
     @Test
@@ -168,9 +170,10 @@ class PostRendererImageLongPressTest {
             }
         }
 
+        // Same rationale as the no-actions case: the missing OnLongClick semantics pins the
+        // ineligible URL's inertness without poking the base selection machinery.
         composeTestRule.onNodeWithContentDescription("photo")
             .assert(SemanticsMatcher.keyNotDefined(SemanticsActions.OnLongClick))
-            .performTouchInput { longClick() }
 
         assertNull(received)
     }

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererImageLongPressTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererImageLongPressTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.click
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -90,6 +91,27 @@ class PostRendererImageLongPressTest {
         assertEquals(inlineUrl, received?.url)
         assertEquals("photo", received?.description)
         assertNull(received?.linkUrl)
+    }
+
+    @Test
+    fun `a short tap on an inline image never fires the long-press action`() {
+        // Tap-transparency contract (Codex gate): the interceptor observes without consuming,
+        // so a plain click must NOT open the menu — and by construction cannot eat the tap.
+        var received: PostImageTarget? = null
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                CompositionLocalProvider(
+                    LocalPostImageActions provides PostImageActions(onLongPress = { received = it }),
+                ) {
+                    PostRenderer(content = inlineImageContent(inlineUrl), selectable = true)
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("photo")
+            .performTouchInput { click() }
+
+        assertNull(received)
     }
 
     @Test

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererImageLongPressTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererImageLongPressTest.kt
@@ -1,0 +1,155 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.core.app.ApplicationProvider
+import coil3.ColorImage
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.test.FakeImageLoaderEngine
+import fr.forumhfr.redface2.core.model.PostBlock
+import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.model.PostInline
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * #831 — pins the long-press plumbing of the image contextual menu on BOTH image render paths
+ * (inline `[img]` inside the selectable Text, and block image), and the two OFF states:
+ * no [LocalPostImageActions] provided (MP / editor preview / signatures) and an ineligible URL
+ * (`data:`). The gesture must reach the handler even under the `selectable = true`
+ * SelectionContainer (#281) — the very interception #831 is about. The fine finger-level
+ * interplay with selection drags is dogfooded on the emulator at integration time.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@OptIn(ExperimentalTestApi::class)
+class PostRendererImageLongPressTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val inlineUrl = "https://rehost.diberie.com/Picture/Get/f/inline.png"
+    private val blockUrl = "https://rehost.diberie.com/Picture/Get/f/block.png"
+
+    @OptIn(coil3.annotation.DelicateCoilApi::class)
+    @Before
+    fun installFakeImageLoader() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val engine = FakeImageLoaderEngine.Builder()
+            .intercept(inlineUrl, ColorImage(0xFF2E7D32.toInt(), width = 80, height = 60))
+            .intercept(blockUrl, ColorImage(0xFF1565C0.toInt(), width = 400, height = 300))
+            .build()
+        SingletonImageLoader.setUnsafe(ImageLoader.Builder(context).components { add(engine) }.build())
+    }
+
+    private fun inlineImageContent(url: String) = PostContent(
+        blocks = listOf(
+            PostBlock.Paragraph(
+                inlines = listOf(
+                    PostInline.Text("regarde "),
+                    PostInline.InlineImage(url = url, description = "photo"),
+                    PostInline.Text(" !"),
+                ),
+            ),
+        ),
+    )
+
+    @Test
+    fun `long press on an inline image reaches the provided handler with the image URL`() {
+        var received: PostImageTarget? = null
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                CompositionLocalProvider(
+                    LocalPostImageActions provides PostImageActions(onLongPress = { received = it }),
+                ) {
+                    PostRenderer(content = inlineImageContent(inlineUrl), selectable = true)
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("photo")
+            .performTouchInput { longClick() }
+
+        assertEquals(inlineUrl, received?.url)
+        assertEquals("photo", received?.description)
+        assertNull(received?.linkUrl)
+    }
+
+    @Test
+    fun `long press on a block image reaches the provided handler`() {
+        var received: PostImageTarget? = null
+        val content = PostContent(
+            blocks = listOf(PostBlock.Image(url = blockUrl, description = "diagramme")),
+        )
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                CompositionLocalProvider(
+                    LocalPostImageActions provides PostImageActions(onLongPress = { received = it }),
+                ) {
+                    PostRenderer(content = content, selectable = true)
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("diagramme")
+            .performTouchInput { longClick() }
+
+        assertEquals(blockUrl, received?.url)
+        assertNull(received?.linkUrl)
+    }
+
+    @Test
+    fun `without provided actions the image stays inert (MP, preview, signatures)`() {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                // No CompositionLocalProvider: the default null keeps every surface unchanged.
+                PostRenderer(content = inlineImageContent(inlineUrl), selectable = true)
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("photo")
+            .assert(SemanticsMatcher.keyNotDefined(SemanticsActions.OnLongClick))
+            // A long press must not crash either — it simply lands in the selection machinery.
+            .performTouchInput { longClick() }
+    }
+
+    @Test
+    fun `an ineligible URL keeps the image inert even with actions provided`() {
+        var received: PostImageTarget? = null
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                CompositionLocalProvider(
+                    LocalPostImageActions provides PostImageActions(onLongPress = { received = it }),
+                ) {
+                    PostRenderer(
+                        content = inlineImageContent("data:image/png;base64,iVBORw0KGgo="),
+                        selectable = true,
+                    )
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("photo")
+            .assert(SemanticsMatcher.keyNotDefined(SemanticsActions.OnLongClick))
+            .performTouchInput { longClick() }
+
+        assertNull(received)
+    }
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererImageLongPressTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererImageLongPressTest.kt
@@ -181,6 +181,48 @@ class PostRendererImageLongPressTest {
     }
 
     @Test
+    fun `known limitation - a linked inline image in a mixed paragraph stays behind the link overlay`() {
+        // CHARACTERIZATION, not a feature (2nd Codex gate arbitration): a [url=…][img] image whose
+        // paragraph also carries text is NOT promoted to a block, and BasicText's LinkAnnotation
+        // overlay intercepts the down on the placeholder region — the long-press never reaches the
+        // image, tap AND long-press open the link exactly as before this PR. #831 stays OPEN for
+        // this shape (viewer / global interception strategy). INVERT or DELETE this test when the
+        // linked-inline case is actually covered.
+        var received: PostImageTarget? = null
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                CompositionLocalProvider(
+                    LocalPostImageActions provides PostImageActions(onLongPress = { received = it }),
+                ) {
+                    PostRenderer(
+                        content = PostContent(
+                            blocks = listOf(
+                                PostBlock.Paragraph(
+                                    inlines = listOf(
+                                        PostInline.Text("regarde "),
+                                        PostInline.Link(
+                                            url = "https://example.org/full",
+                                            children = listOf(
+                                                PostInline.InlineImage(url = inlineUrl, description = "photo"),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                        selectable = false,
+                    )
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("photo")
+            .performTouchInput { longClick() }
+
+        assertNull(received)
+    }
+
+    @Test
     fun `without provided actions the image stays inert (MP, preview, signatures)`() {
         composeTestRule.setContent {
             RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostImageActionsViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostImageActionsViewModel.kt
@@ -1,0 +1,57 @@
+package fr.forumhfr.redface2.feature.topic
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.forumhfr.redface2.core.domain.media.ImageSaveException
+import fr.forumhfr.redface2.core.domain.media.PostImageSaver
+import javax.inject.Inject
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+
+/**
+ * #831 — the THIN ViewModel behind [PostImageMenuSheet]'s « Enregistrer l'image » action.
+ * Deliberately its own small `@HiltViewModel` (precedent: [QuickReplyViewModel]) instead of a new
+ * member on the `@AssistedInject` TopicViewModel: the save needs exactly one injected seam
+ * ([PostImageSaver], `:core:domain`) and one feedback channel, nothing of the topic state.
+ *
+ * The save runs in [viewModelScope], NOT in the sheet's composition: the sheet closes on tap
+ * (feedback-through-Toast convention of `:feature:topic`) and the write must survive its
+ * dismissal. Effects are one-shot (Channel, same idiom as [QuickReplyViewModel]) and rendered as
+ * Toasts by the hosting screen.
+ */
+@HiltViewModel
+class PostImageActionsViewModel @Inject constructor(
+    private val postImageSaver: PostImageSaver,
+) : ViewModel() {
+
+    /** One-shot feedback of a save request — mapped to a Toast string by the host. */
+    enum class SaveImageEffect {
+        SAVED,
+        FAILED_FETCH,
+        FAILED_STORAGE,
+        FAILED_TOO_LARGE,
+    }
+
+    private val _effects: Channel<SaveImageEffect> = Channel(capacity = Channel.BUFFERED)
+    val effects: Flow<SaveImageEffect> = _effects.receiveAsFlow()
+
+    /** Saves the image behind [url] into the shared Pictures collection (fire-and-report). */
+    fun saveImage(url: String) {
+        viewModelScope.launch {
+            val effect = try {
+                postImageSaver.save(url)
+                SaveImageEffect.SAVED
+            } catch (e: ImageSaveException) {
+                when (e) {
+                    is ImageSaveException.Fetch -> SaveImageEffect.FAILED_FETCH
+                    is ImageSaveException.Storage -> SaveImageEffect.FAILED_STORAGE
+                    is ImageSaveException.TooLarge -> SaveImageEffect.FAILED_TOO_LARGE
+                }
+            }
+            _effects.send(effect)
+        }
+    }
+}

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostImageMenuSheet.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostImageMenuSheet.kt
@@ -1,0 +1,195 @@
+package fr.forumhfr.redface2.feature.topic
+
+import android.content.ActivityNotFoundException
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
+import fr.forumhfr.redface2.core.ui.post.PostImageTarget
+import fr.forumhfr.redface2.core.ui.post.PostImageThumbnail
+
+/**
+ * #831 — contextual menu of a post image, opened by a long-press on the image (inline `[img]`,
+ * block image or promoted gallery image — cf. `LocalPostImageActions` in `:core:ui`). Layout
+ * clones [PostMenuSheet] (#362): a hero row identifying the target, then stacked full-width
+ * actions:
+ *
+ * - « Enregistrer l'image » (filled, primary action) — delegates to [onSave]
+ *   ([PostImageActionsViewModel] → `PostImageSaver`); feedback arrives as a Toast from the
+ *   ViewModel's effects, after the sheet has closed;
+ * - « Copier l'URL de l'image » — clipboard write, Diagnostics feedback pattern (system overlay
+ *   on Android 13+, Toast below);
+ * - « Ouvrir dans le navigateur » — `ACTION_VIEW` on the image URL (the DIRECT image, not the
+ *   `[url=…]` link, which the block tap already covers);
+ * - « Afficher en taille réelle (à venir) » — DISABLED placeholder (#288 « menu vitrine »
+ *   pattern, same as PostMenuSheet's « Alerter »): the affordance shows the roadmap, the PR2
+ *   fullscreen viewer (#182) will enable it.
+ *
+ * The hero shows the image thumbnail (Coil caches, `:core:ui`) + the host and full URL so the
+ * user can tell WHICH image the menu targets when a post carries several.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun PostImageMenuSheet(
+    target: PostImageTarget,
+    onSave: (url: String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState()
+    val coroutineScope = rememberCoroutineScope()
+    val context = LocalContext.current
+    // Resolved at composition time — the action callbacks run outside composition.
+    val copiedFeedback = stringResource(R.string.topic_image_menu_url_copied)
+    val browserFailedFeedback = stringResource(R.string.topic_post_menu_no_browser)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .navigationBarsPadding(),
+        ) {
+            PostImageMenuHero(target)
+
+            Spacer(Modifier.height(16.dp))
+
+            Button(
+                onClick = {
+                    onSave(target.url)
+                    hideThenDismiss(coroutineScope, sheetState, onDismiss)
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.topic_image_menu_save))
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            OutlinedButton(
+                onClick = {
+                    copyImageUrlToClipboard(context, target.url, copiedFeedback)
+                    hideThenDismiss(coroutineScope, sheetState, onDismiss)
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.topic_image_menu_copy_url))
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            OutlinedButton(
+                onClick = {
+                    openImageUrlInBrowser(context, target.url, browserFailedFeedback)
+                    hideThenDismiss(coroutineScope, sheetState, onDismiss)
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.topic_post_menu_open_in_browser))
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            // PR2 (#182) — fullscreen viewer placeholder, greyed « menu vitrine » (#288 pattern):
+            // the affordance is visible, the « (à venir) » suffix explains why it is disabled.
+            OutlinedButton(
+                onClick = {},
+                enabled = false,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.topic_image_menu_full_size_soon))
+            }
+
+            Spacer(Modifier.height(8.dp))
+        }
+    }
+}
+
+/**
+ * Hero row of the sheet — thumbnail + host + full URL, mirroring [PostMenuHero]'s
+ * avatar + identity layout. The host alone is the human-readable line (« rehost.diberie.com »),
+ * the full URL underneath disambiguates several images from the same host.
+ */
+@Composable
+private fun PostImageMenuHero(target: PostImageTarget) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        PostImageThumbnail(
+            url = target.url,
+            contentDescription = target.description,
+        )
+        Column {
+            Text(
+                text = target.url.toUri().host ?: target.url,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = target.url,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+/**
+ * Clipboard write + feedback for the image URL — same Diagnostics pattern as
+ * [copyPermalinkToClipboard]: Android 13+ (T) shows the system « copié » overlay on its own,
+ * older API levels get a Toast.
+ */
+private fun copyImageUrlToClipboard(context: Context, url: String, feedback: String) {
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    clipboard.setPrimaryClip(ClipData.newPlainText("redface2 image url", url))
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+        Toast.makeText(context, feedback, Toast.LENGTH_SHORT).show()
+    }
+}
+
+/**
+ * Fires an `ACTION_VIEW` on the direct image URL — same survive-no-handler contract as
+ * [openPermalinkInBrowser] (a Toast instead of a crash).
+ */
+private fun openImageUrlInBrowser(context: Context, url: String, failureFeedback: String) {
+    try {
+        context.startActivity(Intent(Intent.ACTION_VIEW, url.toUri()))
+    } catch (ignored: ActivityNotFoundException) {
+        Toast.makeText(context, failureFeedback, Toast.LENGTH_SHORT).show()
+    }
+}

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostMenuSheet.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostMenuSheet.kt
@@ -384,10 +384,10 @@ private fun openPermalinkInBrowser(context: Context, permalink: String, failureF
 /**
  * Plays the sheet's hide animation, then invokes [onDismiss] once the sheet is actually
  * off-screen — same Material 3 « animated dismiss » idiom as ProfilePreviewSheet's
- * `hideThenNavigate`.
+ * `hideThenNavigate`. `internal` (#831): shared with [PostImageMenuSheet].
  */
 @OptIn(ExperimentalMaterial3Api::class)
-private fun hideThenDismiss(
+internal fun hideThenDismiss(
     coroutineScope: CoroutineScope,
     sheetState: SheetState,
     onDismiss: () -> Unit,

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1370,9 +1370,11 @@ private fun TopicLoadedContent(
                 PostImageActionsViewModel.SaveImageEffect.FAILED_TOO_LARGE ->
                     R.string.topic_image_menu_save_failed_too_large
             }
+            // The @StringRes overload resolves at show() time — no LocalContext resource query
+            // (LocalContextGetResourceValueCall) for a one-shot Toast.
             android.widget.Toast.makeText(
                 imageActionsContext,
-                imageActionsContext.getString(messageRes),
+                messageRes,
                 android.widget.Toast.LENGTH_SHORT,
             ).show()
         }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -105,9 +105,12 @@ import fr.forumhfr.redface2.core.ui.RedfacePlaceholderScreen
 import fr.forumhfr.redface2.core.ui.error.sharedLabelResOrNull
 import fr.forumhfr.redface2.core.ui.icon.RedfaceVectorIcon
 import fr.forumhfr.redface2.core.ui.pager.pageSwipeEdgeHint
+import fr.forumhfr.redface2.core.ui.post.LocalPostImageActions
 import fr.forumhfr.redface2.core.ui.post.PostCardShell
 import fr.forumhfr.redface2.core.ui.post.PostIdentityBand
 import fr.forumhfr.redface2.core.ui.post.PostIdentityHeader
+import fr.forumhfr.redface2.core.ui.post.PostImageActions
+import fr.forumhfr.redface2.core.ui.post.PostImageTarget
 import fr.forumhfr.redface2.core.ui.post.PostListScaffold
 import fr.forumhfr.redface2.core.ui.post.PostRenderer
 import fr.forumhfr.redface2.core.ui.theme.LocalBlockedQuoteAuthors
@@ -1342,6 +1345,38 @@ private fun TopicLoadedContent(
     // it needs a Hilt ViewModel). Deliberately NOT rememberSaveable: Post is not Parcelable
     // and losing an open overflow menu across process death is acceptable.
     var menuPost by remember { mutableStateOf<Post?>(null) }
+    // #831 — post image whose contextual menu is open (null = closed). Same local-UI-state
+    // rationale as menuPost above (no async data in the sheet itself); the target is a small
+    // value type but deliberately NOT rememberSaveable either — losing an open image menu across
+    // process death is acceptable, and symmetry with menuPost keeps ONE dismissal model.
+    var imageMenuTarget by remember { mutableStateOf<PostImageTarget?>(null) }
+    // #831 — one stable handler instance provided (via TopicPostCard) to the post bodies'
+    // LocalPostImageActions; remembered so providing it never invalidates the cards.
+    val postImageActions = remember { PostImageActions(onLongPress = { imageMenuTarget = it }) }
+    // #831 — « Enregistrer l'image » seam. A dedicated thin @HiltViewModel (precedent
+    // QuickReplyViewModel) so the save survives the sheet's dismissal; feedback = Toast
+    // (feature-topic convention, no SnackbarHost in TopicScreen).
+    val imageActionsViewModel: PostImageActionsViewModel = hiltViewModel()
+    val imageActionsContext = androidx.compose.ui.platform.LocalContext.current
+    LaunchedEffect(imageActionsViewModel) {
+        imageActionsViewModel.effects.collect { effect ->
+            val messageRes = when (effect) {
+                PostImageActionsViewModel.SaveImageEffect.SAVED ->
+                    R.string.topic_image_menu_saved
+                PostImageActionsViewModel.SaveImageEffect.FAILED_FETCH ->
+                    R.string.topic_image_menu_save_failed_fetch
+                PostImageActionsViewModel.SaveImageEffect.FAILED_STORAGE ->
+                    R.string.topic_image_menu_save_failed_storage
+                PostImageActionsViewModel.SaveImageEffect.FAILED_TOO_LARGE ->
+                    R.string.topic_image_menu_save_failed_too_large
+            }
+            android.widget.Toast.makeText(
+                imageActionsContext,
+                imageActionsContext.getString(messageRes),
+                android.widget.Toast.LENGTH_SHORT,
+            ).show()
+        }
+    }
     // #509 — posts the reader chose to reveal despite the author being blacklisted. Temporary and
     // re-keyed on `topic.page`, not persisted: re-hiding on a page change is the intended "masqué by
     // default" behaviour (decision #6). This composable instance is bound to one (cat, post), so the
@@ -1569,6 +1604,8 @@ private fun TopicLoadedContent(
                         // without opening the « … » menu. Null/non-null under the SAME gate as « Citer »
                         // (derived together above), so the « + » and « Citer » always appear as a pair.
                         onToggleMultiQuote = multiQuoteToggle,
+                        // #831 — long-press on a post image opens the image contextual menu.
+                        onImageLongPress = postImageActions.onLongPress,
                     )
                 }
                 if (showLastReadMarker) {
@@ -1667,6 +1704,16 @@ private fun TopicLoadedContent(
             } else {
                 { onSetAuthorBlocked(post.author, post.numreponse !in hiddenNumreponses) }
             },
+        )
+    }
+    // #831 — per-image contextual menu, opened by a long-press on a post image (wired through
+    // LocalPostImageActions inside TopicPostCard). Hosted at the same level as PostMenuSheet so
+    // the two sheets share one lifecycle model.
+    imageMenuTarget?.let { target ->
+        PostImageMenuSheet(
+            target = target,
+            onSave = imageActionsViewModel::saveImage,
+            onDismiss = { imageMenuTarget = null },
         )
     }
 }
@@ -2092,6 +2139,14 @@ internal fun TopicPostCard(
      * Null keeps the headers inert (previews/tests that render a card without navigation).
      */
     onGoToCitedPost: ((page: Int, numreponse: Int) -> Unit)? = null,
+    /**
+     * #831 — provided as [LocalPostImageActions] around the BODY renderer only, so a long-press
+     * on a post image (inline `[img]`, block, promoted) opens the image contextual menu. The
+     * signature render below stays OUTSIDE the provider on purpose — signatures keep their
+     * historical inert images, same stance as MP threads and the editor preview (default null).
+     * Null (previews/tests) leaves every image inert.
+     */
+    onImageLongPress: ((PostImageTarget) -> Unit)? = null,
 ) {
     // #287 — structural spacing from the active density preset (Comfort = the historical rhythm).
     val m = LocalDisplayMetrics.current
@@ -2164,7 +2219,15 @@ internal fun TopicPostCard(
                 verticalArrangement = Arrangement.spacedBy(m.postSpacing),
             ) {
                 // #281 — topic posts are selectable/copyable (opt-in; default is OFF in PostRenderer).
-                PostRenderer(content = post.content, selectable = true, onGoToCitedPost = onGoToCitedPost)
+                // #831 — the image-actions handler rides a CompositionLocal read inside the two image
+                // render paths of PostRenderer, so neither the frozen content models nor the invariant
+                // AnnotatedString (#175) change. Wrapped around the BODY only (cf. onImageLongPress KDoc).
+                val imageActions = remember(onImageLongPress) {
+                    onImageLongPress?.let { PostImageActions(onLongPress = it) }
+                }
+                CompositionLocalProvider(LocalPostImageActions provides imageActions) {
+                    PostRenderer(content = post.content, selectable = true, onGoToCitedPost = onGoToCitedPost)
+                }
                 // #330 — the author signature (web parity), gated by the reading preference. Rendered
                 // with the shared PostRenderer (the signature is BBCode/HTML like the body) but in a
                 // subdued style: a divider separates it from the body and a reduced alpha makes it

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -80,6 +80,17 @@
         <item quantity="one">Cité %1$d fois sur cette page</item>
         <item quantity="other">Cité %1$d fois sur cette page</item>
     </plurals>
+    <!-- #831 — menu contextuel d'appui long sur les images de post (PostImageMenuSheet).
+         « Ouvrir dans le navigateur » et son échec réutilisent topic_post_menu_open_in_browser /
+         topic_post_menu_no_browser. -->
+    <string name="topic_image_menu_save">Enregistrer l\'image</string>
+    <string name="topic_image_menu_saved">Image enregistrée dans Pictures/Redface2</string>
+    <string name="topic_image_menu_save_failed_fetch">Téléchargement de l\'image impossible</string>
+    <string name="topic_image_menu_save_failed_storage">Enregistrement de l\'image impossible</string>
+    <string name="topic_image_menu_save_failed_too_large">Image trop volumineuse pour être enregistrée</string>
+    <string name="topic_image_menu_copy_url">Copier l\'URL de l\'image</string>
+    <string name="topic_image_menu_url_copied">URL copiée</string>
+    <string name="topic_image_menu_full_size_soon">Afficher en taille réelle (à venir)</string>
     <!-- #239 — badge on a post showing how many posts of the CURRENT page cite it. -->
     <plurals name="topic_post_cited_count">
         <item quantity="one">cité %1$d fois</item>

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/PostImageActionsViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/PostImageActionsViewModelTest.kt
@@ -1,0 +1,91 @@
+package fr.forumhfr.redface2.feature.topic
+
+import app.cash.turbine.test
+import fr.forumhfr.redface2.core.domain.media.ImageSaveException
+import fr.forumhfr.redface2.core.domain.media.PostImageSaver
+import fr.forumhfr.redface2.core.domain.media.SavedPostImage
+import fr.forumhfr.redface2.feature.topic.PostImageActionsViewModel.SaveImageEffect
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * #831 — pins the effect mapping of the « Enregistrer l'image » ViewModel: one one-shot effect
+ * per save request, typed failure → typed Toast message (fetch / storage / too-large), and the
+ * saver called with the exact image URL. The saver is faked (interface in `:core:domain`), same
+ * seam-testing stance as the upload reader.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PostImageActionsViewModelTest {
+
+    private class FakePostImageSaver(
+        private val behaviour: (String) -> SavedPostImage,
+    ) : PostImageSaver {
+        val requests = mutableListOf<String>()
+        override suspend fun save(url: String): SavedPostImage {
+            requests += url
+            return behaviour(url)
+        }
+    }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `a successful save emits SAVED and forwards the URL to the saver`() = runTest {
+        val saver = FakePostImageSaver { SavedPostImage(displayName = "vacances.png") }
+        val viewModel = PostImageActionsViewModel(saver)
+
+        viewModel.effects.test {
+            viewModel.saveImage("https://images.example/vacances.png")
+            assertEquals(SaveImageEffect.SAVED, awaitItem())
+        }
+        assertEquals(listOf("https://images.example/vacances.png"), saver.requests)
+    }
+
+    @Test
+    fun `a fetch failure emits FAILED_FETCH`() = runTest {
+        val viewModel = PostImageActionsViewModel(FakePostImageSaver { throw ImageSaveException.Fetch() })
+
+        viewModel.effects.test {
+            viewModel.saveImage("https://images.example/gone.png")
+            assertEquals(SaveImageEffect.FAILED_FETCH, awaitItem())
+        }
+    }
+
+    @Test
+    fun `a storage failure emits FAILED_STORAGE`() = runTest {
+        val viewModel = PostImageActionsViewModel(FakePostImageSaver { throw ImageSaveException.Storage() })
+
+        viewModel.effects.test {
+            viewModel.saveImage("https://images.example/full-disk.png")
+            assertEquals(SaveImageEffect.FAILED_STORAGE, awaitItem())
+        }
+    }
+
+    @Test
+    fun `an oversized image emits FAILED_TOO_LARGE`() = runTest {
+        val viewModel = PostImageActionsViewModel(
+            FakePostImageSaver { throw ImageSaveException.TooLarge(maxBytes = 1L) },
+        )
+
+        viewModel.effects.test {
+            viewModel.saveImage("https://images.example/huge.png")
+            assertEquals(SaveImageEffect.FAILED_TOO_LARGE, awaitItem())
+        }
+    }
+}

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/PostImageMenuSheetTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/PostImageMenuSheetTest.kt
@@ -1,0 +1,98 @@
+package fr.forumhfr.redface2.feature.topic
+
+import android.app.Application
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import fr.forumhfr.redface2.core.ui.post.PostImageTarget
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * #831 — pins the four entries of the image contextual menu: « Enregistrer » routes to the save
+ * callback, « Copier l'URL » writes the clipboard, « Ouvrir dans le navigateur » fires an
+ * ACTION_VIEW on the DIRECT image URL, and « Afficher en taille réelle » stays a DISABLED
+ * placeholder until the PR2 viewer (#182). Same Robolectric compose harness as
+ * [MultiQuoteFabClearTest].
+ *
+ * The target URL uses the reserved `.invalid` TLD so the hero thumbnail's Coil request fails
+ * fast without touching the network — the sheet never blocks on the bitmap by design.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@OptIn(ExperimentalTestApi::class)
+class PostImageMenuSheetTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val target = PostImageTarget(
+        url = "https://images.invalid/photos/vacances.png",
+        description = "photo",
+        linkUrl = null,
+    )
+
+    private fun mount(onSave: (String) -> Unit = {}, onDismiss: () -> Unit = {}) {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                PostImageMenuSheet(target = target, onSave = onSave, onDismiss = onDismiss)
+            }
+        }
+    }
+
+    @Test
+    fun `the save entry routes the image URL to the save callback`() {
+        val saved = mutableListOf<String>()
+        mount(onSave = { saved += it })
+
+        composeTestRule.onNodeWithText("Enregistrer l'image").performClick()
+
+        assertEquals(listOf(target.url), saved)
+    }
+
+    @Test
+    fun `the copy entry writes the image URL to the clipboard`() {
+        mount()
+
+        composeTestRule.onNodeWithText("Copier l'URL de l'image").performClick()
+
+        val clipboard = ApplicationProvider.getApplicationContext<Application>()
+            .getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        val copied = clipboard.primaryClip?.getItemAt(0)?.text?.toString()
+        assertEquals(target.url, copied)
+    }
+
+    @Test
+    fun `the browser entry fires an ACTION_VIEW on the direct image URL`() {
+        mount()
+
+        composeTestRule.onNodeWithText("Ouvrir dans le navigateur").performClick()
+
+        val started = Shadows.shadowOf(ApplicationProvider.getApplicationContext<Application>())
+            .nextStartedActivity
+        assertEquals(Intent.ACTION_VIEW, started.action)
+        assertEquals(target.url, started.data.toString())
+    }
+
+    @Test
+    fun `the full-size entry is a disabled PR2 placeholder`() {
+        mount()
+
+        composeTestRule.onNodeWithText("Afficher en taille réelle (à venir)")
+            .assertIsNotEnabled()
+    }
+}


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Refs #831 — **l'issue reste ouverte** (couverture partielle, cf. « Limite connue »).

## Quoi
Menu contextuel au long-press sur les images de post (lecture topic uniquement) : **Copier l'URL**, **Ouvrir dans le navigateur**, **Enregistrer** (+ « Taille réelle » désactivé, à venir avec le viewer #182). Architecture : `LocalPostImageActions` (CompositionLocal, défaut null = MP/préview/signatures inertes), `PostImageSaver` (:core:domain) + `AndroidPostImageSaver` (:core:data, octets ORIGINAUX via le disk cache Coil — GIF préservés, fallback re-fetch anonyme, plafond 32 MiB, MediaStore `IS_PENDING` 1→0 avec nettoyage sur échec, MIME sniffé magic-bytes), `PostImageActionsViewModel` léger + Toast.

## Contrat de gestes (3 passes de gate Codex)
- Bloc/promue **liée** : `combinedClickable` — tap = navigateur (#257 verbatim), long-press = menu.
- Bloc non liée : long-press only. Inline non liée : `detectTapGestures(onLongPress)` + sémantique TalkBack.
- Le **claim du down est assumé et documenté** : la variante « tap-transparente » essayée après le NO-GO de la 2ᵉ passe a été invalidée par ses propres tests (sans claim, la sélection de texte + loupe démarrent SOUS le menu — crash Magnifier pinné par Robolectric). La sélection exige un down vierge, le scroll non (il drague sur les MOVE non consommés) ; le tap inline était déjà un no-op documenté.

## Limite connue (arbitrage 3ᵉ passe : ship strict, issue ouverte)
> Le menu image n'est pas accessible pour les images `[url=][img]` restées inline dans un paragraphe contenant aussi du texte. Dans ce cas, l'overlay cliquable posé par `BasicText` pour le lien intercepte le down sur la région du placeholder ; le long-press n'atteint donc pas l'image. La PR couvre les images non liées inline, les blocs `PostBlock.Image` et les images promues image-only, mais pas les images liées inline non promues. #831 reste ouvert pour traiter ce cas avec le viewer / la stratégie d'interception globale.

Un **test de caractérisation** (`known limitation - …`) pinne cette non-couverture — à inverser/supprimer quand le cas sera traité.

## Tests (7, tous verts)
Long-press inline/bloc/promue-liée atteint le handler (url + linkUrl) ; tap court ne tire jamais ; états inertes pinnés par la sémantique (pas d'OnLongClick) ; caractérisation de la limite.

## Validation
Canonique complète verte ×2 (detekt — 4 findings corrigés, lint — 1 erreur corrigée, tests, assemble). Dogfood émulateur : tap bloc lié → navigateur préservé ✓ (3 occurrences), frontière smiley perso → sélection normale ✓, limite liée-inline constatée et documentée ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pm28ny4V5GSegmKJxTPVAM