### PR TITLE
fix(topic,editor) : champ d'écriture prioritaire sur écran court + fermeture de la feuille en un back

### DIFF
--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorScreen.kt
@@ -14,6 +14,7 @@ import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -52,6 +53,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -179,32 +181,43 @@ private fun PostEditorContent(
 
                 // #604 lot 3 (mockup P3) — the armed citations as cards ABOVE the field, the same
                 // rendering as the quick-reply sheet : the field only ever holds the user's text,
-                // the [quotemsg] blocks are materialised at submit. Scrolls internally past a few
-                // cards so a heavy multiquote can never crush the weighted field below. (Renders
-                // nothing without cards — the empty-check lives inside, detekt complexity budget.)
-                EditorQuoteCards(
-                    quotes = state.quotes,
-                    enabled = !state.isSubmitting,
-                    onIntent = onIntent,
-                )
+                // the [quotemsg] blocks are materialised at submit.
+                // #555 — everything that competes with the field for vertical space (draft
+                // banner, error banners, cards) lives in ONE top zone that scrolls past its
+                // budget : the field keeps EDITOR_FIELD_MIN_HEIGHT no matter how short the
+                // IME leaves the window. Before this, the field was the only weighted child
+                // and fixed content could crush it to zero pixels on a short display (thibw).
+                BoxWithConstraints(modifier = Modifier.weight(1f)) {
+                    val topZoneMaxHeight = editorTopZoneMaxHeight(available = maxHeight)
+                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        EditorTopZone(
+                            state = state,
+                            onIntent = onIntent,
+                            maxHeight = topZoneMaxHeight,
+                        )
 
-                BbcodeTextField(
-                    value = state.draft,
-                    onValueChange = { value -> onIntent(PostEditorIntent.ContentChanged(value)) },
-                    label = stringResource(R.string.editor_field_label),
-                    placeholder = stringResource(R.string.editor_field_placeholder),
-                    modifier = Modifier.weight(1f),
-                    // #275/#410 — grow-with-content field in its own scrollable viewport so the
-                    // cursor stays visible under the IME (typing AND refocus after the preview).
-                    fillViewport = true,
-                    // Multi-image upload — lock editing during a batch so the user can't move the
-                    // caret between two programmatic [img] insertions (keeps them in pick order).
-                    readOnly = state.isUploading,
-                    // #555 — the editor opens ready to type: focus + IME on entry. Critical in edit
-                    // mode (field hydrated with a long post: nothing set the focus, keyboard closed,
-                    // #447 caret-follow inert) ; for a reply it is the expected behaviour anyway.
-                    autoFocus = true,
-                )
+                        BbcodeTextField(
+                            value = state.draft,
+                            onValueChange = { value -> onIntent(PostEditorIntent.ContentChanged(value)) },
+                            label = stringResource(R.string.editor_field_label),
+                            placeholder = stringResource(R.string.editor_field_placeholder),
+                            modifier = Modifier.weight(1f),
+                            // #275/#410 — grow-with-content field in its own scrollable viewport so
+                            // the cursor stays visible under the IME (typing AND refocus after the
+                            // preview).
+                            fillViewport = true,
+                            // Multi-image upload — lock editing during a batch so the user can't
+                            // move the caret between two programmatic [img] insertions (keeps them
+                            // in pick order).
+                            readOnly = state.isUploading,
+                            // #555 — the editor opens ready to type: focus + IME on entry. Critical
+                            // in edit mode (field hydrated with a long post: nothing set the focus,
+                            // keyboard closed, #447 caret-follow inert) ; for a reply it is the
+                            // expected behaviour anyway.
+                            autoFocus = true,
+                        )
+                    }
+                }
 
                 Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
                     TextButton(onClick = { onIntent(PostEditorIntent.TogglePreview) }) {
@@ -230,35 +243,6 @@ private fun PostEditorContent(
                             .verticalScroll(rememberScrollState()),
                     ) {
                         BbcodePreview(content = state.preview)
-                    }
-                }
-
-                if (state.restorableDraft != null) {
-                    DraftRestoreBanner(
-                        onRestore = { onIntent(PostEditorIntent.DraftRestoreRequested) },
-                        onDiscard = { onIntent(PostEditorIntent.DraftDiscardRequested) },
-                    )
-                }
-
-                state.submitError?.let { error ->
-                    Text(
-                        text = stringResource(error.bannerResId),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.error,
-                    )
-                    TextButton(onClick = { onIntent(PostEditorIntent.ErrorDismissed) }) {
-                        Text(text = stringResource(R.string.editor_error_dismiss))
-                    }
-                }
-
-                state.uploadError?.let { error ->
-                    Text(
-                        text = error.bannerText(),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.error,
-                    )
-                    TextButton(onClick = { onIntent(PostEditorIntent.UploadErrorDismissed) }) {
-                        Text(text = stringResource(R.string.editor_error_dismiss))
                     }
                 }
 
@@ -373,10 +357,71 @@ internal fun DraftRestoreBanner(
 }
 
 /**
+ * #555 — the editor's TOP ZONE : everything that competes with the draft field for vertical
+ * space (draft-restore banner, submit/upload error banners, quote cards) in one scrollable
+ * column bounded by [maxHeight] (the [editorTopZoneMaxHeight] budget). Scrolling past the
+ * budget keeps every element reachable while the field keeps its guaranteed minimum below.
+ */
+@Composable
+private fun EditorTopZone(
+    state: PostEditorState,
+    onIntent: (PostEditorIntent) -> Unit,
+    maxHeight: Dp,
+) {
+    // Gate Codex — an alert must not appear below the zone's internal fold : snap the zone
+    // back to the top whenever a banner (draft, submit, upload) shows up, so it is the first
+    // thing in the viewport.
+    val scroll = rememberScrollState()
+    val hasAlert = state.restorableDraft != null ||
+        state.submitError != null || state.uploadError != null
+    LaunchedEffect(hasAlert) {
+        if (hasAlert) scroll.animateScrollTo(0)
+    }
+    Column(
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier
+            .heightIn(max = maxHeight)
+            .verticalScroll(scroll),
+    ) {
+        if (state.restorableDraft != null) {
+            DraftRestoreBanner(
+                onRestore = { onIntent(PostEditorIntent.DraftRestoreRequested) },
+                onDiscard = { onIntent(PostEditorIntent.DraftDiscardRequested) },
+            )
+        }
+        state.submitError?.let { error ->
+            Text(
+                text = stringResource(error.bannerResId),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error,
+            )
+            TextButton(onClick = { onIntent(PostEditorIntent.ErrorDismissed) }) {
+                Text(text = stringResource(R.string.editor_error_dismiss))
+            }
+        }
+        state.uploadError?.let { error ->
+            Text(
+                text = error.bannerText(),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error,
+            )
+            TextButton(onClick = { onIntent(PostEditorIntent.UploadErrorDismissed) }) {
+                Text(text = stringResource(R.string.editor_error_dismiss))
+            }
+        }
+        EditorQuoteCards(
+            quotes = state.quotes,
+            enabled = !state.isSubmitting,
+            onIntent = onIntent,
+        )
+    }
+}
+
+/**
  * #604 lot 3 (mockup P3) — the quote cards block of the full-screen editor : the shared
  * [QuoteCard] rendering plus « Tout vider » (#436, shown from two cards up — for one card the
- * per-card ✕ is the same act). The cards column scrolls internally above [MAX_VISIBLE_CARDS_HEIGHT]
- * so a heavy multiquote (the case that FORCES the full screen) never crushes the draft field.
+ * per-card ✕ is the same act). Deliberately UNBOUNDED here : the block lives inside the
+ * editor's budgeted top zone (#555), whose single scroll keeps every card reachable.
  */
 @Composable
 private fun EditorQuoteCards(
@@ -407,15 +452,28 @@ private fun EditorQuoteCards(
                 onMoveDown = { numreponse -> onIntent(PostEditorIntent.QuoteMoved(numreponse, delta = 1)) },
                 onRemove = { numreponse -> onIntent(PostEditorIntent.QuoteRemoved(numreponse)) },
             ),
-            modifier = Modifier
-                .heightIn(max = MAX_VISIBLE_CARDS_HEIGHT)
-                .verticalScroll(rememberScrollState()),
         )
     }
 }
 
-// #604 lot 3 — ~4 one-line cards ; past that the cards column scrolls internally.
-private val MAX_VISIBLE_CARDS_HEIGHT = 192.dp
+/**
+ * #555 — the top-zone budget of the editor : the draft banner, error banners and quote cards
+ * share whatever the available height leaves ABOVE the field's guaranteed minimum, bounded by
+ * [EDITOR_TOP_ZONE_MAX_HEIGHT] on a roomy display. Pure — pinned by unit test.
+ */
+internal fun editorTopZoneMaxHeight(available: Dp): Dp =
+    (available - EDITOR_FIELD_MIN_HEIGHT - EDITOR_ZONE_SPACING)
+        .coerceIn(0.dp, EDITOR_TOP_ZONE_MAX_HEIGHT)
+
+// #555 — « Tout vider » + ~4 one-line cards (the historical 240dp cards budget) + room for a
+// draft/error banner. Past that the top zone scrolls.
+internal val EDITOR_TOP_ZONE_MAX_HEIGHT = 360.dp
+
+// #555 — the draft field never shrinks below this, whatever the IME + top zone demand.
+internal val EDITOR_FIELD_MIN_HEIGHT = 96.dp
+
+// Spacing between the top zone and the field inside their shared weighted box.
+private val EDITOR_ZONE_SPACING = 12.dp
 
 /**
  * Display state of [EditorSubmitBar]. [confirmArmed] is the « confirmation avant

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/EditorCardsZoneBudgetTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/EditorCardsZoneBudgetTest.kt
@@ -1,0 +1,39 @@
+package fr.forumhfr.redface2.feature.editor
+
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #555 — the pure budget behind the editor's {top zone + field} weighted box : the top zone
+ * (draft banner, error banners, quote cards) gets whatever the available height leaves ABOVE
+ * the field's guaranteed minimum, bounded by the roomy-display cap. Pinning it here is what
+ * keeps « the field can never be crushed to zero by the IME + cards » true (thibw, dev 0.26.1).
+ */
+class EditorCardsZoneBudgetTest {
+
+    @Test
+    fun `roomy display keeps the historical cap`() {
+        // 700 − 96 − 12 = 592 → capped at 360 (banner + « Tout vider » + ~4 cards).
+        assertEquals(360.dp, editorTopZoneMaxHeight(available = 700.dp))
+    }
+
+    @Test
+    fun `short window hands the top zone only what the field minimum leaves`() {
+        // 300 − 96 − 12 = 192 → below the cap, the top zone shrinks.
+        assertEquals(192.dp, editorTopZoneMaxHeight(available = 300.dp))
+        // 200 − 96 − 12 = 92.
+        assertEquals(92.dp, editorTopZoneMaxHeight(available = 200.dp))
+    }
+
+    @Test
+    fun `tiny window gives everything to the field`() {
+        // 100 − 96 − 12 < 0 → clamped to zero, the field takes the whole zone.
+        assertEquals(0.dp, editorTopZoneMaxHeight(available = 100.dp))
+    }
+
+    @Test
+    fun `field minimum plus spacing is the exact break-even point`() {
+        assertEquals(0.dp, editorTopZoneMaxHeight(available = EDITOR_FIELD_MIN_HEIGHT + 12.dp))
+    }
+}

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySheet.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySheet.kt
@@ -96,7 +96,12 @@ internal fun QuickReplySheet(
     // refresh) or replay it at the next opening. `submitting` is read through
     // rememberUpdatedState because both guards below are remembered once.
     val submitting = rememberUpdatedState(state.isSubmitting)
+    // #854 — no half-height stop : this is a TYPING surface (autofocused field, IME quasi
+    // permanent), the M3 PartiallyExpanded state only ever appears when a short display makes
+    // the content taller than half the screen — and then a back/swipe must dismiss in ONE step,
+    // not park the sheet at mid-height (thibw : « 3× retour pour revenir au topic »).
     val sheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true,
         confirmValueChange = { target -> target != SheetValue.Hidden || !submitting.value },
     )
     ModalBottomSheet(
@@ -113,92 +118,99 @@ internal fun QuickReplySheet(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 8.dp)
                 .imePadding()
-                .navigationBarsPadding()
-                // #604 lot 4a — the sheet content scrolls : with the keyboard up (~40 % of the
-                // screen), two cards + the field + Envoyer can overflow a small or landscape
-                // display, leaving the send button unreachable (cadrage Codex, item 1).
-                .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+                .navigationBarsPadding(),
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    text = stringResource(R.string.quick_reply_title),
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.weight(1f),
-                )
-                IconButton(
-                    onClick = viewModel::onEscalateRequested,
-                    // Gate #788 — no escalation while a POST is in flight (submit vs navigation
-                    // race) ; #805 — nor while a [quotemsg] insert is being fetched.
-                    enabled = !state.isSubmitting && !state.isPreparingQuotes,
-                    modifier = Modifier.semantics { contentDescription = fullScreenLabel },
-                ) {
-                    RedfaceVectorIcon(
-                        resId = fr.forumhfr.redface2.core.ui.R.drawable.ic_ms_open_in_new,
-                    )
-                }
-            }
-            // #604 lot 4a — shared column : cards + live-region announcements + post-removal
-            // focus (always composed ; renders nothing visible without cards).
-            // #808 — the cards block is CAPPED and scrolls internally so a heavy selection can
-            // never push the field and « Envoyer » under the IME fold : the field is the priority
-            // surface. Same pattern as the editor's EditorQuoteCards (192dp) and
-            // RecipientManagerSheet. Unconditional cap (no isImeVisible gate) : the field
-            // autofocuses on open so the IME is quasi-permanent here, and the cap also covers
-            // landscape ; nested same-direction scroll has a working precedent in
-            // RecipientManagerSheet.
-            QuoteCardsColumn(
-                quotes = state.quotes,
-                enabled = !state.isSubmitting,
-                callbacks = QuoteCardsCallbacks(
-                    onMoveUp = { numreponse -> viewModel.onQuoteMoved(numreponse, delta = -1) },
-                    onMoveDown = { numreponse -> viewModel.onQuoteMoved(numreponse, delta = 1) },
-                    onRemove = viewModel::onQuoteRemoved,
-                ),
+            // #855 — only the FIELDS scroll ; « Envoyer » is pinned OUTSIDE the scroll, always
+            // visible above the IME. Before this, the whole column scrolled (#604 lot 4a) and on
+            // a short display the send button silently sat below the keyboard fold (thibw).
+            // weight(fill = false) : take AT MOST the space above the pinned row, never stretch
+            // the sheet taller than its natural content on a roomy display.
+            Column(
                 modifier = Modifier
-                    .heightIn(max = QUICK_REPLY_MAX_CARDS_HEIGHT)
-                    .verticalScroll(rememberScrollState())
-                    .testTag("quick_reply_quote_cards"),
-            )
-            OutlinedTextField(
-                value = state.text,
-                onValueChange = viewModel::onTextChanged,
-                enabled = !state.isSubmitting,
-                // #807 — same #237 contract as BbcodeTextField : Compose capitalises NOTHING by
-                // default, the IME needs the explicit autoCap hint (surface regression, v220).
-                keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
-                placeholder = { Text(stringResource(R.string.quick_reply_hint)) },
-                minLines = 3,
-                maxLines = 6,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .focusRequester(focusRequester),
-            )
-            // #805 cards OFF — the [quotemsg] fetch runs at opening : typing stays enabled (the
-            // insert concatenates onto the live field), only send/escalate wait for it.
-            if (state.isPreparingQuotes) {
+                    .weight(1f, fill = false)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.padding(end = 8.dp).size(16.dp),
-                        strokeWidth = 2.dp,
-                    )
                     Text(
-                        text = stringResource(R.string.quick_reply_preparing_quote),
+                        text = stringResource(R.string.quick_reply_title),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.weight(1f),
+                    )
+                    IconButton(
+                        onClick = viewModel::onEscalateRequested,
+                        // Gate #788 — no escalation while a POST is in flight (submit vs navigation
+                        // race) ; #805 — nor while a [quotemsg] insert is being fetched.
+                        enabled = !state.isSubmitting && !state.isPreparingQuotes,
+                        modifier = Modifier.semantics { contentDescription = fullScreenLabel },
+                    ) {
+                        RedfaceVectorIcon(
+                            resId = fr.forumhfr.redface2.core.ui.R.drawable.ic_ms_open_in_new,
+                        )
+                    }
+                }
+                // #604 lot 4a — shared column : cards + live-region announcements + post-removal
+                // focus (always composed ; renders nothing visible without cards).
+                // #808 — the cards block is CAPPED and scrolls internally so a heavy selection can
+                // never push the field and « Envoyer » under the IME fold : the field is the priority
+                // surface. Same pattern as the editor's EditorQuoteCards (192dp) and
+                // RecipientManagerSheet. Unconditional cap (no isImeVisible gate) : the field
+                // autofocuses on open so the IME is quasi-permanent here, and the cap also covers
+                // landscape ; nested same-direction scroll has a working precedent in
+                // RecipientManagerSheet.
+                QuoteCardsColumn(
+                    quotes = state.quotes,
+                    enabled = !state.isSubmitting,
+                    callbacks = QuoteCardsCallbacks(
+                        onMoveUp = { numreponse -> viewModel.onQuoteMoved(numreponse, delta = -1) },
+                        onMoveDown = { numreponse -> viewModel.onQuoteMoved(numreponse, delta = 1) },
+                        onRemove = viewModel::onQuoteRemoved,
+                    ),
+                    modifier = Modifier
+                        .heightIn(max = QUICK_REPLY_MAX_CARDS_HEIGHT)
+                        .verticalScroll(rememberScrollState())
+                        .testTag("quick_reply_quote_cards"),
+                )
+                OutlinedTextField(
+                    value = state.text,
+                    onValueChange = viewModel::onTextChanged,
+                    enabled = !state.isSubmitting,
+                    // #807 — same #237 contract as BbcodeTextField : Compose capitalises NOTHING by
+                    // default, the IME needs the explicit autoCap hint (surface regression, v220).
+                    keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
+                    placeholder = { Text(stringResource(R.string.quick_reply_hint)) },
+                    minLines = 3,
+                    maxLines = 6,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .focusRequester(focusRequester),
+                )
+                // #805 cards OFF — the [quotemsg] fetch runs at opening : typing stays enabled (the
+                // insert concatenates onto the live field), only send/escalate wait for it.
+                if (state.isPreparingQuotes) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.padding(end = 8.dp).size(16.dp),
+                            strokeWidth = 2.dp,
+                        )
+                        Text(
+                            text = stringResource(R.string.quick_reply_preparing_quote),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                state.submitError?.let { error ->
+                    Text(
+                        text = stringResource(error.messageRes()),
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        color = MaterialTheme.colorScheme.error,
                     )
                 }
-            }
-            state.submitError?.let { error ->
-                Text(
-                    text = stringResource(error.messageRes()),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.error,
-                )
             }
             Row(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
                 horizontalArrangement = Arrangement.End,
                 verticalAlignment = Alignment.CenterVertically,
             ) {

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySendPinnedTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplySendPinnedTest.kt
@@ -1,0 +1,107 @@
+package fr.forumhfr.redface2.feature.topic
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.model.write.QuotedPostPreview
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import fr.forumhfr.redface2.core.ui.editor.QuoteCardsCallbacks
+import fr.forumhfr.redface2.core.ui.editor.QuoteCardsColumn
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * #855 — « Envoyer » is PINNED below the scrolling fields, never behind the keyboard fold. This
+ * mounts the exact quick-reply layout skeleton (scrollable weight(1f, fill = false) fields column
+ * + pinned send row, same card cap) inside a SHORT window — the h480dp qualifier plays the role
+ * of the IME-shrunk viewport — and pins the contract : however tall the cards + field grow, the
+ * send button stays inside the visible bounds without any scrolling.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h480dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class QuickReplySendPinnedTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `send button stays visible on a short window despite five cards`() {
+        val quotes = (1..5).map { n ->
+            QuotedPostPreview(numreponse = n, author = "author$n", excerpt = "excerpt $n")
+        }
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+                    Column(
+                        modifier = Modifier
+                            .weight(1f, fill = false)
+                            .verticalScroll(rememberScrollState()),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        Text("Réponse rapide")
+                        QuoteCardsColumn(
+                            quotes = quotes,
+                            enabled = true,
+                            callbacks = QuoteCardsCallbacks({}, {}, {}),
+                            modifier = Modifier
+                                .heightIn(max = QUICK_REPLY_MAX_CARDS_HEIGHT)
+                                .verticalScroll(rememberScrollState()),
+                        )
+                        OutlinedTextField(
+                            value = "brouillon",
+                            onValueChange = {},
+                            minLines = 3,
+                            maxLines = 6,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
+                        horizontalArrangement = Arrangement.End,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        TextButton(onClick = {}, modifier = Modifier.testTag(SEND_TAG)) {
+                            Text("Envoyer")
+                        }
+                    }
+                }
+            }
+        }
+
+        val send = composeTestRule.onNodeWithTag(SEND_TAG, useUnmergedTree = true)
+        send.assertIsDisplayed()
+        val sendBounds = send.fetchSemanticsNode().boundsInRoot
+        val rootBounds = composeTestRule.onRoot().fetchSemanticsNode().boundsInRoot
+        assertTrue(
+            "send button bottom ${sendBounds.bottom} overflows the ${rootBounds.bottom} window",
+            sendBounds.bottom <= rootBounds.bottom + 1f,
+        )
+    }
+
+    private companion object {
+        const val SEND_TAG = "quick_reply_send_under_test"
+    }
+}


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Réponse aux retours de thibw sur la checklist de test (fil DEV, dev 0.26.1) — les trois bugs reproduits en émulateur sur écran court simulé (1080×1700), cartes de citation activées.

## Bugs corrigés (réfs #854, #855, #555 de la checklist — tickets déjà fermés, pas de mot-clé de fermeture)

1. **Réf #854 — « parfois 3× retour pour revenir au topic »** : quand l'écran court force la feuille de réponse rapide en pleine hauteur, le back M3 la garait d'abord à mi-hauteur avant de la fermer. `skipPartiallyExpanded = true` : surface de saisie, l'arrêt mi-hauteur n'a aucun usage — un back (après celui du clavier) ferme désormais.
2. **Réf #855 — « Envoyer » sous le clavier** : seule la zone des champs scrolle désormais (`weight(1f, fill = false)`) ; la rangée « Envoyer » est épinglée hors du scroll, toujours visible au-dessus du clavier.
3. **Réf #555 — champ écrasé à ~0 px** : tout ce qui concurrence le champ (bannière brouillon, bandeaux d'erreur, cartes de citation) vit dans une **zone haute budgétée** (`EditorTopZone`, scrollable au-delà de `editorTopZoneMaxHeight()`) ; le champ garde **96 dp minimum par construction**. À l'apparition d'une alerte, la zone se recale en haut (réserve du gate).

## Validation
- Cadrage Codex AVANT implémentation (GO / GO-a-r ×2, réserves intégrées : plancher explicite plutôt que fraction, zone unique weighted, périmètre topic-reply seulement) puis **gate Codex du diff : GO**.
- Canonique vert (detekt + lint + tests + assemble) ; **5 nouveaux tests exécutés** (budget pur + géométrie Robolectric fenêtre courte h480dp).
- Dogfood émulateur : 1080×1700 (back ×2 ✓, Envoyer épinglé ✓, champ jamais écrasé même avec bannière + 3 cartes ✓) et 1080×2400 (rendu antérieur inchangé ✓).

Follow-up hors lot (cadrage) : audit du même pattern sur TopicFormScreen et les éditeurs MP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pm28ny4V5GSegmKJxTPVAM