### PR TITLE
feat(topic,flags): long-press on the title removes the topic's drapeau (#809)

### DIFF
--- a/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppAccountViewModelTest.kt
+++ b/app/src/test/kotlin/fr/forumhfr/redface2/navigation/AppAccountViewModelTest.kt
@@ -203,6 +203,11 @@ class AppAccountViewModelTest {
             // Not exercised in these tests — included to satisfy the interface (#99).
             return Result.success(Unit)
         }
+
+        override suspend fun findFlag(cat: Int, topicId: Int): fr.forumhfr.redface2.core.model.Flag? {
+            // Not exercised in these tests — included to satisfy the interface (#809).
+            return null
+        }
     }
 
     /**

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/flags/DefaultFlagRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/flags/DefaultFlagRepository.kt
@@ -230,6 +230,57 @@ class DefaultFlagRepository @Inject constructor(
     }
 
     /**
+     * #809 — resolves the full [Flag] for a `(cat, topicId)` pair so callers outside the Drapeaux
+     * view (the topic top-bar long-press) can feed [removeFlag] the complete object it keys the
+     * `delflag.php` mutation on. Never fabricates a partial [Flag].
+     *
+     * Memory-first, **per-bucket** : scans the warm per-type success caches under the
+     * [cachedSuccesses] lock. On a hit, returns immediately (no network). On a miss, only the COLD
+     * buckets are fetched (each writes its success into [cachedSuccesses] via [fetch]'s
+     * generation-guarded write), then a re-scan resolves. A warm bucket is authoritative **for its
+     * own type only** and is never implicitly refreshed (the Drapeaux view owns refresh policy) —
+     * but it says nothing about the other types : the Drapeaux screen warms one tab at a time, so
+     * « CYAN warm + miss » must still check a never-loaded FAVORITE bucket (review finding : the
+     * earlier any-bucket-warm short-circuit made a FAVORITE-only topic unremovable from the topic
+     * screen until its tab had been visited). All three warm + miss → null with zero network. An
+     * anonymous session holds no drapeaux, so it short-circuits to null before any round-trip.
+     *
+     * When a topic carries several drapeaux (e.g. participated AND favori), the [FlagType] iteration
+     * order (CYAN, RED, FAVORITE) breaks the tie deterministically — enough for the MVP « retirer »,
+     * which keys `delflag.php` on that row's own `type`.
+     */
+    override suspend fun findFlag(cat: Int, topicId: Int): Flag? {
+        val (cachedMatch, warmTypes) = synchronized(cachedSuccesses) {
+            scanCachedFlags(cat = cat, topicId = topicId) to cachedSuccesses.keys.toSet()
+        }
+        if (cachedMatch != null) return cachedMatch
+        // Warm buckets are authoritative for their own type ; only the COLD ones need a fetch.
+        val coldTypes = FlagType.entries.filterNot { it in warmTypes }
+        val userId = currentUserId()
+        if (coldTypes.isNotEmpty() && userId != null) {
+            // Same parallel idiom as [fetch]'s per-cat fan-out. [fetchDeduplicated] collapses this
+            // with any concurrent observe/refresh of the same bucket.
+            coroutineScope {
+                coldTypes.map { type ->
+                    async { fetchDeduplicated(type = type, userId = userId) }
+                }.awaitAll()
+            }
+        }
+        return synchronized(cachedSuccesses) { scanCachedFlags(cat = cat, topicId = topicId) }
+    }
+
+    /**
+     * First flag matching `(cat, topicId)` across every warm per-type bucket, or null. Must be called
+     * under the [cachedSuccesses] lock (#809). EnumMap iteration is CYAN → RED → FAVORITE, so a topic
+     * present in several buckets resolves deterministically to the earliest one.
+     */
+    private fun scanCachedFlags(cat: Int, topicId: Int): Flag? =
+        cachedSuccesses.values
+            .asSequence()
+            .flatMap { it.flags.asSequence() }
+            .firstOrNull { it.cat == cat && it.topicId == topicId }
+
+    /**
      * Drops [flag] from the in-memory success cache and Room, then re-emits the trimmed
      * list to active observers of its tab. Called only after a confirmed `delflag.php`
      * success, so it never has to reason about a partial mutation.

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/flags/DefaultFlagRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/flags/DefaultFlagRepositoryTest.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -1005,6 +1006,166 @@ class DefaultFlagRepositoryTest {
         assertTrue("anonymous removeFlag must fail", result.isFailure)
         coVerify(exactly = 0) {
             hfrClient.removeFlag(cat = any(), subcat = any(), topicId = any(), type = any(), page = any())
+        }
+    }
+
+    // ─── findFlag (#809) ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `findFlag returns a warm cached flag without any further network - 809`() = runTest {
+        // Only the CYAN (participated) bucket is stubbed; warming it seeds topic 35395 (cat 23).
+        val (apiClient, forumRepository) = wireDeps {
+            stubFlagsCall(13, HfrRestFlagBucket.PARTICIPATED, EMPTY_PAGE)
+            stubFlagsCall(23, HfrRestFlagBucket.PARTICIPATED, capturedParticipatedFixture)
+        }
+        val repo = buildRepository(apiClient, forumRepository)
+        repo.observe(FlagType.CYAN).first { it is FlagsResult.Success }
+
+        val found = repo.findFlag(cat = 23, topicId = 35395)
+        assertEquals(35395, found?.topicId)
+        assertEquals(FlagType.CYAN, found?.type)
+
+        // A memory hit fires NO fallback fan-out: the RED / FAVORITE buckets were never queried.
+        coVerify(exactly = 0) {
+            apiClient.getCategoryFlagTopics(
+                cat = any(), bucket = HfrRestFlagBucket.READ, page = any(), resultsPerPage = any(), useAuth = any(),
+            )
+        }
+        coVerify(exactly = 0) {
+            apiClient.getCategoryFlagTopics(
+                cat = any(),
+                bucket = HfrRestFlagBucket.FAVORITES,
+                page = any(),
+                resultsPerPage = any(),
+                useAuth = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `findFlag resolves a cold FAVORITE behind a warm CYAN miss - 809`() = runTest {
+        // Review finding #809 — the Drapeaux screen warms ONE tab at a time : a warm-but-missing
+        // CYAN bucket says nothing about a never-loaded FAVORITE bucket. The cold buckets — and
+        // only those — are fetched, so a FAVORITE-only topic stays removable from the topic screen.
+        val (apiClient, forumRepository) = wireDeps {
+            stubFlagsCall(13, HfrRestFlagBucket.PARTICIPATED, EMPTY_PAGE)
+            stubFlagsCall(23, HfrRestFlagBucket.PARTICIPATED, EMPTY_PAGE)
+            stubFlagsCall(13, HfrRestFlagBucket.READ, EMPTY_PAGE)
+            stubFlagsCall(23, HfrRestFlagBucket.READ, EMPTY_PAGE)
+            stubFlagsCall(13, HfrRestFlagBucket.FAVORITES, EMPTY_PAGE)
+            stubFlagsCall(23, HfrRestFlagBucket.FAVORITES, capturedParticipatedFixture)
+        }
+        val repo = buildRepository(apiClient, forumRepository)
+        repo.observe(FlagType.CYAN).first { it is FlagsResult.Success } // warms CYAN only
+
+        val found = repo.findFlag(cat = 23, topicId = 35395)
+        assertEquals(35395, found?.topicId)
+        assertEquals(FlagType.FAVORITE, found?.type)
+
+        // The warm CYAN bucket was authoritative for its own type : never implicitly re-fetched.
+        coVerify(exactly = 1) {
+            apiClient.getCategoryFlagTopics(
+                cat = 23,
+                bucket = HfrRestFlagBucket.PARTICIPATED,
+                page = any(),
+                resultsPerPage = any(),
+                useAuth = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `findFlag misses with zero network when all three buckets are warm - 809`() = runTest {
+        val (apiClient, forumRepository) = wireDeps {
+            stubFlagsCall(13, HfrRestFlagBucket.PARTICIPATED, EMPTY_PAGE)
+            stubFlagsCall(23, HfrRestFlagBucket.PARTICIPATED, capturedParticipatedFixture)
+            stubFlagsCall(13, HfrRestFlagBucket.READ, EMPTY_PAGE)
+            stubFlagsCall(23, HfrRestFlagBucket.READ, EMPTY_PAGE)
+            stubFlagsCall(13, HfrRestFlagBucket.FAVORITES, EMPTY_PAGE)
+            stubFlagsCall(23, HfrRestFlagBucket.FAVORITES, EMPTY_PAGE)
+        }
+        val repo = buildRepository(apiClient, forumRepository)
+        FlagType.entries.forEach { type ->
+            repo.observe(type).first { it is FlagsResult.Success }
+        }
+
+        // Every bucket warm + miss → null with ZERO additional network (one observe fetch per
+        // bucket per cat, nothing more — the Drapeaux view owns refresh policy).
+        val found = repo.findFlag(cat = 23, topicId = 999_999)
+        assertNull(found)
+        HfrRestFlagBucket.entries.forEach { bucket ->
+            coVerify(exactly = 1) {
+                apiClient.getCategoryFlagTopics(
+                    cat = 23, bucket = bucket, page = any(), resultsPerPage = any(), useAuth = any(),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `findFlag fans out the three buckets and hits when no cache is warm - 809`() = runTest {
+        // Cold caches: every bucket of every cat must be stubbed since the fallback fans all three out.
+        // The target 35395 lives in the FAVORITES bucket, so the re-scan resolves it as a FAVORITE.
+        val (apiClient, forumRepository) = wireDeps {
+            stubFlagsCall(13, HfrRestFlagBucket.PARTICIPATED, EMPTY_PAGE)
+            stubFlagsCall(23, HfrRestFlagBucket.PARTICIPATED, EMPTY_PAGE)
+            stubFlagsCall(13, HfrRestFlagBucket.READ, EMPTY_PAGE)
+            stubFlagsCall(23, HfrRestFlagBucket.READ, EMPTY_PAGE)
+            stubFlagsCall(13, HfrRestFlagBucket.FAVORITES, EMPTY_PAGE)
+            stubFlagsCall(23, HfrRestFlagBucket.FAVORITES, capturedParticipatedFixture)
+        }
+        val repo = buildRepository(apiClient, forumRepository)
+
+        val found = repo.findFlag(cat = 23, topicId = 35395)
+        assertEquals(35395, found?.topicId)
+        assertEquals(FlagType.FAVORITE, found?.type)
+
+        // The fan-out actually queried the FAVORITES bucket that held the match.
+        coVerify {
+            apiClient.getCategoryFlagTopics(
+                cat = 23, bucket = HfrRestFlagBucket.FAVORITES, page = any(), resultsPerPage = any(), useAuth = true,
+            )
+        }
+    }
+
+    @Test
+    fun `findFlag tie-breaks a multi-bucket topic to the earliest FlagType - 809`() = runTest {
+        // Gate Codex #809 — topic 35395 warm in BOTH the CYAN and FAVORITE buckets : the EnumMap
+        // iteration (CYAN → RED → FAVORITE) must resolve it deterministically to CYAN, the type
+        // `removeFlag` will key `delflag.php` on.
+        val (apiClient, forumRepository) = wireDeps {
+            stubFlagsCall(13, HfrRestFlagBucket.PARTICIPATED, EMPTY_PAGE)
+            stubFlagsCall(23, HfrRestFlagBucket.PARTICIPATED, capturedParticipatedFixture)
+            stubFlagsCall(13, HfrRestFlagBucket.FAVORITES, EMPTY_PAGE)
+            stubFlagsCall(23, HfrRestFlagBucket.FAVORITES, capturedParticipatedFixture)
+        }
+        val repo = buildRepository(apiClient, forumRepository)
+        repo.observe(FlagType.CYAN).first { it is FlagsResult.Success }
+        repo.observe(FlagType.FAVORITE).first { it is FlagsResult.Success }
+
+        val found = repo.findFlag(cat = 23, topicId = 35395)
+        assertEquals(35395, found?.topicId)
+        assertEquals(FlagType.CYAN, found?.type)
+    }
+
+    @Test
+    fun `findFlag returns null for an anonymous session without hitting the network - 809`() = runTest {
+        val apiClient = mockk<HfrApiClient>(relaxed = true)
+        val anonymousAuth = mockk<AuthRepository>()
+        every { anonymousAuth.observeAuthState() } returns flowOf(AuthState.Anonymous)
+        val repo = buildRepository(
+            apiClient = apiClient,
+            forumRepository = stubForumRepository(sampleCategories),
+            authRepository = anonymousAuth,
+        )
+
+        // Cold cache + anonymous → short-circuit to null before any REST round-trip.
+        val found = repo.findFlag(cat = 23, topicId = 35395)
+        assertNull(found)
+        coVerify(exactly = 0) {
+            apiClient.getCategoryFlagTopics(
+                cat = any(), bucket = any(), page = any(), resultsPerPage = any(), useAuth = any(),
+            )
         }
     }
 

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/flags/FlagRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/flags/FlagRepository.kt
@@ -58,6 +58,25 @@ interface FlagRepository {
      * otherwise — including transport / session-expiry errors.
      */
     suspend fun removeFlag(flag: Flag): Result<Unit>
+
+    /**
+     * Resolve the full [Flag] for a `(cat, topicId)` pair (#809), for surfaces OUTSIDE the Drapeaux
+     * view that hold a topic identity but not the loaded [Flag] — e.g. the topic screen's long-press
+     * « Retirer le drapeau ». [removeFlag] needs the complete object (its `subcat` / `type` /
+     * `lastReadPage` form the `delflag.php` key), so a partial [Flag] must never be fabricated : this
+     * lookup returns the real cached/fetched row or nothing.
+     *
+     * Resolution order (per-bucket) :
+     * - Scans the in-memory per-type success caches first ; a hit returns without any network.
+     * - A warm bucket is authoritative **for its own type only** and is never implicitly refreshed
+     *   (the Drapeaux view owns refresh policy). On a miss, the **cold** buckets — and only those —
+     *   are fetched so the lookup can still resolve a type whose tab was never opened ; then a
+     *   re-scan decides. All three warm + miss → null with zero network.
+     * - An anonymous session (no HFR user) can hold no drapeaux : null with no round-trip.
+     *
+     * Returns the matching [Flag], or null when the topic is not flagged / unresolvable / anonymous.
+     */
+    suspend fun findFlag(cat: Int, topicId: Int): Flag?
 }
 
 /**

--- a/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
+++ b/feature/flags/src/test/kotlin/fr/forumhfr/redface2/feature/flags/FlagsViewModelTest.kt
@@ -2389,6 +2389,11 @@ class FlagsViewModelTest {
             return removeFlagResult.await()
         }
 
+        override suspend fun findFlag(cat: Int, topicId: Int): Flag? {
+            // #809 — not exercised by the Drapeaux-view tests (findFlag serves the topic screen).
+            return null
+        }
+
         suspend fun emit(type: FlagType, result: FlagsResult) {
             perType.getValue(type).emit(result)
         }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -95,6 +95,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.forumhfr.redface2.core.domain.author.isRf2Creator
+import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.Poll
 import fr.forumhfr.redface2.core.model.Post
 import fr.forumhfr.redface2.core.model.Topic
@@ -342,6 +343,10 @@ fun TopicScreen(
     val searchFailedMsg = stringResource(R.string.topic_search_failed)
     // Chantier B (#546) — « no further result » Toast (resolved upfront, same rationale).
     val searchResultsEndMsg = stringResource(R.string.topic_search_results_end)
+    // #809 — flag-removal feedback messages (resolved upfront, same rationale).
+    val flagRemovedMsg = stringResource(R.string.topic_remove_flag_success)
+    val flagRemoveFailedMsg = stringResource(R.string.topic_remove_flag_failure)
+    val flagNotFoundMsg = stringResource(R.string.topic_remove_flag_not_found)
     // #292 — delete feedback messages, resolved upfront (same rationale as refreshFailedMsg).
     val deleteSuccessMsg = stringResource(R.string.topic_post_delete_success)
     val deleteFailedLoginMsg = stringResource(R.string.topic_post_delete_failed_login)
@@ -350,6 +355,10 @@ fun TopicScreen(
     // #292 — `numreponse` awaiting delete confirmation (null = no dialog). Local UI state: the
     // confirmation is a pure view concern, only the confirmed deletion reaches the ViewModel.
     var deleteCandidate by rememberSaveable { mutableStateOf<Int?>(null) }
+    // #809 — long-press flag removal. The confirmation dialog is state-driven (the ViewModel owns the
+    // resolve → confirm → remove flow); the outcomes ride the screen's single TopicEffect collector
+    // below, like every other one-shot Toast on this screen.
+    val removeTopicFlagState by viewModel.removeTopicFlagState.collectAsStateWithLifecycle()
 
     // Bug fix (build 89) — report the loaded title up so `:app` caches it per topic. The next page
     // (recreated screen) reads it back through `request.titleHint`, keeping the top bar title stable
@@ -481,6 +490,28 @@ fun TopicScreen(
                         android.widget.Toast.LENGTH_SHORT,
                     ).show()
                 }
+                TopicEffect.TopicFlagRemoved -> {
+                    // #809 — delflag confirmed; the Drapeaux caches are already reconciled.
+                    android.widget.Toast.makeText(
+                        context,
+                        flagRemovedMsg,
+                        android.widget.Toast.LENGTH_SHORT,
+                    ).show()
+                }
+                TopicEffect.TopicFlagRemovalFailed -> {
+                    android.widget.Toast.makeText(
+                        context,
+                        flagRemoveFailedMsg,
+                        android.widget.Toast.LENGTH_LONG,
+                    ).show()
+                }
+                TopicEffect.TopicFlagNotFound -> {
+                    android.widget.Toast.makeText(
+                        context,
+                        flagNotFoundMsg,
+                        android.widget.Toast.LENGTH_SHORT,
+                    ).show()
+                }
             }
         }
     }
@@ -532,6 +563,44 @@ fun TopicScreen(
             onDismiss = { deleteCandidate = null },
         )
     }
+
+    // #809 — confirmation gate before the delflag call. Renders only while the ViewModel is in the
+    // Confirming state; confirming moves to Removing (action disabled) and fires the removal.
+    (removeTopicFlagState as? RemoveTopicFlagState.Confirming)?.let { confirming ->
+        RemoveTopicFlagConfirmDialog(
+            flag = confirming.flag,
+            onConfirm = viewModel::confirmRemoveTopicFlag,
+            onDismiss = viewModel::cancelRemoveTopicFlag,
+        )
+    }
+}
+
+/**
+ * #809 — M3 confirmation dialog shown before the `delflag.php` call, mirroring the Drapeaux view's
+ * `RemoveFlagConfirmationDialog` (#99). Spells out the topic title so the user knows exactly what is
+ * being un-flagged — the removal is not undoable in-app (no optimistic re-add).
+ */
+@Composable
+private fun RemoveTopicFlagConfirmDialog(
+    flag: Flag,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.topic_remove_flag_dialog_title)) },
+        text = { Text(stringResource(R.string.topic_remove_flag_dialog_message, flag.title)) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.topic_remove_flag_dialog_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.topic_remove_flag_dialog_cancel))
+            }
+        },
+    )
 }
 
 /**
@@ -1087,6 +1156,8 @@ internal fun TopicTopBar(
     val titleStateLabel = stringResource(
         if (titleExpanded) R.string.topic_title_expanded else R.string.topic_title_collapsed,
     )
+    // #809 — long-press on the title opens the drapeau-removal flow (the tap toggle is unchanged).
+    val titleLongPressLabel = stringResource(R.string.topic_remove_flag_long_press)
     Column {
         TopAppBar(
             title = {
@@ -1097,16 +1168,26 @@ internal fun TopicTopBar(
                         maxLines = if (titleExpanded) 2 else 1,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier
-                            .clickable(onClickLabel = titleToggleLabel) {
-                                val expanding = !titleExpanded
-                                titleExpanded = expanding
-                                if (expanding) {
-                                    // enterAlways may hold the bar partially collapsed — re-deploy
-                                    // it so the freshly granted second line shows instead of
-                                    // staying clipped behind the current height offset.
-                                    scrollBehavior?.state?.heightOffset = 0f
-                                }
-                            }
+                            // #809 — combinedClickable adds the long-press (« Gérer le drapeau ») on
+                            // top of the #772 tap toggle. onClick is the SAME toggle as before
+                            // (heightOffset re-deploy included) so TopicTopBarTitleExpandTest stays
+                            // green; onClickLabel + the stateDescription semantics are preserved.
+                            .combinedClickable(
+                                onClickLabel = titleToggleLabel,
+                                onLongClickLabel = titleLongPressLabel,
+                                role = Role.Button,
+                                onLongClick = { onIntent(TopicIntent.RequestRemoveTopicFlag) },
+                                onClick = {
+                                    val expanding = !titleExpanded
+                                    titleExpanded = expanding
+                                    if (expanding) {
+                                        // enterAlways may hold the bar partially collapsed — re-deploy
+                                        // it so the freshly granted second line shows instead of
+                                        // staying clipped behind the current height offset.
+                                        scrollBehavior?.state?.heightOffset = 0f
+                                    }
+                                },
+                            )
                             .semantics { stateDescription = titleStateLabel },
                     )
                     Text(

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -1,6 +1,7 @@
 package fr.forumhfr.redface2.feature.topic
 
 import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
+import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.Topic
 import fr.forumhfr.redface2.core.model.editor.WritingSurfacePreset
 
@@ -209,6 +210,13 @@ sealed interface TopicIntent {
      */
     data class SetAuthorBlocked(val author: String, val blocked: Boolean) : TopicIntent
 
+    /**
+     * #809 — a long-press on the top-bar title requests removing THIS topic's drapeau. Carries no
+     * payload : the ViewModel already knows the topic from its [TopicRequest] and resolves the full
+     * [fr.forumhfr.redface2.core.model.Flag] through `FlagRepository.findFlag` before confirming.
+     */
+    data object RequestRemoveTopicFlag : TopicIntent
+
     // ─── intra-topic search (#546) ───────────────────────────────────────────────
 
     /** Open the search bar. No-op if the loaded page has no usable search form. */
@@ -341,4 +349,41 @@ sealed interface TopicEffect {
      * sober Toast (« Aucun résultat suivant ») and the next arrow disables.
      */
     data object SearchResultsEnd : TopicEffect
+
+    // ─── #809 — one-shot outcomes of the title long-press flag removal. They ride THIS channel
+    // (the screen's single effects collector + Toast surface, like PostDeleted) rather than a
+    // parallel consumable StateFlow — one one-shot mechanism per screen (review finding).
+
+    /** #809 — `delflag.php` confirmed the removal ; the Drapeaux caches are already reconciled. */
+    data object TopicFlagRemoved : TopicEffect
+
+    /** #809 — the removal failed (refused, transport, session) ; nothing was touched. */
+    data object TopicFlagRemovalFailed : TopicEffect
+
+    /**
+     * #809 — the long-press resolved to no removable drapeau : topic not flagged, anonymous
+     * session, or an unresolvable lookup (resolve failure folds here — cf. TopicViewModel).
+     */
+    data object TopicFlagNotFound : TopicEffect
 }
+
+/**
+ * #809 — drives the « Retirer le drapeau » long-press interaction on the topic top bar. MVI-style
+ * explicit state so the confirmation gates the network call. Mirrors FlagsViewModel's
+ * `RemoveFlagState`, plus a [Resolving] step the Drapeaux view never needs : that screen already
+ * holds the [Flag], whereas the topic screen must first resolve it through `FlagRepository.findFlag`
+ * (which may fan out the network on a cold cache).
+ *
+ * - [Idle] — nothing pending.
+ * - [Resolving] — the long-press fired ; the flag lookup is in flight. Blocks a second long-press.
+ * - [Confirming] — a drapeau was found ; the screen shows the confirmation dialog ([flag] feeds its
+ *   title). Absent this state, no dialog.
+ * - [Removing] — the user confirmed ; the `delflag.php` call is in flight (anti double-tap).
+ */
+sealed interface RemoveTopicFlagState {
+    data object Idle : RemoveTopicFlagState
+    data object Resolving : RemoveTopicFlagState
+    data class Confirming(val flag: Flag) : RemoveTopicFlagState
+    data class Removing(val flag: Flag) : RemoveTopicFlagState
+}
+

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -11,6 +11,7 @@ import fr.forumhfr.redface2.core.domain.auth.AuthRepository
 import fr.forumhfr.redface2.core.domain.blacklist.BlacklistRepository
 import fr.forumhfr.redface2.core.domain.blacklist.canonicalizePseudo
 import fr.forumhfr.redface2.core.domain.error.classifyHfrError
+import fr.forumhfr.redface2.core.domain.flags.FlagRepository
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.search.SearchRepository
 import fr.forumhfr.redface2.core.domain.topic.NoTopicSearchResultsException
@@ -51,7 +52,12 @@ import kotlinx.coroutines.withTimeoutOrNull
  * synthetic chain of pages.
  */
 @HiltViewModel(assistedFactory = TopicViewModel.Factory::class)
-@Suppress("LongParameterList") // ViewModel aggregates its injected repositories; one per concern.
+// LongParameterList: the ViewModel aggregates its injected repositories, one per concern.
+// LargeClass (#809): the topic ViewModel is the reading surface's single MVI hub — load / pagination /
+// refresh / delete / intra-topic search / flag removal all live here by design (same aggregator shape
+// as FlagsViewModel). Adding the #809 flow tipped it over the threshold; splitting the hub is a
+// separate refactor, tracked rather than forced by this feature.
+@Suppress("LongParameterList", "LargeClass")
 class TopicViewModel @AssistedInject constructor(
     // #750 — `var`, not `val`: when [TopicRequest.resolveScrollToPage] is set the real target page
     // is only known after the resolution probe; the resolved request then REPLACES this one (and
@@ -65,6 +71,9 @@ class TopicViewModel @AssistedInject constructor(
     private val blacklistRepository: BlacklistRepository,
     private val topicSearchRepository: TopicSearchRepository,
     private val searchRepository: SearchRepository,
+    // #809 — plain Hilt dependency (the assisted Factory is unchanged): resolves + removes THIS
+    // topic's drapeau for the top-bar long-press.
+    private val flagRepository: FlagRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(TopicUiState.initial(request))
@@ -207,6 +216,7 @@ class TopicViewModel @AssistedInject constructor(
             is TopicIntent.DeletePost -> deletePost(intent.numreponse)
             TopicIntent.Refresh -> refresh()
             is TopicIntent.SetAuthorBlocked -> setAuthorBlocked(intent.author, intent.blocked)
+            TopicIntent.RequestRemoveTopicFlag -> requestRemoveTopicFlag()
             TopicIntent.OpenSearch -> openSearch()
             TopicIntent.CloseSearch -> closeSearch()
             is TopicIntent.SearchWordChanged ->
@@ -670,6 +680,93 @@ class TopicViewModel @AssistedInject constructor(
             } catch (@Suppress("TooGenericExceptionCaught") refreshError: Exception) {
                 android.util.Log.w(LOG_TAG, "Post-delete refresh failed", refreshError)
                 loadCurrentPage()
+            }
+        }
+    }
+
+    // ─── remove topic flag (#809) ─────────────────────────────────────────────────
+
+    /**
+     * #809 — drives the top-bar long-press « Retirer le drapeau » interaction. Explicit MVI state so
+     * the confirmation gates the delflag call and the anti double-press guard is observable. The
+     * [RemoveTopicFlagState.Resolving] step (which FlagsViewModel lacks — it already holds the Flag)
+     * covers the async lookup that may fan out the network on a cold flag cache.
+     */
+    private val _removeTopicFlagState = MutableStateFlow<RemoveTopicFlagState>(RemoveTopicFlagState.Idle)
+    val removeTopicFlagState: StateFlow<RemoveTopicFlagState> = _removeTopicFlagState.asStateFlow()
+
+    /**
+     * #809 — user long-pressed the title : resolve THIS topic's drapeau, then either raise the
+     * confirmation dialog ([RemoveTopicFlagState.Confirming]) or emit [TopicEffect.TopicFlagNotFound]
+     * (topic not flagged, anonymous, or an unresolvable lookup — see below). The outcome rides the
+     * screen's single [effects] channel like every other one-shot Toast (review finding : no parallel
+     * consumable StateFlow). No-op while a lookup or a removal is already running, so a second
+     * long-press during the (possibly network-bound) resolve cannot launch a duplicate.
+     */
+    @Suppress("TooGenericExceptionCaught") // gate #809 — any resolve failure folds to NotFound below;
+    // cancellation is rethrown after releasing the state.
+    fun requestRemoveTopicFlag() {
+        val current = _removeTopicFlagState.value
+        if (current is RemoveTopicFlagState.Resolving || current is RemoveTopicFlagState.Removing) return
+        _removeTopicFlagState.value = RemoveTopicFlagState.Resolving
+        viewModelScope.launch {
+            // Gate Codex #809 — findFlag can die mid-resolve (an in-flight fetch cancelled by an
+            // account switch, an unexpected runtime failure) : fold it to « unresolvable » instead of
+            // leaving the state wedged in Resolving with no event — the long-press would otherwise be
+            // dead until the VM is recreated. CancellationException is rethrown (the scope is going
+            // away) AFTER releasing the state.
+            val flag = try {
+                flagRepository.findFlag(cat = request.cat, topicId = request.post)
+            } catch (cancelled: CancellationException) {
+                _removeTopicFlagState.value = RemoveTopicFlagState.Idle
+                throw cancelled
+            } catch (_: Exception) {
+                null
+            }
+            if (flag != null) {
+                _removeTopicFlagState.value = RemoveTopicFlagState.Confirming(flag)
+            } else {
+                _effects.send(TopicEffect.TopicFlagNotFound)
+                _removeTopicFlagState.value = RemoveTopicFlagState.Idle
+            }
+        }
+    }
+
+    /** #809 — user dismissed the confirmation dialog without confirming. */
+    fun cancelRemoveTopicFlag() {
+        if (_removeTopicFlagState.value is RemoveTopicFlagState.Confirming) {
+            _removeTopicFlagState.value = RemoveTopicFlagState.Idle
+        }
+    }
+
+    /**
+     * #809 — user confirmed in the dialog : move to [RemoveTopicFlagState.Removing] (disables the
+     * action), call the repository, then emit the one-shot outcome on [effects]. The repository owns
+     * the cache reconciliation, so nothing optimistic happens here.
+     */
+    fun confirmRemoveTopicFlag() {
+        val confirming = _removeTopicFlagState.value as? RemoveTopicFlagState.Confirming ?: return
+        val flag = confirming.flag
+        _removeTopicFlagState.value = RemoveTopicFlagState.Removing(flag)
+        viewModelScope.launch {
+            try {
+                // Review #809 — removeFlag CAN throw outside its Result (evictFlagFromCaches runs in
+                // `.onSuccess`, past the internal runCatching) : fold a raw throw to Failure so the
+                // user still gets feedback instead of a crash. Cancellation propagates untouched
+                // (the finally below releases the lock either way).
+                val result = runCatching { flagRepository.removeFlag(flag) }
+                    .getOrElse { raised ->
+                        if (raised is CancellationException) throw raised
+                        Result.failure(raised)
+                    }
+                _effects.send(
+                    if (result.isSuccess) TopicEffect.TopicFlagRemoved else TopicEffect.TopicFlagRemovalFailed,
+                )
+            } finally {
+                // #603 audit fix (fork #5) — always release the Removing lock, even if removeFlag
+                // throws outside its Result (or the coroutine is cancelled). Otherwise the state stays
+                // Removing forever and the anti double-tap guard wedges until the VM is recreated.
+                _removeTopicFlagState.value = RemoveTopicFlagState.Idle
             }
         }
     }

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -143,6 +143,15 @@
     <string name="topic_title_collapse">Réduire le titre</string>
     <string name="topic_title_expanded">Titre développé</string>
     <string name="topic_title_collapsed">Titre réduit</string>
+    <!-- #809 : appui long sur le titre de la top bar pour retirer le drapeau du sujet. -->
+    <string name="topic_remove_flag_long_press">Gérer le drapeau</string>
+    <string name="topic_remove_flag_dialog_title">Retirer le drapeau de ce sujet ?</string>
+    <string name="topic_remove_flag_dialog_message">Retirer le drapeau de « %1$s » ? Cette action est définitive depuis l\'app.</string>
+    <string name="topic_remove_flag_dialog_confirm">Retirer</string>
+    <string name="topic_remove_flag_dialog_cancel">Annuler</string>
+    <string name="topic_remove_flag_success">Drapeau retiré</string>
+    <string name="topic_remove_flag_failure">Impossible de retirer le drapeau</string>
+    <string name="topic_remove_flag_not_found">Aucun drapeau trouvé pour ce sujet</string>
     <!-- Vague 4 (#604) lot 1 : feuille de réponse rapide. Wording d'erreurs = copie locale de
          feature/editor (les modules res ne se partagent pas ; promotion :core:ui si un 3e copieur
          apparaît). -->

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicTopBarTitleExpandTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicTopBarTitleExpandTest.kt
@@ -6,9 +6,12 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
 import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -72,6 +75,34 @@ class TopicTopBarTitleExpandTest {
         composeTestRule.onNode(withStateDescription(EXPANDED_STATE)).assertHasClickAction()
         composeTestRule.onNodeWithText(LONG_TITLE).performClick()
         composeTestRule.onNode(withStateDescription(COLLAPSED_STATE)).assertHasClickAction()
+    }
+
+    @Test
+    fun `a long press emits the flag-removal intent while a short tap still toggles (#809)`() {
+        val intents = mutableListOf<TopicIntent>()
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                TopicTopBar(
+                    state = sampleState(),
+                    barTitle = LONG_TITLE,
+                    barPageIndicator = "page 3 / 10",
+                    backLabel = "Retour",
+                    scrollBehavior = null,
+                    onBack = {},
+                    onIntent = { intents += it },
+                )
+            }
+        }
+
+        // A long press fires the drapeau-removal intent and does NOT toggle the title (combinedClickable
+        // routes a long press to onLongClick only): the title stays collapsed and clickable.
+        composeTestRule.onNodeWithText(LONG_TITLE).performTouchInput { longClick() }
+        assertEquals(listOf<TopicIntent>(TopicIntent.RequestRemoveTopicFlag), intents)
+        composeTestRule.onNode(withStateDescription(COLLAPSED_STATE)).assertHasClickAction()
+
+        // A short tap still toggles to expanded — the #772 tap contract survives the #809 long-press wiring.
+        composeTestRule.onNodeWithText(LONG_TITLE).performClick()
+        composeTestRule.onNode(withStateDescription(EXPANDED_STATE)).assertHasClickAction()
     }
 
     private fun withStateDescription(value: String): SemanticsMatcher =

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -6,6 +6,8 @@ import fr.forumhfr.redface2.core.domain.blacklist.BlacklistRepository
 import fr.forumhfr.redface2.core.domain.blacklist.canonicalizePseudo
 import fr.forumhfr.redface2.core.domain.error.HfrErrorKind
 import fr.forumhfr.redface2.core.domain.error.HfrServerException
+import fr.forumhfr.redface2.core.domain.flags.FlagRepository
+import fr.forumhfr.redface2.core.domain.flags.FlagsResult
 import fr.forumhfr.redface2.core.domain.preferences.DisplayDensity
 import fr.forumhfr.redface2.core.domain.preferences.CategoryBandStyle
 import fr.forumhfr.redface2.core.domain.preferences.FlagGlyphStyle
@@ -35,6 +37,7 @@ import fr.forumhfr.redface2.core.domain.write.DeletePostRepository
 import fr.forumhfr.redface2.core.domain.write.DeletePostResult
 import fr.forumhfr.redface2.core.model.AuthState
 import fr.forumhfr.redface2.core.model.blacklist.BlacklistEntry
+import fr.forumhfr.redface2.core.model.Flag
 import fr.forumhfr.redface2.core.model.FlagType
 import fr.forumhfr.redface2.core.model.write.EditPostContext
 import fr.forumhfr.redface2.core.model.write.ReplyFailureReason
@@ -1346,6 +1349,224 @@ class TopicViewModelTest {
     }
 
     /** Chantier B (#546) — a topic repo that loads a 5-page topic carrying [form] (keeps lines short). */
+    // ──────────────────────────────────────────────────────────────────────
+    // #809 — long-press flag removal from the topic top bar
+    // ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `requestRemoveTopicFlag resolves then moves to Confirming when a flag is found (#809)`() = runTest {
+        val flag = fakeFlag()
+        // Gate the lookup so the Resolving frame is observable (an instant findFlag would be conflated
+        // by the StateFlow before the collector reads it).
+        val gate = CompletableDeferred<Unit>()
+        val flagRepo = FakeFlagRepository(flagToFind = flag).apply { findFlagGate = gate }
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(2, 3)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            flagRepository = flagRepo,
+        )
+
+        viewModel.removeTopicFlagState.test {
+            assertEquals(RemoveTopicFlagState.Idle, awaitItem())
+            viewModel.send(TopicIntent.RequestRemoveTopicFlag)
+            assertEquals(RemoveTopicFlagState.Resolving, awaitItem())
+            gate.complete(Unit)
+            val confirming = awaitItem() as RemoveTopicFlagState.Confirming
+            assertEquals(flag, confirming.flag)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(1, flagRepo.findFlagCalls)
+    }
+
+    @Test
+    fun `requestRemoveTopicFlag emits NotFound and returns to Idle when no flag is found (#809)`() = runTest {
+        val flagRepo = FakeFlagRepository(flagToFind = null)
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(2, 3)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            flagRepository = flagRepo,
+        )
+
+        viewModel.send(TopicIntent.RequestRemoveTopicFlag)
+
+        viewModel.effects.test {
+            assertEquals(TopicEffect.TopicFlagNotFound, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(RemoveTopicFlagState.Idle, viewModel.removeTopicFlagState.value)
+        assertTrue(
+            "a NotFound resolution must never reach the confirmation dialog",
+            viewModel.removeTopicFlagState.value !is RemoveTopicFlagState.Confirming,
+        )
+    }
+
+    @Test
+    fun `requestRemoveTopicFlag folds a resolve failure into NotFound and returns to Idle (#809)`() = runTest {
+        // Gate Codex #809 — a findFlag that dies mid-resolve (cancelled in-flight fetch after an
+        // account switch, runtime failure) must not wedge the state in Resolving with no event :
+        // it folds to NotFound and the long-press stays usable.
+        val flagRepo = FakeFlagRepository(flagToFind = fakeFlag()).apply {
+            findFlagError = RuntimeException("resolve died")
+        }
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(2, 3)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            flagRepository = flagRepo,
+        )
+
+        viewModel.send(TopicIntent.RequestRemoveTopicFlag)
+
+        viewModel.effects.test {
+            assertEquals(TopicEffect.TopicFlagNotFound, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(RemoveTopicFlagState.Idle, viewModel.removeTopicFlagState.value)
+
+        // The guard is released : a next long-press resolves again instead of being wedged.
+        flagRepo.findFlagError = null
+        viewModel.send(TopicIntent.RequestRemoveTopicFlag)
+        assertTrue(
+            "after a failed resolve, a retry must reach Confirming",
+            viewModel.removeTopicFlagState.value is RemoveTopicFlagState.Confirming,
+        )
+    }
+
+    @Test
+    fun `requestRemoveTopicFlag ignores a second press while Resolving (#809)`() = runTest {
+        val gate = CompletableDeferred<Unit>()
+        val flagRepo = FakeFlagRepository(flagToFind = fakeFlag()).apply { findFlagGate = gate }
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(2, 3)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            flagRepository = flagRepo,
+        )
+
+        viewModel.send(TopicIntent.RequestRemoveTopicFlag) // → Resolving, awaiting the gate
+        viewModel.send(TopicIntent.RequestRemoveTopicFlag) // ignored while Resolving
+
+        assertEquals(RemoveTopicFlagState.Resolving, viewModel.removeTopicFlagState.value)
+        assertEquals("the second long-press must not launch a duplicate lookup", 1, flagRepo.findFlagCalls)
+        gate.complete(Unit)
+    }
+
+    @Test
+    fun `requestRemoveTopicFlag ignores a press while a removal is in flight (#809)`() = runTest {
+        val removeGate = CompletableDeferred<Unit>()
+        val flagRepo = FakeFlagRepository(flagToFind = fakeFlag()).apply { removeFlagGate = removeGate }
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(2, 3)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            flagRepository = flagRepo,
+        )
+
+        viewModel.send(TopicIntent.RequestRemoveTopicFlag) // resolves instantly → Confirming
+        viewModel.confirmRemoveTopicFlag() // → Removing, awaiting the removal gate
+        assertTrue(viewModel.removeTopicFlagState.value is RemoveTopicFlagState.Removing)
+
+        viewModel.send(TopicIntent.RequestRemoveTopicFlag) // ignored while Removing
+
+        assertEquals("no re-resolution while a removal is in flight", 1, flagRepo.findFlagCalls)
+        assertTrue(viewModel.removeTopicFlagState.value is RemoveTopicFlagState.Removing)
+        removeGate.complete(Unit)
+    }
+
+    @Test
+    fun `confirmRemoveTopicFlag success emits Success and resets to Idle (#809)`() = runTest {
+        val flag = fakeFlag(title = "Redface 2")
+        val flagRepo = FakeFlagRepository(flagToFind = flag, removeResult = Result.success(Unit))
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(2, 3)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            flagRepository = flagRepo,
+        )
+
+        viewModel.send(TopicIntent.RequestRemoveTopicFlag)
+        assertTrue(viewModel.removeTopicFlagState.value is RemoveTopicFlagState.Confirming)
+        viewModel.confirmRemoveTopicFlag()
+
+        viewModel.effects.test {
+            assertEquals(TopicEffect.TopicFlagRemoved, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(RemoveTopicFlagState.Idle, viewModel.removeTopicFlagState.value)
+        assertEquals(1, flagRepo.removeFlagCalls)
+        assertEquals(flag, flagRepo.lastRemovedFlag)
+    }
+
+    @Test
+    fun `confirmRemoveTopicFlag failure emits Failure and resets to Idle (#809)`() = runTest {
+        val flag = fakeFlag(title = "Redface 2")
+        val flagRepo = FakeFlagRepository(
+            flagToFind = flag,
+            removeResult = Result.failure(IllegalStateException("delflag refused")),
+        )
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(2, 3)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            flagRepository = flagRepo,
+        )
+
+        viewModel.send(TopicIntent.RequestRemoveTopicFlag)
+        viewModel.confirmRemoveTopicFlag()
+
+        viewModel.effects.test {
+            assertEquals(TopicEffect.TopicFlagRemovalFailed, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        // The Removing lock is always released in the finally block (#603 fork 5 lesson).
+        assertEquals(RemoveTopicFlagState.Idle, viewModel.removeTopicFlagState.value)
+    }
+
+    @Test
+    fun `confirmRemoveTopicFlag folds a raw removeFlag throw into RemovalFailed (#809)`() = runTest {
+        // Review #809 — removeFlag CAN throw outside its Result (evictFlagFromCaches runs in
+        // `.onSuccess`, past the internal runCatching) : the user still gets the failure toast
+        // and the Removing lock is released, instead of an app crash with no feedback.
+        val flagRepo = FakeFlagRepository(flagToFind = fakeFlag()).apply {
+            removeFlagError = IllegalStateException("evict blew up")
+        }
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(2, 3)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            flagRepository = flagRepo,
+        )
+
+        viewModel.send(TopicIntent.RequestRemoveTopicFlag)
+        viewModel.confirmRemoveTopicFlag()
+
+        viewModel.effects.test {
+            assertEquals(TopicEffect.TopicFlagRemovalFailed, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(RemoveTopicFlagState.Idle, viewModel.removeTopicFlagState.value)
+    }
+
+    @Test
+    fun `cancelRemoveTopicFlag dismisses the confirmation without removing (#809)`() = runTest {
+        val flagRepo = FakeFlagRepository(flagToFind = fakeFlag())
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(2, 3)) })),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            flagRepository = flagRepo,
+        )
+
+        viewModel.send(TopicIntent.RequestRemoveTopicFlag)
+        assertTrue(viewModel.removeTopicFlagState.value is RemoveTopicFlagState.Confirming)
+        viewModel.cancelRemoveTopicFlag()
+
+        assertEquals(RemoveTopicFlagState.Idle, viewModel.removeTopicFlagState.value)
+        assertEquals("cancelling must never call delflag", 0, flagRepo.removeFlagCalls)
+    }
+
     private fun searchableRepo(form: TopicSearchForm): FakeTopicRepository =
         FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 5, searchForm = form)) }))
 
@@ -1359,6 +1580,7 @@ class TopicViewModelTest {
         blacklistRepository: BlacklistRepository = FakeBlacklistRepository(),
         topicSearchRepository: TopicSearchRepository = FakeTopicSearchRepository(),
         searchRepository: SearchRepository = FakeSearchRepository(),
+        flagRepository: FlagRepository = FakeFlagRepository(),
     ): TopicViewModel = TopicViewModel(
         request = request,
         topicRepository = topicRepository,
@@ -1368,6 +1590,7 @@ class TopicViewModelTest {
         blacklistRepository = blacklistRepository,
         topicSearchRepository = topicSearchRepository,
         searchRepository = searchRepository,
+        flagRepository = flagRepository,
     )
 
     private fun topicRequest(
@@ -1975,6 +2198,23 @@ class TopicViewModelTest {
         postIndex = null,
     )
 
+    // #809 — a full drapeau for the SAMPLE topic, as FlagRepository.findFlag would resolve it.
+    private fun fakeFlag(title: String = "fake flag"): Flag = Flag(
+        cat = SAMPLE_CAT,
+        subcat = SAMPLE_SUBCAT,
+        topicId = SAMPLE_POST,
+        title = title,
+        totalPages = 10,
+        replyCount = 42,
+        type = FlagType.CYAN,
+        hasUnread = true,
+        lastReadPage = 7,
+        lastPostReadId = 1234L,
+        firstPostAuthor = "XaT",
+        lastReplyAuthor = "XaTelitte",
+        lastReplyAt = "2026-05-03 12:00",
+    )
+
     private inline fun <reified T : TopicUiState.Mode> assertMode(state: TopicUiState): T {
         val mode = state.mode
         assertTrue("expected mode ${T::class.simpleName} but was ${mode::class.simpleName}", mode is T)
@@ -2081,6 +2321,52 @@ private class FakeDeletePostRepository(
     override suspend fun deletePost(context: EditPostContext): DeletePostResult {
         calls += context
         return result
+    }
+}
+
+/**
+ * #809 — canned FlagRepository for the topic ViewModel. [flagToFind] is what `findFlag` resolves
+ * (null = not flagged / anonymous), [removeResult] the removal outcome. Optional [findFlagGate] /
+ * [removeFlagGate] hold the respective call in flight so a test can observe the Resolving / Removing
+ * states and their anti double-press guard. The read APIs (`observe` / `refresh` / `clearSessionCache`)
+ * fail loudly — the topic ViewModel must never touch them.
+ */
+private class FakeFlagRepository(
+    private val flagToFind: Flag? = null,
+    private val removeResult: Result<Unit> = Result.success(Unit),
+) : FlagRepository {
+    var findFlagCalls = 0
+    var removeFlagCalls = 0
+    var lastRemovedFlag: Flag? = null
+    var findFlagGate: CompletableDeferred<Unit>? = null
+    var removeFlagGate: CompletableDeferred<Unit>? = null
+
+    /** Gate #809 — when set, [findFlag] throws instead of returning (resolve failure path). */
+    var findFlagError: Throwable? = null
+
+    /** Review #809 — when set, [removeFlag] throws RAW (outside its Result contract). */
+    var removeFlagError: Throwable? = null
+
+    override fun observe(type: FlagType): Flow<FlagsResult> =
+        error("TopicViewModel must not observe flags")
+
+    override suspend fun refresh(type: FlagType) = error("TopicViewModel must not refresh flags")
+
+    override fun clearSessionCache() = error("TopicViewModel must not clear the flags cache")
+
+    override suspend fun findFlag(cat: Int, topicId: Int): Flag? {
+        findFlagCalls++
+        findFlagGate?.await()
+        findFlagError?.let { throw it }
+        return flagToFind
+    }
+
+    override suspend fun removeFlag(flag: Flag): Result<Unit> {
+        removeFlagCalls++
+        lastRemovedFlag = flag
+        removeFlagGate?.await()
+        removeFlagError?.let { throw it }
+        return removeResult
     }
 }
 


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi

**#809** (#tagsuggestion tinc) : **appui long sur le titre** de la top bar du topic → retirer le drapeau du sujet courant, sans repasser par la liste. MVP « retirer » seul (option (a) arbitrée ; `addflag` = favoris only, hors périmètre).

- `FlagRepository.findFlag(cat, topicId)` : lookup mémoire-d'abord **par bucket** — un bucket chaud fait autorité pour son seul type, les buckets froids sont fetchés à la demande (un FAVORITE jamais chargé reste retirable), all-warm+miss → zéro réseau, anonyme → zéro réseau. Tie-break multi-bucket déterministe CYAN→RED→FAVORITE (EnumMap, épinglé par test).
- `TopicViewModel` : machine d'états `Resolving/Confirming/Removing` (anti double-appui, `finally`→Idle), issues one-shot sur le **canal `TopicEffect` existant** (pas de StateFlow consommable parallèle), gardes try/catch autour du resolve ET du delflag (`evictFlagFromCaches` vit dans `.onSuccess`, hors `runCatching`).
- UI : `combinedClickable` sur le titre (toggle #772 strictement intact, `heightOffset` compris ; a11y onClickLabel/onLongClickLabel/stateDescription), dialog contextuel « Retirer le drapeau de ce sujet ? », toasts (canal existant de l'écran).

## Validation

- Cadrage Codex GO → gate **NO-GO** (findFlag non gardé) → fixes → **re-gate GO-avec-réserves** (les 2 réserves levées par preuve : EnumMap vérifié ligne 86 + canonique verte).
- **Review multi-angles (8 angles, 4 finders + vérification)** : 4 findings ≥ 65 confirmés et **corrigés** — faux négatif per-bucket, canal one-shot dupliqué, throw brut de removeFlag, payload mort. Non retenus (< 65, documentés) : NotFound confond « pas de drapeau » et « vérification impossible » (limitation MVP assumée), pas de spinner pendant Resolving, duplication du dialog avec la vue Drapeaux (2ᵉ copie — promotion :core:ui au 3ᵉ copieur, convention du repo), split de TopicViewModel (dette LargeClass suivie ici même).
- Canonique complète : BUILD SUCCESSFUL. 12 tests VM + 6 tests repo + test top bar long-press.
- Dogfood émulateur : appui long → dialog (titre du sujet inclus) → « Drapeau retiré » → le sujet disparaît de la liste Drapeaux (réconciliation live) ; re-appui long sur le sujet dé-drapeauté → pas de dialog (chemin NotFound, fan-out des buckets froids).

Closes #809.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqxgKdydUwQEqqJm6rkGUh
