### PR TITLE
fix(editor): caret revealed above the IME at escalation (#880)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextField.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/BbcodeTextField.kt
@@ -5,8 +5,10 @@ import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.relocation.bringIntoViewRequester
@@ -28,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextLayoutResult
@@ -174,9 +177,22 @@ private fun BbcodeFieldImpl(
     // layout result (a new one lands after every text change) AND the selection (caret moves
     // without relayout: taps, arrow keys), never on `value.text` alone — that would fire
     // against the stale layout of the previous text.
-    LaunchedEffect(isFocused, value.selection, textLayout) {
+    //
+    // #880 — ALSO keyed on the IME bottom inset. At the sheet → full-screen escalation the
+    // resumed draft (and its end-of-text caret) lands ASYNC, after autoFocus already fired and
+    // while the keyboard is still animating in under `adjustNothing` : the follow then runs
+    // against a viewport that has not shrunk yet, judges the caret « already visible », and
+    // nothing re-triggers it once the IME finally covers the field. Re-keying on the inset
+    // re-issues the bring-into-view when the viewport settles ; each key change cancels the
+    // previous effect (and its in-flight bringIntoView), so requests never pile up.
+    val imeBottom = WindowInsets.ime.getBottom(LocalDensity.current)
+    LaunchedEffect(isFocused, value.selection, textLayout, imeBottom) {
         if (!isFocused) return@LaunchedEffect
         val layout = textLayout ?: return@LaunchedEffect
+        // #880 — a layout for ANOTHER text (the async restore replaced the value, its fresh
+        // layout not delivered yet) would scroll to a meaningless rect : skip, the matching
+        // `onTextLayout` re-keys this effect immediately after.
+        if (layout.layoutInput.text.text != value.text) return@LaunchedEffect
         val cursorOffset = value.selection.end.coerceIn(0, layout.layoutInput.text.length)
         bringCursorIntoView.bringIntoView(layout.getCursorRect(cursorOffset))
     }


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Réf #880 (fermeture manuelle après merge).

## Symptôme (tinc, dev 0.26.3)
À l'escalade réponse rapide → plein écran avec reprise du texte, le champ est focusé mais le curseur (fin du texte repris) reste masqué par le clavier.

## Cause racine
Le caret-follow (#447) n'est keyé que sur focus/sélection/layout. À l'escalade, le brouillon repris arrive en **asynchrone** (après l'autoFocus) pendant que l'IME s'anime encore sous `adjustNothing` : le bring-into-view joue contre un viewport pas encore rétréci (« déjà visible »), et rien ne le relance quand le clavier finit de couvrir le champ.

## Fix (cadrage GPT-5.6 Sol : pistes A+B, fusionnées)
- L'effet est aussi keyé sur **l'inset IME bottom** : quand le viewport se stabilise, le bring-into-view est ré-émis. Chaque re-key annule l'effet précédent (pas d'empilement de requêtes — condition Sol).
- Garde « layout ↔ texte » : un layout qui ne correspond pas au texte courant (restore async) est ignoré, le `onTextLayout` frais re-keye immédiatement — couvre le déclencheur de la piste B.
- Pas d'`imePadding` dans le scrollable (double comptage, classe de bug #624) ; le requester reste sur le Box offset-free (contrat KDoc).

## Validation
- Tests JVM : viewport tests existants verts (l'IME n'est pas simulable en Robolectric — documenté dans BbcodeTextFieldViewportTest) ; detekt vert.
- **Dogfood émulateur avant merge** : taper dans la feuille → escalader → curseur visible au-dessus du clavier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqxgKdydUwQEqqJm6rkGUh