### PR TITLE
chore(release): 0.27.1 — Vue Topic fixes lot

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,18 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.27.1` — `internal` (dev) — 2026-07-12
+
+**Lot de 4 fixes Vue Topic** (#877, #879, #880, #863 — cadrage groupé, gate Codex par PR, dogfood émulateur de chaque flux dont migration Room v14→v15 en conditions réelles).
+
+### Vue Topic
+- #877 : **top bar stable pendant les chargements** (PR #889) — la pilule affiche « Chargement… » tant que la page est provisoire (fini le numéro de page périmé pendant les transitions), la loupe reste visible en mode chargé authentifié, fetch du formulaire de recherche latest-wins.
+- #879 : **recherche intra-topic conforme au contrat transsearch** (PR #891) — le mode filtré couvre TOUT le sujet (plus d'ancrage à la page courante), pagination des résultats filtrés (« résultats suivants ») avec critères figés à la soumission et retour en tête de liste.
+- #863 : **badge « cité ×N » = compteur serveur** (PR #892) — « Message cité N fois », cross-pages et autoritaire, persisté en cache (migration Room v15) ; l'index local limité à la page courante est supprimé.
+
+### Éditeur & réponse rapide
+- #880 : **le curseur reste visible au-dessus du clavier** à l'escalade réponse rapide → plein écran (PR #890) — le suivi du caret se re-déclenche quand le clavier finit de s'installer.
+
 ## `0.27.0` — `internal` (dev) — 2026-07-12
 
 **Lot d'arbitrages et reliquats de la phase** (#792, #809, #881, #805-exp — cadrage + gates Codex par PR, review multi-angles sur #809, dogfood émulateur de chaque flux).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.27.0"
+        versionName = "0.27.1"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,6 +1,6 @@
-Redface 2 v0.27.0 — dev.
+Redface 2 v0.27.1 — dev.
 
-- Long-press a topic's title to remove its flag without going back to the list.
-- Post menu: "Send a PM" to the author, with the composer prefilled.
-- Quote: the cursor now starts below the quoted block.
-- The "Quote cards" setting is now labelled experimental.
+- Topic view: stable top bar while pages load ("Loading…", no stale page number).
+- In-topic search: the filter now covers the whole topic, results are paginated.
+- "Quoted xN" badge: server-side counter, across all pages.
+- Quick reply → full screen: the caret stays visible above the keyboard.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,6 +1,6 @@
-Redface 2 v0.27.0 — dev.
+Redface 2 v0.27.1 — dev.
 
-- Appui long sur le titre d'un sujet : retirer son drapeau sans repasser par la liste.
-- Menu d'un post : « Envoyer un MP » à l'auteur, composeur pré-rempli.
-- Citer : le curseur démarre sous la citation.
-- Le réglage « Citations en cartes » est marqué expérimental.
+- Vue topic : top bar stable pendant les chargements (« Chargement… », plus de numéro périmé).
+- Recherche dans le sujet : le filtre couvre tout le sujet, résultats paginés.
+- Badge « cité ×N » : compteur serveur, toutes pages confondues.
+- Réponse rapide → plein écran : le curseur reste visible au-dessus du clavier.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Release `dev` **0.27.1** — lot de 4 fixes Vue Topic, tous mergés sur `dev` avec gate Codex GO + CI verte + dogfood émulateur :

- #877 top bar stable pendant les chargements (PR #889)
- #879 recherche intra-topic : ancrage par mode + pages de résultats (PR #891)
- #880 curseur visible au-dessus de l'IME à l'escalade (PR #890)
- #863 badge « cité ×N » = compteur serveur, Room v15 (PR #892)

Contenu : bump `versionName` 0.27.0 → 0.27.1 (politique A : patch, lot suivant du même chantier), entrée `app/CHANGELOG.md`, whatsnew fr/en (version en 1re ligne).

Après merge : dispatch `release.yml --ref dev -f channel=dev` (autorisation standing canal dev), vérif F-Droid, changelog sur le fil DEV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqxgKdydUwQEqqJm6rkGUh
