### PR TITLE
chore(release): bump versionName to 0.27.0 (dev)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,18 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.27.0` — `internal` (dev) — 2026-07-12
+
+**Lot d'arbitrages et reliquats de la phase** (#792, #809, #881, #805-exp — cadrage + gates Codex par PR, review multi-angles sur #809, dogfood émulateur de chaque flux).
+
+### Vue Topic
+- #809 (#tagsuggestion tinc) : **appui long sur le titre → retirer le drapeau** du sujet courant (PR #887) — confirmation avant retrait, résultat en toast, la liste Drapeaux se met à jour sans refetch. Un drapeau d'un onglet jamais ouvert est retrouvé à la demande. Le tap court (dépliage du titre) est inchangé.
+- #792 (suggestion Dintr-un lemn) : **« Envoyer un MP »** dans le menu contextuel « … » d'un post (PR #886) — ouvre le composeur avec l'auteur pré-rempli. Absent sur ses propres posts et hors session.
+
+### Éditeur & réponse rapide
+- #881 (arbitrage du fil) : **le curseur démarre sous la citation** (PR #885) — un retour à la ligne unique après le bloc [quotemsg] quand il termine le champ, feuille et plein écran.
+- #805 : le réglage **« Citations en cartes » est étiqueté (expérimental)** (PR #885) — défaut inchangé (désactivé) ; le chantier design des cartes est reporté à l'itération Vue · Topic 2.
+
 ## `0.26.3` — `internal` (dev) — 2026-07-10
 
 **Suite de la nuit rf2-12** (lot d'issues non démarrées de la phase).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.26.3"
+        versionName = "0.27.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,4 +1,6 @@
-Redface 2 v0.26.3 — dev.
+Redface 2 v0.27.0 — dev.
 
-- The smiley picker respects the forum's scale: standard smileys small and crisp, perso smileys large.
-- Rotating the screen inside a PM conversation no longer kicks you back to the message list.
+- Long-press a topic's title to remove its flag without going back to the list.
+- Post menu: "Send a PM" to the author, with the composer prefilled.
+- Quote: the cursor now starts below the quoted block.
+- The "Quote cards" setting is now labelled experimental.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,4 +1,6 @@
-Redface 2 v0.26.3 — dev.
+Redface 2 v0.27.0 — dev.
 
-- Le sélecteur de smileys respecte l'échelle du forum : standards petits et nets, persos en grand.
-- Tourner l'écran dans une conversation MP ne ramène plus à la liste des messages.
+- Appui long sur le titre d'un sujet : retirer son drapeau sans repasser par la liste.
+- Menu d'un post : « Envoyer un MP » à l'auteur, composeur pré-rempli.
+- Citer : le curseur démarre sous la citation.
+- Le réglage « Citations en cartes » est marqué expérimental.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump de version pour la release dev 0.27.0 — lot d'arbitrages de la phase Vue Topic (#604) :

- #809 — appui long sur le titre → retirer le drapeau du sujet (PR #887)
- #792 — « Envoyer un MP » dans le menu contextuel d'un post (PR #886)
- #881 — le curseur démarre sous la citation (retour à la ligne après le bloc quotemsg) (PR #885)
- #805 — réglage « Citations en cartes » étiqueté (expérimental) (PR #885)

Contenu : `versionName` 0.26.3 → 0.27.0, entrée `app/CHANGELOG.md`, whatsnew fr-FR/en-US (version en 1re ligne).

Bump purement mécanique — pas de review Codex (exception de la cadence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqxgKdydUwQEqqJm6rkGUh