### PR TITLE
fix(ui): recalibrate block image height cap for mobile (#842)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicy.kt
@@ -130,25 +130,29 @@ internal object PostMediaDisplayPolicy {
      * the bitmap arrives so the container occupies exactly the slot the loaded image will fill, hence
      * zero layout shift (anti-CLS, #249) when it crossfades in.
      *
-     * #610 — the size is the unified HFR-web parity policy ([imageParityDisplaySize]): native size,
-     * no upscale, height ≤ [IMAGE_MAX_HEIGHT_UNITS] (web `max-height: 200px`), width ≤
-     * [SMILEY_RELATIVE_MAX_WIDTH_FRACTION] × [availableWidthDp] (web `max-width: 90%`). Before →
-     * after: a measured block image used to FILL the column width — upscaling any source narrower
-     * than the column — with its height `width × h/w` clamped to the [blockImageMinHeight] /
-     * [blockImageMaxHeight] (160/480 dp) slot; it now renders at its capped NATIVE size, the same
-     * numbers the inline path produces in sp, so a lone posted photo and the same photo inside prose
-     * finally match.
+     * #610/#842 — the size is the unified parity policy ([imageParityDisplaySize]): native size, no
+     * upscale, width ≤ [SMILEY_RELATIVE_MAX_WIDTH_FRACTION] × [availableWidthDp] (web `max-width: 90%`),
+     * height ≤ [maxHeightDp]. #610 passed a flat 200 here (matching the inline sp cap); #842 lets the
+     * caller pass the mobile-recalibrated [blockImageMaxHeightDp] (`max(400, 0.5 × screenHeightDp)`) so
+     * a square/portrait photo reaches ~90 % width instead of being squeezed to ~48 % by a 200 dp cap
+     * with no web basis. Before #610: a measured block image FILLED the column width — upscaling any
+     * source narrower than the column — with its height `width × h/w` clamped to the [blockImageMinHeight]
+     * / [blockImageMaxHeight] (160/480 dp) slot; it now renders at its capped NATIVE size.
      *
      * [measured] is `null` for a not-yet-measured image — a cold cache before the measure effect lands,
      * or a measurement failure (dead host / 404). Both the paragraph effect (#175/#224) and, since the
      * #249 follow-up, the standalone `PostBlock.Image` effect feed the cache; callers fall back to the
      * legacy [blockImageMinHeight]-anchored slot until (or unless) a size lands.
      */
-    fun blockImageDisplaySize(measured: PixelSize?, availableWidthDp: Float): PixelSize? {
+    fun blockImageDisplaySize(
+        measured: PixelSize?,
+        availableWidthDp: Float,
+        maxHeightDp: Int = IMAGE_MAX_HEIGHT_UNITS,
+    ): PixelSize? {
         val size = measured?.takeIf { it.width > 0 && it.height > 0 }
         if (size == null || availableWidthDp <= 0f) return null
         val maxWidthDp = (availableWidthDp * SMILEY_RELATIVE_MAX_WIDTH_FRACTION).roundToInt()
-        return imageParityDisplaySize(size, maxWidthUnits = maxWidthDp)
+        return imageParityDisplaySize(size, maxWidthUnits = maxWidthDp, maxHeightUnits = maxHeightDp)
     }
 
     /**
@@ -252,16 +256,37 @@ internal val builtinPreseedSize = PixelSize(16, 16)
 internal val persoColdFallbackSize = PixelSize(70, 50)
 
 /**
- * #610 — HFR-web parity height cap for ANY `[img]`, inline or block: the web rule is
- * `img { max-height: 200px }`, mirrored here with the native px treated as logical units (`.sp` on the
- * inline path so the image tracks the text size, `.dp` on the block path — documented fontScale
- * asymmetry: inline grows with the user font, block does not, exactly like text vs images on the web).
- * Replaces (#610, before → after) the former `INLINE_IMAGE_MAX_HEIGHT_SP` (200 sp → same 200, the
- * inline path was already at web parity) and the MEASURED-path use of
- * [PostMediaDisplayPolicy.blockImageMaxHeight] (480 dp → 200 dp; the block path exceeded the web cap
- * 2.4×, the visible #610 divergence).
+ * Height cap for the INLINE `[img]` path and the pure/legacy default of [imageParityDisplaySize]
+ * (native px treated as logical units, fed as `.sp` inline so the image tracks the text size).
+ *
+ * #610 originally applied this same 200 to BOTH paths as `img { max-height: 200px }` "web parity".
+ * #842 walked that back for the BLOCK path only (see [blockImageMaxHeightDp]): the HFR fixtures carry
+ * NO `max-height` on post images — the only web rule is `img { max-width: 90% }` — and 200 dp on a
+ * ~360-411 dp phone column binds any image narrower than ~1.6:1, squeezing a square photo to ~48 %
+ * width (the #842 report). The INLINE path keeps 200 sp: in-prose images stay conservative so a large
+ * reaction image never grows tall enough to break the text flow, and small inline sources (cc-image
+ * 16×16, reactions) never reach the cap anyway (no upscale).
  */
 internal const val IMAGE_MAX_HEIGHT_UNITS = 200
+
+/**
+ * #842 — mobile-recalibrated height cap (in **dp**) for the BLOCK `[img]` path, replacing the flat
+ * [IMAGE_MAX_HEIGHT_UNITS] that #610 applied there. Real photos land on the block path (promoted at
+ * width ≥ [IMAGE_PROMOTION_WIDTH_UNITS]); the cap is now relative to the viewport height so it scales
+ * with the device while still guarding against a 4000×3000 RAW screenshot blowing up the post:
+ * `max(400 dp, 0.5 × screenHeightDp)`. The 400 dp floor keeps a near-square image at ~90 % width on a
+ * typical ~410 dp-wide phone (there the 90 % width cap ≈ 370 dp binds first, so the height cap no
+ * longer bites), instead of re-creating a visible height cap. Pure so the caller
+ * (`PostRenderer.BlockImage`, which knows `screenHeightDp` via `LocalConfiguration`) stays a one-liner
+ * and the recalibration is JVM-testable.
+ */
+internal const val BLOCK_IMAGE_MAX_HEIGHT_FLOOR_DP = 400
+internal const val BLOCK_IMAGE_MAX_HEIGHT_SCREEN_FRACTION = 0.5f
+
+internal fun blockImageMaxHeightDp(screenHeightDp: Int): Int = maxOf(
+    BLOCK_IMAGE_MAX_HEIGHT_FLOOR_DP,
+    (screenHeightDp * BLOCK_IMAGE_MAX_HEIGHT_SCREEN_FRACTION).roundToInt(),
+)
 
 /**
  * #610 — block-promotion width threshold. Before #610 this was `INLINE_IMAGE_MAX_WIDTH_SP` (240), the

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -893,10 +894,11 @@ private fun ImageBlock(block: PostBlock.Image) = BlockImage(url = block.url, des
  * the whole block is tappable and opens that URL (#257), so a linked image gets the block treatment
  * AND keeps its tap-through instead of being kept as a small inline thumbnail.
  *
- * #610 — a MEASURED image renders in a box of EXACTLY its web-parity display size
+ * #610/#842 — a MEASURED image renders in a box of EXACTLY its parity display size
  * ([PostMediaDisplayPolicy.blockImageDisplaySize]: native size, no upscale, width ≤ 90% of the
- * column, height ≤ 200 dp), centred. Before #610 the container FILLED the column width — upscaling
- * any narrower source — with its height clamped to the legacy [160, 480] dp slot; that slot now only
+ * column, height ≤ the mobile-recalibrated [blockImageMaxHeightDp]), centred. Before #610 the
+ * container FILLED the column width — upscaling any narrower source — with its height clamped to the
+ * legacy [160, 480] dp slot; that slot now only
  * hosts a not-yet-measured image (cold cache / failed measurement). Bounded either way, so a
  * 4000×3000 RAW screenshot can't blow up the post and destroy the scroll position.
  *
@@ -936,15 +938,21 @@ private fun BlockImage(url: String, description: String?, linkUrl: String? = nul
         )
     }
 
+    // #842 — the block height cap is recalibrated for mobile (relative to the viewport), read here
+    // where the screen height is known; #610's flat 200 dp squeezed square/portrait photos to ~48 %
+    // width on phones (the width cap ≈ 90 % never got a chance to bind).
+    val screenHeightDp = LocalConfiguration.current.screenHeightDp
     // contentAlignment centres the (usually narrower-than-column, #610) exact box on its own line —
     // the same visual centring the pre-#610 full-width Fit letterboxing produced.
     BoxWithConstraints(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
         val displaySize = PostMediaDisplayPolicy.blockImageDisplaySize(
             measured = measured?.let { PixelSize(it.width, it.height) },
             availableWidthDp = maxWidth.value,
+            maxHeightDp = blockImageMaxHeightDp(screenHeightDp),
         )
-        // #610/#249 — the EXACT web-parity box when measured (no upscale, ≤ 90% width, ≤ 200 dp tall;
-        // anti-CLS: it is also the reserved loading slot), else the legacy full-width min/max slot.
+        // #610/#249/#842 — the EXACT parity box when measured (no upscale, ≤ 90% width, ≤ the
+        // mobile-recalibrated height cap; anti-CLS: it is also the reserved loading slot), else the
+        // legacy full-width min/max slot.
         val sizeModifier = if (displaySize != null) {
             Modifier.size(displaySize.width.dp, displaySize.height.dp)
         } else {

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicyTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostMediaDisplayPolicyTest.kt
@@ -65,9 +65,11 @@ class PostMediaDisplayPolicyTest {
     }
 
     @Test
-    fun `block display size caps a tall portrait to 200 like the web`() {
-        // The issue-repro shape (360×640): web max-height:200px → ~113×200. Before #610 the block
-        // path rendered it full-width and 480 dp tall (blockImageMaxHeight letterbox).
+    fun `block display size defaults to the legacy 200 height cap when none is passed`() {
+        // #842 — the DEFAULT [maxHeightDp] is the legacy inline value 200 (backward compat for the
+        // pure policy). The issue-repro shape (360×640) with the default → ~113×200. In production the
+        // renderer overrides this with the mobile-recalibrated [blockImageMaxHeightDp] (see the tests
+        // below); the flat 200 was never a real web rule (no max-height on HFR post images).
         val size = PostMediaDisplayPolicy.blockImageDisplaySize(
             measured = PixelSize(width = 360, height = 640),
             availableWidthDp = 400f,
@@ -127,10 +129,13 @@ class PostMediaDisplayPolicyTest {
     }
 
     @Test
-    fun `inline and block paths produce the same parity numbers (#610)`() {
-        // The whole point of #610: for any measured native size, the inline box (sp) and the block
-        // box (dp) carry the SAME numbers — units differ, values match. The inline path adds a
-        // one-line legibility floor (#253) that is a no-op for these ≥16-tall parity results.
+    fun `inline and block paths share the same parity policy at equal caps (#610)`() {
+        // #610's shared math: for any measured native size, at the SAME caps the inline box (sp) and
+        // the block box (dp) carry the SAME numbers — units differ, values match. The inline path adds
+        // a one-line legibility floor (#253) that is a no-op for these ≥16-tall parity results. NB
+        // #842: in production the two paths pass DIFFERENT height caps (inline 200 sp, block the
+        // recalibrated dp), so on-screen sizes diverge by design — this pins the shared policy, not
+        // the runtime caps (each image takes only one path per the width ≥ 240 promotion threshold).
         val columnWidthDp = 400f
         val relativeCapUnits = 360 // 0.9 × column, what the renderer passes on both paths
         listOf(
@@ -141,9 +146,69 @@ class PostMediaDisplayPolicyTest {
             PixelSize(300, 150),
         ).forEach { native ->
             val inline = imageParityDisplaySize(native, maxWidthUnits = relativeCapUnits)
+            // Pass the same default cap on both sides to compare the shared policy, not the caps.
             val block = PostMediaDisplayPolicy.blockImageDisplaySize(native, columnWidthDp)
             assertEquals("parity broken for $native", inline, block)
         }
+    }
+
+    // #842 — mobile recalibration of the BLOCK height cap (relative to the viewport), replacing the
+    // flat 200 that squeezed square/portrait photos to ~48 % width on phones.
+
+    @Test
+    fun `blockImageMaxHeightDp floors at 400 and scales with tall viewports`() {
+        // Floor wins on typical phones (0.5 × 700 = 350 < 400) so a near-square image reaches ~90 %
+        // width; the fraction wins on taller viewports so the cap grows with the device.
+        assertEquals(400, blockImageMaxHeightDp(screenHeightDp = 700))
+        assertEquals(400, blockImageMaxHeightDp(screenHeightDp = 800))
+        assertEquals(458, blockImageMaxHeightDp(screenHeightDp = 916))
+        assertEquals(500, blockImageMaxHeightDp(screenHeightDp = 1000))
+    }
+
+    @Test
+    fun `block display size lets a near-square photo fill ~90 percent width with the recalibrated cap`() {
+        // #842 report shape: an ~800×800 LEGO box on a ~411 dp-wide column (relative cap 370). With the
+        // flat 200 cap it rendered 200×200 (~48 % width); with the recalibrated cap (458 on a 916 dp
+        // viewport) the 90 % WIDTH cap binds first → 370×370, i.e. the intended ~90 % width.
+        val recalibrated = blockImageMaxHeightDp(screenHeightDp = 916)
+        val fixed = PostMediaDisplayPolicy.blockImageDisplaySize(
+            measured = PixelSize(width = 800, height = 800),
+            availableWidthDp = 411f,
+            maxHeightDp = recalibrated,
+        )
+        assertEquals(PixelSize(370, 370), fixed)
+        // Contrast: the shipped 0.26.0 behaviour (flat 200) — the regression this fixes.
+        assertEquals(
+            PixelSize(200, 200),
+            PostMediaDisplayPolicy.blockImageDisplaySize(
+                measured = PixelSize(width = 800, height = 800),
+                availableWidthDp = 411f,
+            ),
+        )
+    }
+
+    @Test
+    fun `block display size keeps a tall portrait bounded but taller than the old 200 cap`() {
+        // 800×1200 on a 411 dp column (relative cap 370), recalibrated cap 458: height binds →
+        // 305×458. Bounded (no scroll-destroying blow-up) yet no longer crushed to 133×200.
+        val fixed = PostMediaDisplayPolicy.blockImageDisplaySize(
+            measured = PixelSize(width = 800, height = 1200),
+            availableWidthDp = 411f,
+            maxHeightDp = blockImageMaxHeightDp(screenHeightDp = 916),
+        )
+        assertEquals(PixelSize(305, 458), fixed)
+    }
+
+    @Test
+    fun `block display size fills width for a landscape photo regardless of the height cap`() {
+        // 1200×675 on a 411 dp column (relative cap 370): width binds (as before), the height cap is
+        // irrelevant → 370×208, full ~90 % width. The recalibration never shrinks a landscape image.
+        val fixed = PostMediaDisplayPolicy.blockImageDisplaySize(
+            measured = PixelSize(width = 1200, height = 675),
+            availableWidthDp = 411f,
+            maxHeightDp = blockImageMaxHeightDp(screenHeightDp = 916),
+        )
+        assertEquals(PixelSize(370, 208), fixed)
     }
 
     @Test

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererImageParityRoborazziTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererImageParityRoborazziTest.kt
@@ -35,16 +35,20 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 
 /**
- * #610 — diagnostic-only Roborazzi captures of the unified inline/block `[img]` parity
- * (HFR-web `img { max-width: 90%; max-height: 200px }`, no upscale).
+ * #610/#842 — diagnostic-only Roborazzi captures of the `[img]` sizing (`max-width: 90%`, no upscale).
  *
- * Visual proof of the three #610 properties:
- *  - **inline/block parity**: the same 360×640 portrait renders at the SAME size (~113×200) inside
- *    prose (inline path, sp) and as a standalone `PostBlock.Image` (block path, dp) — pre-#610 the
- *    block was full-width and 480 dp tall while the inline was 113×200;
+ * Visual proof of the current properties (config `w360dp-h780dp` → block height cap
+ * [blockImageMaxHeightDp] = `max(400, 0.5×780)` = 400 dp):
+ *  - **inline height cap 200 (conservative, #842)**: a 360×640 portrait inside prose (inline path, sp)
+ *    stays ~113×200 so it never breaks the text flow;
+ *  - **block fills the width (#842)**: the SAME portrait as a standalone `PostBlock.Image` (block path)
+ *    now renders ~225×400 under the recalibrated cap — deliberately taller/wider than the inline box
+ *    (each image takes only one path per the width ≥ 240 promotion threshold), reversing #610's flat
+ *    200 that squeezed it to ~113×200 (~48 % width);
  *  - **no block upscale**: a small 80×60 image posted alone stays 80×60 centred — pre-#610
  *    `fillMaxWidth` blew it up to the column width;
- *  - **height cap**: a large 4:3 photo caps at 200 (267×200), not the legacy 480 dp letterbox.
+ *  - **bounded**: a large 4:3 photo is still bounded (width cap → ~295×221 here), not the legacy
+ *    480 dp letterbox nor a scroll-destroying blow-up.
  *
  * Images are fed by a [FakeImageLoaderEngine] returning distinct-coloured [ColorImage]s at native px,
  * and the intrinsic cache is pre-seeded so the first composition is already at the final size (no
@@ -90,17 +94,19 @@ class PostRendererImageParityRoborazziTest {
 
     @Test
     fun portraitInlineInProse() {
-        // The #610/#813-repro paragraph shape: text + [img] + text → INLINE path. Expected ~113×200.
-        capture("img_610_inline_in_prose", widthDp = 360) {
+        // The #610/#813-repro paragraph shape: text + [img] + text → INLINE path. Inline keeps the
+        // conservative 200 height cap (#842) → ~113×200, so an in-prose image never breaks the flow.
+        capture("img_inline_in_prose_cap200", widthDp = 360) {
             PostRenderer(content = inlineInProseContent())
         }
     }
 
     @Test
-    fun portraitStandaloneBlock() {
-        // Same portrait as a standalone PostBlock.Image → BLOCK path. Expected the SAME ~113×200,
-        // centred — compare with img_610_inline_in_prose (pre-#610: full width, 480 dp tall).
-        capture("img_610_standalone_block", widthDp = 360) {
+    fun portraitStandaloneBlockFillsWidth() {
+        // #842 — same portrait as a standalone PostBlock.Image → BLOCK path, recalibrated cap 400 dp
+        // (h780dp) → ~225×400, deliberately larger than the inline box above (compare
+        // img_inline_in_prose_cap200). Reverses #610's flat 200 (~113×200, ~48 % width).
+        capture("img_842_standalone_block_fills_width", widthDp = 360) {
             PostRenderer(content = standaloneBlockContent(portraitUrl))
         }
     }
@@ -114,9 +120,10 @@ class PostRendererImageParityRoborazziTest {
     }
 
     @Test
-    fun largePhotoBlockCapsAt200() {
-        // 4000×3000 → 267×200 (height cap), not the legacy full-width 480 dp letterbox.
-        capture("img_610_large_block_cap200", widthDp = 360) {
+    fun largePhotoBlockStaysBounded() {
+        // #842 — 4000×3000 stays bounded by the 90 % width cap → ~295×221 here (not the legacy
+        // 480 dp letterbox, not a full-screen blow-up). The recalibrated height cap never upscales.
+        capture("img_842_large_block_bounded", widthDp = 360) {
             PostRenderer(content = standaloneBlockContent(photoUrl))
         }
     }
@@ -127,7 +134,7 @@ class PostRendererImageParityRoborazziTest {
                 inlines = listOf(
                     PostInline.Text("Texte avant la photo "),
                     PostInline.InlineImage(url = portraitUrl, description = "portrait"),
-                    PostInline.Text(" puis texte après : la photo est capée à 200 de haut (parité web)."),
+                    PostInline.Text(" puis texte après : en inline la photo est capée à 200 de haut (#842)."),
                 ),
             ),
         ),


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Closes #842.

## Problème
Retour fil DEV (0.26.0) : les images de post quasi carrées/portrait ne remplissent pas ~90 % de la largeur — mesuré **~48 %** sur une boîte LEGO carrée (écran 411 dp). Cause : #610 a introduit un cap de **hauteur** `IMAGE_MAX_HEIGHT_UNITS = 200` appliqué en dp sur le chemin bloc. Pour un ratio < ~1,6:1, `min(0,9×largeur/w ; 200/h ; 1)` est dominé par `200/h` → largeur bridée. Ce 200 n'a **pas de base web** (les fixtures HFR ne portent aucun `max-height` ; la règle web est `img { max-width: 90% }`), hérité d'une suggestion arbitraire de #224.

## Correctif (chemin BLOC uniquement)
- `blockImageDisplaySize` gagne `maxHeightDp: Int = IMAGE_MAX_HEIGHT_UNITS` (défaut 200 = rétrocompat de la policy pure + parité inline inchangée).
- Nouveau helper pur `blockImageMaxHeightDp(screenHeightDp) = max(400, 0,5 × screenHeightDp)`.
- `BlockImage` lit `LocalConfiguration.current.screenHeightDp` et passe le cap recalibré.
- **Inline inchangé** (200 sp, conservateur pour le flux texte). Aucun upscale introduit. #610 (classification inline/bloc) reste valide.

Effet : une image carrée 800×800 sur colonne ~411 dp passe de **200×200 (~48 %)** à **370×370 (~90 % de largeur)** ; paysage inchangé (remplit déjà la largeur) ; portrait borné (par ex. 800×1200 → 305×458) sans exploser le scroll.

## Validation
- **Cadrage + gate Codex** (gpt-5.5/xhigh) : **GO**, arithmétique et no-upscale validés ; seul suivi hors-gate non bloquant : aligner le slot cold-cache (480 dp) au nouveau cap pour un anti-CLS strict sur très grands écrans.
- Canonique complète (detektAll, lintDebug, lintProdDebug, testDebugUnitTest, assembleProdDebug) : **verte**.
- Tests pur-JVM : cap recalibré (carré → 370×370, portrait → 305×458, paysage → 370×208, contraste avec le flat 200 → 200×200) + helper ; Roborazzi diagnostique recommenté.
- Dogfood émulateur : app OK (pas de crash), images rendues ; capture Roborazzi = preuve déterministe du portrait bloc qui remplit désormais la largeur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pm28ny4V5GSegmKJxTPVAM