### PR TITLE
feat(ui): collapsed preview for long quotes — tap body to expand, header still jumps (#784)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -36,9 +36,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.luminance
@@ -165,13 +168,49 @@ private fun inlineVisibleTextLength(inline: PostInline): Int = when (inline) {
 }
 
 /**
- * Issue #332 — true when a quote must fold to a one-line header by default because it is "long".
+ * Issue #332 — true when a quote must fold by default because it is "long" (since #784 the fold
+ * shows a bounded PREVIEW instead of a bare header line, cf. [FoldableQuoteBlock]).
  * Restricted to [quoteDepth] == 0: a nested quote is already governed by the depth rule
  * ([isCollapsedQuoteDepth]) and the parent fold, so folding it again by length would stack two
  * different toggles on the same sub-tree. Pure decision, pinned in [PostRendererQuoteDepthTest].
  */
 internal fun isLongQuote(block: PostBlock.Quote, quoteDepth: Int): Boolean =
     quoteDepth == 0 && quoteVisibleTextLength(block.content) > LONG_QUOTE_CHAR_THRESHOLD
+
+/**
+ * #784 — how many `bodyMedium` lines of a folded long quote stay visible as a PREVIEW. 5 lines ≈
+ * the reading depth of a short citation: enough context to decide whether the wall of text is
+ * worth unfolding, small enough that a folded quote never dominates the post. Pure constant so
+ * the budget is pinned in [PostRendererQuoteDepthTest] and any change is a deliberate review step.
+ */
+internal const val LONG_QUOTE_PREVIEW_LINES = 5
+
+/** #784 — fallback line height (sp) when the theme leaves `bodyMedium.lineHeight` unspecified. */
+internal const val LONG_QUOTE_FALLBACK_LINE_HEIGHT_SP = 20f
+
+/**
+ * #784 — max height (sp) of the folded preview container: [LONG_QUOTE_PREVIEW_LINES] ×
+ * the body line height. Sp on purpose so the preview grows with the user's font scale (a fixed
+ * dp cap would show fewer lines at accessibility font sizes). Pure so the sizing rule is
+ * testable without composing anything ([PostRendererQuoteDepthTest]).
+ */
+internal fun longQuotePreviewMaxHeightSp(bodyLineHeightSp: Float): Float {
+    val line = if (bodyLineHeightSp > 0f) bodyLineHeightSp else LONG_QUOTE_FALLBACK_LINE_HEIGHT_SP
+    return line * LONG_QUOTE_PREVIEW_LINES
+}
+
+/** #784 — tolerance for the clip decision below (sub-pixel rounding of the constrained height). */
+internal const val LONG_QUOTE_CLIP_TOLERANCE_PX = 1f
+
+/**
+ * #784 — whether the folded preview actually CLIPPED its content: the constrained box reports a
+ * height at (or within a rounding tolerance of) the cap only when the content wanted more room.
+ * Gates the bottom fade so a quote that is « long » by character count but renders short (wide
+ * screen, media-light text) is not painted with a misleading « more below » scrim. Pure decision,
+ * pinned in [PostRendererQuoteDepthTest].
+ */
+internal fun isLongQuotePreviewClipped(contentHeightPx: Float, maxHeightPx: Float): Boolean =
+    contentHeightPx >= maxHeightPx - LONG_QUOTE_CLIP_TOLERANCE_PX
 
 /**
  * Which themed accent the [QuoteFrame] left bar uses. Issue #252 — a **bare** `[quote]` (typed by
@@ -492,12 +531,18 @@ private fun QuoteHeader(
 }
 
 /**
- * Issue #332 — a "long" top-level citation (`isLongQuote`) folds to a single header line by default,
- * dépliable au clic puis repliable. Mirrors the [SpoilerBlock] interaction (a `rememberSaveable`
- * boolean + a clickable header carrying an "Afficher"/"Masquer" affordance) and reuses [QuoteFrame]
- * so the accent bar, surface and bare-quote palette stay identical to a normal quote. Unlike
+ * Issue #332 — a "long" top-level citation (`isLongQuote`) folds by default, dépliable au clic puis
+ * repliable. Since #784 the folded state is a bounded PREVIEW ([LongQuotePreview]: the first
+ * ~[LONG_QUOTE_PREVIEW_LINES] lines, clipped, with a bottom fade) instead of a bare header line, so
+ * the reader gets enough context to decide whether to unfold. Reuses [QuoteFrame] so the accent
+ * bar, surface and bare-quote palette stay identical to a normal quote. Unlike
  * [CollapsedQuoteBlock] (issue #3 depth fold, which resets depth to 0 on reveal) this fold keeps the
  * real [quoteDepth] when expanded so a long quote that also nests deeply still hits the depth rule.
+ *
+ * Gesture contract (#784, Codex framing): the FRAME — preview body, fade, « Déplier »/« Replier »
+ * label — toggles the fold, with its own a11y `onClickLabel`; the HEADER keeps its distinct #699
+ * « go to the cited post » tap (its clickable consumes the event before the frame's). Inline links
+ * inside the preview keep consuming their own taps, like everywhere else in the renderer.
  */
 @Composable
 private fun FoldableQuoteBlock(
@@ -509,7 +554,11 @@ private fun FoldableQuoteBlock(
     QuoteFrame(
         quoteDepth = quoteDepth,
         isBareQuote = isBareQuote(block),
-        modifier = Modifier.clickable { expanded = !expanded },
+        modifier = Modifier.clickable(
+            onClickLabel = stringResource(
+                if (expanded) R.string.post_quote_collapse_label else R.string.post_quote_expand_label,
+            ),
+        ) { expanded = !expanded },
     ) {
         Row(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -520,9 +569,9 @@ private fun FoldableQuoteBlock(
             QuoteHeader(block, onGoToCitedPost)
             Text(
                 text = if (expanded) {
-                    stringResource(R.string.post_quote_hide)
+                    stringResource(R.string.post_quote_collapse)
                 } else {
-                    stringResource(R.string.post_quote_show)
+                    stringResource(R.string.post_quote_expand)
                 },
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.primary,
@@ -534,7 +583,70 @@ private fun FoldableQuoteBlock(
                 quoteDepth = quoteDepth + 1,
                 onGoToCitedPost = onGoToCitedPost,
             )
+        } else {
+            LongQuotePreview(block, quoteDepth, onGoToCitedPost)
         }
+    }
+}
+
+/** #784 — height of the bottom fade hinting at the clipped remainder of a folded preview. */
+private val LONG_QUOTE_FADE_HEIGHT: Dp = 28.dp
+
+/**
+ * #784 — bounded, clipped preview of a folded long quote: the normal [PostBlocksRenderer] inside a
+ * `heightIn(max = ~5 bodyMedium lines)` + `clipToBounds` container, with a bottom fade towards the
+ * frame's own container colour hinting at the hidden remainder.
+ *
+ * STRICTLY a container: no AnnotatedString is ever rebuilt to measure or truncate the text (the
+ * #175 invariance pivot — the paragraphs inside are byte-identical to the expanded render), and no
+ * intrinsic measurement is asked of the subtree (`SubcomposeAsyncImage` crashes under
+ * `IntrinsicSize`, cf. the [QuoteFrame] history note). The fade is skipped when the content
+ * actually fits under the cap ([isLongQuotePreviewClipped]) so a char-count-long but visually
+ * short quote is not painted with a misleading « more below » scrim.
+ */
+@Composable
+private fun LongQuotePreview(
+    block: PostBlock.Quote,
+    quoteDepth: Int,
+    onGoToCitedPost: ((page: Int, numreponse: Int) -> Unit)?,
+) {
+    val bodyLineHeight = MaterialTheme.typography.bodyMedium.lineHeight
+    val density = LocalDensity.current
+    // Sp-based cap so the preview keeps showing ~the same LINE COUNT at any font scale.
+    val maxHeight = with(density) {
+        longQuotePreviewMaxHeightSp(
+            bodyLineHeightSp = if (bodyLineHeight.isSp) bodyLineHeight.value else 0f,
+        ).sp.toDp()
+    }
+    val maxHeightPx = with(density) { maxHeight.toPx() }
+    // The fade dissolves the clipped last line into the quote card's own surface colour.
+    val fadeColor = MaterialTheme.colorScheme.surfaceContainerHighest
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(max = maxHeight)
+            .clipToBounds()
+            .drawWithContent {
+                drawContent()
+                if (isLongQuotePreviewClipped(contentHeightPx = size.height, maxHeightPx = maxHeightPx)) {
+                    val fadeHeightPx = LONG_QUOTE_FADE_HEIGHT.toPx()
+                    drawRect(
+                        brush = Brush.verticalGradient(
+                            colors = listOf(Color.Transparent, fadeColor),
+                            startY = size.height - fadeHeightPx,
+                            endY = size.height,
+                        ),
+                        topLeft = Offset(0f, size.height - fadeHeightPx),
+                        size = Size(size.width, fadeHeightPx),
+                    )
+                }
+            },
+    ) {
+        PostBlocksRenderer(
+            blocks = block.content.blocks,
+            quoteDepth = quoteDepth + 1,
+            onGoToCitedPost = onGoToCitedPost,
+        )
     }
 }
 

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -11,6 +11,12 @@
     <string name="post_quote_collapsed_revealed">Citations imbriquées</string>
     <string name="post_quote_show">Afficher</string>
     <string name="post_quote_hide">Masquer</string>
+    <!-- #784 : aperçu borné des citations longues. Libellés visibles du dépli/repli, plus les
+         libellés a11y du tap sur le corps/cadre — distincts de post_quote_go_to (saut du header). -->
+    <string name="post_quote_expand">Déplier</string>
+    <string name="post_quote_collapse">Replier</string>
+    <string name="post_quote_expand_label">Déplier la citation</string>
+    <string name="post_quote_collapse_label">Replier la citation</string>
     <string name="post_spoiler_default_label">Spoiler</string>
     <string name="post_spoiler_show">(afficher)</string>
     <string name="post_spoiler_hide">(masquer)</string>

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererLongQuoteFoldTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererLongQuoteFoldTest.kt
@@ -1,0 +1,105 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import fr.forumhfr.redface2.core.model.PostBlock
+import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.model.PostInline
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * #784 — a folded long quote (#332) shows a bounded PREVIEW of its body instead of a bare header
+ * line, and the gesture contract is desambiguated: tapping the body/preview UNFOLDS, tapping the
+ * « Citation de X » header still JUMPS to the cited post (#699) without toggling the fold. The pure
+ * sizing/clip decisions are pinned separately in [PostRendererQuoteDepthTest].
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@OptIn(ExperimentalTestApi::class)
+class PostRendererLongQuoteFoldTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    // Well over LONG_QUOTE_CHAR_THRESHOLD (280) so the quote folds by default.
+    private val wallOfText = "Mur de texte volontairement long pour déclencher le repli. ".repeat(12)
+
+    private fun longQuote(): PostBlock.Quote = PostBlock.Quote(
+        author = "Lt Ripley",
+        numreponse = 74749781,
+        page = 8270,
+        content = PostContent(
+            blocks = listOf(PostBlock.Paragraph(inlines = listOf(PostInline.Text(wallOfText)))),
+        ),
+    )
+
+    private fun setPost(onGoToCitedPost: ((page: Int, numreponse: Int) -> Unit)? = null) {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                Surface(color = MaterialTheme.colorScheme.surface) {
+                    PostRenderer(
+                        content = PostContent(blocks = listOf(longQuote())),
+                        onGoToCitedPost = onGoToCitedPost,
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `a long quote folds to a preview - body visible, Déplier offered`() {
+        setPost()
+
+        // #784 vs #332: the folded state now RENDERS the beginning of the body (bounded preview)
+        // instead of hiding it entirely.
+        composeTestRule.onNodeWithText("Mur de texte", substring = true).assertExists()
+        composeTestRule.onNodeWithText("Déplier").assertExists()
+        composeTestRule.onNodeWithText("Replier").assertDoesNotExist()
+    }
+
+    @Test
+    fun `tapping the preview body expands, tapping Replier collapses back`() {
+        setPost()
+
+        // Tap INSIDE the visible part of the preview body (top-left corner of the text node: the
+        // node's own bounds may extend past the clip, but its top is always visible). Plain text
+        // carries no click handler of its own, so the tap reaches the frame's fold toggle.
+        composeTestRule.onNodeWithText("Mur de texte", substring = true)
+            .performTouchInput { click(Offset(10f, 10f)) }
+        composeTestRule.onNodeWithText("Replier").assertExists()
+        composeTestRule.onNodeWithText("Déplier").assertDoesNotExist()
+
+        composeTestRule.onNodeWithText("Replier").performClick()
+        composeTestRule.onNodeWithText("Déplier").assertExists()
+        composeTestRule.onNodeWithText("Replier").assertDoesNotExist()
+    }
+
+    @Test
+    fun `tapping the header jumps to the cited post without toggling the fold`() {
+        var jumpedTo: Pair<Int, Int>? = null
+        setPost(onGoToCitedPost = { page, numreponse -> jumpedTo = page to numreponse })
+
+        composeTestRule.onNodeWithText("Citation de Lt Ripley").performClick()
+
+        // #699 contract untouched: the header's clickable consumed the tap for the jump…
+        assertEquals(8270 to 74749781, jumpedTo)
+        // …and the frame's fold toggle never fired (still folded, still offering « Déplier »).
+        composeTestRule.onNodeWithText("Déplier").assertExists()
+        composeTestRule.onNodeWithText("Replier").assertDoesNotExist()
+    }
+}

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteDepthTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteDepthTest.kt
@@ -215,6 +215,49 @@ class PostRendererQuoteDepthTest {
     }
 
     // ---------------------------------------------------------------------------------------------
+    // #784 — folded long quotes show a bounded preview. The container/fade rendering lives in the
+    // @Composable LongQuotePreview (PostRendererLongQuoteFoldTest, Robolectric); here we pin the
+    // pure sizing and clip decisions.
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    fun `the preview keeps the documented number of body lines`() {
+        assertEquals(
+            "Changing LONG_QUOTE_PREVIEW_LINES changes how much of every folded quote is visible " +
+                "— keep it a deliberate review step.",
+            5,
+            LONG_QUOTE_PREVIEW_LINES,
+        )
+    }
+
+    @Test
+    fun `preview max height is the line height times the line budget, with a fallback`() {
+        // bodyMedium's M3 line height (20sp) → 100sp of preview.
+        assertEquals(20f * LONG_QUOTE_PREVIEW_LINES, longQuotePreviewMaxHeightSp(20f), 0f)
+        // A theme leaving lineHeight unspecified (0 / negative) falls back to the documented value
+        // instead of collapsing the preview to zero height.
+        assertEquals(
+            LONG_QUOTE_FALLBACK_LINE_HEIGHT_SP * LONG_QUOTE_PREVIEW_LINES,
+            longQuotePreviewMaxHeightSp(0f),
+            0f,
+        )
+        assertEquals(
+            LONG_QUOTE_FALLBACK_LINE_HEIGHT_SP * LONG_QUOTE_PREVIEW_LINES,
+            longQuotePreviewMaxHeightSp(-1f),
+            0f,
+        )
+    }
+
+    @Test
+    fun `the bottom fade draws only when the preview actually clipped`() {
+        // At (or within rounding tolerance of) the cap = the box was constrained → content hidden.
+        assertTrue(isLongQuotePreviewClipped(contentHeightPx = 500f, maxHeightPx = 500f))
+        assertTrue(isLongQuotePreviewClipped(contentHeightPx = 499.5f, maxHeightPx = 500f))
+        // Clearly under the cap = the whole quote is visible; a « more below » fade would lie.
+        assertFalse(isLongQuotePreviewClipped(contentHeightPx = 300f, maxHeightPx = 500f))
+    }
+
+    // ---------------------------------------------------------------------------------------------
     // #785 — the blacklist applies inside quotes. The rendering branch lives in the @Composable
     // QuoteBlock/BlockedQuoteBlock (PostRendererBlockedQuoteTest, Robolectric); here we pin the pure
     // decision so the canonical-match contract can't drift silently.

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteRoborazziTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererQuoteRoborazziTest.kt
@@ -143,10 +143,10 @@ class PostRendererQuoteRoborazziTest {
     }
 
     /**
-     * Issue #332 — a "long" top-level citation folds to a single header line by default ("longues
-     * citations repliées sur une ligne, dépliables au clic puis repliables"). This captures the
-     * default *folded* state: the framed quote shows only its "Citation de X" header + the
-     * "(afficher)" affordance, and the wall-of-text body is hidden until tapped.
+     * Issue #332 — a "long" top-level citation folds by default. Since #784 the folded state is a
+     * bounded PREVIEW: the "Citation de X" header + « Déplier » affordance, the first
+     * ~[LONG_QUOTE_PREVIEW_LINES] lines of the body clipped in place, and a bottom fade hinting at
+     * the hidden remainder. This captures that default folded/preview state.
      */
     @Test
     fun postRendererLongQuoteFoldedLight() {


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Closes #784. **3/3 de la pile citations** — empilée sur #838 et #839.

## Quoi
Les citations dépassant ~5 lignes (`LONG_QUOTE_PREVIEW_LINES`, converti en cap sp — survit au font scale) sont repliées en aperçu borné : `heightIn(max)` + `clipToBounds` + fondu bas 28dp (`drawWithContent`), seulement si réellement clippé (tolérance 1px). STRICTEMENT UI : le `PostBlocksRenderer` intérieur est INCHANGÉ — zéro rebuild d'AnnotatedString (invariant #175), zéro IntrinsicSize.

## Contrat de gestes (cadrage Codex)
Header de citation = aller au post cité (#699, inchangé — son clickable consomme) ; frame/aperçu/fondu = déplier/replier. Deux `onClickLabel` a11y distincts (« Déplier la citation » vs « Aller au message cité »).

## Tests
`PostRendererLongQuoteFoldTest` : aperçu + « Déplier » repliés, tap corps = déplie, « Replier » = replie, tap header = saut SANS toggle ; +3 cas purs du seuil ; interaction #785 pinnée (citation longue d'un auteur bloqué → placeholder bloqué prioritaire, pas d'aperçu).

## Validation
Canonique complète verte (pile) ; gate Codex du lot : **GO franc** (réserve marginale : faux positif possible du fondu à la limite exacte du cap, non bloquant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pm28ny4V5GSegmKJxTPVAM