### PR TITLE
chore(release): bump versionName to 0.26.0 (Vue Topic wave 5)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,29 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.26.0` — `internal` (dev) — 2026-07-07
+
+**Vague 5 Vue Topic (#604)** : interactions image, lot citations, rendu média parité web, gestes d'appui long, recherche smileys, fix Drapeaux.
+
+### Lecture (vue Topic)
+- #831 (partiel) : **appui long sur une image de post → menu contextuel** (PR #837) — Copier l'URL, Ouvrir dans le navigateur, Enregistrer (octets originaux via le cache disque Coil, GIF préservés ; « Taille réelle » arrive avec le viewer #182). Le tap court sur une image liée ouvre toujours le navigateur (#257). Limite connue : le menu n'est pas accessible sur les images `[url=][img]` restées inline dans un paragraphe mixte — l'issue #831 reste ouverte pour ce cas.
+- #610 : le dimensionnement des `[img]` s'aligne sur HFR web (max-width 90 %, max-height ~200 dp, PR #836) — parité visuelle avec le site, ni upscale ni débordement.
+- #256 : fast-path de rendu pour le marqueur `hfr-cc-image` (PR #835) — matching strict sur la query (garde anti-fragment), règle « un intrus = pas de marqueur ».
+
+### Citations
+- #785 : la black-list masque aussi le **contenu des citations** d'un auteur bloqué (PR #838) — bandeau « Citation de X masquée », tap pour révéler.
+- #782 : après un saut vers un post cité, **le retour ramène à la position de lecture précédente** (PR #839) — pile de retour par onglet, vidée à la sortie du topic.
+- #784 : les **citations longues sont repliées** avec un aperçu (PR #840) — tap sur le corps pour déplier, l'en-tête continue de sauter au post cité.
+
+### Gestes
+- #822/#823 : appui long sur les **FAB de pagination → première/dernière page**, appui long sur **Citer → éditeur plein écran** (PR #833) — haptique + libellés TalkBack.
+
+### Éditeur
+- #441/#824 : recherche de smileys unifiée derrière `SmileyPickerController` (un seul chemin feuille/plein écran) et **recherche restaurée à la réouverture** du picker, onglet inclus (PR #834).
+
+### Drapeaux
+- #825 : le filtre « masquer les catégories vides » ne s'applique plus à l'**onglet lus** (PR #832).
+
 ## `0.25.2` — `internal` (dev) — 2026-07-05
 
 **Presets de surface d'écriture (#806)** + lot d'hygiène d'état (audit rf2-10) + deux fixes de veille.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.25.2"
+        versionName = "0.26.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,5 +1,7 @@
-Redface 2 v0.25.2 — dev.
+Redface 2 v0.26.0 — dev.
 
-- New "Writing surface" setting: choose what Reply and Quote open (quick-reply sheet or full-screen editor).
-- Unreadable text colors auto-corrected in dark themes.
-- Settings always fresh, last keystrokes saved on editor close, sharper smiley search.
+- Long-press an image: copy URL, open, save.
+- Quotes: blacklisted authors hidden inside quotes too, back returns to your reading spot after a quote jump, long quotes collapse to a preview.
+- Images sized like the website.
+- Long-press: page FABs → first/last, Quote → full editor.
+- Smiley search restored on reopen; empty-categories filter fixed on the read tab.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,5 +1,7 @@
-Redface 2 v0.25.2 — dev.
+Redface 2 v0.26.0 — dev.
 
-- Nouveau réglage « Surface d'écriture » : choisissez ce qu'ouvrent Répondre et Citer (feuille rapide ou éditeur plein écran).
-- Couleurs de texte illisibles en thème sombre corrigées automatiquement.
-- Réglages toujours à jour, dernière frappe sauvée à la fermeture des éditeurs, recherche de smileys plus précise.
+- Appui long sur une image : copier l'URL, ouvrir, enregistrer.
+- Citations : auteurs black-listés masqués aussi en citation, retour à la position de lecture après un saut, citations longues repliées avec aperçu.
+- Images à la taille du site web.
+- Appui long : FAB de page → première/dernière, Citer → éditeur plein écran.
+- Recherche de smileys conservée à la réouverture ; filtre « catégories vides » corrigé sur l'onglet lus.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump `versionName` 0.25.2 → **0.26.0** (mineur — 1er lot de la vague 5 du chantier Vue Topic #604, politique de versioning A) + entrée `app/CHANGELOG.md` + whatsnew fr/en (guard `check-whatsnew.sh 0.26.0` vert en local, 455/390 car.).

Contenu de la vague (depuis 0.25.2) : #831 partiel (menu image, PR #837), #610 (parité web images, PR #836), #256 (marqueur cc-image, PR #835), #785/#782/#784 (lot citations, PRs #838/#839/#840), #822+#823 (gestes, PR #833), #441+#824 (smileys, PR #834), #825 (drapeaux, PR #832).

À merger après la PR #837 ; dispatch `channel=dev --ref dev` ensuite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pm28ny4V5GSegmKJxTPVAM