### PR TITLE
fix(topic,app): surface the draft-restore banner on cold full-editor opens (#843)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -2504,12 +2504,30 @@ private fun RedfaceNavHost(
                         topicScrollNavState.onAnchorSaved(route.cat, route.post, route.page, anchor)
                     },
                     onOpenProfile = onOpenProfile,
-                    // #604 lots 1-3 — onReply is the quick-reply sheet's ESCALATION : the sheet
-                    // just persisted the shared #405 row, so the editor auto-applies it (#790,
-                    // resumeSharedDraft) instead of surfacing the restore banner. The armed quote
-                    // cards travel as FULL previews through the in-memory handoff (lot 3, mockup
-                    // P3) — the editor renders the same cards and materialises at submit.
+                    // #843 — onReply is a COLD full-editor open (FAB under FULL_EDITOR, « Citer »
+                    // routed to the editor, #823 long-press): no sheet is in flight, so
+                    // resumeSharedDraft = false and an existing #405 draft is SURFACED via the
+                    // restore banner (Restaurer / Ignorer) instead of being silently re-applied. The
+                    // armed quote cards still travel as FULL previews through the in-memory handoff
+                    // (lot 3) — cards are independent of the text draft. The genuine sheet escalation
+                    // uses onEscalateToFullEditor below.
                     onReply = { subcat, page, quotes ->
+                        multiQuoteNavState.onEditorQuotesHandoff(quotes.takeIf { it.isNotEmpty() })
+                        backStack.add(
+                            PostEditorRoute(
+                                mode = PostEditorMode.Reply,
+                                cat = route.cat,
+                                topicId = route.post,
+                                page = page,
+                                subcat = subcat,
+                                resumeSharedDraft = false,
+                            ),
+                        )
+                    },
+                    // #843/#790 — the quick-reply sheet's ESCALATION only: the sheet just persisted
+                    // the shared #405 row, so the editor auto-applies it (resumeSharedDraft = true,
+                    // silent append — same composition act) WITHOUT surfacing the restore banner.
+                    onEscalateToFullEditor = { subcat, page, quotes ->
                         multiQuoteNavState.onEditorQuotesHandoff(quotes.takeIf { it.isNotEmpty() })
                         backStack.add(
                             PostEditorRoute(
@@ -2568,8 +2586,10 @@ private fun RedfaceNavHost(
                         // handed to the editor (cards, mockup P3) through the in-memory handoff.
                         // The basket is cleared on launch: the selection's intent is consumed,
                         // and backing out of the editor should not re-arm a stale « Citer N ».
-                        // resumeSharedDraft (Codex fork 4) : quoting is a continuation of this
-                        // topic's composition — any sheet-drafted text is picked up bannerless.
+                        // #843 — « Citer N » (3+) is a COLD full-editor open, not a sheet escalation:
+                        // resumeSharedDraft = false, so an existing text draft is offered via the
+                        // restore banner (cards are independent of it), instead of the silent append
+                        // the escalation flag used to force here (pre-#843 Codex fork 4).
                         val selection = multiQuoteNavState.basket
                             ?.takeIf { it.matches(route.cat, route.post) }
                             ?.selections
@@ -2583,7 +2603,7 @@ private fun RedfaceNavHost(
                                     topicId = route.post,
                                     page = page,
                                     subcat = subcat,
-                                    resumeSharedDraft = true,
+                                    resumeSharedDraft = false,
                                 ),
                             )
                             multiQuoteNavState.onClear()

--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorRequest.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorRequest.kt
@@ -31,10 +31,15 @@ data class PostEditorRequest(
      */
     val initialQuotes: List<QuotedPostPreview> = emptyList(),
     /**
-     * #790 (#604 lot 2) — `true` when this editor is the ESCALATION of a quick-reply sheet. The
+     * #790 (#604 lot 2) — `true` ONLY when this editor is the ESCALATION of a quick-reply sheet. The
      * ViewModel then auto-applies the shared #405 draft row instead of surfacing the restore
      * banner (appending to anything already typed — the escalation continues the same
      * composition act).
+     *
+     * #843 — this flag is escalation-ONLY again. The #829/#833 COLD full-editor opens (FAB under the
+     * FULL_EDITOR preset, « Citer », long-press, « Citer N » 3+) had wrongly set it too, silently
+     * re-applying an old draft with no « Ignorer »; they now pass `false` so the restore banner is
+     * surfaced. Only `RedfaceNavigation.onEscalateToFullEditor` sets it `true`.
      */
     val resumeSharedDraft: Boolean = false,
 )

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -134,15 +134,25 @@ import kotlinx.coroutines.flow.first
 fun TopicScreen(
     request: TopicRequest,
     /**
-     * Open the FULL-SCREEN reply editor for this topic — since #604 lot 1 this is the quick-reply
-     * sheet's ESCALATION only (the reply FAB opens the sheet). The lambda receives the topic's
-     * sub-category id, the current page, and the armed quote cards as FULL previews in citation
-     * order (lot 3 — empty for a plain escalation) ; cat and topicId are derived from [request].
-     * `:app` hands the previews to the editor through the in-memory handoff (never the route) with
-     * `resumeSharedDraft = true` (#790) so the editor auto-applies the sheet's #405 row and
-     * renders the same cards (mockup P3).
+     * Open the FULL-SCREEN reply editor COLD for this topic — the reply FAB under the FULL_EDITOR
+     * preset, « Citer » routed to the full editor (#806), and the #823 long-press. The lambda
+     * receives the topic's sub-category id, the current page, and the armed quote cards as FULL
+     * previews in citation order (empty for a plain reply) ; cat and topicId are derived from
+     * [request]. `:app` hands the previews to the editor through the in-memory handoff (never the
+     * route). #843 — a COLD open sets `resumeSharedDraft = false`, so an existing #405 draft is
+     * SURFACED via the restore banner (Restaurer / Ignorer) instead of being silently re-applied:
+     * these cold paths had lost that choice when #829/#833 reused the escalation flag.
      */
     onReply: (subcat: Int, page: Int, quotes: List<QuotedPostPreview>) -> Unit,
+    /**
+     * #843 — the quick-reply sheet's ESCALATION to the full editor (the only genuine « resume the
+     * same composition » case). Same handoff as [onReply] but `:app` sets `resumeSharedDraft = true`
+     * (#790): the sheet JUST wrote the #405 row, so the editor auto-applies it (appending to any
+     * typed text) WITHOUT a banner — re-proposing a draft the user is visibly continuing would be
+     * noise. Defaults to a no-op for non-topic callers (previews/tests never escalate).
+     */
+    onEscalateToFullEditor: (subcat: Int, page: Int, quotes: List<QuotedPostPreview>) -> Unit =
+        { _, _, _ -> },
     /**
      * Vague 4 (#604) lot 1 — HFR accepted a reply POSTed from the quick-reply sheet. `:app` must
      * refresh this topic route exactly like the full editor's onSubmitSucceeded (replace the route
@@ -473,6 +483,7 @@ fun TopicScreen(
         onIntent = viewModel::send,
         onBack = onBack,
         onReply = onReply,
+        onEscalateToFullEditor = onEscalateToFullEditor,
         onQuickReplySubmitted = onQuickReplySubmitted,
         onEdit = onEdit,
         onEditFirstPost = onEditFirstPost,
@@ -720,6 +731,10 @@ internal fun TopicContent(
     onIntent: (TopicIntent) -> Unit,
     onBack: () -> Unit,
     onReply: (subcat: Int, page: Int, quotes: List<QuotedPostPreview>) -> Unit,
+    // #843 — the quick-reply sheet's escalation (resumeSharedDraft = true, silent append) ; distinct
+    // from [onReply] which is a COLD full-editor open (resumeSharedDraft = false → restore banner).
+    onEscalateToFullEditor: (subcat: Int, page: Int, quotes: List<QuotedPostPreview>) -> Unit =
+        { _, _, _ -> },
     onEdit: (subcat: Int, page: Int, numreponse: Int) -> Unit,
     onEditFirstPost: (subcat: Int, page: Int, numreponse: Int) -> Unit,
     onOpenPage: (Int) -> Unit,
@@ -819,8 +834,9 @@ internal fun TopicContent(
                                 page = page,
                             ),
                         )
-                        // Same :app path as the sheet's escalation — in-memory quote handoff
-                        // (empty) + PostEditorRoute(resumeSharedDraft = true).
+                        // #843 — cold full-editor open (no sheet in flight): in-memory quote handoff
+                        // (empty) + PostEditorRoute(resumeSharedDraft = false) → an existing draft is
+                        // offered via the restore banner, not silently re-applied.
                         WritingSurface.FULL_EDITOR -> onReply(subcat, page, emptyList())
                     }
                 },
@@ -921,8 +937,10 @@ internal fun TopicContent(
                                 hiddenNumreponses = mode.hiddenNumreponses,
                                 // #604 lot 2 / #806 — « Citer » opens the quick-reply sheet with the
                                 // card pre-armed (1-citation session), unless the preset routes any
-                                // citation to the full-screen editor (decision at tap time; same :app
-                                // path as the sheet's escalation, resumeSharedDraft = true).
+                                // citation to the full-screen editor (decision at tap time). #843 —
+                                // that full-editor open is COLD (onReply, resumeSharedDraft = false):
+                                // the cards are handed over, an existing text draft is offered via the
+                                // restore banner, not silently appended.
                                 onQuoteRequested = { preview ->
                                     when (writingSurfaceFor(state.writingSurfacePreset, quoteCount = 1)) {
                                         WritingSurface.SHEET -> quickReplyFor = QuickReplyLaunch(
@@ -940,10 +958,10 @@ internal fun TopicContent(
                                 },
                                 // #823 — LONG press on « Citer » : one-shot override of the #806
                                 // preset — always the full-screen editor, through the same :app path
-                                // as the FULL_EDITOR branch above (in-memory handoff +
-                                // resumeSharedDraft = true, #790). Deliberately does NOT consult
-                                // writingSurfaceFor: the gesture IS the routing decision (identical
-                                // to the tap under the FULL_EDITOR preset).
+                                // as the FULL_EDITOR branch above (cold open, in-memory handoff +
+                                // resumeSharedDraft = false → restore banner, #843). Deliberately
+                                // does NOT consult writingSurfaceFor: the gesture IS the routing
+                                // decision (identical to the tap under the FULL_EDITOR preset).
                                 onQuoteFullEditorRequested = { preview ->
                                     onReply(mode.topic.subcat, mode.topic.page, listOf(preview))
                                 },
@@ -976,7 +994,9 @@ internal fun TopicContent(
             onDismiss = { quickReplyFor = null },
             onEscalate = { quotes ->
                 quickReplyFor = null
-                onReply(launch.request.subcat, launch.request.page, quotes)
+                // #843 — genuine escalation: resumeSharedDraft = true (silent append), NOT the cold
+                // onReply path which surfaces the restore banner.
+                onEscalateToFullEditor(launch.request.subcat, launch.request.page, quotes)
             },
             onSubmitted = { targetPage, scrollTo ->
                 quickReplyFor = null


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Closes #843.

## Problème
Retour fil DEV (0.26.0) : « le message pour les brouillons a disparu ». `resumeSharedDraft` avait dérivé de son contrat #790 (escalade de feuille UNIQUEMENT) : les presets #829, l'appui long #823 et le multi-quote 3+ le posaient aussi sur des ouvertures **à froid** → un vieux brouillon était ré-appliqué silencieusement, sans bannière ni « Ignorer ».

## Correctif (cadrage Codex, verdict A)
- Scission au niveau TopicScreen : **`onReply` = ouverture à froid** (navigation pose `resumeSharedDraft = false` → bannière Restaurer/Ignorer) ; **nouveau `onEscalateToFullEditor`** = escalade génuine de la feuille (`= true`, append silencieux — #790 inchangé), appelé uniquement par `QuickReplySheet.onEscalate`.
- « Citer N » 3+ : bascule aussi à froid (`false`) — les cartes de citation sont indépendantes du texte brouillon et voyagent comme avant (handoff mémoire).
- Doc de `PostEditorRequest.resumeSharedDraft` réaffirmée « escalation-ONLY ». Le branchement du ViewModel est **inchangé** (déjà pinné par `PostEditorViewModelTest` dans les deux sens).
- Hors périmètre : MP, topic-form, édition, Drapeaux (bannières intactes) ; la feuille par défaut (auto-apply silencieux) est un comportement pré-existant — suivi UX possible séparément.

## Validation
- **Cadrage + gate Codex** (gpt-5.5/xhigh) : **GO** — recâblage exhaustif vérifié, contrat #790 préservé, cartes cohérentes.
- Canonique complète : **verte**.
- **Dogfood émulateur** (3 flux) : appui long « Citer » avec brouillon en attente → **bannière « Un brouillon non envoyé a été retrouvé » + carte de citation + champ vide** ✓ ; « Restaurer » → texte rétabli, bannière fermée ✓ ; feuille → escalade → texte repris **sans** bannière ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pm28ny4V5GSegmKJxTPVAM