### PR TITLE
chore(release): 0.27.2 — intra-topic search v2

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,16 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.27.2` — `internal` (dev) — 2026-07-12
+
+**Recherche intra-topic v2** (#894, retours XaTriX sur 0.27.1 — contrat `transsearch` re-vérifié live, cadrage + gates Codex, dogfoods sur le serveur réel).
+
+### Vue Topic — recherche
+- **Le mode non-filtré refonctionne** (PR #896) : le form des réponses transsearch (sans `firstnum`) parse à nouveau — le curseur de match n'est plus perdu (« Aucun résultat » systématique corrigé).
+- **Ancrage parité web** (PR #897) : la recherche part de la page courante vers la fin (ancre de session explicite) ; nouvelle option « **Chercher depuis le début du sujet** » (défaut décoché).
+- **« Afficher les résultats suivants »** (PR #897) : quand HFR tronque sa fenêtre de scan (~200 matches), un footer de continuation reprend au curseur annoncé — le batch suivant remplace la liste et s'ouvre en haut. Le pager `p` de 0.27.1 (sans effet serveur) est supprimé.
+- Les étapes ‹ › et le retour au premier résultat re-soumettent les critères figés de la recherche affichée, plus jamais la barre en cours d'édition.
+
 ## `0.27.1` — `internal` (dev) — 2026-07-12
 
 **Lot de 4 fixes Vue Topic** (#877, #879, #880, #863 — cadrage groupé, gate Codex par PR, dogfood émulateur de chaque flux dont migration Room v14→v15 en conditions réelles).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.27.1"
+        versionName = "0.27.2"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,6 +1,5 @@
-Redface 2 v0.27.1 — dev.
+Redface 2 v0.27.2 — dev.
 
-- Topic view: stable top bar while pages load ("Loading…", no stale page number).
-- In-topic search: the filter now covers the whole topic, results are paginated.
-- "Quoted xN" badge: server-side counter, across all pages.
-- Quick reply → full screen: the caret stays visible above the keyboard.
+- In-topic search: non-filtered author search works again.
+- Searches start from the current page (site parity); new "Search from the beginning" option.
+- Filtered results: "Show next results" button when HFR truncates the list (~200).

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,6 +1,5 @@
-Redface 2 v0.27.1 — dev.
+Redface 2 v0.27.2 — dev.
 
-- Vue topic : top bar stable pendant les chargements (« Chargement… », plus de numéro périmé).
-- Recherche dans le sujet : le filtre couvre tout le sujet, résultats paginés.
-- Badge « cité ×N » : compteur serveur, toutes pages confondues.
-- Réponse rapide → plein écran : le curseur reste visible au-dessus du clavier.
+- Recherche dans le sujet : la recherche par pseudo sans filtre refonctionne.
+- La recherche part de la page courante (comme le site) ; option « Chercher depuis le début du sujet ».
+- Résultats filtrés : bouton « Afficher les résultats suivants » quand HFR tronque la liste (~200).


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Release `dev` **0.27.2** — recherche intra-topic v2 (#894, fermée), mergée sur `dev` en deux PRs avec gates Codex + CI verte + dogfoods serveur réel :

- #896 : le mode non-filtré refonctionne (parser des réponses transsearch)
- #897 : ancrage page courante (parité web) + option « depuis le début » + « Résultats suivants » (continuation sur troncature ~200) + retrait du pager `p`

Contenu : bump `versionName` 0.27.1 → 0.27.2 (politique A), entrée `app/CHANGELOG.md`, whatsnew fr/en (version en 1re ligne).

Après merge : dispatch `release.yml --ref dev -f channel=dev` (autorisation standing canal dev), vérif F-Droid, changelog fil DEV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqxgKdydUwQEqqJm6rkGUh
