### PR TITLE
feat(search): real transsearch semantics — page anchoring, from-start opt-in, results continuation (#894 PR2)

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicSearchRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicSearchRepositoryImpl.kt
@@ -56,17 +56,13 @@ class TopicSearchRepositoryImpl @Inject constructor(
             spseudo = request.spseudo,
             onlyMatches = request.onlyMatches,
             hashCheck = request.form.hashCheck,
-            // #546/#879 — la sémantique du point de départ est PAR MODE (arbitrage cadrage) :
-            // - FILTRÉ (liste des matches, défaut) : tout le topic → firstnum OMIS. Avec firstnum
-            //   HFR ancre EN AVANT et rate les matches antérieurs (vérifié live #546, bug tinc
-            //   2788609 « aucun résultat alors que le web en a »).
-            // - NON FILTRÉ (occurrence suivante) : parité web #879 — le fresh part de la page
-            //   courante (firstnum = 1er post de la page affichée) ; le STEP l'omet TOUJOURS
-            //   (le renvoyer ré-ancre HFR sur le 1er match et le curseur n'avance plus).
-            firstnum = if (!request.onlyMatches && !request.isStep) request.form.firstnum else null,
+            // #894 — the anchor decision (« which firstnum, if any ») belongs to the ViewModel :
+            // session anchor (current page — HFR's own default), 0 (« depuis le début » opt-in),
+            // or null (steps and continuations MUST omit it — re-sending an anchor re-anchors HFR
+            // on the first match, live-verified #546). Forwarded verbatim.
+            firstnum = request.anchor,
             owntopic = request.form.owntopic,
             currentnum = request.currentNum,
-            p = request.page,
         )
         if (html.hasNoSearchResults()) {
             // Chantier B (#546) — HFR rendered « aucune réponse n'a été trouvée » (a frequent term

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicSearchRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicSearchRepositoryImplTest.kt
@@ -19,19 +19,19 @@ import org.junit.Assert.assertThrows
 import org.junit.Test
 
 /**
- * Chantier C (#546) — tests for [TopicSearchRepositoryImpl].
+ * Chantier C (#546) + #894 — tests for [TopicSearchRepositoryImpl].
  *
  * The HfrClient is mocked ; the parser stays real so the response → [fr.forumhfr.redface2.core.model.Topic]
- * mapping is exercised. We assert the REQUEST construction (each form field forwarded verbatim from
- * the parsed [TopicSearchForm]) and that the response page is re-parsed as a topic. The `transsearch`
- * RESPONSE is never asserted against a real capture — none exists (see the model KDoc) — so we feed
- * the parser a known topic-page fixture as a stand-in to prove the round-trip wiring.
+ * mapping is exercised. We assert the REQUEST construction — since #894 the anchor decision
+ * (`firstnum`) belongs entirely to the CALLER ([TopicSearchRequest.anchor] forwarded verbatim,
+ * `null` = omitted) and result batches are reached through the `currentnum` resume cursor, never a
+ * `p` pager (verified live : `p` paginates nothing).
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class TopicSearchRepositoryImplTest {
 
     @Test
-    fun `filtered search forwards every form field and covers the whole topic (no firstnum)`() = runTest {
+    fun `forwards the caller-decided anchor verbatim (#894 fresh default = current page)`() = runTest {
         val hfrClient = mockk<HfrClient>()
         coEvery {
             hfrClient.searchInTopic(
@@ -44,7 +44,6 @@ class TopicSearchRepositoryImplTest {
                 firstnum = any(),
                 owntopic = any(),
                 currentnum = any(),
-                p = any(),
             )
         } returns fixture("topic_page_single.html")
 
@@ -54,6 +53,7 @@ class TopicSearchRepositoryImplTest {
                 word = "betatest",
                 spseudo = "XaTriX",
                 onlyMatches = true,
+                anchor = 2783602,
             ),
         )
 
@@ -67,24 +67,22 @@ class TopicSearchRepositoryImplTest {
                 spseudo = "XaTriX",
                 onlyMatches = true,
                 hashCheck = "tok",
-                // #546/#879 (per-mode semantics) — a FILTERED search lists ALL the matches of the
-                // topic : firstnum stays null (with it HFR anchors ahead and misses earlier
-                // matches — bug tinc 2788609), even though form.firstnum is non-null.
-                firstnum = null,
+                // #894 — HFR's own semantics : the fresh default anchors on the current page
+                // (« search from here onwards »), the VALUE decided by the ViewModel.
+                firstnum = 2783602,
                 owntopic = 0,
                 currentnum = null,
-                p = 1,
             )
         }
     }
 
     @Test
-    fun `non-filtered fresh anchors on the current page and carries owntopic verbatim (#879)`() = runTest {
+    fun `sends an explicit 0 anchor for a from-start search (#894 opt-in)`() = runTest {
         val hfrClient = mockk<HfrClient>()
         coEvery {
             hfrClient.searchInTopic(
                 cat = any(), topicId = any(), word = any(), spseudo = any(), onlyMatches = any(),
-                hashCheck = any(), firstnum = any(), owntopic = any(), currentnum = any(), p = any(),
+                hashCheck = any(), firstnum = any(), owntopic = any(), currentnum = any(),
             )
         } returns fixture("topic_page_single.html")
 
@@ -93,32 +91,30 @@ class TopicSearchRepositoryImplTest {
                 form = TopicSearchForm(hashCheck = "tok", topicId = 7, cat = 32, firstnum = 16244, owntopic = 1),
                 word = "",
                 spseudo = "someone",
-                onlyMatches = false,
-                currentNum = "16300",
+                onlyMatches = true,
+                // « Chercher depuis le début » — an explicit whole-topic anchor, never a silent
+                // omission (cadrage F1).
+                anchor = 0,
             ),
         )
 
         coVerify(exactly = 1) {
-            // owntopic + currentnum forwarded verbatim ; #879 web parity — a NON-FILTERED fresh
-            // (isStep=false) anchors on the current page : firstnum = form.firstnum.
             hfrClient.searchInTopic(
-                cat = 32, topicId = 7, word = "", spseudo = "someone", onlyMatches = false,
-                hashCheck = "tok", firstnum = 16244, owntopic = 1, currentnum = "16300",
-                p = 1,
+                cat = 32, topicId = 7, word = "", spseudo = "someone", onlyMatches = true,
+                hashCheck = "tok", firstnum = 0, owntopic = 1, currentnum = null,
             )
         }
     }
 
     @Test
     fun `omits firstnum on a navigation step and forwards currentnum so HFR advances the cursor`() = runTest {
-        // #546/#879 — a STEP request (isStep=true) ALWAYS drops firstnum, whatever the mode :
-        // re-sending it re-anchors HFR on the first match and the cursor never advances
-        // (live-verified stepping bug). Only the non-filtered FRESH sends firstnum (web parity).
+        // #546/#894 — a STEP request carries NO anchor : re-sending one re-anchors HFR on the
+        // first match and the cursor never advances (live-verified stepping bug).
         val hfrClient = mockk<HfrClient>()
         coEvery {
             hfrClient.searchInTopic(
                 cat = any(), topicId = any(), word = any(), spseudo = any(), onlyMatches = any(),
-                hashCheck = any(), firstnum = any(), owntopic = any(), currentnum = any(), p = any(),
+                hashCheck = any(), firstnum = any(), owntopic = any(), currentnum = any(),
             )
         } returns fixture("topic_page_single.html")
 
@@ -130,6 +126,7 @@ class TopicSearchRepositoryImplTest {
                 onlyMatches = false,
                 currentNum = "2786594",
                 isStep = true,
+                anchor = null,
             ),
         )
 
@@ -137,37 +134,37 @@ class TopicSearchRepositoryImplTest {
             hfrClient.searchInTopic(
                 cat = 23, topicId = 35395, word = "betatest", spseudo = "", onlyMatches = false,
                 hashCheck = "tok", firstnum = null, owntopic = 0, currentnum = "2786594",
-                p = 1,
             )
         }
     }
 
     @Test
-    fun `forwards the requested result page as p (#879 filtered pagination)`() = runTest {
+    fun `a filtered continuation posts the resume cursor with no anchor (#894 web parity)`() = runTest {
+        // #894 — « Résultats suivants » : HFR's truncated scan resumes from the cursor its
+        // previous response advertised. Same criteria, `currentnum` = cursor, NO `firstnum`.
         val hfrClient = mockk<HfrClient>()
         coEvery {
             hfrClient.searchInTopic(
                 cat = any(), topicId = any(), word = any(), spseudo = any(), onlyMatches = any(),
-                hashCheck = any(), firstnum = any(), owntopic = any(), currentnum = any(), p = any(),
+                hashCheck = any(), firstnum = any(), owntopic = any(), currentnum = any(),
             )
         } returns fixture("topic_page_single.html")
 
         buildRepository(hfrClient).searchInTopic(
             TopicSearchRequest(
-                form = TopicSearchForm(hashCheck = "tok", topicId = 35395, cat = 23, firstnum = 2783602),
-                word = "betatest",
-                spseudo = "",
+                form = TopicSearchForm(hashCheck = "tok", topicId = 35395, cat = 23, firstnum = null),
+                word = "",
+                spseudo = "XaTriX",
                 onlyMatches = true,
-                page = 3,
+                currentNum = "2783327",
+                anchor = null,
             ),
         )
 
         coVerify(exactly = 1) {
             hfrClient.searchInTopic(
-                cat = 23, topicId = 35395, word = "betatest", spseudo = "", onlyMatches = true,
-                hashCheck = "tok", firstnum = null, owntopic = 0, currentnum = null,
-                // #879 — the historically frozen p=1 made result pages beyond the first unreachable.
-                p = 3,
+                cat = 23, topicId = 35395, word = "", spseudo = "XaTriX", onlyMatches = true,
+                hashCheck = "tok", firstnum = null, owntopic = 0, currentnum = "2783327",
             )
         }
     }
@@ -186,7 +183,7 @@ class TopicSearchRepositoryImplTest {
         coEvery {
             hfrClient.searchInTopic(
                 cat = any(), topicId = any(), word = any(), spseudo = any(), onlyMatches = any(),
-                hashCheck = any(), firstnum = any(), owntopic = any(), currentnum = any(), p = any(),
+                hashCheck = any(), firstnum = any(), owntopic = any(), currentnum = any(),
             )
         } returns noResultPage
 
@@ -198,6 +195,7 @@ class TopicSearchRepositoryImplTest {
                         word = "topic",
                         spseudo = "",
                         onlyMatches = false,
+                        anchor = 1,
                     ),
                 )
             }
@@ -213,7 +211,7 @@ class TopicSearchRepositoryImplTest {
         coEvery {
             hfrClient.searchInTopic(
                 cat = any(), topicId = any(), word = any(), spseudo = any(), onlyMatches = any(),
-                hashCheck = any(), firstnum = any(), owntopic = any(), currentnum = any(), p = any(),
+                hashCheck = any(), firstnum = any(), owntopic = any(), currentnum = any(),
             )
         } returns fixture("topic_page_single.html")
         val diagnostics = DiagnosticsLog()
@@ -224,6 +222,7 @@ class TopicSearchRepositoryImplTest {
                 word = "word-secret",
                 spseudo = "pseudo-secret",
                 onlyMatches = true,
+                anchor = 1,
             ),
         )
 
@@ -242,7 +241,7 @@ class TopicSearchRepositoryImplTest {
         coEvery {
             hfrClient.searchInTopic(
                 cat = any(), topicId = any(), word = any(), spseudo = any(), onlyMatches = any(),
-                hashCheck = any(), firstnum = any(), owntopic = any(), currentnum = any(), p = any(),
+                hashCheck = any(), firstnum = any(), owntopic = any(), currentnum = any(),
             )
         } throws SessionExpiredException("<redacted>")
 
@@ -254,6 +253,7 @@ class TopicSearchRepositoryImplTest {
                         word = "x",
                         spseudo = "",
                         onlyMatches = true,
+                        anchor = 1,
                     ),
                 )
             }

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/TopicSearch.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/TopicSearch.kt
@@ -74,14 +74,20 @@ data class TopicSearchForm(
  * @property onlyMatches the real semantics of HFR's `filter` checkbox : when `true`, HFR re-renders
  *   the topic page showing ONLY the messages matching the search ; when `false` it returns the
  *   page with the matches highlighted in place. Named for intent, not for the wire (`filter=1`).
- * @property currentNum the server-side navigation cursor (HFR's JS-managed `currentnum`). `null`/blank
- *   for a FRESH search (the documented "clear on submit" behaviour : HFR re-anchors on the first
- *   match) ; carries the current match's `numreponse` for a next/previous STEP so HFR advances to the
- *   following match. Built by the ViewModel from the previous response's [TopicSearchForm.currentNum].
- * @property isStep `true` for a next/previous navigation step (as opposed to a fresh search). When
- *   stepping, the repository OMITS `firstnum` (and `dep`) from the POST : re-sending `firstnum`
- *   re-anchors HFR on the FIRST match and the cursor never progresses (the live-verified stepping bug
- *   — Chantier B / #546). A fresh search keeps `firstnum` (the page anchor HFR expects).
+ * @property currentNum the server-side cursor (HFR's JS-managed `currentnum`). `null`/blank for a
+ *   FRESH search (the documented "clear on submit" behaviour : HFR re-anchors on the first match).
+ *   Carries a `numreponse` for : a next/previous STEP in non-filtered mode (HFR advances to the
+ *   following match), or a FILTERED CONTINUATION (#894 : « Résultats suivants » — HFR's truncated
+ *   scan resumes from the cursor its response advertised). Built by the ViewModel from the previous
+ *   response's [TopicSearchForm.currentNum].
+ * @property isStep `true` for a next/previous navigation step (as opposed to a fresh search).
+ *   Informational since #894 (diagnostics) — the wire decision (« send `firstnum` or not ») is
+ *   carried explicitly by [anchor].
+ * @property anchor the `firstnum` value to POST, or `null` to omit the field entirely (#894).
+ *   The ViewModel decides it : a fresh search sends the SESSION anchor (first `numreponse` of the
+ *   real topic page the search started from — HFR's own « search from the current page onwards »
+ *   semantics), `0` when the user opted into « chercher depuis le début », and `null` on steps and
+ *   continuations (re-sending an anchor re-anchors HFR on the first match — live-verified, #546).
  */
 data class TopicSearchRequest(
     val form: TopicSearchForm,
@@ -90,13 +96,7 @@ data class TopicSearchRequest(
     val onlyMatches: Boolean,
     val currentNum: String? = null,
     val isStep: Boolean = false,
-    /**
-     * #879 — page of the transsearch RESULTS to fetch (HFR's `p` form field, historically frozen
-     * to 1 : only the first page of a filtered result list was ever reachable, so late matches
-     * were silently dropped). The result pager is OWN to the search — never the canonical topic
-     * pager. Fresh submits send 1 ; « résultats suivants » re-submits with the next page.
-     */
-    val page: Int = 1,
+    val anchor: Int? = null,
 ) {
     /** HFR needs at least a term or an author ; an all-blank search is meaningless. */
     val isMeaningful: Boolean get() = word.isNotBlank() || spseudo.isNotBlank()

--- a/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
+++ b/core/network/src/main/kotlin/fr/forumhfr/redface2/core/network/HfrClient.kt
@@ -549,9 +549,6 @@ class HfrClient @Inject constructor(
         firstnum: Int?,
         owntopic: Int = 0,
         currentnum: String? = null,
-        // #879 — page of the RESULTS (HFR `p`). Frozen to 1 before, which made every result page
-        // beyond the first unreachable (filtered lists truncated to the oldest matches).
-        p: Int = 1,
     ): String {
         val url = baseUrl.newBuilder()
             .addPathSegment("transsearch.php")
@@ -561,7 +558,10 @@ class HfrClient @Inject constructor(
             .add("post", topicId.toString())
             .add("cat", cat.toString())
             .add("config", "hfr.inc")
-            .add("p", p.toString())
+            // #894 — constant hidden field of the web form. NOT a results pager : `p` paginates
+            // nothing on transsearch (verified live, `p=2` returns the same page) — result batches
+            // beyond HFR's scan window are reached through the `currentnum` resume cursor instead.
+            .add("p", "1")
             .add("sondage", "0")
             .add("owntopic", owntopic.toString())
             .add("word", word)

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1368,6 +1368,28 @@ private fun TopicSearchBar(
                     Text(stringResource(R.string.topic_search_submit))
                 }
             }
+            // #894 (cadrage F4) — the « depuis le début » opt-in on its own labelled options row :
+            // the default stays HFR's own semantics (anchored to the current page, forward).
+            // Ephemeral bar state — no persisted preference.
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Checkbox(
+                    checked = search.fromStart,
+                    onCheckedChange = { onIntent(TopicIntent.SearchFromStartChanged(it)) },
+                    enabled = search.status != TopicSearchStatus.Loading,
+                )
+                Text(
+                    text = stringResource(R.string.topic_search_from_start),
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier
+                        .weight(1f)
+                        .clickable(enabled = search.status != TopicSearchStatus.Loading) {
+                            onIntent(TopicIntent.SearchFromStartChanged(!search.fromStart))
+                        },
+                )
+            }
             // Chantier B (#546) — per-result navigation (non-filtered) / « no result » feedback.
             TopicSearchResultNav(search = search, onIntent = onIntent)
         }
@@ -1763,11 +1785,7 @@ private fun TopicLoadedContent(
             if (state.search.status != TopicSearchStatus.Loading) {
                 item {
                     if (state.search.hasMoreFilteredResults) {
-                        SearchMoreResultsCard(
-                            resultPage = state.search.resultPage,
-                            resultTotalPages = state.search.resultTotalPages,
-                            onNext = onSearchNextResults,
-                        )
+                        SearchMoreResultsCard(onNext = onSearchNextResults)
                     } else if (state.search.status == TopicSearchStatus.Done) {
                         EndOfSearchResultsCard()
                     }
@@ -1992,12 +2010,13 @@ private fun PageBoundaryCard(donePage: Int, onNextPage: () -> Unit) {
 }
 
 /**
- * #879 — footer of a FILTERED search-result page when more result pages exist. Same actionable
- * card language as [PageBoundaryCard] (filled primaryContainer = « there is more ») but the tap
- * re-submits the SEARCH with `p = resultPage + 1` — never the canonical pager.
+ * #894 — footer of a FILTERED search-result list when HFR truncated its scan window (the response
+ * advertised a resume cursor). Same actionable card language as [PageBoundaryCard] (filled
+ * primaryContainer = « there is more ») ; the tap re-submits the SEARCH with the resume cursor —
+ * web parity with HFR's own « Résultats suivants » button, never the canonical pager.
  */
 @Composable
-private fun SearchMoreResultsCard(resultPage: Int, resultTotalPages: Int, onNext: () -> Unit) {
+private fun SearchMoreResultsCard(onNext: () -> Unit) {
     Card(
         onClick = onNext,
         colors = CardDefaults.cardColors(
@@ -2015,11 +2034,7 @@ private fun SearchMoreResultsCard(resultPage: Int, resultTotalPages: Int, onNext
         ) {
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = stringResource(
-                        R.string.topic_search_results_page_done,
-                        resultPage,
-                        resultTotalPages,
-                    ),
+                    text = stringResource(R.string.topic_search_results_truncated),
                     style = MaterialTheme.typography.titleSmall,
                 )
                 Text(

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -188,6 +188,19 @@ data class TopicSearchUiState(
     val word: String = "",
     val spseudo: String = "",
     val onlyMatches: Boolean = true,
+    /**
+     * #894 — the « Chercher depuis le début » opt-in : a fresh submit sends `firstnum=0` (whole
+     * topic) instead of the session anchor (HFR's default « from the current page onwards »).
+     * EPHEMERAL by design (cadrage F4) : plain bar state, no persisted preference.
+     */
+    val fromStart: Boolean = false,
+    /**
+     * #894 — the search anchor of the topic page the user is READING : the form `firstnum` of the
+     * last REAL topic page rendered (a transsearch response carries none, so it never overwrites
+     * this). A fresh default-mode submit sends it ; a fresh submit from a results page reuses it
+     * (the on-screen response form has no anchor of its own).
+     */
+    val sessionAnchor: Int? = null,
     val status: TopicSearchStatus = TopicSearchStatus.Idle,
     val canGoPreviousResult: Boolean = false,
     val canGoNextResult: Boolean = false,
@@ -200,30 +213,34 @@ data class TopicSearchUiState(
      */
     val showingFilteredResults: Boolean = false,
     /**
-     * #879 — pager of the filtered RESULT list (HFR paginates transsearch like a topic). This is
-     * the search's OWN pager — the canonical `availablePages` is never touched by it. `resultPage`
-     * / `resultTotalPages` come from the transsearch reply ; « résultats suivants » re-submits
-     * with `p = resultPage + 1`.
+     * #894 — resume cursor of the displayed FILTERED result list. HFR truncates its scan window
+     * (~200 matches observed) : a truncated response advertises the resume point in its form's
+     * `currentnum` (⇒ « Résultats suivants » available), a COMPLETE response carries none.
+     * `null` = no further batch. The continuation re-submits the FROZEN criteria below with
+     * `currentnum = resumeCursor` (and NO anchor) ; the next batch REPLACES the list (web parity).
      */
-    val resultPage: Int = 1,
-    val resultTotalPages: Int = 1,
+    val resumeCursor: Int? = null,
     /**
-     * #879 (gate finding 1) — the criteria the displayed result list was actually SUBMITTED with.
-     * The pager belongs to that submission, not to the live editable fields : « résultats
-     * suivants » re-submits THESE, so editing the bar (or flipping « Filtrer ») after page 1 can
-     * never fetch « page 2 of a different search ».
+     * #879 (gate finding 1) + #894 — the criteria the displayed results were actually SUBMITTED
+     * with. The continuation, the non-filtered steps and the backward replay re-submit THESE,
+     * never the live editable fields : editing the bar after a render can never fetch « the next
+     * batch of a different search ». [resultAnchor] is the `firstnum` actually sent (`0` when
+     * « depuis le début » was checked) — the backward replay re-anchors on it, a response form
+     * carrying no anchor of its own.
      */
     val resultWord: String = "",
     val resultSpseudo: String = "",
+    val resultAnchor: Int? = null,
 ) {
     /**
-     * #879 — more filtered result pages are reachable. Deliberately PAGER-based only (gate
-     * finding 3) : during Loading the footer is simply hidden by the screen, and after a failed
-     * next-page fetch the pager is untouched — the card stays and doubles as the retry
-     * affordance. `EndOfSearchResultsCard` is only truthful on `Done && !hasMore`.
+     * #894 — a further batch of filtered results is reachable. Deliberately CURSOR-based only
+     * (gate #879 finding 3, carried over) : during Loading the footer is simply hidden by the
+     * screen, and after a failed continuation the cursor is untouched — the card stays and
+     * doubles as the retry affordance. `EndOfSearchResultsCard` is only truthful on
+     * `Done && !hasMore`.
      */
     val hasMoreFilteredResults: Boolean
-        get() = showingFilteredResults && resultPage < resultTotalPages
+        get() = showingFilteredResults && resumeCursor != null
 
     /** HFR needs at least a term or an author ; the submit button is disabled otherwise. */
     val canSubmit: Boolean get() = word.isNotBlank() || spseudo.isNotBlank()
@@ -289,6 +306,9 @@ sealed interface TopicIntent {
     data class SearchPseudoChanged(val pseudo: String) : TopicIntent
 
     data class SearchOnlyMatchesChanged(val onlyMatches: Boolean) : TopicIntent
+
+    /** #894 — toggle « Chercher depuis le début » (fresh submits send `firstnum=0`). Ephemeral. */
+    data class SearchFromStartChanged(val fromStart: Boolean) : TopicIntent
 
     /** Submit the intra-topic search (`POST transsearch.php`). */
     data object SubmitSearch : TopicIntent

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -236,6 +236,8 @@ class TopicViewModel @AssistedInject constructor(
                 _state.update { it.copy(search = it.search.copy(spseudo = intent.pseudo)) }
             is TopicIntent.SearchOnlyMatchesChanged ->
                 _state.update { it.copy(search = it.search.copy(onlyMatches = intent.onlyMatches)) }
+            is TopicIntent.SearchFromStartChanged ->
+                _state.update { it.copy(search = it.search.copy(fromStart = intent.fromStart)) }
             TopicIntent.SubmitSearch -> submitSearch()
             TopicIntent.SearchNextResultsPage -> searchNextResultsPage()
             TopicIntent.NextResult -> nextResult()
@@ -324,6 +326,7 @@ class TopicViewModel @AssistedInject constructor(
                     it.copy(
                         mode = loadedMode(topic),
                         availablePages = (1..topic.totalPages).toList(),
+                        search = it.search.capturingAnchor(topic),
                     )
                 }
                 // Re-arm the page+1 warmup, like `loadCurrentPage` (l. ~219). Unlike the post-submit
@@ -447,6 +450,9 @@ class TopicViewModel @AssistedInject constructor(
                             // terminal after a failed refresh).
                             mode = loadedMode(topic, provisional = emission.provisional),
                             availablePages = (1..topic.totalPages).toList(),
+                            // #894 — a REAL topic page refreshes the search session anchor
+                            // (a transsearch response has no form anchor : no-op there).
+                            search = it.search.capturingAnchor(topic),
                         )
                     }
                     // First content visible — close the async section. Subsequent emissions
@@ -905,17 +911,27 @@ class TopicViewModel @AssistedInject constructor(
                     status = if (s.status == TopicSearchStatus.Loading) TopicSearchStatus.Idle else s.status,
                     canGoPreviousResult = false,
                     canGoNextResult = false,
-                    // #879 — a normal load owns the page again : the filtered-results footer and
-                    // its pager are stale, reset them (transverse risk : state paginé mal remis).
+                    // #879/#894 — a normal load owns the page again : the filtered-results footer,
+                    // its resume cursor and the frozen criteria are stale, reset them (transverse
+                    // risk : state de résultats mal remis). `sessionAnchor` deliberately SURVIVES —
+                    // it describes the page being read, and the incoming load refreshes it.
                     showingFilteredResults = false,
-                    resultPage = 1,
-                    resultTotalPages = 1,
+                    resumeCursor = null,
                     resultWord = "",
                     resultSpseudo = "",
+                    resultAnchor = null,
                 ),
             )
         }
     }
+
+    /**
+     * #894 — refresh [TopicSearchUiState.sessionAnchor] from a rendered REAL topic page. A
+     * `transsearch` response ships its form without `firstnum`, so it can never overwrite the
+     * anchor of the page the user was actually reading — exactly the intended no-op.
+     */
+    private fun TopicSearchUiState.capturingAnchor(topic: Topic): TopicSearchUiState =
+        topic.searchForm?.firstnum?.let { copy(sessionAnchor = it) } ?: this
 
     /** Chantier B (#546) — drop the client-side result cursor history (no search position active). */
     private fun resetSearchCursors() {
@@ -951,13 +967,14 @@ class TopicViewModel @AssistedInject constructor(
         // fresh-form fetch has not landed yet (or failed) : fail EXPLICITLY (same Toast as a
         // network search failure) and retry the form fetch, never a silent no-op tap. The toast
         // only fires on a submittable bar — a tap with empty criteria stays inert either way.
-        // #894 — a NON-FILTERED fresh search needs the page anchor (`firstnum`), which only the
-        // form of a real topic page carries : a `transsearch` RESPONSE form ships without it.
-        // A null anchor must fail explicitly (same recovery as a missing form) — silently sending
-        // no `firstnum` would run a whole-topic search the user did not ask for. The proper
-        // « search again from the results » flow (frozen session anchor) is the #894 semantics PR.
-        val missingAnchor = !current.search.onlyMatches && form != null && form.firstnum == null
-        if (form == null || !form.canSearch || missingAnchor) {
+        // #894 — resolve the anchor of a FRESH search : « depuis le début » sends an explicit 0,
+        // the default sends the anchor of the page the search starts from — the on-screen form's
+        // `firstnum` (a real topic page) or, from a results page (whose form carries none), the
+        // frozen session anchor. A default-mode submit with NO anchor available must fail
+        // explicitly (same recovery as a missing form) — silently omitting `firstnum` would run a
+        // whole-topic search the user did not ask for (cadrage F1).
+        val anchor = if (current.search.fromStart) 0 else form?.firstnum ?: current.search.sessionAnchor
+        if (form == null || !form.canSearch || anchor == null) {
             if (current.search.canSubmit) {
                 viewModelScope.launch { _effects.send(TopicEffect.SearchFailed) }
                 ensureSearchForm()
@@ -969,7 +986,8 @@ class TopicViewModel @AssistedInject constructor(
             word = current.search.word.trim(),
             spseudo = current.search.spseudo.trim(),
             onlyMatches = current.search.onlyMatches,
-            // Fresh search: no cursor, keep firstnum (isStep = false). HFR re-anchors on the first match.
+            // Fresh search : no cursor (HFR re-anchors on the first match at-or-after the anchor).
+            anchor = anchor,
         )
         if (!current.search.canSubmit || !request.isMeaningful) return
         resetSearchCursors()
@@ -977,24 +995,27 @@ class TopicViewModel @AssistedInject constructor(
     }
 
     /**
-     * #879 — fetch the NEXT page of a FILTERED result list (« résultats suivants » footer). A plain
-     * re-submit of the same criteria with `p = resultPage + 1` ; latest-wins via the same
-     * generation token as every search. The form is re-read from the page on screen (a transsearch
-     * reply carries its own form).
+     * #894 — fetch the NEXT batch of a FILTERED result list (« Résultats suivants » footer, web
+     * parity) : HFR's scan window truncated and its response advertised a resume cursor. The
+     * continuation re-POSTs the FROZEN criteria with `currentnum = resumeCursor` and NO anchor
+     * (cadrage F3) ; latest-wins via the same generation token as every search. The form is
+     * re-read from the page on screen (a transsearch reply carries its own form).
      */
     private fun searchNextResultsPage() {
         val current = _state.value
-        val form = (current.mode as? TopicUiState.Mode.Loaded)?.topic?.searchForm
-        // One combined gate : more pages announced + a usable form on the rendered result page.
-        if (!current.search.hasMoreFilteredResults || form == null || !form.canSearch) return
+        val form = (current.mode as? TopicUiState.Mode.Loaded)?.topic?.searchForm?.takeIf { it.canSearch }
+        // One combined gate : a batch announced (hasMore ⇒ cursor non-null) + a usable form on the
+        // rendered result page.
+        val cursor = current.search.resumeCursor?.takeIf { current.search.hasMoreFilteredResults }
+        if (cursor == null || form == null) return
         val request = TopicSearchRequest(
             form = form,
-            // Gate finding 1 — the pager belongs to the SUBMITTED search : page N+1 is fetched
-            // with the frozen criteria, whatever the (editable) bar currently shows.
+            // Gate #879 finding 1 — the cursor belongs to the SUBMITTED search : the next batch is
+            // fetched with the frozen criteria, whatever the (editable) bar currently shows.
             word = current.search.resultWord,
             spseudo = current.search.resultSpseudo,
             onlyMatches = true,
-            page = current.search.resultPage + 1,
+            currentNum = cursor.toString(),
         )
         if (!request.isMeaningful) return
         launchSearch(request, isFresh = false)
@@ -1021,11 +1042,15 @@ class TopicViewModel @AssistedInject constructor(
         val form = navigableSearchForm(current).takeIf { searchCursorIndex > 0 } ?: return
         val targetIndex = searchCursorIndex - 1
         val request = if (targetIndex == 0) {
+            // #894 (cadrage F5) — the replay to the FIRST result re-issues the fresh search with
+            // the FROZEN criteria and the FROZEN anchor of the displayed search session : the
+            // on-screen response form carries no anchor, and the editable bar may have changed.
             TopicSearchRequest(
                 form = form,
-                word = current.search.word.trim(),
-                spseudo = current.search.spseudo.trim(),
+                word = current.search.resultWord,
+                spseudo = current.search.resultSpseudo,
                 onlyMatches = false,
+                anchor = current.search.resultAnchor,
             )
         } else {
             stepRequest(form, current.search, cursor = searchCursors[targetIndex - 1])
@@ -1043,15 +1068,19 @@ class TopicViewModel @AssistedInject constructor(
         return (current.mode as? TopicUiState.Mode.Loaded)?.topic?.searchForm?.takeIf { it.canSearch }
     }
 
-    /** Chantier B (#546) — a next/previous STEP request (cursor set, firstnum omitted via isStep). */
+    /**
+     * Chantier B (#546) — a next/previous STEP request : cursor set, NO anchor (re-sending one
+     * re-anchors HFR on the first match). #894 (cadrage F5) — steps re-submit the FROZEN criteria
+     * of the displayed search, never the live editable bar.
+     */
     private fun stepRequest(
         form: TopicSearchForm,
         search: TopicSearchUiState,
         cursor: Int,
     ): TopicSearchRequest = TopicSearchRequest(
         form = form,
-        word = search.word.trim(),
-        spseudo = search.spseudo.trim(),
+        word = search.resultWord,
+        spseudo = search.resultSpseudo,
         onlyMatches = false,
         currentNum = cursor.toString(),
         isStep = true,
@@ -1081,16 +1110,27 @@ class TopicViewModel @AssistedInject constructor(
                     topic,
                     isFresh = isFresh,
                     rewindToIndex = rewindToIndex,
-                    requestedPage = request.page,
-                    submittedWord = request.word,
-                    submittedSpseudo = request.spseudo,
-                    onlyMatches = request.onlyMatches,
+                    submitted = request,
                 )
             } catch (cancellation: CancellationException) {
                 throw cancellation
             } catch (noResults: NoTopicSearchResultsException) {
                 android.util.Log.i(LOG_TAG, "Intra-topic search returned no result", noResults)
                 if (generation != searchGeneration) return@launch
+                if (request.onlyMatches && !isFresh) {
+                    // #894 — an empty FILTERED CONTINUATION (matches deleted since the previous
+                    // batch advertised the cursor) is the END of the results, never « Aucun
+                    // résultat » (cadrage F6) : keep the displayed batch, drop the cursor.
+                    _state.update {
+                        it.copy(
+                            search = it.search.copy(
+                                status = TopicSearchStatus.Done,
+                                resumeCursor = null,
+                            ),
+                        )
+                    }
+                    return@launch
+                }
                 // Same dispatch as a parsed reply with no usable landing (fresh→no results,
                 // rewind→replay failure ≠ end, forward→end of results).
                 signalNoLanding(isFresh, rewindToIndex)
@@ -1118,35 +1158,32 @@ class TopicViewModel @AssistedInject constructor(
         topic: Topic,
         isFresh: Boolean,
         rewindToIndex: Int?,
-        // #879 — the result page this reply was asked for (anti-loop clamp in filtered mode).
-        requestedPage: Int,
-        // #879 (gate finding 1) — the criteria of THIS submission, frozen into the state with the
-        // filtered pager so the footer can never mix a new bar content with an old pager.
-        submittedWord: String,
-        submittedSpseudo: String,
-        // Snapshot of the MODE the request was launched with — NOT the live toggle, which the user
-        // may have flipped mid-flight (Codex review : that would apply a non-filtered reply as
-        // filtered or vice-versa).
-        onlyMatches: Boolean,
+        // #894 — the request this reply answers : its criteria are frozen into the state (gate
+        // #879 finding 1 — the footer/steps must never mix new bar content with old results), its
+        // `onlyMatches` snapshot dispatches the branch (never the live toggle, which the user may
+        // have flipped mid-flight — Codex review), and its cursor drives the anti-loop guard.
+        submitted: TopicSearchRequest,
     ) {
-        if (onlyMatches) {
-            // #879 — the filtered page is ONE page of the result list ; its pager (topic.page /
-            // topic.totalPages) is the SEARCH's, never the canonical one. Anti-loop guard (3C) :
-            // a reply that did not land on the requested page (HFR re-served an earlier one)
-            // clamps the total to what was actually reached — « résultats suivants » disappears
-            // instead of looping on the same page.
-            val reachedTotal = if (requestedPage > topic.page) topic.page else topic.totalPages
+        if (submitted.onlyMatches) {
+            // #894 — the filtered page is ONE batch of the result list. HFR advertises a further
+            // batch through the response form's `currentnum` (truncated scan) ; a COMPLETE list
+            // carries none. Anti-loop guard (cadrage F3) : a continuation cursor that did not
+            // STRICTLY advance past the one we sent would re-serve the same batch forever — treat
+            // it as the end instead.
+            val sentCursor = submitted.currentNum?.toIntOrNull()
+            val resumeCursor = topic.searchForm?.currentNum
+                ?.takeIf { sentCursor == null || it > sentCursor }
             renderSearchPage(
                 topic,
                 TopicSearchStatus.Done,
                 canPrev = false,
                 canNext = false,
-                filteredPager = topic.page to reachedTotal,
-                // Gate finding 1 — freeze the SUBMITTED criteria with the pager they belong to.
-                submittedCriteria = submittedWord to submittedSpseudo,
+                filteredResumeCursor = resumeCursor,
+                showingFiltered = true,
+                submitted = submitted,
             )
-            // Gate finding 2 — the list content was replaced in place : reposition at the top so
-            // the first results of this page are visible (fresh AND next-page renders alike).
+            // Gate #879 finding 2 — the list content was replaced in place : reposition at the top
+            // so the first results of this batch are visible (fresh AND continuation alike).
             _effects.send(TopicEffect.ScrollToTopOfResults)
             return
         }
@@ -1171,6 +1208,9 @@ class TopicViewModel @AssistedInject constructor(
             // Forward-only HFR never reports a count up front; keep « next » enabled until a step
             // actually reports the end (onStepEnd disables it).
             canNext = true,
+            // #894 (cadrage F5) — freeze the criteria + anchor for the steps and the backward
+            // replay, which must never read the live editable bar.
+            submitted = submitted,
         )
         _effects.send(TopicEffect.ScrollToPost(landed))
     }
@@ -1217,15 +1257,19 @@ class TopicViewModel @AssistedInject constructor(
      * and the prev/next affordances, keeping the previously-known [TopicUiState.availablePages] (the
      * transsearch pager is not the canonical topic pager) and never scheduling a prefetch off it.
      */
+    @Suppress("LongParameterList") // single render seam of the search state : one param per facet.
     private fun renderSearchPage(
         topic: Topic,
         status: TopicSearchStatus,
         canPrev: Boolean,
         canNext: Boolean,
-        // #879 — non-null ONLY for a filtered render : (page, total) of the RESULT list.
-        filteredPager: Pair<Int, Int>? = null,
-        // #879 (gate finding 1) — the criteria the filtered list was submitted with.
-        submittedCriteria: Pair<String, String>? = null,
+        // #894 — resume cursor advertised by a FILTERED response (null = complete list).
+        filteredResumeCursor: Int? = null,
+        // #894 — `true` ONLY for a filtered render (the batch replaces the list on screen).
+        showingFiltered: Boolean = false,
+        // #879 finding 1 + #894 F5 — the request this render answers : criteria + anchor frozen
+        // with the results they produced, for the continuation / steps / backward replay.
+        submitted: TopicSearchRequest? = null,
     ) {
         _state.update {
             it.copy(
@@ -1234,11 +1278,13 @@ class TopicViewModel @AssistedInject constructor(
                     status = status,
                     canGoPreviousResult = canPrev,
                     canGoNextResult = canNext,
-                    showingFilteredResults = filteredPager != null,
-                    resultPage = filteredPager?.first ?: 1,
-                    resultTotalPages = filteredPager?.second ?: 1,
-                    resultWord = submittedCriteria?.first ?: "",
-                    resultSpseudo = submittedCriteria?.second ?: "",
+                    showingFilteredResults = showingFiltered,
+                    resumeCursor = filteredResumeCursor,
+                    resultWord = submitted?.word ?: "",
+                    resultSpseudo = submitted?.spseudo ?: "",
+                    // A step/continuation carries no anchor : keep the one frozen by the fresh
+                    // submit — the backward replay re-anchors on it.
+                    resultAnchor = submitted?.anchor ?: it.search.resultAnchor,
                 ),
             )
         }

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -44,10 +44,12 @@
     <string name="topic_search_word_hint">Mot</string>
     <string name="topic_search_pseudo_hint">Pseudo</string>
     <string name="topic_search_only_matches">Filtrer (résultats uniquement)</string>
+    <!-- #894 — opt-in « depuis le début » ; le défaut reste ancré à la page courante (parité web). -->
+    <string name="topic_search_from_start">Chercher depuis le début du sujet</string>
     <string name="topic_search_submit">Rechercher</string>
     <string name="topic_search_failed">La recherche dans le sujet a échoué.</string>
-    <!-- #879 — pagination de la liste de résultats FILTRÉS (pager propre à la recherche). -->
-    <string name="topic_search_results_page_done">Résultats — page %1$d / %2$d</string>
+    <!-- #894 — continuation des résultats FILTRÉS (fenêtre de scan HFR tronquée, parité web). -->
+    <string name="topic_search_results_truncated">La liste s’arrête ici, d’autres résultats existent</string>
     <string name="topic_search_results_next">Afficher les résultats suivants</string>
     <string name="topic_search_results_list_end">Fin des résultats de la recherche</string>
     <!-- Chantier B (#546) — navigation entre résultats + cas « aucun résultat ». -->

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -1206,12 +1206,24 @@ class TopicViewModelTest {
     }
 
     @Test
-    fun `#879 filtered results expose their own pager and fetch the next page on demand`() = runTest {
+    fun `#894 a truncated filtered reply exposes the resume cursor and fetches the next batch`() = runTest {
         val form = TopicSearchForm(hashCheck = "tok", topicId = SAMPLE_POST, cat = SAMPLE_CAT, firstnum = 999)
-        val page1 = fakeTopic(page = 1, totalPages = 3, title = "results-p1", searchForm = form)
-        val page2 = fakeTopic(page = 2, totalPages = 3, title = "results-p2", searchForm = form)
+        // Batch 1 : HFR truncated its scan → the response form advertises the resume cursor.
+        // Batch 2 : complete list → no cursor.
+        val batch1 = fakeTopic(
+            page = 1,
+            totalPages = 1,
+            title = "results-b1",
+            searchForm = form.copy(firstnum = null, currentNum = 500),
+        )
+        val batch2 = fakeTopic(
+            page = 1,
+            totalPages = 1,
+            title = "results-b2",
+            searchForm = form.copy(firstnum = null, currentNum = null),
+        )
         val searchRepo = FakeTopicSearchRepository()
-        searchRepo.responder = { req -> if (req.page >= 2) page2 else page1 }
+        searchRepo.responder = { req -> if (req.currentNum == "500") batch2 else batch1 }
         val viewModel = topicViewModel(
             request = topicRequest(page = 1),
             topicRepository = FakeTopicRepository(
@@ -1224,28 +1236,36 @@ class TopicViewModelTest {
         viewModel.send(TopicIntent.SearchWordChanged("iwds"))
         viewModel.send(TopicIntent.SubmitSearch)
 
-        // The filtered reply carries the RESULT pager — own to the search, canonical pager intact.
-        assertEquals("results-p1", assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value).topic.title)
+        // The truncated reply advertises a further batch — canonical pager intact.
+        assertEquals("results-b1", assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value).topic.title)
         assertEquals(true, viewModel.state.value.search.showingFilteredResults)
-        assertEquals(1, viewModel.state.value.search.resultPage)
-        assertEquals(3, viewModel.state.value.search.resultTotalPages)
+        assertEquals(500, viewModel.state.value.search.resumeCursor)
         assertEquals(true, viewModel.state.value.search.hasMoreFilteredResults)
         assertEquals(listOf(1, 2, 3, 4, 5), viewModel.state.value.availablePages)
+        // The fresh submit anchored on the current page (web parity, #894).
+        assertEquals(999, searchRepo.requests.single().anchor)
 
         viewModel.send(TopicIntent.SearchNextResultsPage)
 
         assertEquals(2, searchRepo.requests.size)
-        assertEquals("the footer must re-submit with p = resultPage + 1", 2, searchRepo.requests.last().page)
-        assertEquals(true, searchRepo.requests.last().onlyMatches)
-        assertEquals("results-p2", assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value).topic.title)
-        assertEquals(2, viewModel.state.value.search.resultPage)
-        assertEquals(true, viewModel.state.value.search.hasMoreFilteredResults)
+        val continuation = searchRepo.requests.last()
+        assertEquals("the footer must re-submit the resume cursor", "500", continuation.currentNum)
+        assertEquals("a continuation never re-sends an anchor", null, continuation.anchor)
+        assertEquals(true, continuation.onlyMatches)
+        assertEquals("results-b2", assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value).topic.title)
+        assertEquals("a complete batch ends the continuation", null, viewModel.state.value.search.resumeCursor)
+        assertEquals(false, viewModel.state.value.search.hasMoreFilteredResults)
     }
 
     @Test
     fun `#879 the footer re-submits the FROZEN criteria, not the edited bar (gate finding 1)`() = runTest {
         val form = TopicSearchForm(hashCheck = "tok", topicId = SAMPLE_POST, cat = SAMPLE_CAT, firstnum = 999)
-        val results = fakeTopic(page = 1, totalPages = 3, title = "results", searchForm = form)
+        val results = fakeTopic(
+            page = 1,
+            totalPages = 1,
+            title = "results",
+            searchForm = form.copy(firstnum = null, currentNum = 500),
+        )
         val searchRepo = FakeTopicSearchRepository(result = results)
         val viewModel = topicViewModel(
             request = topicRequest(page = 1),
@@ -1265,17 +1285,22 @@ class TopicViewModelTest {
 
         assertEquals(2, searchRepo.requests.size)
         assertEquals(
-            "page 2 must belong to the SUBMITTED search, never the edited bar",
+            "the next batch must belong to the SUBMITTED search, never the edited bar",
             "iwds",
             searchRepo.requests.last().word,
         )
-        assertEquals(2, searchRepo.requests.last().page)
+        assertEquals("500", searchRepo.requests.last().currentNum)
     }
 
     @Test
     fun `#879 every filtered render repositions at the top of the results (gate finding 2)`() = runTest {
         val form = TopicSearchForm(hashCheck = "tok", topicId = SAMPLE_POST, cat = SAMPLE_CAT, firstnum = 999)
-        val results = fakeTopic(page = 1, totalPages = 3, title = "results", searchForm = form)
+        val results = fakeTopic(
+            page = 1,
+            totalPages = 1,
+            title = "results",
+            searchForm = form.copy(firstnum = null, currentNum = 500),
+        )
         val searchRepo = FakeTopicSearchRepository(result = results)
         val viewModel = topicViewModel(
             request = topicRequest(page = 1),
@@ -1297,12 +1322,17 @@ class TopicViewModelTest {
     }
 
     @Test
-    fun `#879 a failed next-page fetch keeps the pager so the footer stays as retry (gate finding 3)`() = runTest {
+    fun `#879 a failed continuation keeps the cursor so the footer stays as retry (gate finding 3)`() = runTest {
         val form = TopicSearchForm(hashCheck = "tok", topicId = SAMPLE_POST, cat = SAMPLE_CAT, firstnum = 999)
-        val page1 = fakeTopic(page = 1, totalPages = 3, title = "results-p1", searchForm = form)
+        val batch1 = fakeTopic(
+            page = 1,
+            totalPages = 1,
+            title = "results-b1",
+            searchForm = form.copy(firstnum = null, currentNum = 500),
+        )
         val searchRepo = FakeTopicSearchRepository()
         searchRepo.responder = { req ->
-            if (req.page >= 2) throw IOException("boom") else page1
+            if (req.currentNum != null) throw IOException("boom") else batch1
         }
         val viewModel = topicViewModel(
             request = topicRequest(page = 1),
@@ -1319,18 +1349,24 @@ class TopicViewModelTest {
 
         viewModel.send(TopicIntent.SearchNextResultsPage)
 
-        // The fetch failed : the pager is untouched — the « more » card doubles as retry.
-        assertEquals(1, viewModel.state.value.search.resultPage)
+        // The fetch failed : the cursor is untouched — the « more » card doubles as retry.
+        assertEquals(500, viewModel.state.value.search.resumeCursor)
         assertEquals(true, viewModel.state.value.search.hasMoreFilteredResults)
         assertEquals(true, viewModel.state.value.search.showingFilteredResults)
     }
 
     @Test
-    fun `#879 anti-loop — a filtered reply that did not advance clamps the results pager`() = runTest {
+    fun `#894 anti-loop — a continuation cursor that did not advance ends the results`() = runTest {
         val form = TopicSearchForm(hashCheck = "tok", topicId = SAMPLE_POST, cat = SAMPLE_CAT, firstnum = 999)
-        // HFR mis-reports : the reply to the p=2 request re-serves page 1 (total still 3).
-        val page1 = fakeTopic(page = 1, totalPages = 3, title = "results-p1", searchForm = form)
-        val searchRepo = FakeTopicSearchRepository(result = page1)
+        // HFR mis-reports : the continuation re-advertises the SAME cursor it was sent — following
+        // it would re-serve the same batch forever.
+        val batch = fakeTopic(
+            page = 1,
+            totalPages = 1,
+            title = "results-b1",
+            searchForm = form.copy(firstnum = null, currentNum = 500),
+        )
+        val searchRepo = FakeTopicSearchRepository(result = batch)
         val viewModel = topicViewModel(
             request = topicRequest(page = 1),
             topicRepository = FakeTopicRepository(
@@ -1346,17 +1382,64 @@ class TopicViewModelTest {
 
         viewModel.send(TopicIntent.SearchNextResultsPage)
 
-        // The reply landed on page 1 < requested 2 → the total is clamped to what was reached :
-        // the footer disappears instead of looping on the same page forever.
-        assertEquals(1, viewModel.state.value.search.resultPage)
-        assertEquals(1, viewModel.state.value.search.resultTotalPages)
+        // A non-advancing cursor is treated as the end : footer gone, no infinite loop.
+        assertEquals(null, viewModel.state.value.search.resumeCursor)
         assertEquals(false, viewModel.state.value.search.hasMoreFilteredResults)
+        assertEquals(true, viewModel.state.value.search.showingFilteredResults)
     }
 
     @Test
-    fun `#879 a normal load resets the filtered results pager`() = runTest {
+    fun `#894 an EMPTY filtered continuation is the end of results, never « Aucun résultat »`() = runTest {
+        // Cadrage F6 — the matches behind the advertised cursor were deleted meanwhile : HFR
+        // answers its « aucune réponse n'a été trouvée » page. The displayed batch must STAY on
+        // screen, the status settle on Done (not NoResults) and the cursor drop so the footer
+        // becomes the end card.
         val form = TopicSearchForm(hashCheck = "tok", topicId = SAMPLE_POST, cat = SAMPLE_CAT, firstnum = 999)
-        val results = fakeTopic(page = 1, totalPages = 3, title = "results", searchForm = form)
+        val batch1 = fakeTopic(
+            page = 1,
+            totalPages = 1,
+            title = "results-b1",
+            searchForm = form.copy(firstnum = null, currentNum = 500),
+        )
+        val searchRepo = FakeTopicSearchRepository()
+        searchRepo.responder = { req ->
+            if (req.currentNum != null) throw NoTopicSearchResultsException() else batch1
+        }
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(
+                flowsToReturn = listOf(flow { emit(fakeTopic(1, 5, searchForm = form)) }),
+            ),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            topicSearchRepository = searchRepo,
+        )
+        viewModel.send(TopicIntent.OpenSearch)
+        viewModel.send(TopicIntent.SearchWordChanged("iwds"))
+        viewModel.send(TopicIntent.SubmitSearch)
+        assertEquals(true, viewModel.state.value.search.hasMoreFilteredResults)
+
+        viewModel.send(TopicIntent.SearchNextResultsPage)
+
+        assertEquals(TopicSearchStatus.Done, viewModel.state.value.search.status)
+        assertEquals(null, viewModel.state.value.search.resumeCursor)
+        assertEquals(false, viewModel.state.value.search.hasMoreFilteredResults)
+        assertEquals(true, viewModel.state.value.search.showingFilteredResults)
+        assertEquals(
+            "the displayed batch must stay on screen",
+            "results-b1",
+            assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value).topic.title,
+        )
+    }
+
+    @Test
+    fun `#879 a normal load resets the filtered results state`() = runTest {
+        val form = TopicSearchForm(hashCheck = "tok", topicId = SAMPLE_POST, cat = SAMPLE_CAT, firstnum = 999)
+        val results = fakeTopic(
+            page = 1,
+            totalPages = 1,
+            title = "results",
+            searchForm = form.copy(firstnum = null, currentNum = 500),
+        )
         val searchRepo = FakeTopicSearchRepository(result = results)
         val viewModel = topicViewModel(
             request = topicRequest(page = 1),
@@ -1377,10 +1460,75 @@ class TopicViewModelTest {
 
         viewModel.send(TopicIntent.Refresh)
 
-        // A normal-load owner reset the search pager : footer gone, no stale « résultats suivants ».
+        // A normal-load owner reset the results state : footer gone, no stale « résultats suivants ».
         assertEquals(false, viewModel.state.value.search.showingFilteredResults)
-        assertEquals(1, viewModel.state.value.search.resultPage)
+        assertEquals(null, viewModel.state.value.search.resumeCursor)
         assertEquals(false, viewModel.state.value.search.hasMoreFilteredResults)
+    }
+
+    @Test
+    fun `#894 from-start submits an explicit 0 anchor, default anchors the current page`() = runTest {
+        val form = TopicSearchForm(hashCheck = "tok", topicId = SAMPLE_POST, cat = SAMPLE_CAT, firstnum = 999)
+        val results = fakeTopic(
+            page = 1,
+            totalPages = 1,
+            title = "results",
+            searchForm = form.copy(firstnum = null, currentNum = null),
+        )
+        val searchRepo = FakeTopicSearchRepository(result = results)
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(
+                flowsToReturn = listOf(flow { emit(fakeTopic(1, 5, searchForm = form)) }),
+            ),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            topicSearchRepository = searchRepo,
+        )
+        viewModel.send(TopicIntent.OpenSearch)
+        viewModel.send(TopicIntent.SearchWordChanged("iwds"))
+        viewModel.send(TopicIntent.SearchFromStartChanged(true))
+        viewModel.send(TopicIntent.SubmitSearch)
+
+        assertEquals("« depuis le début » = explicit 0", 0, searchRepo.requests.last().anchor)
+
+        viewModel.send(TopicIntent.SearchFromStartChanged(false))
+        viewModel.send(TopicIntent.SubmitSearch)
+
+        assertEquals("default anchors the current page", 999, searchRepo.requests.last().anchor)
+    }
+
+    @Test
+    fun `#894 a fresh submit from a results page reuses the frozen session anchor`() = runTest {
+        // The on-screen page is a transsearch RESPONSE (form without anchor) : a new fresh submit
+        // must reuse the session anchor captured from the last REAL topic page, never fail and
+        // never silently search the whole topic.
+        val pageForm = TopicSearchForm(hashCheck = "tok", topicId = SAMPLE_POST, cat = SAMPLE_CAT, firstnum = 777)
+        val results = fakeTopic(
+            page = 1,
+            totalPages = 1,
+            title = "results",
+            searchForm = pageForm.copy(firstnum = null, currentNum = null),
+        )
+        val searchRepo = FakeTopicSearchRepository(result = results)
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(
+                flowsToReturn = listOf(flow { emit(fakeTopic(1, 5, searchForm = pageForm)) }),
+            ),
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            topicSearchRepository = searchRepo,
+        )
+        viewModel.send(TopicIntent.OpenSearch)
+        viewModel.send(TopicIntent.SearchWordChanged("iwds"))
+        viewModel.send(TopicIntent.SubmitSearch)
+        assertEquals(777, searchRepo.requests.last().anchor)
+
+        // Second fresh submit FROM the rendered results page (its form has no firstnum).
+        viewModel.send(TopicIntent.SearchWordChanged("autre"))
+        viewModel.send(TopicIntent.SubmitSearch)
+
+        assertEquals(2, searchRepo.requests.size)
+        assertEquals("the session anchor survives the results render", 777, searchRepo.requests.last().anchor)
     }
 
     @Test


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Closes #894.

**PR 2/2 de #894** — la sémantique v2, sur le contrat re-vérifié live (la PR 1/2 #896, correctif parser, est mergée).

## Changements

- **Ancrage par défaut = page courante** (parité web) : `TopicSearchRequest.anchor` explicite, décidé par le ViewModel — ancre de session par défaut (capturée à chaque rendu de vraie page topic ; une réponse transsearch n'en porte pas et ne l'écrase jamais), **0 explicite** avec la nouvelle option, `null` sur steps/continuations. Une soumission sans ancre disponible échoue explicitement (jamais de tout-le-topic silencieux — cadrage F1).
- **Option « Chercher depuis le début du sujet »** : checkbox sur sa propre ligne de la barre, état éphémère, défaut décoché (cadrage F4). Couvre le cas historique tinc 2788609 (matches antérieurs voulus) sans changer le défaut web.
- **« Résultats suivants » (parité web)** : HFR tronque sa fenêtre de scan (~200 matches) et annonce un curseur de reprise dans le `currentnum` du form de réponse ; le footer re-POSTe les critères FIGÉS avec ce curseur, le batch suivant REMPLACE la liste + retour en tête (F3). Anti-boucle : curseur non strictement croissant = fin ; continuation vide = fin, jamais « Aucun résultat » (F6).
- **Retrait du pager `p` de #879** : `p` ne pagine RIEN sur transsearch (vérifié live, `p=2` = même page) — `TopicSearchRequest.page`, `resultPage`/`resultTotalPages` et le footer pager supprimés ; le wire garde le champ caché constant `p=1` (parité form web).
- **F5** : les steps non-filtrés et le replay arrière re-soumettent les critères ET l'ancre FIGÉS de la recherche affichée, plus jamais la barre éditable.

## Validation

- Canonique complète verte ; tests repo réécrits (ancre verbatim, 0 explicite, step sans ancre, continuation curseur) + tests VM réécrits/ajoutés (curseur de reprise, critères figés, retry, anti-boucle, reset, from-start, ancre de session depuis une page de résultats).
- Gate Codex + dogfood émulateur avant merge (ancrage p25, from-start, footer sur le cap 200 réel du pseudo XaTriX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqxgKdydUwQEqqJm6rkGUh
