### PR TITLE
chore(release) : bump versionName 0.26.2 (fixes écriture écran court)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,15 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.26.2` — `internal` (dev) — 2026-07-10
+
+**Écriture sur écran court** (retour de la checklist de test, thibw — PR #861, cadrage + gate Codex GO, dogfood émulateur 1080×1700 et 1080×2400).
+
+### Éditeur & réponse rapide
+- Le **champ de saisie n'est plus jamais écrasé par le clavier** (réf #555) : dans l'éditeur plein écran, tout ce qui concurrence le champ (bannière de brouillon, bandeaux d'erreur, cartes de citation) vit dans une zone haute budgétée qui défile au-delà de son budget — le champ garde 96 dp minimum par construction. À l'apparition d'une alerte, la zone se recale en haut.
+- **« Envoyer » toujours visible dans la réponse rapide** (réf #855) : seule la zone des champs défile, la rangée « Envoyer » est épinglée au-dessus du clavier.
+- **Fermer la réponse rapide = un seul retour** (réf #854) : la feuille ne s'arrête plus à mi-hauteur quand un petit écran l'avait forcée en pleine hauteur (fini le « 3× retour pour revenir au sujet »).
+
 ## `0.26.1` — `internal` (dev) — 2026-07-07
 
 **Réponses aux deux premiers retours du fil DEV sur la 0.26.0** (même soirée).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.26.1"
+        versionName = "0.26.2"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,4 +1,4 @@
-Redface 2 v0.26.1 — dev.
+Redface 2 v0.26.2 — dev.
 
-- Square and portrait images finally fill ~90% of the width (height cap recalibrated for mobile).
-- The "draft found" message (Restore / Discard) is back when opening the editor with a pending draft.
+- Writing on small screens: the text field and "Send" always stay visible, even with the keyboard up and several quote cards.
+- Closing the quick reply takes a single back press again (no more half-height stop).

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,4 +1,4 @@
-Redface 2 v0.26.1 — dev.
+Redface 2 v0.26.2 — dev.
 
-- Les images carrées et portrait remplissent enfin ~90 % de la largeur (le plafond de hauteur est recalibré pour mobile).
-- Le message « brouillon retrouvé » (Restaurer / Ignorer) est de retour quand on ouvre l'éditeur avec un brouillon en attente.
+- Écriture sur petit écran : le champ de saisie et « Envoyer » restent toujours visibles, même clavier ouvert avec plusieurs citations.
+- Fermer la réponse rapide ne demande plus qu'un seul retour (fini l'arrêt à mi-hauteur).


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump + changelog + whatsnew pour la release dev 0.26.2 (PR #861 : réfs #555/#854/#855 de la checklist de test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)