### PR TITLE
feat(topic): « Envoyer un MP » in the post contextual menu (#792)

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -2519,6 +2519,11 @@ private fun RedfaceNavHost(
                         topicScrollNavState.onAnchorSaved(route.cat, route.post, route.page, anchor)
                     },
                     onOpenProfile = onOpenProfile,
+                    // #792 — « Envoyer un MP » from a post's menu : the NEW-conversation composer
+                    // opens with the post's author prefilled (the route arg was designed for this).
+                    onSendPrivateMessage = { author ->
+                        backStack.add(PrivateMessageComposeRoute(prefilledRecipient = author))
+                    },
                     // #843 — onReply is a COLD full-editor open (FAB under FULL_EDITOR, « Citer »
                     // routed to the editor, #823 long-press): no sheet is in flight, so
                     // resumeSharedDraft = false and an existing #405 draft is SURFACED via the

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostMenuSheet.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostMenuSheet.kt
@@ -98,6 +98,14 @@ internal fun PostMenuSheet(
      */
     onOpenProfile: (() -> Unit)? = null,
     /**
+     * #792 — « Envoyer un MP » : opens the NEW-conversation MP composer with this post's
+     * author prefilled as recipient. Null hides the entry (anonymous session, own post, or
+     * no real profile — cf. `shouldShowSendPrivateMessage`). The sheet hides first, then
+     * dismisses AND navigates (same order as « Modifier le premier message ») so the
+     * composer never opens under a still-visible menu sheet.
+     */
+    onSendPrivateMessage: (() -> Unit)? = null,
+    /**
      * #291 — whether this post already sits in the multi-quote basket; flips the entry's
      * label between « Ajouter à » and « Retirer de » la citation multiple.
      */
@@ -240,6 +248,23 @@ internal fun PostMenuSheet(
                             },
                         ),
                     )
+                }
+            }
+
+            if (onSendPrivateMessage != null) {
+                Spacer(Modifier.height(8.dp))
+                // #792 — person-directed action, grouped with the author-scoped entry below. Hide
+                // first, then dismiss AND navigate (same order as « Modifier le premier message »).
+                OutlinedButton(
+                    onClick = {
+                        hideThenDismiss(coroutineScope, sheetState) {
+                            onDismiss()
+                            onSendPrivateMessage()
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(stringResource(R.string.topic_post_menu_send_private_message))
                 }
             }
 

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -223,6 +223,14 @@ fun TopicScreen(
      */
     onOpenProfile: (userId: Int, pseudo: String, avatarUrl: String?) -> Unit = { _, _, _ -> },
     /**
+     * #792 — « Envoyer un MP » from a post's contextual menu : `:app` opens the NEW-conversation
+     * MP composer with [author] prefilled as recipient (`PrivateMessageComposeRoute.prefilledRecipient`
+     * was designed for exactly this entry point). Only emitted on an authenticated session, never
+     * for the user's own posts, and only when the post carries a real profile — cf.
+     * [shouldShowSendPrivateMessage].
+     */
+    onSendPrivateMessage: (author: String) -> Unit = {},
+    /**
      * #307 — saved read position to restore for THIS `(cat, post, page)` landing, or `null` when
      * nothing should be restored. `:app` resolves the full priority chain
      * (`resolveTopicScrollRestoration`: route `scrollTo` > post-submit landing > saved anchor >
@@ -503,6 +511,7 @@ fun TopicScreen(
             )
         },
         onOpenProfile = onOpenProfile,
+        onSendPrivateMessage = onSendPrivateMessage,
         onDeleteRequest = { numreponse -> deleteCandidate = numreponse },
         multiQuoteSelections = multiQuoteSelections,
         onToggleMultiQuote = onToggleMultiQuote,
@@ -741,6 +750,8 @@ internal fun TopicContent(
     // #699 — quote-header tap, threaded down to the post cards (cf. TopicScreen KDoc).
     onGoToPost: (page: Int, numreponse: Int) -> Unit = { _, _ -> },
     onOpenProfile: (userId: Int, pseudo: String, avatarUrl: String?) -> Unit = { _, _, _ -> },
+    // #792 — « Envoyer un MP » entry of the post menu, forwarded up to `:app` (MP composer).
+    onSendPrivateMessage: (author: String) -> Unit = {},
     // #292 — a per-post « Supprimer » tap; the screen owns the confirmation dialog, so this only
     // requests it (carrying the post's numreponse). Never invoked for the first post (excluded).
     onDeleteRequest: (numreponse: Int) -> Unit = {},
@@ -970,6 +981,7 @@ internal fun TopicContent(
                                 onOpenPage = onOpenPage,
                                 onGoToPost = onGoToPost,
                                 onOpenProfile = onOpenProfile,
+                                onSendPrivateMessage = onSendPrivateMessage,
                                 onDeleteRequest = onDeleteRequest,
                                 onDoubleTapRefresh = { onIntent(TopicIntent.Refresh) },
                                 listState = listState,
@@ -1338,6 +1350,8 @@ private fun TopicLoadedContent(
     // #699 — quote-header tap, forwarded into each TopicPostCard's PostRenderer.
     onGoToPost: (page: Int, numreponse: Int) -> Unit = { _, _ -> },
     onOpenProfile: (userId: Int, pseudo: String, avatarUrl: String?) -> Unit = { _, _, _ -> },
+    // #792 — « Envoyer un MP » entry of the post menu (gated at the mount below).
+    onSendPrivateMessage: (author: String) -> Unit = {},
     onDeleteRequest: (numreponse: Int) -> Unit = {},
     /** #382 — double-tap anywhere on the list refreshes the current page (RF1 parity). */
     onDoubleTapRefresh: () -> Unit = {},
@@ -1708,6 +1722,13 @@ private fun TopicLoadedContent(
             // anonymous reads expose no profile link, the hero stays inert.
             onOpenProfile = post.profileId?.let { profileId ->
                 { onOpenProfile(profileId, post.author, post.avatarUrl) }
+            },
+            // #792 — « Envoyer un MP » : auth-gated, never on own posts, real profiles only
+            // (« Publicité » rows are not messageable). Carries the author pseudo to `:app`.
+            onSendPrivateMessage = if (shouldShowSendPrivateMessage(post, state.isAuthenticated)) {
+                { onSendPrivateMessage(post.author) }
+            } else {
+                null
             },
             // #291 — multi-quote toggle, same gate as « Citer » (quoting is a flavour of
             // replying; a locked topic or an anonymous session has nothing to quote).
@@ -3093,6 +3114,13 @@ internal fun effectiveMultiQuoteCount(topic: Topic, isAuthenticated: Boolean, se
 
 internal fun shouldShowQuoteAction(topic: Topic, isAuthenticated: Boolean): Boolean =
     topic.canReply && isAuthenticated
+
+// #792 — « Envoyer un MP » from the post's contextual menu. Auth-only (the MP composer is a
+// logged-in surface), never on the user's own posts, and only for authors with a real HFR
+// profile (`profileId != null` : « Publicité » rows and anonymous reads are not messageable —
+// same gate as the profile hero). Topic lock is irrelevant : the MP leaves the topic entirely.
+internal fun shouldShowSendPrivateMessage(post: Post, isAuthenticated: Boolean): Boolean =
+    isAuthenticated && !post.isOwnPost && post.profileId != null
 
 internal fun shouldShowEditAction(topic: Topic, post: Post, isAuthenticated: Boolean): Boolean =
     post.isEditable && topic.canReply && isAuthenticated

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -69,6 +69,8 @@
     <string name="topic_post_menu_open_in_browser">Ouvrir dans le navigateur</string>
     <string name="topic_post_menu_no_browser">Aucun navigateur disponible</string>
     <string name="topic_post_menu_report_soon">Alerter (à venir)</string>
+    <!-- #792 — entrée « Envoyer un MP » du menu contextuel de post (composeur MP pré-rempli). -->
+    <string name="topic_post_menu_send_private_message">Envoyer un MP</string>
     <!-- #509 — entrée du menu post : masquer / réafficher tous les posts de l'auteur (blacklist). -->
     <string name="topic_post_menu_block_author">Masquer cet utilisateur</string>
     <string name="topic_post_menu_unblock_author">Ne plus masquer cet utilisateur</string>

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicActionGatesTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicActionGatesTest.kt
@@ -140,6 +140,31 @@ class TopicActionGatesTest {
         )
     }
 
+    @Test
+    fun `send private message requires auth, a real profile, and someone else's post`() {
+        val other = post(profileId = 123)
+
+        assertTrue(
+            "#792 — authenticated + someone else's profiled post exposes « Envoyer un MP »",
+            shouldShowSendPrivateMessage(other, isAuthenticated = true),
+        )
+        assertFalse(
+            "#220 — logged-out must never see « Envoyer un MP »",
+            shouldShowSendPrivateMessage(other, isAuthenticated = false),
+        )
+        assertFalse(
+            "no MP to oneself",
+            shouldShowSendPrivateMessage(
+                post(profileId = 123, isOwnPost = true),
+                isAuthenticated = true,
+            ),
+        )
+        assertFalse(
+            "profile-less rows (« Publicité », anonymous reads) are not messageable",
+            shouldShowSendPrivateMessage(post(profileId = null), isAuthenticated = true),
+        )
+    }
+
     private fun topic(
         canReply: Boolean,
         posts: List<Post> = listOf(post()),
@@ -163,6 +188,8 @@ class TopicActionGatesTest {
         isEditable: Boolean = false,
         quoteRef: Int? = 1,
         numreponse: Int = 16244,
+        isOwnPost: Boolean = isEditable,
+        profileId: Int? = null,
     ): Post = Post(
         numreponse = numreponse,
         author = "XaTriX",
@@ -170,10 +197,10 @@ class TopicActionGatesTest {
         content = PostContent(blocks = emptyList()),
         avatarUrl = null,
         isEditable = isEditable,
-        isOwnPost = isEditable,
+        isOwnPost = isOwnPost,
         quotedAuthors = emptyList(),
         postIndex = null,
         quoteRef = quoteRef,
-        profileId = null,
+        profileId = profileId,
     )
 }


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi

**#792** (suggestion Dintr-un lemn, fil DEV) : entrée **« Envoyer un MP »** dans le menu contextuel « … » d'un post → ouvre le composeur MP nouvelle conversation avec l'auteur pré-rempli en destinataire.

- Gate pure `shouldShowSendPrivateMessage` : session authentifiée, jamais son propre post, profil réel (`profileId != null` — les rows « Publicité » ne sont pas joignables). Gate en amont, callback null = entrée masquée (pattern du sheet).
- La route `PrivateMessageComposeRoute.prefilledRecipient` et le VM (`initialRecipient`, trim inclus) existaient déjà — conçus pour ce point d'entrée exact ; zéro changement côté :feature:messages.
- Feuille masquée puis dismiss AVANT la navigation (pattern « Modifier le premier message »).

## Validation

- Cadrage + gate Codex GO-avec-réserves (réserves de couverture UI non bloquantes : comportement prouvé au dogfood ci-dessous ; trim du pseudo déjà dans le VM existant).
- Canonique complète : BUILD SUCCESSFUL (assembleProdDebug + tests + lint + detektAll).
- 4 cas de gate épinglés dans `TopicActionGatesTest`.
- Dogfood émulateur : menu post XaTriX → « Envoyer un MP » (placée entre citation multiple et Masquer) → composeur « Nouveau message » avec « XaTriX » pré-rempli ; entrée absente sur les surfaces non connectées.

Closes #792.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqxgKdydUwQEqqJm6rkGUh
