### PR TITLE
fix(topic,ui): hide blacklisted authors inside quotes too (#785)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -81,8 +81,10 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import coil3.size.Precision
 import coil3.size.Scale
+import fr.forumhfr.redface2.core.domain.blacklist.canonicalizePseudo
 import fr.forumhfr.redface2.core.ui.motion.rememberAnimationsEnabled
 import fr.forumhfr.redface2.core.ui.R
+import fr.forumhfr.redface2.core.ui.theme.LocalBlockedQuoteAuthors
 import fr.forumhfr.redface2.core.ui.theme.LocalFoldLongQuotes
 import fr.forumhfr.redface2.core.ui.theme.LocalIgnoreInlineColors
 import fr.forumhfr.redface2.core.model.PostBlock
@@ -202,6 +204,20 @@ internal fun quoteAccentRole(quoteDepth: Int, isBareQuote: Boolean): QuoteAccent
  */
 internal fun isBareQuote(quote: PostBlock.Quote): Boolean =
     quote.author == null && quote.numreponse == null && quote.page == null
+
+/**
+ * #785 — true when a quote cites a black-listed author: the quote's parsed author matches (by the
+ * canonical key, cf. [canonicalizePseudo]) one of the blocked canonicals the reading surface
+ * provided through [LocalBlockedQuoteAuthors]. Author-only on purpose: a citation HFR served in
+ * the dynamic `forum2.php` form keeps `page`/`numreponse` null but still carries the author, so
+ * the mask must never depend on the jump coordinates. A `[quotemsg]` forged with an arbitrary
+ * pseudo masks too — acceptable, the author line is the only identity a citation carries. Pure
+ * decision so it is pinned in [PostRendererQuoteDepthTest] without entering Compose.
+ */
+internal fun isBlockedQuoteAuthor(author: String?, blockedCanonicals: Set<String>): Boolean {
+    if (author == null || blockedCanonicals.isEmpty()) return false
+    return canonicalizePseudo(author) in blockedCanonicals
+}
 
 @Composable
 fun PostRenderer(
@@ -397,12 +413,23 @@ private fun ParagraphBlock(inlines: List<PostInline>) {
     }
 }
 
+// ReturnCount: the guard chain (blocked author first, then the folds) IS the dispatch.
+@Suppress("ReturnCount")
 @Composable
 private fun QuoteBlock(
     block: PostBlock.Quote,
     quoteDepth: Int,
     onGoToCitedPost: ((page: Int, numreponse: Int) -> Unit)? = null,
 ) {
+    // #785 — the blacklist applies INSIDE quotes too: a citation whose author is black-listed is
+    // masked like that author's own posts are. This branch runs BEFORE the depth/length folds so a
+    // blocked quote can never leak through an expanded render; the QuoteBlock recursion covers
+    // nested citations natively, and the local's empty default keeps every non-topic surface
+    // (editor preview, MP threads, signatures) unchanged.
+    if (isBlockedQuoteAuthor(block.author, LocalBlockedQuoteAuthors.current)) {
+        BlockedQuoteBlock(block, quoteDepth, onGoToCitedPost)
+        return
+    }
     if (isCollapsedQuoteDepth(quoteDepth)) {
         CollapsedQuoteBlock(block, quoteDepth, onGoToCitedPost)
         return
@@ -626,6 +653,59 @@ private fun CollapsedQuoteBlock(
             PostBlocksRenderer(
                 blocks = block.content.blocks,
                 quoteDepth = 0,
+                onGoToCitedPost = onGoToCitedPost,
+            )
+        }
+    }
+}
+
+/**
+ * #785 — placeholder for a quote whose author is black-listed, mirroring the [CollapsedQuoteBlock]
+ * interaction (one-line label + « Afficher »/« Masquer », the whole frame toggles) and the topic
+ * screen's `HiddenPostCard` copy (the pseudo stays visible, consistent with the post-level mask).
+ * The reveal is per-quote and transient (`rememberSaveable`, same lifetime as the other folds).
+ * Unlike [CollapsedQuoteBlock] the reveal keeps the REAL depth (`quoteDepth + 1`, like the expanded
+ * render): revealing a blocked quote must not grant extra nesting levels, and a blocked citation
+ * nested inside the revealed body stays masked through the recursion.
+ */
+@Composable
+private fun BlockedQuoteBlock(
+    block: PostBlock.Quote,
+    quoteDepth: Int,
+    onGoToCitedPost: ((page: Int, numreponse: Int) -> Unit)? = null,
+) {
+    var revealed by rememberSaveable(block) { mutableStateOf(false) }
+    QuoteFrame(
+        quoteDepth = quoteDepth,
+        isBareQuote = isBareQuote(block),
+        modifier = Modifier.clickable { revealed = !revealed },
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                // isBlockedQuoteAuthor never matches a null author, so the fallback is defensive.
+                text = stringResource(R.string.post_quote_blocked_author, block.author.orEmpty()),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = if (revealed) {
+                    stringResource(R.string.post_quote_hide)
+                } else {
+                    stringResource(R.string.post_quote_show)
+                },
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+        if (revealed) {
+            // #252/#699 — same header rule as the expanded QuoteBlock (and same jump affordance).
+            QuoteHeader(block, onGoToCitedPost)
+            PostBlocksRenderer(
+                blocks = block.content.blocks,
+                quoteDepth = quoteDepth + 1,
                 onGoToCitedPost = onGoToCitedPost,
             )
         }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/DisplayMetrics.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/DisplayMetrics.kt
@@ -82,6 +82,17 @@ val LocalFoldLongQuotes = staticCompositionLocalOf { true }
 val LocalShowScrollbar = staticCompositionLocalOf { true }
 
 /**
+ * #785 — canonical pseudos (cf. `canonicalizePseudo`) of the black-listed authors, provided by the
+ * topic reading surface around its post list so `QuoteBlock` can mask a citation OF a blocked
+ * author embedded in another user's post (the post-level mask alone let a blocked author's words
+ * resurface through quotes). Defaults to the empty set: every other PostRenderer host (editor
+ * preview, MP threads, signatures) keeps rendering quotes untouched. `staticCompositionLocalOf`:
+ * the value changes only when the blacklist changes, so a one-shot subtree recomposition on change
+ * is acceptable (same stance as [LocalFoldLongQuotes]).
+ */
+val LocalBlockedQuoteAuthors = staticCompositionLocalOf { emptySet<String>() }
+
+/**
  * Project CompositionLocal asking the post renderer to IGNORE the author's inline `[color]` styling
  * for the subtree it wraps (#553). HFR signatures embed colours chosen for the white web background;
  * rendered as-is on the app theme (especially dark) they read as unreadable/garish, so the signature

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -4,6 +4,9 @@
     <string name="post_quote_bare">Citation</string>
     <!-- #699 : libellé a11y du tap sur l'en-tête d'une citation sourcée (aller au message cité). -->
     <string name="post_quote_go_to">Aller au message cité</string>
+    <!-- #785 : placeholder d'une citation dont l'auteur est black-listé. Le pseudo reste visible,
+         cohérent avec topic_post_hidden_by_author côté posts (le lecteur sait QUI est masqué). -->
+    <string name="post_quote_blocked_author">Citation de %1$s masquée</string>
     <string name="post_quote_collapsed">Citation imbriquée repliée</string>
     <string name="post_quote_collapsed_revealed">Citations imbriquées</string>
     <string name="post_quote_show">Afficher</string>

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererBlockedQuoteTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererBlockedQuoteTest.kt
@@ -1,0 +1,123 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import fr.forumhfr.redface2.core.model.PostBlock
+import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.model.PostInline
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import fr.forumhfr.redface2.core.ui.theme.LocalBlockedQuoteAuthors
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * #785 — the blacklist applies INSIDE quotes: a citation whose author is black-listed renders as
+ * the `BlockedQuoteBlock` placeholder (body hidden, « Afficher »/« Masquer » reveal), while every
+ * surface that does not provide [LocalBlockedQuoteAuthors] (editor preview, MP threads, signatures)
+ * keeps rendering quotes untouched through the empty default. The pure canonical-match decision
+ * (`isBlockedQuoteAuthor`) is pinned separately in [PostRendererQuoteDepthTest].
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@OptIn(ExperimentalTestApi::class)
+class PostRendererBlockedQuoteTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val quotedBody = "propos du posteur masqué"
+
+    private fun quoteFrom(author: String, body: String = quotedBody): PostBlock.Quote = PostBlock.Quote(
+        author = author,
+        numreponse = 12345,
+        page = 3,
+        content = PostContent(
+            blocks = listOf(PostBlock.Paragraph(inlines = listOf(PostInline.Text(body)))),
+        ),
+    )
+
+    private fun setPost(blocked: Set<String>?, vararg blocks: PostBlock) {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                Surface(color = MaterialTheme.colorScheme.surface) {
+                    val content = PostContent(blocks = blocks.toList())
+                    if (blocked != null) {
+                        CompositionLocalProvider(LocalBlockedQuoteAuthors provides blocked) {
+                            PostRenderer(content = content)
+                        }
+                    } else {
+                        // No provider — exercises the empty default every non-topic surface gets.
+                        PostRenderer(content = content)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `a blocked author's quote is masked by default and reveals on tap`() {
+        setPost(setOf("alice"), quoteFrom("Alice"))
+
+        // Masked: placeholder visible (with the pseudo, HiddenPostCard parity), body absent.
+        composeTestRule.onNodeWithText("Citation de Alice masquée").assertExists()
+        composeTestRule.onNodeWithText(quotedBody).assertDoesNotExist()
+
+        // Reveal: tap the frame (via its « Afficher » affordance) → header + body render.
+        composeTestRule.onNodeWithText("Afficher").performClick()
+        composeTestRule.onNodeWithText(quotedBody).assertExists()
+        composeTestRule.onNodeWithText("Citation de Alice").assertExists()
+
+        // Re-mask: the toggle is symmetric (« Masquer »), like the other quote folds.
+        composeTestRule.onNodeWithText("Masquer").performClick()
+        composeTestRule.onNodeWithText(quotedBody).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a non-blocked author's quote renders untouched next to a blocked one`() {
+        val visibleBody = "propos parfaitement visibles"
+        setPost(
+            setOf("alice"),
+            quoteFrom("Alice"),
+            quoteFrom("Bob", body = visibleBody),
+        )
+
+        composeTestRule.onNodeWithText("Citation de Alice masquée").assertExists()
+        composeTestRule.onNodeWithText(visibleBody).assertExists()
+        composeTestRule.onNodeWithText("Citation de Bob").assertExists()
+    }
+
+    @Test
+    fun `a blocked citation nested inside another quote is masked too`() {
+        val outer = PostBlock.Quote(
+            author = "Bob",
+            numreponse = 22222,
+            page = 1,
+            content = PostContent(blocks = listOf(quoteFrom("Alice"))),
+        )
+        setPost(setOf("alice"), outer)
+
+        // The outer (non-blocked) quote renders; the nested blocked one collapses to the placeholder.
+        composeTestRule.onNodeWithText("Citation de Bob").assertExists()
+        composeTestRule.onNodeWithText("Citation de Alice masquée").assertExists()
+        composeTestRule.onNodeWithText(quotedBody).assertDoesNotExist()
+    }
+
+    @Test
+    fun `without a provider the default empty set leaves quotes alone`() {
+        // Editor preview / MP threads / signatures never provide the local: nothing may mask there.
+        setPost(blocked = null, quoteFrom("Alice"))
+
+        composeTestRule.onNodeWithText(quotedBody).assertExists()
+        composeTestRule.onNodeWithText("Citation de Alice masquée").assertDoesNotExist()
+    }
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteDepthTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteDepthTest.kt
@@ -213,4 +213,37 @@ class PostRendererQuoteDepthTest {
         )
         assertEquals(2, quoteVisibleTextLength(content))
     }
+
+    // ---------------------------------------------------------------------------------------------
+    // #785 — the blacklist applies inside quotes. The rendering branch lives in the @Composable
+    // QuoteBlock/BlockedQuoteBlock (PostRendererBlockedQuoteTest, Robolectric); here we pin the pure
+    // decision so the canonical-match contract can't drift silently.
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    fun `isBlockedQuoteAuthor matches the blocked set through the canonical key`() {
+        // The provided set carries CANONICAL keys (cf. canonicalizePseudo); the quote author is raw
+        // parser output ("X a écrit"), so case and stray whitespace must not defeat the match.
+        val blocked = setOf("alice")
+        assertTrue(isBlockedQuoteAuthor("alice", blocked))
+        assertTrue(isBlockedQuoteAuthor("Alice", blocked))
+        assertTrue(isBlockedQuoteAuthor("  aLiCe  ", blocked))
+    }
+
+    @Test
+    fun `isBlockedQuoteAuthor never matches a null author or a non-blocked one`() {
+        // A bare [quote] has no author: nothing to match, never masked. A sourced citation from a
+        // non-blocked user must render untouched.
+        val blocked = setOf("alice")
+        assertFalse(isBlockedQuoteAuthor(null, blocked))
+        assertFalse(isBlockedQuoteAuthor("Bob", blocked))
+    }
+
+    @Test
+    fun `isBlockedQuoteAuthor is inert on the empty default set`() {
+        // LocalBlockedQuoteAuthors defaults to emptySet(): every non-topic surface (editor preview,
+        // MP threads, signatures) must keep rendering quotes unchanged.
+        assertFalse(isBlockedQuoteAuthor("Alice", emptySet()))
+        assertFalse(isBlockedQuoteAuthor(null, emptySet()))
+    }
 }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -110,6 +110,7 @@ import fr.forumhfr.redface2.core.ui.post.PostIdentityBand
 import fr.forumhfr.redface2.core.ui.post.PostIdentityHeader
 import fr.forumhfr.redface2.core.ui.post.PostListScaffold
 import fr.forumhfr.redface2.core.ui.post.PostRenderer
+import fr.forumhfr.redface2.core.ui.theme.LocalBlockedQuoteAuthors
 import fr.forumhfr.redface2.core.ui.theme.LocalDisplayMetrics
 import fr.forumhfr.redface2.core.ui.theme.LocalIgnoreInlineColors
 import fr.forumhfr.redface2.core.ui.theme.rememberCreatorPseudoBrush
@@ -887,54 +888,61 @@ internal fun TopicContent(
                         // (overlaying the list's right edge, outside the scrolled element), so the
                         // manual Box + LazyListScrollbar wrapper is gone. PullToRefreshBox stays the
                         // feature's wrapper (its refresh state belongs to the ViewModel).
-                        TopicLoadedContent(
-                            state = state,
-                            topic = mode.topic,
-                            hiddenNumreponses = mode.hiddenNumreponses,
-                            // #604 lot 2 / #806 — « Citer » opens the quick-reply sheet with the
-                            // card pre-armed (1-citation session), unless the preset routes any
-                            // citation to the full-screen editor (decision at tap time; same :app
-                            // path as the sheet's escalation, resumeSharedDraft = true).
-                            onQuoteRequested = { preview ->
-                                when (writingSurfaceFor(state.writingSurfacePreset, quoteCount = 1)) {
-                                    WritingSurface.SHEET -> quickReplyFor = QuickReplyLaunch(
-                                        request = QuickReplyRequest(
-                                            cat = state.request.cat,
-                                            subcat = mode.topic.subcat,
-                                            topicId = state.request.post,
-                                            page = mode.topic.page,
-                                        ),
-                                        initialQuotes = listOf(preview),
-                                    )
-                                    WritingSurface.FULL_EDITOR ->
-                                        onReply(mode.topic.subcat, mode.topic.page, listOf(preview))
-                                }
-                            },
-                            // #823 — LONG press on « Citer » : one-shot override of the #806
-                            // preset — always the full-screen editor, through the same :app path
-                            // as the FULL_EDITOR branch above (in-memory handoff +
-                            // resumeSharedDraft = true, #790). Deliberately does NOT consult
-                            // writingSurfaceFor: the gesture IS the routing decision (identical
-                            // to the tap under the FULL_EDITOR preset).
-                            onQuoteFullEditorRequested = { preview ->
-                                onReply(mode.topic.subcat, mode.topic.page, listOf(preview))
-                            },
-                            onEdit = onEdit,
-                            onEditFirstPost = onEditFirstPost,
-                            onOpenPage = onOpenPage,
-                            onGoToPost = onGoToPost,
-                            onOpenProfile = onOpenProfile,
-                            onDeleteRequest = onDeleteRequest,
-                            onDoubleTapRefresh = { onIntent(TopicIntent.Refresh) },
-                            listState = listState,
-                            multiQuoteSelection = multiQuoteNumreponses,
-                            onToggleMultiQuote = onToggleMultiQuote,
-                            onSetAuthorBlocked = { author, blocked ->
-                                onIntent(TopicIntent.SetAuthorBlocked(author, blocked))
-                            },
-                            pollManualExpanded = pollManualExpanded,
-                            onPollExpansionChanged = onPollExpansionChanged,
-                        )
+                        //
+                        // #785 — the blacklist applies inside quotes too: the canonical blocked set
+                        // is provided to the post renderers so QuoteBlock masks a citation OF a
+                        // blocked author. Scoped to the reading list only — the quick-reply sheet
+                        // and editor previews (outside this provider) keep the empty default.
+                        CompositionLocalProvider(LocalBlockedQuoteAuthors provides mode.blockedQuoteAuthors) {
+                            TopicLoadedContent(
+                                state = state,
+                                topic = mode.topic,
+                                hiddenNumreponses = mode.hiddenNumreponses,
+                                // #604 lot 2 / #806 — « Citer » opens the quick-reply sheet with the
+                                // card pre-armed (1-citation session), unless the preset routes any
+                                // citation to the full-screen editor (decision at tap time; same :app
+                                // path as the sheet's escalation, resumeSharedDraft = true).
+                                onQuoteRequested = { preview ->
+                                    when (writingSurfaceFor(state.writingSurfacePreset, quoteCount = 1)) {
+                                        WritingSurface.SHEET -> quickReplyFor = QuickReplyLaunch(
+                                            request = QuickReplyRequest(
+                                                cat = state.request.cat,
+                                                subcat = mode.topic.subcat,
+                                                topicId = state.request.post,
+                                                page = mode.topic.page,
+                                            ),
+                                            initialQuotes = listOf(preview),
+                                        )
+                                        WritingSurface.FULL_EDITOR ->
+                                            onReply(mode.topic.subcat, mode.topic.page, listOf(preview))
+                                    }
+                                },
+                                // #823 — LONG press on « Citer » : one-shot override of the #806
+                                // preset — always the full-screen editor, through the same :app path
+                                // as the FULL_EDITOR branch above (in-memory handoff +
+                                // resumeSharedDraft = true, #790). Deliberately does NOT consult
+                                // writingSurfaceFor: the gesture IS the routing decision (identical
+                                // to the tap under the FULL_EDITOR preset).
+                                onQuoteFullEditorRequested = { preview ->
+                                    onReply(mode.topic.subcat, mode.topic.page, listOf(preview))
+                                },
+                                onEdit = onEdit,
+                                onEditFirstPost = onEditFirstPost,
+                                onOpenPage = onOpenPage,
+                                onGoToPost = onGoToPost,
+                                onOpenProfile = onOpenProfile,
+                                onDeleteRequest = onDeleteRequest,
+                                onDoubleTapRefresh = { onIntent(TopicIntent.Refresh) },
+                                listState = listState,
+                                multiQuoteSelection = multiQuoteNumreponses,
+                                onToggleMultiQuote = onToggleMultiQuote,
+                                onSetAuthorBlocked = { author, blocked ->
+                                    onIntent(TopicIntent.SetAuthorBlocked(author, blocked))
+                                },
+                                pollManualExpanded = pollManualExpanded,
+                                onPollExpansionChanged = onPollExpansionChanged,
+                            )
+                        }
                     }
                 }
             }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -102,6 +102,16 @@ data class TopicUiState(
              * first emission (combine with the blacklist) so a blocked post never flashes before hiding.
              */
             val hiddenNumreponses: Set<Int> = emptySet(),
+            /**
+             * #785 — canonical pseudos (cf. `canonicalizePseudo`) of the black-listed authors — the
+             * same blacklist snapshot [hiddenNumreponses] was computed from. The screen provides it
+             * to the post renderers (`LocalBlockedQuoteAuthors`) so a citation OF a blocked author
+             * inside another user's post is masked too. Kept in lock-step with [hiddenNumreponses]
+             * by `TopicViewModel.loadedMode` — the single construction seam for this mode — so the
+             * post-level and quote-level masks can never diverge across the load / refresh /
+             * force-refresh / post-delete / search / live-refilter paths.
+             */
+            val blockedQuoteAuthors: Set<String> = emptySet(),
         ) : Mode
 
         data class Error(

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -259,11 +259,10 @@ class TopicViewModel @AssistedInject constructor(
                 blockedCanonicals = blocked
                 _state.update { current ->
                     val loaded = current.mode as? TopicUiState.Mode.Loaded ?: return@update current
-                    current.copy(
-                        mode = loaded.copy(
-                            hiddenNumreponses = computeHiddenNumreponses(loaded.topic, blocked),
-                        ),
-                    )
+                    // #785 — rebuild the WHOLE loaded mode through the single seam (loadedMode) so
+                    // the post-level mask (hiddenNumreponses) and the quote-level canonical set
+                    // (blockedQuoteAuthors) re-filter together on a live blacklist change.
+                    current.copy(mode = loadedMode(loaded.topic))
                 }
             }
             // This collector is independent of any load job, so an unhandled error here would tear
@@ -298,7 +297,7 @@ class TopicViewModel @AssistedInject constructor(
                 val topic = topicRepository.refreshTopicPage(request.cat, request.post, request.page)
                 _state.update {
                     it.copy(
-                        mode = TopicUiState.Mode.Loaded(topic, computeHiddenNumreponses(topic, blockedCanonicals)),
+                        mode = loadedMode(topic),
                         availablePages = (1..topic.totalPages).toList(),
                     )
                 }
@@ -416,7 +415,7 @@ class TopicViewModel @AssistedInject constructor(
                 .collect { topic ->
                     _state.update {
                         it.copy(
-                            mode = TopicUiState.Mode.Loaded(topic, computeHiddenNumreponses(topic, blockedCanonicals)),
+                            mode = loadedMode(topic),
                             availablePages = (1..topic.totalPages).toList(),
                         )
                     }
@@ -429,6 +428,22 @@ class TopicViewModel @AssistedInject constructor(
                 }
         }
     }
+
+    /**
+     * #785 — SINGLE construction seam for [TopicUiState.Mode.Loaded]. Every path that puts a page on
+     * screen (cache-aside load, manual refresh, post-submit force refresh, post-delete refetch,
+     * intra-topic search, live blacklist re-filter) builds the mode here, from the same
+     * [blockedCanonicals] snapshot, so the post-level mask ([TopicUiState.Mode.Loaded.hiddenNumreponses])
+     * and the quote-level canonical set ([TopicUiState.Mode.Loaded.blockedQuoteAuthors]) can never
+     * diverge — a path bypassing this seam would make masked citations flicker across
+     * refresh/search/delete (Codex framing reservation on #785).
+     */
+    private fun loadedMode(topic: Topic): TopicUiState.Mode.Loaded =
+        TopicUiState.Mode.Loaded(
+            topic = topic,
+            hiddenNumreponses = computeHiddenNumreponses(topic, blockedCanonicals),
+            blockedQuoteAuthors = blockedCanonicals,
+        )
 
     /**
      * #509 — `numreponse` of the posts in [topic] whose author is blacklisted (canonical match). The
@@ -490,7 +505,7 @@ class TopicViewModel @AssistedInject constructor(
                 val topic = topicRepository.refreshTopicPage(request.cat, request.post, request.page)
                 _state.update {
                     it.copy(
-                        mode = TopicUiState.Mode.Loaded(topic, computeHiddenNumreponses(topic, blockedCanonicals)),
+                        mode = loadedMode(topic),
                         availablePages = (1..topic.totalPages).toList(),
                     )
                 }
@@ -646,7 +661,7 @@ class TopicViewModel @AssistedInject constructor(
                 val topic = topicRepository.refreshTopicPage(request.cat, request.post, request.page)
                 _state.update {
                     it.copy(
-                        mode = TopicUiState.Mode.Loaded(topic, computeHiddenNumreponses(topic, blockedCanonicals)),
+                        mode = loadedMode(topic),
                         availablePages = (1..topic.totalPages).toList(),
                     )
                 }
@@ -959,7 +974,7 @@ class TopicViewModel @AssistedInject constructor(
     private fun renderSearchPage(topic: Topic, status: TopicSearchStatus, canPrev: Boolean, canNext: Boolean) {
         _state.update {
             it.copy(
-                mode = TopicUiState.Mode.Loaded(topic, computeHiddenNumreponses(topic, blockedCanonicals)),
+                mode = loadedMode(topic),
                 search = it.search.copy(
                     status = status,
                     canGoPreviousResult = canPrev,

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -813,6 +813,40 @@ class TopicViewModelTest {
     }
 
     @Test
+    fun `the canonical blocked set is exposed for quote masking and re-filters live (#785)`() = runTest {
+        // #785 — the screen provides Loaded.blockedQuoteAuthors to the quote renderer
+        // (LocalBlockedQuoteAuthors), so the set must (a) land with the initial load — even when the
+        // blocked author has NO post on the page, only citations of them — and (b) follow live
+        // blacklist changes through the same seam as hiddenNumreponses (loadedMode).
+        val topic = fakeTopic(
+            page = 1,
+            totalPages = 1,
+            posts = listOf(fakePost(100, author = "Alice"), fakePost(101, author = "Bob")),
+        )
+        val blacklist = FakeBlacklistRepository(blockedCanonicals = setOf("charlie"))
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(topic) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            blacklistRepository = blacklist,
+        )
+
+        viewModel.state.test {
+            val initial = assertMode<TopicUiState.Mode.Loaded>(awaitItem())
+            // charlie posts nothing on this page (hiddenNumreponses empty), yet the canonical set is
+            // exposed so a CITATION of charlie in Alice/Bob's posts can be masked by the renderer.
+            assertEquals(setOf("charlie"), initial.blockedQuoteAuthors)
+            assertEquals(emptySet<Int>(), initial.hiddenNumreponses)
+
+            blacklist.block("Alice")
+            val refiltered = assertMode<TopicUiState.Mode.Loaded>(awaitItem())
+            assertEquals(setOf("charlie", "alice"), refiltered.blockedQuoteAuthors)
+            assertEquals(setOf(100), refiltered.hiddenNumreponses)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `blocking an author after a pull-to-refresh hides their posts live (#509 beta)`() = runTest {
         // Beta regression: the blacklist used to be collected only inside loadCurrentPage's combine, so
         // a refresh (which cancels loadJob and runs a one-shot refetch) FROZE the live re-filter — a


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Closes #785. **1/3 de la pile citations** (#785 → #782 → #784, ordre ferme du cadrage Codex) — merger celle-ci d'abord.

## Quoi
Le contenu d'une citation dont l'auteur est black-listé est masqué comme ses posts le sont : filtre AU RENDERER (`isBlockedQuoteAuthor` en tête de `QuoteBlock`, avant les plis de profondeur/longueur — une citation bloquée ne fuit jamais par un rendu déplié, récursion native pour l'imbriqué), placeholder « Citation de X masquée » avec Afficher/Masquer transient (clone `CollapsedQuoteBlock`).

## Réserve Codex traitée
Le set canonique est exposé dans TOUS les chemins `Loaded` via un helper `loadedMode(topic)` = seam unique de construction (load, refresh, force-refresh, post-delete, transsearch, re-filtre live #509). Set exposé = set entier (les auteurs cités ne postent pas forcément sur la page). Provider limité à la liste de lecture (sheet/éditeur/MP hors périmètre, défaut vide).

## Tests
`PostRendererBlockedQuoteTest` (masqué par défaut, reveal/re-hide, non-bloqué intact, imbriqué masqué, surface sans provider intacte) + `TopicViewModelTest` (set exposé sans post du bloqué sur la page, re-filtre live) + 3 cas purs de canonicalisation.

## Validation
Canonique complète verte (pile) ; gate Codex du lot : **GO franc** (« loadedMode couvre les 6 chemins, masquage prioritaire sur les plis, reveal sain »).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pm28ny4V5GSegmKJxTPVAM