### PR TITLE
chore(release): bump versionName to 0.26.1 (image height cap + draft banner fixes)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,16 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.26.1` — `internal` (dev) — 2026-07-07
+
+**Réponses aux deux premiers retours du fil DEV sur la 0.26.0** (même soirée).
+
+### Lecture (vue Topic)
+- #842 : le **plafond de hauteur des images bloc est recalibré pour mobile** — `max(400 dp, 0,5 × hauteur d'écran)` au lieu du flat 200 dp de #610 (PR #844). Une image quasi carrée/portrait remplit maintenant ~90 % de la largeur (mesurée à ~48 % sur le retour du fil) ; paysage inchangé ; toujours borné (pas d'explosion du scroll), aucun upscale. Le 200 n'avait pas de base web réelle (la seule règle HFR est `max-width: 90%`) — l'étiquette « parité web » de #610 est corrigée dans le code. Chemin inline inchangé (200 sp, conservateur dans la prose).
+
+### Éditeur & brouillons
+- #843 : la **bannière « Un brouillon non envoyé a été retrouvé » (Restaurer / Ignorer) est de retour sur les ouvertures à froid** de l'éditeur plein écran (PR #845) — FAB en preset plein écran, « Citer » routé vers l'éditeur, appui long #823, « Citer N » 3+. `resumeSharedDraft` avait dérivé de son contrat #790 : ces chemins ré-appliquaient silencieusement un vieux brouillon, sans choix d'ignorer. L'escalade feuille → éditeur garde l'append silencieux (#790 inchangé).
+
 ## `0.26.0` — `internal` (dev) — 2026-07-07
 
 **Vague 5 Vue Topic (#604)** : interactions image, lot citations, rendu média parité web, gestes d'appui long, recherche smileys, fix Drapeaux.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.26.0"
+        versionName = "0.26.1"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,7 +1,4 @@
-Redface 2 v0.26.0 — dev.
+Redface 2 v0.26.1 — dev.
 
-- Long-press an image: copy URL, open, save.
-- Quotes: blacklisted authors hidden inside quotes too, back returns to your reading spot after a quote jump, long quotes collapse to a preview.
-- Images sized like the website.
-- Long-press: page FABs → first/last, Quote → full editor.
-- Smiley search restored on reopen; empty-categories filter fixed on the read tab.
+- Square and portrait images finally fill ~90% of the width (height cap recalibrated for mobile).
+- The "draft found" message (Restore / Discard) is back when opening the editor with a pending draft.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,7 +1,4 @@
-Redface 2 v0.26.0 — dev.
+Redface 2 v0.26.1 — dev.
 
-- Appui long sur une image : copier l'URL, ouvrir, enregistrer.
-- Citations : auteurs black-listés masqués aussi en citation, retour à la position de lecture après un saut, citations longues repliées avec aperçu.
-- Images à la taille du site web.
-- Appui long : FAB de page → première/dernière, Citer → éditeur plein écran.
-- Recherche de smileys conservée à la réouverture ; filtre « catégories vides » corrigé sur l'onglet lus.
+- Les images carrées et portrait remplissent enfin ~90 % de la largeur (le plafond de hauteur est recalibré pour mobile).
+- Le message « brouillon retrouvé » (Restaurer / Ignorer) est de retour quand on ouvre l'éditeur avec un brouillon en attente.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump `versionName` 0.26.0 → **0.26.1** (patch, politique A) + entrée `app/CHANGELOG.md` + whatsnew fr/en (guard `check-whatsnew.sh 0.26.1` vert en local).

Contenu : #842 (recalibration du cap de hauteur des images bloc, PR #844) + #843 (bannière brouillon sur ouverture à froid, PR #845) — les réponses aux deux retours du fil DEV sur la 0.26.0.

Dispatch `channel=dev --ref dev` après merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pm28ny4V5GSegmKJxTPVAM