### PR TITLE
chore(release) : bump versionName 0.26.3 (#816 échelle smileys + #812 rotation MP)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,16 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.26.3` — `internal` (dev) — 2026-07-10
+
+**Suite de la nuit rf2-12** (lot d'issues non démarrées de la phase).
+
+### Éditeur
+- #816 (suggestion thibw) : le **sélecteur de smileys respecte l'échelle du forum** (PR #865) — les standards s'affichent près de leur taille native (petits, pixel-art net), les persos remplissent la cellule. Fini l'uniforme 30 dp qui rendait les standards énormes et flous et les persos à l'étroit.
+
+### Messages privés
+- #812 : **tourner l'écran dans une conversation ne ramène plus à la liste des MP** (PR #866) — le nettoyage de session se rejouait à chaque recréation d'activité et résetait la pile de navigation Messages ; il est désormais limité aux vraies transitions de session (login, logout, changement de compte).
+
 ## `0.26.2` — `internal` (dev) — 2026-07-10
 
 **Écriture sur écran court** (retour de la checklist de test, thibw — PR #861, cadrage + gate Codex GO, dogfood émulateur 1080×1700 et 1080×2400).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.26.2"
+        versionName = "0.26.3"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,4 +1,4 @@
-Redface 2 v0.26.2 — dev.
+Redface 2 v0.26.3 — dev.
 
-- Writing on small screens: the text field and "Send" always stay visible, even with the keyboard up and several quote cards.
-- Closing the quick reply takes a single back press again (no more half-height stop).
+- The smiley picker respects the forum's scale: standard smileys small and crisp, perso smileys large.
+- Rotating the screen inside a PM conversation no longer kicks you back to the message list.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,4 +1,4 @@
-Redface 2 v0.26.2 — dev.
+Redface 2 v0.26.3 — dev.
 
-- Écriture sur petit écran : le champ de saisie et « Envoyer » restent toujours visibles, même clavier ouvert avec plusieurs citations.
-- Fermer la réponse rapide ne demande plus qu'un seul retour (fini l'arrêt à mi-hauteur).
+- Le sélecteur de smileys respecte l'échelle du forum : standards petits et nets, persos en grand.
+- Tourner l'écran dans une conversation MP ne ramène plus à la liste des messages.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump + changelog + whatsnew pour la release dev 0.26.3 (PRs #865, #866).

🤖 Generated with [Claude Code](https://claude.com/claude-code)