### PR TITLE
fix(topic): stable top bar — permanent Loupe, no pagenum flash (#877)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImpl.kt
@@ -10,6 +10,7 @@ import fr.forumhfr.redface2.core.database.entities.PostEntity
 import fr.forumhfr.redface2.core.database.entities.TopicEntity
 import fr.forumhfr.redface2.core.domain.coroutines.IoDispatcher
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
+import fr.forumhfr.redface2.core.domain.topic.TopicPageEmission
 import fr.forumhfr.redface2.core.domain.topic.TopicRepository
 import fr.forumhfr.redface2.core.model.Topic
 import fr.forumhfr.redface2.core.network.HfrClient
@@ -55,7 +56,12 @@ class TopicRepositoryImpl @Inject constructor(
      * - Cache miss → fetch directly. A failure here propagates so the UI can
      *   show its error state.
      */
-    override fun observeTopicPage(cat: Int, post: Int, page: Int, forceRefresh: Boolean): Flow<Topic> = flow {
+    override fun observeTopicPage(
+        cat: Int,
+        post: Int,
+        page: Int,
+        forceRefresh: Boolean,
+    ): Flow<TopicPageEmission> = flow {
         // Alpha "Ignorer le cache topic" toggle (Phase 2 finish): when enabled, skip the
         // Room read entirely and emit a fresh network fetch. The result is still persisted
         // so toggling back OFF later finds a cache coherent with the current parser. We
@@ -64,21 +70,24 @@ class TopicRepositoryImpl @Inject constructor(
             userPreferencesRepository.observeIgnoreTopicCache().first()
         }
         if (ignoreTopicCache) {
-            emit(fetchAndPersist(cat, post, page, FetchMode.AUTHENTICATED))
+            emit(TopicPageEmission(fetchAndPersist(cat, post, page, FetchMode.AUTHENTICATED), provisional = false))
             return@flow
         }
 
         val cached = withContext(ioDispatcher) { loadFromCache(cat, post, page) }
         if (cached != null) {
-            emit(cached.topic)
             // #231 — `forceRefresh` (set when opening a topic from a flag, where the user
-            // wants the latest posts) bypasses the snappy-cache TTL: the cached page was
-            // emitted instantly above, but we still always re-fetch below so a followed
+            // wants the latest posts) bypasses the snappy-cache TTL: the cached page is
+            // emitted instantly, but we still always re-fetch below so a followed
             // topic that grew is never shown stale within the 60s window. The TTL skip
             // remains for ordinary back-nav (forceRefresh = false).
             val canSkipRefresh = !forceRefresh &&
                 cached.authMode == FetchMode.AUTHENTICATED &&
                 CachePolicy.isFresh(cached.fetchedAt, CachePolicy.topicPage, clock)
+            // #877 — the cache page is provisional ONLY when a refresh follows on this very
+            // flow. On the TTL-skip path it IS the settled page: flagging it provisional
+            // would strand the pill on « Chargement… » with nothing left to confirm it.
+            emit(TopicPageEmission(cached.topic, provisional = !canSkipRefresh))
             if (canSkipRefresh) {
                 return@flow
             }
@@ -88,14 +97,18 @@ class TopicRepositoryImpl @Inject constructor(
             // needs a structural change here). CancellationException is rethrown to
             // keep structured concurrency semantics intact.
             try {
-                emit(fetchAndPersist(cat, post, page, FetchMode.AUTHENTICATED))
+                emit(TopicPageEmission(fetchAndPersist(cat, post, page, FetchMode.AUTHENTICATED), provisional = false))
             } catch (cancellation: CancellationException) {
                 throw cancellation
             } catch (@Suppress("TooGenericExceptionCaught") refreshError: Exception) {
                 Log.w(LOG_TAG, "Stale refresh failed for cat=$cat post=$post page=$page", refreshError)
+                // #877 — terminal re-emission: the refresh is not coming, so the cache page is
+                // now the settled one. Without this, a provisional-gated pill would show
+                // « Chargement… » forever on an offline back-nav to a stale page.
+                emit(TopicPageEmission(cached.topic, provisional = false))
             }
         } else {
-            emit(fetchAndPersist(cat, post, page, FetchMode.AUTHENTICATED))
+            emit(TopicPageEmission(fetchAndPersist(cat, post, page, FetchMode.AUTHENTICATED), provisional = false))
         }
     }
 

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -39,6 +39,7 @@ import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.SocketPolicy
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -88,7 +89,9 @@ class TopicRepositoryImplTest {
         val repository = repository(now = Instant.parse("2026-04-26T18:00:00Z"))
 
         repository.observeTopicPage(cat = 1, post = 999_395, page = 1).test {
-            val fresh = awaitItem()
+            val emission = awaitItem()
+            assertFalse("#877 — a direct network page is settled", emission.provisional)
+            val fresh = emission.topic
             assertEquals(1, fresh.cat)
             assertEquals(999_395, fresh.post)
             assertEquals(1, fresh.page)
@@ -120,7 +123,10 @@ class TopicRepositoryImplTest {
         repo.observeTopicPage(1, 999_395, 1).test {
             val cached = awaitItem()
             awaitComplete()
-            assertTrue("cache emission should carry posts", cached.posts.isNotEmpty())
+            assertTrue("cache emission should carry posts", cached.topic.posts.isNotEmpty())
+            // #877 — the TTL-skip cache page IS the settled page (no refresh follows) : it must
+            // NOT be provisional, or the pill would show « Chargement… » with nothing coming.
+            assertFalse("TTL-skip emission must be settled", cached.provisional)
         }
         assertEquals("fresh cache hit must not trigger a refresh", 1, server.requestCount)
     }
@@ -137,8 +143,10 @@ class TopicRepositoryImplTest {
 
         // Same fixed clock → cache fresh by TTL → without forceRefresh it would skip.
         repo.observeTopicPage(1, 999_395, 1, forceRefresh = true).test {
-            awaitItem() // cached emission (instant)
-            awaitItem() // forced refresh emission
+            // #877 — the instant cache emission is provisional (a refresh follows) ; the forced
+            // refresh emission settles the page.
+            assertTrue("cached emission must be provisional", awaitItem().provisional)
+            assertFalse("refresh emission must be settled", awaitItem().provisional)
             awaitComplete()
         }
         assertEquals(
@@ -160,13 +168,15 @@ class TopicRepositoryImplTest {
         staleRepository.observeTopicPage(1, 999_395, 1).test {
             val cached = awaitItem()
             val fresh = awaitItem()
-            assertEquals(cached.title, fresh.title)
-            assertEquals(cached.posts.size, fresh.posts.size)
+            assertTrue("#877 — stale cache emission is provisional", cached.provisional)
+            assertFalse("#877 — refresh emission settles the page", fresh.provisional)
+            assertEquals(cached.topic.title, fresh.topic.title)
+            assertEquals(cached.topic.posts.size, fresh.topic.posts.size)
             // Round-trip the PostContent AST through the Room JSON converter:
             // the cached read goes through PostContentSerializer.decode while the
             // fresh read comes straight from HfrParser, so equality proves the
             // converter preserves the polymorphic block/inline hierarchy.
-            assertEquals(fresh.posts.first().content, cached.posts.first().content)
+            assertEquals(fresh.topic.posts.first().content, cached.topic.posts.first().content)
             awaitComplete()
         }
         assertEquals("stale cache must trigger one refresh request", 2, server.requestCount)
@@ -179,13 +189,20 @@ class TopicRepositoryImplTest {
         repository(now = Instant.parse("2026-04-26T18:00:00Z")).refreshTopicPage(1, 999_395, 1)
 
         // Stale TTL → refresh path triggers, but the next response is a hard
-        // disconnect. The flow must emit the cached page exactly once and complete
-        // without rethrowing the network failure.
+        // disconnect. The flow must keep the cached page on screen and complete
+        // without rethrowing the network failure. #877 — the failed refresh now yields a
+        // TERMINAL re-emission of the same cache page with provisional=false, so a
+        // provisional-gated pill can settle on « page X / Y » instead of a stuck
+        // « Chargement… » on an offline back-nav.
         server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
         val staleRepository = repository(now = Instant.parse("2026-04-26T18:05:00Z"))
         staleRepository.observeTopicPage(1, 999_395, 1).test {
             val cached = awaitItem()
-            assertTrue("cache emission should carry the warmed posts", cached.posts.isNotEmpty())
+            assertTrue("cache emission should carry the warmed posts", cached.topic.posts.isNotEmpty())
+            assertTrue("first emission is provisional (refresh attempted)", cached.provisional)
+            val terminal = awaitItem()
+            assertFalse("failed refresh must settle the cache page", terminal.provisional)
+            assertEquals(cached.topic, terminal.topic)
             awaitComplete()
         }
         assertEquals(2, server.requestCount)
@@ -234,8 +251,9 @@ class TopicRepositoryImplTest {
         server.enqueue(MockResponse().setBody(fixtureHtml("topic_page_single.html")))
         val repo = repository(now = Instant.parse("2026-04-26T18:00:00Z"))
         repo.observeTopicPage(1, 999_395, 1).test {
-            awaitItem() // cached anon emission
-            awaitItem() // authenticated refresh
+            // #877 — anon cache emission = provisional (auth refresh always follows).
+            assertTrue(awaitItem().provisional)
+            assertFalse(awaitItem().provisional)
             awaitComplete()
         }
         assertEquals("anon cache must trigger an auth refresh regardless of TTL", 2, server.requestCount)
@@ -329,7 +347,7 @@ class TopicRepositoryImplTest {
 
         // Same clock → fresh cache → no network refresh.
         repo.observeTopicPage(13, 84_540, 2).test {
-            val cached = awaitItem()
+            val cached = awaitItem().topic
             awaitComplete()
             val cachedSamePost = cached.posts.first { it.numreponse == freshWithQuote.numreponse }
             assertEquals(
@@ -360,7 +378,7 @@ class TopicRepositoryImplTest {
 
         // Same clock → fresh cache → no network refresh.
         repo.observeTopicPage(13, 84_540, 2).test {
-            val cached = awaitItem()
+            val cached = awaitItem().topic
             awaitComplete()
             assertEquals(
                 "editedAt must round-trip Room v8 unchanged on cache hit",
@@ -396,7 +414,8 @@ class TopicRepositoryImplTest {
         val bypass = repository(now = Instant.parse("2026-04-26T18:00:00Z"), userPreferences = prefs)
         bypass.observeTopicPage(1, 999_395, 1).test {
             val fresh = awaitItem()
-            assertTrue(fresh.posts.isNotEmpty())
+            assertTrue(fresh.topic.posts.isNotEmpty())
+            assertFalse("#877 — bypass network page is settled", fresh.provisional)
             awaitComplete()
         }
 

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/topic/TopicRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/topic/TopicRepository.kt
@@ -18,8 +18,13 @@ interface TopicRepository {
      * Network errors after a cache emission are swallowed so the user keeps
      * seeing the last-known-good page; on a cold cache, errors are surfaced as
      * exceptions on the flow.
+     *
+     * #877 — each emission carries its provenance ([TopicPageEmission.provisional]) so the
+     * UI can tell a cache page that a network refresh will supersede from a settled page.
+     * Only this repository knows whether a refresh follows (TTL skip, refresh failure), so
+     * the flag is decided here, never inferred downstream.
      */
-    fun observeTopicPage(cat: Int, post: Int, page: Int, forceRefresh: Boolean = false): Flow<Topic>
+    fun observeTopicPage(cat: Int, post: Int, page: Int, forceRefresh: Boolean = false): Flow<TopicPageEmission>
 
     /**
      * Forces a network fetch, bypasses TTL, and writes the result to the cache.
@@ -55,3 +60,17 @@ interface TopicRepository {
      */
     suspend fun prefetch(cat: Int, post: Int, page: Int)
 }
+
+/**
+ * #877 — one emission of [TopicRepository.observeTopicPage], tagged with its provenance.
+ *
+ * [provisional] is `true` only when this page comes from the cache AND a network refresh is
+ * still expected to follow on the same flow. It is `false` for network pages, for cache pages
+ * the TTL skip settles on (no refresh coming), and for the terminal re-emission after a failed
+ * refresh — so `provisional` always terminates: the UI can safely hold back derived affordances
+ * (the « page X / Y » pill) while it is `true` without ever getting stuck.
+ */
+data class TopicPageEmission(
+    val topic: Topic,
+    val provisional: Boolean,
+)

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1097,7 +1097,10 @@ internal fun TopicContent(
  */
 @Composable
 private fun topicBarPageIndicator(state: TopicUiState, loaded: TopicUiState.Mode.Loaded?): String = when {
-    loaded != null -> stringResource(
+    // #877 — a provisional page is the instant cache emission (possibly a stale total, or an
+    // anonymous prefetch row) : keep « Chargement… » until the settled emission lands, so the
+    // pill never flashes a wrong « page X / Y ». The repository guarantees termination.
+    loaded != null && !loaded.provisional -> stringResource(
         R.string.topic_page_indicator,
         loaded.topic.page,
         loaded.topic.totalPages,
@@ -1118,8 +1121,8 @@ private val TopBarExpandedTitleExtraHeight = 24.dp
 
 /**
  * #285/#284 + Chantier C (#546) — the topic top app bar (title + page counter + back) plus the
- * intra-topic search affordance : a search icon in `actions` (only when the loaded page exposes a
- * usable, authenticated transsearch form) that opens the [TopicSearchBar] directly beneath the bar.
+ * intra-topic search affordance : a search icon in `actions` (authenticated + page on screen —
+ * #877 : NOT gated on the transient form) that opens the [TopicSearchBar] directly beneath the bar.
  * Extracted from `TopicContent` to keep that builder under detekt's cyclomatic-complexity cap.
  * Internal (not private) so the Robolectric UI test can drive the #772 title expansion directly,
  * same pattern as [TopicPostCard].
@@ -1221,7 +1224,9 @@ internal fun TopicTopBar(
                 }
             },
             actions = {
-                if (state.canSearchInTopic && !state.search.isActive) {
+                // #877 — gated on canOpenSearch (auth + page à l'écran), PAS sur le form transient :
+                // les émissions cache n'en portent pas et faisaient disparaître la Loupe.
+                if (state.canOpenSearch && !state.search.isActive) {
                     IconButton(
                         onClick = { onIntent(TopicIntent.OpenSearch) },
                         modifier = Modifier.semantics { contentDescription = searchLabel },

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -113,6 +113,15 @@ data class TopicUiState(
              * force-refresh / post-delete / search / live-refilter paths.
              */
             val blockedQuoteAuthors: Set<String> = emptySet(),
+            /**
+             * #877 — `true` while this page is the instant cache emission that a network refresh
+             * will supersede on the same load (cf. `TopicPageEmission.provisional`). The posts
+             * render normally (cache-first snappiness) but the top-bar pill keeps « Chargement… »
+             * instead of a possibly stale « page X / Y ». The repository guarantees a terminal
+             * `provisional = false` emission on every path (network page, TTL skip, failed
+             * refresh), so this can never strand the pill.
+             */
+            val provisional: Boolean = false,
         ) : Mode
 
         data class Error(
@@ -128,13 +137,24 @@ data class TopicUiState(
     }
 
     /**
-     * Helper used by the screen : `true` when the loaded topic page exposes a usable intra-topic
-     * search form (authenticated, non-empty `hash_check`). Drives the search icon affordance,
-     * symmetric with the reply gate. The form is transient (never cached), so a cold cache row
-     * keeps search disabled until a live authenticated load.
+     * `true` when the loaded topic page exposes a usable intra-topic search form (authenticated,
+     * non-empty `hash_check`). The form is transient (never cached) — a cache emission carries
+     * none, which is why the ICON affordance is no longer gated on it (cf. [canOpenSearch], #877) :
+     * this gate keeps protecting the actual POST paths (submit / step).
      */
     val canSearchInTopic: Boolean
         get() = (mode as? Mode.Loaded)?.topic?.searchForm?.canSearch == true
+
+    /**
+     * #877 — search ICON affordance : authenticated + a page on screen. Deliberately decoupled
+     * from the transient [canSearchInTopic] : cache emissions (and the TTL-skip path, which never
+     * refetches) carry no `searchForm`, and gating the icon on it made the Loupe vanish between
+     * pages — deterministic on a fresh authenticated cache, perceived as intermittent. Opening
+     * the bar without a form triggers a fresh form fetch (`TopicViewModel.ensureSearchForm`) ;
+     * a submit that still has no form fails explicitly (Toast), never silently.
+     */
+    val canOpenSearch: Boolean
+        get() = isAuthenticated && mode is Mode.Loaded
 
     companion object {
         fun initial(request: TopicRequest): TopicUiState =

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -98,6 +98,14 @@ class TopicViewModel @AssistedInject constructor(
     private var searchJob: Job? = null
 
     /**
+     * #877 — at most one background « fetch a fresh search form » in flight (cf. [ensureSearchForm]).
+     * Fired when the search bar opens over a page whose transient `searchForm` is absent — the
+     * TTL-skip cache path never refetches, so without this the form (and thus submit) would stay
+     * unavailable until an unrelated reload.
+     */
+    private var searchFormJob: Job? = null
+
+    /**
      * Chantier C (#546) — monotonic token guarding against a stale `transsearch` write.
      * Incremented whenever ANY flow that owns the page (a normal load, refresh, force-refresh,
      * post-delete refetch or a new search) takes over. [submitSearch] snapshots it before the POST
@@ -272,7 +280,10 @@ class TopicViewModel @AssistedInject constructor(
                     // #785 — rebuild the WHOLE loaded mode through the single seam (loadedMode) so
                     // the post-level mask (hiddenNumreponses) and the quote-level canonical set
                     // (blockedQuoteAuthors) re-filter together on a live blacklist change.
-                    current.copy(mode = loadedMode(loaded.topic))
+                    // #877 — this is a LOCAL transformation of the page already on screen : it must
+                    // carry the provenance over, or a re-filter landing between the provisional
+                    // cache emission and the settled one would fake-settle the pill (gate finding).
+                    current.copy(mode = loadedMode(loaded.topic, provisional = loaded.provisional))
                 }
             }
             // This collector is independent of any load job, so an unhandled error here would tear
@@ -422,10 +433,15 @@ class TopicViewModel @AssistedInject constructor(
                     // still draws a bounded sliver from intent to terminal state.
                     endFirstContentSectionIfNeeded()
                 }
-                .collect { topic ->
+                .collect { emission ->
+                    val topic = emission.topic
                     _state.update {
                         it.copy(
-                            mode = loadedMode(topic),
+                            // #877 — the provenance flag rides into Mode.Loaded so the top-bar
+                            // pill can hold « Chargement… » through the cache emission and only
+                            // show « page X / Y » once the page is settled (network / TTL skip /
+                            // terminal after a failed refresh).
+                            mode = loadedMode(topic, provisional = emission.provisional),
                             availablePages = (1..topic.totalPages).toList(),
                         )
                     }
@@ -448,11 +464,15 @@ class TopicViewModel @AssistedInject constructor(
      * diverge — a path bypassing this seam would make masked citations flicker across
      * refresh/search/delete (Codex framing reservation on #785).
      */
-    private fun loadedMode(topic: Topic): TopicUiState.Mode.Loaded =
+    private fun loadedMode(topic: Topic, provisional: Boolean = false): TopicUiState.Mode.Loaded =
         TopicUiState.Mode.Loaded(
             topic = topic,
             hiddenNumreponses = computeHiddenNumreponses(topic, blockedCanonicals),
             blockedQuoteAuthors = blockedCanonicals,
+            // #877 — default false : every other caller (refresh, force-refresh, post-delete,
+            // search, live re-filter) renders a settled network page ; only the cache-aside
+            // collect above forwards the repository's provenance.
+            provisional = provisional,
         )
 
     /**
@@ -774,13 +794,63 @@ class TopicViewModel @AssistedInject constructor(
     // ─── intra-topic search (#546) ───────────────────────────────────────────────
 
     /**
-     * Open the search bar. No-op unless the loaded page exposes a usable search form
-     * ([TopicUiState.canSearchInTopic]) — the screen only shows the affordance in that case, but we
-     * re-check here so a stale tap can never open an inert bar.
+     * Open the search bar. Gated on [TopicUiState.canOpenSearch] (authenticated + page on screen,
+     * #877) — NOT on the transient `searchForm`, whose absence on a cache emission made the Loupe
+     * vanish. When the form is missing (TTL-skip cache, provisional page), [ensureSearchForm]
+     * fetches a fresh one in the background so the submit gate is usually satisfied by the time
+     * the user finished typing ; a submit that still has no form fails explicitly (Toast).
      */
     private fun openSearch() {
-        if (!_state.value.canSearchInTopic) return
+        if (!_state.value.canOpenSearch) return
         _state.update { it.copy(search = it.search.copy(isActive = true)) }
+        ensureSearchForm()
+    }
+
+    /**
+     * #877 — background fetch of a fresh, authenticated page for the sole purpose of harvesting
+     * its transient `searchForm` (hash_check). Never persisted beyond the normal page cache — the
+     * session token itself is NEVER written to Room (cadrage : périssable + sensible). The fresh
+     * page replaces the on-screen one through the single [loadedMode] seam (same page, newer
+     * posts — an acceptable, even desirable, side effect). Failures are silent : the submit path
+     * owns the explicit error surface.
+     */
+    private fun ensureSearchForm() {
+        val loaded = _state.value.mode as? TopicUiState.Mode.Loaded ?: return
+        // No fetch when : the form is already usable ; the page is provisional (the cache-aside
+        // network refresh is in flight and will carry the form — if it fails, the terminal
+        // re-emission drops `provisional` and a re-open of the bar or the submit failure path
+        // retries from here) ; or a fetch is already running.
+        val shouldFetch = loaded.topic.searchForm?.canSearch != true &&
+            !loaded.provisional &&
+            searchFormJob?.isActive != true
+        if (!shouldFetch) return
+        // Snapshot the request AND the generation token : `request` is a var (page changes mutate
+        // it), and `request == fetchedFor` alone cannot tell two successive owners of the SAME
+        // page apart (a refresh or a search taking over between our launch and our landing). Every
+        // owner change bumps `searchGeneration` (takeOverFromSearch / launchSearch), so a stale
+        // form-fetch reply is dropped exactly like a stale transsearch reply (gate finding, #877).
+        val fetchedFor = request
+        val generation = searchGeneration
+        searchFormJob = viewModelScope.launch {
+            runCatching {
+                topicRepository.refreshTopicPage(fetchedFor.cat, fetchedFor.post, fetchedFor.page)
+            }.onSuccess { fresh ->
+                _state.update { state ->
+                    // Latest-wins : same page still on screen AND no newer owner took over.
+                    if (state.mode is TopicUiState.Mode.Loaded &&
+                        request == fetchedFor &&
+                        generation == searchGeneration
+                    ) {
+                        state.copy(
+                            mode = loadedMode(fresh),
+                            availablePages = (1..fresh.totalPages).toList(),
+                        )
+                    } else {
+                        state
+                    }
+                }
+            }
+        }
     }
 
     /**
@@ -812,6 +882,9 @@ class TopicViewModel @AssistedInject constructor(
      */
     private fun takeOverFromSearch() {
         searchJob?.cancel()
+        // #877 — a form fetch tied to the outgoing page is moot (its inject guard would drop the
+        // result anyway) : cancel it so it does not waste a network round-trip.
+        searchFormJob?.cancel()
         searchGeneration++
         // A normal-load path owns the page now, so the result cursor history is stale: a later
         // next/prev would step from a position that no longer matches what is on screen. Reset it
@@ -863,7 +936,17 @@ class TopicViewModel @AssistedInject constructor(
         val current = _state.value
         val form = (current.mode as? TopicUiState.Mode.Loaded)?.topic?.searchForm
         // Re-validate the gate server-side: never POST without a usable (authenticated) form.
-        if (form == null || !form.canSearch || !current.search.canSubmit) return
+        // #877 — with the icon decoupled from the transient form, this path is reachable when the
+        // fresh-form fetch has not landed yet (or failed) : fail EXPLICITLY (same Toast as a
+        // network search failure) and retry the form fetch, never a silent no-op tap. The toast
+        // only fires on a submittable bar — a tap with empty criteria stays inert either way.
+        if (form == null || !form.canSearch) {
+            if (current.search.canSubmit) {
+                viewModelScope.launch { _effects.send(TopicEffect.SearchFailed) }
+                ensureSearchForm()
+            }
+            return
+        }
         val request = TopicSearchRequest(
             form = form,
             word = current.search.word.trim(),
@@ -871,7 +954,7 @@ class TopicViewModel @AssistedInject constructor(
             onlyMatches = current.search.onlyMatches,
             // Fresh search: no cursor, keep firstnum (isStep = false). HFR re-anchors on the first match.
         )
-        if (!request.isMeaningful) return
+        if (!current.search.canSubmit || !request.isMeaningful) return
         resetSearchCursors()
         launchSearch(request, isFresh = true)
     }

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -24,6 +24,7 @@ import fr.forumhfr.redface2.core.domain.preferences.PlusLusIndicatorStyle
 import fr.forumhfr.redface2.core.domain.preferences.UserPreferencesRepository
 import fr.forumhfr.redface2.core.domain.search.SearchRepository
 import fr.forumhfr.redface2.core.domain.topic.NoTopicSearchResultsException
+import fr.forumhfr.redface2.core.domain.topic.TopicPageEmission
 import fr.forumhfr.redface2.core.domain.topic.TopicRepository
 import fr.forumhfr.redface2.core.domain.topic.TopicSearchRepository
 import fr.forumhfr.redface2.core.model.TopicSearchForm
@@ -55,6 +56,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -205,6 +207,108 @@ class TopicViewModelTest {
 
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun `#877 provisional cache emission is exposed then settles on the network emission`() = runTest {
+        val cached = fakeTopic(page = 1, totalPages = 3, title = "cached")
+        val fresh = fakeTopic(page = 1, totalPages = 5, title = "fresh")
+        val controlled = MutableSharedFlow<TopicPageEmission>(replay = 0)
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeStreamingEmissionTopicRepository(controlled),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+
+        viewModel.state.test {
+            assertMode<TopicUiState.Mode.Loading>(awaitItem())
+
+            controlled.emit(TopicPageEmission(cached, provisional = true))
+            val provisional = assertMode<TopicUiState.Mode.Loaded>(awaitItem())
+            assertEquals("cached", provisional.topic.title)
+            assertTrue("the cache emission must surface as provisional", provisional.provisional)
+
+            controlled.emit(TopicPageEmission(fresh, provisional = false))
+            val settled = assertMode<TopicUiState.Mode.Loaded>(awaitItem())
+            assertEquals("fresh", settled.topic.title)
+            assertFalse("the network emission must settle the page", settled.provisional)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `#877 live blacklist re-filter preserves the provisional flag`() = runTest {
+        // Gate finding : loadedMode() defaults provisional=false, and the independent blacklist
+        // collector rebuilds Mode.Loaded from the page ON SCREEN. Landing between the provisional
+        // cache emission and the settled one, it must carry the provenance over — not fake-settle.
+        val cached = fakeTopic(
+            page = 1,
+            totalPages = 3,
+            title = "cached",
+            posts = listOf(fakePost(100, author = "Alice"), fakePost(101, author = "Bob")),
+        )
+        val controlled = MutableSharedFlow<TopicPageEmission>(replay = 0)
+        val blacklist = FakeBlacklistRepository()
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeStreamingEmissionTopicRepository(controlled),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            blacklistRepository = blacklist,
+        )
+
+        viewModel.state.test {
+            assertMode<TopicUiState.Mode.Loading>(awaitItem())
+            controlled.emit(TopicPageEmission(cached, provisional = true))
+            assertTrue(assertMode<TopicUiState.Mode.Loaded>(awaitItem()).provisional)
+
+            blacklist.block("alice")
+            val refiltered = assertMode<TopicUiState.Mode.Loaded>(awaitItem())
+            assertEquals(setOf(100), refiltered.hiddenNumreponses)
+            assertTrue("the local re-filter must NOT fake-settle the page", refiltered.provisional)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `#877 a stale form fetch is dropped after a newer owner took the same page`() = runTest {
+        // Gate finding : `request == fetchedFor` cannot tell two successive owners of the SAME page
+        // apart — the generation token must drop the late form-fetch reply, like a stale transsearch.
+        val form = TopicSearchForm(hashCheck = "tok", topicId = SAMPLE_POST, cat = SAMPLE_CAT, firstnum = 1)
+        val gate = CompletableDeferred<Unit>()
+        var gated = true
+        val repo = FakeTopicRepository(
+            flowsToReturn = listOf(flow { emit(fakeTopic(1, 3, title = "no-form")) }),
+            // Consumed in COMPLETION order : the (ungated) pull-to-refresh takes the first item,
+            // the released form fetch takes the second.
+            refreshTopicsToReturn = listOf(
+                fakeTopic(1, 3, title = "refreshed"),
+                fakeTopic(1, 3, title = "late-form", searchForm = form),
+            ),
+        )
+        repo.refreshHook = { _, _, _ ->
+            if (gated) {
+                gated = false
+                gate.await()
+            }
+        }
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = repo,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+
+        viewModel.send(TopicIntent.OpenSearch) // ensureSearchForm suspends on the gate
+        viewModel.send(TopicIntent.Refresh) // same page, NEW owner → bumps the generation
+        assertEquals("refreshed", assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value).topic.title)
+
+        gate.complete(Unit) // the late form fetch lands — and must be dropped
+
+        assertEquals(
+            "the stale form fetch must not clobber the newer owner",
+            "refreshed",
+            assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value).topic.title,
+        )
     }
 
     @Test
@@ -970,17 +1074,69 @@ class TopicViewModelTest {
     // ─── intra-topic search (#546) ───────────────────────────────────────────────
 
     @Test
-    fun `OpenSearch is a no-op when the loaded page exposes no usable search form`() = runTest {
-        // No searchForm ⇒ canSearchInTopic=false ⇒ the bar must not open.
+    fun `#877 OpenSearch without a form opens the bar and fetches a fresh form`() = runTest {
+        // The TTL-skip cache path serves a settled page WITHOUT a searchForm (transient, never
+        // cached). Pre-#877 the Loupe simply vanished ; now the bar opens (auth + page on screen)
+        // and ensureSearchForm harvests a fresh form in the background.
+        val form = TopicSearchForm(hashCheck = "tok", topicId = SAMPLE_POST, cat = SAMPLE_CAT, firstnum = 1)
+        val repo = FakeTopicRepository(
+            flowsToReturn = listOf(flow { emit(fakeTopic(1, 3, title = "no-form")) }),
+            refreshTopicsToReturn = listOf(fakeTopic(1, 3, title = "fresh-form", searchForm = form)),
+        )
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = repo,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+
+        assertEquals(true, viewModel.state.value.canOpenSearch)
+        viewModel.send(TopicIntent.OpenSearch)
+
+        assertEquals(true, viewModel.state.value.search.isActive)
+        assertEquals("the fresh-form fetch must fire", 1, repo.refreshCalls.size)
+        val loaded = assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value)
+        assertEquals("fresh-form", loaded.topic.title)
+        assertEquals("the harvested form makes submit usable", true, viewModel.state.value.canSearchInTopic)
+    }
+
+    @Test
+    fun `#877 OpenSearch stays a no-op when logged out`() = runTest {
         val viewModel = topicViewModel(
             request = topicRequest(page = 1),
             topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) })),
-            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            authRepository = FakeAuthRepository(AuthState.Anonymous),
         )
 
         viewModel.send(TopicIntent.OpenSearch)
 
+        assertEquals(false, viewModel.state.value.canOpenSearch)
         assertEquals(false, viewModel.state.value.search.isActive)
+    }
+
+    @Test
+    fun `#877 SubmitSearch without a form fails explicitly and retries the form fetch`() = runTest {
+        // Both refresh fetches come back formless (e.g. session lost server-side) : the submit
+        // must surface an explicit SearchFailed Toast — never a silent no-op tap — and retry.
+        val repo = FakeTopicRepository(
+            flowsToReturn = listOf(flow { emit(fakeTopic(1, 3, title = "no-form")) }),
+            refreshTopicsToReturn = listOf(
+                fakeTopic(1, 3, title = "still-no-form"),
+                fakeTopic(1, 3, title = "still-no-form-2"),
+            ),
+        )
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = repo,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+        )
+        viewModel.send(TopicIntent.OpenSearch) // consumes refresh #1, lands formless
+        viewModel.send(TopicIntent.SearchWordChanged("betatest"))
+
+        viewModel.effects.test {
+            viewModel.send(TopicIntent.SubmitSearch)
+            assertEquals(TopicEffect.SearchFailed, awaitItem())
+        }
+        assertEquals("submit must retry the form fetch", 2, repo.refreshCalls.size)
     }
 
     @Test
@@ -2293,10 +2449,14 @@ private class FakeTopicRepository(
      */
     var refreshHook: (suspend (cat: Int, post: Int, page: Int) -> Unit)? = null
 
-    override fun observeTopicPage(cat: Int, post: Int, page: Int, forceRefresh: Boolean): Flow<Topic> {
+    override fun observeTopicPage(cat: Int, post: Int, page: Int, forceRefresh: Boolean): Flow<TopicPageEmission> {
         calls += Triple(cat, post, page)
         lastForceRefresh = forceRefresh
-        return queue.removeFirstOrNull() ?: error("No more flows queued")
+        val flow = queue.removeFirstOrNull() ?: error("No more flows queued")
+        // #877 — tests enqueue plain Flow<Topic> ; the fake settles every page (provisional =
+        // false) so the pre-#877 assertions keep their meaning. Provisional-specific tests use
+        // [FakeStreamingEmissionTopicRepository].
+        return flow.map { TopicPageEmission(it, provisional = false) }
     }
 
     override suspend fun refreshTopicPage(cat: Int, post: Int, page: Int): Topic {
@@ -2438,7 +2598,8 @@ private class FakeTopicSearchRepository(
 private class FakeStreamingTopicRepository(
     private val source: Flow<Topic>,
 ) : TopicRepository {
-    override fun observeTopicPage(cat: Int, post: Int, page: Int, forceRefresh: Boolean): Flow<Topic> = source
+    override fun observeTopicPage(cat: Int, post: Int, page: Int, forceRefresh: Boolean): Flow<TopicPageEmission> =
+        source.map { TopicPageEmission(it, provisional = false) }
 
     override suspend fun refreshTopicPage(cat: Int, post: Int, page: Int): Topic {
         error("refreshTopicPage not used by ViewModel under test")
@@ -2446,6 +2607,30 @@ private class FakeStreamingTopicRepository(
 
     override suspend fun prefetch(cat: Int, post: Int, page: Int) {
         // no-op for streaming tests
+    }
+}
+
+/**
+ * #877 — streaming fake whose emissions carry an explicit [TopicPageEmission.provisional] flag,
+ * for the provenance tests (cache emission held provisional, settled page confirmed).
+ */
+private class FakeStreamingEmissionTopicRepository(
+    private val source: Flow<TopicPageEmission>,
+    private val refreshTopicsToReturn: List<Topic> = emptyList(),
+) : TopicRepository {
+    private val refreshQueue = ArrayDeque(refreshTopicsToReturn)
+    val refreshCalls: MutableList<Triple<Int, Int, Int>> = mutableListOf()
+
+    override fun observeTopicPage(cat: Int, post: Int, page: Int, forceRefresh: Boolean): Flow<TopicPageEmission> =
+        source
+
+    override suspend fun refreshTopicPage(cat: Int, post: Int, page: Int): Topic {
+        refreshCalls += Triple(cat, post, page)
+        return refreshQueue.removeFirstOrNull() ?: error("No refresh topic queued (#877 ensureSearchForm)")
+    }
+
+    override suspend fun prefetch(cat: Int, post: Int, page: Int) {
+        // no-op
     }
 }
 


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Réf #877 (fermeture manuelle après merge — pas de mot-clé).

## Symptômes
1. La Loupe (recherche intra-topic) disparaît par intermittence aux changements de page et ne revient pas toujours.
2. Flash d'un contenu erroné dans la pilule avant « page X / Y » au chargement.

## Cause racine commune
L'UI ne distinguait pas l'émission **cache** (instantanée, sans `searchForm` transient, total potentiellement périmé — souvent la ligne de prefetch anonyme) de l'émission **réseau** confirmée. Pire : sur le chemin TTL-skip (`canSkipRefresh`), la seule émission est le cache → la Loupe ne revenait **jamais** sur une page fraîchement cachée.

## Fix
- `observeTopicPage` émet désormais `TopicPageEmission(topic, provisional)` — seul le repository sait si un refresh suit. Terminaison garantie sur tous les chemins (réseau, TTL-skip, **ré-émission terminale après échec de refresh**).
- La pilule garde « Chargement… » tant que `provisional` (portée pilule uniquement, la surface reste cache-first).
- La Loupe est gatée sur `canOpenSearch` (auth + page à l'écran), plus jamais sur le form transient. À l'ouverture sans form : `ensureSearchForm` récupère un form frais (le hash_check n'est **jamais** persisté) ; un submit sans form échoue explicitement (Toast SearchFailed) puis réessaie.

## Verdicts intégrés
Cadrage GPT-5.6 Sol : fork visibilité = découplage (option ii), `provisional` = « refresh en attente ». Gate diff NO-GO → 2 findings corrigés : le re-filter live de la blacklist préserve `provisional` ; `ensureSearchForm` est gardé par le token `searchGeneration` (latest-wins réel). Tests de non-régression ajoutés pour les deux.

## Validation
- Canonique Docker verte (assemble + tests + lint + detekt).
- Tests : provenance repository (TTL-skip settled, stale provisional→settled, échec réseau = terminal), séquence provisional VM, re-filter préserve provisional, stale form fetch drop, OpenSearch sans form, submit sans form explicite.
- Dogfood émulateur avant merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqxgKdydUwQEqqJm6rkGUh