### PR TITLE
fix(app) : la rotation ne ramène plus une conversation MP ouverte à la liste (#812)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -465,6 +465,24 @@ private fun StartScreenChoice.toTopLevelDestination(): TopLevelDestination = whe
     StartScreenChoice.MESSAGES -> TopLevelDestination.Messages
 }
 
+// #812 — the stable identity of an auth state, used to detect real SESSION TRANSITIONS
+// (login, logout, account switch) : the session-clearing effect must ignore the re-emission
+// that follows an activity recreation, whose identity compares equal. Anonymous is safe as
+// an identity (never a loading placeholder) : observeAuthState() filters the cookie jar's
+// un-loaded null state, so its FIRST emission is already the persisted-session verdict.
+// userId is the canonical key (gate Codex) ; pseudo only backs the rare cookie sets without
+// `md_id`. Pure — pinned by test.
+internal fun authIdentityKey(auth: AuthState?): String? = when (auth) {
+    null -> null
+    AuthState.Anonymous -> "anon"
+    is AuthState.Authenticated -> "auth:${auth.userId ?: "pseudo:${auth.pseudo}"}"
+}
+
+// #812 — a transition needs a KNOWN previous identity that differs : the first delivery of a
+// cold start (previous == null) and a post-recreation re-delivery (equal) are both no-ops.
+internal fun isAuthTransition(previous: String?, identity: String): Boolean =
+    previous != null && previous != identity
+
 // #603 PR6 / #679 — what a bottom-bar tap should do, given the tapped tab, the current tab and the
 // Drapeaux stack depth. Pure (no callbacks → no LongParameterList, fully testable); the host maps the
 // result to an action via [runTopLevelTap].
@@ -1112,37 +1130,34 @@ fun RedfaceApp(intent: Intent?) {
         // only, never serialized into a route.
         var topicPollExpansionCache by remember { mutableStateOf(emptyMap<TopicPollKey, Boolean>()) }
 
+        // #812 — the session-clearing block below must run on real SESSION TRANSITIONS only
+        // (login, logout, account switch), never on the re-emission that follows an activity
+        // recreation : LaunchedEffect restarts on every rotation, and the un-guarded reset was
+        // wiping the Messages back stack (an open conversation silently fell back to the list)
+        // plus every read-state cache. rememberSaveable makes the guard itself survive the
+        // recreation, so the first post-restore delivery compares equal and is a no-op.
+        var lastAuthIdentity by rememberSaveable { mutableStateOf<String?>(null) }
         LaunchedEffect(authState) {
-            when (authState) {
-                null -> Unit
-                AuthState.Anonymous -> {
-                    readPrivateMessageThreadIds = emptyMap()
-                    multiRecipientThreadIds = emptySet()
-                    unreadOnOpenThreadIds = emptySet()
-                    openThreadDates = emptyMap()
-                    // #531 — stay in lockstep with the VM's generation reset (clearPrivateState).
-                    lastReconciledGeneration = 0
-                    privateMessageSentSignal = null
-                    // #291 — a write intention armed under another session must not survive the
-                    // transition (Codex review: stale « Citer N » after logout/login).
-                    multiQuoteBasket = null
-                    pendingEditorQuotes = null
-                    resetStack(messagesBackStack, MessagesRoute, MessagesRoute)
-                }
-                is AuthState.Authenticated -> {
-                    readPrivateMessageThreadIds = emptyMap()
-                    multiRecipientThreadIds = emptySet()
-                    unreadOnOpenThreadIds = emptySet()
-                    openThreadDates = emptyMap()
-                    // #531 — the VM reloads page 1 (generation back to 1) on a fresh authentication;
-                    // resetting here lets that first reconcile run.
-                    lastReconciledGeneration = 0
-                    privateMessageSentSignal = null
-                    multiQuoteBasket = null
-                    pendingEditorQuotes = null
-                    resetStack(messagesBackStack, MessagesRoute, MessagesRoute)
-                }
-            }
+            val identity = authIdentityKey(authState) ?: return@LaunchedEffect
+            val previous = lastAuthIdentity
+            lastAuthIdentity = identity
+            // First delivery of a cold start (fresh stacks, nothing to clear) or the same
+            // session re-delivered after a recreation (restored stacks must survive) — not a
+            // transition, nothing to reset.
+            if (!isAuthTransition(previous, identity)) return@LaunchedEffect
+            readPrivateMessageThreadIds = emptyMap()
+            multiRecipientThreadIds = emptySet()
+            unreadOnOpenThreadIds = emptySet()
+            openThreadDates = emptyMap()
+            // #531 — stay in lockstep with the VM's generation reset (clearPrivateState on
+            // logout ; reload from generation 1 on a fresh authentication).
+            lastReconciledGeneration = 0
+            privateMessageSentSignal = null
+            // #291 — a write intention armed under another session must not survive the
+            // transition (Codex review: stale « Citer N » after logout/login).
+            multiQuoteBasket = null
+            pendingEditorQuotes = null
+            resetStack(messagesBackStack, MessagesRoute, MessagesRoute)
         }
 
         // #624 — the post/topic editor pins an « Envoyer » bar above the keyboard. Inside the bottom-nav

--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AuthTransitionGuardTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AuthTransitionGuardTest.kt
@@ -1,0 +1,51 @@
+package fr.forumhfr.redface2.navigation
+
+import fr.forumhfr.redface2.core.model.AuthState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #812 — the session-clearing effect (Messages back-stack reset, read-state caches, #291
+ * write intentions) must fire on REAL session transitions only. Before this guard, the
+ * effect re-ran on every activity recreation and a rotation inside an open MP conversation
+ * silently kicked the user back to the list.
+ */
+class AuthTransitionGuardTest {
+
+    @Test
+    fun `identity keys are stable per session`() {
+        assertEquals(null, authIdentityKey(null))
+        assertEquals("anon", authIdentityKey(AuthState.Anonymous))
+        // userId is the canonical key (survives a display-pseudo change at constant session).
+        assertEquals(
+            "auth:54596",
+            authIdentityKey(AuthState.Authenticated(pseudo = "XaTriX", userId = 54596)),
+        )
+        // Older cookie sets without `md_id` still get a stable identity from the pseudo.
+        assertEquals(
+            "auth:pseudo:XaTriX",
+            authIdentityKey(AuthState.Authenticated(pseudo = "XaTriX", userId = null)),
+        )
+    }
+
+    @Test
+    fun `recreation re-delivery of the same session is not a transition`() {
+        assertFalse(isAuthTransition(previous = "auth:XaTriX", identity = "auth:XaTriX"))
+        assertFalse(isAuthTransition(previous = "anon", identity = "anon"))
+    }
+
+    @Test
+    fun `cold start first delivery is not a transition`() {
+        assertFalse(isAuthTransition(previous = null, identity = "auth:XaTriX"))
+        assertFalse(isAuthTransition(previous = null, identity = "anon"))
+    }
+
+    @Test
+    fun `login logout and account switch are transitions`() {
+        assertTrue(isAuthTransition(previous = "anon", identity = "auth:XaTriX"))
+        assertTrue(isAuthTransition(previous = "auth:XaTriX", identity = "anon"))
+        assertTrue(isAuthTransition(previous = "auth:XaTriX", identity = "auth:autre"))
+    }
+}


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Reproduit en émulateur : les back stacks Nav3 sont déjà saveable, mais le `LaunchedEffect(authState)` de nettoyage de session redémarre à chaque recréation d'activité et prenait la ré-émission du même `Authenticated` pour un événement neuf → reset inconditionnel de la stack Messages (la conversation ouverte retombait sur la liste), vidage des caches d'état lu et des intentions d'écriture (#291) — sur une simple rotation.

**Fix** : garde de transition — `lastAuthIdentity` en `rememberSaveable` comparé à une clé d'identité stable (`anon` / `auth:<userId>`, fallback pseudo pour les vieux cookies sans `md_id`). Le nettoyage ne s'exécute plus que sur les vraies transitions de session (login, logout, changement de compte).

- Gate Codex : NO-GO initial → clé par userId + preuve que `Anonymous` n'est jamais un placeholder (`observeAuthState()` filtre l'état non-chargé du cookie jar) → **GO**.
- 4 tests unitaires (`AuthTransitionGuardTest`) exécutés ; canonique vert.
- Dogfood émulateur : conversation MP + rotation → la conversation reste affichée (avant : retour liste).

Closes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pm28ny4V5GSegmKJxTPVAM