### PR TITLE
feat(composer): newline after [/quotemsg] + experimental quote cards label (#881, #805)

### DIFF
--- a/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
+++ b/feature/editor/src/main/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModel.kt
@@ -260,7 +260,11 @@ class PostEditorViewModel @AssistedInject constructor(
                     val prefills = form.initialContent.trimEnd()
                     _state.update { current ->
                         val existing = current.draft.text
-                        val combined = if (existing.isBlank()) prefills else prefills + "\n\n" + existing
+                        // #881 — a quote block that ends the field carries exactly ONE trailing
+                        // newline so typing starts under the citation. In the prepend branch the
+                        // existing "\n\n" separator already provides it; a later resumeSharedDraft
+                        // append trimEnd()s the field first, so both orders stay commutative (#790).
+                        val combined = if (existing.isBlank()) prefills + "\n" else prefills + "\n\n" + existing
                         current
                             .withFormHydration(form.copy(initialContent = ""), current.preview)
                             .copy(draft = TextFieldValue(text = combined, selection = TextRange(combined.length)))

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -1727,6 +1727,24 @@ class PostEditorViewModelTest {
     }
 
     @Test
+    fun `cards OFF - a quote block ending the field carries exactly one trailing newline`() = runTest {
+        // #881 — typing starts under the citation : one normalised newline (never two, never
+        // the raw HFR trailing newline), caret on the fresh line.
+        replyRepository.formResultsByNumrep = mapOf(
+            101 to Result.success(authenticatedForm(initialContent = "[quotemsg=101,1,9]a[/quotemsg]\n\n")),
+        )
+        val viewModel = newReplyViewModel(
+            initialQuotes = listOf(card(101)),
+            userPreferencesRepository = FakeUserPreferencesRepository(quoteCardsEnabled = false),
+        )
+        testScheduler.advanceUntilIdle()
+
+        val draft = viewModel.state.value.draft
+        assertEquals("[quotemsg=101,1,9]a[/quotemsg]\n", draft.text)
+        assertEquals("caret sits after the newline", draft.text.length, draft.selection.start)
+    }
+
+    @Test
     fun `cards OFF - resumeSharedDraft appends after the prefill with exactly one quote block`() = runTest {
         // Réserve Codex n°5 — the #790 trio restored : quote-form hydration (prepend) + shared-row
         // append must compose to ONE [quotemsg] block and a stable order, whichever lands first.

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -1745,6 +1745,30 @@ class PostEditorViewModelTest {
     }
 
     @Test
+    fun `cards OFF - a quote prepended onto typed text keeps the plain double-newline separator`() = runTest {
+        // #881 réserve gate — the prepend branch adds NO extra newline : the "\n\n" separator
+        // already puts the existing typing under the citation. The fetch is gated so the
+        // typing deterministically lands first (same interleave as the race test above).
+        val formGate = CompletableDeferred<Unit>()
+        replyRepository.formGate = formGate
+        replyRepository.formResultsByNumrep = mapOf(
+            101 to Result.success(authenticatedForm(initialContent = "[quotemsg=101,1,9]a[/quotemsg]\n\n")),
+        )
+        val viewModel = newReplyViewModel(
+            initialQuotes = listOf(card(101)),
+            userPreferencesRepository = FakeUserPreferencesRepository(quoteCardsEnabled = false),
+        )
+        viewModel.submit(PostEditorIntent.ContentChanged(TextFieldValue("déjà tapé")))
+        formGate.complete(Unit)
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(
+            "[quotemsg=101,1,9]a[/quotemsg]\n\ndéjà tapé",
+            viewModel.state.value.draft.text,
+        )
+    }
+
+    @Test
     fun `cards OFF - resumeSharedDraft appends after the prefill with exactly one quote block`() = runTest {
         // Réserve Codex n°5 — the #790 trio restored : quote-form hydration (prepend) + shared-row
         // append must compose to ONE [quotemsg] block and a stable order, whichever lands first.

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -364,8 +364,9 @@
     <string name="settings_writing_surface_full_editor">Toujours plein écran</string>
     <string name="settings_writing_surface_full_editor_description">Répondre et citer ouvrent directement l\'éditeur plein écran.</string>
     <string name="settings_writing_surface_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
-    <string name="settings_quote_cards_title">Citations en cartes</string>
-    <string name="settings_quote_cards_description">Représente les citations par des cartes compactes au-dessus du champ. Désactivé : la citation est insérée en BBCode, modifiable dans le texte.</string>
+    <!-- #805 — statut expérimental acté (arbitrage 11/07) : même pattern que settings_mp_sync_write_title. -->
+    <string name="settings_quote_cards_title">Citations en cartes (expérimental)</string>
+    <string name="settings_quote_cards_description">Expérimental : représente les citations par des cartes compactes au-dessus du champ. Désactivé (défaut) : la citation est insérée en BBCode, modifiable dans le texte.</string>
     <string name="settings_quote_cards_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
 
     <!-- #459 PR3 — entrée vers l'écran « Mes images uploadées » depuis le catalogue de réglages. -->

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModel.kt
@@ -230,7 +230,11 @@ class QuickReplyViewModel @AssistedInject constructor(
                 val prefills = form.initialContent.trimEnd()
                 _state.update { current ->
                     val existing = current.text.text
-                    val combined = if (existing.isBlank()) prefills else existing.trimEnd() + "\n\n" + prefills
+                    // #881 — the inserted quote block ends the field here, so it carries exactly
+                    // ONE trailing newline (normalised: prefills are trimEnd()'d above, never
+                    // blind-appended) and the caret lands on the fresh line below the citation.
+                    val combined =
+                        (if (existing.isBlank()) prefills else existing.trimEnd() + "\n\n" + prefills) + "\n"
                     current.copy(
                         text = TextFieldValue(text = combined, selection = TextRange(combined.length)),
                         isPreparingQuotes = false,

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModelTest.kt
@@ -331,9 +331,10 @@ class QuickReplyViewModelTest {
     @Test
     fun `inline mode appends the quote BBCode after the row body and arms no card`() = runTest {
         val repository = FakeQuickReplyRepository()
+        val draftStore = FakeQuickReplyDraftStore(initialBody = "brouillon")
         val viewModel = quickReplyViewModel(
             replyRepository = repository,
-            draftStore = FakeQuickReplyDraftStore(initialBody = "brouillon"),
+            draftStore = draftStore,
             quoteCardsEnabled = false,
         )
         viewModel.onSheetOpened(listOf(preview(101, "alice")))
@@ -345,6 +346,8 @@ class QuickReplyViewModelTest {
         assertEquals(state.text.text.length, state.text.selection.start)
         assertTrue(state.quotes.isEmpty())
         assertFalse(state.isPreparingQuotes)
+        // #881 réserve gate — the autosave persists the field verbatim, trailing newline included.
+        assertEquals(state.text.text, draftStore.savedBodies.last())
         // Prefetch (plain) then the quote form — whose hash the later submit rides.
         assertEquals(listOf(null, 101), repository.fetchedQuotedNumreponses)
     }
@@ -381,6 +384,7 @@ class QuickReplyViewModelTest {
 
         val state = viewModel.state.value
         assertEquals("pendant le fetch\n\n[quotemsg=101]corps[/quotemsg]\n", state.text.text)
+        assertEquals("caret on the fresh line", state.text.text.length, state.text.selection.start)
         assertFalse(state.isPreparingQuotes)
         assertTrue(state.canSubmit)
     }

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModelTest.kt
@@ -340,7 +340,9 @@ class QuickReplyViewModelTest {
         advanceUntilIdle()
 
         val state = viewModel.state.value
-        assertEquals("brouillon\n\n[quotemsg=101]corps[/quotemsg]", state.text.text)
+        // #881 — exactly one trailing newline: typing starts under the citation.
+        assertEquals("brouillon\n\n[quotemsg=101]corps[/quotemsg]\n", state.text.text)
+        assertEquals(state.text.text.length, state.text.selection.start)
         assertTrue(state.quotes.isEmpty())
         assertFalse(state.isPreparingQuotes)
         // Prefetch (plain) then the quote form — whose hash the later submit rides.
@@ -355,7 +357,7 @@ class QuickReplyViewModelTest {
         advanceUntilIdle()
 
         assertEquals(
-            "[quotemsg=202]corps[/quotemsg]\n\n[quotemsg=101]corps[/quotemsg]",
+            "[quotemsg=202]corps[/quotemsg]\n\n[quotemsg=101]corps[/quotemsg]\n",
             viewModel.state.value.text.text,
         )
         assertTrue(viewModel.state.value.quotes.isEmpty())
@@ -378,7 +380,7 @@ class QuickReplyViewModelTest {
         advanceUntilIdle()
 
         val state = viewModel.state.value
-        assertEquals("pendant le fetch\n\n[quotemsg=101]corps[/quotemsg]", state.text.text)
+        assertEquals("pendant le fetch\n\n[quotemsg=101]corps[/quotemsg]\n", state.text.text)
         assertFalse(state.isPreparingQuotes)
         assertTrue(state.canSubmit)
     }
@@ -452,7 +454,7 @@ class QuickReplyViewModelTest {
         val state = viewModel.state.value
         assertTrue("no card survives an OFF opening", state.quotes.isEmpty())
         assertEquals(
-            "[quotemsg=101]corps[/quotemsg]\n\n[quotemsg=202]corps[/quotemsg]",
+            "[quotemsg=101]corps[/quotemsg]\n\n[quotemsg=202]corps[/quotemsg]\n",
             state.text.text,
         )
     }


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi

Deux arbitrages du 11/07 :

1. **#881 — retour à la ligne après `[/quotemsg]`** : quand le bloc de citation inséré termine le champ (feuille de réponse rapide = append ; éditeur ouvert sans corps = prepend), il porte exactement **un** retour à la ligne normalisé — le caret démarre sous la citation. La branche prepend avec corps existant est inchangée (le séparateur `\n\n` fournit déjà le saut). Chemins POST (cartes ON) et `ReplyQuoteMaterializer` intacts ; commutativité `resumeSharedDraft` préservée (son `trimEnd()` absorbe le `\n`).
2. **#805 — statut expérimental** : le réglage « Citations en cartes » est étiqueté « (expérimental) », description préfixée — iso-pattern `settings_mp_sync_write_title`. Défaut OFF inchangé. Le chantier design est reporté au milestone Vue · Topic 2.

## Validation

- Cadrage Codex GO-avec-ajustements (lot) + gate diff GO-avec-réserves → les 3 réserves actionnables épinglées par tests (branche prepend via `formGate`, caret mid-fetch, autosave verbatim) ; la 4ᵉ (échec fetch) était déjà couverte par un test existant hors diff.
- Canonique complète : BUILD SUCCESSFUL (assembleProdDebug + tests + lint + detektAll).
- Tests ciblés re-exécutés `--rerun-tasks` : verts.

Closes #881. Réf #805 (reste ouverte — reportée à Vue · Topic 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqxgKdydUwQEqqJm6rkGUh
