### PR TITLE
feat(topic): back returns to the previous reading position after a quote jump (#782)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -1081,6 +1081,16 @@ fun RedfaceApp(intent: Intent?) {
         // above (plain remember: lost on activity/process recreation, which falls back to the
         // pre-#412 top landing instead of replaying a stale bottom scroll).
         var topicPendingBottomLanding by remember { mutableStateOf<TopicScrollKey?>(null) }
+        // #782 — quote-jump return stack: each « aller au message cité » tap pushes the departure
+        // (page + tap-time anchor) so the system back unwinds the jump chain instead of leaving the
+        // topic. One stack at a time, keyed (cat, post) like the multi-quote basket; capped
+        // (TOPIC_JUMP_STACK_MAX). Plain remember on purpose: process death drops it and back exits
+        // the topic as before — a serialized chain would replay stale returns (cf. PR #420 stance).
+        var topicJumpStack by remember { mutableStateOf<TopicJumpStack?>(null) }
+        // #782 — the one return landing currently owed its anchor: armed by the back interception,
+        // matched + consumed by the next TopicRoute landing. Same transient lifecycle as
+        // topicPendingBottomLanding above.
+        var topicJumpPendingReturn by remember { mutableStateOf<TopicJumpReturn?>(null) }
         // #291 — multi-quote basket: numreponses selected for quoting, in tap order, keyed by
         // (cat, post) so a page change (which destroys the topic nav entry, cf. titles above)
         // keeps the cross-page selection while a different topic never sees it. One basket at a
@@ -1311,6 +1321,16 @@ fun RedfaceApp(intent: Intent?) {
                             },
                             pendingBottomLanding = topicPendingBottomLanding,
                             onPendingBottomLanding = { topicPendingBottomLanding = it },
+                        ),
+                        topicJumpNavState = TopicJumpNavState(
+                            stack = topicJumpStack,
+                            pendingReturn = topicJumpPendingReturn,
+                            onPush = { cat, post, entry ->
+                                topicJumpStack = topicJumpStack.pushedJump(cat, post, entry)
+                            },
+                            onPop = { topicJumpStack = topicJumpStack?.popped() },
+                            onClear = { topicJumpStack = null },
+                            onPendingReturn = { topicJumpPendingReturn = it },
                         ),
                         multiQuoteNavState = MultiQuoteNavState(
                             basket = multiQuoteBasket,
@@ -1704,6 +1724,29 @@ private data class TopicScrollNavState(
 )
 
 /**
+ * #782 — quote-jump return bundle threaded into [RedfaceNavHost], same hoisted-state shape as
+ * [TopicScrollNavState] (the `var`s live in [RedfaceApp] so they survive the per-jump TopicRoute
+ * replacement, which destroys the nav entry).
+ *
+ * @property stack the active topic's return stack, or `null` (no pending returns anywhere).
+ * @property pendingReturn the one return landing currently owed its anchor (armed by the back
+ *   interception, consumed by the next TopicRoute landing) — cf. [TopicJumpReturn].
+ * @property onPush records a departure right before a quote jump replaces the route.
+ * @property onPop drops the entry the back interception is returning to.
+ * @property onClear empties the stack — manual page navigation and leaving the topic invalidate
+ *   the return chain (browser-like: a new navigation clears the forward history of the gesture).
+ * @property onPendingReturn arms (or clears, `null`) the return landing.
+ */
+private data class TopicJumpNavState(
+    val stack: TopicJumpStack?,
+    val pendingReturn: TopicJumpReturn?,
+    val onPush: (cat: Int, post: Int, entry: TopicJumpEntry) -> Unit,
+    val onPop: () -> Unit,
+    val onClear: () -> Unit,
+    val onPendingReturn: (TopicJumpReturn?) -> Unit,
+)
+
+/**
  * #291 — multi-quote nav bundle threaded into [RedfaceNavHost], same shape as the other
  * hoisted-state bundles ([TopicScrollNavState], `TopicTitleNavState`).
  *
@@ -1884,6 +1927,8 @@ private fun RedfaceNavHost(
     topicTitleNavState: TopicTitleNavState,
     // #307 — per-page scroll-anchor cache, same hoisting rationale as topicTitleNavState.
     topicScrollNavState: TopicScrollNavState,
+    // #782 — quote-jump return stack, same hoisting rationale (survives the per-jump entry swap).
+    topicJumpNavState: TopicJumpNavState,
     // #291 — multi-quote basket, same hoisting rationale (survives the per-page entry swap).
     multiQuoteNavState: MultiQuoteNavState,
     // #465 — per-topic poll-expansion cache, same hoisting rationale (survives the per-page swap).
@@ -2370,11 +2415,54 @@ private fun RedfaceNavHost(
                 )
             }
             entry<TopicRoute>(metadata = mapOf(TOPIC_SCENE_METADATA_KEY to true)) { route ->
+                // #782 — THIS topic's quote-jump return stack (another topic's stack must never arm
+                // the in-topic back interception).
+                val jumpStack = topicJumpNavState.stack?.takeIf { it.matches(route.cat, route.post) }
+                // #782 — after a quote jump (#699), back returns to the previous reading position
+                // (page + tap-time anchor) instead of leaving the topic; once the chain is unwound
+                // the handler disables itself and the next back pops out as before. Composed INSIDE
+                // the entry so it registers after — and therefore wins over — NavDisplay's own back
+                // handling and the app-level TabRootBackHandler. Known trade-off: while enabled it
+                // suppresses the predictive-pop preview for this gesture, which is correct — the
+                // route is replaced in place, there is no destination underneath to preview.
+                BackHandler(enabled = jumpStack != null) {
+                    val jumpEntry = jumpStack?.entries?.lastOrNull() ?: return@BackHandler
+                    topicJumpNavState.onPop()
+                    // Hand the captured anchor to the NEXT landing through the transient pending
+                    // slot; the landing matches it against its exact (cat, post, page) and consumes
+                    // it (cf. TopicJumpReturn — never a route field, PR #420 stance).
+                    topicJumpNavState.onPendingReturn(
+                        TopicJumpReturn(
+                            key = TopicScrollKey(route.cat, route.post, jumpEntry.page),
+                            anchor = jumpEntry.anchor,
+                        ),
+                    )
+                    // A return is not a « page - 1 » reading step (same rule as onGoToPost below).
+                    topicScrollNavState.onPendingBottomLanding(null)
+                    backStack[backStack.lastIndex] = TopicRoute(
+                        cat = route.cat,
+                        post = route.post,
+                        page = jumpEntry.page,
+                        scrollTo = null,
+                    )
+                }
+                // #782 — the return anchor owed to THIS landing, if the interception above armed one.
+                val jumpReturnAnchor = topicJumpNavState.pendingReturn
+                    ?.takeIf { it.key == TopicScrollKey(route.cat, route.post, route.page) }
+                    ?.anchor
+                // #782 — one-shot consumption, keyed on the route (one run per landing). Clearing
+                // recomposes this entry with the pending slot empty, but the screen already LATCHED
+                // the resolved anchor at first composition (TopicScrollRestorationEffects applies it
+                // from a LaunchedEffect(Unit) closure), so the flip can neither re-scroll nor change
+                // the landing — same one-shot stance as onStartAtBottomConsumed (#412).
+                LaunchedEffect(route) {
+                    if (jumpReturnAnchor != null) topicJumpNavState.onPendingReturn(null)
+                }
                 // #307 — resolve what the initial scroll of this landing should do. Strict priority
-                // (route scrollTo > post-submit landing > saved anchor > top) lives in the pure
-                // resolver; only a RestoreSaved outcome hands the screen an anchor to apply — the
-                // Follow* levels resolve to null so the existing ScrollToPost / ScrollToEndOfPage
-                // effects (#200/#226/#344) keep sole ownership of their landings.
+                // (route scrollTo > post-submit landing > jump return (#782) > saved anchor > top)
+                // lives in the pure resolver; only a RestoreSaved outcome hands the screen an anchor
+                // to apply — the Follow* levels resolve to null so the existing ScrollToPost /
+                // ScrollToEndOfPage effects (#200/#226/#344) keep sole ownership of their landings.
                 val scrollRestoration = resolveTopicScrollRestoration(
                     scrollTo = route.scrollTo,
                     submitSignal = route.submitSignal,
@@ -2385,6 +2473,9 @@ private fun RedfaceNavHost(
                     // flag would replay the bottom landing on process/config restore).
                     previousPageLanding = topicScrollNavState.pendingBottomLanding ==
                         TopicScrollKey(route.cat, route.post, route.page),
+                    // #782 — the tap-time departure anchor beats the disposal-saved one: an
+                    // intra-page jump already overwrote the latter with the cited post's position.
+                    jumpReturnAnchor = jumpReturnAnchor,
                 )
                 TopicScreen(
                     request = TopicRequest(
@@ -2541,6 +2632,10 @@ private fun RedfaceNavHost(
                             TopicScrollKey(route.cat, route.post, targetPage)
                                 .takeIf { targetPage == route.page - 1 },
                         )
+                        // #782 — a MANUAL page navigation (swipe, pager, FAB, boundary card)
+                        // invalidates the quote-jump return chain, browser-like: back after it
+                        // exits the topic instead of replaying a stale return.
+                        topicJumpNavState.onClear()
                         // #282 — replace the top entry IN PLACE rather than removeAt + add. The two-step
                         // version briefly leaves the parent on top (size-1), an observable intermediate
                         // state NavDisplay can start transitioning toward; an indexed set is a single
@@ -2552,13 +2647,21 @@ private fun RedfaceNavHost(
                             scrollTo = null,
                         )
                     },
-                    onGoToPost = { targetPage, numreponse ->
+                    onGoToPost = { targetPage, numreponse, sourceAnchor ->
                         // #699 — jump to a cited post: the same single-mutation in-place replace as
                         // onOpenPage (#282), with the deep-link scroll anchor so the landing scrolls
                         // to and highlights the target (#200 mechanism). Uniform whether the cited
                         // post is on the current page or another. Not a « page - 1 » reading step —
                         // clear any stale bottom-landing marker (same rule as onOpenPage's takeIf).
                         topicScrollNavState.onPendingBottomLanding(null)
+                        // #782 — remember the departure (page + tap-time anchor, captured by the
+                        // screen from its LazyListState) so the back interception above can unwind
+                        // this jump. Pushing on a different topic resets the stack (pushedJump).
+                        topicJumpNavState.onPush(
+                            route.cat,
+                            route.post,
+                            TopicJumpEntry(page = route.page, anchor = sourceAnchor),
+                        )
                         backStack[backStack.lastIndex] = TopicRoute(
                             cat = route.cat,
                             post = route.post,
@@ -2570,6 +2673,9 @@ private fun RedfaceNavHost(
                         // #285 — explicit back affordance in the topic top bar. Pop to the screen that
                         // opened the topic (list / flags). Guard size > 1 so we never pop a tab root
                         // (mirrors the global back handling used across the other entries).
+                        // #782 — the arrow's contract is « leave the topic » : it never unwinds the
+                        // quote-jump chain, and leaving drops the chain with it.
+                        topicJumpNavState.onClear()
                         if (backStack.size > 1) {
                             backStack.removeAt(backStack.lastIndex)
                         }
@@ -2585,6 +2691,8 @@ private fun RedfaceNavHost(
                         // concurrent post that pushes totalPages further during the refresh window does
                         // not start a moving-tail chase. Indexed set (not removeAt + add) for the same
                         // single-mutation reason as onOpenPage (#282).
+                        // #782 — a page change like onOpenPage: drop the quote-jump return chain.
+                        topicJumpNavState.onClear()
                         backStack[backStack.lastIndex] = TopicRoute(
                             cat = route.cat,
                             post = route.post,

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/TopicJumpStack.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/TopicJumpStack.kt
@@ -1,0 +1,60 @@
+package fr.forumhfr.redface2.navigation
+
+import fr.forumhfr.redface2.feature.topic.TopicScrollAnchor
+
+/**
+ * #782 — one quote-jump departure: the page the reader jumped FROM and their exact read position at
+ * tap time. The anchor is captured by the topic screen when the quote header is tapped (never at
+ * disposal — an intra-page jump would have already scrolled away by then, cf. `onGoToPost`).
+ */
+internal data class TopicJumpEntry(val page: Int, val anchor: TopicScrollAnchor)
+
+/**
+ * #782 — the quote-jump return stack of ONE topic. Same single-owner stance as [MultiQuoteBasket]:
+ * at most one stack lives at a time, keyed by `(cat, post)` so another topic's jumps can never arm
+ * the in-topic back interception ([matches]). Deliberately TRANSIENT session state hoisted in
+ * `RedfaceApp` (a plain `remember`), never serialized into a route: process death drops it and the
+ * back button just exits the topic as before — replaying a stale return chain after a restore would
+ * be worse (same rationale as `pendingBottomLanding`, Codex review on PR #420).
+ */
+internal data class TopicJumpStack(
+    val cat: Int,
+    val post: Int,
+    val entries: List<TopicJumpEntry>,
+) {
+    fun matches(cat: Int, post: Int): Boolean = this.cat == cat && this.post == post
+}
+
+/**
+ * #782 — depth cap of the return stack. Deep enough for any realistic quote-chase (each entry is
+ * one « aller au message cité » tap without an intervening manual navigation), small enough that a
+ * pathological chain cannot make the system back feel stuck in the topic: past the cap the OLDEST
+ * departure is dropped, so back always unwinds at most this many jumps before leaving the topic.
+ */
+internal const val TOPIC_JUMP_STACK_MAX = 8
+
+/**
+ * #782 — push a departure onto the topic's return stack. A jump in a DIFFERENT topic than the
+ * current stack's resets it (one stack at a time, cf. [TopicJumpStack]); overflow past
+ * [TOPIC_JUMP_STACK_MAX] drops the oldest entry. Pure so `TopicJumpStackTest` pins the contract.
+ */
+internal fun TopicJumpStack?.pushedJump(cat: Int, post: Int, entry: TopicJumpEntry): TopicJumpStack {
+    val kept = this?.takeIf { it.matches(cat, post) }?.entries.orEmpty()
+    return TopicJumpStack(cat = cat, post = post, entries = (kept + entry).takeLast(TOPIC_JUMP_STACK_MAX))
+}
+
+/**
+ * #782 — drop the most recent departure (the one the back interception is returning to). An emptied
+ * stack collapses to `null` so the `BackHandler` disables itself and the NEXT back leaves the topic
+ * through the normal pop, exactly like before the feature.
+ */
+internal fun TopicJumpStack.popped(): TopicJumpStack? =
+    entries.dropLast(1).takeIf { it.isNotEmpty() }?.let { copy(entries = it) }
+
+/**
+ * #782 — the one return landing currently owed its anchor: armed by the back interception right
+ * before it replaces the `TopicRoute`, matched by the next landing against its exact
+ * `(cat, post, page)` [key], consumed (cleared) once that landing has resolved its scroll
+ * restoration. Transient nav state like [TopicJumpStack] — never a route field.
+ */
+internal data class TopicJumpReturn(val key: TopicScrollKey, val anchor: TopicScrollAnchor)

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/TopicScrollRestore.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/TopicScrollRestore.kt
@@ -83,21 +83,29 @@ internal sealed interface TopicScrollRestoration {
  *     [TopicScrollRestoration.FollowScrollTo] ;
  *  2. post-submit route (`submitSignal != null`, covers the #344 `ScrollToEndOfPage` path and the
  *     #226 overflow landing) → [TopicScrollRestoration.FollowSubmitLanding] ;
- *  3. saved anchor for the page → [TopicScrollRestoration.RestoreSaved] ;
- *  4. « page précédente » navigation (#412, `previousPageLanding`) →
+ *  3. quote-jump return anchor (#782, `jumpReturnAnchor` — the position captured at the tap that
+ *     started the jump, handed back by the back interception) → [TopicScrollRestoration.RestoreSaved].
+ *     ABOVE the saved anchor on purpose: an intra-page jump overwrites the disposal-saved anchor of
+ *     the same `(cat, post, page)` with the CITED post's position, so on a return the tap-time
+ *     capture is the only truthful one. A return route never carries `scrollTo`/`submitSignal`, so
+ *     in practice this level owns its landing ;
+ *  4. saved anchor for the page → [TopicScrollRestoration.RestoreSaved] ;
+ *  5. « page précédente » navigation (#412, `previousPageLanding`) →
  *     [TopicScrollRestoration.StartAtBottom] ;
- *  5. nothing → [TopicScrollRestoration.StartAtTop].
+ *  6. nothing → [TopicScrollRestoration.StartAtTop].
  *
- * Pure so the five levels are unit-testable without Compose/nav3 (cf. `TopicScrollRestorationTest`).
+ * Pure so the six levels are unit-testable without Compose/nav3 (cf. `TopicScrollRestorationTest`).
  */
 internal fun resolveTopicScrollRestoration(
     scrollTo: Int?,
     submitSignal: Long?,
     savedAnchor: TopicScrollAnchor?,
     previousPageLanding: Boolean = false,
+    jumpReturnAnchor: TopicScrollAnchor? = null,
 ): TopicScrollRestoration = when {
     scrollTo != null -> TopicScrollRestoration.FollowScrollTo
     submitSignal != null -> TopicScrollRestoration.FollowSubmitLanding
+    jumpReturnAnchor != null -> TopicScrollRestoration.RestoreSaved(jumpReturnAnchor)
     savedAnchor != null -> TopicScrollRestoration.RestoreSaved(savedAnchor)
     previousPageLanding -> TopicScrollRestoration.StartAtBottom
     else -> TopicScrollRestoration.StartAtTop

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/TopicJumpStackTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/TopicJumpStackTest.kt
@@ -1,0 +1,72 @@
+package fr.forumhfr.redface2.navigation
+
+import fr.forumhfr.redface2.feature.topic.TopicScrollAnchor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #782 — pure contract of the quote-jump return stack: LIFO push/pop, the depth cap dropping the
+ * OLDEST departure, single-stack-at-a-time across topics, and the null collapse that disables the
+ * in-topic back interception once the chain is unwound.
+ */
+class TopicJumpStackTest {
+
+    private fun entry(page: Int, index: Int = page * 10) =
+        TopicJumpEntry(page = page, anchor = TopicScrollAnchor(index = index, offset = 5))
+
+    @Test
+    fun `x jumps then x pops unwind in LIFO order and collapse to null`() {
+        var stack: TopicJumpStack? = null
+        stack = stack.pushedJump(cat = 13, post = 999, entry = entry(page = 3))
+        stack = stack.pushedJump(cat = 13, post = 999, entry = entry(page = 7))
+        stack = stack.pushedJump(cat = 13, post = 999, entry = entry(page = 5))
+
+        assertEquals(listOf(3, 7, 5), stack.entries.map { it.page })
+
+        // Unwind: each back consumes the MOST RECENT departure first.
+        assertEquals(entry(page = 5), stack.entries.last())
+        stack = stack.popped()
+        assertEquals(entry(page = 7), stack!!.entries.last())
+        stack = stack.popped()
+        assertEquals(entry(page = 3), stack!!.entries.last())
+        // The emptied stack collapses to null so the BackHandler disables itself.
+        assertNull(stack.popped())
+    }
+
+    @Test
+    fun `the cap drops the oldest departure so back is never stuck past the cap`() {
+        var stack: TopicJumpStack? = null
+        repeat(TOPIC_JUMP_STACK_MAX + 3) { i ->
+            stack = stack.pushedJump(cat = 13, post = 999, entry = entry(page = i + 1))
+        }
+
+        val pages = stack!!.entries.map { it.page }
+        assertEquals(TOPIC_JUMP_STACK_MAX, pages.size)
+        // Oldest (pages 1..3) dropped; the most recent departures are all retained in order.
+        assertEquals((4..TOPIC_JUMP_STACK_MAX + 3).toList(), pages)
+    }
+
+    @Test
+    fun `jumping in another topic resets the stack (one stack at a time)`() {
+        var stack: TopicJumpStack? = null
+        stack = stack.pushedJump(cat = 13, post = 999, entry = entry(page = 3))
+        stack = stack.pushedJump(cat = 13, post = 999, entry = entry(page = 7))
+
+        stack = stack.pushedJump(cat = 2, post = 111, entry = entry(page = 1))
+
+        assertEquals(2, stack.cat)
+        assertEquals(111, stack.post)
+        assertEquals(listOf(1), stack.entries.map { it.page })
+    }
+
+    @Test
+    fun `matches gates the interception to the stack's own topic`() {
+        val empty: TopicJumpStack? = null
+        val stack = empty.pushedJump(cat = 13, post = 999, entry = entry(page = 3))
+
+        assertEquals(true, stack.matches(cat = 13, post = 999))
+        assertEquals(false, stack.matches(cat = 13, post = 998))
+        assertEquals(false, stack.matches(cat = 12, post = 999))
+    }
+}

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/TopicScrollRestorationTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/TopicScrollRestorationTest.kt
@@ -5,9 +5,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
- * Covers the pure priority resolver for the initial scroll of a topic page landing (#307, #412):
- * route `scrollTo` > post-submit landing (`submitSignal`, #344) > saved anchor >
- * previous-page bottom (#412) > top.
+ * Covers the pure priority resolver for the initial scroll of a topic page landing (#307, #412,
+ * #782): route `scrollTo` > post-submit landing (`submitSignal`, #344) > quote-jump return anchor
+ * (#782) > saved anchor > previous-page bottom (#412) > top.
  */
 class TopicScrollRestorationTest {
 
@@ -122,6 +122,49 @@ class TopicScrollRestorationTest {
                 submitSignal = 1_000L,
                 savedAnchor = null,
                 previousPageLanding = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `level 3bis - a quote-jump return anchor beats the saved anchor (#782)`() {
+        // An INTRA-page jump overwrites the disposal-saved anchor of the same (cat, post, page)
+        // with the cited post's position; on the back-return only the tap-time capture is truthful.
+        val jumpReturn = TopicScrollAnchor(index = 42, offset = 17)
+
+        val restoration = resolveTopicScrollRestoration(
+            scrollTo = null,
+            submitSignal = null,
+            savedAnchor = savedAnchor,
+            previousPageLanding = true,
+            jumpReturnAnchor = jumpReturn,
+        )
+
+        assertEquals(TopicScrollRestoration.RestoreSaved(jumpReturn), restoration)
+    }
+
+    @Test
+    fun `level 1 and 2 - scrollTo and submit landings still beat a jump return anchor (#782)`() {
+        // Defensive: a return route never carries scrollTo/submitSignal today, but the strict order
+        // must hold if a future flow arms both — the scroll effects own those landings.
+        val jumpReturn = TopicScrollAnchor(index = 42, offset = 17)
+
+        assertEquals(
+            TopicScrollRestoration.FollowScrollTo,
+            resolveTopicScrollRestoration(
+                scrollTo = 4242,
+                submitSignal = null,
+                savedAnchor = null,
+                jumpReturnAnchor = jumpReturn,
+            ),
+        )
+        assertEquals(
+            TopicScrollRestoration.FollowSubmitLanding,
+            resolveTopicScrollRestoration(
+                scrollTo = null,
+                submitSignal = 1_000L,
+                savedAnchor = null,
+                jumpReturnAnchor = jumpReturn,
             ),
         )
     }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -81,8 +81,10 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import coil3.size.Precision
 import coil3.size.Scale
+import fr.forumhfr.redface2.core.domain.blacklist.canonicalizePseudo
 import fr.forumhfr.redface2.core.ui.motion.rememberAnimationsEnabled
 import fr.forumhfr.redface2.core.ui.R
+import fr.forumhfr.redface2.core.ui.theme.LocalBlockedQuoteAuthors
 import fr.forumhfr.redface2.core.ui.theme.LocalFoldLongQuotes
 import fr.forumhfr.redface2.core.ui.theme.LocalIgnoreInlineColors
 import fr.forumhfr.redface2.core.model.PostBlock
@@ -202,6 +204,20 @@ internal fun quoteAccentRole(quoteDepth: Int, isBareQuote: Boolean): QuoteAccent
  */
 internal fun isBareQuote(quote: PostBlock.Quote): Boolean =
     quote.author == null && quote.numreponse == null && quote.page == null
+
+/**
+ * #785 — true when a quote cites a black-listed author: the quote's parsed author matches (by the
+ * canonical key, cf. [canonicalizePseudo]) one of the blocked canonicals the reading surface
+ * provided through [LocalBlockedQuoteAuthors]. Author-only on purpose: a citation HFR served in
+ * the dynamic `forum2.php` form keeps `page`/`numreponse` null but still carries the author, so
+ * the mask must never depend on the jump coordinates. A `[quotemsg]` forged with an arbitrary
+ * pseudo masks too — acceptable, the author line is the only identity a citation carries. Pure
+ * decision so it is pinned in [PostRendererQuoteDepthTest] without entering Compose.
+ */
+internal fun isBlockedQuoteAuthor(author: String?, blockedCanonicals: Set<String>): Boolean {
+    if (author == null || blockedCanonicals.isEmpty()) return false
+    return canonicalizePseudo(author) in blockedCanonicals
+}
 
 @Composable
 fun PostRenderer(
@@ -397,12 +413,23 @@ private fun ParagraphBlock(inlines: List<PostInline>) {
     }
 }
 
+// ReturnCount: the guard chain (blocked author first, then the folds) IS the dispatch.
+@Suppress("ReturnCount")
 @Composable
 private fun QuoteBlock(
     block: PostBlock.Quote,
     quoteDepth: Int,
     onGoToCitedPost: ((page: Int, numreponse: Int) -> Unit)? = null,
 ) {
+    // #785 — the blacklist applies INSIDE quotes too: a citation whose author is black-listed is
+    // masked like that author's own posts are. This branch runs BEFORE the depth/length folds so a
+    // blocked quote can never leak through an expanded render; the QuoteBlock recursion covers
+    // nested citations natively, and the local's empty default keeps every non-topic surface
+    // (editor preview, MP threads, signatures) unchanged.
+    if (isBlockedQuoteAuthor(block.author, LocalBlockedQuoteAuthors.current)) {
+        BlockedQuoteBlock(block, quoteDepth, onGoToCitedPost)
+        return
+    }
     if (isCollapsedQuoteDepth(quoteDepth)) {
         CollapsedQuoteBlock(block, quoteDepth, onGoToCitedPost)
         return
@@ -626,6 +653,59 @@ private fun CollapsedQuoteBlock(
             PostBlocksRenderer(
                 blocks = block.content.blocks,
                 quoteDepth = 0,
+                onGoToCitedPost = onGoToCitedPost,
+            )
+        }
+    }
+}
+
+/**
+ * #785 — placeholder for a quote whose author is black-listed, mirroring the [CollapsedQuoteBlock]
+ * interaction (one-line label + « Afficher »/« Masquer », the whole frame toggles) and the topic
+ * screen's `HiddenPostCard` copy (the pseudo stays visible, consistent with the post-level mask).
+ * The reveal is per-quote and transient (`rememberSaveable`, same lifetime as the other folds).
+ * Unlike [CollapsedQuoteBlock] the reveal keeps the REAL depth (`quoteDepth + 1`, like the expanded
+ * render): revealing a blocked quote must not grant extra nesting levels, and a blocked citation
+ * nested inside the revealed body stays masked through the recursion.
+ */
+@Composable
+private fun BlockedQuoteBlock(
+    block: PostBlock.Quote,
+    quoteDepth: Int,
+    onGoToCitedPost: ((page: Int, numreponse: Int) -> Unit)? = null,
+) {
+    var revealed by rememberSaveable(block) { mutableStateOf(false) }
+    QuoteFrame(
+        quoteDepth = quoteDepth,
+        isBareQuote = isBareQuote(block),
+        modifier = Modifier.clickable { revealed = !revealed },
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                // isBlockedQuoteAuthor never matches a null author, so the fallback is defensive.
+                text = stringResource(R.string.post_quote_blocked_author, block.author.orEmpty()),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = if (revealed) {
+                    stringResource(R.string.post_quote_hide)
+                } else {
+                    stringResource(R.string.post_quote_show)
+                },
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+        if (revealed) {
+            // #252/#699 — same header rule as the expanded QuoteBlock (and same jump affordance).
+            QuoteHeader(block, onGoToCitedPost)
+            PostBlocksRenderer(
+                blocks = block.content.blocks,
+                quoteDepth = quoteDepth + 1,
                 onGoToCitedPost = onGoToCitedPost,
             )
         }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/DisplayMetrics.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/theme/DisplayMetrics.kt
@@ -82,6 +82,17 @@ val LocalFoldLongQuotes = staticCompositionLocalOf { true }
 val LocalShowScrollbar = staticCompositionLocalOf { true }
 
 /**
+ * #785 — canonical pseudos (cf. `canonicalizePseudo`) of the black-listed authors, provided by the
+ * topic reading surface around its post list so `QuoteBlock` can mask a citation OF a blocked
+ * author embedded in another user's post (the post-level mask alone let a blocked author's words
+ * resurface through quotes). Defaults to the empty set: every other PostRenderer host (editor
+ * preview, MP threads, signatures) keeps rendering quotes untouched. `staticCompositionLocalOf`:
+ * the value changes only when the blacklist changes, so a one-shot subtree recomposition on change
+ * is acceptable (same stance as [LocalFoldLongQuotes]).
+ */
+val LocalBlockedQuoteAuthors = staticCompositionLocalOf { emptySet<String>() }
+
+/**
  * Project CompositionLocal asking the post renderer to IGNORE the author's inline `[color]` styling
  * for the subtree it wraps (#553). HFR signatures embed colours chosen for the white web background;
  * rendered as-is on the app theme (especially dark) they read as unreadable/garish, so the signature

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -4,6 +4,9 @@
     <string name="post_quote_bare">Citation</string>
     <!-- #699 : libellé a11y du tap sur l'en-tête d'une citation sourcée (aller au message cité). -->
     <string name="post_quote_go_to">Aller au message cité</string>
+    <!-- #785 : placeholder d'une citation dont l'auteur est black-listé. Le pseudo reste visible,
+         cohérent avec topic_post_hidden_by_author côté posts (le lecteur sait QUI est masqué). -->
+    <string name="post_quote_blocked_author">Citation de %1$s masquée</string>
     <string name="post_quote_collapsed">Citation imbriquée repliée</string>
     <string name="post_quote_collapsed_revealed">Citations imbriquées</string>
     <string name="post_quote_show">Afficher</string>

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererBlockedQuoteTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererBlockedQuoteTest.kt
@@ -1,0 +1,123 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import fr.forumhfr.redface2.core.model.PostBlock
+import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.model.PostInline
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import fr.forumhfr.redface2.core.ui.theme.LocalBlockedQuoteAuthors
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * #785 — the blacklist applies INSIDE quotes: a citation whose author is black-listed renders as
+ * the `BlockedQuoteBlock` placeholder (body hidden, « Afficher »/« Masquer » reveal), while every
+ * surface that does not provide [LocalBlockedQuoteAuthors] (editor preview, MP threads, signatures)
+ * keeps rendering quotes untouched through the empty default. The pure canonical-match decision
+ * (`isBlockedQuoteAuthor`) is pinned separately in [PostRendererQuoteDepthTest].
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@OptIn(ExperimentalTestApi::class)
+class PostRendererBlockedQuoteTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val quotedBody = "propos du posteur masqué"
+
+    private fun quoteFrom(author: String, body: String = quotedBody): PostBlock.Quote = PostBlock.Quote(
+        author = author,
+        numreponse = 12345,
+        page = 3,
+        content = PostContent(
+            blocks = listOf(PostBlock.Paragraph(inlines = listOf(PostInline.Text(body)))),
+        ),
+    )
+
+    private fun setPost(blocked: Set<String>?, vararg blocks: PostBlock) {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                Surface(color = MaterialTheme.colorScheme.surface) {
+                    val content = PostContent(blocks = blocks.toList())
+                    if (blocked != null) {
+                        CompositionLocalProvider(LocalBlockedQuoteAuthors provides blocked) {
+                            PostRenderer(content = content)
+                        }
+                    } else {
+                        // No provider — exercises the empty default every non-topic surface gets.
+                        PostRenderer(content = content)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `a blocked author's quote is masked by default and reveals on tap`() {
+        setPost(setOf("alice"), quoteFrom("Alice"))
+
+        // Masked: placeholder visible (with the pseudo, HiddenPostCard parity), body absent.
+        composeTestRule.onNodeWithText("Citation de Alice masquée").assertExists()
+        composeTestRule.onNodeWithText(quotedBody).assertDoesNotExist()
+
+        // Reveal: tap the frame (via its « Afficher » affordance) → header + body render.
+        composeTestRule.onNodeWithText("Afficher").performClick()
+        composeTestRule.onNodeWithText(quotedBody).assertExists()
+        composeTestRule.onNodeWithText("Citation de Alice").assertExists()
+
+        // Re-mask: the toggle is symmetric (« Masquer »), like the other quote folds.
+        composeTestRule.onNodeWithText("Masquer").performClick()
+        composeTestRule.onNodeWithText(quotedBody).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a non-blocked author's quote renders untouched next to a blocked one`() {
+        val visibleBody = "propos parfaitement visibles"
+        setPost(
+            setOf("alice"),
+            quoteFrom("Alice"),
+            quoteFrom("Bob", body = visibleBody),
+        )
+
+        composeTestRule.onNodeWithText("Citation de Alice masquée").assertExists()
+        composeTestRule.onNodeWithText(visibleBody).assertExists()
+        composeTestRule.onNodeWithText("Citation de Bob").assertExists()
+    }
+
+    @Test
+    fun `a blocked citation nested inside another quote is masked too`() {
+        val outer = PostBlock.Quote(
+            author = "Bob",
+            numreponse = 22222,
+            page = 1,
+            content = PostContent(blocks = listOf(quoteFrom("Alice"))),
+        )
+        setPost(setOf("alice"), outer)
+
+        // The outer (non-blocked) quote renders; the nested blocked one collapses to the placeholder.
+        composeTestRule.onNodeWithText("Citation de Bob").assertExists()
+        composeTestRule.onNodeWithText("Citation de Alice masquée").assertExists()
+        composeTestRule.onNodeWithText(quotedBody).assertDoesNotExist()
+    }
+
+    @Test
+    fun `without a provider the default empty set leaves quotes alone`() {
+        // Editor preview / MP threads / signatures never provide the local: nothing may mask there.
+        setPost(blocked = null, quoteFrom("Alice"))
+
+        composeTestRule.onNodeWithText(quotedBody).assertExists()
+        composeTestRule.onNodeWithText("Citation de Alice masquée").assertDoesNotExist()
+    }
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteDepthTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteDepthTest.kt
@@ -213,4 +213,37 @@ class PostRendererQuoteDepthTest {
         )
         assertEquals(2, quoteVisibleTextLength(content))
     }
+
+    // ---------------------------------------------------------------------------------------------
+    // #785 — the blacklist applies inside quotes. The rendering branch lives in the @Composable
+    // QuoteBlock/BlockedQuoteBlock (PostRendererBlockedQuoteTest, Robolectric); here we pin the pure
+    // decision so the canonical-match contract can't drift silently.
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    fun `isBlockedQuoteAuthor matches the blocked set through the canonical key`() {
+        // The provided set carries CANONICAL keys (cf. canonicalizePseudo); the quote author is raw
+        // parser output ("X a écrit"), so case and stray whitespace must not defeat the match.
+        val blocked = setOf("alice")
+        assertTrue(isBlockedQuoteAuthor("alice", blocked))
+        assertTrue(isBlockedQuoteAuthor("Alice", blocked))
+        assertTrue(isBlockedQuoteAuthor("  aLiCe  ", blocked))
+    }
+
+    @Test
+    fun `isBlockedQuoteAuthor never matches a null author or a non-blocked one`() {
+        // A bare [quote] has no author: nothing to match, never masked. A sourced citation from a
+        // non-blocked user must render untouched.
+        val blocked = setOf("alice")
+        assertFalse(isBlockedQuoteAuthor(null, blocked))
+        assertFalse(isBlockedQuoteAuthor("Bob", blocked))
+    }
+
+    @Test
+    fun `isBlockedQuoteAuthor is inert on the empty default set`() {
+        // LocalBlockedQuoteAuthors defaults to emptySet(): every non-topic surface (editor preview,
+        // MP threads, signatures) must keep rendering quotes unchanged.
+        assertFalse(isBlockedQuoteAuthor("Alice", emptySet()))
+        assertFalse(isBlockedQuoteAuthor(null, emptySet()))
+    }
 }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -110,6 +110,7 @@ import fr.forumhfr.redface2.core.ui.post.PostIdentityBand
 import fr.forumhfr.redface2.core.ui.post.PostIdentityHeader
 import fr.forumhfr.redface2.core.ui.post.PostListScaffold
 import fr.forumhfr.redface2.core.ui.post.PostRenderer
+import fr.forumhfr.redface2.core.ui.theme.LocalBlockedQuoteAuthors
 import fr.forumhfr.redface2.core.ui.theme.LocalDisplayMetrics
 import fr.forumhfr.redface2.core.ui.theme.LocalIgnoreInlineColors
 import fr.forumhfr.redface2.core.ui.theme.rememberCreatorPseudoBrush
@@ -887,54 +888,61 @@ internal fun TopicContent(
                         // (overlaying the list's right edge, outside the scrolled element), so the
                         // manual Box + LazyListScrollbar wrapper is gone. PullToRefreshBox stays the
                         // feature's wrapper (its refresh state belongs to the ViewModel).
-                        TopicLoadedContent(
-                            state = state,
-                            topic = mode.topic,
-                            hiddenNumreponses = mode.hiddenNumreponses,
-                            // #604 lot 2 / #806 — « Citer » opens the quick-reply sheet with the
-                            // card pre-armed (1-citation session), unless the preset routes any
-                            // citation to the full-screen editor (decision at tap time; same :app
-                            // path as the sheet's escalation, resumeSharedDraft = true).
-                            onQuoteRequested = { preview ->
-                                when (writingSurfaceFor(state.writingSurfacePreset, quoteCount = 1)) {
-                                    WritingSurface.SHEET -> quickReplyFor = QuickReplyLaunch(
-                                        request = QuickReplyRequest(
-                                            cat = state.request.cat,
-                                            subcat = mode.topic.subcat,
-                                            topicId = state.request.post,
-                                            page = mode.topic.page,
-                                        ),
-                                        initialQuotes = listOf(preview),
-                                    )
-                                    WritingSurface.FULL_EDITOR ->
-                                        onReply(mode.topic.subcat, mode.topic.page, listOf(preview))
-                                }
-                            },
-                            // #823 — LONG press on « Citer » : one-shot override of the #806
-                            // preset — always the full-screen editor, through the same :app path
-                            // as the FULL_EDITOR branch above (in-memory handoff +
-                            // resumeSharedDraft = true, #790). Deliberately does NOT consult
-                            // writingSurfaceFor: the gesture IS the routing decision (identical
-                            // to the tap under the FULL_EDITOR preset).
-                            onQuoteFullEditorRequested = { preview ->
-                                onReply(mode.topic.subcat, mode.topic.page, listOf(preview))
-                            },
-                            onEdit = onEdit,
-                            onEditFirstPost = onEditFirstPost,
-                            onOpenPage = onOpenPage,
-                            onGoToPost = onGoToPost,
-                            onOpenProfile = onOpenProfile,
-                            onDeleteRequest = onDeleteRequest,
-                            onDoubleTapRefresh = { onIntent(TopicIntent.Refresh) },
-                            listState = listState,
-                            multiQuoteSelection = multiQuoteNumreponses,
-                            onToggleMultiQuote = onToggleMultiQuote,
-                            onSetAuthorBlocked = { author, blocked ->
-                                onIntent(TopicIntent.SetAuthorBlocked(author, blocked))
-                            },
-                            pollManualExpanded = pollManualExpanded,
-                            onPollExpansionChanged = onPollExpansionChanged,
-                        )
+                        //
+                        // #785 — the blacklist applies inside quotes too: the canonical blocked set
+                        // is provided to the post renderers so QuoteBlock masks a citation OF a
+                        // blocked author. Scoped to the reading list only — the quick-reply sheet
+                        // and editor previews (outside this provider) keep the empty default.
+                        CompositionLocalProvider(LocalBlockedQuoteAuthors provides mode.blockedQuoteAuthors) {
+                            TopicLoadedContent(
+                                state = state,
+                                topic = mode.topic,
+                                hiddenNumreponses = mode.hiddenNumreponses,
+                                // #604 lot 2 / #806 — « Citer » opens the quick-reply sheet with the
+                                // card pre-armed (1-citation session), unless the preset routes any
+                                // citation to the full-screen editor (decision at tap time; same :app
+                                // path as the sheet's escalation, resumeSharedDraft = true).
+                                onQuoteRequested = { preview ->
+                                    when (writingSurfaceFor(state.writingSurfacePreset, quoteCount = 1)) {
+                                        WritingSurface.SHEET -> quickReplyFor = QuickReplyLaunch(
+                                            request = QuickReplyRequest(
+                                                cat = state.request.cat,
+                                                subcat = mode.topic.subcat,
+                                                topicId = state.request.post,
+                                                page = mode.topic.page,
+                                            ),
+                                            initialQuotes = listOf(preview),
+                                        )
+                                        WritingSurface.FULL_EDITOR ->
+                                            onReply(mode.topic.subcat, mode.topic.page, listOf(preview))
+                                    }
+                                },
+                                // #823 — LONG press on « Citer » : one-shot override of the #806
+                                // preset — always the full-screen editor, through the same :app path
+                                // as the FULL_EDITOR branch above (in-memory handoff +
+                                // resumeSharedDraft = true, #790). Deliberately does NOT consult
+                                // writingSurfaceFor: the gesture IS the routing decision (identical
+                                // to the tap under the FULL_EDITOR preset).
+                                onQuoteFullEditorRequested = { preview ->
+                                    onReply(mode.topic.subcat, mode.topic.page, listOf(preview))
+                                },
+                                onEdit = onEdit,
+                                onEditFirstPost = onEditFirstPost,
+                                onOpenPage = onOpenPage,
+                                onGoToPost = onGoToPost,
+                                onOpenProfile = onOpenProfile,
+                                onDeleteRequest = onDeleteRequest,
+                                onDoubleTapRefresh = { onIntent(TopicIntent.Refresh) },
+                                listState = listState,
+                                multiQuoteSelection = multiQuoteNumreponses,
+                                onToggleMultiQuote = onToggleMultiQuote,
+                                onSetAuthorBlocked = { author, blocked ->
+                                    onIntent(TopicIntent.SetAuthorBlocked(author, blocked))
+                                },
+                                pollManualExpanded = pollManualExpanded,
+                                onPollExpansionChanged = onPollExpansionChanged,
+                            )
+                        }
                     }
                 }
             }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -171,8 +171,13 @@ fun TopicScreen(
      * href. `:app` wires it to the same in-place `TopicRoute` replace as [onOpenPage], but with
      * `scrollTo = numreponse` so the landing scrolls to and highlights the cited post (the #200
      * deep-link mechanism) — one uniform path whether the target is on this page or another.
+     *
+     * #782 — also carries [sourceAnchor], the reader's EXACT position captured AT TAP TIME from the
+     * screen-owned `LazyListState`, so `:app` can push a return entry before replacing the route.
+     * Tap-time capture is mandatory: the disposal-saved anchor (#307) is written AFTER the jump has
+     * scrolled away, so an intra-page jump would overwrite it with the cited post's position.
      */
-    onGoToPost: (page: Int, numreponse: Int) -> Unit,
+    onGoToPost: (page: Int, numreponse: Int, sourceAnchor: TopicScrollAnchor) -> Unit,
     /**
      * #285 — leave the topic and go back to the screen that opened it (topic list / flags).
      * Wired to a back-stack pop in `:app`. Surfaced as an explicit back arrow in the top app
@@ -469,7 +474,20 @@ fun TopicScreen(
         onEdit = onEdit,
         onEditFirstPost = onEditFirstPost,
         onOpenPage = onOpenPage,
-        onGoToPost = onGoToPost,
+        // #782 — enrich the quote jump with the CURRENT scroll anchor, read at tap time from the
+        // screen-owned LazyListState (raw index/offset, header-aware — same shape as the #307
+        // disposal save). TopicContent and everything below keep the plain (page, numreponse)
+        // callback; only this seam knows about the list state.
+        onGoToPost = { page, numreponse ->
+            onGoToPost(
+                page,
+                numreponse,
+                TopicScrollAnchor(
+                    index = lazyListState.firstVisibleItemIndex,
+                    offset = lazyListState.firstVisibleItemScrollOffset,
+                ),
+            )
+        },
         onOpenProfile = onOpenProfile,
         onDeleteRequest = { numreponse -> deleteCandidate = numreponse },
         multiQuoteSelections = multiQuoteSelections,

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -102,6 +102,16 @@ data class TopicUiState(
              * first emission (combine with the blacklist) so a blocked post never flashes before hiding.
              */
             val hiddenNumreponses: Set<Int> = emptySet(),
+            /**
+             * #785 — canonical pseudos (cf. `canonicalizePseudo`) of the black-listed authors — the
+             * same blacklist snapshot [hiddenNumreponses] was computed from. The screen provides it
+             * to the post renderers (`LocalBlockedQuoteAuthors`) so a citation OF a blocked author
+             * inside another user's post is masked too. Kept in lock-step with [hiddenNumreponses]
+             * by `TopicViewModel.loadedMode` — the single construction seam for this mode — so the
+             * post-level and quote-level masks can never diverge across the load / refresh /
+             * force-refresh / post-delete / search / live-refilter paths.
+             */
+            val blockedQuoteAuthors: Set<String> = emptySet(),
         ) : Mode
 
         data class Error(

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -259,11 +259,10 @@ class TopicViewModel @AssistedInject constructor(
                 blockedCanonicals = blocked
                 _state.update { current ->
                     val loaded = current.mode as? TopicUiState.Mode.Loaded ?: return@update current
-                    current.copy(
-                        mode = loaded.copy(
-                            hiddenNumreponses = computeHiddenNumreponses(loaded.topic, blocked),
-                        ),
-                    )
+                    // #785 — rebuild the WHOLE loaded mode through the single seam (loadedMode) so
+                    // the post-level mask (hiddenNumreponses) and the quote-level canonical set
+                    // (blockedQuoteAuthors) re-filter together on a live blacklist change.
+                    current.copy(mode = loadedMode(loaded.topic))
                 }
             }
             // This collector is independent of any load job, so an unhandled error here would tear
@@ -298,7 +297,7 @@ class TopicViewModel @AssistedInject constructor(
                 val topic = topicRepository.refreshTopicPage(request.cat, request.post, request.page)
                 _state.update {
                     it.copy(
-                        mode = TopicUiState.Mode.Loaded(topic, computeHiddenNumreponses(topic, blockedCanonicals)),
+                        mode = loadedMode(topic),
                         availablePages = (1..topic.totalPages).toList(),
                     )
                 }
@@ -416,7 +415,7 @@ class TopicViewModel @AssistedInject constructor(
                 .collect { topic ->
                     _state.update {
                         it.copy(
-                            mode = TopicUiState.Mode.Loaded(topic, computeHiddenNumreponses(topic, blockedCanonicals)),
+                            mode = loadedMode(topic),
                             availablePages = (1..topic.totalPages).toList(),
                         )
                     }
@@ -429,6 +428,22 @@ class TopicViewModel @AssistedInject constructor(
                 }
         }
     }
+
+    /**
+     * #785 — SINGLE construction seam for [TopicUiState.Mode.Loaded]. Every path that puts a page on
+     * screen (cache-aside load, manual refresh, post-submit force refresh, post-delete refetch,
+     * intra-topic search, live blacklist re-filter) builds the mode here, from the same
+     * [blockedCanonicals] snapshot, so the post-level mask ([TopicUiState.Mode.Loaded.hiddenNumreponses])
+     * and the quote-level canonical set ([TopicUiState.Mode.Loaded.blockedQuoteAuthors]) can never
+     * diverge — a path bypassing this seam would make masked citations flicker across
+     * refresh/search/delete (Codex framing reservation on #785).
+     */
+    private fun loadedMode(topic: Topic): TopicUiState.Mode.Loaded =
+        TopicUiState.Mode.Loaded(
+            topic = topic,
+            hiddenNumreponses = computeHiddenNumreponses(topic, blockedCanonicals),
+            blockedQuoteAuthors = blockedCanonicals,
+        )
 
     /**
      * #509 — `numreponse` of the posts in [topic] whose author is blacklisted (canonical match). The
@@ -490,7 +505,7 @@ class TopicViewModel @AssistedInject constructor(
                 val topic = topicRepository.refreshTopicPage(request.cat, request.post, request.page)
                 _state.update {
                     it.copy(
-                        mode = TopicUiState.Mode.Loaded(topic, computeHiddenNumreponses(topic, blockedCanonicals)),
+                        mode = loadedMode(topic),
                         availablePages = (1..topic.totalPages).toList(),
                     )
                 }
@@ -646,7 +661,7 @@ class TopicViewModel @AssistedInject constructor(
                 val topic = topicRepository.refreshTopicPage(request.cat, request.post, request.page)
                 _state.update {
                     it.copy(
-                        mode = TopicUiState.Mode.Loaded(topic, computeHiddenNumreponses(topic, blockedCanonicals)),
+                        mode = loadedMode(topic),
                         availablePages = (1..topic.totalPages).toList(),
                     )
                 }
@@ -959,7 +974,7 @@ class TopicViewModel @AssistedInject constructor(
     private fun renderSearchPage(topic: Topic, status: TopicSearchStatus, canPrev: Boolean, canNext: Boolean) {
         _state.update {
             it.copy(
-                mode = TopicUiState.Mode.Loaded(topic, computeHiddenNumreponses(topic, blockedCanonicals)),
+                mode = loadedMode(topic),
                 search = it.search.copy(
                     status = status,
                     canGoPreviousResult = canPrev,

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -813,6 +813,40 @@ class TopicViewModelTest {
     }
 
     @Test
+    fun `the canonical blocked set is exposed for quote masking and re-filters live (#785)`() = runTest {
+        // #785 — the screen provides Loaded.blockedQuoteAuthors to the quote renderer
+        // (LocalBlockedQuoteAuthors), so the set must (a) land with the initial load — even when the
+        // blocked author has NO post on the page, only citations of them — and (b) follow live
+        // blacklist changes through the same seam as hiddenNumreponses (loadedMode).
+        val topic = fakeTopic(
+            page = 1,
+            totalPages = 1,
+            posts = listOf(fakePost(100, author = "Alice"), fakePost(101, author = "Bob")),
+        )
+        val blacklist = FakeBlacklistRepository(blockedCanonicals = setOf("charlie"))
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(topic) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            blacklistRepository = blacklist,
+        )
+
+        viewModel.state.test {
+            val initial = assertMode<TopicUiState.Mode.Loaded>(awaitItem())
+            // charlie posts nothing on this page (hiddenNumreponses empty), yet the canonical set is
+            // exposed so a CITATION of charlie in Alice/Bob's posts can be masked by the renderer.
+            assertEquals(setOf("charlie"), initial.blockedQuoteAuthors)
+            assertEquals(emptySet<Int>(), initial.hiddenNumreponses)
+
+            blacklist.block("Alice")
+            val refiltered = assertMode<TopicUiState.Mode.Loaded>(awaitItem())
+            assertEquals(setOf("charlie", "alice"), refiltered.blockedQuoteAuthors)
+            assertEquals(setOf(100), refiltered.hiddenNumreponses)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `blocking an author after a pull-to-refresh hides their posts live (#509 beta)`() = runTest {
         // Beta regression: the blacklist used to be collected only inside loadCurrentPage's combine, so
         // a refresh (which cancels loadJob and runs a one-shot refetch) FROZE the live re-filter — a


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Closes #782. **2/3 de la pile citations** — empilée sur #838 (son commit disparaît du diff net après le merge de #838).

## Quoi
Après un saut de citation (#699/#765), le back système revient à la position de lecture précédente (page + ancre) au lieu de quitter le topic ; back suivant = comportement normal. `TopicJumpStack` dans `:app` : état de navigation TRANSITOIRE (jamais sérialisé — process death assumé, stance PR #420), LIFO capé à 8 (au-delà on droppe le plus ancien, le back n'est jamais « coincé »), reset cross-topic. `BackHandler(enabled = jumpStack != null)` composé DANS l'entry TopicRoute (précédence sur NavDisplay/TabRootBackHandler) ; pop → `TopicJumpReturn` one-shot → route-replace ; l'ancre est capturée AU TAP depuis `lazyListState` (l'ancre de disposition s'écrit trop tard pour les sauts intra-page) ; `onOpenPage`/dernière page/back volontaire VIDENT la pile (browser-like). Résolveur de scroll : niveau 3-bis `jumpReturnAnchor` (au-dessus de `savedAnchor`, sous scrollTo/submit) ; le one-shot ne peut pas re-scroller (latch au premier `LaunchedEffect(Unit)`, documenté).

## Réserves Codex traitées
État :app transitoire capé testé ✓ ; perte assumée de la preview predictive-back sur ce geste (route remplacée in-place) ✓ ; dogfood du back système sur chaîne de sauts avant merge (fait, cf. commentaire de PR).

## Tests
`TopicJumpStackTest` (LIFO x sauts = x retours, cap, reset cross-topic, collapse) + `TopicScrollRestorationTest` (3-bis bat savedAnchor/previousPageLanding ; scrollTo/submit gardent la priorité).

## Validation
Canonique complète verte (pile) ; gate Codex du lot : **GO franc**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pm28ny4V5GSegmKJxTPVAM